### PR TITLE
compose_validate: Fetch all subscribers before private channel warning.

### DIFF
--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -227,10 +227,10 @@ function get_stream_id_for_textarea($textarea: JQuery<HTMLTextAreaElement>): num
     return compose_state.stream_id();
 }
 
-export function warn_if_private_stream_is_linked(
+export async function warn_if_private_stream_is_linked(
     linked_stream: StreamSubscription,
     $textarea: JQuery<HTMLTextAreaElement>,
-): void {
+): Promise<void> {
     const stream_id = get_stream_id_for_textarea($textarea);
 
     if (!stream_id) {
@@ -264,10 +264,24 @@ export function warn_if_private_stream_is_linked(
     // everyone will be subscribed to the linked stream and so
     // knows it exists.  (But always warn Zephyr users, since
     // we may not know their stream's subscribers.)
+    // Note: `is_subscriber_subset` can return `null` if we encounter
+    // an error fetching subscriber data. In that case, we just show
+    // the banner.
     if (
-        peer_data.is_subscriber_subset(stream_id, linked_stream.stream_id) &&
+        (await peer_data.is_subscriber_subset(stream_id, linked_stream.stream_id)) &&
         !realm.realm_is_zephyr_mirror_realm
     ) {
+        return;
+    }
+
+    // If we've changed streams since fetching subscriber data,
+    // don't update the UI anymore.
+    // Note: The user might have removed the mention of the private
+    // stream during the fetch, and in that case the banner will
+    // still (possibly) show up. If we add logic in the future to
+    // remove banners as the user edits their message, we could use
+    // that here as well.
+    if (stream_id !== get_stream_id_for_textarea($textarea)) {
         return;
     }
 

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1244,7 +1244,7 @@ export function content_typeahead_selected(
                 beginning += "#**" + item.name + ">";
             }
 
-            compose_validate.warn_if_private_stream_is_linked(item, $textbox);
+            void compose_validate.warn_if_private_stream_is_linked(item, $textbox);
             break;
         case "syntax": {
             // Isolate the end index of the triple backticks/tildes, including

--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -135,9 +135,18 @@ async function get_full_subscriber_set(
     return get_loaded_subscriber_subset(stream_id);
 }
 
-export function is_subscriber_subset(stream_id1: number, stream_id2: number): boolean {
-    const sub1_set = get_loaded_subscriber_subset(stream_id1);
-    const sub2_set = get_loaded_subscriber_subset(stream_id2);
+export async function is_subscriber_subset(
+    stream_id1: number,
+    stream_id2: number,
+): Promise<boolean | null> {
+    const sub1_promise = get_full_subscriber_set(stream_id1, false);
+    const sub2_promise = get_full_subscriber_set(stream_id2, false);
+    const sub1_set = await sub1_promise;
+    const sub2_set = await sub2_promise;
+    // This happens if we encountered an error feteching subscribers.
+    if (sub1_set === null || sub2_set === null) {
+        return null;
+    }
 
     return [...sub1_set.keys()].every((key) => sub2_set.has(key));
 }

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -139,7 +139,7 @@ user_groups.initialize({realm_user_groups: [nobody, everyone, admin, moderators,
 function test_ui(label, f) {
     run_test(label, (helpers) => {
         $("textarea#compose-textarea").val("some message");
-        f(helpers);
+        return f(helpers);
     });
 }
 
@@ -583,7 +583,7 @@ test_ui("needs_subscribe_warning", () => {
     assert.equal(compose_validate.needs_subscribe_warning(bob.user_id, sub.stream_id), true);
 });
 
-test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
+test_ui("warn_if_private_stream_is_linked", async ({mock_template}) => {
     const $textarea = $("<textarea>").attr("id", "compose-textarea");
     stub_message_row($textarea);
     const test_sub = {
@@ -610,18 +610,19 @@ test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
         return "<banner-stub>";
     });
 
-    function test_noop_case(invite_only) {
+    async function test_noop_case(invite_only) {
         banner_rendered = false;
         compose_state.set_message_type("stream");
         denmark.invite_only = invite_only;
-        compose_validate.warn_if_private_stream_is_linked(denmark, $textarea);
+        await compose_validate.warn_if_private_stream_is_linked(denmark, $textarea);
         assert.ok(!banner_rendered);
     }
 
-    test_noop_case(false);
+    compose_state.set_selected_recipient_id(undefined);
+    void test_noop_case(false);
     // invite_only=true and current compose stream subscribers are a subset
     // of mentioned_stream subscribers.
-    test_noop_case(true);
+    void test_noop_case(true);
 
     $("#compose_private").hide();
     compose_state.set_message_type("stream");
@@ -634,11 +635,12 @@ test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
         name: "Denmark",
         stream_id: 22,
     };
+    peer_data.set_subscribers(secret_stream.stream_id, []);
     stream_data.add_sub(secret_stream);
     banner_rendered = false;
     const $banner_container = $("#compose_banners");
     $banner_container.set_find_results(".private_stream_warning", []);
-    compose_validate.warn_if_private_stream_is_linked(secret_stream, $textarea);
+    await compose_validate.warn_if_private_stream_is_linked(secret_stream, $textarea);
     assert.ok(banner_rendered);
 
     // Simulate that the row was added to the DOM.
@@ -651,7 +653,7 @@ test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
     // not render.
     banner_rendered = false;
     $banner_container.set_find_results(".private_stream_warning", $warning_row);
-    compose_validate.warn_if_private_stream_is_linked(secret_stream, $textarea);
+    await compose_validate.warn_if_private_stream_is_linked(secret_stream, $textarea);
     assert.ok(!banner_rendered);
 });
 

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -371,7 +371,7 @@ test("get_subscriber_count", () => {
     assert.deepStrictEqual(peer_data.get_subscriber_count(india.stream_id, false), 1);
 });
 
-test("is_subscriber_subset", () => {
+test("is_subscriber_subset", async () => {
     function make_sub(stream_id, user_ids) {
         const sub = {
             stream_id,
@@ -399,7 +399,10 @@ test("is_subscriber_subset", () => {
     ];
 
     for (const row of matrix) {
-        assert.equal(peer_data.is_subscriber_subset(row[0].stream_id, row[1].stream_id), row[2]);
+        assert.equal(
+            await peer_data.is_subscriber_subset(row[0].stream_id, row[1].stream_id),
+            row[2],
+        );
     }
 
     // Two untracked streams should never be passed into us.
@@ -411,7 +414,7 @@ test("is_subscriber_subset", () => {
         "warn",
         "We called get_loaded_subscriber_subset for an untracked stream: 99999",
     );
-    peer_data.is_subscriber_subset(99999, 88888);
+    await peer_data.is_subscriber_subset(99999, 88888);
     blueslip.reset();
 
     // Warn about hypothetical undefined stream_ids.
@@ -419,8 +422,17 @@ test("is_subscriber_subset", () => {
         "warn",
         "We called get_loaded_subscriber_subset for an untracked stream: undefined",
     );
-    peer_data.is_subscriber_subset(undefined, sub_a.stream_id);
+    await peer_data.is_subscriber_subset(undefined, sub_a.stream_id);
     blueslip.reset();
+
+    // Errors when fetching subscriber data return `null`
+    channel.get = () => {
+        throw new Error("error");
+    };
+    peer_data.clear_for_testing();
+    // Expect two calls, one for each channel
+    blueslip.expect("error", "Failure fetching channel subscribers", 2);
+    assert.equal(await peer_data.is_subscriber_subset(sub_a.stream_id, sub_b.stream_id), null);
 });
 
 test("get_unique_subscriber_count_for_streams", () => {


### PR DESCRIPTION
Work towards #34244.
    
This is the only call to `peer_data.is_subscriber_subset`, so after this commit all calls to that function work with our new model for partial subscriber data.


To test these changes locally, use `env PARTIAL_SUBSCRIBERS=1 ./tools/run-dev`, and to see the delay add `await new Promise((resolve) => setTimeout(resolve, 1000));` before the call to the server in `maybe_fetch_stream_subscribers`. 
