### PR TITLE
api-docs: Revise POST report-message endpoint descriptions.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9294,21 +9294,20 @@ paths:
       summary: Report a message
       tags: ["messages"]
       description: |
-        Reports a message to the moderation request channel if the
-        `moderation_request_channel` is configured. Moderators can
-        review the reports and act on the reported content.
+        Sends a notification to the organization's moderation request channel,
+        if it is configured, that reports the targeted message for review and
+        moderation.
 
-        Clients should check for whether the `moderation_request_channel`
-        setting is enabled to decide whether to show the message
-        report option in the UI.
+        Clients should check the `moderation_request_channel` realm setting to
+        decide whether to show the option to report messages in the UI.
 
-        If the `report_type` for the report is `other`, the `description`
-        parameter will become required. Clients should also enforce and
-        communicate this behavior in the UI.
+        If the `report_type` parameter value is `"other"`, the `description`
+        parameter is required. Clients should also enforce and communicate this
+        behavior in the UI.
 
-        **Changes**: New in Zulip 10.0 (feature level 382). This API builds
-        on the `moderation_request_channel` setting (feature 331)
-        which was previously a non-operational realm-level setting.
+        **Changes**: New in Zulip 11.0 (feature level 382). This API builds on
+        the `moderation_request_channel` realm setting, which was added in
+        feature level 331.
       parameters:
         - $ref: "#/components/parameters/MessageId"
       requestBody:
@@ -9320,7 +9319,8 @@ paths:
               properties:
                 report_type:
                   description: |
-                    The type of moderation request selected by the reporting user.
+                    The reason that best describes why the current user is reporting the
+                    target message for moderation.
                   type: string
                   enum:
                     - spam
@@ -9331,15 +9331,15 @@ paths:
                   example: harassment
                 description:
                   description: |
-                    The client should provide a text input of maximum length
-                    1000 characters for the reporting user to provide additional
-                    context explaining the report.
+                    A short description with additional context about why the current user
+                    is reporting the target message for moderation.
 
-                    If the `report_type` for the report is `other`, this field
-                    will become required.
+                    Clients should limit this string to a maximum length of 1000 characters.
 
+                    If the `report_type` parameter is `"other"`, this parameter is required,
+                    and its value cannot be an empty string.
                   type: string
-                  example: "this message is bullying Frodo."
+                  example: "This message insults and mocks Frodo, which is against the code of conduct."
               required:
                 - report_type
       responses:
@@ -9359,8 +9359,8 @@ paths:
                         "code": "BAD_REQUEST",
                       }
                     description: |
-                      An example JSON error response for when trying to report a
-                      message with `moderation_request_channel` disabled:
+                      An example JSON error response for when the organization's moderation
+                      request channel is not configured:
   /user_uploads:
     post:
       operationId: upload-file


### PR DESCRIPTION
Follow-up to #32811.

**Updates**:
- Fixes the version of Zulip in the main changes note for this new endpoint.
- Revises the main description and the parameter/error descriptions.

---

**Screenshots and screen captures:**

![Screenshot from 2025-05-07 17-28-11](https://github.com/user-attachments/assets/b012cdca-65e2-481f-a723-b3c86d459e4a)
![Screenshot from 2025-05-07 17-37-19](https://github.com/user-attachments/assets/d64626ea-07bb-41c7-9e21-08f5236b6948)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
