### PR TITLE
authentication: Implement the AzureADB2COAuth2 from Django social_core.

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -31,6 +31,7 @@ authentication providers:
 - GitHub accounts, with `GitHubAuthBackend`
 - GitLab accounts, with `GitLabAuthBackend`
 - Microsoft Entra ID (AzureAD), with `AzureADAuthBackend`
+- Microsoft Entra B2C ID (AzureADB2C), with `AzureADB2CAuthBackend`
 
 Each of these requires one to a handful of lines of configuration in
 `settings.py`, as well as a secret in `zulip-secrets.conf`. Details
@@ -103,10 +104,12 @@ In either configuration, you will need to do the following:
    - Set `AUTH_LDAP_REVERSE_EMAIL_SEARCH` to a query that will find
      an LDAP user given their email address (i.e. a search by
      `LDAP_EMAIL_ATTR`). For example:
+
      ```python
      AUTH_LDAP_REVERSE_EMAIL_SEARCH = LDAPSearch("ou=users,dc=example,dc=com",
                                                  ldap.SCOPE_SUBTREE, "(mail=%(email)s)")
      ```
+
    - Set `AUTH_LDAP_USERNAME_ATTR` to the name of the LDAP
      attribute for the user's LDAP username in that search result.
 
@@ -134,6 +137,7 @@ of the following configurations:
   ```
 
 - To access by Active Directory email address:
+
   ```python
   AUTH_LDAP_USER_SEARCH = LDAPSearch("ou=users,dc=example,dc=com",
                                      ldap.SCOPE_SUBTREE, "(mail=%(user)s)")
@@ -575,9 +579,11 @@ other IdPs (identity providers). You can configure it as follows:
       trust, which consists of multiple certificates. The private key cannot be encrypted
       with a password, as then Zulip will not be able to load it. An example pair can be
       generated using:
+
       ```bash
       openssl req -x509 -newkey rsa:2056 -keyout zulip-private-key.key -out zulip-cert.crt -days 365 -nodes
       ```
+
    4. Set the proper permissions on these files and directories:
 
       ```bash
@@ -737,10 +743,12 @@ integration](../production/scim.md).
       certificate on the Zulip server and import them into Keycloak:
 
       1. Generate **Zulip server public certificate** and the corresponding **private key**:
+
          ```bash
          openssl req -x509 -newkey rsa:2056 -keyout zulip-private-key.key \
            -out zulip-cert.crt -days 365 -nodes
          ```
+
       2. Generate a JKS keystore (replace `{mypassword}` and
          `{myalias}` in the `keytool` invocation):
 
@@ -754,7 +762,7 @@ integration](../production/scim.md).
          You can run the above on the Zulip server. If you instead run
          it on a Mac, you may want to use the keychain
          administration tool to generate the JKS keystore with a UI instead of
-         using the `keytool` command. (see also: https://stackoverflow.com/a/41250334)
+         using the `keytool` command. (see also: <https://stackoverflow.com/a/41250334>)
 
       3. Then switch to the `SAML Keys` tab of your Keycloak
          client. Import `domainname.pfx` into Keycloak. After

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -19456,6 +19456,10 @@ paths:
                             description: |
                               Whether the user can authenticate using their Microsoft Entra ID account.
                             type: boolean
+                          azureadb2c:
+                            description: |
+                              Whether the user can authenticate using their Microsoft Entra B2C ID account.
+                            type: boolean
                           gitlab:
                             description: |
                               Whether the user can authenticate using their GitLab account.
@@ -19633,6 +19637,7 @@ paths:
                             "remoteuser": false,
                             "github": true,
                             "azuread": false,
+                            "azureadb2c": false,
                             "google": true,
                             "saml": true,
                           },

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -50,6 +50,7 @@ from onelogin.saml2.xml_utils import OneLogin_Saml2_XML
 from requests import HTTPError
 from social_core.backends.apple import AppleIdAuth
 from social_core.backends.azuread import AzureADOAuth2
+from social_core.backends.azuread_b2c import AzureADB2COAuth2
 from social_core.backends.base import BaseAuth
 from social_core.backends.github import GithubOAuth2, GithubOrganizationOAuth2, GithubTeamOAuth2
 from social_core.backends.gitlab import GitLabOAuth2
@@ -2293,6 +2294,22 @@ class GitHubAuthBackend(SocialAuthMixin, GithubOAuth2):
                 return dict(auth_failed_reason="GitHub user is not member of required organization")
 
         raise AssertionError("Invalid configuration")
+
+
+@external_auth_method
+class AzureADB2CAuthBackend(SocialAuthMixin, AzureADB2COAuth2):
+    # Allows authentication via Azure B2C in tenants
+
+    sort_order = 40
+    name = "azuread-b2c-oauth2"
+    auth_backend_name = "AzureADB2C"
+    display_icon = staticfiles_storage.url("images/authentication_backends/azuread-icon.png")
+
+    available_for_cloud_plans = [
+        Realm.PLAN_TYPE_STANDARD,
+        Realm.PLAN_TYPE_STANDARD_FREE,
+        Realm.PLAN_TYPE_PLUS,
+    ]
 
 
 @external_auth_method

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -1144,6 +1144,7 @@ else:
 SOCIAL_AUTH_GITHUB_SECRET = get_secret("social_auth_github_secret")
 SOCIAL_AUTH_GITLAB_SECRET = get_secret("social_auth_gitlab_secret")
 SOCIAL_AUTH_AZUREAD_OAUTH2_SECRET = get_secret("social_auth_azuread_oauth2_secret")
+SOCIAL_AUTH_AZUREAD_B2C_OAUTH2_SECRET = get_secret("social_auth_azuread_b2c_oauth2_secret")
 
 SOCIAL_AUTH_GITHUB_SCOPE = ["user:email"]
 if SOCIAL_AUTH_GITHUB_ORG_NAME or SOCIAL_AUTH_GITHUB_TEAM_ID:

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -83,6 +83,10 @@ SOCIAL_AUTH_GITHUB_TEAM_ID: str | None = None
 SOCIAL_AUTH_GITLAB_KEY = get_secret("social_auth_gitlab_key", development_only=True)
 SOCIAL_AUTH_SUBDOMAIN: str | None = None
 SOCIAL_AUTH_AZUREAD_OAUTH2_KEY = get_secret("social_auth_azuread_oauth2_key", development_only=True)
+SOCIAL_AUTH_AZUREAD_B2C_OAUTH2_SECRET = get_secret(
+    "social_auth_azuread_b2c_oauth2_secret", development_only=True
+)
+
 SOCIAL_AUTH_GOOGLE_KEY = get_secret("social_auth_google_key", development_only=True)
 # SAML:
 SOCIAL_AUTH_SAML_SP_ENTITY_ID: str | None = None

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -58,6 +58,7 @@ AUTHENTICATION_BACKENDS: tuple[str, ...] = (
     "zproject.backends.GoogleAuthBackend",
     "zproject.backends.SAMLAuthBackend",
     # 'zproject.backends.AzureADAuthBackend',
+    # 'zproject.backends.AzureADB2CAuthBackend',
     "zproject.backends.GitLabAuthBackend",
     "zproject.backends.AppleAuthBackend",
     "zproject.backends.GenericOpenIdConnectBackend",

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -154,6 +154,7 @@ AUTHENTICATION_BACKENDS: tuple[str, ...] = (
     # "zproject.backends.GitHubAuthBackend",  # GitHub auth, setup below
     # "zproject.backends.GitLabAuthBackend",  # GitLab auth, setup below
     # "zproject.backends.AzureADAuthBackend",  # Microsoft Entra ID (AzureAD) auth, setup below
+    # "zproject.backends.AzureADB2CAuthBackend",  # Microsoft Entra B2C ID (AzureAD) auth, setup below
     # "zproject.backends.AppleAuthBackend",  # Apple auth, setup below
     # "zproject.backends.SAMLAuthBackend",  # SAML, setup below
     # "zproject.backends.ZulipLDAPAuthBackend",  # LDAP, setup below
@@ -554,6 +555,46 @@ SOCIAL_AUTH_SAML_SUPPORT_CONTACT = {
 ## (4) Enter the application ID for the app as SOCIAL_AUTH_AZUREAD_OAUTH2_KEY below
 ## and the generated secret Value in zulip-secrets.conf as `social_auth_azuread_oauth2_secret`.
 # SOCIAL_AUTH_AZUREAD_OAUTH2_KEY = ""
+
+########
+## Microsoft Entra B2C ID (AzureADB2C) OAuth.
+##
+## To set up Microsoft Entra B2C ID authentication, you'll need to do the following:
+##
+## (1) Log into the Tenant Directory within your Azure Root Subscription and
+## navigate to "Azure AD B2C" -> "Manage" -> "App registrations", open
+## "App registrations" and click "New registration".
+##
+## (2) Give the Application a name, such as "Zulip Auth" and select
+## "Accounts in any identity provider or organizational directory (for authenticating users with user flows)"
+## under Supported account types.
+##
+## (3) In the "Redirect URI (recommended)" section, select Web as the platform
+## and enter https://zulip.example.com/complete/azuread-b2c-oauth2/ as the redirect URI,
+## based on your values of EXTERNAL_HOST and SOCIAL_AUTH_SUBDOMAIN.
+##
+## (4) Select "Authentication" and under "Implicit grant and hybrid flows" select
+## "Access tokens" and "ID tokens" and under "Advanced settings" set "Allow public client flows"
+## to "Yes"
+##
+## (5) Next, go to "Certificates & secrets" and generate a new client secret.
+## Make sure to save the generated Value.
+##
+## (4) Enter the application ID for the app as SOCIAL_AUTH_AZUREAD_B2C_OAUTH2_KEY below
+## and the generated secret Value in zulip-secrets.conf as `social_auth_azuread_b2c_oauth2_secret`.
+##
+## (5) Return to the "Azure AD B2C" Blade and select "Policies" then "User flows" and create
+## a new User Flow of the type you require. At a minimum, this should be "Sign in"
+##
+## (6) Click "Create" then configure the values as you require, but ensure that under "2. Identity Providers" you
+## select "Email signin" and under "5. Application claims" you select "Email Addresses"
+##
+## (7) Enter the B2C User flow policy name below as "SOCIAL_AUTH_AZUREAD_B2C_OAUTH2_POLICY"
+##
+## (8) Enter the name of your tenant as "SOCIAL_AUTH_AZUREAD_B2C_OAUTH2_TENANT_NAME" below
+# SOCIAL_AUTH_AZUREAD_B2C_OAUTH2_KEY = ""
+# SOCIAL_AUTH_AZUREAD_B2C_OAUTH2_POLICY = ""
+# SOCIAL_AUTH_AZUREAD_B2C_OAUTH2_TENANT_NAME = ""
 
 ########
 ## SSO via REMOTE_USER.


### PR DESCRIPTION
This change adds the ability to authenticate using Azure B2C applications. This provides the ability for an organisation to provide access to Zulip to users who don't have or need full Azure licenses and/or who are not part of the Azure root subscription.

