### PR TITLE
tests: Replace unnecessary regex use for removing /user_uploads/

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -2252,7 +2252,8 @@ class ZulipTestCase(ZulipTestCaseMixin, TestCase):
             response = self.assert_json_success(
                 self.client_post("/json/user_uploads", {"file": image_file})
             )
-            return re.sub(r"/user_uploads/", "", response["url"])
+            assert response["url"].startswith("/user_uploads/")
+            return response["url"].removeprefix("/user_uploads/")
 
     def upload_and_thumbnail_image(self, image_name: str) -> str:
         with self.captureOnCommitCallbacks(execute=True):

--- a/zerver/tests/test_delete_unclaimed_attachments.py
+++ b/zerver/tests/test_delete_unclaimed_attachments.py
@@ -1,5 +1,4 @@
 import os
-import re
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -33,7 +32,8 @@ class UnclaimedAttachmentTest(UploadSerializeMixin, ZulipTestCase):
                 response = self.assert_json_success(
                     self.client_post("/json/user_uploads", {"file": file_obj})
                 )
-            path_id = re.sub(r"/user_uploads/", "", response["url"])
+            assert response["url"].startswith("/user_uploads/")
+            path_id = response["url"].removeprefix("/user_uploads/")
             return Attachment.objects.get(path_id=path_id)
 
     def assert_exists(

--- a/zerver/tests/test_markdown_thumbnail.py
+++ b/zerver/tests/test_markdown_thumbnail.py
@@ -1,4 +1,3 @@
-import re
 from unittest.mock import patch
 
 import pyvips
@@ -154,7 +153,8 @@ class MarkdownThumbnailTest(ZulipTestCase):
                 read_test_image_file("img.png"),
                 self.example_user("othello"),
             )[0]
-            path_id = re.sub(r"/user_uploads/", "", url)
+            assert url.startswith("/user_uploads/")
+            path_id = url.removeprefix("/user_uploads/")
             self.assertTrue(ImageAttachment.objects.filter(path_id=path_id).exists())
         message_id = self.send_message_content(f"[I am 95% ± 5% certain!](/user_uploads/{path_id})")
         expected = (

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -2632,9 +2632,8 @@ class ScrubRealmTest(ZulipTestCase):
         for n in range(1, 4):
             content = f"content{n}".encode()
             url = upload_message_attachment(f"dummy{n}.txt", "text/plain", content, hamlet)[0]
-            base = "/user_uploads/"
-            self.assertEqual(base, url[: len(base)])
-            path_id = re.sub(r"/user_uploads/", "", url)
+            assert url.startswith("/user_uploads/")
+            path_id = url.removeprefix("/user_uploads/")
             self.assertTrue(os.path.isfile(os.path.join(settings.LOCAL_FILES_DIR, path_id)))
             path_ids.append(path_id)
 
@@ -2707,9 +2706,8 @@ class ScrubRealmTest(ZulipTestCase):
         for n, owner in enumerate([iago, othello, hamlet, cordelia, king]):
             content = f"content{n}".encode()
             url = upload_message_attachment(f"dummy{n}.txt", "text/plain", content, owner)[0]
-            base = "/user_uploads/"
-            self.assertEqual(base, url[: len(base)])
-            file_path = os.path.join(settings.LOCAL_FILES_DIR, re.sub(r"/user_uploads/", "", url))
+            assert url.startswith("/user_uploads/")
+            file_path = os.path.join(settings.LOCAL_FILES_DIR, url.removeprefix("/user_uploads/"))
             self.assertTrue(os.path.isfile(file_path))
             file_paths.append(file_path)
 

--- a/zerver/tests/test_scheduled_messages.py
+++ b/zerver/tests/test_scheduled_messages.py
@@ -1,4 +1,3 @@
-import re
 import time
 from datetime import timedelta
 from io import StringIO
@@ -656,13 +655,15 @@ class ScheduledMessageTest(ZulipTestCase):
         attachment_file1 = StringIO("zulip!")
         attachment_file1.name = "dummy_1.txt"
         result = self.client_post("/json/user_uploads", {"file": attachment_file1})
-        path_id1 = re.sub(r"/user_uploads/", "", result.json()["url"])
+        assert result.json()["url"].startswith("/user_uploads/")
+        path_id1 = result.json()["url"].removeprefix("/user_uploads/")
         attachment_object1 = Attachment.objects.get(path_id=path_id1)
 
         attachment_file2 = StringIO("zulip!")
         attachment_file2.name = "dummy_1.txt"
         result = self.client_post("/json/user_uploads", {"file": attachment_file2})
-        path_id2 = re.sub(r"/user_uploads/", "", result.json()["url"])
+        assert result.json()["url"].startswith("/user_uploads/")
+        path_id2 = result.json()["url"].removeprefix("/user_uploads/")
         attachment_object2 = Attachment.objects.get(path_id=path_id2)
 
         content = f"Test [zulip.txt](http://{hamlet.realm.host}/user_uploads/{path_id1})"

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -1,4 +1,3 @@
-import re
 from dataclasses import asdict
 from io import BytesIO, StringIO
 from unittest.mock import patch
@@ -318,7 +317,8 @@ class TestStoreThumbnail(ZulipTestCase):
                 response = self.assert_json_success(
                     self.client_post("/json/user_uploads", {"file": image_file})
                 )
-            path_id = re.sub(r"/user_uploads/", "", response["url"])
+            assert response["url"].startswith("/user_uploads/")
+            path_id = response["url"].removeprefix("/user_uploads/")
             self.assertEqual(Attachment.objects.filter(path_id=path_id).count(), 1)
 
             image_attachment = ImageAttachment.objects.get(path_id=path_id)
@@ -419,7 +419,8 @@ class TestStoreThumbnail(ZulipTestCase):
                     response = self.assert_json_success(
                         self.client_post("/json/user_uploads", {"file": image_file})
                     )
-                    path_id = re.sub(r"/user_uploads/", "", response["url"])
+                    assert response["url"].startswith("/user_uploads/")
+                    path_id = response["url"].removeprefix("/user_uploads/")
                     self.assertEqual(Attachment.objects.filter(path_id=path_id).count(), 1)
 
                     image_attachment = ImageAttachment.objects.get(path_id=path_id)
@@ -449,7 +450,8 @@ class TestStoreThumbnail(ZulipTestCase):
                     response = self.assert_json_success(
                         self.client_post("/json/user_uploads", {"file": image_file})
                     )
-                    path_id = re.sub(r"/user_uploads/", "", response["url"])
+                    assert response["url"].startswith("/user_uploads/")
+                    path_id = response["url"].removeprefix("/user_uploads/")
                     self.assertEqual(Attachment.objects.filter(path_id=path_id).count(), 1)
                     self.assertEqual(ImageAttachment.objects.filter(path_id=path_id).count(), 1)
                 with BytesIO() as fh:
@@ -469,7 +471,8 @@ class TestStoreThumbnail(ZulipTestCase):
                 response = self.assert_json_success(
                     self.client_post("/json/user_uploads", {"file": image_file})
                 )
-                path_id = re.sub(r"/user_uploads/", "", response["url"])
+                assert response["url"].startswith("/user_uploads/")
+                path_id = response["url"].removeprefix("/user_uploads/")
                 self.assertEqual(Attachment.objects.filter(path_id=path_id).count(), 1)
                 self.assertEqual(ImageAttachment.objects.filter(path_id=path_id).count(), 0)
 
@@ -484,7 +487,8 @@ class TestStoreThumbnail(ZulipTestCase):
                 response = self.assert_json_success(
                     self.client_post("/json/user_uploads", {"file": image_file})
                 )
-            path_id = re.sub(r"/user_uploads/", "", response["url"])
+            assert response["url"].startswith("/user_uploads/")
+            path_id = response["url"].removeprefix("/user_uploads/")
             self.assertEqual(Attachment.objects.filter(path_id=path_id).count(), 1)
 
             image_attachment = ImageAttachment.objects.get(path_id=path_id)
@@ -535,7 +539,8 @@ class TestStoreThumbnail(ZulipTestCase):
                 response = self.assert_json_success(
                     self.client_post("/json/user_uploads", {"file": image_file})
                 )
-            path_id = re.sub(r"/user_uploads/", "", response["url"])
+            assert response["url"].startswith("/user_uploads/")
+            path_id = response["url"].removeprefix("/user_uploads/")
             self.assertTrue(Attachment.objects.filter(path_id=path_id).exists())
             self.assertFalse(ImageAttachment.objects.filter(path_id=path_id).exists())
 
@@ -556,7 +561,8 @@ class TestStoreThumbnail(ZulipTestCase):
             response = self.assert_json_success(
                 self.client_post("/json/user_uploads", {"file": image_file})
             )
-            path_id = re.sub(r"/user_uploads/", "", response["url"])
+            assert response["url"].startswith("/user_uploads/")
+            path_id = response["url"].removeprefix("/user_uploads/")
             self.assertTrue(Attachment.objects.filter(path_id=path_id).exists())
             self.assertFalse(ImageAttachment.objects.filter(path_id=path_id).exists())
 
@@ -567,7 +573,8 @@ class TestStoreThumbnail(ZulipTestCase):
             response = self.assert_json_success(
                 self.client_post("/json/user_uploads", {"file": image_file})
             )
-            path_id = re.sub(r"/user_uploads/", "", response["url"])
+            assert response["url"].startswith("/user_uploads/")
+            path_id = response["url"].removeprefix("/user_uploads/")
             self.assertTrue(Attachment.objects.filter(path_id=path_id).exists())
             self.assertTrue(ImageAttachment.objects.filter(path_id=path_id).exists())
 
@@ -581,7 +588,8 @@ class TestStoreThumbnail(ZulipTestCase):
                 response = self.assert_json_success(
                     self.client_post("/json/user_uploads", {"file": image_file})
                 )
-            path_id = re.sub(r"/user_uploads/", "", response["url"])
+            assert response["url"].startswith("/user_uploads/")
+            path_id = response["url"].removeprefix("/user_uploads/")
             self.assertEqual(Attachment.objects.filter(path_id=path_id).count(), 1)
 
             # This doesn't generate an ImageAttachment row because it's corrupted
@@ -767,7 +775,8 @@ class TestThumbnailRetrieval(ZulipTestCase):
                 json_response = self.assert_json_success(
                     self.client_post("/json/user_uploads", {"file": image_file})
                 )
-                path_id = re.sub(r"/user_uploads/", "", json_response["url"])
+                assert json_response["url"].startswith("/user_uploads/")
+                path_id = json_response["url"].removeprefix("/user_uploads/")
 
                 # Image itself is available immediately
                 response = self.client_get(f"/user_uploads/{path_id}")
@@ -817,7 +826,8 @@ class TestThumbnailRetrieval(ZulipTestCase):
                 json_response = self.assert_json_success(
                     self.client_post("/json/user_uploads", {"file": text_file})
                 )
-                text_path_id = re.sub(r"/user_uploads/", "", json_response["url"])
+                assert json_response["url"].startswith("/user_uploads/")
+                text_path_id = json_response["url"].removeprefix("/user_uploads/")
             response = self.client_get(f"/user_uploads/thumbnail/{text_path_id}/{webp_still!s}")
             self.assertEqual(response.status_code, 404)
             self.assertEqual(response.headers["Content-Type"], "image/png")
@@ -872,7 +882,8 @@ class TestThumbnailRetrieval(ZulipTestCase):
                 json_response = self.assert_json_success(
                     self.client_post("/json/user_uploads", {"file": image_file})
                 )
-                path_id = re.sub(r"/user_uploads/", "", json_response["url"])
+                assert json_response["url"].startswith("/user_uploads/")
+                path_id = json_response["url"].removeprefix("/user_uploads/")
                 # Exit the block, triggering the thumbnailing worker
 
             still_response = self.client_get(f"/user_uploads/thumbnail/{path_id}/{webp_still!s}")
@@ -913,7 +924,8 @@ class TestThumbnailRetrieval(ZulipTestCase):
             json_response = self.assert_json_success(
                 self.client_post("/json/user_uploads", {"file": image_file})
             )
-            path_id = re.sub(r"/user_uploads/", "", json_response["url"])
+            assert json_response["url"].startswith("/user_uploads/")
+            path_id = json_response["url"].removeprefix("/user_uploads/")
             # Exit the block, triggering the thumbnailing worker
 
         image_attachment = ImageAttachment.objects.get(path_id=path_id)

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1,5 +1,4 @@
 import os
-import re
 from datetime import timedelta
 from io import StringIO
 from unittest import mock
@@ -508,7 +507,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         d1.name = "dummy_1.txt"
         result = self.client_post("/json/user_uploads", {"file": d1})
         response_dict = self.assert_json_success(result)
-        d1_path_id = re.sub(r"/user_uploads/", "", response_dict["url"])
+        assert response_dict["url"].startswith("/user_uploads/")
+        d1_path_id = response_dict["url"].removeprefix("/user_uploads/")
 
         self.subscribe(self.example_user("hamlet"), "Denmark")
         host = self.example_user("hamlet").realm.host
@@ -527,7 +527,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         d1.name = "dummy_1.txt"
         result = self.client_post("/json/user_uploads", {"file": d1})
         response_dict = self.assert_json_success(result)
-        d1_path_id = re.sub(r"/user_uploads/", "", response_dict["url"])
+        assert response_dict["url"].startswith("/user_uploads/")
+        d1_path_id = response_dict["url"].removeprefix("/user_uploads/")
         host = self.example_user("hamlet").realm.host
 
         self.make_stream("private_stream", invite_only=True)
@@ -587,11 +588,13 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         self.login_user(hamlet)
         result = self.client_post("/json/user_uploads", {"file": f1})
         response_dict = self.assert_json_success(result)
-        f1_path_id = re.sub(r"/user_uploads/", "", response_dict["url"])
+        assert response_dict["url"].startswith("/user_uploads/")
+        f1_path_id = response_dict["url"].removeprefix("/user_uploads/")
 
         result = self.client_post("/json/user_uploads", {"file": f2})
         response_dict = self.assert_json_success(result)
-        f2_path_id = re.sub(r"/user_uploads/", "", response_dict["url"])
+        assert response_dict["url"].startswith("/user_uploads/")
+        f2_path_id = response_dict["url"].removeprefix("/user_uploads/")
 
         self.subscribe(hamlet, "test")
         body = (
@@ -602,7 +605,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         result = self.client_post("/json/user_uploads", {"file": f3})
         response_dict = self.assert_json_success(result)
-        f3_path_id = re.sub(r"/user_uploads/", "", response_dict["url"])
+        assert response_dict["url"].startswith("/user_uploads/")
+        f3_path_id = response_dict["url"].removeprefix("/user_uploads/")
 
         new_body = (
             f"[f3.txt](http://{host}/user_uploads/" + f3_path_id + ") "
@@ -690,7 +694,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         d1.name = "dummy_1.txt"
         result = self.client_post("/json/user_uploads", {"file": d1})
         response_dict = self.assert_json_success(result)
-        d1_path_id = re.sub(r"/user_uploads/", "", response_dict["url"])
+        assert response_dict["url"].startswith("/user_uploads/")
+        d1_path_id = response_dict["url"].removeprefix("/user_uploads/")
         d1_attachment = Attachment.objects.get(path_id=d1_path_id)
 
         realm = get_realm("zulip")
@@ -750,7 +755,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
         url = self.assert_json_success(result)["url"]
-        fp_path_id = re.sub(r"/user_uploads/", "", url)
+        assert url.startswith("/user_uploads/")
+        fp_path_id = url.removeprefix("/user_uploads/")
         body = f"First message ...[zulip.txt](http://{host}/user_uploads/" + fp_path_id + ")"
         with self.settings(CROSS_REALM_BOT_EMAILS={user_2.email, user_3.email}):
             internal_send_private_message(
@@ -796,7 +802,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
         url = self.assert_json_success(result)["url"]
-        fp_path_id = re.sub(r"/user_uploads/", "", url)
+        assert url.startswith("/user_uploads/")
+        fp_path_id = url.removeprefix("/user_uploads/")
         body = f"First message ...[zulip.txt](http://{realm.host}/user_uploads/" + fp_path_id + ")"
         self.send_stream_message(hamlet, stream_name, body, "test")
         self.logout()
@@ -848,7 +855,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
         url = self.assert_json_success(result)["url"]
-        fp_path_id = re.sub(r"/user_uploads/", "", url)
+        assert url.startswith("/user_uploads/")
+        fp_path_id = url.removeprefix("/user_uploads/")
         body = (
             f"First message ...[zulip.txt](http://{user.realm.host}/user_uploads/"
             + fp_path_id
@@ -917,7 +925,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
         url = self.assert_json_success(result)["url"]
-        fp_path_id = re.sub(r"/user_uploads/", "", url)
+        assert url.startswith("/user_uploads/")
+        fp_path_id = url.removeprefix("/user_uploads/")
         for i in range(20):
             body = (
                 f"First message ...[zulip.txt](http://{hamlet.realm.host}/user_uploads/"
@@ -962,7 +971,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
         url = self.assert_json_success(result)["url"]
-        fp_path_id = re.sub(r"/user_uploads/", "", url)
+        assert url.startswith("/user_uploads/")
+        fp_path_id = url.removeprefix("/user_uploads/")
         body = f"First message ...[zulip.txt](http://{realm.host}/user_uploads/" + fp_path_id + ")"
         self.send_stream_message(self.example_user("hamlet"), "test-subscribe", body, "test")
         self.logout()
@@ -987,7 +997,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
             fp.name = name
             result = self.client_post("/json/user_uploads", {"file": fp})
             url = self.assert_json_success(result)["url"]
-            fp_path_id = re.sub(r"/user_uploads/", "", url)
+            assert url.startswith("/user_uploads/")
+            fp_path_id = url.removeprefix("/user_uploads/")
             fp_path = os.path.split(fp_path_id)[0]
             if download:
                 url = url.replace("/user_uploads/", "/user_uploads/download/")

--- a/zerver/tests/test_upload_local.py
+++ b/zerver/tests/test_upload_local.py
@@ -34,9 +34,8 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
         user_profile = self.example_user("hamlet")
         url = upload_message_attachment("dummy.txt", "text/plain", b"zulip!", user_profile)[0]
 
-        base = "/user_uploads/"
-        self.assertEqual(base, url[: len(base)])
-        path_id = re.sub(r"/user_uploads/", "", url)
+        assert url.startswith("/user_uploads/")
+        path_id = url.removeprefix("/user_uploads/")
         assert settings.LOCAL_UPLOADS_DIR is not None
         assert settings.LOCAL_FILES_DIR is not None
         file_path = os.path.join(settings.LOCAL_FILES_DIR, path_id)
@@ -49,7 +48,8 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
         user_profile = self.example_user("hamlet")
         url = upload_message_attachment("dummy.txt", "text/plain", b"zulip!", user_profile)[0]
 
-        path_id = re.sub(r"/user_uploads/", "", url)
+        assert url.startswith("/user_uploads/")
+        path_id = url.removeprefix("/user_uploads/")
         output = BytesIO()
         save_attachment_contents(path_id, output)
         self.assertEqual(output.getvalue(), b"zulip!")
@@ -59,7 +59,8 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
         url = upload_message_attachment(
             "img.png", "image/png", read_test_image_file("img.png"), user_profile
         )[0]
-        path_id = re.sub(r"/user_uploads/", "", url)
+        assert url.startswith("/user_uploads/")
+        path_id = url.removeprefix("/user_uploads/")
 
         source = attachment_vips_source(path_id)
         self.assertIsInstance(source, StreamingSourceWithSize)
@@ -93,7 +94,8 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
 
         response_dict = self.assert_json_success(result)
         self.assertEqual(response_dict["uri"], response_dict["url"])
-        path_id = re.sub(r"/user_uploads/", "", response_dict["url"])
+        assert response_dict["url"].startswith("/user_uploads/")
+        path_id = response_dict["url"].removeprefix("/user_uploads/")
 
         assert settings.LOCAL_FILES_DIR is not None
         file_path = os.path.join(settings.LOCAL_FILES_DIR, path_id)
@@ -110,9 +112,8 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
         path_ids = []
         for n in range(1, 1005):
             url = upload_message_attachment("dummy.txt", "text/plain", b"zulip!", user_profile)[0]
-            base = "/user_uploads/"
-            self.assertEqual(base, url[: len(base)])
-            path_id = re.sub(r"/user_uploads/", "", url)
+            assert url.startswith("/user_uploads/")
+            path_id = url.removeprefix("/user_uploads/")
             path_ids.append(path_id)
             file_path = os.path.join(settings.LOCAL_FILES_DIR, path_id)
             self.assertTrue(os.path.isfile(file_path))

--- a/zerver/tests/test_upload_s3.py
+++ b/zerver/tests/test_upload_s3.py
@@ -57,9 +57,8 @@ class S3Test(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         url = upload_message_attachment("dummy.txt", "text/plain", b"zulip!", user_profile)[0]
 
-        base = "/user_uploads/"
-        self.assertEqual(base, url[: len(base)])
-        path_id = re.sub(r"/user_uploads/", "", url)
+        assert url.startswith("/user_uploads/")
+        path_id = url.removeprefix("/user_uploads/")
         content = bucket.Object(path_id).get()["Body"].read()
         self.assertEqual(b"zulip!", content)
 
@@ -76,7 +75,8 @@ class S3Test(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         url = upload_message_attachment("dummy.txt", "text/plain", b"zulip!", user_profile)[0]
 
-        path_id = re.sub(r"/user_uploads/", "", url)
+        assert url.startswith("/user_uploads/")
+        path_id = url.removeprefix("/user_uploads/")
         output = BytesIO()
         save_attachment_contents(path_id, output)
         self.assertEqual(output.getvalue(), b"zulip!")
@@ -88,7 +88,8 @@ class S3Test(ZulipTestCase):
         url = upload_message_attachment(
             "img.png", "image/png", read_test_image_file("img.png"), user_profile
         )[0]
-        path_id = re.sub(r"/user_uploads/", "", url)
+        assert url.startswith("/user_uploads/")
+        path_id = url.removeprefix("/user_uploads/")
 
         source = attachment_vips_source(path_id)
         self.assertIsInstance(source, StreamingSourceWithSize)
@@ -123,7 +124,8 @@ class S3Test(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         url = upload_message_attachment("dummy.txt", "text/plain", b"zulip!", user_profile)[0]
 
-        path_id = re.sub(r"/user_uploads/", "", url)
+        assert url.startswith("/user_uploads/")
+        path_id = url.removeprefix("/user_uploads/")
         self.assertIsNotNone(bucket.Object(path_id).get())
         self.assertTrue(delete_message_attachment(path_id))
         with self.assertRaises(botocore.exceptions.ClientError):
@@ -137,7 +139,8 @@ class S3Test(ZulipTestCase):
         path_ids = []
         for n in range(1, 5):
             url = upload_message_attachment("dummy.txt", "text/plain", b"zulip!", user_profile)[0]
-            path_id = re.sub(r"/user_uploads/", "", url)
+            assert url.startswith("/user_uploads/")
+            path_id = url.removeprefix("/user_uploads/")
             self.assertIsNotNone(bucket.Object(path_id).get())
             path_ids.append(path_id)
 
@@ -170,14 +173,16 @@ class S3Test(ZulipTestCase):
         path_ids = []
         for n in range(1, 5):
             url = upload_message_attachment("dummy.txt", "text/plain", b"zulip!", user_profile)[0]
-            path_ids.append(re.sub(r"/user_uploads/", "", url))
+            assert url.startswith("/user_uploads/")
+            path_ids.append(url.removeprefix("/user_uploads/"))
 
         # Put an image in, which gets thumbnailed
         with self.captureOnCommitCallbacks(execute=True):
             url = upload_message_attachment(
                 "img.png", "image/png", read_test_image_file("img.png"), user_profile
             )[0]
-            image_path_id = re.sub(r"/user_uploads/", "", url)
+            assert url.startswith("/user_uploads/")
+            image_path_id = url.removeprefix("/user_uploads/")
             path_ids.append(image_path_id)
 
         found_paths = [r[0] for r in all_message_attachments()]


### PR DESCRIPTION
Fixes RUF055 Plain string pattern passed to `re` function (preview rule).