### PR TITLE
tools: Update docs for create-api-changelog tool.

### DIFF
--- a/docs/documentation/api.md
+++ b/docs/documentation/api.md
@@ -334,14 +334,23 @@ above.
    post an example of the output in the pull request.
 
 1. Run `./tools/create-api-changelog` which will create a new empty
-   changelog file in `api_docs/unmerged.d/` directory. Open this
-   file and document the API changes. The content of this file will be
-   merged into `api_docs/changelog.md` when your commit is merged into the
-   `main` branch.
+   markdown file in `api_docs/unmerged.d/` directory
+   (e.g., `api_docs/unmerged.d/ZF-1f4a39.md`). Open this
+   file and document the API changes, formatted as an unordered list
+   (`*` bullets). The raw content of this file will be merged into
+   `api_docs/changelog.md` when your commit is merged into the `main`
+   branch. Therefore, keep the formatting and line wrapping consistent
+   with the content in `api_docs/changelog.md`.
 
-1. Add a `**Changes**` entry in the description of the new API/event in
-   `zerver/openapi/zulip.yaml`, and mention the name of the file generated
-   in the previous step in place of the API feature level.
+1. Add a `**Changes**` note in the description of all updates and
+   additions to the API documentation (`zerver/openapi/zulip.yaml`),
+   and mention the name of the file generated in the previous step
+   (without the `.md` extension) in place of the API feature level,
+   for example:
+
+   ```yaml
+   **Changes**: New in Zulip 11.0 (feature level ZF-1f4a39).
+   ```
 
 ## Why a custom system?
 

--- a/tools/create-api-changelog
+++ b/tools/create-api-changelog
@@ -28,5 +28,8 @@ if __name__ == "__main__":
         f"""Created an empty API changelog file.
 If you've made changes to the API, document them here:
 {file_path}
+
+For help, see:
+    https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 """
     )


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Added link to documentation when creating unmerged changelog file using `create-api-changelog` and updated docs for `create-api-changelog` tools.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
