### PR TITLE
Port `topic_link_util.ts` to python.

### DIFF
--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -1,3 +1,5 @@
+// Keep this synchronized with zerver/lib/topic_link_util.py
+
 import assert from "minimalistic-assert";
 
 import * as hash_util from "./hash_util.ts";

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -72,6 +72,7 @@ from zerver.lib.topic import (
     update_edit_history,
     update_messages_for_topic_edit,
 )
+from zerver.lib.topic_link_util import get_stream_topic_link_syntax
 from zerver.lib.types import DirectMessageEditRequest, EditHistoryEvent, StreamMessageEditRequest
 from zerver.lib.url_encoding import near_stream_message_url
 from zerver.lib.user_message import bulk_insert_all_ums
@@ -286,8 +287,8 @@ def send_message_moved_breadcrumbs(
     old_topic_name = message_edit_request.orig_topic_name
     new_stream = message_edit_request.target_stream
     new_topic_name = message_edit_request.target_topic_name
-    old_topic_link = f"#**{old_stream.name}>{old_topic_name}**"
-    new_topic_link = f"#**{new_stream.name}>{new_topic_name}**"
+    old_topic_link = get_stream_topic_link_syntax(old_stream.id, old_stream.name, old_topic_name)
+    new_topic_link = get_stream_topic_link_syntax(new_stream.id, new_stream.name, new_topic_name)
     message = {
         "id": target_message.id,
         "stream_id": new_stream.id,

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -75,6 +75,7 @@ from zerver.lib.string_validation import check_stream_name
 from zerver.lib.thumbnail import get_user_upload_previews, rewrite_thumbnailed_images
 from zerver.lib.timestamp import timestamp_to_datetime
 from zerver.lib.topic import participants_for_topic
+from zerver.lib.topic_link_util import get_stream_link_syntax
 from zerver.lib.url_preview.types import UrlEmbedData
 from zerver.lib.user_groups import (
     check_any_user_has_permission_by_role,
@@ -1536,7 +1537,7 @@ def send_pm_if_empty_stream(
                     return
                 arg_dict = {
                     **arg_dict,
-                    "channel_name": f"#**{stream.name}**",
+                    "channel_name": f"{get_stream_link_syntax(stream.id, stream.name)}",
                 }
                 content = _(
                     "Your bot {bot_identity} tried to send a message to "

--- a/zerver/lib/topic_link_util.py
+++ b/zerver/lib/topic_link_util.py
@@ -1,0 +1,81 @@
+# Keep this synchronized with web/src/topic_link_util.ts
+
+import re
+import urllib.parse
+
+invalid_stream_topic_regex = re.compile(r"[`>*&\[\]]|(\$\$)")
+
+
+def will_produce_broken_stream_topic_link(word: str) -> bool:
+    return bool(invalid_stream_topic_regex.search(word))
+
+
+escape_mapping = {
+    "`": "&#96;",
+    ">": "&gt;",
+    "*": "&#42;",
+    "&": "&amp;",
+    "$$": "&#36;&#36;",
+    "[": "&#91;",
+    "]": "&#93;",
+}
+
+
+def escape_invalid_stream_topic_characters(text: str) -> str:
+    return re.sub(
+        invalid_stream_topic_regex,
+        lambda match: escape_mapping.get(match.group(0), match.group(0)),
+        text,
+    )
+
+
+hash_replacements = {
+    "%": ".",
+    "(": ".28",
+    ")": ".29",
+    ".": ".2E",
+}
+
+
+def encode_hash_component(s: str) -> str:
+    encoded = urllib.parse.quote(s, safe="*")
+    return "".join(hash_replacements.get(c, c) for c in encoded)
+
+
+def channel_topic_url(stream_id: int, stream_name: str, topic_name: str | None = None) -> str:
+    link = f"#narrow/channel/{stream_id}-{encode_hash_component(stream_name.replace(' ', '-'))}"
+    if topic_name:
+        link += f"/topic/{encode_hash_component(topic_name)}"
+    return link
+
+
+def get_fallback_markdown_link(
+    stream_id: int, stream_name: str, topic_name: str | None = None
+) -> str:
+    """
+    Generates the markdown link syntax for a stream or topic link.
+    """
+    escape = escape_invalid_stream_topic_characters
+    url = channel_topic_url(stream_id, stream_name, topic_name)
+    if topic_name:
+        return f"[#{escape(stream_name)} > {escape(topic_name)}]({url})"
+
+    return f"[#{escape(stream_name)}]({url})"
+
+
+def get_stream_topic_link_syntax(stream_id: int, stream_name: str, topic_name: str) -> str:
+    # If the topic name is such that it will generate an invalid #**stream>topic** syntax,
+    # we revert to generating the normal markdown syntax for a link.
+    if will_produce_broken_stream_topic_link(topic_name) or will_produce_broken_stream_topic_link(
+        stream_name
+    ):
+        return get_fallback_markdown_link(stream_id, stream_name, topic_name)
+    return f"#**{stream_name}>{topic_name}**"
+
+
+def get_stream_link_syntax(stream_id: int, stream_name: str) -> str:
+    # If the topic name is such that it will generate an invalid #**stream>topic** syntax,
+    # we revert to generating the normal markdown syntax for a link.
+    if will_produce_broken_stream_topic_link(stream_name):
+        return get_fallback_markdown_link(stream_id, stream_name)
+    return f"#**{stream_name}**"

--- a/zerver/tests/test_topic_link_util.py
+++ b/zerver/tests/test_topic_link_util.py
@@ -1,0 +1,72 @@
+from typing_extensions import override
+
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.topic_link_util import get_stream_link_syntax, get_stream_topic_link_syntax
+
+
+class TestTopicLinkUtil(ZulipTestCase):
+    def test_stream_link_syntax(self) -> None:
+        sweden_id = self.make_stream("Sweden").id
+        money_id = self.make_stream("$$MONEY$$").id
+        md_id = self.make_stream("Markdown [md]").id
+
+        self.assertEqual(get_stream_link_syntax(sweden_id, "Sweden"), "#**Sweden**")
+
+        self.assertEqual(
+            get_stream_link_syntax(money_id, "$$MONEY$$"),
+            f"[#&#36;&#36;MONEY&#36;&#36;](#narrow/channel/{money_id}-.24.24MONEY.24.24)",
+        )
+
+        self.assertEqual(
+            get_stream_link_syntax(md_id, "Markdown [md]"),
+            f"[#Markdown &#91;md&#93;](#narrow/channel/{md_id}-Markdown-.5Bmd.5D)",
+        )
+
+    def test_stream_topic_link_syntax(self) -> None:
+        sweden_id = self.make_stream("Sweden").id
+        money_id = self.make_stream("$$MONEY$$").id
+        denmark_id = self.get_stream_id("Denmark")
+
+        self.assertEqual(
+            get_stream_topic_link_syntax(sweden_id, "Sweden", "topic"), "#**Sweden>topic**"
+        )
+        self.assertEqual(
+            get_stream_topic_link_syntax(sweden_id, "Sweden", "test `test` test"),
+            f"[#Sweden > test &#96;test&#96; test](#narrow/channel/{sweden_id}-Sweden/topic/test.20.60test.60.20test)",
+        )
+        self.assertEqual(
+            get_stream_topic_link_syntax(denmark_id, "Denmark", "test `test` test`s"),
+            f"[#Denmark > test &#96;test&#96; test&#96;s](#narrow/channel/{denmark_id}-Denmark/topic/test.20.60test.60.20test.60s)",
+        )
+        self.assertEqual(
+            get_stream_topic_link_syntax(sweden_id, "Sweden", "error due to *"),
+            f"[#Sweden > error due to &#42;](#narrow/channel/{sweden_id}-Sweden/topic/error.20due.20to.20*)",
+        )
+        self.assertEqual(
+            get_stream_topic_link_syntax(sweden_id, "Sweden", "*asterisk"),
+            f"[#Sweden > &#42;asterisk](#narrow/channel/{sweden_id}-Sweden/topic/*asterisk)",
+        )
+        self.assertEqual(
+            get_stream_topic_link_syntax(sweden_id, "Sweden", "greaterthan>"),
+            f"[#Sweden > greaterthan&gt;](#narrow/channel/{sweden_id}-Sweden/topic/greaterthan.3E)",
+        )
+        self.assertEqual(
+            get_stream_topic_link_syntax(money_id, "$$MONEY$$", "dollar"),
+            f"[#&#36;&#36;MONEY&#36;&#36; > dollar](#narrow/channel/{money_id}-.24.24MONEY.24.24/topic/dollar)",
+        )
+        self.assertEqual(
+            get_stream_topic_link_syntax(sweden_id, "Sweden", "swe$$dish"),
+            f"[#Sweden > swe&#36;&#36;dish](#narrow/channel/{sweden_id}-Sweden/topic/swe.24.24dish)",
+        )
+        self.assertEqual(
+            get_stream_topic_link_syntax(sweden_id, "Sweden", "&ab"),
+            f"[#Sweden > &amp;ab](#narrow/channel/{sweden_id}-Sweden/topic/.26ab)",
+        )
+        self.assertEqual(
+            get_stream_topic_link_syntax(sweden_id, "Sweden", "&ab]"),
+            f"[#Sweden > &amp;ab&#93;](#narrow/channel/{sweden_id}-Sweden/topic/.26ab.5D)",
+        )
+        self.assertEqual(
+            get_stream_topic_link_syntax(sweden_id, "Sweden", "&a[b"),
+            f"[#Sweden > &amp;a&#91;b](#narrow/channel/{sweden_id}-Sweden/topic/.26a.5Bb)",
+        )

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -84,6 +84,7 @@ from zerver.lib.topic import (
     maybe_rename_general_chat_to_empty_topic,
     messages_for_topic,
 )
+from zerver.lib.topic_link_util import get_stream_link_syntax
 from zerver.lib.typed_endpoint import ApiParamConfig, PathOnly, typed_endpoint
 from zerver.lib.typed_endpoint_validators import check_color
 from zerver.lib.types import UserGroupMembersData
@@ -855,7 +856,9 @@ def send_messages_for_new_subscribers(
 
             content = content.format(
                 user_name=silent_mention_syntax_for_user(user_profile),
-                new_channels=", ".join(f"#**{s.name}**" for s in created_streams),
+                new_channels=", ".join(
+                    f"{get_stream_link_syntax(s.id, s.name)}" for s in created_streams
+                ),
             )
 
             sender = get_system_bot(


### PR DESCRIPTION
### First commit
We implement a minimal version of the frontend `topic_link_util.ts` in the backend to
handle topic links in notification bot messages etc, which are prone to the same errors as fixed in #30071.

We also mimic the channel name slugging behaviour in `internal_url.ts`.

This module explicitly requires the stream id from the caller, which the frontend module computed with the help
of `stream_data`.

The test cases added for this module are the same as those in `topic_link_util.test.cjs` (though some parts are excluded).

TODO: Add support for message links (using the `@` syntax)

### Second commit
We use the module to generate topic links in notification bot messages and a few other places. 

Fixes: #34608

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

CZO: [#issues > 📂 Link to topic with backticks in notification message @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20Link.20to.20topic.20with.20backticks.20in.20notification.20message/near/2159703)

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
