### PR TITLE
Add support for reactivating groups.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 11.0
 
+**Feature level 386**
+
+* [`PATCH /user_groups/{user_group_id}`](/api/update-user-group):
+  Added support to reactivate groups by passing `deactivated`
+  parameter as `False`.
+
 **Feature level 385**
 
 * [`POST /register`](/api/register-queue), [`PATCH/settings`](/api/update-settings),

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 385
+API_FEATURE_LEVEL = 386
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1275,7 +1275,14 @@ export function handle_deleted_group(group_id: number): void {
     }
 
     if (is_editing_group(group_id)) {
+        const user_group = user_groups.get_user_group_from_id(group_id);
         $("#groups_overlay .deactivated-user-group-icon-right").show();
+
+        update_group_deactivated_banner(user_group);
+        update_deactivate_and_reactivate_buttons(user_group);
+        update_toggler_for_group_setting(user_group);
+        update_members_panel_ui(user_group);
+        update_group_membership_button(user_group.id);
     }
     redraw_user_group_list();
 }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1005,7 +1005,7 @@ h4.user_group_setting_subsection_title {
     .stream_settings_header {
         white-space: nowrap;
         display: flex;
-        margin-left: 15px;
+        margin-left: 18px;
 
         .tab-container {
             .tab-switcher {

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -10,16 +10,17 @@
               attention="quiet" intent="brand" }}
             {{/if}}
         </div>
-        {{#unless group.deactivated}}
         {{> ../components/icon_button icon="user-group-x" intent="danger" custom_classes="deactivate-group-button deactivate tippy-zulip-delayed-tooltip"
           data-tippy-content=(t 'Deactivate group') }}
-        {{/unless}}
+        {{> ../components/icon_button icon="user-group-plus" intent="success" custom_classes="reactivate-group-button reactivate tippy-zulip-delayed-tooltip"
+          data-tippy-content=(t 'Reactivate group') }}
     </div>
 </div>
 <div class="user_group_settings_wrapper" data-group-id="{{group.id}}">
     <div class="inner-box">
 
         <div class="group_general_settings group_setting_section" data-group-section="general">
+            <div class="group-reactivation-error-banner"></div>
             <div class="group-banner"></div>
             <div class="group-header">
                 <div class="group-name-wrapper">

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -22135,13 +22135,18 @@ paths:
         Update the name, description or any of the permission settings
         of a [user group](/help/user-groups).
 
+        This endpoint is also used to reactivate a user group.
+
         Note that while permissions settings of deactivated groups can
         be edited by this API endpoint, and those permissions settings
         do affect the ability to modify the deactivated group and its
         membership, the deactivated group itself cannot be mentioned
         or used in the value of any permission without first being reactivated.
 
-        **Changes**: Prior to Zulip 10.0 (feature level 340), only the name field
+        **Changes**: Starting with Zulip 11.0 (feature level ZF-61b9bf), this
+        endpoint can be used to reactivate a user group.
+
+        Prior to Zulip 10.0 (feature level 340), only the name field
         of deactivated groups could be modified.
       parameters:
         - $ref: "#/components/parameters/UserGroupId"
@@ -22293,6 +22298,18 @@ paths:
                           "old": 11,
                         }
                     - $ref: "#/components/schemas/GroupSettingValueUpdate"
+                deactivated:
+                  description: |
+                    A deactivated user group can be reactivated by passing this
+                    parameter as `false`.
+
+                    Passing `true` does nothing as user group is deactivated
+                    using [`POST /user_groups/{user_group_id}/deactivate`](deactivate-user-group)
+                    endpoint.
+
+                    **Changes**: New in Zulip 11.0 (feature level 386).
+                  type: boolean
+                  example: false
             encoding:
               can_add_members_group:
                 contentType: application/json
@@ -22305,6 +22322,8 @@ paths:
               can_mention_group:
                 contentType: application/json
               can_remove_members_group:
+                contentType: application/json
+              deactivated:
                 contentType: application/json
       responses:
         "200":

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -13,6 +13,7 @@ from zerver.actions.user_groups import (
     check_add_user_group,
     do_change_user_group_permission_setting,
     do_deactivate_user_group,
+    do_reactivate_user_group,
     do_update_user_group_description,
     do_update_user_group_name,
     remove_subgroups_from_user_group,
@@ -139,6 +140,7 @@ def edit_user_group(
     can_manage_group: Json[GroupSettingChangeRequest] | None = None,
     can_mention_group: Json[GroupSettingChangeRequest] | None = None,
     can_remove_members_group: Json[GroupSettingChangeRequest] | None = None,
+    deactivated: Json[bool] | None = None,
 ) -> HttpResponse:
     if (
         name is None
@@ -149,6 +151,7 @@ def edit_user_group(
         and can_manage_group is None
         and can_mention_group is None
         and can_remove_members_group is None
+        and deactivated is None
     ):
         raise JsonableError(_("No new data supplied"))
 
@@ -162,6 +165,9 @@ def edit_user_group(
 
     if description is not None and description != user_group.description:
         do_update_user_group_description(user_group, description, acting_user=user_profile)
+
+    if deactivated is not None and not deactivated and user_group.deactivated:
+        do_reactivate_user_group(user_group, acting_user=user_profile)
 
     request_settings_dict = locals()
     nobody_group = get_system_user_group_by_name(SystemGroups.NOBODY, user_profile.realm_id)


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit adds API support for reactivating groups.
- Second commit adds UI to reactivate group.
- Third commit is to live update UI when deactivating group.
- Last commit is a small alignment fix.

Fixes: <!-- Issue link, or clear description.--> #23568.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/user-attachments/assets/84f1198c-ce0b-4808-a351-1fc8caeddd44)
![Peek 2025-05-09 13-01](https://github.com/user-attachments/assets/74cc16ad-24d6-4449-a0f2-6e0cc1bd9913)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
