### PR TITLE
organization settings: Clean up labels for custom time limits.

### DIFF
--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -122,6 +122,8 @@ IGNORED_PHRASES = [
     r"^cookie$",
     # Used to refer custom time limits
     r"\bN\b",
+    r"minute",
+    r"minutes",
     # Capital c feels obtrusive in clear status option
     r"clear",
     r"group direct messages with \{recipient\}",
@@ -278,6 +280,8 @@ def check_banned_words(text: str) -> list[str]:
                 or "realm_uri" in lower_cased_text
                 or "realm_url" in lower_cased_text
                 or "remote_realm_host" in lower_cased_text
+                or "realm_message" in lower_cased_text
+                or "realm_move" in lower_cased_text
             ):
                 continue
             kwargs = dict(word=word, text=text, reason=reason)

--- a/web/src/admin.ts
+++ b/web/src/admin.ts
@@ -156,6 +156,14 @@ export function build_page(): void {
             settings_components.get_realm_time_limits_in_minutes(
                 "realm_message_content_edit_limit_seconds",
             ),
+        realm_move_messages_between_streams_limit_minutes:
+            settings_components.get_realm_time_limits_in_minutes(
+                "realm_move_messages_between_streams_limit_seconds",
+            ),
+        realm_move_messages_within_stream_limit_minutes:
+            settings_components.get_realm_time_limits_in_minutes(
+                "realm_move_messages_within_stream_limit_seconds",
+            ),
         realm_message_content_delete_limit_minutes:
             settings_components.get_realm_time_limits_in_minutes(
                 "realm_message_content_delete_limit_seconds",

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -305,6 +305,19 @@ function get_jitsi_server_url_setting_value(
     return JSON.stringify($custom_input_elem.val());
 }
 
+export function update_custom_time_limit_minute_text($input: JQuery<HTMLInputElement>): void {
+    const $minutes_text = $input.parent().find(".time-unit-text");
+    const count = Number.parseInt($input.val()!, 10);
+    $minutes_text.text(
+        $t(
+            {
+                defaultMessage: "{count, plural, one {minute} other {minutes}}",
+            },
+            {count},
+        ),
+    );
+}
+
 export function update_custom_value_input(property_name: MessageTimeLimitSetting): void {
     const $dropdown_elem = $(`#id_${CSS.escape(property_name)}`);
     const custom_input_elem_id = $dropdown_elem
@@ -314,11 +327,11 @@ export function update_custom_value_input(property_name: MessageTimeLimitSetting
 
     const show_custom_limit_input = $dropdown_elem.val() === "custom_period";
     change_element_block_display_property(custom_input_elem_id, show_custom_limit_input);
-    if (show_custom_limit_input) {
-        $(`#${CSS.escape(custom_input_elem_id)}`).val(
-            get_realm_time_limits_in_minutes(property_name),
-        );
+    if (!show_custom_limit_input) {
+        return;
     }
+    $(`#${CSS.escape(custom_input_elem_id)}`).val(get_realm_time_limits_in_minutes(property_name));
+    update_custom_time_limit_minute_text($(`#${CSS.escape(custom_input_elem_id)}`));
 }
 
 export function get_time_limit_dropdown_setting_value(

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -1349,6 +1349,16 @@ export function build_page(): void {
 
     register_save_discard_widget_handlers($(".admin-realm-form"), "/json/realm", false);
 
+    $(".org-permissions-form").on(
+        "input change",
+        ".time-limit-custom-input",
+        function (this: HTMLInputElement, e) {
+            e.preventDefault();
+            e.stopPropagation();
+            settings_components.update_custom_time_limit_minute_text($(this));
+        },
+    );
+
     $(".settings-subsection-parent").on("keydown", "input", (e) => {
         e.stopPropagation();
         if (keydown_util.is_enter_event(e)) {

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -171,14 +171,19 @@
                     </select>
                     <div class="dependent-settings-block">
                         <label for="id_realm_message_content_edit_limit_minutes" class="inline-block realm-time-limit-label">
-                            {{t 'Duration editing is allowed after posting (minutes)'}}:&nbsp;
+                            {{t 'Time limit'}}:&nbsp;
                         </label>
                         <input type="text" id="id_realm_message_content_edit_limit_minutes"
                           name="realm_message_content_edit_limit_minutes"
                           class="time-limit-custom-input"
                           autocomplete="off"
                           value="{{ realm_message_content_edit_limit_minutes }}"
-                          {{#unless realm_allow_message_editing}}disabled{{/unless}}/>
+                          {{#unless realm_allow_message_editing}}disabled{{/unless}}/>&nbsp;
+                        <span class="time-unit-text">
+                            {{t "{realm_message_content_edit_limit_minutes, plural, one {minute} other {minutes}}"}}
+                        </span>
+
+
                     </div>
                 </div>
             </div>
@@ -205,12 +210,15 @@
                 </select>
                 <div class="dependent-settings-block">
                     <label for="id_realm_move_messages_within_stream_limit_minutes" class="inline-block realm-time-limit-label">
-                        {{t 'Duration editing is allowed after posting (minutes)'}}:&nbsp;
+                        {{t 'Time limit'}}:&nbsp;
                     </label>
                     <input type="text" id="id_realm_move_messages_within_stream_limit_minutes"
                       name="realm_move_messages_within_stream_limit_minutes"
                       class="time-limit-custom-input"
-                      autocomplete="off"/>
+                      autocomplete="off"/>&nbsp;
+                    <span class="time-unit-text">
+                        {{t "{realm_move_messages_within_stream_limit_minutes, plural, one {minute} other {minutes}}"}}
+                    </span>
                 </div>
             </div>
 
@@ -227,12 +235,15 @@
                 </select>
                 <div class="dependent-settings-block">
                     <label for="id_realm_move_messages_between_streams_limit_minutes" class="inline-block realm-time-limit-label">
-                        {{t 'Duration moving is allowed after posting (minutes)'}}:&nbsp;
+                        {{t 'Time limit'}}:&nbsp;
                     </label>
                     <input type="text" id="id_realm_move_messages_between_streams_limit_minutes"
                       name="realm_move_messages_between_streams_limit_minutes"
                       class="time-limit-custom-input"
-                      autocomplete="off"/>
+                      autocomplete="off"/>&nbsp;
+                    <span class="time-unit-text">
+                        {{t "{realm_move_messages_between_streams_limit_minutes, plural, one {minute} other {minutes}}"}}
+                    </span>
                 </div>
             </div>
 
@@ -268,13 +279,14 @@
                     </select>
                     <div class="dependent-settings-block">
                         <label for="id_realm_message_content_delete_limit_minutes" class="inline-block realm-time-limit-label">
-                            {{t "Duration deletion is allowed after posting (minutes)" }}:
+                            {{t "Time limit" }}:&nbsp;
                         </label>
                         <input type="text" id="id_realm_message_content_delete_limit_minutes"
                           name="realm_message_content_delete_limit_minutes"
                           class="time-limit-custom-input"
                           autocomplete="off"
-                          value="{{ realm_message_content_delete_limit_minutes }}"/>
+                          value="{{ realm_message_content_delete_limit_minutes }}"/>&nbsp;
+                        <span class="time-unit-text">{{t "{realm_message_content_delete_limit_minutes, plural, one {minute} other {minutes}}"}}</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
In the future, we could make the units configurable as in the invitation modal.

Fixes #34692

CZO: [#design > Label in moving messages in org settings @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/Label.20in.20moving.20messages.20in.20org.20settings/near/2177342)


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>

<summary>Screenshots and screen captures</summary>

<img width="458" alt="image" src="https://github.com/user-attachments/assets/5e0c81e1-547c-4cc5-8ab6-db708db66fcb" />


<img width="774" alt="image" src="https://github.com/user-attachments/assets/9bb3c543-693b-4701-b4fc-3e45a43771e9" />

I took the liberty of making the change to message deletion too.
<img width="613" alt="image" src="https://github.com/user-attachments/assets/85786341-d320-4f70-9449-be044aa8e776" />



</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
