### PR TITLE
new: Tweak import tip.

### DIFF
--- a/templates/zerver/realm_creation_form.html
+++ b/templates/zerver/realm_creation_form.html
@@ -94,7 +94,7 @@
             </select>
             <div class="not-editable-realm-field extra-info-realm-creation-import-from">
                 {% trans %}
-                You can also import from
+                Or learn how to import from
                 <a href="/help/import-from-mattermost">Mattermost</a> or
                 <a href="/help/import-from-rocketchat">Rocket.Chat</a>.
                 {% endtrans %}


### PR DESCRIPTION
I changed the string, as the previous one was hard to understand when "Don't import" is selected. It's now:

![Screenshot 2025-05-15 at 12 11 10](https://github.com/user-attachments/assets/d4560503-e14e-45f4-bd5e-3837c1f5ba22)


@amanagr Could you tweak this PR to use the same below-the-field tip styling as we use elsewhere:

![Screenshot 2025-05-15 at 12 10 47](https://github.com/user-attachments/assets/77f22d1f-32c2-4641-99ea-1a1e471fb9c9)
