### PR TITLE
settings: Prep commits for grid rewrite for two pane overlay.

### DIFF
--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -218,6 +218,27 @@ function resize_navbar_alerts(): void {
     }
 }
 
+export function resize_settings_overlay(): void {
+    if ($(".two-pane-settings-overlay.show").length === 0) {
+        return;
+    }
+
+    $(".two-pane-settings-left-simplebar-container").css(
+        "height",
+        height_of($(".two-pane-settings-container")) -
+            height_of($(".two-pane-settings-header")) -
+            height_of($(".two-pane-settings-overlay .display-type")) -
+            height_of($(".two-pane-settings-search")),
+    );
+
+    $(".two-pane-settings-right-simplebar-container").css(
+        "height",
+        height_of($(".two-pane-settings-container")) -
+            height_of($(".two-pane-settings-header")) -
+            height_of($(".two-pane-settings-overlay .display-type")),
+    );
+}
+
 export function resize_settings_creation_overlay(): void {
     if ($(".two-pane-settings-creation-simplebar-container").length === 0) {
         return;
@@ -237,5 +258,6 @@ export function resize_page_components(): void {
     resize_sidebars();
     resize_bottom_whitespace();
     resize_stream_subscribers_list();
+    resize_settings_overlay();
     resize_settings_creation_overlay();
 }

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -1033,6 +1033,7 @@ export function launch(
                 }
             }
         }, 0);
+        resize.resize_settings_overlay();
     });
 }
 

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -2128,6 +2128,7 @@ export function launch(
             },
         });
         change_state(section, left_side_tab, right_side_tab);
+        resize.resize_settings_overlay();
     });
     if (!get_active_data().id) {
         if (section === "new") {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1815,8 +1815,8 @@ label.preferences-radio-choice-label {
     }
 }
 
-/* This value needs to match with the same in subscriptions.css, as
-   we have some shared styles declared there */
+/* We should eventually consolidate some of these styles with the styles
+   in subscriptions.css, using shared classnames. */
 @container settings-overlay (width < $settings_overlay_sidebar_collapse_breakpoint) {
     .profile-settings-form {
         .user-avatar-section {
@@ -1868,9 +1868,25 @@ label.preferences-radio-choice-label {
             #settings_content {
                 height: 100%;
             }
+        }
 
-            &.right {
-                top: 47px;
+        .content-wrapper.right {
+            position: absolute;
+            display: block;
+            left: 101%;
+            margin: 0;
+            width: 100%;
+            height: calc(100% - var(--settings-overlay-header-height));
+
+            top: var(--settings-overlay-header-height);
+            background-color: var(--color-background-modal);
+            border: none;
+
+            transition: left 0.3s ease; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
+            z-index: 10;
+
+            &.show {
+                left: 0%;
             }
         }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -520,7 +520,6 @@ h4.user_group_setting_subsection_title {
         position: relative;
         display: inline-block;
         vertical-align: top;
-        height: calc(100% - var(--settings-overlay-header-height));
         margin: 0 -2px;
     }
 
@@ -654,11 +653,6 @@ h4.user_group_setting_subsection_title {
     position: relative;
     overflow: auto;
     -webkit-overflow-scrolling: touch;
-    /* Calculated from several heights and padding/margin measurements
-    in .list-toggler-container and .stream_filter, with some added
-    fiddling to see what worked best at 12px - 20px font sizes.
-    When we redesign this area we should make this less brittle. */
-    height: calc(100% - 3.4em - 40px);
     width: 100%;
 }
 
@@ -1143,7 +1137,6 @@ h4.user_group_setting_subsection_title {
 
     .settings {
         position: relative;
-        height: calc(100% - var(--settings-overlay-header-height));
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1398,10 +1398,6 @@ div.settings-radio-input-parent {
         flex-wrap: wrap;
     }
 
-    .list-toggler-container {
-        text-align: center;
-    }
-
     #groups_overlay .group_settings_header,
     #subscription_overlay .stream_settings_header {
         flex-wrap: wrap;
@@ -1417,10 +1413,6 @@ div.settings-radio-input-parent {
     .two-pane-settings-container {
         position: relative;
         overflow: hidden;
-
-        .list-toggler-container {
-            text-align: left;
-        }
 
         .two-pane-settings-header .fa-chevron-left {
             visibility: visible;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1425,6 +1425,10 @@ div.settings-radio-input-parent {
         .two-pane-settings-header .fa-chevron-left {
             visibility: visible;
         }
+
+        .two-pane-settings-header.slide-left {
+            border-bottom: none;
+        }
     }
 
     .two-pane-settings-overlay .left,
@@ -1440,11 +1444,7 @@ div.settings-radio-input-parent {
     .two-pane-settings-overlay .right {
         position: absolute;
         left: 101%;
-
-        top: var(--settings-overlay-header-height);
         background-color: var(--color-background-modal);
-        border-top: none;
-
         transition: left 0.3s ease; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
         z-index: 10;
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1433,7 +1433,6 @@ div.settings-radio-input-parent {
         display: block;
         margin: 0;
         width: 100%;
-        height: calc(100% - var(--settings-overlay-header-height));
 
         border: none;
     }
@@ -1474,15 +1473,9 @@ div.settings-radio-input-parent {
         }
     }
 
-    .two-pane-settings-overlay {
-        .two-pane-settings-container {
-            height: 95%;
-        }
-
-        .settings {
-            overflow: auto;
-            -webkit-overflow-scrolling: touch;
-        }
+    .two-pane-settings-overlay .settings {
+        overflow: auto;
+        -webkit-overflow-scrolling: touch;
     }
 }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -944,8 +944,9 @@ h4.user_group_setting_subsection_title {
             justify-content: space-between;
             position: absolute;
             bottom: 0;
-            width: calc(100% - 27px);
-            padding: 9px 15px 15px;
+            /* Subtract 15px padding on either side. */
+            width: calc(100% - 30px);
+            padding: 9px 15px;
             text-align: right;
             background-color: var(--color-background-modal-bar);
             border-top: 1px solid var(--color-border-modal-bar);

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1405,11 +1405,8 @@ div.settings-radio-input-parent {
     }
 }
 
-/* Note that this block has settings_page CSS as well, and thus needs
-   to match the media queries in settings.css
-
-   We should eventually consolidate some of these styles with the settings
-   menu, using shared classnames. */
+/* We should eventually consolidate some of these styles with the styles
+   in settings.css, using shared classnames. */
 @container settings-overlay (width < $settings_overlay_sidebar_collapse_breakpoint) {
     .two-pane-settings-container {
         position: relative;
@@ -1443,26 +1440,6 @@ div.settings-radio-input-parent {
 
         &.show {
             transform: translateX(0%);
-        }
-    }
-
-    #settings_page .content-wrapper.right {
-        position: absolute;
-        display: block;
-        left: 101%;
-        margin: 0;
-        width: 100%;
-        height: calc(100% - var(--settings-overlay-header-height));
-
-        top: var(--settings-overlay-header-height);
-        background-color: var(--color-background-modal);
-        border: none;
-
-        transition: left 0.3s ease; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
-        z-index: 10;
-
-        &.show {
-            left: 0%;
         }
     }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1443,13 +1443,13 @@ div.settings-radio-input-parent {
 
     .two-pane-settings-overlay .right {
         position: absolute;
-        left: 101%;
+        transform: translateX(101%);
+        transition: transform 0.3s ease;
         background-color: var(--color-background-modal);
-        transition: left 0.3s ease; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
         z-index: 10;
 
         &.show {
-            left: 0%;
+            transform: translateX(0%);
         }
     }
 

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -1,4 +1,4 @@
-<div class="hide" id="stream-creation" tabindex="-1" role="dialog"
+<div class="hide two-pane-settings-right-simplebar-container" id="stream-creation" tabindex="-1" role="dialog"
   aria-label="{{t 'Channel creation' }}">
     <form id="stream_creation_form">
         <div class="two-pane-settings-creation-simplebar-container" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -19,7 +19,7 @@
                         <div class="float-clear"></div>
                     </div>
                 </div>
-                <div class="input-append stream_name_search_section" id="stream_filter">
+                <div class="input-append stream_name_search_section two-pane-settings-search" id="stream_filter">
                     <input type="text" name="stream_name" id="search_stream_name" class="filter_text_input" autocomplete="off"
                       placeholder="{{t 'Filter' }}" value=""/>
                     <button type="button" class="clear_search_button" id="clear_search_stream_name">
@@ -58,7 +58,7 @@
                         </span>
                     </div>
                 </div>
-                <div class="streams-list" data-simplebar data-simplebar-tab-index="-1">
+                <div class="streams-list two-pane-settings-left-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
                 </div>
             </div>
             <div class="right">
@@ -76,7 +76,7 @@
                         {{/unless}}
                     </div>
                 </div>
-                <div id="stream_settings" class="settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+                <div id="stream_settings" class="two-pane-settings-right-simplebar-container settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
                     {{!-- edit stream here --}}
                 </div>
                 {{> stream_creation_form . }}

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -1,4 +1,4 @@
-<div class="hide" id="user-group-creation" tabindex="-1" role="dialog"
+<div class="hide two-pane-settings-right-simplebar-container" id="user-group-creation" tabindex="-1" role="dialog"
   aria-label="{{t 'User group creation' }}">
     <form id="user_group_creation_form">
         <div class="two-pane-settings-creation-simplebar-container" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -19,7 +19,7 @@
                         <div class="float-clear"></div>
                     </div>
                 </div>
-                <div class="input-append group_name_search_section" id="group_filter">
+                <div class="input-append group_name_search_section two-pane-settings-search" id="group_filter">
                     <input type="text" name="group_name" id="search_group_name" class="filter_text_input" autocomplete="off"
                       placeholder="{{t 'Filter' }}" value=""/>
                     <button type="button" class="clear_search_button" id="clear_search_group_name">
@@ -33,7 +33,7 @@
                 </div>
                 <div class="no-groups-to-show">
                 </div>
-                <div class="user-groups-list" data-simplebar data-simplebar-tab-index="-1">
+                <div class="user-groups-list two-pane-settings-left-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
                 </div>
             </div>
             <div class="right">
@@ -53,7 +53,7 @@
                         {{/unless}}
                     </div>
                 </div>
-                <div id="user_group_settings" class="settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+                <div id="user_group_settings" class="two-pane-settings-right-simplebar-container settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
                     {{!-- edit user group here --}}
                 </div>
                 {{> user_group_creation_form . }}


### PR DESCRIPTION
Prep work for #34125.

The only visual changes from this PR should be:

1. More even padding on the footer (from `two_pane_settings: Clean up padding and width on creation window footer.`)
2. Heights set on the modal body being more accurate, improving the scrolling experience.