### PR TITLE
corporate: Revise internal billing emails for stale audit log data.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -5470,7 +5470,7 @@ def maybe_send_invoice_overdue_email(
             "billing_entity": billing_session.billing_entity_display_name,
             "support_url": billing_session.support_url(),
             "last_audit_log_update": "Never uploaded",
-            "notice_reason": "invoice_overdue",
+            "notice_reason": "stale_audit_log_data",
         }
         send_email(
             "zerver/emails/internal_billing_notice",
@@ -5492,7 +5492,7 @@ def maybe_send_invoice_overdue_email(
         "billing_entity": billing_session.billing_entity_display_name,
         "support_url": billing_session.support_url(),
         "last_audit_log_update": last_audit_log_update.strftime("%Y-%m-%d"),
-        "notice_reason": "invoice_overdue",
+        "notice_reason": "stale_audit_log_data",
     }
     send_email(
         "zerver/emails/internal_billing_notice",

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -8734,7 +8734,7 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
         self.assertEqual(message.to[0], "sales@zulip.com")
         self.assertEqual(
             message.subject,
-            f"Invoice overdue for {self.billing_session.billing_entity_display_name} due to stale data",
+            f"Stale audit log data for {self.billing_session.billing_entity_display_name}'s plan",
         )
         self.assertIn(
             f"Support URL: {self.billing_session.support_url()}",
@@ -8744,7 +8744,7 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
             f"Internal billing notice for {self.billing_session.billing_entity_display_name}.",
             message.body,
         )
-        self.assertIn("Recent invoice is overdue for payment.", message.body)
+        self.assertIn("Unable to verify current licenses needed for plan.", message.body)
         self.assertIn(
             f"Last data upload: {last_audit_log_update.strftime('%Y-%m-%d')}", message.body
         )
@@ -10272,7 +10272,7 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
         self.assertEqual(message.to[0], "sales@zulip.com")
         self.assertEqual(
             message.subject,
-            f"Invoice overdue for {self.billing_session.billing_entity_display_name} due to stale data",
+            f"Stale audit log data for {self.billing_session.billing_entity_display_name}'s plan",
         )
         self.assertIn(
             f"Support URL: {self.billing_session.support_url()}",
@@ -10282,7 +10282,7 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
             f"Internal billing notice for {self.billing_session.billing_entity_display_name}.",
             message.body,
         )
-        self.assertIn("Recent invoice is overdue for payment.", message.body)
+        self.assertIn("Unable to verify current licenses needed for plan.", message.body)
         self.assertIn(
             f"Last data upload: {last_audit_log_upload.strftime('%Y-%m-%d')}", message.body
         )

--- a/templates/zerver/emails/internal_billing_notice.html
+++ b/templates/zerver/emails/internal_billing_notice.html
@@ -6,8 +6,8 @@
 
 {% if notice_reason == "fixed_price_plan_ends_soon" %}
 <p>Reminder to re-evaluate the pricing and configure a new fixed-price plan accordingly.</p>
-{% elif notice_reason == "invoice_overdue" %}
-<p>Recent invoice is overdue for payment.</p>
+{% elif notice_reason == "stale_audit_log_data" %}
+<p>Unable to verify current licenses needed for plan.</p>
 <b>Last data upload</b>: {{ last_audit_log_update }}
 {% elif notice_reason == "locally_deleted_realm_on_paid_plan" %}
 <p>Investigate why remote realm is marked as locally deleted when it's on a paid plan.</p>

--- a/templates/zerver/emails/internal_billing_notice.subject.txt
+++ b/templates/zerver/emails/internal_billing_notice.subject.txt
@@ -1,7 +1,7 @@
 {% if notice_reason == "fixed_price_plan_ends_soon" %}
 Fixed-price plan for {{ billing_entity }} ends on {{ end_date }}
-{% elif notice_reason == "invoice_overdue" %}
-Invoice overdue for {{ billing_entity }} due to stale data
+{% elif notice_reason == "stale_audit_log_data" %}
+Stale audit log data for {{ billing_entity }}'s plan
 {% elif notice_reason == "locally_deleted_realm_on_paid_plan" %}
 {{ billing_entity }} on paid plan marked as locally deleted
 {% elif notice_reason == "license_discrepancy" %}

--- a/templates/zerver/emails/internal_billing_notice.txt
+++ b/templates/zerver/emails/internal_billing_notice.txt
@@ -2,8 +2,8 @@ Internal billing notice for {{ billing_entity }}.
 
 {% if notice_reason == "fixed_price_plan_ends_soon" %}
 Reminder to re-evaluate the pricing and configure a new fixed-price plan accordingly.
-{% elif notice_reason == "invoice_overdue" %}
-Recent invoice is overdue for payment.
+{% elif notice_reason == "stale_audit_log_data" %}
+Unable to verify current licenses needed for plan.
 
 Last data upload: {{ last_audit_log_update }}
 {% elif notice_reason == "locally_deleted_realm_on_paid_plan" %}


### PR DESCRIPTION
These emails are not necessarily sent when an self-hosted customer has an outstanding invoice, e.g., they are on an annual plan and the monthly check for additional licenses happens when the audit log data is stale.

**Notes**:
- Updates the notice_reason to be "stale_audit_log_data" instead of "invoice_overdue". Revises the email subject and text to better reflect what the support admin needs to investigate.
- We may want to update the `invoice_overdue_email_sent` field on the `CustomerPlan` object as it's only used in this case?
  - We currently have 4 flags for internal billing notices, and two of those set a field to `True` on a plan.
  - This field and `reminder_to_review_plan_email_sent`, which are used to only send the internal billing notice once and not every time `invoice_plans_as_needed` is run via the daily cron job.

---

**After these changes**:
*The support views with `stale_audit_log_data` correspond to the state in which these emails would be sent during the invoicing cron job.*
```console
$ git grep stale_audit_log_data
corporate/lib/stripe.py:            "notice_reason": "stale_audit_log_data",
corporate/lib/stripe.py:        "notice_reason": "stale_audit_log_data",
corporate/lib/support.py:        stale_audit_log_data = has_stale_audit_log(billing_session.remote_server)
corporate/lib/support.py:        stale_audit_log_data = has_stale_audit_log(billing_session.remote_realm.server)
corporate/lib/support.py:    plan_data = get_plan_data_for_support_view(billing_session, user_count, stale_audit_log_data)
corporate/lib/support.py:        has_stale_audit_log=stale_audit_log_data,
templates/zerver/emails/internal_billing_notice.html:{% elif notice_reason == "stale_audit_log_data" %}
templates/zerver/emails/internal_billing_notice.subject.txt:{% elif notice_reason == "stale_audit_log_data" %}
templates/zerver/emails/internal_billing_notice.txt:{% elif notice_reason == "stale_audit_log_data" %}
```



---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
