### PR TITLE
settings: Fix message retention period related save/discard widget bugs.

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1450,7 +1450,10 @@ function enable_or_disable_save_button($subsection_elem: JQuery): void {
         time_limit_settings.length > 0 &&
         should_disable_save_button_for_time_limit_settings(time_limit_settings)
     ) {
-        if ($subsection_elem.attr("id") === "org-message-retention") {
+        if (
+            $subsection_elem.attr("id") === "org-message-retention" ||
+            $subsection_elem.attr("id") === "stream-advanced-configurations"
+        ) {
             ui_util.disable_element_and_add_tooltip(
                 $save_button,
                 $t({

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -35,6 +35,7 @@ import {stream_subscription_schema} from "./sub_store.ts";
 import type {GroupSettingPillContainer} from "./typeahead_helper.ts";
 import {group_setting_value_schema} from "./types.ts";
 import type {HTMLSelectOneElement} from "./types.ts";
+import * as ui_util from "./ui_util.ts";
 import * as user_group_pill from "./user_group_pill.ts";
 import * as user_groups from "./user_groups.ts";
 import type {UserGroup} from "./user_groups.ts";
@@ -1445,45 +1446,40 @@ function should_disable_save_button_for_group_settings(settings: string[]): bool
 }
 
 function enable_or_disable_save_button($subsection_elem: JQuery): void {
+    const $save_button = $subsection_elem.find(".save-button");
+
     const time_limit_settings = [...$subsection_elem.find(".time-limit-setting")];
-
-    let disable_save_button = false;
-    if (time_limit_settings.length > 0) {
-        disable_save_button =
-            should_disable_save_button_for_time_limit_settings(time_limit_settings);
-    } else if ($subsection_elem.attr("id") === "org-compose-settings") {
-        disable_save_button = should_disable_save_button_for_jitsi_server_url_setting();
-        const $button_wrapper = $subsection_elem.find<tippy.PopperElement>(
-            ".subsection-changes-save",
-        );
-        const tippy_instance = util.the($button_wrapper)._tippy;
-        if (disable_save_button) {
-            // avoid duplication of tippy
-            if (!tippy_instance) {
-                const opts: Partial<tippy.Props> = {placement: "top"};
-                initialize_disable_button_hint_popover(
-                    $button_wrapper,
-                    $t({defaultMessage: "Cannot save invalid Jitsi server URL."}),
-                    opts,
-                );
-            }
-        } else {
-            if (tippy_instance) {
-                tippy_instance.destroy();
-            }
-        }
+    if (
+        time_limit_settings.length > 0 &&
+        should_disable_save_button_for_time_limit_settings(time_limit_settings)
+    ) {
+        $save_button.prop("disabled", true);
+        return;
     }
 
-    if (!disable_save_button) {
-        const group_settings = [...$subsection_elem.find(".pill-container")].map((elem) =>
-            extract_property_name($(elem)),
+    if (
+        $subsection_elem.attr("id") === "org-compose-settings" &&
+        should_disable_save_button_for_jitsi_server_url_setting()
+    ) {
+        ui_util.disable_element_and_add_tooltip(
+            $save_button,
+            $t({defaultMessage: "Cannot save invalid Jitsi server URL."}),
         );
-        if (group_settings.length > 0) {
-            disable_save_button = should_disable_save_button_for_group_settings(group_settings);
-        }
+        return;
     }
 
-    $subsection_elem.find(".subsection-changes-save button").prop("disabled", disable_save_button);
+    const group_settings = [...$subsection_elem.find(".pill-container")].map((elem) =>
+        extract_property_name($(elem)),
+    );
+    if (
+        group_settings.length > 0 &&
+        should_disable_save_button_for_group_settings(group_settings)
+    ) {
+        $save_button.prop("disabled", true);
+        return;
+    }
+
+    ui_util.enable_element_and_remove_tooltip($save_button);
 }
 
 export function initialize_disable_button_hint_popover(

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1453,6 +1453,15 @@ function enable_or_disable_save_button($subsection_elem: JQuery): void {
         time_limit_settings.length > 0 &&
         should_disable_save_button_for_time_limit_settings(time_limit_settings)
     ) {
+        if ($subsection_elem.attr("id") === "org-message-retention") {
+            ui_util.disable_element_and_add_tooltip(
+                $save_button,
+                $t({
+                    defaultMessage: "Cannot save invalid message retention period.",
+                }),
+            );
+            return;
+        }
         $save_button.prop("disabled", true);
         return;
     }

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -371,9 +371,6 @@ function get_message_retention_setting_value(
         .parent()
         .find<HTMLInputElement>(".message-retention-setting-custom-input")
         .val()!;
-    if (custom_input_val.length === 0) {
-        return settings_config.retain_message_forever;
-    }
     return util.check_time_input(custom_input_val);
 }
 

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -238,7 +238,7 @@ $("body").on(
     },
 );
 
-$("body").on("click", ".advanced-configurations-container .advance-config-title-container", (e) => {
+$("body").on("click", ".advanced-configurations-container .advance-config-toggle-area", (e) => {
     e.stopPropagation();
     toggle_advanced_configurations();
 });

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -278,11 +278,16 @@ export function disable_element_and_add_tooltip($element: JQuery, tooltip_text: 
     // tippy tooltips on disabled elements. So, as a workaround, we wrap the
     // disabled element in a span and show the tooltip on this wrapper instead.
     // https://atomiks.github.io/tippyjs/v6/constructor/#disabled-elements
-    if ($element.prop("disabled")) {
-        // If already disabled, there's nothing to do.
+    $element.prop("disabled", true);
+    const $disabled_tooltip_wrapper = $element.parent(".disabled-tooltip");
+    if ($disabled_tooltip_wrapper.length > 0) {
+        // If element is already wrapped in a disabled-tooltip wrapper,
+        // only update the tooltip text if it has changed.
+        if ($disabled_tooltip_wrapper.attr("data-tippy-content") !== tooltip_text) {
+            $disabled_tooltip_wrapper.attr("data-tippy-content", tooltip_text);
+        }
         return;
     }
-    $element.prop("disabled", true);
     const $tooltip_target_wrapper = $("<span>");
     $tooltip_target_wrapper.addClass("disabled-tooltip");
     $tooltip_target_wrapper.attr("data-tippy-content", tooltip_text).attr("tabindex", "0");

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -299,9 +299,12 @@ export function enable_element_and_remove_tooltip($element: JQuery): void {
     // and explicitly removes any attached tooltips on the wrapper to prevent
     // ghost tooltips.
     $element.prop("disabled", false);
-    const tooltip_wrapper: tippy.ReferenceElement = $element.parent(".disabled-tooltip")[0]!;
-    if (tooltip_wrapper?._tippy) {
-        tooltip_wrapper._tippy.destroy();
+    const tooltip_wrapper: tippy.ReferenceElement | undefined =
+        $element.parent(".disabled-tooltip")[0];
+    if (tooltip_wrapper) {
+        if (tooltip_wrapper._tippy) {
+            tooltip_wrapper._tippy.destroy();
+        }
+        $element.unwrap(".disabled-tooltip");
     }
-    $element.unwrap(".disabled-tooltip");
 }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -490,8 +490,11 @@ input[type="checkbox"] {
 }
 
 .advanced-configurations-container {
-    .advance-config-title-container {
+    .advance-config-toggle-area {
         cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 0 0.625em;
 
         .stream_setting_subsection_title {
             margin: 4px 0;

--- a/web/templates/stream_settings/stream_types.hbs
+++ b/web/templates/stream_settings/stream_types.hbs
@@ -45,8 +45,10 @@
 
 <div id="stream-advanced-configurations" class="advanced-configurations-container stream-permissions {{#if is_stream_edit}}settings-subsection-parent{{/if}}">
     <div class="advance-config-title-container {{#if is_stream_edit}}subsection-header{{/if}}">
-        <i class="fa fa-sm fa-caret-right toggle-advanced-configurations-icon" aria-hidden="true"></i>
-        <h4 class="stream_setting_subsection_title"><span>{{t 'Advanced configurations' }}</span></h4>
+        <div class="advance-config-toggle-area">
+            <i class="fa fa-sm fa-caret-right toggle-advanced-configurations-icon" aria-hidden="true"></i>
+            <h4 class="stream_setting_subsection_title"><span>{{t 'Advanced configurations' }}</span></h4>
+        </div>
         {{#if is_stream_edit}}
             {{> ../settings/settings_save_discard_widget section_name="stream-permissions" }}
         {{/if}}

--- a/web/tests/settings_org.test.cjs
+++ b/web/tests/settings_org.test.cjs
@@ -22,6 +22,10 @@ mock_esm("../src/buttons", {
     modify_action_button_style: noop,
 });
 mock_esm("../src/scroll_util", {scroll_element_into_container: noop});
+mock_esm("../src/ui_util", {
+    disable_element_and_add_tooltip: noop,
+    enable_element_and_remove_tooltip: noop,
+});
 set_global("document", "document-stub");
 
 set_global("requestAnimationFrame", (func) => func());
@@ -95,6 +99,7 @@ function createSaveButtons(subsection) {
     $stub_save_button_header.set_find_results(".time-limit-setting", []);
     $stub_save_button_header.set_find_results(".pill-container", []);
     $stub_save_button_header.set_find_results(".subsection-changes-save button", $stub_save_button);
+    $stub_save_button_header.set_find_results(".save-button", $stub_save_button);
 
     return {
         props,


### PR DESCRIPTION
Fixes: [#issues > custom retention period settings UI bug @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/custom.20retention.20period.20settings.20UI.20bug/near/2168324)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![Screenshot 2025-05-15 at 3 28 39 PM](https://github.com/user-attachments/assets/415238f0-6de7-42bc-b895-65afa2818aca) | ![Screenshot 2025-05-15 at 3 26 05 PM](https://github.com/user-attachments/assets/102b9d64-a349-4e41-87ed-32af9652af5a) |
| ![Screenshot 2025-05-15 at 3 28 20 PM](https://github.com/user-attachments/assets/cebebc7a-4d3e-4d94-b0c1-98d04c62abcb) | ![Screenshot 2025-05-15 at 3 27 00 PM](https://github.com/user-attachments/assets/1575d096-4e10-4f5b-ad30-dc0c2498faa9) | 
| ![before_toggleable_fix](https://github.com/user-attachments/assets/4b4d31c7-187d-4017-b390-1b8739a1320f) | ![after_toggleable_fix](https://github.com/user-attachments/assets/eddb1b5d-31ac-4859-a0a4-300c1eece542) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
