### PR TITLE
compose_validate: Fetch subscribers before warning about mentioning unsubscribed user or group

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1192,7 +1192,7 @@ export function content_typeahead_selected(
                 let user_group_mention_text = is_silent ? "@_*" : "@*";
                 user_group_mention_text += item.name + "* ";
                 beginning += user_group_mention_text;
-                compose_validate.warn_if_mentioning_unsubscribed_group(
+                void compose_validate.warn_if_mentioning_unsubscribed_group(
                     item,
                     $textbox,
                     is_silent ?? false,

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1210,7 +1210,7 @@ export function content_typeahead_selected(
                     is_silent,
                 );
                 if (!is_silent && item.type !== "broadcast") {
-                    compose_validate.warn_if_mentioning_unsubscribed_user(item, $textbox);
+                    void compose_validate.warn_if_mentioning_unsubscribed_user(item, $textbox);
                     mention_text = compose_validate.convert_mentions_to_silent_in_direct_messages(
                         mention_text,
                         item.user.full_name,

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -10,6 +10,8 @@ const {run_test, noop} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
 const $ = require("./lib/zjquery.cjs");
 
+const channel = mock_esm("../src/channel");
+
 const compose_banner = zrequire("compose_banner");
 const compose_pm_pill = zrequire("compose_pm_pill");
 const compose_state = zrequire("compose_state");
@@ -139,7 +141,7 @@ user_groups.initialize({realm_user_groups: [nobody, everyone, admin, moderators,
 function test_ui(label, f) {
     run_test(label, (helpers) => {
         $("textarea#compose-textarea").val("some message");
-        f(helpers);
+        return f(helpers);
     });
 }
 
@@ -569,7 +571,7 @@ test_ui("test_check_overflow_text", ({override, override_rewire}) => {
     }
 });
 
-test_ui("needs_subscribe_warning", () => {
+test_ui("needs_subscribe_warning", async () => {
     const invalid_user_id = 999;
 
     const test_bot = {
@@ -590,17 +592,23 @@ test_ui("needs_subscribe_warning", () => {
 
     blueslip.expect("error", "Unknown user_id in maybe_get_user_by_id");
     // Test with an invalid user id.
-    assert.equal(compose_validate.needs_subscribe_warning(invalid_user_id, sub.stream_id), false);
+    assert.equal(
+        await compose_validate.needs_subscribe_warning(invalid_user_id, sub.stream_id),
+        false,
+    );
 
     // Test with bot user.
-    assert.equal(compose_validate.needs_subscribe_warning(test_bot.user_id, sub.stream_id), false);
+    assert.equal(
+        await compose_validate.needs_subscribe_warning(test_bot.user_id, sub.stream_id),
+        false,
+    );
 
     // Test when user is subscribed to the stream.
-    assert.equal(compose_validate.needs_subscribe_warning(bob.user_id, sub.stream_id), false);
+    assert.equal(await compose_validate.needs_subscribe_warning(bob.user_id, sub.stream_id), false);
 
     peer_data.remove_subscriber(sub.stream_id, bob.user_id);
     // Test when the user is not subscribed.
-    assert.equal(compose_validate.needs_subscribe_warning(bob.user_id, sub.stream_id), true);
+    assert.equal(await compose_validate.needs_subscribe_warning(bob.user_id, sub.stream_id), true);
 });
 
 test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
@@ -675,7 +683,7 @@ test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
     assert.ok(!banner_rendered);
 });
 
-test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
+test_ui("warn_if_mentioning_unsubscribed_user", async ({override, mock_template}) => {
     const $textarea = $("<textarea>").attr("id", "compose-textarea");
     stub_message_row($textarea);
     compose_state.set_stream_id("");
@@ -698,19 +706,19 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
         return "<banner-stub>";
     });
 
-    function test_noop_case(is_private, is_zephyr_mirror, type) {
+    async function test_noop_case(is_private, is_zephyr_mirror, type) {
         new_banner_rendered = false;
         const msg_type = is_private ? "private" : "stream";
         compose_state.set_message_type(msg_type);
         override(realm, "realm_is_zephyr_mirror_realm", is_zephyr_mirror);
         mentioned_details.type = type;
-        compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
+        await compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
         assert.ok(!new_banner_rendered);
     }
 
-    test_noop_case(true, false, "user");
-    test_noop_case(false, true, "user");
-    test_noop_case(false, false, "broadcast");
+    await test_noop_case(true, false, "user");
+    await test_noop_case(false, true, "user");
+    await test_noop_case(false, false, "broadcast");
 
     $("#compose_invite_users").hide();
     compose_state.set_message_type("stream");
@@ -719,7 +727,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
     // Test with empty stream name in compose box. It should return noop.
     new_banner_rendered = false;
     assert.equal(compose_state.stream_name(), "");
-    compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
+    await compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
     assert.ok(!new_banner_rendered);
 
     const sub = {
@@ -734,10 +742,10 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
 
     // Test with invalid stream in compose box. It should return noop.
     new_banner_rendered = false;
-    compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
+    await compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
     assert.ok(!new_banner_rendered);
 
-    // Test mentioning a user that should gets a warning.
+    // Test mentioning a user that should get a warning.
     mentioned_details = {
         type: "user",
         user: {
@@ -751,8 +759,14 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
     new_banner_rendered = false;
     const $banner_container = $("#compose_banners");
     $banner_container.set_find_results(".recipient_not_subscribed", []);
+    channel.get = (opts) => {
+        assert.equal(opts.url, `/json/streams/${sub.stream_id}/members`);
+        return {
+            subscribers: [],
+        };
+    };
 
-    compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
+    await compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
     assert.ok(new_banner_rendered);
 
     // Simulate that the row was added to the DOM.
@@ -766,7 +780,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
     // not render.
     new_banner_rendered = false;
     $banner_container.set_find_results(".recipient_not_subscribed", $warning_row);
-    compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
+    await compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
     assert.ok(!new_banner_rendered);
 });
 

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -115,7 +115,7 @@ test("unsubscribe", () => {
     assert.ok(!sub.subscribed);
 });
 
-test("subscribers", () => {
+test("subscribers", async () => {
     const sub = {
         name: "Rome",
         subscribed: true,
@@ -225,6 +225,18 @@ test("subscribers", () => {
     assert.ok(!stream_data.is_user_subscribed(stream_id, brutus.user_id));
     peer_data.remove_subscriber(stream_id, brutus.user_id);
     assert.ok(!stream_data.is_user_subscribed(stream_id, brutus.user_id));
+    blueslip.reset();
+
+    // Same test but for `maybe_fetch_is_user_subscribed`
+    blueslip.expect(
+        "warn",
+        "We got a maybe_fetch_is_user_subscribed call for a non-existent or inaccessible stream.",
+        2,
+    );
+    peer_data.add_subscriber(stream_id, brutus.user_id);
+    assert.ok(!(await stream_data.maybe_fetch_is_user_subscribed(stream_id, brutus.user_id)));
+    peer_data.remove_subscriber(stream_id, brutus.user_id);
+    assert.ok(!(await stream_data.maybe_fetch_is_user_subscribed(stream_id, brutus.user_id)));
     blueslip.reset();
 
     // Verify that we don't crash for a bad stream.


### PR DESCRIPTION
Work towards #34244.

To test these changes locally, use `env PARTIAL_SUBSCRIBERS=1 ./tools/run-dev`, and to see the delay add `await new Promise((resolve) => setTimeout(resolve, 1000));` before the call to the server in `maybe_fetch_stream_subscribers`. 
