### PR TITLE
help-beta: Pass fill property to component instead of str manipulation.

### DIFF
--- a/help-beta/astro.config.mjs
+++ b/help-beta/astro.config.mjs
@@ -34,11 +34,6 @@ export default defineConfig({
                         throw new Error("Zulip icon not found.");
                     },
                 },
-                transform(svg, _collection, _icon) {
-                    // unplugin-icons suggests to set the fill color,
-                    // there were some cases were it was being set to none.
-                    return svg.replace(/^<svg /, '<svg fill="currentColor" ');
-                },
             }),
         ],
     },

--- a/help-beta/src/components/KeyboardTip.astro
+++ b/help-beta/src/components/KeyboardTip.astro
@@ -17,7 +17,7 @@ Link: https://github.com/withastro/starlight/pull/2261
 -->
 <aside aria-label={title} class={`starlight-aside starlight-aside--tip`}>
 	<p class="starlight-aside__title" aria-hidden="true">
-		<ZulipIconsKeyboard class="starlight-aside__icon" />{title}
+		<ZulipIconsKeyboard fill="currentColor" class="starlight-aside__icon" />{title}
 	</p>
 	<div class="starlight-aside__content">
 		<slot />


### PR DESCRIPTION
The reason we were doing string manipulation was that when using the keyboard icon for KeyboardTip.astro, we were getting a blank spot if the fill was not sent to currentColor. This commit instead passes the currentColor for the imported unplugin icon directly. This commit only addresses this specific component, any other instances of the icon color being same as the page color still remain and this commit does not solve that.

<!-- Describe your pull request here.-->

Fixes: https://github.com/zulip/zulip/pull/34644#discussion_r2091785559

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
