### PR TITLE
overlay: Fix automatic overlay closing on click when <select> is active.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -143,7 +143,7 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=1943053 -->
 <div id="settings_overlay_container"></div>
 <div id="message-edit-history-overlay-container"></div>
 <div class="informational-overlays overlay" data-overlay="informationalOverlays" aria-hidden="true">
-    <div class="overlay-content overlay-container">
+    <div class="overlay-container">
         <div class="overlay-tabs">
             <span class="exit">&times;</span>
         </div>

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -140,8 +140,7 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=1943053 -->
 <div id="drafts_table"></div>
 <div id="scheduled_messages_overlay_container"></div>
 <div id="reminders-overlay-container"></div>
-<div id="settings_overlay_container" class="overlay" data-overlay="settings" aria-hidden="true">
-</div>
+<div id="settings_overlay_container"></div>
 <div id="message-edit-history-overlay-container"></div>
 <div class="informational-overlays overlay" data-overlay="informationalOverlays" aria-hidden="true">
     <div class="overlay-content overlay-container">

--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -577,7 +577,7 @@ export async function manage_organization(page: Page): Promise<void> {
     const organization_settings = '.link-item a[href="#organization"]';
     await page.waitForSelector(organization_settings, {visible: true});
     await page.click(organization_settings);
-    await page.waitForSelector("#settings_overlay_container.show", {visible: true});
+    await page.waitForSelector("#settings_overlay_container .overlay.show", {visible: true});
 
     const url = await page_url_with_fragment(page);
     assert.match(url, /^http:\/\/[^/]+\/#organization/, "Unexpected organization settings URL");

--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -35,7 +35,7 @@ async function navigate_to_settings(page: Page): Promise<void> {
 
     await page.click("#settings_page .content-wrapper .exit");
     // Wait until the overlay is completely closed.
-    await page.waitForSelector("#settings_overlay_container", {hidden: true});
+    await page.waitForSelector("#settings_overlay_container .overlay", {hidden: true});
 }
 
 async function navigate_to_subscriptions(page: Page): Promise<void> {

--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -30,7 +30,7 @@ async function open_settings(page: Page): Promise<void> {
         `Page url: ${page_url} does not contain /#settings/`,
     );
     // Wait for settings overlay to open.
-    await page.waitForSelector("#settings_overlay_container", {visible: true});
+    await page.waitForSelector("#settings_overlay_container .overlay", {visible: true});
 }
 
 async function close_settings_and_date_picker(page: Page): Promise<void> {
@@ -41,7 +41,7 @@ async function close_settings_and_date_picker(page: Page): Promise<void> {
 
     await page.keyboard.press("Escape");
     await page.waitForSelector(".flatpickr-calendar", {hidden: true});
-    await page.waitForSelector("#settings_overlay_container", {hidden: true});
+    await page.waitForSelector("#settings_overlay_container .overlay", {hidden: true});
 }
 
 async function test_change_full_name(page: Page): Promise<void> {

--- a/web/e2e-tests/user-deactivation.test.ts
+++ b/web/e2e-tests/user-deactivation.test.ts
@@ -13,7 +13,7 @@ async function navigate_to_user_list(page: Page): Promise<void> {
     await page.waitForSelector(organization_settings, {visible: true});
     await page.click(organization_settings);
 
-    await page.waitForSelector("#settings_overlay_container.show", {visible: true});
+    await page.waitForSelector("#settings_overlay_container .overlay.show", {visible: true});
     await page.click("li[data-section='users']");
     await page.waitForSelector("#admin-user-list.show", {visible: true});
 }

--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -184,7 +184,7 @@ export function initialize(): void {
 
         // if the target is not the div.overlay element, search up the node tree
         // until it is found.
-        if ($target.is(".exit, .exit-sign, .overlay-content, .exit span")) {
+        if ($target.is(".exit, .exit-sign, .exit span")) {
             $target = $target.closest("[data-overlay]");
         } else if (!$target.is("div.overlay")) {
             // not a valid click target then.

--- a/web/src/settings.ts
+++ b/web/src/settings.ts
@@ -163,7 +163,7 @@ export function build_page(): void {
 export function open_settings_overlay(): void {
     overlays.open_overlay({
         name: "settings",
-        $overlay: $("#settings_overlay_container"),
+        $overlay: $("#settings_page"),
         on_close() {
             browser_history.exit_overlay();
             flatpickr.close_all();

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -362,7 +362,8 @@ div.overlay {
     transition-property: opacity, visibility;
     overflow: hidden;
 
-    .overlay-content {
+    .overlay-container {
+        background-color: var(--color-background-modal);
         transform: translateY(20px);
         transition: transform 0.2s ease-in;
         z-index: 102;
@@ -374,7 +375,7 @@ div.overlay {
         visibility: visible;
         transition: opacity 0.2s ease-out;
 
-        .overlay-content {
+        .overlay-container {
             transform: translateY(0);
             transition-timing-function: ease-out;
         }
@@ -383,10 +384,6 @@ div.overlay {
     .overlay-scroll-container {
         max-height: 60vh;
         padding: 15px;
-    }
-
-    .overlay-container {
-        background-color: var(--color-background-modal);
     }
 }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -181,7 +181,7 @@
     #draft_overlay,
     #scheduled_messages_overlay_container,
     #message-edit-history-overlay-container {
-        .flex.overlay-content > .overlay-container {
+        .overlay-container {
             box-shadow: 0 0 30px hsl(213deg 31% 0%);
         }
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -174,6 +174,7 @@
     & div.overlay .flex.overlay-content > .overlay-container,
     #settings_page,
     #subscription_overlay .overlay-container,
+    #reminders-overlay .overlay-container,
     .informational-overlays .overlay-content {
         box-shadow: 0 0 30px hsl(212deg 32% 7%);
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -177,7 +177,7 @@
     #groups_overlay .overlay-container,
     #reminders-overlay .overlay-container,
     #about-zulip .overlay-container,
-    .informational-overlays .overlay-content {
+    .informational-overlays .overlay-container {
         box-shadow: 0 0 30px hsl(212deg 32% 7%);
     }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -172,7 +172,7 @@
     }
 
     & div.overlay .flex.overlay-content > .overlay-container,
-    #settings_page,
+    #settings_page .overlay-container,
     #subscription_overlay .overlay-container,
     #groups_overlay .overlay-container,
     #reminders-overlay .overlay-container,

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -173,6 +173,7 @@
 
     & div.overlay .flex.overlay-content > .overlay-container,
     #settings_page,
+    #subscription_overlay .overlay-container,
     .informational-overlays .overlay-content {
         box-shadow: 0 0 30px hsl(212deg 32% 7%);
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -176,6 +176,7 @@
     #subscription_overlay .overlay-container,
     #groups_overlay .overlay-container,
     #reminders-overlay .overlay-container,
+    #about-zulip .overlay-container,
     .informational-overlays .overlay-content {
         box-shadow: 0 0 30px hsl(212deg 32% 7%);
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -174,6 +174,7 @@
     & div.overlay .flex.overlay-content > .overlay-container,
     #settings_page,
     #subscription_overlay .overlay-container,
+    #groups_overlay .overlay-container,
     #reminders-overlay .overlay-container,
     .informational-overlays .overlay-content {
         box-shadow: 0 0 30px hsl(212deg 32% 7%);

--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -80,3 +80,19 @@
         width: 15px;
     }
 }
+
+#draft_overlay.overlay {
+    .overlay-container {
+        margin: 2.5vh auto;
+        transform: translateY(20px);
+        transition: transform 0.2s ease-in;
+        z-index: 102;
+    }
+
+    &.show {
+        .overlay-container {
+            transform: translateY(0);
+            transition-timing-function: ease-out;
+        }
+    }
+}

--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -84,15 +84,5 @@
 #draft_overlay.overlay {
     .overlay-container {
         margin: 2.5vh auto;
-        transform: translateY(20px);
-        transition: transform 0.2s ease-in;
-        z-index: 102;
-    }
-
-    &.show {
-        .overlay-container {
-            transform: translateY(0);
-            transition-timing-function: ease-out;
-        }
     }
 }

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -1,5 +1,5 @@
 .informational-overlays {
-    .overlay-content {
+    .overlay-container {
         width: var(--informational-overlay-max-width);
         margin: 0 auto;
         position: relative;
@@ -96,7 +96,7 @@
 
 @media only screen and (width < $md_min) {
     .informational-overlays {
-        .overlay-content {
+        .overlay-container {
             width: calc(100% - 20px);
             /* Constrain to same width as in larger viewports. */
             max-width: var(--informational-overlay-max-width);

--- a/web/styles/message_edit_history.css
+++ b/web/styles/message_edit_history.css
@@ -67,3 +67,19 @@
         align-items: center;
     }
 }
+
+#message-history-overlay.overlay {
+    .overlay-container {
+        margin: 2.5vh auto;
+        transform: translateY(20px);
+        transition: transform 0.2s ease-in;
+        z-index: 102;
+    }
+
+    &.show {
+        .overlay-container {
+            transform: translateY(0);
+            transition-timing-function: ease-out;
+        }
+    }
+}

--- a/web/styles/message_edit_history.css
+++ b/web/styles/message_edit_history.css
@@ -71,15 +71,5 @@
 #message-history-overlay.overlay {
     .overlay-container {
         margin: 2.5vh auto;
-        transform: translateY(20px);
-        transition: transform 0.2s ease-in;
-        z-index: 102;
-    }
-
-    &.show {
-        .overlay-container {
-            transform: translateY(0);
-            transition-timing-function: ease-out;
-        }
     }
 }

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -439,7 +439,8 @@
 }
 
 .modal__body,
-.overlay-content {
+.overlay-content,
+.overlay-container {
     .dropdown-widget-button,
     .dropdown_widget_with_label_wrapper {
         width: var(--modal-input-width);

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -439,7 +439,6 @@
 }
 
 .modal__body,
-.overlay-content,
 .overlay-container {
     .dropdown-widget-button,
     .dropdown_widget_with_label_wrapper {

--- a/web/styles/scheduled_messages.css
+++ b/web/styles/scheduled_messages.css
@@ -13,16 +13,6 @@
 #scheduled_messages_overlay.overlay {
     .overlay-container {
         margin: 2.5vh auto;
-        transform: translateY(20px);
-        transition: transform 0.2s ease-in;
-        z-index: 102;
-    }
-
-    &.show {
-        .overlay-container {
-            transform: translateY(0);
-            transition-timing-function: ease-out;
-        }
     }
 }
 

--- a/web/styles/scheduled_messages.css
+++ b/web/styles/scheduled_messages.css
@@ -9,7 +9,8 @@
     }
 }
 
-#reminders-overlay.overlay {
+#reminders-overlay.overlay,
+#scheduled_messages_overlay.overlay {
     .overlay-container {
         margin: 2.5vh auto;
         transform: translateY(20px);

--- a/web/styles/scheduled_messages.css
+++ b/web/styles/scheduled_messages.css
@@ -9,6 +9,22 @@
     }
 }
 
+#reminders-overlay.overlay {
+    .overlay-container {
+        margin: 2.5vh auto;
+        transform: translateY(20px);
+        transition: transform 0.2s ease-in;
+        z-index: 102;
+    }
+
+    &.show {
+        .overlay-container {
+            transform: translateY(0);
+            transition-timing-function: ease-out;
+        }
+    }
+}
+
 #scheduled_message_indicator {
     display: block;
     margin-left: 10px;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1635,21 +1635,6 @@ label.preferences-radio-choice-label {
     }
 }
 
-#settings_page.overlay {
-    .overlay-container {
-        transform: translateY(20px);
-        transition: transform 0.2s ease-in;
-        z-index: 102;
-    }
-
-    &.show {
-        .overlay-container {
-            transform: translateY(0);
-            transition-timing-function: ease-out;
-        }
-    }
-}
-
 .time-limit-custom-input,
 .realm_jitsi_server_url_custom_input {
     padding: 4px 6px;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1413,7 +1413,7 @@ label.preferences-radio-choice-label {
 }
 
 /* -- new settings overlay -- */
-#settings_page {
+#settings_page .overlay-container {
     height: 95vh;
     width: 97vw;
     max-width: 73.1429em; /* 1024px at 14px em */
@@ -1632,6 +1632,21 @@ label.preferences-radio-choice-label {
 
     .preferences-settings-form select {
         width: var(--modal-input-width);
+    }
+}
+
+#settings_page.overlay {
+    .overlay-container {
+        transform: translateY(20px);
+        transition: transform 0.2s ease-in;
+        z-index: 102;
+    }
+
+    &.show {
+        .overlay-container {
+            transform: translateY(0);
+            transition-timing-function: ease-out;
+        }
     }
 }
 
@@ -1930,7 +1945,7 @@ label.preferences-radio-choice-label {
         --single-column: yes;
     }
 
-    #settings_page {
+    #settings_page .overlay-container {
         .settings-header.mobile {
             display: flex;
             justify-content: space-between;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1405,6 +1405,22 @@ div.settings-radio-input-parent {
     }
 }
 
+#subscription_overlay.overlay {
+    .overlay-container {
+        margin: 2.5vh auto;
+        transform: translateY(20px);
+        transition: transform 0.2s ease-in;
+        z-index: 102;
+    }
+
+    &.show {
+        .overlay-container {
+            transform: translateY(0);
+            transition-timing-function: ease-out;
+        }
+    }
+}
+
 #deactivation-confirm-modal {
     .alert {
         padding-right: 14px;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1409,16 +1409,6 @@ div.settings-radio-input-parent {
 #groups_overlay.overlay {
     .overlay-container {
         margin: 2.5vh auto;
-        transform: translateY(20px);
-        transition: transform 0.2s ease-in;
-        z-index: 102;
-    }
-
-    &.show {
-        .overlay-container {
-            transform: translateY(0);
-            transition-timing-function: ease-out;
-        }
     }
 }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1405,7 +1405,8 @@ div.settings-radio-input-parent {
     }
 }
 
-#subscription_overlay.overlay {
+#subscription_overlay.overlay,
+#groups_overlay.overlay {
     .overlay-container {
         margin: 2.5vh auto;
         transform: translateY(20px);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1546,21 +1546,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
     }
 }
 
-#about-zulip {
-    .overlay-container {
-        transform: translateY(20px);
-        transition: transform 0.2s ease-in;
-        z-index: 102;
-    }
-
-    &.show {
-        .overlay-container {
-            transform: translateY(0);
-            transition-timing-function: ease-out;
-        }
-    }
-}
-
 @media (width < $xl_min) or (height < $short_navbar_cutoff_height) {
     .spectator-view {
         #navbar-middle {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1519,7 +1519,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
         color: hsl(0deg 0% 67%);
     }
 
-    .overlay-content {
+    .overlay-container {
         width: 440px;
         border-radius: 4px;
     }
@@ -1543,6 +1543,21 @@ div.topic_edit_spinner .loading_indicator_spinner {
     .overlay-body {
         max-height: 60vh;
         padding: 15px;
+    }
+}
+
+#about-zulip {
+    .overlay-container {
+        transform: translateY(20px);
+        transition: transform 0.2s ease-in;
+        z-index: 102;
+    }
+
+    &.show {
+        .overlay-container {
+            transform: translateY(0);
+            transition-timing-function: ease-out;
+        }
     }
 }
 

--- a/web/templates/about_zulip.hbs
+++ b/web/templates/about_zulip.hbs
@@ -1,5 +1,5 @@
 <div id="about-zulip" class="overlay flex" tabindex="-1" role="dialog" data-overlay="about-zulip" aria-hidden="true">
-    <div class="overlay-content overlay-container">
+    <div class="overlay-container">
         <button type="button" class="exit" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <div class="overlay-body">
             <div class="about-zulip-logo">

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -1,34 +1,32 @@
 <div id="draft_overlay" class="overlay" data-overlay="drafts">
-    <div class="flex overlay-content">
-        <div class="drafts-container overlay-messages-container overlay-container">
-            <div class="overlay-messages-header">
-                <h1>{{t 'Drafts' }}</h1>
-                <div class="exit">
-                    <span class="exit-sign">&times;</span>
+    <div class="drafts-container overlay-messages-container overlay-container">
+        <div class="overlay-messages-header">
+            <h1>{{t 'Drafts' }}</h1>
+            <div class="exit">
+                <span class="exit-sign">&times;</span>
+            </div>
+            <div id="draft_overlay_banner_container" class="banner-container banner-wrapper"></div>
+            <div class="header-body">
+                <div class="drafts-header-note">
+                    <div class="overlay-keyboard-shortcuts">
+                        {{#tr}}
+                            To restore a draft, click on it or press <z-shortcut></z-shortcut>.
+                            {{#*inline "z-shortcut"}}{{popover_hotkey_hints "Enter"}}{{/inline}}
+                        {{/tr}}
+                    </div>
+                    <div>{{t "Drafts are not synced to other devices and browsers." }}</div>
                 </div>
-                <div id="draft_overlay_banner_container" class="banner-container banner-wrapper"></div>
-                <div class="header-body">
-                    <div class="drafts-header-note">
-                        <div class="overlay-keyboard-shortcuts">
-                            {{#tr}}
-                                To restore a draft, click on it or press <z-shortcut></z-shortcut>.
-                                {{#*inline "z-shortcut"}}{{popover_hotkey_hints "Enter"}}{{/inline}}
-                            {{/tr}}
-                        </div>
-                        <div>{{t "Drafts are not synced to other devices and browsers." }}</div>
+                <div class="delete-drafts-group">
+                    <div class="delete-selected-drafts-button-container">
+                        {{> ./components/icon_button intent="danger" custom_classes="delete-selected-drafts-button" icon="trash" disabled=true  }}
                     </div>
-                    <div class="delete-drafts-group">
-                        <div class="delete-selected-drafts-button-container">
-                            {{> ./components/icon_button intent="danger" custom_classes="delete-selected-drafts-button" icon="trash" disabled=true  }}
-                        </div>
-                        <button class="action-button action-button-quiet-neutral select-drafts-button" role="checkbox" aria-checked="false">
-                            <span>{{t "Select all drafts" }}</span>
-                            <i class="fa fa-square-o select-state-indicator" aria-hidden="true"></i>
-                        </button>
-                    </div>
+                    <button class="action-button action-button-quiet-neutral select-drafts-button" role="checkbox" aria-checked="false">
+                        <span>{{t "Select all drafts" }}</span>
+                        <i class="fa fa-square-o select-state-indicator" aria-hidden="true"></i>
+                    </button>
                 </div>
             </div>
-            {{> drafts_list context }}
         </div>
+        {{> drafts_list context }}
     </div>
 </div>

--- a/web/templates/message_history_overlay.hbs
+++ b/web/templates/message_history_overlay.hbs
@@ -1,29 +1,27 @@
 <div id="message-history-overlay" class="overlay" data-overlay="message_edit_history">
-    <div class="flex overlay-content">
-        <div class="message-edit-history-container overlay-messages-container overlay-container">
-            <div class="overlay-messages-header">
-                {{#if move_history_only}}
-                <h1>{{t "Message move history" }}</h1>
+    <div class="message-edit-history-container overlay-messages-container overlay-container">
+        <div class="overlay-messages-header">
+            {{#if move_history_only}}
+            <h1>{{t "Message move history" }}</h1>
+            {{else}}
+            {{#if edited}}
+                {{#if moved}}
+                <h1>{{t "Message edit and move history" }}</h1>
                 {{else}}
-                {{#if edited}}
-                    {{#if moved}}
-                    <h1>{{t "Message edit and move history" }}</h1>
-                    {{else}}
-                    <h1>{{t "Message edit history" }}</h1>
-                    {{/if}}
-                {{else if moved}}
-                    <h1>{{t "Message move history" }}</h1>
+                <h1>{{t "Message edit history" }}</h1>
                 {{/if}}
-                {{/if}}
-                <div class="exit">
-                    <span class="exit-sign">&times;</span>
-                </div>
+            {{else if moved}}
+                <h1>{{t "Message move history" }}</h1>
+            {{/if}}
+            {{/if}}
+            <div class="exit">
+                <span class="exit-sign">&times;</span>
             </div>
-            <div class="message-edit-history-list overlay-messages-list">
-            </div>
-            <div class="loading_indicator"></div>
-            <div id="message-history-error" class="alert">
-            </div>
+        </div>
+        <div class="message-edit-history-list overlay-messages-list">
+        </div>
+        <div class="loading_indicator"></div>
+        <div id="message-history-error" class="alert">
         </div>
     </div>
 </div>

--- a/web/templates/reminders_overlay.hbs
+++ b/web/templates/reminders_overlay.hbs
@@ -1,16 +1,14 @@
 <div id="reminders-overlay" class="overlay" data-overlay="reminders">
-    <div class="flex overlay-content">
-        <div class="overlay-messages-container overlay-container reminders-container">
-            <div class="overlay-messages-header">
-                <h1>{{t 'Scheduled reminders' }}</h1>
-                <div class="exit">
-                    <span class="exit-sign">&times;</span>
-                </div>
+    <div class="overlay-messages-container overlay-container reminders-container">
+        <div class="overlay-messages-header">
+            <h1>{{t 'Scheduled reminders' }}</h1>
+            <div class="exit">
+                <span class="exit-sign">&times;</span>
             </div>
-            <div class="reminders-list overlay-messages-list">
-                <div class="no-overlay-messages">
-                    {{t 'No reminders scheduled.'}}
-                </div>
+        </div>
+        <div class="reminders-list overlay-messages-list">
+            <div class="no-overlay-messages">
+                {{t 'No reminders scheduled.'}}
             </div>
         </div>
     </div>

--- a/web/templates/scheduled_messages_overlay.hbs
+++ b/web/templates/scheduled_messages_overlay.hbs
@@ -1,24 +1,22 @@
 <div id="scheduled_messages_overlay" class="overlay" data-overlay="scheduled">
-    <div class="flex overlay-content">
-        <div class="overlay-messages-container overlay-container scheduled-messages-container">
-            <div class="overlay-messages-header">
-                <h1>{{t 'Scheduled messages' }}</h1>
-                <div class="exit">
-                    <span class="exit-sign">&times;</span>
-                </div>
-                <div class="removed-drafts">
-                    <div class="overlay-keyboard-shortcuts">
-                        {{#tr}}
-                            To edit or reschedule a message, click on it or press <z-shortcut></z-shortcut>.
-                            {{#*inline "z-shortcut"}}{{popover_hotkey_hints "Enter"}}{{/inline}}
-                        {{/tr}}
-                    </div>
+    <div class="overlay-messages-container overlay-container scheduled-messages-container">
+        <div class="overlay-messages-header">
+            <h1>{{t 'Scheduled messages' }}</h1>
+            <div class="exit">
+                <span class="exit-sign">&times;</span>
+            </div>
+            <div class="removed-drafts">
+                <div class="overlay-keyboard-shortcuts">
+                    {{#tr}}
+                        To edit or reschedule a message, click on it or press <z-shortcut></z-shortcut>.
+                        {{#*inline "z-shortcut"}}{{popover_hotkey_hints "Enter"}}{{/inline}}
+                    {{/tr}}
                 </div>
             </div>
-            <div class="scheduled-messages-list overlay-messages-list">
-                <div class="no-overlay-messages">
-                    {{t 'No scheduled messages.'}}
-                </div>
+        </div>
+        <div class="scheduled-messages-list overlay-messages-list">
+            <div class="no-overlay-messages">
+                {{t 'No scheduled messages.'}}
             </div>
         </div>
     </div>

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -1,161 +1,163 @@
-<div id="settings_page" class="overlay-content overlay-container">
-    <div class="settings-header mobile">
-        <i class="fa fa-chevron-left" aria-hidden="true"></i>
-        <h1>{{t "Settings" }}<span class="section"></span></h1>
-        <div class="exit">
-            <span class="exit-sign">&times;</span>
-        </div>
-    </div>
-    <div class="sidebar-wrapper">
-        <div class="tab-container"></div>
-        <div class="sidebar left" data-simplebar data-simplebar-tab-index="-1">
-            <div class="sidebar-list dark-grey small-text">
-                <ul class="normal-settings-list">
-                    <li class="sidebar-item" tabindex="0" data-section="profile">
-                        <i class="sidebar-item-icon fa fa-user" aria-hidden="true"></i>
-                        <div class="text">{{t "Profile" }}</div>
-                    </li>
-                    <li class="sidebar-item" tabindex="0" data-section="account-and-privacy">
-                        <i class="sidebar-item-icon fa fa-lock" aria-hidden="true"></i>
-                        <div class="text">{{t "Account & privacy" }}</div>
-                    </li>
-                    <li class="sidebar-item" tabindex="0" data-section="preferences">
-                        <i class="sidebar-item-icon fa fa-sliders" aria-hidden="true"></i>
-                        <div class="text">{{t "Preferences" }}</div>
-                    </li>
-                    <li class="sidebar-item" tabindex="0" data-section="notifications">
-                        <i class="sidebar-item-icon fa fa-exclamation-triangle" aria-hidden="true"></i>
-                        <div class="text">{{t "Notifications" }}</div>
-                    </li>
-                    {{#unless is_guest}}
-                    <li class="sidebar-item" tabindex="0" data-section="your-bots">
-                        <i class="sidebar-item-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
-                        <div class="text">{{t "Bots" }}</div>
-                    </li>
-                    {{/unless}}
-                    <li class="sidebar-item" tabindex="0" data-section="alert-words">
-                        <i class="sidebar-item-icon fa fa-book" aria-hidden="true"></i>
-                        <div class="text">{{t "Alert words" }}</div>
-                    </li>
-                    {{#if show_uploaded_files_section}}
-                    <li class="sidebar-item" tabindex="0" data-section="uploaded-files">
-                        <i class="sidebar-item-icon fa fa-paperclip" aria-hidden="true"></i>
-                        <div class="text">{{t "Uploaded files" }}</div>
-                    </li>
-                    {{/if}}
-                    <li class="sidebar-item" tabindex="0" data-section="topics">
-                        <i class="sidebar-item-icon zulip-icon zulip-icon-topic" aria-hidden="true"></i>
-                        <div class="text">{{t "Topics" }}</div>
-                    </li>
-                    <li class="sidebar-item" tabindex="0" data-section="muted-users">
-                        <i class="sidebar-item-icon fa fa-eye-slash" aria-hidden="true"></i>
-                        <div class="text">{{t "Muted users" }}</div>
-                    </li>
-                </ul>
-
-                <ul class="org-settings-list">
-                    <li class="sidebar-item" tabindex="0" data-section="organization-profile">
-                        <i class="sidebar-item-icon fa fa-id-card" aria-hidden="true"></i>
-                        <div class="text">{{t "Organization profile" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    <li class="sidebar-item" class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-settings">
-                        <i class="sidebar-item-icon fa fa-sliders" aria-hidden="true"></i>
-                        <div class="text">{{t "Organization settings" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings' }}"></i>
-                    </li>
-                    <li class="sidebar-item" class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-permissions">
-                        <i class="sidebar-item-icon fa fa-lock" aria-hidden="true"></i>
-                        <div class="text">{{t "Organization permissions" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    <li class="sidebar-item" tabindex="0" data-section="emoji-settings">
-                        <i class="sidebar-item-icon fa fa-smile-o" aria-hidden="true"></i>
-                        <div class="text">{{t "Custom emoji" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#unless show_emoji_settings_lock}}style="display: none;"{{/unless}} data-tippy-content="{{t 'You do not have permission to add custom emoji.'}}"></i>
-                    </li>
-                    <li class="sidebar-item" tabindex="0" data-section="linkifier-settings">
-                        <i class="sidebar-item-icon fa fa-font" aria-hidden="true"></i>
-                        <div class="text">{{t "Linkifiers" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    <li class="sidebar-item" tabindex="0" data-section="playground-settings">
-                        <i class="sidebar-item-icon fa fa-external-link" aria-hidden="true"></i>
-                        <div class="text">{{t "Code playgrounds" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    {{#unless is_guest}}
-                    <li class="sidebar-item" tabindex="0" data-section="users">
-                        <i class="sidebar-item-icon fa fa-user" aria-hidden="true"></i>
-                        <div class="text">{{t "Users" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if can_edit_user_panel }}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    {{/unless}}
-                    {{#unless is_guest}}
-                    <li class="sidebar-item" tabindex="0" data-section="bot-list-admin">
-                        <i class="sidebar-item-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
-                        <div class="text">{{t "Bots" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if can_create_new_bots}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    {{/unless}}
-                    {{#if is_admin}}
-                    <li class="sidebar-item" tabindex="0" data-section="profile-field-settings">
-                        <i class="sidebar-item-icon fa fa-id-card" aria-hidden="true"></i>
-                        <div class="text">{{t "Custom profile fields" }}</div>
-                    </li>
-                    {{/if}}
-                    <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-level-user-defaults">
-                        <i class="sidebar-item-icon fa fa-cog" aria-hidden="true"></i>
-                        <div class="text">{{t "Default user settings" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="channel-folders">
-                        <i class="sidebar-item-icon zulip-icon zulip-icon-folder"></i>
-                        <div class="text">{{t "Channel folders" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    {{#unless is_guest}}
-                    <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="default-channels-list">
-                        <i class="sidebar-item-icon fa fa-exchange" aria-hidden="true"></i>
-                        <div class="text">{{t "Default channels" }}</div>
-                        {{#unless is_admin}}
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                        {{/unless}}
-                    </li>
-                    {{/unless}}
-                    <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="auth-methods">
-                        <i class="sidebar-item-icon fa fa-key" aria-hidden="true"></i>
-                        <div class="text">{{t "Authentication methods" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_owner}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization owners can edit these settings.' }}"></i>
-                    </li>
-                    {{#if is_admin}}
-                    <li class="sidebar-item" tabindex="0" data-section="data-exports-admin">
-                        <i class="sidebar-item-icon fa fa-database" aria-hidden="true"></i>
-                        <div class="text">{{t "Data exports" }}</div>
-                    </li>
-                    {{/if}}
-                    {{#unless is_admin}}
-                    <li class="sidebar-item collapse-settings-button">
-                        <i id='toggle_collapse_chevron' class='sidebar-item-icon fa fa-angle-double-down'></i>
-                        <div class="text" id='toggle_collapse'>{{t "Show more" }}</div>
-                    </li>
-                    {{/unless}}
-                </ul>
-            </div>
-        </div>
-    </div>
-    <div class="content-wrapper right">
-        <div class="settings-header">
+<div id="settings_page" class="overlay" data-overlay="settings" aria-hidden="true">
+    <div class="overlay-container">
+        <div class="settings-header mobile">
+            <i class="fa fa-chevron-left" aria-hidden="true"></i>
             <h1>{{t "Settings" }}<span class="section"></span></h1>
             <div class="exit">
                 <span class="exit-sign">&times;</span>
             </div>
         </div>
-        <div id="settings_content" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
-            <div class="organization-box organization">
+        <div class="sidebar-wrapper">
+            <div class="tab-container"></div>
+            <div class="sidebar left" data-simplebar data-simplebar-tab-index="-1">
+                <div class="sidebar-list dark-grey small-text">
+                    <ul class="normal-settings-list">
+                        <li class="sidebar-item" tabindex="0" data-section="profile">
+                            <i class="sidebar-item-icon fa fa-user" aria-hidden="true"></i>
+                            <div class="text">{{t "Profile" }}</div>
+                        </li>
+                        <li class="sidebar-item" tabindex="0" data-section="account-and-privacy">
+                            <i class="sidebar-item-icon fa fa-lock" aria-hidden="true"></i>
+                            <div class="text">{{t "Account & privacy" }}</div>
+                        </li>
+                        <li class="sidebar-item" tabindex="0" data-section="preferences">
+                            <i class="sidebar-item-icon fa fa-sliders" aria-hidden="true"></i>
+                            <div class="text">{{t "Preferences" }}</div>
+                        </li>
+                        <li class="sidebar-item" tabindex="0" data-section="notifications">
+                            <i class="sidebar-item-icon fa fa-exclamation-triangle" aria-hidden="true"></i>
+                            <div class="text">{{t "Notifications" }}</div>
+                        </li>
+                        {{#unless is_guest}}
+                        <li class="sidebar-item" tabindex="0" data-section="your-bots">
+                            <i class="sidebar-item-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
+                            <div class="text">{{t "Bots" }}</div>
+                        </li>
+                        {{/unless}}
+                        <li class="sidebar-item" tabindex="0" data-section="alert-words">
+                            <i class="sidebar-item-icon fa fa-book" aria-hidden="true"></i>
+                            <div class="text">{{t "Alert words" }}</div>
+                        </li>
+                        {{#if show_uploaded_files_section}}
+                        <li class="sidebar-item" tabindex="0" data-section="uploaded-files">
+                            <i class="sidebar-item-icon fa fa-paperclip" aria-hidden="true"></i>
+                            <div class="text">{{t "Uploaded files" }}</div>
+                        </li>
+                        {{/if}}
+                        <li class="sidebar-item" tabindex="0" data-section="topics">
+                            <i class="sidebar-item-icon zulip-icon zulip-icon-topic" aria-hidden="true"></i>
+                            <div class="text">{{t "Topics" }}</div>
+                        </li>
+                        <li class="sidebar-item" tabindex="0" data-section="muted-users">
+                            <i class="sidebar-item-icon fa fa-eye-slash" aria-hidden="true"></i>
+                            <div class="text">{{t "Muted users" }}</div>
+                        </li>
+                    </ul>
 
+                    <ul class="org-settings-list">
+                        <li class="sidebar-item" tabindex="0" data-section="organization-profile">
+                            <i class="sidebar-item-icon fa fa-id-card" aria-hidden="true"></i>
+                            <div class="text">{{t "Organization profile" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        <li class="sidebar-item" class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-settings">
+                            <i class="sidebar-item-icon fa fa-sliders" aria-hidden="true"></i>
+                            <div class="text">{{t "Organization settings" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings' }}"></i>
+                        </li>
+                        <li class="sidebar-item" class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-permissions">
+                            <i class="sidebar-item-icon fa fa-lock" aria-hidden="true"></i>
+                            <div class="text">{{t "Organization permissions" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        <li class="sidebar-item" tabindex="0" data-section="emoji-settings">
+                            <i class="sidebar-item-icon fa fa-smile-o" aria-hidden="true"></i>
+                            <div class="text">{{t "Custom emoji" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#unless show_emoji_settings_lock}}style="display: none;"{{/unless}} data-tippy-content="{{t 'You do not have permission to add custom emoji.'}}"></i>
+                        </li>
+                        <li class="sidebar-item" tabindex="0" data-section="linkifier-settings">
+                            <i class="sidebar-item-icon fa fa-font" aria-hidden="true"></i>
+                            <div class="text">{{t "Linkifiers" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        <li class="sidebar-item" tabindex="0" data-section="playground-settings">
+                            <i class="sidebar-item-icon fa fa-external-link" aria-hidden="true"></i>
+                            <div class="text">{{t "Code playgrounds" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        {{#unless is_guest}}
+                        <li class="sidebar-item" tabindex="0" data-section="users">
+                            <i class="sidebar-item-icon fa fa-user" aria-hidden="true"></i>
+                            <div class="text">{{t "Users" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if can_edit_user_panel }}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        {{/unless}}
+                        {{#unless is_guest}}
+                        <li class="sidebar-item" tabindex="0" data-section="bot-list-admin">
+                            <i class="sidebar-item-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
+                            <div class="text">{{t "Bots" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if can_create_new_bots}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        {{/unless}}
+                        {{#if is_admin}}
+                        <li class="sidebar-item" tabindex="0" data-section="profile-field-settings">
+                            <i class="sidebar-item-icon fa fa-id-card" aria-hidden="true"></i>
+                            <div class="text">{{t "Custom profile fields" }}</div>
+                        </li>
+                        {{/if}}
+                        <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-level-user-defaults">
+                            <i class="sidebar-item-icon fa fa-cog" aria-hidden="true"></i>
+                            <div class="text">{{t "Default user settings" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="channel-folders">
+                            <i class="sidebar-item-icon zulip-icon zulip-icon-folder"></i>
+                            <div class="text">{{t "Channel folders" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        {{#unless is_guest}}
+                        <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="default-channels-list">
+                            <i class="sidebar-item-icon fa fa-exchange" aria-hidden="true"></i>
+                            <div class="text">{{t "Default channels" }}</div>
+                            {{#unless is_admin}}
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                            {{/unless}}
+                        </li>
+                        {{/unless}}
+                        <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="auth-methods">
+                            <i class="sidebar-item-icon fa fa-key" aria-hidden="true"></i>
+                            <div class="text">{{t "Authentication methods" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_owner}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization owners can edit these settings.' }}"></i>
+                        </li>
+                        {{#if is_admin}}
+                        <li class="sidebar-item" tabindex="0" data-section="data-exports-admin">
+                            <i class="sidebar-item-icon fa fa-database" aria-hidden="true"></i>
+                            <div class="text">{{t "Data exports" }}</div>
+                        </li>
+                        {{/if}}
+                        {{#unless is_admin}}
+                        <li class="sidebar-item collapse-settings-button">
+                            <i id='toggle_collapse_chevron' class='sidebar-item-icon fa fa-angle-double-down'></i>
+                            <div class="text" id='toggle_collapse'>{{t "Show more" }}</div>
+                        </li>
+                        {{/unless}}
+                    </ul>
+                </div>
             </div>
-            <div class="settings-box">
+        </div>
+        <div class="content-wrapper right">
+            <div class="settings-header">
+                <h1>{{t "Settings" }}<span class="section"></span></h1>
+                <div class="exit">
+                    <span class="exit-sign">&times;</span>
+                </div>
+            </div>
+            <div id="settings_content" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+                <div class="organization-box organization">
+
+                </div>
+                <div class="settings-box">
+                </div>
             </div>
         </div>
     </div>

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -1,93 +1,91 @@
 <div id="subscription_overlay" class="overlay two-pane-settings-overlay" data-overlay="subscriptions">
-    <div class="flex overlay-content">
-        <div class="two-pane-settings-container overlay-container">
-            <div class="two-pane-settings-header">
-                <div class="fa fa-chevron-left"></div>
-                <span class="subscriptions-title">{{t 'Channels' }}</span>
-                <div class="exit">
-                    <span class="exit-sign">&times;</span>
-                </div>
+    <div class="two-pane-settings-container overlay-container">
+        <div class="two-pane-settings-header">
+            <div class="fa fa-chevron-left"></div>
+            <span class="subscriptions-title">{{t 'Channels' }}</span>
+            <div class="exit">
+                <span class="exit-sign">&times;</span>
             </div>
-            <div class="two-pane-settings-subheader">
-                <div class="left">
-                    <div class="list-toggler-container">
-                        <div id="add_new_subscription">
-                            {{#if can_create_streams}}
-                            <button class="create_stream_button two-pane-settings-plus-button tippy-zulip-delayed-tooltip" data-tooltip-template-id="create-new-stream-tooltip-template" data-tippy-placement="bottom">
-                                <i class="create_button_plus_sign zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
-                            </button>
-                            {{/if}}
-                            <div class="float-clear"></div>
-                        </div>
-                    </div>
-                </div>
-                <div class="right">
-                    <div class="display-type">
-                        <div id="stream_settings_title" class="stream-info-title">{{t 'Channel settings' }}</div>
-                    </div>
-                </div>
-            </div>
-            <div class="two-pane-settings-body">
-                <div class="left">
-                    <div class="input-append stream_name_search_section two-pane-settings-search" id="stream_filter">
-                        <input type="text" name="stream_name" id="search_stream_name" class="filter_text_input" autocomplete="off"
-                          placeholder="{{t 'Filter' }}" value=""/>
-                        <button type="button" class="clear_search_button" id="clear_search_stream_name">
-                            <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
+        </div>
+        <div class="two-pane-settings-subheader">
+            <div class="left">
+                <div class="list-toggler-container">
+                    <div id="add_new_subscription">
+                        {{#if can_create_streams}}
+                        <button class="create_stream_button two-pane-settings-plus-button tippy-zulip-delayed-tooltip" data-tooltip-template-id="create-new-stream-tooltip-template" data-tippy-placement="bottom">
+                            <i class="create_button_plus_sign zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
                         </button>
-                        <div class="stream_settings_filter_container {{#unless realm_has_archived_channels}}hide_filter{{/unless}}">
-                            {{> ../dropdown_widget widget_name="stream_settings_filter"}}
-                        </div>
-                    </div>
-                    <div class="no-streams-to-show">
-                        <div class="subscribed_streams_tab_empty_text">
-                            <span class="settings-empty-option-text">
-                                {{t 'You are not subscribed to any channels.'}}
-                                {{#if can_view_all_streams}}
-                                <a href="#channels/all">{{t 'View all channels'}}</a>
-                                {{/if}}
-                            </span>
-                        </div>
-                        <div class="not_subscribed_streams_tab_empty_text">
-                            <span class="settings-empty-option-text">
-                                {{t 'No channels to show.'}}
-                                <a href="#channels/all">{{t 'View all channels'}}</a>
-                            </span>
-                        </div>
-                        <div class="no_stream_match_filter_empty_text">
-                            <span class="settings-empty-option-text">
-                                {{t 'No channels match your filter.'}}
-                            </span>
-                        </div>
-                        <div class="all_streams_tab_empty_text">
-                            <span class="settings-empty-option-text">
-                                {{t 'There are no channels you can view in this organization.'}}
-                                {{#if can_create_streams}}
-                                    <a href="#channels/new">{{t 'Create a channel'}}</a>
-                                {{/if}}
-                            </span>
-                        </div>
-                    </div>
-                    <div class="streams-list two-pane-settings-left-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
+                        {{/if}}
+                        <div class="float-clear"></div>
                     </div>
                 </div>
-                <div class="right">
-                    <div class="nothing-selected">
-                        <div class="stream-info-banner banner-wrapper"></div>
-                        <div class="create-stream-button-container">
-                            <button type="button" class="create_stream_button animated-purple-button" {{#unless can_create_streams}}disabled{{/unless}}>{{t 'Create channel' }}</button>
-                            {{#unless can_create_streams}}
-                            <span class="settings-empty-option-text">
-                                {{t 'You do not have permission to create channels.' }}
-                            </span>
-                            {{/unless}}
-                        </div>
-                    </div>
-                    <div id="stream_settings" class="two-pane-settings-right-simplebar-container settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
-                        {{!-- edit stream here --}}
-                    </div>
-                    {{> stream_creation_form . }}
+            </div>
+            <div class="right">
+                <div class="display-type">
+                    <div id="stream_settings_title" class="stream-info-title">{{t 'Channel settings' }}</div>
                 </div>
+            </div>
+        </div>
+        <div class="two-pane-settings-body">
+            <div class="left">
+                <div class="input-append stream_name_search_section two-pane-settings-search" id="stream_filter">
+                    <input type="text" name="stream_name" id="search_stream_name" class="filter_text_input" autocomplete="off"
+                      placeholder="{{t 'Filter' }}" value=""/>
+                    <button type="button" class="clear_search_button" id="clear_search_stream_name">
+                        <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
+                    </button>
+                    <div class="stream_settings_filter_container {{#unless realm_has_archived_channels}}hide_filter{{/unless}}">
+                        {{> ../dropdown_widget widget_name="stream_settings_filter"}}
+                    </div>
+                </div>
+                <div class="no-streams-to-show">
+                    <div class="subscribed_streams_tab_empty_text">
+                        <span class="settings-empty-option-text">
+                            {{t 'You are not subscribed to any channels.'}}
+                            {{#if can_view_all_streams}}
+                            <a href="#channels/all">{{t 'View all channels'}}</a>
+                            {{/if}}
+                        </span>
+                    </div>
+                    <div class="not_subscribed_streams_tab_empty_text">
+                        <span class="settings-empty-option-text">
+                            {{t 'No channels to show.'}}
+                            <a href="#channels/all">{{t 'View all channels'}}</a>
+                        </span>
+                    </div>
+                    <div class="no_stream_match_filter_empty_text">
+                        <span class="settings-empty-option-text">
+                            {{t 'No channels match your filter.'}}
+                        </span>
+                    </div>
+                    <div class="all_streams_tab_empty_text">
+                        <span class="settings-empty-option-text">
+                            {{t 'There are no channels you can view in this organization.'}}
+                            {{#if can_create_streams}}
+                                <a href="#channels/new">{{t 'Create a channel'}}</a>
+                            {{/if}}
+                        </span>
+                    </div>
+                </div>
+                <div class="streams-list two-pane-settings-left-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
+                </div>
+            </div>
+            <div class="right">
+                <div class="nothing-selected">
+                    <div class="stream-info-banner banner-wrapper"></div>
+                    <div class="create-stream-button-container">
+                        <button type="button" class="create_stream_button animated-purple-button" {{#unless can_create_streams}}disabled{{/unless}}>{{t 'Create channel' }}</button>
+                        {{#unless can_create_streams}}
+                        <span class="settings-empty-option-text">
+                            {{t 'You do not have permission to create channels.' }}
+                        </span>
+                        {{/unless}}
+                    </div>
+                </div>
+                <div id="stream_settings" class="two-pane-settings-right-simplebar-container settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+                    {{!-- edit stream here --}}
+                </div>
+                {{> stream_creation_form . }}
             </div>
         </div>
     </div>

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -1,67 +1,65 @@
 <div id="groups_overlay" class="two-pane-settings-overlay overlay" data-overlay="group_subscriptions">
-    <div class="flex overlay-content">
-        <div class="two-pane-settings-container overlay-container">
-            <div class="two-pane-settings-header">
-                <div class="fa fa-chevron-left"></div>
-                <span class="user-groups-title">{{t 'User groups' }}</span>
-                <div class="exit">
-                    <span class="exit-sign">&times;</span>
-                </div>
+    <div class="two-pane-settings-container overlay-container">
+        <div class="two-pane-settings-header">
+            <div class="fa fa-chevron-left"></div>
+            <span class="user-groups-title">{{t 'User groups' }}</span>
+            <div class="exit">
+                <span class="exit-sign">&times;</span>
             </div>
-            <div class="two-pane-settings-subheader">
-                <div class="left">
-                    <div class="list-toggler-container">
-                        <div id="add_new_user_group">
-                            <button class="create_user_group_button two-pane-settings-plus-button">
-                                <i class="create_button_plus_sign zulip-icon zulip-icon-user-group-plus" aria-hidden="true"></i>
-                            </button>
-                            <div class="float-clear"></div>
-                        </div>
-                    </div>
-                </div>
-                <div class="right">
-                    <div class="display-type">
-                        <div id="user_group_settings_title" class="user-group-info-title">{{t 'User group settings' }}</div>
-                        <i class="fa fa-ban deactivated-user-icon deactivated-user-group-icon-right"></i>
-                    </div>
-                </div>
-            </div>
-            <div class="two-pane-settings-body">
-                <div class="left">
-                    <div class="input-append group_name_search_section two-pane-settings-search" id="group_filter">
-                        <input type="text" name="group_name" id="search_group_name" class="filter_text_input" autocomplete="off"
-                          placeholder="{{t 'Filter' }}" value=""/>
-                        <button type="button" class="clear_search_button" id="clear_search_group_name">
-                            <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
+        </div>
+        <div class="two-pane-settings-subheader">
+            <div class="left">
+                <div class="list-toggler-container">
+                    <div id="add_new_user_group">
+                        <button class="create_user_group_button two-pane-settings-plus-button">
+                            <i class="create_button_plus_sign zulip-icon zulip-icon-user-group-plus" aria-hidden="true"></i>
                         </button>
-                        <span>
-                            <label class="checkbox" id="user-group-edit-filter-options">
-                                {{> ../dropdown_widget widget_name="user_group_visibility_settings"}}
-                            </label>
+                        <div class="float-clear"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="right">
+                <div class="display-type">
+                    <div id="user_group_settings_title" class="user-group-info-title">{{t 'User group settings' }}</div>
+                    <i class="fa fa-ban deactivated-user-icon deactivated-user-group-icon-right"></i>
+                </div>
+            </div>
+        </div>
+        <div class="two-pane-settings-body">
+            <div class="left">
+                <div class="input-append group_name_search_section two-pane-settings-search" id="group_filter">
+                    <input type="text" name="group_name" id="search_group_name" class="filter_text_input" autocomplete="off"
+                      placeholder="{{t 'Filter' }}" value=""/>
+                    <button type="button" class="clear_search_button" id="clear_search_group_name">
+                        <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
+                    </button>
+                    <span>
+                        <label class="checkbox" id="user-group-edit-filter-options">
+                            {{> ../dropdown_widget widget_name="user_group_visibility_settings"}}
+                        </label>
+                    </span>
+                </div>
+                <div class="no-groups-to-show">
+                </div>
+                <div class="user-groups-list-wrapper two-pane-settings-left-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
+                    <div class="user-groups-list"></div>
+                </div>
+            </div>
+            <div class="right">
+                <div class="nothing-selected">
+                    <div class="group-info-banner banner-wrapper"></div>
+                    <div class="create-group-button-container">
+                        {{> ../settings/upgrade_tip_widget . }}
+                        <button type="button" class="create_user_group_button animated-purple-button">{{t 'Create user group' }}</button>
+                        <span class="settings-empty-option-text creation-permission-text">
+                            {{t 'You do not have permission to create user groups.' }}
                         </span>
                     </div>
-                    <div class="no-groups-to-show">
-                    </div>
-                    <div class="user-groups-list-wrapper two-pane-settings-left-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
-                        <div class="user-groups-list"></div>
-                    </div>
                 </div>
-                <div class="right">
-                    <div class="nothing-selected">
-                        <div class="group-info-banner banner-wrapper"></div>
-                        <div class="create-group-button-container">
-                            {{> ../settings/upgrade_tip_widget . }}
-                            <button type="button" class="create_user_group_button animated-purple-button">{{t 'Create user group' }}</button>
-                            <span class="settings-empty-option-text creation-permission-text">
-                                {{t 'You do not have permission to create user groups.' }}
-                            </span>
-                        </div>
-                    </div>
-                    <div id="user_group_settings" class="two-pane-settings-right-simplebar-container settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
-                        {{!-- edit user group here --}}
-                    </div>
-                    {{> user_group_creation_form . }}
+                <div id="user_group_settings" class="two-pane-settings-right-simplebar-container settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+                    {{!-- edit user group here --}}
                 </div>
+                {{> user_group_creation_form . }}
             </div>
         </div>
     </div>


### PR DESCRIPTION
When `select` dropdown is open, click events outside `<select>` is registered to common parent node of `<select>` and `<select>` element on which user click. This led to overlay exiting sometimes.

This commit fixes this behaviour by making sure we don't close the overlay if the click was on overlay-container or inside it.

Fixes: zulip#33464.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**Before:**

[Screencast from 2025-07-07 00-59-56.webm](https://github.com/user-attachments/assets/e89a7650-5fb7-4906-9eeb-82d56725c528)

**After:**

[Screencast from 2025-07-07 00-59-12.webm](https://github.com/user-attachments/assets/d5f01c3b-8804-434d-bf6a-f2ead793a0fa)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>