### PR TITLE
buddy_list: Fetch all subscribers before showing search results.

### DIFF
--- a/web/src/activity_ui.ts
+++ b/web/src/activity_ui.ts
@@ -8,7 +8,9 @@ import * as buddy_data from "./buddy_data.ts";
 import {buddy_list} from "./buddy_list.ts";
 import * as keydown_util from "./keydown_util.ts";
 import {ListCursor} from "./list_cursor.ts";
+import * as loading from "./loading.ts";
 import * as narrow_state from "./narrow_state.ts";
+import * as peer_data from "./peer_data.ts";
 import * as people from "./people.ts";
 import * as pm_list from "./pm_list.ts";
 import * as popovers from "./popovers.ts";
@@ -137,13 +139,68 @@ export function rewire_build_user_sidebar(value: typeof build_user_sidebar): voi
     build_user_sidebar = value;
 }
 
+export function remove_loading_indicator_for_search(): void {
+    loading.destroy_indicator($("#buddy-list-loading-subscribers"));
+    $("#buddy_list_wrapper").show();
+}
+
+// We need to make sure we have all subscribers before displaying
+// users during search, because we show all matching users and
+// sort them by if they're subscribed. We store all pending fetches,
+// in case we navigate away from a stream and back to it and kick
+// off another search. We also store the current pending fetch so
+// we know if it's still relevant once it's completed.
+let pending_fetch_for_search_stream_id: number | undefined;
+const all_pending_fetches_for_search = new Map<number, Promise<void>>();
+
+export async function await_pending_promise_for_testing(): Promise<void> {
+    assert(pending_fetch_for_search_stream_id !== undefined);
+    await all_pending_fetches_for_search.get(pending_fetch_for_search_stream_id);
+}
+
 function do_update_users_for_search(): void {
     // Hide all the popovers but not userlist sidebar
     // when the user is searching.
     popovers.hide_all();
-    build_user_sidebar();
-    assert(user_cursor !== undefined);
-    user_cursor.reset();
+
+    const stream_id = narrow_state.stream_id(narrow_state.filter(), true);
+    if (!stream_id || peer_data.has_full_subscriber_data(stream_id)) {
+        pending_fetch_for_search_stream_id = undefined;
+        build_user_sidebar();
+        assert(user_cursor !== undefined);
+        user_cursor.reset();
+        return;
+    }
+
+    pending_fetch_for_search_stream_id = stream_id;
+
+    // If we're already fetching for this stream, we don't need to wait for
+    // another promise. The sidebar will be updated once that promise resolves.
+    if (all_pending_fetches_for_search.has(stream_id)) {
+        return;
+    }
+
+    all_pending_fetches_for_search.set(
+        stream_id,
+        (async () => {
+            $("#buddy_list_wrapper").hide();
+            loading.make_indicator($("#buddy-list-loading-subscribers"));
+            await peer_data.maybe_fetch_stream_subscribers(stream_id);
+            all_pending_fetches_for_search.delete(stream_id);
+
+            // If we changed narrows during the fetch, don't rebuild the sidebar
+            // anymore. Let the new narrow handle its own state. The loading indicator
+            // should have already been removed on narrow change.
+            if (pending_fetch_for_search_stream_id !== stream_id) {
+                return;
+            }
+            remove_loading_indicator_for_search();
+            pending_fetch_for_search_stream_id = undefined;
+            build_user_sidebar();
+            assert(user_cursor !== undefined);
+            user_cursor.reset();
+        })(),
+    );
 }
 
 const update_users_for_search = _.throttle(do_update_users_for_search, 50);
@@ -281,6 +338,7 @@ export function initiate_search(): void {
 export function clear_search(): void {
     if (user_filter) {
         user_filter.clear_search();
+        remove_loading_indicator_for_search();
     }
 }
 

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -723,8 +723,9 @@ export class BuddyList extends BuddyListConf {
 
         // After the `await`, we might have changed to a different channel view.
         // If so, we shouldn't update the DOM anymore, and should let the newer `populate`
-        // call set things up with fresh data.
-        if (current_sub !== this.render_data.current_sub) {
+        // call set things up with fresh data. We also want to make sure not to show
+        // the links when searching users, which might have changed since fetching data.
+        if (current_sub !== this.render_data.current_sub || buddy_data.get_is_searching_users()) {
             return;
         }
 

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -646,3 +646,9 @@
         }
     }
 }
+
+#buddy-list-loading-subscribers {
+    margin: auto;
+    padding-right: var(--width-simplebar-scroll-hover);
+    padding-top: 30px;
+}

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -34,6 +34,7 @@
                     </a>
                 </div>
             </div>
+            <div id="buddy-list-loading-subscribers"></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Work towards https://github.com/zulip/zulip/issues/34244.

Simulated with 5 sec fetch delay:

![Kapture 2025-05-19 at 20 45 28](https://github.com/user-attachments/assets/1c86465e-e485-4366-b465-1c693ce7f92b)
