### PR TITLE
user_circles: Bump up offline contrast, esp. in typeahead highlights.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1617,6 +1617,10 @@
     --color-user-circle-active: light-dark(#43a35e, #4cdc75);
     --color-user-circle-idle: light-dark(#f5b266, #ae640a);
     --color-user-circle-offline: light-dark(#bcc0cf, #545764);
+    --color-user-circle-offline-typeahead-highlight: light-dark(
+        #adb2c5,
+        #737582
+    );
     --color-user-circle-deactivated: hsl(0deg 0% 50%);
     --gradient-user-circle-idle: linear-gradient(
         to right,

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2097,8 +2097,8 @@
         hsl(220deg 12% 100% / 7%)
     );
     --background-color-active-typeahead-item: light-dark(
-        hsl(221.14deg 89.74% 92.35%),
-        hsl(226.35deg 82.53% 55.1% / 38.82%)
+        hsl(220deg 12% 4.9% / 5%),
+        hsl(220deg 12% 100% / 7%)
     );
     --color-typeahead-option-label: light-dark(
         var(--grey-500),

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1619,7 +1619,7 @@
     --color-user-circle-offline: light-dark(#bcc0cf, #545764);
     --color-user-circle-offline-typeahead-highlight: light-dark(
         #adb2c5,
-        #737582
+        #646671
     );
     --color-user-circle-deactivated: hsl(0deg 0% 50%);
     --gradient-user-circle-idle: linear-gradient(

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1616,7 +1616,7 @@
     --color-tab-picker-icon: light-dark(hsl(200deg 100% 40%), hsl(0deg 0% 80%));
     --color-user-circle-active: light-dark(#43a35e, #4cdc75);
     --color-user-circle-idle: light-dark(#f5b266, #ae640a);
-    --color-user-circle-offline: light-dark(#c1c6d7, #454854);
+    --color-user-circle-offline: light-dark(#bcc0cf, #545764);
     --color-user-circle-deactivated: hsl(0deg 0% 50%);
     --gradient-user-circle-idle: linear-gradient(
         to right,

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -109,6 +109,12 @@
             color: var(--color-active-dropdown-item);
             background-color: var(--background-color-active-typeahead-item);
         }
+
+        & .user-circle-offline {
+            /* Ensure better contrast on highlighted
+               typeahead items. */
+            color: var(--color-user-circle-offline-typeahead-highlight);
+        }
     }
 
     .pronouns,


### PR DESCRIPTION
This PR subtly increases the contrast of user circles in both light and dark mode, and also adjusts the contrast in highlighted typeahead elements so that offline circles have the same apparent contrast as their non-highlighted counterparts.

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/empty.20presence.20bubbles.20in.20typeahead/near/2170914)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![dark-mode-sidebar-before](https://github.com/user-attachments/assets/8aee938c-0ddd-47d9-b5ac-de9d8485d709) | ![dark-mode-sidebar-after](https://github.com/user-attachments/assets/46b73ee7-81a6-4f7b-96a0-2a06b46c7556) |
| ![light-mode-sidebar-before](https://github.com/user-attachments/assets/6698bed6-de9c-4763-9fbd-90c1b30db7ec) | ![light-mode-sidebar-after](https://github.com/user-attachments/assets/849ccd6f-bd6e-4692-9e57-ea28fe8b1f84) |
| ![dark-mode-highlight-before](https://github.com/user-attachments/assets/ae5b2fab-096d-4896-9a73-55b53ac3152d) | ![dark-mode-highlight-after](https://github.com/user-attachments/assets/42e6a1c8-e361-49bf-a740-22dbc2e65112) |
| ![light-mode-highlight-before](https://github.com/user-attachments/assets/8166a489-f53d-47b3-b854-31ef1d5f93ca) | ![light-mode-highlight-after](https://github.com/user-attachments/assets/603790a7-cb01-4692-a038-4419d649a246) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>