### PR TITLE
hotkey: Fix toggle compose preview (Alt+P) hotkey.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -850,9 +850,9 @@ export function process_hotkey(e, hotkey) {
 
         if (compose_state.composing()) {
             if ($("#compose").hasClass("preview_mode")) {
-                compose.show_preview_area();
-            } else {
                 compose.clear_preview_area();
+            } else {
+                compose.show_preview_area();
             }
             return true;
         }


### PR DESCRIPTION
The hotkey for 'Toggle compose preview' (Alt+P) was not working due to a small logical bug introduced in 26f664be697f949bbe206cd90d.

We were calling `compose.show_preview_area()` when the compose is already in preview mode, instead of `compose.clear_preview_area()`.

This PR fixes the bug.



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
