### PR TITLE
buttons: Redesign buttons in personal settings.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -447,6 +447,10 @@ input[type="checkbox"] {
     }
 }
 
+.send_test_notification {
+    margin-bottom: 10px;
+}
+
 .preferences-settings-form {
     .tab-picker {
         width: 325px;

--- a/web/templates/settings/language_selection_widget.hbs
+++ b/web/templates/settings/language_selection_widget.hbs
@@ -5,7 +5,7 @@
         {{> ../help_link_widget link=help_link_widget_link }}
         {{/if}}
     </label>
-    <button type="button" id="id_language_selection_button" class="language_selection_button button rounded tippy-zulip-delayed-tooltip" data-section="{{section_name}}" data-tippy-content="{{t 'Change language' }}">
+    <button type="button" id="id_language_selection_button" class="language_selection_button action-button action-button-quiet-neutral tippy-zulip-delayed-tooltip" data-section="{{section_name}}" data-tippy-content="{{t 'Change language' }}">
         <span class="{{section_name}}" data-language-code="{{language_code}}">{{setting_value}}</span>
     </button>
 </div>

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -110,7 +110,12 @@
         <div class="desktop-notification-settings-banners"></div>
 
         {{#unless for_realm_settings}}
-        <p><a class="send_test_notification">{{t "Send a test notification" }}</a></p>
+        {{> ../components/action_button
+          label=(t "Send a test notification")
+          attention="quiet"
+          intent="neutral"
+          custom_classes="send_test_notification"
+          }}
         {{/unless}}
 
         {{#each notification_settings.desktop_notification_settings}}


### PR DESCRIPTION
This PR modifies the Preferences button to an action button in neutral, and 'Send a test notification' into a medium-emphasis neutral action button.

Fixes: #34535.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|-------|
| ![before-subscribe](https://github.com/user-attachments/assets/ec36f9c4-f9b9-424f-bd85-7de4e782b930) | ![after-subscribe](https://github.com/user-attachments/assets/0c4414ad-2cb3-4d46-9550-34b25e51a126) |
| ![before-unsubscribe](https://github.com/user-attachments/assets/4751db48-b167-4fa7-bded-f1305f3da3dd)) | ![after-unsubscribe](https://github.com/user-attachments/assets/1d4c7cbd-f1b4-4d89-b686-d81825918bd3) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
