### PR TITLE
Fix glitch when hovering a message as its editing window expires 

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -215,6 +215,14 @@ export function is_content_editable(message: Message, edit_limit_seconds_buffer 
     return false;
 }
 
+export function remaining_content_edit_time(message: Message): number {
+    if (!is_content_editable(message)) {
+        return 0;
+    }
+    const limit_seconds = realm.realm_message_content_edit_limit_seconds ?? Infinity;
+    return limit_seconds + (message.timestamp - Date.now() / 1000);
+}
+
 export function is_message_sent_by_my_bot(message: Message): boolean {
     const user = people.get_by_user_id(message.sender_id);
     if (!user.is_bot || user.bot_owner_id === null) {

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -310,6 +310,15 @@ export function can_move_message(message: Message): boolean {
     return is_topic_editable(message) || is_stream_editable(message);
 }
 
+export function remaining_message_move_time(message: Message): number {
+    if (!can_move_message(message)) {
+        return 0;
+    }
+
+    const limit_seconds = realm.realm_move_messages_within_stream_limit_seconds ?? Infinity;
+    return limit_seconds + (message.timestamp - Date.now() / 1000);
+}
+
 export function stream_and_topic_exist_in_edit_history(
     message: Message,
     stream_id: number,

--- a/web/src/message_list_hover.ts
+++ b/web/src/message_list_hover.ts
@@ -3,6 +3,7 @@ import assert from "minimalistic-assert";
 
 import * as message_edit from "./message_edit.ts";
 import * as message_lists from "./message_lists.ts";
+import type {Message} from "./message_store.ts";
 import * as rows from "./rows.ts";
 import * as thumbnail from "./thumbnail.ts";
 import {user_settings} from "./user_settings.ts";
@@ -35,27 +36,28 @@ export function message_hover($message_row: JQuery): void {
         return;
     }
 
+    change_edit_content_button($message_row, message);
+}
+
+function change_edit_content_button($message_row: JQuery, message: Message): void {
     // But the message edit hover icon is determined by whether the message is still editable
     const is_content_editable = message_edit.is_content_editable(message);
     const can_move_message = message_edit.can_move_message(message);
-    const args = {
-        is_content_editable,
-        can_move_message,
-    };
+
     const $edit_content = $message_row.find(".edit_content");
-    if (args.is_content_editable && !$edit_content.hasClass("can-edit-content")) {
+    if (is_content_editable && !$edit_content.hasClass("can-edit-content")) {
         $edit_content.addClass("can-edit-content");
         $edit_content.removeClass("can-move-message");
         $edit_content.attr("data-tooltip-template-id", "edit-content-tooltip-template");
     } else if (
-        !args.is_content_editable &&
-        args.can_move_message &&
+        !is_content_editable &&
+        can_move_message &&
         !$edit_content.hasClass("can-move-message")
     ) {
         $edit_content.addClass("can-move-message");
         $edit_content.removeClass("can-edit-content");
         $edit_content.attr("data-tooltip-template-id", "move-message-tooltip-template");
-    } else if (!args.is_content_editable && !args.can_move_message) {
+    } else if (!is_content_editable && !can_move_message) {
         $edit_content.removeClass("can-edit-content can-move-message");
     }
 }

--- a/web/src/message_list_hover.ts
+++ b/web/src/message_list_hover.ts
@@ -10,6 +10,7 @@ import {user_settings} from "./user_settings.ts";
 
 let $current_message_hover: JQuery | undefined;
 let edit_timeout: ReturnType<typeof setTimeout> | undefined;
+let move_timeout: ReturnType<typeof setTimeout> | undefined;
 export function message_unhover(): void {
     if ($current_message_hover === undefined) {
         return;
@@ -17,6 +18,10 @@ export function message_unhover(): void {
     if (edit_timeout !== undefined) {
         clearTimeout(edit_timeout);
         edit_timeout = undefined;
+    }
+    if (move_timeout !== undefined) {
+        clearTimeout(move_timeout);
+        move_timeout = undefined;
     }
     $current_message_hover.removeClass("can-edit-content can-move-message");
     $current_message_hover = undefined;
@@ -76,6 +81,19 @@ function change_edit_content_button($message_row: JQuery, message: Message): voi
                 }
                 change_edit_content_button($message_row, message);
             }, remaining_edit_time);
+        }
+    }
+
+    if (move_timeout === undefined) {
+        const remaining_move_time = message_edit.remaining_message_move_time(message) * 1000;
+        if (remaining_move_time > 0 && remaining_move_time < Infinity) {
+            move_timeout = setTimeout(() => {
+                const visible = $.contains(document.body, $edit_content[0]!);
+                if (!visible) {
+                    return;
+                }
+                change_edit_content_button($message_row, message);
+            }, remaining_move_time);
         }
     }
 }


### PR DESCRIPTION
To fix the glitch, we use timeout to reevaluate what buttons should be there in message controls.

To test the PR, we can set the message edit time limit to 1 minute, send a message and keep the mouse over the sent message.

Fixes: #15810

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
