### PR TITLE
support: Show file upload usage compared to realm upload quota.

### DIFF
--- a/corporate/lib/support.py
+++ b/corporate/lib/support.py
@@ -126,10 +126,30 @@ class CloudSupportData:
     plan_data: PlanData
     sponsorship_data: SponsorshipData
     user_data: UserData
+    file_upload_usage: str
 
 
 def get_stripe_customer_url(stripe_id: str) -> str:
     return f"https://dashboard.stripe.com/customers/{stripe_id}"  # nocoverage
+
+
+def get_formatted_realm_upload_space_used(realm: Realm) -> str:  # nocoverage
+    realm_bytes_used = realm.currently_used_upload_space_bytes()
+    files_uploaded = realm_bytes_used > 0
+
+    realm_uploads = "No uploads"
+    if files_uploaded:
+        realm_uploads = str(round(realm_bytes_used / 1024 / 1024, 2))
+
+    quota = realm.upload_quota_bytes()
+    if quota is None:
+        if files_uploaded:
+            return f"{realm_uploads} MB / No quota"
+        return f"{realm_uploads} / No quota"
+    if quota == 0:
+        return f"{realm_uploads} / 0.0 MB"
+    quota_mb = round(quota / 1024 / 1024, 2)
+    return f"{realm_uploads} / {quota_mb} MB"
 
 
 def get_realm_user_data(realm: Realm) -> UserData:
@@ -477,4 +497,5 @@ def get_data_for_cloud_support_view(billing_session: BillingSession) -> CloudSup
         plan_data=plan_data,
         sponsorship_data=sponsorship_data,
         user_data=user_data,
+        file_upload_usage=get_formatted_realm_upload_space_used(billing_session.realm),
     )

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -751,7 +751,7 @@ class TestSupportEndpoint(ZulipTestCase):
     def test_realm_support_view_queries(self) -> None:
         iago = self.example_user("iago")
         self.login_user(iago)
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(22):
             result = self.client_get("/activity/support", {"q": "zulip"}, subdomain="zulip")
             self.assertEqual(result.status_code, 200)
 

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -55,6 +55,8 @@
         {% set user_data = realm_support_data[realm.id].user_data %}
         {% include 'corporate/support/basic_realm_data.html' %}
     {% endwith %}
+    <br />
+    <b>File upload usage</b>: {{ realm_support_data[realm.id].file_upload_usage }}<br />
 </div>
 <div>
     <div class="realm-management-actions">


### PR DESCRIPTION
**Notes**:
- Implemented on Zulip Cloud support view only since this information isn't relevant for self-hosted support actions.
- Looking up the realm's currently used upload space adds 3 database queries to the support view test as there is no `RealmCount` data for the upload quota used in the test. And therefore `installation_epoch` is called for the realm.
  - With `RealmCount` upload quota used data, only 2 additional database queries would be made for the realm's support view data.

**Screenshots and screen captures:**

| Case | Screenshot |
| --- | --- |
| Uploaded videos, upload quota is None | ![Screenshot from 2025-05-08 17-07-18](https://github.com/user-attachments/assets/1e416ec9-1f55-4c92-bbea-6ff2a2b3a513)
| No uploads, upload quota is None | ![Screenshot from 2025-05-08 17-06-15](https://github.com/user-attachments/assets/7b4d583b-7dea-45c6-b1b9-563b70e5a375)
| Tiny upload, upload quota is set | ![Screenshot from 2025-05-08 17-06-06](https://github.com/user-attachments/assets/fef2a2a0-18ab-43fd-8848-ec74b330fbc9)


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
