### PR TITLE
events: Add option to send partial data.

### DIFF
--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -43,6 +43,7 @@ from zerver.models.users import (
     active_user_ids,
     base_bulk_get_user_queryset,
     base_get_user_queryset,
+    get_partial_realm_user_dicts,
     get_realm_user_dicts,
     get_realm_user_dicts_from_ids,
     get_user_by_id_in_realm_including_cross_realm,
@@ -1058,6 +1059,8 @@ def get_user_dicts_in_realm(
 ) -> tuple[list[RawUserDict], list[APIUserDict]]:
     if user_ids is not None:
         all_user_dicts = get_realm_user_dicts_from_ids(realm.id, user_ids)
+    elif settings.PARTIAL_USERS:
+        all_user_dicts = get_partial_realm_user_dicts(realm.id, user_profile)
     else:
         all_user_dicts = get_realm_user_dicts(realm.id)
     if check_user_can_access_all_users(user_profile):

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -1116,6 +1116,27 @@ def get_realm_user_dicts(realm_id: int) -> list[RawUserDict]:
     )
 
 
+def get_partial_realm_user_dicts(
+    realm_id: int, user_profile: UserProfile | None
+) -> list[RawUserDict]:
+    """Returns a subset of the users in the realm, guaranteed to
+    include the current user as well as all bots in the realm.
+    """
+
+    # Currently, we send the minimum set of users permitted by the API.
+    user_selection_clause = Q(is_bot=True)
+    if user_profile is not None:
+        user_selection_clause |= Q(id=user_profile.id)
+
+    return list(
+        UserProfile.objects.filter(realm_id=realm_id)
+        .filter(
+            user_selection_clause,
+        )
+        .values(*realm_user_dict_fields)
+    )
+
+
 def get_realm_user_dicts_from_ids(realm_id: int, user_ids: list[int]) -> list[RawUserDict]:
     return list(
         UserProfile.objects.filter(

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -1304,3 +1304,5 @@ SCIM_SERVICE_PROVIDER = {
 
 # Which API key to use will be determined based on TOPIC_SUMMARIZATION_MODEL.
 TOPIC_SUMMARIZATION_API_KEY = get_secret("topic_summarization_api_key", None)
+
+PARTIAL_USERS = bool(os.environ.get("PARTIAL_USERS"))


### PR DESCRIPTION
Server can now send partial data to the client to help in developement. We don't want this to be widely used right now, hence no documentation changes have been made.

discussion: https://chat.zulip.org/#narrow/channel/378-api-design/topic/defer.20loading.20user.20data/with/2175031