### PR TITLE
Improve topic_link_util module.

### DIFF
--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -4,6 +4,7 @@ import assert from "minimalistic-assert";
 
 import * as hash_util from "./hash_util.ts";
 import * as stream_data from "./stream_data.ts";
+import * as util from "./util.ts";
 
 const invalid_stream_topic_regex = /[`>*&[\]]|(\$\$)/g;
 
@@ -64,14 +65,15 @@ export function get_topic_link_content(
     const escape = html_escape_markdown_syntax_characters;
     if (topic_name !== undefined) {
         const stream_topic_url = hash_util.by_stream_topic_url(stream_id, topic_name);
+        const topic_display_name = util.get_final_topic_display_name(topic_name);
         if (message_id !== undefined) {
             return {
-                text: `#${escape(stream_name)} > ${escape(topic_name)} @ 💬`,
+                text: `#${escape(stream_name)} > ${escape(topic_display_name)} @ 💬`,
                 url: `${stream_topic_url}/near/${message_id}`,
             };
         }
         return {
-            text: `#${escape(stream_name)} > ${escape(topic_name)}`,
+            text: `#${escape(stream_name)} > ${escape(topic_display_name)}`,
             url: stream_topic_url,
         };
     }

--- a/web/tests/topic_link_util.test.cjs
+++ b/web/tests/topic_link_util.test.cjs
@@ -13,6 +13,9 @@ mock_esm("../src/user_settings", {
         web_channel_default_view: settings_config.web_channel_default_view_values.channel_feed.code,
     },
 });
+mock_esm("../src/state_data", {
+    realm: {realm_empty_topic_display_name: "general chat"},
+});
 
 const sweden_stream = {
     name: "Sweden",
@@ -123,6 +126,23 @@ run_test("stream_topic_link_syntax_test", () => {
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("Sweden", "&a[b"),
         "[#Sweden > &amp;a&#91;b](#narrow/channel/1-Sweden/topic/.26a.5Bb)",
+    );
+
+    assert.equal(topic_link_util.get_stream_topic_link_syntax("Sweden", ""), "#**Sweden>**");
+
+    assert.equal(
+        topic_link_util.get_stream_topic_link_syntax("$$MONEY$$", ""),
+        "[#&#36;&#36;MONEY&#36;&#36; > translated: general chat](#narrow/channel/6-.24.24MONEY.24.24/topic/)",
+    );
+
+    assert.equal(
+        topic_link_util.get_fallback_markdown_link("Sweden", "abc", 123),
+        "[#Sweden > abc @ 💬](#narrow/channel/1-Sweden/topic/abc/near/123)",
+    );
+
+    assert.equal(
+        topic_link_util.get_fallback_markdown_link("Sweden", "", 123),
+        "[#Sweden > translated: general chat @ 💬](#narrow/channel/1-Sweden/topic//near/123)",
     );
 
     // Only for full coverage of the module.

--- a/zerver/lib/topic_link_util.py
+++ b/zerver/lib/topic_link_util.py
@@ -45,10 +45,10 @@ def encode_hash_component(s: str) -> str:
 
 
 def get_fallback_markdown_link(
-    stream_id: int, stream_name: str, topic_name: str | None = None
+    stream_id: int, stream_name: str, topic_name: str | None = None, message_id: int | None = None
 ) -> str:
     """
-    Generates the markdown link syntax for a stream or topic link.
+    Generates the markdown link syntax for a stream/topic/message link.
     """
     escape = escape_invalid_stream_topic_characters
     link = f"#narrow/channel/{stream_id}-{encode_hash_component(stream_name.replace(' ', '-'))}"
@@ -59,7 +59,24 @@ def get_fallback_markdown_link(
             topic_name = Message.EMPTY_TOPIC_FALLBACK_NAME
         text += f" > {escape(topic_name)}"
 
+    if message_id is not None:
+        link += f"/near/{message_id}"
+        text += " @ 💬"
+
     return f"[{text}]({link})"
+
+
+def get_message_link_syntax(
+    stream_id: int, stream_name: str, topic_name: str, message_id: int
+) -> str:
+    # If the stream/topic name is such that it will
+    # generate an invalid #**stream>topic@message_id** syntax,
+    # we revert to generating the normal markdown syntax for a link.
+    if will_produce_broken_stream_topic_link(topic_name) or will_produce_broken_stream_topic_link(
+        stream_name
+    ):
+        return get_fallback_markdown_link(stream_id, stream_name, topic_name, message_id)
+    return f"#**{stream_name}>{topic_name}@{message_id}**"
 
 
 def get_stream_topic_link_syntax(stream_id: int, stream_name: str, topic_name: str) -> str:

--- a/zerver/tests/test_topic_link_util.py
+++ b/zerver/tests/test_topic_link_util.py
@@ -1,5 +1,9 @@
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.topic_link_util import get_stream_link_syntax, get_stream_topic_link_syntax
+from zerver.lib.topic_link_util import (
+    get_message_link_syntax,
+    get_stream_link_syntax,
+    get_stream_topic_link_syntax,
+)
 
 
 class TestTopicLinkUtil(ZulipTestCase):
@@ -75,4 +79,23 @@ class TestTopicLinkUtil(ZulipTestCase):
         self.assertEqual(
             get_stream_topic_link_syntax(sweden_id, "Sw*den", ""),
             f"[#Sw&#42;den > general chat](#narrow/channel/{sweden_id}-Sw*den/topic/)",
+        )
+
+    def test_message_link_syntax(self) -> None:
+        sweden_id = self.make_stream("Sweden").id
+        self.assertEqual(
+            get_message_link_syntax(sweden_id, "Sweden", "topic", 123),
+            "#**Sweden>topic@123**",
+        )
+        self.assertEqual(
+            get_message_link_syntax(sweden_id, "Sweden", "", 123),
+            "#**Sweden>@123**",
+        )
+        self.assertEqual(
+            get_message_link_syntax(sweden_id, "Sw*den", "topic", 123),
+            f"[#Sw&#42;den > topic @ 💬](#narrow/channel/{sweden_id}-Sw*den/topic/topic/near/123)",
+        )
+        self.assertEqual(
+            get_message_link_syntax(sweden_id, "Sw*den", "", 123),
+            f"[#Sw&#42;den > general chat @ 💬](#narrow/channel/{sweden_id}-Sw*den/topic//near/123)",
         )

--- a/zerver/tests/test_topic_link_util.py
+++ b/zerver/tests/test_topic_link_util.py
@@ -68,3 +68,11 @@ class TestTopicLinkUtil(ZulipTestCase):
             get_stream_topic_link_syntax(sweden_id, "Sweden", "&a[b"),
             f"[#Sweden > &amp;a&#91;b](#narrow/channel/{sweden_id}-Sweden/topic/.26a.5Bb)",
         )
+        self.assertEqual(
+            get_stream_topic_link_syntax(sweden_id, "Sweden", ""),
+            "#**Sweden>**",
+        )
+        self.assertEqual(
+            get_stream_topic_link_syntax(sweden_id, "Sw*den", ""),
+            f"[#Sw&#42;den > general chat](#narrow/channel/{sweden_id}-Sw*den/topic/)",
+        )


### PR DESCRIPTION
This PR:
- adds support for empty topic names and message links in the backend `topic_link_util` module.
- adds support for empty topic names in the frontend `topic_link_util` module.

The modules in frontend and backend slightly differ in implementation but produce the same syntaxes for almost test cases except when generating stream links in the frontend, which recently started depending on the user setting  `web_channel_default_view`. (The backend module doesn't yet access user settings)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

*It was not possible to render the "general chat" in italics as we do not support that inside markdown `[]()`.*
<img width="955" alt="image" src="https://github.com/user-attachments/assets/ff89698a-b4b7-4009-a836-19c3c2d85eac" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
