### PR TITLE
demo-orgs: Check owner email for missed message emails.

### DIFF
--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -621,6 +621,18 @@ def handle_missedmessage_emails(
         # BUG: Investigate why it's possible to get here.
         return  # nocoverage
 
+    if user_profile.delivery_email == "":
+        # The assertions here are to help document the only circumstance under which
+        # this condition should be possible.
+        assert (
+            user_profile.realm.demo_organization_scheduled_deletion_date is not None
+            and user_profile.is_realm_owner
+        )
+        # Because demo organizations are created without setting an email, we can't
+        # send any missed message emails until they add an email to their account,
+        # e.g., they receive a direct message from the Welcome or Notification bot.
+        return
+
     # Note: This query structure automatically filters out any
     # messages that were permanently deleted, since those would now be
     # in the ArchivedMessage table, not the Message table.


### PR DESCRIPTION
It is possible that a demo organization owner will receive a direct message from a bot when they haven't yet added an email to their account, e.g., the Notification bot sends a reminder about watching the intro to Zulip onboarding video (noticed this exact situation causing an in the dev environment when working on demo organization updates).

Adds a check and early return in `handle_missedmessage_emails` for this demo organization owner case.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
