### PR TITLE
server_events: Extract interface for compose, transmit to new module

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -209,6 +209,7 @@ EXEMPT_FILES = make_set(
         "web/src/sentry.ts",
         "web/src/server_event_types.ts",
         "web/src/server_events.js",
+        "web/src/server_events_state.ts",
         "web/src/settings.ts",
         "web/src/settings_account.ts",
         "web/src/settings_bots.ts",

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -19,7 +19,7 @@ import * as onboarding_steps from "./onboarding_steps.ts";
 import * as people from "./people.ts";
 import * as scheduled_messages from "./scheduled_messages.ts";
 import * as sent_messages from "./sent_messages.ts";
-import * as server_events from "./server_events.js";
+import * as server_events_state from "./server_events_state.ts";
 import {current_user} from "./state_data.ts";
 import * as transmit from "./transmit.js";
 import {user_settings} from "./user_settings.ts";
@@ -86,7 +86,7 @@ export function create_message_object(message_content = compose_state.message_co
         type: compose_state.get_message_type(),
         content: message_content,
         sender_id: current_user.user_id,
-        queue_id: server_events.queue_id,
+        queue_id: server_events_state.queue_id,
         stream_id: undefined,
     };
     message.topic = "";
@@ -257,7 +257,7 @@ export let send_message = (request = create_message_object()) => {
     }
 
     transmit.send_message(request, success, error);
-    server_events.assert_get_events_running(
+    server_events_state.assert_get_events_running(
         "Restarting get_events because it was not running during send",
     );
 

--- a/web/src/server_events.js
+++ b/web/src/server_events.js
@@ -12,13 +12,13 @@ import * as reload from "./reload.ts";
 import * as reload_state from "./reload_state.ts";
 import * as sent_messages from "./sent_messages.ts";
 import * as server_events_dispatch from "./server_events_dispatch.js";
+import {queue_id} from "./server_events_state.ts";
 import {server_message_schema} from "./server_message.ts";
 import * as util from "./util.ts";
 import * as watchdog from "./watchdog.ts";
 
 // Docs: https://zulip.readthedocs.io/en/latest/subsystems/events-system.html
 
-export let queue_id;
 let last_event_id;
 let event_queue_longpoll_timeout_seconds;
 
@@ -267,7 +267,6 @@ export function finished_initial_fetch() {
 }
 
 export function initialize(params) {
-    queue_id = params.queue_id;
     last_event_id = params.last_event_id;
     event_queue_longpoll_timeout_seconds = params.event_queue_longpoll_timeout_seconds;
 

--- a/web/src/server_events_state.ts
+++ b/web/src/server_events_state.ts
@@ -1,0 +1,16 @@
+import type {StateData} from "./state_data";
+
+export let queue_id: string | null;
+export let assert_get_events_running: (error_message: string) => void;
+export let restart_get_events: () => void;
+
+export function initialize(
+    params: StateData["server_events_state"] & {
+        assert_get_events_running: (error_message: string) => void;
+        restart_get_events: () => void;
+    },
+): void {
+    queue_id = params.queue_id;
+    assert_get_events_running = params.assert_get_events_running;
+    restart_get_events = params.restart_get_events;
+}

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -546,7 +546,13 @@ export const state_data_schema = z
     .and(
         z
             .object({
-                queue_id: NOT_TYPED_YET,
+                queue_id: z.nullable(z.string()),
+            })
+            .transform((server_events_state) => ({server_events_state})),
+    )
+    .and(
+        z
+            .object({
                 server_generation: NOT_TYPED_YET,
                 event_queue_longpoll_timeout_seconds: NOT_TYPED_YET,
                 last_event_id: NOT_TYPED_YET,

--- a/web/src/transmit.js
+++ b/web/src/transmit.js
@@ -4,7 +4,7 @@ import * as people from "./people.ts";
 import * as reload from "./reload.ts";
 import * as reload_state from "./reload_state.ts";
 import * as sent_messages from "./sent_messages.ts";
-import * as server_events from "./server_events.js";
+import * as server_events_state from "./server_events_state.ts";
 import {current_user} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 
@@ -48,7 +48,7 @@ export function send_message(request, on_success, error) {
                             `Restarting get_events due to delayed receipt of sent message ${request.local_id}`,
                         );
 
-                        server_events.restart_get_events();
+                        server_events_state.restart_get_events();
                     }, 5000);
                 }
             },
@@ -101,7 +101,7 @@ export function reply_message(opts) {
 
     const reply = {
         sender_id: current_user.user_id,
-        queue_id: server_events.queue_id,
+        queue_id: server_events_state.queue_id,
         local_id,
     };
 

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -111,6 +111,7 @@ import * as scroll_bar from "./scroll_bar.ts";
 import * as scroll_util from "./scroll_util.ts";
 import * as search from "./search.ts";
 import * as server_events from "./server_events.js";
+import * as server_events_state from "./server_events_state.ts";
 import * as settings from "./settings.ts";
 import * as settings_notifications from "./settings_notifications.ts";
 import * as settings_panel_menu from "./settings_panel_menu.ts";
@@ -579,6 +580,11 @@ export function initialize_everything(state_data) {
     overlays.initialize();
     invite.initialize();
     message_view_header.initialize();
+    server_events_state.initialize({
+        ...state_data.server_events_state,
+        assert_get_events_running: server_events.assert_get_events_running,
+        restart_get_events: server_events.restart_get_events,
+    });
     server_events.initialize(state_data.server_events);
     user_status.initialize(state_data.user_status);
     compose_recipient.initialize();

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -44,7 +44,7 @@ const narrow_state = mock_esm("../src/narrow_state");
 const rendered_markdown = mock_esm("../src/rendered_markdown");
 const resize = mock_esm("../src/resize");
 const sent_messages = mock_esm("../src/sent_messages");
-const server_events = mock_esm("../src/server_events");
+const server_events_state = mock_esm("../src/server_events_state");
 const transmit = mock_esm("../src/transmit");
 const upload = mock_esm("../src/upload");
 const onboarding_steps = mock_esm("../src/onboarding_steps");
@@ -285,7 +285,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
 
     override_rewire(drafts, "update_compose_draft_count", noop);
 
-    override(server_events, "assert_get_events_running", () => {
+    override(server_events_state, "assert_get_events_running", () => {
         stub_state.get_events_running_called += 1;
     });
 

--- a/web/tests/transmit.test.cjs
+++ b/web/tests/transmit.test.cjs
@@ -20,7 +20,7 @@ const sent_messages = mock_esm("../src/sent_messages", {
         callback();
     },
 });
-const server_events = mock_esm("../src/server_events");
+const server_events_state = mock_esm("../src/server_events_state");
 
 const people = zrequire("people");
 const transmit = zrequire("transmit");
@@ -155,7 +155,7 @@ run_test("reply_message_stream", ({override}) => {
     });
 
     override(current_user, "user_id", 44);
-    server_events.queue_id = 66;
+    server_events_state.queue_id = 66;
     sent_messages.get_new_local_id = () => "99";
 
     transmit.reply_message({
@@ -196,7 +196,7 @@ run_test("reply_message_private", ({override}) => {
     });
 
     override(current_user, "user_id", 155);
-    server_events.queue_id = 177;
+    server_events_state.queue_id = 177;
     sent_messages.get_new_local_id = () => "199";
 
     transmit.reply_message({


### PR DESCRIPTION
This should allow more TypeScript conversion to proceed without blocking on #32792.

![typescript-roadmap](https://github.com/user-attachments/assets/6771f458-8e82-4cf0-a951-3d38db8a5f1e)