### PR TITLE
[WIP] Implement mechanism for forcing deactivation of a group

### DIFF
--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -1460,27 +1460,39 @@ def send_stream_posting_permission_update_notification(
     *,
     old_setting_value: int | UserGroupMembersData,
     new_setting_value: int | UserGroupMembersData,
-    acting_user: UserProfile,
+    acting_user: UserProfile | None,
 ) -> None:
-    sender = get_system_bot(settings.NOTIFICATION_BOT, acting_user.realm_id)
-    user_mention = silent_mention_syntax_for_user(acting_user)
+    sender = get_system_bot(settings.NOTIFICATION_BOT, stream.realm_id)
 
     old_setting_description = get_users_string_with_permission(old_setting_value)
     new_setting_description = get_users_string_with_permission(new_setting_value)
 
     with override_language(stream.realm.default_language):
-        notification_string = _(
-            "{user} changed the [posting permissions]({help_link}) "
-            "for this channel:\n\n"
-            "* **Old**: {old_setting_description}\n"
-            "* **New**: {new_setting_description}\n"
-        )
-        notification_string = notification_string.format(
-            user=user_mention,
-            help_link="/help/channel-posting-policy",
-            old_setting_description=old_setting_description,
-            new_setting_description=new_setting_description,
-        )
+        if acting_user is not None:
+            user_mention = silent_mention_syntax_for_user(acting_user)
+            template = _(
+                "{user} changed the [posting permissions]({help_link}) for this channel:\n\n"
+                "* **Old** : {old_setting_description}\n"
+                "* **New** : {new_setting_description}\n"
+            )
+            notification_string = template.format(
+                user=user_mention,
+                help_link="/help/channel-posting-policy",
+                old_setting_description=old_setting_description,
+                new_setting_description=new_setting_description,
+            )
+        else:
+            template = _(
+                "The [posting permissions]({help_link}) for this channel were changed:\n\n"
+                "* **Old** : {old_setting_description}\n"
+                "* **New** : {new_setting_description}\n"
+            )
+            notification_string = template.format(
+                help_link="/help/channel-posting-policy",
+                old_setting_description=old_setting_description,
+                new_setting_description=new_setting_description,
+            )
+
         internal_send_stream_message(
             sender,
             stream,
@@ -1786,10 +1798,10 @@ def do_set_stream_property(stream: Stream, name: str, value: Any, acting_user: U
 def do_change_stream_group_based_setting(
     stream: Stream,
     setting_name: str,
-    new_setting_value: NamedUserGroup | UserGroupMembersData,
+    new_setting_value: int | NamedUserGroup | UserGroupMembersData,
     *,
     old_setting_api_value: int | UserGroupMembersData | None = None,
-    acting_user: UserProfile,
+    acting_user: UserProfile | None,
 ) -> None:
     old_user_group = getattr(stream, setting_name)
 
@@ -1804,11 +1816,14 @@ def do_change_stream_group_based_setting(
     if setting_name in Stream.stream_permission_group_settings_granting_metadata_access:
         old_user_ids_with_metadata_access = can_access_stream_metadata_user_ids(stream)
 
-    if isinstance(new_setting_value, NamedUserGroup):
-        user_group: UserGroup = new_setting_value
+    if isinstance(new_setting_value, int):
+        user_group = UserGroup.objects.get(id=new_setting_value)
+    elif isinstance(new_setting_value, NamedUserGroup):
+        user_group = new_setting_value
     else:
         user_group = update_or_create_user_group_for_setting(
             acting_user,
+            stream.realm,
             new_setting_value.direct_members,
             new_setting_value.direct_subgroups,
             old_user_group,
@@ -1915,7 +1930,6 @@ def do_change_stream_group_based_setting(
             )
             send_event_on_commit(stream.realm, event, current_user_ids_with_metadata_access)
 
-        assert acting_user is not None
         send_stream_posting_permission_update_notification(
             stream,
             old_setting_value=old_setting_api_value,

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -366,8 +366,28 @@ class GroupPermissionSetting:
     allow_nobody_group: bool
     allow_everyone_group: bool
     default_group_name: str
+
+    # These settings have a default value, because it's unusual for
+    # them to be different from the default.
     require_system_group: bool = False
     allow_internet_group: bool = False
+
+    # When the group that is the current value of a permission setting
+    # is deactivated by an automated job (say, SAML sync of group
+    # membership), this field specifies the group to use.
+    #
+    # Typically, this will be the default of SystemGroups.NOBODY. But
+    # for rare settings where it being empty would violate an
+    # invariant, the group to use can be specified here.
+    #
+    # A value of None is used with require_system_group=True to assert
+    # the only valid values for this setting are groups that cannot be
+    # deactivated.
+    #
+    # TODO: Move this class to a new file that also defines `class
+    # SystemGroups` so we can use SystemGroups.NOBODY here.
+    replacement_group_name: str | None = "role:nobody"
+
     default_for_system_groups: str | None = None
     allowed_system_groups: list[str] = field(default_factory=list)
 

--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -748,6 +748,10 @@ class Realm(models.Model):
             # Note that user_can_access_all_other_users in the web
             # app is relying on members always have access.
             allowed_system_groups=[SystemGroups.EVERYONE, SystemGroups.MEMBERS],
+            # This setting can only be set to system groups, so the situation
+            # where the group that's the value of the setting gets deactivated
+            # is impossible.
+            replacement_group_name=None,
         ),
         can_add_subscribers_group=GroupPermissionSetting(
             allow_nobody_group=True,
@@ -790,6 +794,9 @@ class Realm(models.Model):
                 SystemGroups.OWNERS,
                 SystemGroups.NOBODY,
             ],
+            # System groups can't be deactivated, so this replacement_group_name
+            # is not needed.
+            replacement_group_name=None,
         ),
         can_create_write_only_bots_group=GroupPermissionSetting(
             allow_nobody_group=True,
@@ -815,11 +822,15 @@ class Realm(models.Model):
             allow_nobody_group=False,
             allow_everyone_group=False,
             default_group_name=SystemGroups.OWNERS,
+            # This setting can't be set to NOBODY without making the realm dysfunctional.
+            replacement_group_name=SystemGroups.OWNERS,
         ),
         can_manage_billing_group=GroupPermissionSetting(
             allow_nobody_group=False,
             allow_everyone_group=False,
             default_group_name=SystemGroups.ADMINISTRATORS,
+            # This setting can't be set to NOBODY without making the realm dysfunctional.
+            replacement_group_name=SystemGroups.OWNERS,
         ),
         can_mention_many_users_group=GroupPermissionSetting(
             allow_nobody_group=True,

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -414,6 +414,7 @@ def update_realm(
                 user_group = access_user_group_for_setting(
                     new_setting_value,
                     user_profile,
+                    user_profile.realm,
                     setting_name=setting_name,
                     permission_configuration=permission_configuration,
                     current_setting_value=current_value,

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -670,6 +670,7 @@ def access_requested_group_permissions(
             group_settings_map[setting_name] = access_user_group_for_setting(
                 setting_value,
                 user_profile,
+                user_profile.realm,
                 setting_name=setting_name,
                 permission_configuration=permission_configuration,
             )

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -86,6 +86,7 @@ def add_user_group(
             setting_value_group = access_user_group_for_setting(
                 setting_value,
                 user_profile,
+                user_profile.realm,
                 setting_name=setting_name,
                 permission_configuration=permission_config,
             )
@@ -195,6 +196,7 @@ def edit_user_group(
             setting_value_group = access_user_group_for_setting(
                 new_setting_value,
                 user_profile,
+                user_profile.realm,
                 setting_name=setting_name,
                 permission_configuration=permission_config,
                 current_setting_value=current_value,


### PR DESCRIPTION
https://chat.zulip.org/#narrow/channel/3-backend/topic/force-deactivate.20a.20group

Adds a force flag to `check_user_group_can_be_deactivated` to make it
resolve any issues standing in the way of correct deactivation - instead
of returning errors.

The implementation is a bit fiddly due to challenges in processing the
removal of the group from permission - and plumbing the correct form of
group data to the `do_change_..._group_permission_setting` function.

We resolve the challenge of "what should be the new value for a
permission if it was directly set to the group?" by adding a new field
`replacement_group_name` to `GroupPermissionSetting` - which allows us
to configure this per-permission.

Doesn't fix tests yet - for now it's an early version, implementing the described functionality. The way of manually testing this is:
1. `run-dev` and set some permission to involve the `hamletcharacters` group.
2. `./manage.py shell`
```
from zerver.lib.user_groups import check_user_group_can_be_deactivated
g = NamedUserGroup.objects.get(name="hamletcharacters")
check_user_group_can_be_deactivated(g)  # shows objections
check_user_group_can_be_deactivated(g, force=True)  # resolves the objections as implemented, returns empty list
```
and verifying that the group got correctly cleared out from all permissions - removed from anonymous groups, replaced with `replacement_group_name` if a permission was set to it directly.