### PR TITLE
thumbnails: Use more muted background, high-contrast hover.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1554,20 +1554,12 @@
     );
     --color-markdown-code-link-hover: var(--color-markdown-link-hover);
     --color-background-image-thumbnail: light-dark(
-        hsl(0deg 0% 0% / 8%),
-        hsl(0deg 0% 100% / 13%)
+        hsl(0deg 0% 0% / 3%),
+        hsl(0deg 0% 100% / 3%)
     );
     --color-background-image-thumbnail-hover: light-dark(
         hsl(0deg 0% 0% / 30%),
         hsl(0deg 0% 100% / 45%)
-    );
-    --color-background-image-thumbnail-dinky: light-dark(
-        hsl(0deg 0% 0% / 3%),
-        hsl(0deg 0% 100% / 3%)
-    );
-    --color-background-image-thumbnail-dinky-hover: light-dark(
-        hsl(0deg 0% 0% / 15%),
-        hsl(0deg 0% 100% / 15%)
     );
 
     /* Icon colors */

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -504,18 +504,6 @@
         transition: background 0.3s ease;
         background: var(--color-background-image-thumbnail);
 
-        /* Inline videos also take the dinky color, as they
-           currently display a larger clickable area than
-           necessary. */
-        &.message_inline_video,
-        &:has(.dinky-thumbnail, .extreme-aspect-ratio) {
-            background: var(--color-background-image-thumbnail-dinky);
-
-            &:hover {
-                background: var(--color-background-image-thumbnail-dinky-hover);
-            }
-        }
-
         &:hover {
             background: var(--color-background-image-thumbnail-hover);
         }


### PR DESCRIPTION
This PR removes different background colors on thumbnails, previously based on extreme aspect ratios. Now, all thumbnails take the lower-contrast background color previously reserved for thumbnails that show more background (extremely narrow, extremely small, and--given that landscape images are allowed to grow to whatever width they like--truly, extremely wide images). This also uses the higher-contrast hover color, to leave as little doubt as possible when a user has hovered over a thumbnail.

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/consolidating.20thumbnail.20background.20colors/near/2178389)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![thumbnail-backgrounds-light-before](https://github.com/user-attachments/assets/21b07510-6609-42e8-83a5-0c82e7900b18) | ![thumbnail-backgrounds-light-after](https://github.com/user-attachments/assets/b34f4860-1f4e-40fc-ade3-44b648a8dc30) | 
| ![thumbnail-backgrounds-dark-before](https://github.com/user-attachments/assets/ea2183ef-c005-4db2-86ac-297af8b91d24) | ![thumbnail-backgrounds-dark-after](https://github.com/user-attachments/assets/cfa59f1e-0b39-44a3-8822-cdeab2bcfb85) |

| Hover states, before | Hover states, after |
| --- | --- |
| ![thumbnail-hovers-light-before](https://github.com/user-attachments/assets/e2d275c1-4446-4c45-a886-10cb92ca7754) | ![thumbnail-hovers-light-after](https://github.com/user-attachments/assets/3a96237e-450b-4ff0-8aa8-242a23d45e35) |
| ![thumbnail-hovers-dark-before](https://github.com/user-attachments/assets/c47f237d-4899-497c-aed3-28b645016359) | ![thumbnail-hovers-dark-after](https://github.com/user-attachments/assets/de53f58e-53fa-4360-9182-95f613dfbc06) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
