### PR TITLE
subscription_info: Send recently active users with partial_subscribers.

### DIFF
--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -32,12 +32,12 @@ export function rewire_max_size_before_shrinking(value: typeof max_size_before_s
     max_size_before_shrinking = value;
 }
 
-export let max_channel_size_to_show_all_subscribers = 75;
+export let MAX_CHANNEL_SIZE_TO_SHOW_ALL_SUBSCRIBERS = 75;
 
-export function rewire_max_channel_size_to_show_all_subscribers(
-    value: typeof max_channel_size_to_show_all_subscribers,
+export function rewire_MAX_CHANNEL_SIZE_TO_SHOW_ALL_SUBSCRIBERS(
+    value: typeof MAX_CHANNEL_SIZE_TO_SHOW_ALL_SUBSCRIBERS,
 ): void {
-    max_channel_size_to_show_all_subscribers = value;
+    MAX_CHANNEL_SIZE_TO_SHOW_ALL_SUBSCRIBERS = value;
 }
 
 let is_searching_users = false;
@@ -365,7 +365,7 @@ function maybe_shrink_list(
     const stream_id = narrow_state.stream_id(narrow_state.filter(), true);
     const filter_by_stream_id =
         stream_id &&
-        peer_data.get_subscriber_count(stream_id) <= max_channel_size_to_show_all_subscribers;
+        peer_data.get_subscriber_count(stream_id) <= MAX_CHANNEL_SIZE_TO_SHOW_ALL_SUBSCRIBERS;
 
     user_ids = user_ids.filter(
         (user_id) =>
@@ -454,7 +454,7 @@ function get_filtered_user_id_list(
         const stream_id = narrow_state.stream_id(narrow_state.filter(), true);
         if (stream_id) {
             const subscribers = peer_data.get_subscribers(stream_id);
-            if (subscribers.length <= max_channel_size_to_show_all_subscribers) {
+            if (subscribers.length <= MAX_CHANNEL_SIZE_TO_SHOW_ALL_SUBSCRIBERS) {
                 const base_user_id_set = new Set([...base_user_id_list, ...subscribers]);
                 base_user_id_list = [...base_user_id_set];
             }

--- a/web/tests/buddy_data.test.cjs
+++ b/web/tests/buddy_data.test.cjs
@@ -435,7 +435,7 @@ test("show offline channel subscribers for small channels", ({override_rewire}) 
     ]);
 
     // Make the max channel size lower, so that we hide the offline users
-    override_rewire(buddy_data, "max_channel_size_to_show_all_subscribers", 2);
+    override_rewire(buddy_data, "MAX_CHANNEL_SIZE_TO_SHOW_ALL_SUBSCRIBERS", 2);
     assert.deepEqual(buddy_data.get_filtered_and_sorted_user_ids(""), [me.user_id, alice.user_id]);
 });
 


### PR DESCRIPTION
Work towards https://github.com/zulip/zulip/issues/34244, setting up the partial subscriber data to more accurately fill in the users we show in the buddy list.

This is a draft because I haven't written backend code for Zulip for a while and wanted to put up what I have so far to see if it seems right.

Unit tests to come!