### PR TITLE
help: Document new setting for marking resolved topic notices as read.

### DIFF
--- a/help/configure-automated-notices.md
+++ b/help/configure-automated-notices.md
@@ -45,8 +45,9 @@ announced.
 ## Notices about topics
 
 A notice is sent when a topic is [resolved or
-unresolved](/help/resolve-a-topic). These notices will be marked as unread only
-for users who had participated in the topic.
+unresolved](/help/resolve-a-topic). Users can
+[configure](/help/marking-messages-as-read#configure-whether-resolved-topic-notices-are-marked-as-read)
+whether these notices are automatically marked as read.
 
 Additionally, when moving messages to another
 [channel](/help/move-content-to-another-channel) or

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -48,6 +48,24 @@ web/desktop app.
 
 {end_tabs}
 
+## Configure whether resolved topic notices are marked as read
+
+Zulip lets you automatically mark as read [notification
+bot](/help/configure-automated-notices) notices indicating that someone
+[resolved or unresolved](/help/resolve-a-topic) a topic, or do so just for
+topics you don't follow.
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{settings_tab|notifications}
+
+1. Under **Topic notifications**, configure **Automatically mark resolved topic
+   notices as read**.
+
+{end_tabs}
+
 ## Mark a message as read
 
 {start_tabs}

--- a/help/resolve-a-topic.md
+++ b/help/resolve-a-topic.md
@@ -11,9 +11,10 @@ Marking a topic as resolved:
 * Puts a ✔ at the beginning of the topic name, e.g., `example topic`
   becomes `✔ example topic`.
 * Triggers an automated notice from the [notification
-  bot](/help/configure-automated-notices) indicating that
-  you resolved the topic. This message will be marked as unread
-  only for users who had participated in the topic.
+  bot](/help/configure-automated-notices) indicating that you resolved the
+  topic. Users can
+  [configure](/help/marking-messages-as-read#configure-whether-resolved-topic-notices-are-marked-as-read)
+  whether these notices are automatically marked as read.
 * Changes whether the topic appears when using the `is:resolved` and
   `-is:resolved` [search filters](/help/search-for-messages#search-filters).
 


### PR DESCRIPTION
Documents #33599 / PR #34226 .


Before: https://zulip.com/help/marking-messages-as-read
After:
![Screenshot 2025-05-13 at 22 20 44](https://github.com/user-attachments/assets/42ae8a6b-245a-48d4-bcc1-91411eb3488c)

----

Before: https://zulip.com/help/configure-automated-notices#notices-about-topics
After:
![Screenshot 2025-05-13 at 22 19 09](https://github.com/user-attachments/assets/f4d6b45b-ee6f-4d19-9b29-5a3eaa04650b)

----
Before: https://zulip.com/help/resolve-a-topic

After: 
![Screenshot 2025-05-13 at 22 22 22](https://github.com/user-attachments/assets/752c6277-e65c-446c-a17c-c062809f5c9b)
