### PR TITLE
stream_edit: Fetch subscribers before showing subscriber tab.

### DIFF
--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -173,7 +173,11 @@ export function potential_subscribers(stream_id: number): User[] {
         other than typeahead.  (The guest use case
         may be moot now for other reasons.)
     */
-
+    if (!fetched_stream_ids.has(stream_id)) {
+        blueslip.error("Fetching potential subscribers for stream without full subscriber data", {
+            stream_id,
+        });
+    }
     const subscribers = get_loaded_subscriber_subset(stream_id);
 
     function is_potential_subscriber(person: User): boolean {

--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -216,6 +216,21 @@ export function get_subscribers(stream_id: number): number[] {
     return [...subscribers.keys()];
 }
 
+export async function get_all_subscribers(
+    stream_id: number,
+    retry_on_failure = true,
+): Promise<number[] | null> {
+    // This function parallels `get_subscribers` but ensures we include all
+    // subscribers, possibly fetching that data from the server.
+    const subscribers = await get_full_subscriber_set(stream_id, retry_on_failure);
+    // This means the request failed, which can only happen if `retry_on_failure`
+    // is false.
+    if (subscribers === null) {
+        return null;
+    }
+    return [...subscribers.keys()];
+}
+
 export function set_subscribers(stream_id: number, user_ids: number[], full_data = true): void {
     const subscribers = new LazySet(user_ids);
     stream_subscribers.set(stream_id, subscribers);

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -136,6 +136,17 @@ h4.user_group_setting_subsection_title {
     line-height: 1.5;
 }
 
+.subscriber_list_settings_container.no-display {
+    display: none;
+}
+
+.subscriber-list-settings-loading {
+    display: flex;
+    align-items: center;
+    margin: auto;
+    margin-top: 100px;
+}
+
 .member-list-box,
 .subscriber-list-box {
     text-align: center;

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -1,5 +1,5 @@
 {{#if render_subscribers}}
-<div class="subscriber_list_settings_container" {{#unless can_access_subscribers}}style="display: none"{{/unless}}>
+<div class="subscriber_list_settings_container">
     <h4 class="stream_setting_subsection_title">
         {{t "Add subscribers" }}
     </h4>

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -1,5 +1,5 @@
 {{#if render_subscribers}}
-<div class="subscriber_list_settings_container">
+<div class="subscriber_list_settings_container no-display">
     <h4 class="stream_setting_subsection_title">
         {{t "Add subscribers" }}
     </h4>
@@ -20,4 +20,5 @@
         {{> stream_members_table .}}
     </div>
 </div>
+<div class="subscriber-list-settings-loading"></div>
 {{/if}}

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -140,6 +140,14 @@ test("subscribers", async () => {
         return users.map((u) => u.user_id).sort();
     }
 
+    blueslip.expect(
+        "error",
+        "Fetching potential subscribers for stream without full subscriber data",
+    );
+    potential_subscriber_ids();
+    blueslip.reset();
+
+    peer_data.set_subscribers(stream_id, []);
     assert.deepEqual(potential_subscriber_ids(), [
         me.user_id,
         fred.user_id,

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -302,6 +302,19 @@ test("maybe_fetch_stream_subscribers", async () => {
     assert.equal(await peer_data.maybe_fetch_is_user_subscribed(india.stream_id, 2, false), true);
     assert.equal(await peer_data.maybe_fetch_is_user_subscribed(india.stream_id, 5, false), false);
 
+    peer_data.clear_for_testing();
+    assert.deepEqual(await peer_data.get_subscribers(india.stream_id), []);
+    assert.deepEqual(await peer_data.get_all_subscribers(india.stream_id), [1, 2, 3, 4]);
+
+    peer_data.clear_for_testing();
+    channel.get = () => {
+        throw new Error("error");
+    };
+    blueslip.expect("error", "Failure fetching channel subscribers");
+    // retry is false, so we get null because there was an error
+    assert.deepEqual(await peer_data.get_all_subscribers(india.stream_id, false), null);
+    blueslip.reset();
+
     channel.get = () => {
         throw new Error("error");
     };


### PR DESCRIPTION
Work towards #34244.
    
Now that we're supporting partial subscriber data, we might need to fetch the full list of subscribers when opening the subscribers tab of the edit channel modal.
    
This commit handles a slow load with a loading spinner while we fetch the data, and also makes sure to ignore the data if it's received after it stops being relevant (in case the user has another stream's data open).

Tested that regular `./tools/run-dev` works fine.

To test these changes locally, use `env PARTIAL_SUBSCRIBERS=1 ./tools/run-dev`, and to see the loading screen add `await new Promise((resolve) => setTimeout(resolve, 1000));` before the call to the server in `maybe_fetch_stream_subscribers`. 

Note that the subscriber counts in the left pane of the channels settings modal will be wrong until #34246 is done.

![Kapture 2025-05-03 at 21 49 00](https://github.com/user-attachments/assets/37bd5c39-4fc8-48a3-9a97-a2c99ba50ddb)

