### PR TITLE
integrations: Clean up `replace_link` in Slack webhook.

### DIFF
--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -9,10 +9,9 @@ from zerver.actions.message_send import send_rate_limited_pm_notification_to_bot
 from zerver.data_import.slack import check_token_access, get_slack_api_data
 from zerver.data_import.slack_message_conversion import (
     SLACK_USERMENTION_REGEX,
-    convert_link_format,
-    convert_mailto_format,
     convert_slack_formatting,
     convert_slack_workspace_mentions,
+    replace_links,
 )
 from zerver.decorator import webhook_view
 from zerver.lib.exceptions import JsonableError, UnsupportedWebhookEventTypeError
@@ -101,12 +100,6 @@ def convert_to_zulip_markdown(text: str, slack_app_token: str) -> str:
     text = convert_slack_formatting(text)
     text = convert_slack_workspace_mentions(text)
     text = convert_slack_user_and_channel_mentions(text, slack_app_token)
-    return text
-
-
-def replace_links(text: str) -> str:
-    text, _ = convert_link_format(text)
-    text, _ = convert_mailto_format(text)
     return text
 
 


### PR DESCRIPTION
Currently the Slack integration uses a duplicate of `replace_link` since it was previously a part of `convert_slack_formatting` in `slack_message_conversion`. It was refactored out recently, so this uses the real `replace_link`.


