### PR TITLE
integration-docs: Update URL in change-zulip-config-file macro. 

### DIFF
--- a/templates/zerver/integrations/include/change-zulip-config-file.md
+++ b/templates/zerver/integrations/include/change-zulip-config-file.md
@@ -5,5 +5,5 @@ following lines to specify the email address and API key for your
 ```
 ZULIP_USER = "{{ integration_name }}-bot@example.com"
 ZULIP_API_KEY = "0123456789abcdef0123456789abcdef"
-ZULIP_SITE = "{{ api_url }}"
+ZULIP_SITE = "{{ zulip_url }}"
 ```


### PR DESCRIPTION
Use the context variable `zulip_url` instead of `api_url` to remove the '/api' suffix.


<details>
<summary><h3>Screenshot</h3></summary>

Example usage: [Git doc](https://zulip.com/integrations/doc/git)

See the last line of the code block setting the `ZULIP_SITE` value.

Before:
![img1](https://github.com/user-attachments/assets/9076c65b-2317-4dcf-88a1-712793694a64)


After:
![img2](https://github.com/user-attachments/assets/00777e3e-8132-4e0f-b283-29b8ff6897ec)



</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
