### PR TITLE
Upgrade stripe to latest version for review.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1189,8 +1189,8 @@ class BillingSession(ABC):
                 is_created_for_free_trial_upgrade=current_plan_id is not None and on_free_trial,
             )
 
-            if charge_automatically:
-                # Stripe takes its sweet hour to charge customers after creating an invoice.
+            if stripe_invoice.status != "paid" and charge_automatically:
+                # Stripe can take its sweet hour to charge customers after creating an invoice.
                 # Since we want to charge customers immediately, we charge them manually.
                 # Then poll for the status of the invoice to see if the payment succeeded.
                 stripe_invoice = stripe.Invoice.pay(stripe_invoice.id)

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -784,9 +784,9 @@ class StripeTestCase(ZulipTestCase):
 
     def setup_mocked_stripe(self, callback: Callable[..., Any], *args: Any, **kwargs: Any) -> Mock:
         with patch.multiple("stripe", Invoice=mock.DEFAULT, InvoiceItem=mock.DEFAULT) as mocked:
-            mocked["Invoice"].create.return_value = None
-            mocked["Invoice"].finalize_invoice.return_value = None
-            mocked["InvoiceItem"].create.return_value = None
+            mocked["Invoice"].create.return_value = mock.Mock()
+            mocked["Invoice"].finalize_invoice.return_value = mock.Mock()
+            mocked["InvoiceItem"].create.return_value = mock.Mock()
             callback(*args, **kwargs)
             return mocked
 

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -3009,8 +3009,11 @@ class StripeTest(StripeTestCase):
         assert customer is not None
         stripe_customer_id = customer.stripe_customer_id
         assert stripe_customer_id is not None
-        stripe.InvoiceItem.create(amount=5000, currency="usd", customer=stripe_customer_id)
         stripe_invoice = stripe.Invoice.create(customer=stripe_customer_id)
+        assert stripe_invoice.id is not None
+        stripe.InvoiceItem.create(
+            invoice=stripe_invoice.id, amount=5000, currency="usd", customer=stripe_customer_id
+        )
         stripe.Invoice.finalize_invoice(stripe_invoice)
         RealmAuditLog.objects.filter(event_type=AuditLogEventType.STRIPE_CARD_CHANGED).delete()
 

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -2999,6 +2999,11 @@ class StripeTest(StripeTestCase):
         user = self.example_user("hamlet")
         self.login_user(user)
         self.add_card_and_upgrade(user)
+
+        # Check that the card is displayed on the billing page.
+        response = self.client_get("/billing/")
+        self.assert_in_success_response(["Visa ending in 4242"], response)
+
         # Create an open invoice
         customer = Customer.objects.first()
         assert customer is not None

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -4736,13 +4736,6 @@ class StripeTest(StripeTestCase):
         invoices = []
         assert customer.stripe_customer_id is not None
         for _ in range(num_invoices):
-            stripe.InvoiceItem.create(
-                amount=10000,
-                currency="usd",
-                customer=customer.stripe_customer_id,
-                description="Zulip Cloud Standard",
-                discountable=False,
-            )
             invoice = stripe.Invoice.create(
                 auto_advance=True,
                 collection_method="send_invoice",
@@ -4750,6 +4743,16 @@ class StripeTest(StripeTestCase):
                 days_until_due=DEFAULT_INVOICE_DAYS_UNTIL_DUE,
                 statement_descriptor="Zulip Cloud Standard",
             )
+            assert invoice.id is not None
+            stripe.InvoiceItem.create(
+                invoice=invoice.id,
+                amount=10000,
+                currency="usd",
+                customer=customer.stripe_customer_id,
+                description="Zulip Cloud Standard",
+                discountable=False,
+            )
+
             stripe.Invoice.finalize_invoice(invoice)
             invoices.append(invoice)
         return invoices

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -659,6 +659,8 @@ class StripeTestCase(ZulipTestCase):
             params.pop(key, None)
 
         if talk_to_stripe:
+            # Store the event after which we pay the invoice so that we can
+            # process all the events from this event to the latest.
             [last_event] = iter(stripe.Event.list(limit=1))
 
         existing_customer = self.billing_session.customer_plan_exists()

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -4669,38 +4669,42 @@ class StripeTest(StripeTestCase):
         lear_customer = RealmBillingSession(king).update_or_create_stripe_customer()
 
         assert zulip_customer.stripe_customer_id
-        stripe.InvoiceItem.create(
-            currency="usd",
-            customer=zulip_customer.stripe_customer_id,
-            description="Zulip Cloud Standard upgrade",
-            discountable=False,
-            unit_amount=800,
-            quantity=8,
-        )
         stripe_invoice = stripe.Invoice.create(
             auto_advance=True,
             collection_method="send_invoice",
             customer=zulip_customer.stripe_customer_id,
             days_until_due=30,
             statement_descriptor="Zulip Cloud Standard",
+        )
+        assert stripe_invoice.id is not None
+        stripe.InvoiceItem.create(
+            invoice=stripe_invoice.id,
+            currency="usd",
+            customer=zulip_customer.stripe_customer_id,
+            description="Zulip Cloud Standard upgrade",
+            discountable=False,
+            unit_amount=800,
+            quantity=8,
         )
         stripe.Invoice.finalize_invoice(stripe_invoice)
 
         assert lear_customer.stripe_customer_id
-        stripe.InvoiceItem.create(
-            currency="usd",
-            customer=lear_customer.stripe_customer_id,
-            description="Zulip Cloud Standard upgrade",
-            discountable=False,
-            unit_amount=800,
-            quantity=8,
-        )
         stripe_invoice = stripe.Invoice.create(
             auto_advance=True,
             collection_method="send_invoice",
             customer=lear_customer.stripe_customer_id,
             days_until_due=30,
             statement_descriptor="Zulip Cloud Standard",
+        )
+        assert stripe_invoice.id is not None
+        stripe.InvoiceItem.create(
+            invoice=stripe_invoice.id,
+            currency="usd",
+            customer=lear_customer.stripe_customer_id,
+            description="Zulip Cloud Standard upgrade",
+            discountable=False,
+            unit_amount=800,
+            quantity=8,
         )
         stripe.Invoice.finalize_invoice(stripe_invoice)
 

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1036,6 +1036,8 @@ class StripeTest(StripeTestCase):
         self.assertFalse(stripe_customer_has_credit_card_as_default_payment_method(stripe_customer))
 
         # Check Charges in Stripe
+        # There is no charge created for out of band payments which is used
+        # to test this method.
         self.assertFalse(stripe.Charge.list(customer=stripe_customer.id))
         # Check Invoices in Stripe
         [invoice] = iter(stripe.Invoice.list(customer=stripe_customer.id))

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -236,15 +236,17 @@ def normalize_fixture_data(
     ]
 
     # We'll replace "invoice_prefix": "A35BC4Q" with something like "invoice_prefix": "NORMA01"
+    # For patterns whose matches can be too generic like `[0-9]+`, include matching field in the translation
+    # to avoid it replacing other occurrences of the pattern. See `exp_month` for example.
     pattern_translations = {
-        r'"exp_month": ([0-9]+)': "1",
-        r'"exp_year": ([0-9]+)': "9999",
-        r'"postal_code": "([0-9]+)"': "12345",
-        r'"invoice_prefix": "([A-Za-z0-9]{7,8})"': "NORMALIZED",
-        r'"fingerprint": "([A-Za-z0-9]{16})"': "NORMALIZED",
-        r'"number": "([A-Za-z0-9]{7,8}-[A-Za-z0-9]{4})"': "NORMALIZED",
-        r'"address": "([A-Za-z0-9]{9}-test_[A-Za-z0-9]{12})"': "000000000-test_NORMALIZED",
-        r'"client_secret": "([\w]+)"': "NORMALIZED",
+        r'"exp_month": [0-9]+': '"exp_month": 1',
+        r'"exp_year": [0-9]+': '"exp_year": 9999',
+        r'"postal_code": "[0-9]+"': '"postal_code": "12345"',
+        r'"invoice_prefix": "[A-Za-z0-9]{7,8}"': '"invoice_prefix": "NORMALIZED"',
+        r'"fingerprint": "[A-Za-z0-9]{16}"': '"fingerprint": "NORMALIZED"',
+        r'"number": "[A-Za-z0-9]{7,8}-[A-Za-z0-9]{4}"': '"number": "NORMALIZED"',
+        r'"address": "[A-Za-z0-9]{9}-test_[A-Za-z0-9]{12}"': '"address": "000000000-test_NORMALIZED"',
+        r'"client_secret": "[\w]+"': '"client_secret": "NORMALIZED"',
         r'"url": "https://billing.stripe.com/p/session/test_([\w]+)"': "NORMALIZED",
         r'"url": "https://checkout.stripe.com/c/pay/cs_test_([\w#%]+)"': "NORMALIZED",
         r'"receipt_url": "https://pay.stripe.com/receipts/invoices/([\w-]+)\?s=[\w]+"': "NORMALIZED",

--- a/uv.lock
+++ b/uv.lock
@@ -4263,15 +4263,15 @@ wheels = [
 
 [[package]]
 name = "stripe"
-version = "11.6.0"
+version = "12.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/a4/7e16668d7adfb45229f4b67c04c79f53fe78335a6d0625303b32024d831c/stripe-11.6.0.tar.gz", hash = "sha256:0ced7cce23a6cb1a393c86a1f7f9435c9d83ae7cbd556362868caf62cb44a92c", size = 1390405, upload-time = "2025-02-24T22:39:46.962Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/c4/4cbc0d81f44d0fd2a991b393597266347082a820df432c9f61df6cb0f80d/stripe-12.1.0.tar.gz", hash = "sha256:4a4b8516952cf5095e982257f0d47c45c1d2bbf7743e2cb12d6685f55da8b8d4", size = 1379855, upload-time = "2025-04-30T19:38:15.563Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/67/e320a11da2049dfd50fd1726952093b173332563f32d1a94cc3758932147/stripe-11.6.0-py2.py3-none-any.whl", hash = "sha256:6e6cf09ebb6d5fc2d708401cb8868fd7bff987a6d09a0433caaa92c62f97dbc5", size = 1636766, upload-time = "2025-02-24T22:39:44.629Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4f/1efeebb7fdc8f1317821006f5830a56e9f030ffbf9369856a0ced16ee252/stripe-12.1.0-py2.py3-none-any.whl", hash = "sha256:1a3c9c0647c46da152efbd3b49f3494a32472b222857758e43df99759e790f29", size = 1622491, upload-time = "2025-04-30T19:38:13.773Z" },
 ]
 
 [[package]]

--- a/version.py
+++ b/version.py
@@ -49,4 +49,4 @@ API_FEATURE_LEVEL = 382
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (326, 2)  # bumped 2025-05-05 to upgrade JavaScript dependencies
+PROVISION_VERSION = (326, 3)  # bumped 2025-05-10 to upgrade stripe


### PR DESCRIPTION
#34598 has the same code with API fixtures. This is just for dropping review comments without making your browser window crash.