### PR TITLE
buttons: Modify the styles of buttons in stream settings.

### DIFF
--- a/web/src/stream_ui_updates.ts
+++ b/web/src/stream_ui_updates.ts
@@ -198,9 +198,15 @@ export function update_settings_button_for_sub(sub: StreamSubscription): void {
     }
 
     if (sub.subscribed) {
-        $settings_button.text($t({defaultMessage: "Unsubscribe"})).removeClass("unsubscribed");
+        $settings_button
+            .text($t({defaultMessage: "Unsubscribe"}))
+            .removeClass("unsubscribed action-button-quiet-brand")
+            .addClass("action-button-quiet-neutral");
     } else {
-        $settings_button.text($t({defaultMessage: "Subscribe"})).addClass("unsubscribed");
+        $settings_button
+            .text($t({defaultMessage: "Subscribe"}))
+            .addClass("unsubscribed action-button-quiet-brand")
+            .removeClass("action-button-quiet-neutral");
     }
     if (stream_data.can_toggle_subscription(sub)) {
         $settings_button.prop("disabled", false);

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -11,7 +11,7 @@
                     {{/tr}}
                 </span>
             </template>
-            <button class="action-button action-button-quiet-brand subscribe-button sub_unsub_button {{#if should_display_subscription_button}}toggle-subscription-tooltip{{/if}} {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button"  data-tooltip-template-id="toggle-subscription-tooltip-template" {{#unless should_display_subscription_button}}disabled="disabled"{{/unless}}>
+            <button class="action-button subscribe-button sub_unsub_button {{#if subscribed}}action-button-quiet-neutral{{else}}action-button-quiet-brand{{/if}} {{#if should_display_subscription_button}}toggle-subscription-tooltip{{/if}} {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button"  data-tooltip-template-id="toggle-subscription-tooltip-template" {{#unless should_display_subscription_button}}disabled="disabled"{{/unless}}>
                 {{#if subscribed }}
                     {{t "Unsubscribe" }}
                 {{else}}
@@ -22,7 +22,7 @@
         {{> ../components/action_button
           icon="eye"
           attention="quiet"
-          intent="info"
+          intent="neutral"
           custom_classes="tippy-zulip-delayed-tooltip"
           data-tooltip-template-id="view-stream-tooltip-template"
           id="preview-stream-button"


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.--> [CZO](https://chat.zulip.org/#narrow/channel/101-design/topic/buttons.20in.20channels.20menu/near/2168977)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|----|---|
<img width="201" alt="Screenshot 2025-05-07 at 11 58 45 PM" src="https://github.com/user-attachments/assets/7e751884-57de-469b-9209-a027843fe188" /> | <img width="203" alt="Screenshot 2025-05-07 at 11 38 31 PM" src="https://github.com/user-attachments/assets/8ef00f46-bd07-4fa0-8626-92dafda8f622" /> |
| <img width="219" alt="Screenshot 2025-05-07 at 11 58 38 PM" src="https://github.com/user-attachments/assets/c7723bcd-9d28-4fe4-96b3-dd75443a6730" />| <img width="223" alt="Screenshot 2025-05-07 at 11 38 25 PM" src="https://github.com/user-attachments/assets/1e11491c-6fbb-4c91-8c2e-8223844516a3" /> |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
