### PR TITLE
settings: Fix update_notification_banner for undefined Notification API and Muted Users Scrolling Blocker

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1320,7 +1320,7 @@ label.preferences-radio-choice-label {
 
 /* -- new settings overlay -- */
 #settings_page {
-    height: 95vh;
+    height: 100%;
     width: 97vw;
     max-width: 73.1429em; /* 1024px at 14px em */
     margin: 2.5vh auto;


### PR DESCRIPTION
Fixes two bugs in the settings page:

1) Handles environments where the Notification API is undefined, preventing crashes.

2) Fixes scroll behavior when jumping to muted users in the settings page.

Fixes zulip/zulip#34668.

<!-- Describe your pull request here.-->
1) This PR fixes a bug where the code assumed the Notification API is always defined, causing runtime errors in environments where it’s not supported.
By adding an explicit typeof Notification !== "undefined" check, the notification banner update logic handles these cases safely and prevents ReferenceErrors.

2) Previously, navigating to Muted Users section did not scroll the page all the way down in Safari, likely due to layout constraints.
By updating the height of #settings_page, we establish a proper scrollable layout. This ensures the Muted users section is correctly displayed upon navigation.

Fixes: <!-- Issue link, or clear description.-->
[zulip/zulip#34668
](https://github.com/zulip/zulip/issues/34668)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


**Screenshots and screen captures:**

**Notification Changes:**
Before change
<img width="394" alt="Screenshot 2025-05-20 at 9 04 05 PM" src="https://github.com/user-attachments/assets/20ef63c6-0031-4ec1-9638-cb4e12a6a34e" />

After change:
<img width="413" alt="Screenshot 2025-05-20 at 8 58 55 PM" src="https://github.com/user-attachments/assets/a3403b59-69e2-4c93-a50c-d8d5f514fff1" />

**Container Scrollbar Changes Demonstrating Visibility of Muted Users Section:**
Before change unable to scroll all the way down to Muted users:

https://github.com/user-attachments/assets/923d33d6-a1f1-4acc-8e89-62e03bf704db


After changes:

https://github.com/user-attachments/assets/800cc5e3-e361-41a3-bd12-d31c0084ae49




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [] Calls out remaining decisions and concerns.
- [] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
