### PR TITLE
settings: Correct for missing `Notification` object in mobile.

### DIFF
--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -85,10 +85,10 @@ function rerender_ui(): void {
     } else {
         $unmatched_streams_table.css("display", "table-row-group");
     }
-    update_notification_banner();
+    update_desktop_notification_banner();
 }
 
-function update_notification_banner(): void {
+function update_desktop_notification_banner(): void {
     // As is also noted in `navbar_alerts.ts`, notifications *basically*
     // don't work on any mobile platforms, so don't event show the banners.
     // This prevents trying to access things that don't exist, like
@@ -389,7 +389,7 @@ export function set_up(settings_panel: SettingsPanel): void {
         // not shown in a mobile context anyway.
         void Notification.requestPermission().then((permission) => {
             if (permission === "granted") {
-                update_notification_banner();
+                update_desktop_notification_banner();
             } else if (permission === "denied") {
                 window.open(
                     "/help/desktop-notifications#check-platform-settings",

--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -89,6 +89,16 @@ function rerender_ui(): void {
 }
 
 function update_notification_banner(): void {
+    // As is also noted in `navbar_alerts.ts`, notifications *basically*
+    // don't work on any mobile platforms, so don't event show the banners.
+    // This prevents trying to access things that don't exist, like
+    // `Notification.permission` in a mobile context, in which we'll also
+    // hide the ability to send a test notification before exiting with an
+    // early return.
+    if (util.is_mobile()) {
+        $(".send_test_notification").hide();
+        return;
+    }
     const permission = Notification.permission;
     const $banner_container = $(".desktop-notification-settings-banners");
     if (permission === "granted") {
@@ -374,6 +384,9 @@ export function set_up(settings_panel: SettingsPanel): void {
 
     $("#settings_content").on("click", ".request-desktop-notifications", (e) => {
         e.preventDefault();
+        // This is only accessed via the notifications banner, so we
+        // do not need to do a mobile check here--as that banner is
+        // not shown in a mobile context anyway.
         void Notification.requestPermission().then((permission) => {
             if (permission === "granted") {
                 update_notification_banner();


### PR DESCRIPTION
This corrects a mobile Safari issue that would fail to render the Notification settings pain when the desktop-notifications banner could not be updated (unnecessary in a mobile context).

To make this issue more obvious in the future, the function has also been renamed from `update_notification_banner` to `update_desktop_notification_banner`.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/buggy.20settings.20UI.20navigation.20on.20Safari.20.28mobile.20web.29.20.2334668/near/2176123)

Fixes #34668

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>