### PR TITLE
mattermost_import: Log when processing messages and add try-except block.

### DIFF
--- a/zerver/lib/utils.py
+++ b/zerver/lib/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import re
 import secrets
 from collections.abc import Callable
@@ -30,13 +31,14 @@ def process_list_in_batches(
     lst: list[T], chunk_size: int, process_batch: Callable[[list[T]], None]
 ) -> None:
     offset = 0
-
+    total_message_length = len(lst)
     while True:
         items = lst[offset : offset + chunk_size]
         if not items:
             break
         process_batch(items)
-        offset += chunk_size
+        offset = min(offset + chunk_size, total_message_length)
+        logging.info("Processed messages up to %s / %s", offset, total_message_length)
 
 
 def optional_bytes_to_mib(value: int | None) -> int | None:

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -912,6 +912,8 @@ class RocketChatImporter(ZulipTestCase):
                 "INFO:root:Done processing emoji",
                 "INFO:root:Direct message group channel found. UIDs: ['LdBZ7kPxtKESyHPEe', 'M2sXGqoQRJQwQoXY2', 'os6N2Xg2JkNMCSW9Z']",
                 "INFO:root:skipping direct messages discussion mention: Discussion with Hermione",
+                "INFO:root:Processed messages up to 35 / 35",
+                "INFO:root:Processed messages up to 8 / 8",
                 "INFO:root:Exporting migration status",
             ],
         )


### PR DESCRIPTION
message processing log:
```
2025-05-21 02:45:20.003 INFO [] Processed messages up to 35 / 35
```

html2text falied log:
```
2025-05-21 05:00:02.140 WARN [] Error converting HTML to text. Message content: 'Xxxxxxx!'; continuing
```

Fixes: [ <!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/31-production-help/topic/Slow.20data.20conversion.20from.20Mattermost.20backup.2E/with/1912233)[#production help > Slow data conversion from Mattermost backup.](https://chat.zulip.org/#narrow/channel/31-production-help/topic/Slow.20data.20conversion.20from.20Mattermost.20backup.2E/with/1912233)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
