### PR TITLE
Miscellaneous fixes in groups UI.

### DIFF
--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1676,7 +1676,7 @@ export function update_empty_left_panel_message(): void {
     }
 
     if (
-        $(".user-groups-list").find(
+        $("#groups_overlay").find(
             ".user-groups-list:not(.hide-deactivated-user-groups) .group-row.deactivated-group, .user-groups-list:not(.hide-active-user-groups) .group-row:not(.deactivated-group)",
         ).length > 0
     ) {

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1677,7 +1677,7 @@ export function update_empty_left_panel_message(): void {
 
     if (
         $(".user-groups-list").find(
-            ".user-groups-list:not(.hide-deactived-user-groups) .group-row.deactivated-group, .user-groups-list:not(.hide-active-user-groups) .group-row:not(.deactivated-group)",
+            ".user-groups-list:not(.hide-deactivated-user-groups) .group-row.deactivated-group, .user-groups-list:not(.hide-active-user-groups) .group-row:not(.deactivated-group)",
         ).length > 0
     ) {
         $(".no-groups-to-show").hide();
@@ -1737,13 +1737,13 @@ export function remove_deactivated_user_from_all_groups(user_id: number): void {
 
 export function update_displayed_groups(filter_id: string): void {
     if (filter_id === FILTERS.ACTIVE_GROUPS) {
-        $(".user-groups-list").addClass("hide-deactived-user-groups");
+        $(".user-groups-list").addClass("hide-deactivated-user-groups");
         $(".user-groups-list").removeClass("hide-active-user-groups");
     } else if (filter_id === FILTERS.DEACTIVATED_GROUPS) {
-        $(".user-groups-list").removeClass("hide-deactived-user-groups");
+        $(".user-groups-list").removeClass("hide-deactivated-user-groups");
         $(".user-groups-list").addClass("hide-active-user-groups");
     } else {
-        $(".user-groups-list").removeClass("hide-deactived-user-groups");
+        $(".user-groups-list").removeClass("hide-deactivated-user-groups");
         $(".user-groups-list").removeClass("hide-active-user-groups");
     }
 }

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1249,6 +1249,7 @@ function hide_membership_toggle_spinner($group_row: JQuery): void {
 
 function empty_right_panel(): void {
     $(".group-row.active").removeClass("active");
+    $("#groups_overlay .right").removeClass("show");
     user_group_components.show_user_group_settings_pane.nothing_selected();
 }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -685,7 +685,7 @@ h4.user_group_setting_subsection_title {
     align-items: center;
 }
 
-.user-groups-list.hide-deactived-user-groups .deactivated-group {
+.user-groups-list.hide-deactivated-user-groups .deactivated-group {
     display: none;
 }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to fix a typo.
- Second commit fixes empty panel text being shown even when groups are present.
- Third commit is to fix view shown when clicking "Cancel" button in groups creation UI for mobile widths.
- Fourth commit is to not open group in right panel when leaving the group by clicking on checkmark.

Fixes: <!-- Issue link, or clear description.--> https://chat.zulip.org/#narrow/channel/9-issues/topic/group.20settings.20UI.20bug/with/2177144

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| | Before | After |
| -------- | ------- | -------- |
| Empty panel text change | ![first-commit-before](https://github.com/user-attachments/assets/f5d75fb7-6ebf-4dc3-a4ca-796f144c0952) | ![first-commit-after](https://github.com/user-attachments/assets/694e50d8-7f57-489e-9bea-f59a8a0f847d) |
| Closing creation UI | ![third-commit-before](https://github.com/user-attachments/assets/31c6b941-9cd5-4f43-8dc1-b2798697e708) | ![third-commit-after](https://github.com/user-attachments/assets/643d2366-38d2-4888-abc3-0d7674f97969) |
| Joining/leaving the group from left panel | ![fourth-commit-before](https://github.com/user-attachments/assets/25743750-2a11-4c7d-954a-e268f07c771b) | ![fourth-commit-after](https://github.com/user-attachments/assets/d3e1159e-9a88-4bc6-8481-71ba16b2fb7e) |
| Joining/leaving the group from left panel (narrow width) | ![fourth commit-mobile-width-before](https://github.com/user-attachments/assets/2f949ec6-69e5-4dce-a101-890bad6794ef) | ![fourth-commit-after-mobile-width](https://github.com/user-attachments/assets/982c1b89-318e-4572-a29d-f619f6e501f4) |







<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
