### PR TITLE
billing: Update CustomerPlan.invoiced_through documentation.

### DIFF
--- a/corporate/models/plans.py
+++ b/corporate/models/plans.py
@@ -120,11 +120,12 @@ class CustomerPlan(AbstractCustomerPlan):
     # an email only once and not every time when cron run.
     reminder_to_review_plan_email_sent = models.BooleanField(default=False)
 
-    # On next_invoice_date, we go through ledger entries that were
-    # created after invoiced_through and process them by generating
-    # invoices for any additional users and/or plan renewal. Once the
-    # invoice is generated, we update the value of invoiced_through
-    # and set it to the last ledger entry we processed.
+    # On next_invoice_date, we call invoice_plan, which goes through
+    # ledger entries that were created after invoiced_through and
+    # process them. An invoice will be generated for any additional
+    # users and/or plan renewal (if it's the end of the billing cycle).
+    # Once all new ledger entries have been processed, invoiced_through
+    # will be have been set to the last ledger entry we checked.
     invoiced_through = models.ForeignKey(
         "LicenseLedger", null=True, on_delete=CASCADE, related_name="+"
     )

--- a/corporate/views/plan_activity.py
+++ b/corporate/views/plan_activity.py
@@ -56,7 +56,7 @@ def get_plan_ledger(request: HttpRequest, plan_id: int) -> HttpResponse:
     if plan.invoiced_through is not None:
         header_entries.append(
             ActivityHeaderEntry(
-                name="Entry for last invoice",
+                name="Entry last checked during invoicing",
                 value=str(plan.invoiced_through),
             )
         )


### PR DESCRIPTION
Clarify what the `invoiced_through` field on a `CustomerPlan` indicates after the changes to the billing state machine as ledger entries are processed in `invoice_plan`.

Updates the plan activity page header, where this field is shown to support admin users, for these changes as well: `"Entry for last invoice"` -> `"Entry last checked during invoicing"`

Follow-up to #34643; see https://github.com/zulip/zulip/pull/34643#discussion_r2093232864.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
