### PR TITLE
compose_send_menu_popover: Fix check for closed popover

### DIFF
--- a/web/src/compose_send_menu_popover.js
+++ b/web/src/compose_send_menu_popover.js
@@ -131,7 +131,7 @@ export function do_schedule_message(send_at_time) {
 
 function get_send_later_menu_items() {
     const $current_schedule_popover_elem = $("[data-tippy-root] #send_later_popover");
-    if (!$current_schedule_popover_elem) {
+    if ($current_schedule_popover_elem.length === 0) {
         blueslip.error("Trying to get menu items when schedule popover is closed.");
         return undefined;
     }


### PR DESCRIPTION
An empty jQuery object is still truthy.

Cc @sayamsamal (#27705).