### PR TITLE
migration: Prepare for backporting of migration 0700.

### DIFF
--- a/zerver/migrations/0700_fix_user_role_system_groups.py
+++ b/zerver/migrations/0700_fix_user_role_system_groups.py
@@ -257,7 +257,8 @@ class Migration(migrations.Migration):
     atomic = False
 
     dependencies = [
-        ("zerver", "0699_scheduledmessage_reminder_target_message_id"),
+        # Because this will be backported to 10.x, we only depend on the last migration in 10.x
+        ("zerver", "0697_empty_topic_name_for_dms_from_third_party_imports"),
     ]
 
     operations = [

--- a/zerver/migrations/0701_merge.py
+++ b/zerver/migrations/0701_merge.py
@@ -1,0 +1,10 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0699_scheduledmessage_reminder_target_message_id"),
+        ("zerver", "0700_fix_user_role_system_groups"),
+    ]
+
+    operations = []


### PR DESCRIPTION
This follows our usual backporting scheme, occurring e.g. in #31468. We make the migration depend on the last migration in 10.x, and create a merge migration to avoid having multiple leafs.
