### PR TITLE
configure-rabbitmq: Restore startup retry loop

### DIFF
--- a/scripts/setup/configure-rabbitmq
+++ b/scripts/setup/configure-rabbitmq
@@ -12,7 +12,13 @@ RABBITMQ_USERNAME=$("$(dirname "$0")/../get-django-setting" RABBITMQ_USERNAME)
 RABBITMQ_PASSWORD=$("$(dirname "$0")/../get-django-setting" RABBITMQ_PASSWORD)
 RABBITMQ_VHOST=$("$(dirname "$0")/../get-django-setting" RABBITMQ_VHOST)
 
+tries=0
+while ((tries < 30)) && ! rabbitmqctl ping -q 2>/dev/null; do
+    ((tries++)) || echo "Waiting for RabbitMQ to start up..."
+    sleep 1
+done
 rabbitmqctl await_startup
+
 rabbitmqctl delete_user "$RABBITMQ_USERNAME" || true
 rabbitmqctl delete_user zulip || true
 rabbitmqctl delete_user guest || true


### PR DESCRIPTION
`rabbitmqctl await_startup` does not retry to wait for the Erlang runtime to start, only to wait for the RabbitMQ application to start once Erlang is running.

Cc @alexmv (#30275).

Fixes a `vagrant up --provision` race condition:

```console
$ vagrant up --provision
…
    default: + sudo -- scripts/setup/configure-rabbitmq
    default: Error: unable to perform an operation on node 'rabbit@ed8d1f15d6a5'. Please see diagnostics information and suggestions below.
    default: 
    default: Most common reasons for this are:
    default: 
    default:  * Target node is unreachable (e.g. due to hostname resolution, TCP connection or firewall issues)
    default:  * CLI tool fails to authenticate with the server (e.g. due to CLI tool's Erlang cookie not matching that of the server)
    default:  * Target node is not running
    default: 
    default: In addition to the diagnostics info below:
    default: 
    default:  * See the CLI, clustering and networking guides on https://rabbitmq.com/documentation.html to learn more
    default:  * Consult server logs on node rabbit@ed8d1f15d6a5
    default:  * If target node is configured to use long node names, don't forget to use --longnames with CLI tools
    default: 
    default: DIAGNOSTICS
    default: ===========
    default: 
    default: attempted to contact: [rabbit@ed8d1f15d6a5]
    default: 
    default: rabbit@ed8d1f15d6a5:
    default:   * connected to epmd (port 4369) on ed8d1f15d6a5
    default:   * epmd reports: node 'rabbit' not running at all
    default:                   no other nodes on ed8d1f15d6a5
    default:   * suggestion: start the node
    default: 
    default: Current node details:
    default:  * node name: 'rabbitmqcli-596-rabbit@ed8d1f15d6a5'
    default:  * effective user's home directory: /var/lib/rabbitmq
    default:  * Erlang cookie hash: c3JzbHkgd3RmIGVybGFuZw==
    default: 
    default: 
    default: Subcommand of /srv/zulip/tools/lib/provision_inner.py failed with exit status 69: sudo -- scripts/setup/configure-rabbitmq
    default: Actual error output for the subcommand is just above this.
    default: 
    default: 
    default: Provisioning failed (exit code 1)!
    default: 
    default: * Look at the traceback(s) above to find more about the errors.
    default: * Resolve the errors or get help on chat.
    default: * If you can fix this yourself, you can re-run tools/provision at any time.
    default: * Logs are here: zulip/var/log/provision.log
    default: 
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```