### PR TITLE
[DRAFT] compose: Introduce shorter recipient row, reduced negative space.

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -274,8 +274,13 @@ function focus_compose_recipient(): void {
     $("#compose_select_recipient_widget_wrapper").trigger("focus");
 }
 
+function on_show_callback(): void {
+    $("#compose_select_recipient_widget").addClass("widget-open");
+}
+
 // NOTE: Since tippy triggers this on `mousedown` it is always triggered before say a `click` on `textarea`.
 function on_hidden_callback(): void {
+    $("#compose_select_recipient_widget").removeClass("widget-open");
     if (!compose_select_recipient_dropdown_widget.item_clicked) {
         // If the dropdown was NOT closed due to selecting an item,
         // don't do anything.
@@ -311,6 +316,7 @@ export function initialize(): void {
         on_exit_with_escape_callback: focus_compose_recipient,
         // We want to focus on topic box if dropdown was closed via selecting an item.
         focus_target_on_hidden: false,
+        on_show_callback,
         on_hidden_callback,
         dropdown_input_visible_selector: "#compose_select_recipient_widget_wrapper",
         prefer_top_start_placement: true,

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -487,9 +487,9 @@
     /*
     Compose-recipient box minimum height. Used in a flexbox context to
     allow elements like DM pills to stack without breaking out of their
-    flex item. 2.1786em is 30.5px at 14px/1em.
+    flex item. 2em is 32px at 16px/1em.
     */
-    --compose-recipient-box-min-height: 2.1786em;
+    --compose-recipient-box-min-height: 2em;
     /* 28px at 14px/1em */
     /* Note that this variable can only be used in contexts where
        the font-size doesn't deviate from the base font-size;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1126,6 +1126,10 @@
         color-mix(in srgb, hsl(0deg 0% 0%) 10%, hsl(232deg 20% 92%)),
         hsl(0deg 0% 0% / 80%)
     );
+    --color-compose-recipient-box-hover: light-dark(
+        hsl(0deg 0% 69%),
+        hsl(0deg 0% 100% / 12%)
+    );
     --color-compose-recipient-box-has-focus: light-dark(
         hsl(0deg 0% 57%),
         hsl(0deg 0% 100% / 27%)

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1561,10 +1561,9 @@ textarea.new_message_textarea {
         }
     }
 
+    /* We suppress the chevron on the channel picker. */
     .zulip-icon-chevron-down {
-        padding-left: 5px;
-        color: var(--color-compose-chevron-arrow);
-        font-weight: lighter;
+        display: none;
     }
 }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -172,7 +172,7 @@
 /* Main geometry for this element is in zulip.css */
 #compose-content {
     background-color: var(--color-compose-box-background);
-    padding: 7px 7px 8px;
+    padding: 4px 4px 6px;
     border: 1px solid var(--color-border-compose-content);
     border-radius: 9px 9px 0 0;
     box-shadow: 0 0 0 hsl(236deg 11% 28%);
@@ -320,7 +320,7 @@
         grid-template-areas:
             "message-content-container message-send-controls-container"
             "message-formatting-controls-container message-send-controls-container";
-        gap: 0 6px;
+        gap: 0 4px;
     }
 
     .message_content {
@@ -644,11 +644,11 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    /* Matched to 6px grid-gap on .messagebox grid. */
-    padding-bottom: 6px;
+    /* Matched to 4px grid-gap on .messagebox grid. */
+    padding-bottom: 4px;
     /* Align to compose controls; that's 112px width,
        plus 6px of grid gap for 118px here. */
-    margin-right: calc(var(--compose-send-controls-width) + 6px);
+    margin-right: calc(var(--compose-send-controls-width) + 4px);
 }
 
 #compose_close {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -216,6 +216,10 @@
 
             #compose_select_recipient_widget {
                 border-radius: 4px !important;
+                /* This height is necessary only for the
+                   DM picker, so that it does not stretch
+                   open taller with multiple rows of user
+                   pills. */
                 height: var(--compose-recipient-box-min-height);
             }
 
@@ -1103,6 +1107,12 @@ textarea.new_message_textarea {
     #stream_message_recipient_topic {
         grid-area: topic;
         color: var(--color-compose-recipient-box-text-color);
+        /* Keep the line-height matched to the font-size
+           for a more predictable box height.
+           This will have to be watched very closely for
+           possible regressions, such as when Unicode emoji
+           appear in the topic box. */
+        line-height: 1;
         /* Override grid's effective `max-content` min-width */
         overflow: hidden;
         text-overflow: ellipsis;
@@ -1110,7 +1120,7 @@ textarea.new_message_textarea {
         box-shadow: none;
         outline: none;
 
-        padding: 4px 6px;
+        padding: 0 6px;
         /* Reset height to let `align-items: stretch` on the grid parent handle this. */
         height: auto;
 
@@ -1121,6 +1131,7 @@ textarea.new_message_textarea {
 
     #topic-not-mandatory-placeholder {
         grid-area: topic-box;
+        align-self: center;
         white-space: nowrap;
         overflow-x: hidden;
         text-overflow: ellipsis;
@@ -1375,10 +1386,9 @@ textarea.new_message_textarea {
 }
 
 #compose-recipient {
-    /* Enforce a shared, 'normal' line-height on
-       the recipient elements for baseline alignment,
-       and better use of the recipient-row space. */
-    line-height: normal;
+    /* Set a line-height equal to the font-size to
+       make a compact, predictably tall recipient row. */
+    line-height: 1;
     display: flex;
     flex: 1 1 0;
     /* Use this containing flex element to

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1090,6 +1090,10 @@ textarea.new_message_textarea {
     transition: border-color 0.2s ease;
     background: var(--color-compose-recipient-box-background-color);
 
+    &:hover {
+        border-color: var(--color-compose-recipient-box-hover);
+    }
+
     /* Give the recipient box, a `<div>`, the
        correct styles when focus is in the
        #stream_message_recipient_topic `<input>` */
@@ -1192,6 +1196,11 @@ textarea.new_message_textarea {
     color: var(--color-compose-recipient-box-text-color);
     background-color: var(--color-compose-recipient-box-background-color);
     border-color: var(--color-compose-recipient-box-border-color);
+
+    &:hover,
+    &.widget-open {
+        border-color: var(--color-compose-recipient-box-hover);
+    }
 
     &.dropdown-widget-button {
         padding: 0 6px;


### PR DESCRIPTION
This PR is effectively preparation for #31971 (also a draft PR) aimed at reducing the overall footprint of the recipient row and the negative space around the edge of the compose box, and between the recipient row and the compose area.

When I began this work, I was concerned that the height of DM pills would be a limiting factor in terms of how short the recipient row could be. However, the true limiting factor appears to be the height of the `<input>` element, which is here reduced as potentially safely as possible with `line-height: 1`. I do have concerns that testing may reveal unacceptable regressions, especially with non-Western-Latin languages and Unicode emoji in the topic box.

[Vlad's spec](https://terpimost.github.io/compose-decomposed/) calls for recipient row items (the channel/DM picker and the topic box) to max out at ~29.86px tall at 16px/1em. I have found that the tightest we can reasonably go here is 32px (30px for the topic box's height, plus another 2px of top- and bottom border on an outer element).

Additionally, I have gone even tighter than Vlad's spec in reducing the space around the edge of the compose box, and between the recipient row and compose area (and to the send area at the compose box's righthand side). The idea is that the changes in #31971 will not present with such vast expanses of space around the unadorned recipient row (no backgrounds, no borders).

Finally, as I have discussed with @alya on multiple occasions, this experiments with suppressing the downward chevron on the channel picker. It might be that we want to change the picker's border color when it is hovered, as currently only the pointer icon indicates that the picker is an actionable UI element.

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/tighter.20recipient.20row/near/2169079)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![closed-compose-before](https://github.com/user-attachments/assets/b1bba734-d919-4c20-9ee0-5c07e9c1058f) | ![closed-compose-after](https://github.com/user-attachments/assets/3f84a091-8361-4fd8-9638-a78a1d8d1218) |
| ![channel-before](https://github.com/user-attachments/assets/43e08fd0-4cb6-453c-aabd-627b1f710aeb) | ![channel-after](https://github.com/user-attachments/assets/4a70d326-be8b-4814-a653-bfa2ad8bd4f3) |
| ![single-line-dm-before](https://github.com/user-attachments/assets/f096c5b8-bb95-47e9-892b-2e88f9c083f8) | ![single-line-dm-after](https://github.com/user-attachments/assets/e59afc16-3460-4a55-8f69-8120219ca798) |
| ![multi-line-dm-before](https://github.com/user-attachments/assets/ae51bfd2-8300-4c2d-93ac-4a75de0fbf83) | ![multi-line-dm-after](https://github.com/user-attachments/assets/2c510ec3-ed22-4839-973f-0ab0f2ee92ae) |




