### PR TITLE
inbox_ui: Fix empty view text for both channel and normal view visible.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -912,7 +912,8 @@ function render_channel_view(channel_id: number): void {
             INBOX_SEARCH_ID,
         }),
     );
-    show_empty_inbox_text(false);
+    // Hide any empty inbox text by default.
+    show_empty_inbox_text(true);
     channel_view_topic_widget = new InboxTopicListWidget(
         $("#inbox-list"),
         channel_id,


### PR DESCRIPTION
Fixed by hiding inbox view empty text when channel view is visible. To ensure normal inbox view empty text is hidden, we make it think there is visible unread topics.


| before | after |
| --- | --- |
| ![Screenshot from 2025-05-13 14 05 50](https://github.com/user-attachments/assets/5beb2147-c565-4203-970f-abb628bf38f4) |![Screenshot from 2025-05-13 14 04 47](https://github.com/user-attachments/assets/cf9e754e-b17b-4dd6-879b-4433127c77fb) |


