### PR TITLE
saml: Implement group sync upon user login. 

### DIFF
--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -142,6 +142,8 @@ _Unreleased_
 - Zulip's incoming email integration was simplified to no longer use
   `postfix`. Installations using the integration will automatically
   uninstall `postfix` when upgraded.
+- The `SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT` setting has been removed.
+  It was deprecated in favor of `SOCIAL_AUTH_SYNC_ATTRS_DICT` in 10.0.
 
 ## Zulip Server 10.x series
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -19,6 +19,7 @@ import ldap
 import orjson
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.sessions.backends.base import SessionBase
 from django.db.migrations.state import StateApps
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.http.request import QueryDict
@@ -397,6 +398,7 @@ class HostRequestMock(HttpRequest):
         self.user = user_profile or AnonymousUser()
         self._body = orjson.dumps(post_data)
         self.content_type = ""
+        self.session = SessionBase()
 
         RequestNotes.set_notes(
             self,

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -137,6 +137,8 @@ from zproject.backends import (
     password_auth_enabled,
 )
 
+logger = logging.getLogger("")
+
 
 @typed_endpoint
 def get_prereg_key_and_redirect(
@@ -507,7 +509,7 @@ def registration_helper(
                     try:
                         ldap_username = backend.django_to_ldap_username(email)
                     except NoMatchingLDAPUserError:
-                        logging.warning("New account email %s could not be found in LDAP", email)
+                        logger.warning("New account email %s could not be found in LDAP", email)
                         break
 
                     # Note that this `ldap_user` object is not a
@@ -860,7 +862,7 @@ def registration_helper(
         )
         if return_data.get("invalid_subdomain"):
             # By construction, this should never happen.
-            logging.error(
+            logger.error(
                 "Subdomain mismatch in registration %s: %s",
                 realm.subdomain,
                 user_profile.delivery_email,
@@ -1315,7 +1317,7 @@ def create_realm(request: HttpRequest, creation_key: str | None = None) -> HttpR
                     request=request,
                 )
             except EmailNotDeliveredError:
-                logging.exception("Failed to deliver email during realm creation")
+                logger.exception("Failed to deliver email during realm creation")
                 if settings.CORPORATE_ENABLED:
                     return render(request, "500.html", status=500)
                 return config_error(request, "smtp")
@@ -1482,7 +1484,7 @@ def accounts_home(
             try:
                 send_confirm_registration_email(email, activation_url, request=request, realm=realm)
             except EmailNotDeliveredError:
-                logging.exception("Failed to deliver email during user registration")
+                logger.exception("Failed to deliver email during user registration")
                 if settings.CORPORATE_ENABLED:
                     return render(request, "500.html", status=500)
                 return config_error(request, "smtp")

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -135,6 +135,7 @@ from zproject.backends import (
     get_external_method_dicts,
     ldap_auth_enabled,
     password_auth_enabled,
+    sync_groups,
 )
 
 logger = logging.getLogger("")
@@ -842,6 +843,8 @@ def registration_helper(
                 # duplicate email address.  Redirect them to the login
                 # form.
                 return redirect_to_email_login_url(email)
+            else:
+                sync_groups_post_registration(request=request, user_profile=user_profile)
 
         if realm_creation:
             # Because for realm creation, registration happens on the
@@ -912,6 +915,34 @@ def registration_helper(
         context.update(get_realm_create_form_context())
 
     return TemplateResponse(request, "zerver/register.html", context=context)
+
+
+def sync_groups_post_registration(request: HttpRequest, user_profile: UserProfile) -> None:
+    group_memberships_sync_data = get_expirable_session_var(
+        request.session, "registration_group_memberships_sync_map", delete=True
+    )
+    if not group_memberships_sync_data:
+        return
+
+    group_memberships_sync_map = orjson.loads(group_memberships_sync_data)
+    if group_memberships_sync_map:
+        logger.info(
+            "Syncing groups post-registration for new user %s in realm %s: %s",
+            user_profile.id,
+            user_profile.realm_id,
+            group_memberships_sync_map,
+        )
+        assert isinstance(group_memberships_sync_map, dict)
+        sync_groups(
+            all_group_names=set(group_memberships_sync_map.keys()),
+            intended_group_names={
+                group_name
+                for group_name, is_member in group_memberships_sync_map.items()
+                if is_member
+            },
+            user_profile=user_profile,
+            logger=logger,
+        )
 
 
 def login_and_go_to_home(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -1215,6 +1215,13 @@ def ensure_dict_path(d: dict[str, Any], keys: list[str]) -> None:
         d = d[key]
 
 
+for dict_for_subdomain in SOCIAL_AUTH_SYNC_ATTRS_DICT.values():
+    for attrs_map in dict_for_subdomain.values():
+        if "zulip_groups" in attrs_map.values():
+            raise AssertionError(
+                "zulip_groups can't be listed as a SAML attribute in SOCIAL_AUTH_SYNC_ATTRS_DICT"
+            )
+
 SOCIAL_AUTH_PIPELINE = [
     "social_core.pipeline.social_auth.social_details",
     "zproject.backends.social_auth_associate_user",

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -65,7 +65,6 @@ from .configured_settings import (
     SOCIAL_AUTH_SAML_SECURITY_CONFIG,
     SOCIAL_AUTH_SUBDOMAIN,
     SOCIAL_AUTH_SYNC_ATTRS_DICT,
-    SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT,
     STATIC_URL,
     SUBMIT_USAGE_STATISTICS,
     TORNADO_PORTS,
@@ -1215,17 +1214,6 @@ def ensure_dict_path(d: dict[str, Any], keys: list[str]) -> None:
             d[key] = {}
         d = d[key]
 
-
-# Merge SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT into SOCIAL_AUTH_SYNC_ATTRS_DICT.
-# This is compat code for the original SOCIAL_AUTH_CUSTOM_ATTRS_DICT setting.
-# TODO/compatibility: Remove this for release Zulip 10.0.
-for subdomain, dict_for_subdomain in SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT.items():
-    for backend_name, custom_attrs_map in dict_for_subdomain.items():
-        ensure_dict_path(SOCIAL_AUTH_SYNC_ATTRS_DICT, [subdomain, backend_name])
-        for custom_attr_name, source_attr_name in custom_attrs_map.items():
-            SOCIAL_AUTH_SYNC_ATTRS_DICT[subdomain][backend_name][f"custom__{custom_attr_name}"] = (
-                source_attr_name
-            )
 
 SOCIAL_AUTH_PIPELINE = [
     "social_core.pipeline.social_auth.social_details",

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -93,6 +93,7 @@ SOCIAL_AUTH_SAML_TECHNICAL_CONTACT: dict[str, str] | None = None
 SOCIAL_AUTH_SAML_SUPPORT_CONTACT: dict[str, str] | None = None
 SOCIAL_AUTH_SAML_ENABLED_IDPS: dict[str, SAMLIdPConfigDict] = {}
 SOCIAL_AUTH_SAML_SECURITY_CONFIG: dict[str, Any] = {}
+
 # Set this to True to enforce that any configured IdP needs to specify
 # the limit_to_subdomains setting to be considered valid:
 SAML_REQUIRE_LIMIT_TO_SUBDOMAINS = False
@@ -112,7 +113,7 @@ SOCIAL_AUTH_APPLE_EMAIL_AS_USERNAME = True
 SOCIAL_AUTH_OIDC_ENABLED_IDPS: dict[str, OIDCIdPConfigDict] = {}
 SOCIAL_AUTH_OIDC_FULL_NAME_VALIDATED = False
 
-SOCIAL_AUTH_SYNC_ATTRS_DICT: dict[str, dict[str, dict[str, str]]] = {}
+SOCIAL_AUTH_SYNC_ATTRS_DICT: dict[str, dict[str, dict[str, str | list[str | tuple[str, str]]]]] = {}
 
 # Other auth
 SSO_APPEND_DOMAIN: str | None = None

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -112,7 +112,6 @@ SOCIAL_AUTH_APPLE_EMAIL_AS_USERNAME = True
 SOCIAL_AUTH_OIDC_ENABLED_IDPS: dict[str, OIDCIdPConfigDict] = {}
 SOCIAL_AUTH_OIDC_FULL_NAME_VALIDATED = False
 
-SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT: dict[str, dict[str, dict[str, str]]] = {}
 SOCIAL_AUTH_SYNC_ATTRS_DICT: dict[str, dict[str, dict[str, str]]] = {}
 
 # Other auth

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -519,6 +519,10 @@ SOCIAL_AUTH_SAML_SUPPORT_CONTACT = {
 #             # Specify custom profile fields with a custom__ prefix for the
 #             # Zulip field name.
 #             "custom__title": "title",
+#             # Sync the membership of the listed Zulip groups with
+#             # the list of group names sent in the "zulip_groups"
+#             # attribute in the SAMLResponse.
+#             "groups": ["group1", "group2", ("samlgroup3", "zulipgroup3"), "group4"],
 #         }
 #     }
 # }

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -441,8 +441,8 @@ SOCIAL_AUTH_SAML_ENABLED_IDPS: dict[str, Any] = {
         "attr_username": "email",
         "attr_email": "email",
         ## List of additional attributes to fetch from the SAMLResponse.
-        ## These attributes will be available for synchronizing custom profile fields.
-        ## in SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT.
+        ## These attributes will be available for synchronizing user profile fields.
+        ## in SOCIAL_AUTH_SYNC_ATTRS_DICT.
         # "extra_attrs": ["title", "mobilePhone", "zulip_role"],
         ##
         ## The "x509cert" attribute is automatically read from


### PR DESCRIPTION
Adds support for syncing group memberships for a user when logging in
via SAML. The list of group memberships is passed by the IdP in the
zulip_groups SAML attribute in the SAMLResponse.

Still missing:
- [x] RTD documentation - pending discussion/revision of the configuration interface
- [ ] `/help/saml-authentication/` documenting how to set things up on the IdP side to pass group names in the zulip_groups attribute
- [x] ~~**Does not work during signup**! That requires another commit, implementing the necessary plumbing of the information. We already do a similar thing to sync role during signup, so this shouldn't be hard - but isn't done in the current state of this PR.~~

This has been tested with Okta, where it just takes adding this in the app's configuration UI:
![image](https://github.com/user-attachments/assets/d827af79-ff4a-4b1c-855f-ba3d0f4d9270)

and it passed a list of names of all the groups the user belongs to, during login. I need to also figure out how to do this with with Auth0.