### PR TITLE
buttons: Modify the styles of buttons in user group settings.

### DIFF
--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -295,9 +295,15 @@ function update_group_membership_button(group_id: number): void {
         true,
     );
     if (is_direct_member) {
-        $group_settings_button.text($t({defaultMessage: "Leave group"}));
+        $group_settings_button
+            .text($t({defaultMessage: "Leave group"}))
+            .removeClass("action-button-quiet-brand")
+            .addClass("action-button-neutral");
     } else {
-        $group_settings_button.text($t({defaultMessage: "Join group"}));
+        $group_settings_button
+            .text($t({defaultMessage: "Join group"}))
+            .removeClass("action-button-quiet-neutral")
+            .addClass("action-button-quiet-brand");
     }
 
     const can_join_group = settings_data.can_join_user_group(group_id);

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -4,7 +4,7 @@
         <div class="join_leave_button_wrapper inline-block">
             {{#if is_direct_member}}
             {{> ../components/action_button label=(t "Leave group") custom_classes="join_leave_button" type="button"
-              attention="quiet" intent="brand" }}
+              attention="quiet" intent="neutral" }}
             {{else}}
             {{> ../components/action_button label=(t "Join group") custom_classes="join_leave_button" type="button"
               attention="quiet" intent="brand" }}


### PR DESCRIPTION
This commit changes the intent of "Leave group" to neutral color (grey), while keeping "Join group" brand-colored.



<!-- Describe your pull request here.-->

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/101-design/topic/buttons.20in.20channels.20menu/near/2171470).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|---|---|
| <img width="166" alt="Screenshot 2025-05-13 at 10 38 37 PM" src="https://github.com/user-attachments/assets/b5512060-0df1-4e41-8b87-f7f824a7f1ed" /> | <img width="165" alt="Screenshot 2025-05-13 at 10 38 57 PM" src="https://github.com/user-attachments/assets/90ccf38d-16f6-4e64-b9af-5e01463ef648" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
