### PR TITLE
drafts: Migrate web app data structures to use a list of user IDs, not API emails, for private_message_recipient

### DIFF
--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -49,7 +49,9 @@ export const pm_recipient = {
     },
 
     async expect(page: Page, expected: string): Promise<void> {
-        const actual_recipients = await page.evaluate(() => zulip_test.private_message_recipient());
+        const actual_recipients = await page.evaluate(() =>
+            zulip_test.private_message_recipient_emails(),
+        );
         assert.equal(actual_recipients, expected);
     },
 };

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -93,7 +93,7 @@ export function create_message_object(message_content = compose_state.message_co
 
     if (message.type === "private") {
         // TODO: this should be collapsed with the code in composebox_typeahead.ts
-        const recipient = compose_state.private_message_recipient();
+        const recipient = compose_state.private_message_recipient_emails();
         const emails = util.extract_pm_recipients(recipient);
         message.to = emails;
         message.reply_to = recipient;

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -22,7 +22,6 @@ import type {ShowMessageViewOpts} from "./message_view.ts";
 import * as message_viewport from "./message_viewport.ts";
 import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
-import * as people from "./people.ts";
 import * as popovers from "./popovers.ts";
 import * as reload_state from "./reload_state.ts";
 import * as resize from "./resize.ts";
@@ -101,8 +100,7 @@ function show_compose_box(opts: ComposeActionsOpts): void {
         opts_by_message_type = {
             trigger: opts.trigger,
             message_type: "private",
-            private_message_recipient:
-                people.user_ids_to_emails_string(opts.private_message_recipient_ids) ?? "",
+            private_message_recipient_ids: opts.private_message_recipient_ids,
         };
     } else {
         opts_by_message_type = {

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -272,7 +272,8 @@ function same_recipient_as_before(opts: ComposeActionsOpts): boolean {
             opts.stream_id === compose_state.stream_id() &&
             opts.topic === compose_state.topic()) ||
             (opts.message_type === "private" &&
-                opts.private_message_recipient === compose_state.private_message_recipient()))
+                opts.private_message_recipient ===
+                    compose_state.private_message_recipient_emails()))
     );
 }
 
@@ -361,7 +362,7 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
     compose_recipient.update_topic_displayed_text(opts.topic);
 
     // Set the recipients with a space after each comma, so it looks nice.
-    compose_state.private_message_recipient(
+    compose_state.private_message_recipient_emails(
         opts.private_message_recipient.replaceAll(/,\s*/g, ", "),
     );
 

--- a/web/src/compose_fade.ts
+++ b/web/src/compose_fade.ts
@@ -34,7 +34,9 @@ export function set_focused_recipient(msg_type?: "private" | "stream"): void {
     } else if (msg_type === "private") {
         // Normalize the recipient list so it matches the one used when
         // adding the message (see message_helper.process_new_message()).
-        const reply_to = util.normalize_recipients(compose_state.private_message_recipient());
+        const reply_to = util.normalize_recipients(
+            compose_state.private_message_recipient_emails(),
+        );
         const to_user_ids = people.reply_to_to_user_ids_string(reply_to);
         focused_recipient = {
             type: msg_type,
@@ -83,7 +85,7 @@ function fade_messages(): void {
             if (
                 message_lists.current !== expected_msg_list ||
                 !compose_state.composing() ||
-                compose_state.private_message_recipient() !== expected_recipient
+                compose_state.private_message_recipient_emails() !== expected_recipient
             ) {
                 return;
             }
@@ -101,7 +103,7 @@ function fade_messages(): void {
         },
         0,
         message_lists.current,
-        compose_state.private_message_recipient(),
+        compose_state.private_message_recipient_emails(),
     );
 }
 

--- a/web/src/compose_pm_pill.ts
+++ b/web/src/compose_pm_pill.ts
@@ -69,6 +69,17 @@ export function set_from_emails(value: string): void {
     widget.appendValue(value);
 }
 
+export function set_from_user_ids(value: number[]): void {
+    clear();
+    for (const user_id of value) {
+        const person = people.get_by_user_id(user_id);
+        user_pill.append_person({
+            pill_widget: widget,
+            person,
+        });
+    }
+}
+
 export function get_user_ids(): number[] {
     return user_pill.get_user_ids(widget);
 }

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -72,9 +72,9 @@ export let update_narrow_to_recipient_visibility = (): void => {
             return;
         }
     } else if (message_type === "private") {
-        const recipients = compose_state.private_message_recipient_emails();
+        const recipients = compose_state.private_message_recipient_ids();
         if (
-            recipients &&
+            recipients.length > 0 &&
             !composing_to_current_private_message_narrow() &&
             compose_state.has_full_recipient()
         ) {
@@ -287,7 +287,7 @@ function on_hidden_callback(): void {
         // after updating the stream.
         ui_util.place_caret_at_end(util.the($("input#stream_message_recipient_topic")));
     } else {
-        if (compose_state.private_message_recipient_emails().length === 0) {
+        if (compose_state.private_message_recipient_ids().length === 0) {
             $("#private_message_recipient").trigger("focus").trigger("select");
         } else {
             $("textarea#compose-textarea").trigger("focus");

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -37,25 +37,12 @@ function composing_to_current_topic_narrow(): boolean {
 }
 
 function composing_to_current_private_message_narrow(): boolean {
-    const compose_state_recipient = compose_state.private_message_recipient_emails();
-    const narrow_state_recipient = narrow_state.pm_emails_string();
-    if (narrow_state_recipient === undefined) {
+    const compose_state_recipient = new Set(compose_state.private_message_recipient_ids());
+    const narrow_state_recipient = narrow_state.pm_ids_set();
+    if (narrow_state_recipient.size === 0) {
         return false;
     }
-    return (
-        Boolean(compose_state_recipient) &&
-        Boolean(narrow_state_recipient) &&
-        _.isEqual(
-            compose_state_recipient
-                .split(",")
-                .map((s) => s.trim())
-                .sort(),
-            narrow_state_recipient
-                .split(",")
-                .map((s) => s.trim())
-                .sort(),
-        )
-    );
+    return _.isEqual(narrow_state_recipient, compose_state_recipient);
 }
 
 export let update_narrow_to_recipient_visibility = (): void => {

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -37,7 +37,7 @@ function composing_to_current_topic_narrow(): boolean {
 }
 
 function composing_to_current_private_message_narrow(): boolean {
-    const compose_state_recipient = compose_state.private_message_recipient();
+    const compose_state_recipient = compose_state.private_message_recipient_emails();
     const narrow_state_recipient = narrow_state.pm_emails_string();
     if (narrow_state_recipient === undefined) {
         return false;
@@ -72,7 +72,7 @@ export let update_narrow_to_recipient_visibility = (): void => {
             return;
         }
     } else if (message_type === "private") {
-        const recipients = compose_state.private_message_recipient();
+        const recipients = compose_state.private_message_recipient_emails();
         if (
             recipients &&
             !composing_to_current_private_message_narrow() &&
@@ -152,7 +152,7 @@ function switch_message_type(message_type: MessageType): void {
         trigger: "switch_message_type",
         stream_id: compose_state.stream_id()!,
         topic: compose_state.topic(),
-        private_message_recipient: compose_state.private_message_recipient(),
+        private_message_recipient: compose_state.private_message_recipient_emails(),
     };
     update_compose_for_message_type(opts);
     update_compose_area_placeholder_text();
@@ -287,7 +287,7 @@ function on_hidden_callback(): void {
         // after updating the stream.
         ui_util.place_caret_at_end(util.the($("input#stream_message_recipient_topic")));
     } else {
-        if (compose_state.private_message_recipient().length === 0) {
+        if (compose_state.private_message_recipient_emails().length === 0) {
             $("#private_message_recipient").trigger("focus").trigger("select");
         } else {
             $("textarea#compose-textarea").trigger("focus");

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -152,7 +152,7 @@ function switch_message_type(message_type: MessageType): void {
         trigger: "switch_message_type",
         stream_id: compose_state.stream_id()!,
         topic: compose_state.topic(),
-        private_message_recipient: compose_state.private_message_recipient_emails(),
+        private_message_recipient_ids: compose_state.private_message_recipient_ids(),
     };
     update_compose_for_message_type(opts);
     update_compose_area_placeholder_text();

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -127,7 +127,7 @@ export let respond_to_message = (opts: {
 
     let stream_id: number | undefined;
     let topic = "";
-    let pm_recipient: string | undefined = "";
+    let private_message_recipient_ids: number[] | undefined;
     if (msg_type === "stream") {
         assert(message.type === "stream");
         stream_id = message.stream_id;
@@ -136,16 +136,16 @@ export let respond_to_message = (opts: {
         // reply_to for direct messages is everyone involved, so for
         // personals replies we need to set the direct message
         // recipient to just the sender
-        pm_recipient = people.get_by_user_id(message.sender_id).email;
+        private_message_recipient_ids = [message.sender_id];
     } else {
-        pm_recipient = people.pm_reply_to(message);
+        private_message_recipient_ids = people.pm_with_user_ids(message);
     }
 
     compose_actions.start({
         message_type: msg_type,
         stream_id,
         topic,
-        ...(pm_recipient !== undefined && {private_message_recipient: pm_recipient}),
+        ...(private_message_recipient_ids !== undefined && {private_message_recipient_ids}),
         ...(opts.trigger !== undefined && {trigger: opts.trigger}),
         is_reply: true,
         keep_composebox_empty: opts.keep_composebox_empty,
@@ -263,7 +263,7 @@ export function quote_message(opts: {
             keep_composebox_empty: opts.keep_composebox_empty,
             content: quoting_placeholder,
             stream_id,
-            private_message_recipient: people.pm_reply_to(message) ?? "",
+            private_message_recipient_ids: people.pm_with_user_ids(message) ?? [],
         });
         compose_recipient.toggle_compose_recipient_dropdown();
     } else {

--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -215,7 +215,7 @@ export function focus_in_empty_compose(
     // Check whether the current input element is empty for each input type.
     switch (focused_element_id) {
         case "private_message_recipient":
-            return private_message_recipient_emails().length === 0;
+            return private_message_recipient_ids().length === 0;
         case "stream_message_recipient_topic":
             return topic() === "";
         case "compose_select_recipient_widget_wrapper":
@@ -263,7 +263,7 @@ export function has_full_recipient(): boolean {
         const has_topic = topic() !== "" || !realm.realm_mandatory_topics;
         return stream_id() !== undefined && has_topic;
     }
-    return private_message_recipient_emails() !== "";
+    return private_message_recipient_ids().length > 0;
 }
 
 export function update_email(user_id: number, new_email: string): void {

--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -215,7 +215,7 @@ export function focus_in_empty_compose(
     // Check whether the current input element is empty for each input type.
     switch (focused_element_id) {
         case "private_message_recipient":
-            return private_message_recipient().length === 0;
+            return private_message_recipient_emails().length === 0;
         case "stream_message_recipient_topic":
             return topic() === "";
         case "compose_select_recipient_widget_wrapper":
@@ -225,9 +225,9 @@ export function focus_in_empty_compose(
     return false;
 }
 
-export function private_message_recipient(): string;
-export function private_message_recipient(value: string): undefined;
-export function private_message_recipient(value?: string): string | undefined {
+export function private_message_recipient_emails(): string;
+export function private_message_recipient_emails(value: string): undefined;
+export function private_message_recipient_emails(value?: string): string | undefined {
     if (typeof value === "string") {
         compose_pm_pill.set_from_emails(value);
         return undefined;
@@ -253,11 +253,11 @@ export function has_full_recipient(): boolean {
         const has_topic = topic() !== "" || !realm.realm_mandatory_topics;
         return stream_id() !== undefined && has_topic;
     }
-    return private_message_recipient() !== "";
+    return private_message_recipient_emails() !== "";
 }
 
 export function update_email(user_id: number, new_email: string): void {
-    let reply_to = private_message_recipient();
+    let reply_to = private_message_recipient_emails();
 
     if (!reply_to) {
         return;
@@ -265,7 +265,7 @@ export function update_email(user_id: number, new_email: string): void {
 
     reply_to = people.update_email_in_reply_to(reply_to, user_id, new_email);
 
-    private_message_recipient(reply_to);
+    private_message_recipient_emails(reply_to);
 }
 
 let _can_restore_drafts = true;

--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -235,6 +235,16 @@ export function private_message_recipient_emails(value?: string): string | undef
     return compose_pm_pill.get_emails();
 }
 
+export function private_message_recipient_ids(): number[];
+export function private_message_recipient_ids(value: number[]): undefined;
+export function private_message_recipient_ids(value?: number[]): number[] | undefined {
+    if (value === undefined) {
+        return compose_pm_pill.get_user_ids();
+    }
+    compose_pm_pill.set_from_user_ids(value);
+    return undefined;
+}
+
 export function has_message_content(): boolean {
     return message_content() !== "";
 }

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -43,7 +43,7 @@ export type ComposeTriggeredOptions = {
       }
     | {
           message_type: "private";
-          private_message_recipient: string;
+          private_message_recipient_ids: number[];
       }
 );
 export type ComposePlaceholderOptions =
@@ -212,7 +212,7 @@ function get_focus_area(opts: ComposeTriggeredOptions): string {
         return "input#stream_message_recipient_topic";
     } else if (
         (opts.message_type === "stream" && opts.stream_id !== undefined) ||
-        (opts.message_type === "private" && opts.private_message_recipient)
+        (opts.message_type === "private" && opts.private_message_recipient_ids.length > 0)
     ) {
         if (opts.trigger === "clear topic button" || opts.trigger === "compose_hotkey") {
             return "input#stream_message_recipient_topic";

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -904,8 +904,7 @@ function validate_private_message(show_banner = true): boolean {
     const user_ids = compose_pm_pill.get_user_ids();
     const user_ids_string = util.sorted_ids(user_ids).join(",");
     const $banner_container = $("#compose_banners");
-    const missing_direct_message_recipient =
-        compose_state.private_message_recipient_emails().length === 0;
+    const missing_direct_message_recipient = user_ids.length === 0;
 
     if (missing_direct_message_recipient) {
         report_validation_error(

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -904,7 +904,8 @@ function validate_private_message(show_banner = true): boolean {
     const user_ids = compose_pm_pill.get_user_ids();
     const user_ids_string = util.sorted_ids(user_ids).join(",");
     const $banner_container = $("#compose_banners");
-    const missing_direct_message_recipient = compose_state.private_message_recipient().length === 0;
+    const missing_direct_message_recipient =
+        compose_state.private_message_recipient_emails().length === 0;
 
     if (missing_direct_message_recipient) {
         report_validation_error(

--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -676,15 +676,10 @@ export function format_draft(draft: LocalStorageDraftWithId): FormattedDraft | u
         };
     }
 
-    let is_dm_with_self = false;
-    const user_ids = draft.private_message_recipient_ids;
-    if (user_ids.length === 1) {
-        const user = people.get_by_user_id(user_ids[0]!);
-        if (user && people.is_direct_message_conversation_with_self([user.user_id])) {
-            is_dm_with_self = true;
-        }
-    }
-    const recipients = people.user_ids_to_full_names_string(user_ids);
+    const is_dm_with_self = people.is_direct_message_conversation_with_self(
+        draft.private_message_recipient_ids,
+    );
+    const recipients = people.user_ids_to_full_names_string(draft.private_message_recipient_ids);
     return {
         draft_id: draft.id,
         is_stream: false,

--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -314,7 +314,7 @@ export function snapshot_message(): LocalStorageDraft | undefined {
         updatedAt: getTimestamp(),
     };
     if (message.type === "private") {
-        const recipient = compose_state.private_message_recipient();
+        const recipient = compose_state.private_message_recipient_emails();
         return {
             ...message,
             type: "private",
@@ -484,7 +484,7 @@ export function current_recipient_data(): {
         return {
             stream_name: undefined,
             topic: undefined,
-            private_recipients: compose_state.private_message_recipient(),
+            private_recipients: compose_state.private_message_recipient_emails(),
         };
     }
     return {

--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -45,8 +45,10 @@ function restore_draft(draft_id: string): void {
             );
         }
     } else {
-        if (compose_args.private_message_recipient !== "") {
-            message_view.show([{operator: "dm", operand: compose_args.private_message_recipient}], {
+        if (compose_args.private_message_recipient_ids.length > 0) {
+            const private_message_recipient_emails =
+                people.user_ids_to_emails_string(compose_args.private_message_recipient_ids) ?? "";
+            message_view.show([{operator: "dm", operand: private_message_recipient_emails}], {
                 trigger: "restore draft",
             });
         }
@@ -148,10 +150,10 @@ export function launch(): void {
     }
 
     function get_header_for_narrow_drafts(): string {
-        const {stream_name, topic, private_recipients} = drafts.current_recipient_data();
-        if (private_recipients) {
-            if (!private_recipients.includes(",")) {
-                const user = people.get_by_email(private_recipients);
+        const {stream_name, topic, private_recipient_ids} = drafts.current_recipient_data();
+        if (private_recipient_ids && private_recipient_ids.length > 0) {
+            if (private_recipient_ids.length === 1) {
+                const user = people.get_by_user_id(private_recipient_ids[0]!);
                 if (user && people.is_direct_message_conversation_with_self([user.user_id])) {
                     return $t({defaultMessage: "Drafts from conversation with yourself"});
                 }
@@ -159,7 +161,7 @@ export function launch(): void {
             return $t(
                 {defaultMessage: "Drafts from conversation with {recipient}"},
                 {
-                    recipient: people.emails_to_full_names_string(private_recipients.split(",")),
+                    recipient: people.user_ids_to_full_names_string(private_recipient_ids),
                 },
             );
         }

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1463,7 +1463,7 @@ export function to_compose_target(): void {
     }
 
     if (compose_state.get_message_type() === "private") {
-        const recipient_string = compose_state.private_message_recipient();
+        const recipient_string = compose_state.private_message_recipient_emails();
         const emails = util.extract_pm_recipients(recipient_string);
         const invalid = emails.filter((email) => !people.is_valid_email_for_compose(email));
         // If there are no recipients or any recipient is

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -102,9 +102,9 @@ function collect_single(terms: NarrowTerm[]): Map<string, string> {
 export function set_compose_defaults(): {
     stream_id?: number;
     topic?: string;
-    private_message_recipient?: string;
+    private_message_recipient_ids?: number[];
 } {
-    const opts: {stream_id?: number; topic?: string; private_message_recipient?: string} = {};
+    const opts: {stream_id?: number; topic?: string; private_message_recipient_ids?: number[]} = {};
     const single = collect_single(search_terms());
 
     // Set the stream, topic, and/or direct message recipient
@@ -123,12 +123,14 @@ export function set_compose_defaults(): {
         opts.topic = topic;
     }
 
-    const private_message_recipient = single.get("dm");
+    const private_message_recipient_emails = single.get("dm");
     if (
-        private_message_recipient !== undefined &&
-        people.is_valid_bulk_emails_for_compose(private_message_recipient.split(","))
+        private_message_recipient_emails !== undefined &&
+        people.is_valid_bulk_emails_for_compose(private_message_recipient_emails.split(","))
     ) {
-        opts.private_message_recipient = private_message_recipient;
+        opts.private_message_recipient_ids = people.emails_string_to_user_ids(
+            private_message_recipient_emails,
+        );
     }
     return opts;
 }

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -275,7 +275,10 @@ export function direct_message_group_string(message: Message): string | undefine
 
 export function user_ids_string_to_emails_string(user_ids_string: string): string | undefined {
     const user_ids = split_to_ints(user_ids_string);
+    return user_ids_to_emails_string(user_ids);
+}
 
+export function user_ids_to_emails_string(user_ids: number[]): string | undefined {
     let emails = util.try_parse_as_truthy(
         user_ids.map((user_id) => {
             const person = people_by_user_id_dict.get(user_id);
@@ -284,7 +287,7 @@ export function user_ids_string_to_emails_string(user_ids_string: string): strin
     );
 
     if (emails === undefined) {
-        blueslip.warn("Unknown user ids: " + user_ids_string);
+        blueslip.warn("Unknown user ids: " + user_ids.join(","));
         return undefined;
     }
 
@@ -383,6 +386,13 @@ export function get_user_type(user_id: number): string | undefined {
 export function emails_strings_to_user_ids_string(emails_string: string): string | undefined {
     const emails = emails_string.split(",");
     return email_list_to_user_ids_string(emails);
+}
+
+export function emails_string_to_user_ids(emails_string: string): number[] {
+    const user_ids_string = email_list_to_user_ids_string(
+        util.extract_pm_recipients(emails_string),
+    );
+    return user_ids_string ? user_ids_string_to_ids_array(user_ids_string) : [];
 }
 
 export let email_list_to_user_ids_string = (emails: string[]): string | undefined => {

--- a/web/src/reload.ts
+++ b/web/src/reload.ts
@@ -69,7 +69,9 @@ function preserve_state(send_after_reload: boolean, save_compose: boolean): void
             url += "+topic=" + encodeURIComponent(compose_state.topic());
         } else if (msg_type === "private") {
             url += "+msg_type=private";
-            url += "+recipient=" + encodeURIComponent(compose_state.private_message_recipient());
+            url +=
+                "+recipient=" +
+                encodeURIComponent(compose_state.private_message_recipient_emails());
         }
 
         if (msg_type) {

--- a/web/src/reload_setup.js
+++ b/web/src/reload_setup.js
@@ -5,6 +5,7 @@ import * as compose_actions from "./compose_actions.ts";
 import {localstorage} from "./localstorage.ts";
 import * as message_fetch from "./message_fetch.ts";
 import * as message_view from "./message_view.ts";
+import * as people from "./people.ts";
 
 // Check if we're doing a compose-preserving reload.  This must be
 // done before the first call to get_events
@@ -51,11 +52,15 @@ export function initialize() {
         const send_now = Number.parseInt(vars.send_after_reload, 10);
 
         try {
+            const private_message_recipient_ids = vars.recipient
+                ? people.emails_string_to_user_ids(vars.recipient)
+                : [];
+
             compose_actions.start({
                 message_type: vars.msg_type,
                 stream_id: Number.parseInt(vars.stream_id, 10) || undefined,
                 topic: vars.topic || "",
-                private_message_recipient: vars.recipient || "",
+                private_message_recipient_ids,
                 content: vars.msg || "",
                 draft_id: vars.draft_id || "",
             });

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -918,11 +918,10 @@ function register_click_handlers(): void {
 
     $("body").on("click", ".respond_personal_button, .compose_private_message", function (e) {
         const user_id = elem_to_user_id($(this).parents("ul"));
-        const email = people.get_by_user_id(user_id).email;
         compose_actions.start({
             message_type: "private",
             trigger: "popover send private",
-            private_message_recipient: email,
+            private_message_recipient_ids: [user_id],
         });
         hide_all();
         if (overlays.any_active()) {

--- a/web/src/zulip_test.ts
+++ b/web/src/zulip_test.ts
@@ -3,7 +3,7 @@
 // Puppeteer tests.  It should not be used in the code itself.
 
 export {set_wildcard_mention_threshold, wildcard_mention_threshold} from "./compose_validate.ts";
-export {private_message_recipient} from "./compose_state.ts";
+export {private_message_recipient_emails} from "./compose_state.ts";
 export {current as current_msg_list} from "./message_lists.ts";
 export {get_stream_id, get_sub, get_subscriber_count} from "./stream_data.ts";
 export {get_by_user_id as get_person_by_user_id, get_user_id_from_name} from "./people.ts";

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -518,7 +518,6 @@ test_ui("finish", ({override, override_rewire}) => {
 
         override_rewire(compose_ui, "compose_spinner_visible", false);
         compose_state.set_message_type("private");
-        override(compose_pm_pill, "get_emails", () => bob.email);
         override(compose_pm_pill, "get_user_ids", () => [bob.user_id]);
         override(realm, "realm_direct_message_permission_group", everyone.id);
         override(realm, "realm_direct_message_initiator_group", everyone.id);

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -109,7 +109,7 @@ function assert_hidden(sel) {
     assert.ok(!$(sel).visible());
 }
 
-function override_private_message_recipient({override}) {
+function override_private_message_recipient_emails({override}) {
     let recipient;
     override(compose_pm_pill, "set_from_emails", (value) => {
         recipient = value;
@@ -146,7 +146,7 @@ test("initial_state", () => {
 
 test("start", ({override, override_rewire, mock_template}) => {
     mock_banners();
-    override_private_message_recipient({override});
+    override_private_message_recipient_emails({override});
     override_rewire(compose_actions, "autosize_message_content", noop);
     override_rewire(compose_actions, "expand_compose_box", noop);
     override_rewire(compose_actions, "complete_starting_tasks", noop);
@@ -259,7 +259,7 @@ test("start", ({override, override_rewire, mock_template}) => {
     assert_hidden("input#stream_message_recipient_topic");
     assert_visible("#compose-direct-recipient");
 
-    assert.equal(compose_state.private_message_recipient(), "foo@example.com");
+    assert.equal(compose_state.private_message_recipient_emails(), "foo@example.com");
     assert.equal($("textarea#compose-textarea").val(), "hello");
     assert.equal(compose_state.get_message_type(), "private");
     assert.ok(compose_state.composing());
@@ -272,7 +272,7 @@ test("start", ({override, override_rewire, mock_template}) => {
 
     start(opts);
 
-    assert.equal(compose_state.private_message_recipient(), "");
+    assert.equal(compose_state.private_message_recipient_emails(), "");
     assert.equal(compose_state.get_message_type(), "private");
     assert.ok(compose_state.composing());
 
@@ -310,7 +310,7 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
 
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
-    override_private_message_recipient({override});
+    override_private_message_recipient_emails({override});
     mock_template("inline_decorated_channel_name.hbs", false, noop);
 
     override(realm, "realm_direct_message_permission_group", nobody.id);
@@ -336,7 +336,7 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
     };
 
     respond_to_message(opts);
-    assert.equal(compose_state.private_message_recipient(), "alice@example.com");
+    assert.equal(compose_state.private_message_recipient_emails(), "alice@example.com");
 
     // Test stream
     const denmark = {
@@ -373,7 +373,7 @@ test("reply_with_mention", ({override, override_rewire, mock_template}) => {
     $elem.set_find_results(".message-textarea", $textarea);
     $elem.set_find_results(".message-limit-indicator", $indicator);
 
-    override_private_message_recipient({override});
+    override_private_message_recipient_emails({override});
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
     mock_template("inline_decorated_channel_name.hbs", false, noop);
 
@@ -448,7 +448,7 @@ test("quote_message", ({disallow, override, override_rewire}) => {
 
     override_rewire(compose_actions, "complete_starting_tasks", noop);
     override_rewire(compose_actions, "clear_textarea", noop);
-    override_private_message_recipient({override});
+    override_private_message_recipient_emails({override});
 
     let selected_message;
     override(message_lists.current, "get", (id) => (id === 100 ? selected_message : undefined));

--- a/web/tests/compose_pm_pill.test.cjs
+++ b/web/tests/compose_pm_pill.test.cjs
@@ -207,6 +207,10 @@ run_test("pills", ({override, override_rewire}) => {
 
     user_ids = compose_pm_pill.get_user_ids();
     assert.deepEqual(user_ids, [othello.user_id]);
+
+    compose_pm_pill.set_from_user_ids([hamlet.user_id]);
+    user_ids = compose_pm_pill.get_user_ids();
+    assert.deepEqual(user_ids, [hamlet.user_id]);
 });
 
 run_test("has_unconverted_data", ({override}) => {

--- a/web/tests/compose_state.test.cjs
+++ b/web/tests/compose_state.test.cjs
@@ -15,7 +15,7 @@ const {set_realm} = zrequire("state_data");
 const realm = {};
 set_realm(realm);
 
-run_test("private_message_recipient", ({override}) => {
+run_test("private_message_recipient_emails", ({override}) => {
     let emails;
     override(compose_pm_pill, "set_from_emails", (value) => {
         emails = value;
@@ -23,8 +23,8 @@ run_test("private_message_recipient", ({override}) => {
 
     override(compose_pm_pill, "get_emails", () => emails);
 
-    compose_state.private_message_recipient("fred@fred.org");
-    assert.equal(compose_state.private_message_recipient(), "fred@fred.org");
+    compose_state.private_message_recipient_emails("fred@fred.org");
+    assert.equal(compose_state.private_message_recipient_emails(), "fred@fred.org");
 });
 
 run_test("has_full_recipient", ({override}) => {
@@ -51,9 +51,9 @@ run_test("has_full_recipient", ({override}) => {
     assert.equal(compose_state.has_full_recipient(), true);
 
     compose_state.set_message_type("private");
-    compose_state.private_message_recipient("");
+    compose_state.private_message_recipient_emails("");
     assert.equal(compose_state.has_full_recipient(), false);
 
-    compose_state.private_message_recipient("foo@zulip.com");
+    compose_state.private_message_recipient_emails("foo@zulip.com");
     assert.equal(compose_state.has_full_recipient(), true);
 });

--- a/web/tests/compose_state.test.cjs
+++ b/web/tests/compose_state.test.cjs
@@ -31,12 +31,12 @@ run_test("has_full_recipient", ({override}) => {
     $(`#compose_banners .topic_resolved`).remove = noop;
     $(".narrow_to_compose_recipients").toggleClass = noop;
 
-    let emails;
-    override(compose_pm_pill, "set_from_emails", (value) => {
-        emails = value;
+    let user_ids;
+    override(compose_pm_pill, "set_from_user_ids", (value) => {
+        user_ids = value;
     });
 
-    override(compose_pm_pill, "get_emails", () => emails);
+    override(compose_pm_pill, "get_user_ids", () => user_ids);
 
     compose_state.set_message_type("stream");
     compose_state.set_stream_id("");
@@ -51,9 +51,9 @@ run_test("has_full_recipient", ({override}) => {
     assert.equal(compose_state.has_full_recipient(), true);
 
     compose_state.set_message_type("private");
-    compose_state.private_message_recipient_emails("");
+    compose_state.private_message_recipient_ids([]);
     assert.equal(compose_state.has_full_recipient(), false);
 
-    compose_state.private_message_recipient_emails("foo@zulip.com");
+    compose_state.private_message_recipient_ids([123]);
     assert.equal(compose_state.has_full_recipient(), true);
 });

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -1281,11 +1281,14 @@ run_test("right-to-left", () => {
 
 const get_focus_area = compose_ui._get_focus_area;
 run_test("get_focus_area", ({override}) => {
-    assert.equal(get_focus_area({message_type: "private"}), "#private_message_recipient");
+    assert.equal(
+        get_focus_area({message_type: "private", private_message_recipient_ids: []}),
+        "#private_message_recipient",
+    );
     assert.equal(
         get_focus_area({
             message_type: "private",
-            private_message_recipient: "bob@example.com",
+            private_message_recipient_ids: [bob.user_id],
         }),
         "textarea#compose-textarea",
     );

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -229,7 +229,7 @@ test_ui("validate", ({mock_template, override}) => {
 
     initialize_pm_pill(mock_template);
     add_content_to_compose_box();
-    compose_state.private_message_recipient("");
+    compose_state.private_message_recipient_emails("");
     let pm_recipient_error_rendered = false;
     override(realm, "realm_direct_message_permission_group", everyone.id);
     override(realm, "realm_direct_message_initiator_group", everyone.id);
@@ -246,7 +246,7 @@ test_ui("validate", ({mock_template, override}) => {
     pm_recipient_error_rendered = false;
 
     people.add_active_user(bob);
-    compose_state.private_message_recipient("bob@example.com");
+    compose_state.private_message_recipient_emails("bob@example.com");
     assert.ok(compose_validate.validate());
     assert.ok(!pm_recipient_error_rendered);
 
@@ -280,7 +280,7 @@ test_ui("validate", ({mock_template, override}) => {
 
     initialize_pm_pill(mock_template);
     add_content_to_compose_box();
-    compose_state.private_message_recipient("welcome-bot@example.com");
+    compose_state.private_message_recipient_emails("welcome-bot@example.com");
     $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
     assert.ok(compose_validate.validate());
 
@@ -301,7 +301,7 @@ test_ui("validate", ({mock_template, override}) => {
         return "<banner-stub>";
     });
     initialize_pm_pill(mock_template);
-    compose_state.private_message_recipient("welcome-bot@example.com");
+    compose_state.private_message_recipient_emails("welcome-bot@example.com");
     $("textarea#compose-textarea").toggleClass = (classname, value) => {
         assert.equal(classname, "invalid");
         assert.equal(value, expected_invalid_state);
@@ -851,7 +851,7 @@ test_ui("test_warn_if_guest_in_dm_recipient", ({mock_template, override}) => {
 
     compose_state.set_message_type("private");
     initialize_pm_pill(mock_template);
-    compose_state.private_message_recipient("guest@example.com");
+    compose_state.private_message_recipient_emails("guest@example.com");
     const classname = compose_banner.CLASSNAMES.guest_in_dm_recipient_warning;
     let $banner = $(`#compose_banners .${CSS.escape(classname)}`);
 
@@ -883,7 +883,7 @@ test_ui("test_warn_if_guest_in_dm_recipient", ({mock_template, override}) => {
     people.add_active_user(new_guest);
 
     initialize_pm_pill(mock_template);
-    compose_state.private_message_recipient("guest@example.com, new_guest@example.com");
+    compose_state.private_message_recipient_emails("guest@example.com, new_guest@example.com");
     $banner = $(`#compose_banners .${CSS.escape(classname)}`);
     $banner.length = 1;
     let is_updated = false;

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -103,7 +103,7 @@ const draft_1 = {
     drafts_version: 1,
 };
 const draft_2 = {
-    private_message_recipient: "aaron@zulip.com",
+    private_message_recipient_ids: [aaron.user_id],
     reply_to: "aaron@zulip.com",
     type: "private",
     content: "Test direct message",
@@ -159,9 +159,18 @@ test("fix buggy drafts", ({override_rewire}) => {
         content: "Test stream message",
         updatedAt: Date.now(),
     };
-    const data = {id1: buggy_draft};
+    const draft_with_pm_emails = {
+        private_message_recipient: "iago@zulip.com,zoe@zulip.com",
+        reply_to: "iago@zulip.com,zoe@zulip.com",
+        type: "private",
+        content: "Test direct message",
+        updatedAt: Date.now(),
+    };
     const ls = localstorage();
-    ls.set("drafts", data);
+    ls.set("drafts", {
+        id1: buggy_draft,
+        id2: draft_with_pm_emails,
+    });
     const draft_model = drafts.draft_model;
 
     // The draft is fixed in this codepath.
@@ -175,6 +184,10 @@ test("fix buggy drafts", ({override_rewire}) => {
     const draft = draft_model.getDraft("id1");
     assert.equal(draft.stream_id, stream_B.stream_id);
     assert.equal(draft.topic, "");
+
+    const fixed_draft = draft_model.getDraft("id2");
+    assert.equal(fixed_draft.private_message_recipient, undefined);
+    assert.deepEqual(fixed_draft.private_message_recipient_ids, [iago.user_id, zoe.user_id]);
 });
 
 test("draft_model add", ({override_rewire}) => {
@@ -467,7 +480,7 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
         drafts_version: 1,
     };
     const draft_2 = {
-        private_message_recipient: "aaron@zulip.com",
+        private_message_recipient_ids: [aaron.user_id],
         reply_to: "aaron@zulip.com",
         type: "private",
         content: "Test direct message",
@@ -485,7 +498,7 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
         drafts_version: 1,
     };
     const draft_4 = {
-        private_message_recipient: "iago@zulip.com",
+        private_message_recipient_ids: [iago.user_id],
         reply_to: "iago@zulip.com",
         type: "private",
         content: "Test direct message 2",
@@ -494,7 +507,7 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
         drafts_version: 1,
     };
     const draft_5 = {
-        private_message_recipient: "zoe@zulip.com,iago@zulip.com",
+        private_message_recipient_ids: [zoe.user_id, iago.user_id],
         reply_to: "zoe@zulip.com,iago@zulip.com",
         type: "private",
         content: "Test direct message 3",
@@ -512,7 +525,7 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
         drafts_version: 1,
     };
     const draft_7 = {
-        private_message_recipient: "",
+        private_message_recipient_ids: [],
         reply_to: "",
         type: "private",
         content: "Test direct message 4",
@@ -642,6 +655,7 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
         // Tests formatting and time-sorting of drafts
         assert.deepEqual(data.narrow_drafts, []);
         assert.deepEqual(data.other_drafts, expected);
+        assert.ok(data);
         return "<draft table stub>";
     });
 
@@ -694,7 +708,7 @@ test("filter_drafts", ({override, override_rewire, mock_template}) => {
         drafts_version: 1,
     };
     const pm_draft_1 = {
-        private_message_recipient: "aaron@zulip.com",
+        private_message_recipient_ids: [aaron.user_id],
         reply_to: "aaron@zulip.com",
         type: "private",
         content: "Test direct message",
@@ -712,7 +726,7 @@ test("filter_drafts", ({override, override_rewire, mock_template}) => {
         drafts_version: 1,
     };
     const pm_draft_2 = {
-        private_message_recipient: "aaron@zulip.com",
+        private_message_recipient_ids: [aaron.user_id],
         reply_to: "aaron@zulip.com",
         type: "private",
         content: "Test direct message 2",
@@ -721,7 +735,7 @@ test("filter_drafts", ({override, override_rewire, mock_template}) => {
         drafts_version: 1,
     };
     const pm_draft_3 = {
-        private_message_recipient: "aaron@zulip.com",
+        private_message_recipient_ids: [aaron.user_id],
         reply_to: "aaron@zulip.com",
         type: "private",
         content: "Test direct message 3",

--- a/web/tests/narrow_state.test.cjs
+++ b/web/tests/narrow_state.test.cjs
@@ -240,13 +240,13 @@ test("set_compose_defaults", () => {
 
     set_filter([["dm", "john@doe.com"]]);
     dm_test = narrow_state.set_compose_defaults();
-    assert.equal(dm_test.private_message_recipient, "john@doe.com");
+    assert.deepEqual(dm_test.private_message_recipient_ids, [john.user_id]);
 
     // Even though we renamed "pm-with" to "dm",
     // compose defaults are set correctly.
     set_filter([["pm-with", "john@doe.com"]]);
     dm_test = narrow_state.set_compose_defaults();
-    assert.equal(dm_test.private_message_recipient, "john@doe.com");
+    assert.deepEqual(dm_test.private_message_recipient_ids, [john.user_id]);
 
     set_filter([
         ["topic", "duplicate"],


### PR DESCRIPTION
Fixes #34468.

note: This PR migrates drafts and composebox, but not messages or narrow terms (which still use emails).

> the drafts data structures in the web app still have a legacy model wherein they store DM recipients as a list of API email addresses and convert those into user IDs. We should just be storing user IDs.
>
> We need to be careful to migrate this to avoid breaking historical drafts.

To avoid breaking historical drafts, drafts with emails are converted to drafts with user ids when we fetch them.

Note that reverting back with user_id drafts will cause parsing issues (do we want to still store the emails for a bit to prevent this?)