### PR TITLE
UI redesign: Add blue links style to message view UI.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1558,13 +1558,29 @@
         var(--color-markdown-pre-border)
     );
     --color-markdown-link: light-dark(
-        hsl(200deg 100% 40%),
-        var(--color-text-generic-link)
+        hsl(210deg 94% 42%),
+        hsl(200deg 100% 43%)
+    );
+    --color-markdown-link-visited: light-dark(
+        hsl(210deg 94% 42% / 20%),
+        hsl(200deg 100% 43% / 30%)
     );
     --color-markdown-code-link: var(--color-markdown-link);
     --color-markdown-link-hover: light-dark(
-        hsl(200deg 100% 25%),
-        var(--color-text-generic-link-interactive)
+        hsl(212deg 100% 50%),
+        hsl(200deg 100% 60%)
+    );
+    --color-markdown-link-hover-decoration: light-dark(
+        hsl(210deg 100% 50% / 70%),
+        var(--color-markdown-link-hover)
+    );
+    --color-markdown-link-active: light-dark(
+        hsl(212deg 100% 30%),
+        hsl(200deg 100% 43%)
+    );
+    --color-markdown-link-active-decoration: light-dark(
+        hsl(210deg 100% 30%),
+        hsl(200deg 100% 40%)
     );
     --color-markdown-code-link-hover: var(--color-markdown-link-hover);
     --color-background-image-thumbnail: light-dark(

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -733,6 +733,24 @@
         }
     }
 
+    & a,
+    & a:link,
+    & a:visited {
+        color: var(--color-markdown-link);
+        text-decoration: underline solid var(--color-markdown-link-visited);
+        text-underline-offset: 3px;
+    }
+
+    & a:hover {
+        color: var(--color-markdown-link-hover);
+        text-decoration-color: var(--color-markdown-link-hover-decoration);
+    }
+
+    & a:active {
+        color: var(--color-markdown-link-active);
+        text-decoration-color: var(--color-markdown-link-active-decoration);
+    }
+
     .main-view-banner-action-button,
     .upload_banner_cancel_button {
         border: none;

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -777,22 +777,34 @@
     }
 
     & a {
-        color: var(--color-markdown-link);
-        text-decoration: none;
-
         & code {
             color: var(--color-markdown-code-link);
         }
 
         &:hover,
         &:focus {
-            color: var(--color-markdown-link-hover);
-            text-decoration: underline;
-
             & code {
                 color: var(--color-markdown-code-link-hover);
             }
         }
+    }
+
+    & a,
+    & a:link,
+    & a:visited {
+        color: var(--color-markdown-link);
+        text-decoration: underline solid var(--color-markdown-link-visited);
+        text-underline-offset: 3px;
+    }
+
+    & a:hover {
+        color: var(--color-markdown-link-hover);
+        text-decoration-color: var(--color-markdown-link-hover-decoration);
+    }
+
+    & a:active {
+        color: var(--color-markdown-link-active);
+        text-decoration-color: var(--color-markdown-link-active-decoration);
     }
 
     & pre {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
As per the suggestion, CSS properties are added for the links in message view UI where there color is adjust so that they match with the underline. As it was discussed [here](https://chat.zulip.org/#narrow/stream/101-design/topic/UI.20redesign.3A.20link.20style), underline is added to the links for better accessibility.


Fixes: #24877 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.


Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
**Screenshots and screen captures:**

<details> <summary>Message links</summary>

Light mode:
- Normal
![Screenshot From 2025-05-06 18-10-48](https://github.com/user-attachments/assets/48c685c1-c642-41a3-821f-b9bb3aa40f0b)

- On hover
![Screenshot From 2025-05-06 18-11-04](https://github.com/user-attachments/assets/70184bc8-5018-4a0f-a78c-83d140779f70)

Dark mode:
- Normal
![Screenshot From 2025-05-06 18-11-21](https://github.com/user-attachments/assets/8b8e0bfa-d0a3-40d5-9df8-a5f258b1d2d8)

- On hover
![Screenshot From 2025-05-06 18-11-35](https://github.com/user-attachments/assets/0a9a9524-ff86-4d0d-99a7-c22ad29bbc92)


</details>

<details><summary>Banners</summary>

Light mode:
- Normal
![Screenshot From 2025-05-06 18-10-02](https://github.com/user-attachments/assets/5f00c405-f2c6-4369-b362-6a93881485f6)

- On hover
![Screenshot From 2025-05-06 18-10-17](https://github.com/user-attachments/assets/2e890d13-9adb-4cf9-ac69-f574d1c496af)

Dark mode:
- Normal
![Screenshot From 2025-05-06 18-09-33](https://github.com/user-attachments/assets/fdb2a64f-af53-44ba-b500-7c7ad33f7f97)

- On hover
![Screenshot From 2025-05-06 18-09-48](https://github.com/user-attachments/assets/e56e56a8-5f38-4386-8fbf-d6045232e0c1)

</details>



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
