### PR TITLE
Fix unread banner not hiding when marking topic as read.

### DIFF
--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -276,7 +276,9 @@ function bulk_update_read_flags_for_narrow(
                             term.negated === false
                         ),
                 );
-                if (message_lists.current?.data.filter.equals(new Filter(filter_terms))) {
+                // Current narrow may have "with" operator around a message target which
+                // we would want to ignore for bulk reading a message list.
+                if (message_lists.current?.data.filter.equals(new Filter(filter_terms), ["with"])) {
                     message_lists.current?.resume_reading();
                     unread_ui.hide_unread_banner();
                 }
@@ -604,6 +606,10 @@ export function process_read_messages_event(message_ids: number[]): void {
         if (message) {
             process_newly_read_message(message, options);
         }
+    }
+
+    if (message_lists.current !== undefined && !message_lists.current.has_unread_messages()) {
+        unread_ui.hide_unread_banner();
     }
 
     unread_ui.update_unread_counts();


### PR DESCRIPTION
Earlier, when we had unread banner in message list and user marks all messages as read for topic, unread banner would persist even though we had no unread messages in current message list.

This commit hides unread banner when there are no unreads just like we show banner when unread messages appear in message list.

Fixes:zulip#33866.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
