### PR TITLE
demo-orgs: Disable removing "invite required to join" until email set.

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -449,7 +449,10 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: "#user_email_address_dropdown_container.disabled_setting_tooltip",
+        target: [
+            "#user_email_address_dropdown_container.disabled_setting_tooltip",
+            "#realm_invite_required_container.disabled_setting_tooltip",
+        ].join(","),
         content: $t({
             defaultMessage: "Configure your email to access this feature.",
         }),

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -10,12 +10,14 @@
                 {{> settings_save_discard_widget section_name="join-settings" }}
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
-                {{> settings_checkbox
-                  setting_name="realm_invite_required"
-                  prefix="id_"
-                  is_checked=realm_invite_required
-                  label=admin_settings_label.realm_invite_required}}
-
+                <div id="realm_invite_required_container" {{#unless user_has_email_set}}class="disabled_setting_tooltip"{{/unless}}>
+                    {{> settings_checkbox
+                      setting_name="realm_invite_required"
+                      prefix="id_"
+                      is_checked=realm_invite_required
+                      is_disabled=(not user_has_email_set)
+                      label=admin_settings_label.realm_invite_required}}
+                </div>
                 {{> group_setting_value_pill_input
                   setting_name="realm_can_invite_users_group"
                   label=group_setting_labels.can_invite_users_group}}

--- a/zerver/lib/demo_organizations.py
+++ b/zerver/lib/demo_organizations.py
@@ -1,0 +1,13 @@
+from django.utils.translation import gettext as _
+
+from zerver.lib.exceptions import JsonableError
+from zerver.models.realms import Realm
+
+
+def check_demo_organization_has_set_email(realm: Realm) -> None:
+    # This should be called after checking that the realm has
+    # a demo_organization_scheduled_deletion_date set.
+    assert realm.demo_organization_scheduled_deletion_date is not None
+    human_owner_emails = set(realm.get_human_owner_users().values_list("delivery_email", flat=True))
+    if "" in human_owner_emails:
+        raise JsonableError(_("Configure owner account email address."))

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -30,6 +30,7 @@ from zerver.actions.realm_settings import (
 )
 from zerver.decorator import require_realm_admin, require_realm_owner
 from zerver.forms import check_subdomain_available as check_subdomain
+from zerver.lib.demo_organizations import check_demo_organization_has_set_email
 from zerver.lib.exceptions import JsonableError, OrganizationOwnerRequiredError
 from zerver.lib.i18n import get_available_language_codes
 from zerver.lib.response import json_success
@@ -496,10 +497,9 @@ def update_realm(
     if string_id is not None:
         if not user_profile.is_realm_owner:
             raise OrganizationOwnerRequiredError
-
         if realm.demo_organization_scheduled_deletion_date is None:
             raise JsonableError(_("Must be a demo organization."))
-
+        check_demo_organization_has_set_email(realm)
         try:
             check_subdomain(string_id)
         except ValidationError as err:

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -254,6 +254,9 @@ def update_realm(
     if waiting_period_threshold is not None and not user_profile.is_realm_owner:
         raise OrganizationOwnerRequiredError
 
+    if realm.demo_organization_scheduled_deletion_date is not None and invite_required is not None:
+        check_demo_organization_has_set_email(realm)
+
     if enable_spectator_access:
         realm.ensure_not_on_limited_plan()
 


### PR DESCRIPTION
Until a demo organization owner sets an email address, we want to restrict other users from joining the organization. Therefore, we disable changing the invite required setting for the organization until they set their email address. Otherwise, the owner could share the demo organization URL with someone and they could create an account via the homepage.

[Relevant CZO discussion](https://chat.zulip.org/#narrow/channel/3-backend/topic/demo.20organizations.3A.20setting.20org.20owner.20email/near/2169294)

**Notes**:
- I used the same tooltip handler that we have for the email visibility dropdown setting in the account and privacy tab in personal settings for demo organizations.
  - Alternatively, we could use the `tooltip_message` field for the settings checkbox in the template, and conditionally set that to either an empty string or the tooltip based on if the user's email is set (I believe I'd need to set the string in the `options` object in `web/src/admin.ts`).

**Screenshots and screen captures:**

| Before email is set | After email is set |
| --- | --- |
| ![Screenshot from 2025-05-13 15-29-02](https://github.com/user-attachments/assets/ad307076-ec29-494a-90a3-2172e282ef14) | ![Screenshot from 2025-05-13 15-30-13](https://github.com/user-attachments/assets/c8792486-eef6-440c-9007-d25de085eddd) |

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
