### PR TITLE
markdown: Move to logical properties for i18n.

### DIFF
--- a/web/.browserslistrc
+++ b/web/.browserslistrc
@@ -2,7 +2,7 @@
 > 0.15% in US
 last 2 versions
 Firefox ESR
-not dead and supports async-functions
+not dead and fully supports css-logical-props
 
 [test]
 current Node

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -654,15 +654,10 @@
 
     .message_inline_ref {
         margin-bottom: var(--markdown-interelement-space-px);
-        margin-left: 5px;
+        margin-inline-start: 5px;
         height: 50px;
         display: block !important;
         border: none !important;
-    }
-
-    &.rtl .message_inline_ref {
-        margin-left: unset;
-        margin-right: 5px;
     }
 
     .message_inline_image .media-image-element {
@@ -764,7 +759,7 @@
            text works as expected. */
         height: calc(var(--length-message-preview-embeds) + 10px);
         padding: 5px;
-        border-left: 3px solid hsl(0deg 0% 93%);
+        border-inline-start: 3px solid hsl(0deg 0% 93%);
 
         .message_embed_title {
             font-size: 1.2em;
@@ -815,14 +810,6 @@
             grid-area: data-container;
             overflow: hidden;
         }
-    }
-
-    /* Although grid will automatically respond to
-       RTL languages, we still need to manually fix
-       the border here, which is not part of grid. */
-    &.rtl .message_embed {
-        border-left: unset;
-        border-right: 3px solid hsl(0deg 0% 93%);
     }
 
     & a {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -183,21 +183,15 @@
         /* This keeps the blockquote text block
            aligned with list-item text blocks.
            12.4px at 16px/1em */
-        padding: 0 0 0 0.775em;
+        padding: 0;
+        padding-inline-start: 0.775em;
         /* We want to keep the border roughly centered
            with bullets and single-digit list markers.
            3.5px at 16px/1em */
-        margin: 0 0 var(--markdown-interelement-space-px) 0.2188em;
-        border-left: 4px solid var(--color-text-message-blockquote-border);
-    }
-
-    &.rtl blockquote {
-        /* 12.4px at 16px/1em */
-        padding: 0 0.775em 0 0;
-        /* 3.5px at 16px/1em */
-        margin: 0 0.2188em var(--markdown-interelement-space-px) 0;
-        border-left: unset;
-        border-right: 4px solid var(--color-text-message-blockquote-border);
+        margin: 0 0 var(--markdown-interelement-space-px) 0;
+        margin-inline-start: 0.2188em;
+        border-inline-start: 4px solid
+            var(--color-text-message-blockquote-border);
     }
 
     /* Formatting for Markdown tables */


### PR DESCRIPTION
This PR does two things:

1. It follows guidance from @andersk for updating `.browserslistrc` to permit logical properties, such as `margin-inline-start`. In so doing, the PR corrects a regression on lists in RTL languages (see screenshots below).
2. It removes the remaining `.rtl` references from `rendered_markdown.css`, shifting previous right/left shifts to their logical properties for margin, padding, and border, as appropriate.

I believe we will need to keep the `rtl` class in the rendered markdown area, as that is responsible for setting the `direction: rtl` value in `zulip.css`--which is what makes the logical properties here work. What we will *not* need are future styles that directly reference the `.rtl` class itself.

[CZO discussion](https://chat.zulip.org/#narrow/channel/6-frontend/topic/*-inline-start.20properties/near/2173457)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![markdown-rtl-before](https://github.com/user-attachments/assets/587cdace-a5c0-4454-8104-2a2b940db504) | ![markdown-rtl-after](https://github.com/user-attachments/assets/4b84a684-2638-4ac5-8c64-496b7cb12f27) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>