### PR TITLE
Clean up unnecessary use of rewires for node tests part 1

### DIFF
--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -201,14 +201,10 @@ export function pm_ids_string(filter?: Filter): string | undefined {
     return user_ids_string;
 }
 
-export let pm_ids_set = (filter?: Filter): Set<number> => {
+export function pm_ids_set(filter?: Filter): Set<number> {
     const ids_string = pm_ids_string(filter);
     const pm_ids_list = ids_string ? people.user_ids_string_to_ids_array(ids_string) : [];
     return new Set(pm_ids_list);
-};
-
-export function rewire_pm_ids_set(value: typeof pm_ids_set): void {
-    pm_ids_set = value;
 }
 
 export function pm_emails_string(

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -176,7 +176,7 @@ export function stream_sub(
     return stream_data.get_sub_by_id(id);
 }
 
-export let topic = (current_filter: Filter | undefined = filter()): string | undefined => {
+export function topic(current_filter: Filter | undefined = filter()): string | undefined {
     if (current_filter === undefined) {
         return undefined;
     }
@@ -185,10 +185,6 @@ export let topic = (current_filter: Filter | undefined = filter()): string | und
         return operands[0];
     }
     return undefined;
-};
-
-export function rewire_topic(value: typeof topic): void {
-    topic = value;
 }
 
 export function pm_ids_string(filter?: Filter): string | undefined {

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -464,7 +464,7 @@ export function canonicalized_name(stream_name: string): string {
     return stream_name.toString().toLowerCase();
 }
 
-export let get_color = (stream_id: number | undefined): string => {
+export function get_color(stream_id: number | undefined): string {
     if (stream_id === undefined) {
         return DEFAULT_COLOR;
     }
@@ -473,10 +473,6 @@ export let get_color = (stream_id: number | undefined): string => {
         return DEFAULT_COLOR;
     }
     return sub.color;
-};
-
-export function rewire_get_color(value: typeof get_color): void {
-    get_color = value;
 }
 
 export function is_muted(stream_id: number): boolean {

--- a/web/src/sub_store.ts
+++ b/web/src/sub_store.ts
@@ -33,11 +33,8 @@ export type StreamSubscription = z.infer<typeof stream_subscription_schema>;
 
 const subs_by_stream_id = new Map<number, StreamSubscription>();
 
-export let get = (stream_id: number): StreamSubscription | undefined =>
-    subs_by_stream_id.get(stream_id);
-
-export function rewire_get(value: typeof get): void {
-    get = value;
+export function get(stream_id: number): StreamSubscription | undefined {
+    return subs_by_stream_id.get(stream_id);
 }
 
 export function validate_stream_ids(stream_ids: number[]): number[] {

--- a/web/tests/buddy_data.test.cjs
+++ b/web/tests/buddy_data.test.cjs
@@ -424,7 +424,7 @@ test("show offline channel subscribers for small channels", ({override_rewire}) 
     assert.deepEqual(buddy_data.get_filtered_and_sorted_user_ids(""), [me.user_id, alice.user_id]);
 });
 
-test("get_conversation_participants", ({override_rewire}) => {
+test("get_conversation_participants", () => {
     people.add_active_user(selma);
 
     const rome_sub = {name: "Rome", subscribed: true, stream_id: 1001};
@@ -432,7 +432,7 @@ test("get_conversation_participants", ({override_rewire}) => {
     peer_data.set_subscribers(rome_sub.stream_id, [selma.user_id, me.user_id]);
 
     const filter = new Filter([
-        {operator: "channel", operand: rome_sub.channel_id},
+        {operator: "channel", operand: rome_sub.stream_id},
         {operator: "topic", operand: "Foo"},
     ]);
     message_lists.set_current({
@@ -443,8 +443,6 @@ test("get_conversation_participants", ({override_rewire}) => {
             },
         },
     });
-    override_rewire(narrow_state, "stream_id", () => rome_sub.stream_id);
-    override_rewire(narrow_state, "topic", () => "Foo");
 
     activity_ui.rerender_user_sidebar_participants();
     assert.deepEqual(

--- a/web/tests/buddy_data.test.cjs
+++ b/web/tests/buddy_data.test.cjs
@@ -21,7 +21,6 @@ mock_esm("../src/buddy_list", {
 const compose_fade_helper = zrequire("compose_fade_helper");
 const activity_ui = zrequire("activity_ui");
 const muted_users = zrequire("muted_users");
-const narrow_state = zrequire("narrow_state");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const presence = zrequire("presence");
@@ -369,9 +368,14 @@ test("always show me", () => {
     assert.deepEqual(buddy_data.get_filtered_and_sorted_user_ids(""), [me.user_id]);
 });
 
-test("always show pm users", ({override_rewire}) => {
+test("always show pm users", () => {
     people.add_active_user(selma);
-    override_rewire(narrow_state, "pm_ids_set", () => new Set([selma.user_id]));
+    message_lists.set_current({
+        data: {
+            filter: new Filter([{operator: "dm", operand: selma.email}]),
+        },
+    });
+
     assert.deepEqual(buddy_data.get_filtered_and_sorted_user_ids(""), [me.user_id, selma.user_id]);
 });
 
@@ -410,7 +414,18 @@ test("show offline channel subscribers for small channels", ({override_rewire}) 
         me.user_id,
     ]);
 
-    override_rewire(narrow_state, "stream_id", () => stream_id);
+    const filter = new Filter([
+        {operator: "channel", operand: sub.stream_id},
+        {operator: "topic", operand: "Foo"},
+    ]);
+    message_lists.set_current({
+        data: {
+            filter,
+            participants: {
+                visible: () => new Set(),
+            },
+        },
+    });
     assert.deepEqual(buddy_data.get_filtered_and_sorted_user_ids(""), [
         me.user_id,
         alice.user_id,

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -216,7 +216,7 @@ function test(label, f) {
     });
 }
 
-test("sort_streams", ({override, override_rewire}) => {
+test("sort_streams", ({override}) => {
     let test_streams = [
         {
             stream_id: 101,
@@ -281,7 +281,7 @@ test("sort_streams", ({override, override_rewire}) => {
     );
 
     stream_list_sort.set_filter_out_inactives();
-    override_rewire(compose_state, "stream_name", () => "Dev");
+    compose_state.set_selected_recipient_id(dev_sub.stream_id);
 
     test_streams = th.sort_streams(test_streams, "d");
     assert.deepEqual(test_streams[0].name, "Dev"); // Stream being composed to
@@ -300,7 +300,8 @@ test("sort_streams", ({override, override_rewire}) => {
     assert.deepEqual(test_streams[4].name, "Dev");
     assert.deepEqual(test_streams[5].name, "Docs");
 
-    override_rewire(compose_state, "stream_name", () => "Different");
+    compose_state.set_selected_recipient_id(linux_sub.stream_id);
+
     // Test sort streams with description
     test_streams = [
         {


### PR DESCRIPTION
This PR removes unnecessary use of override_rewire across, and creates data instead of mocking functions returning that data.




Fixes part of: #32326


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
