### PR TITLE
email_senders: Handle a None realm_id.

### DIFF
--- a/zerver/worker/email_senders_base.py
+++ b/zerver/worker/email_senders_base.py
@@ -64,9 +64,10 @@ class EmailSendingWorker(LoopQueueProcessingWorker):
         if "failed_tries" in copied_event:
             del copied_event["failed_tries"]
         handle_send_email_format_changes(copied_event)
-        if copied_event.get("realm_id") is not None:
+        if "realm_id" in copied_event:
             # "realm" does not serialize over the queue, so we send the realm_id
-            copied_event["realm"] = Realm.objects.get(id=copied_event["realm_id"])
+            if copied_event.get("realm_id") is not None:
+                copied_event["realm"] = Realm.objects.get(id=copied_event["realm_id"])
             del copied_event["realm_id"]
         self.connection = initialize_connection(self.connection)
         send_immediate_email(**copied_event, connection=self.connection)


### PR DESCRIPTION
Some codepaths send an event with `realm_id=None` -- which we still must trim out of the event, even if we do not add a `realm` value for them.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
