### PR TITLE
web: Fix nonsensical use of TypeScript `Omit<>`

### DIFF
--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -259,7 +259,7 @@ export function launch(conf: DialogWidgetConfig): string {
 export function submit_api_request(
     request_method: AjaxRequestHandler,
     url: string,
-    data: Omit<Parameters<AjaxRequestHandler>[0]["data"], "undefined">,
+    data: Record<string, unknown>,
     {
         failure_msg_html = $t_html({defaultMessage: "Failed"}),
         success_continuation,

--- a/web/src/settings_ui.ts
+++ b/web/src/settings_ui.ts
@@ -35,7 +35,7 @@ export const strings = {
 export function do_settings_change(
     request_method: AjaxRequestHandler,
     url: string,
-    data: Omit<Parameters<AjaxRequestHandler>[0]["data"], "undefined">,
+    data: Record<string, unknown>,
     $status_element: JQuery,
     {
         success_msg_html = strings.success_html,


### PR DESCRIPTION
[`Omit<…, "undefined">`](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys) removes the `"undefined"` key from an object. The intention was clearly [`Exclude<…, undefined>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#excludeuniontype-excludedmembers) which removes `undefined` from a union, or [`NonNullable<…>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#nonnullabletype) which removes both `undefined` and `null`. However, it’s simpler here to provide the expected type directly.

Cc @LaPulgaaa (#29263).