### PR TITLE
fix #34724: social_auth: Make email selection boxes keyboard accessible

### DIFF
--- a/templates/zerver/social_auth_select_email.html
+++ b/templates/zerver/social_auth_select_email.html
@@ -14,7 +14,7 @@
 
     <div class="white-box">
         <form method="post" class="select-email-form" action="/complete/{{ backend }}/">
-            <div class="choose-email-box">
+            <div class="choose-email-box" tabindex="0">
                 <input type="hidden" name="email" value="{{ primary_email }}" />
                 {% if avatar_urls[primary_email] %}
                 <img src="{{ avatar_urls[primary_email] }}" alt=""/>
@@ -38,7 +38,7 @@
         </form>
         {% for email in verified_non_primary_emails %}
         <form method="post" class="select-email-form" action="/complete/{{ backend }}/">
-            <div class="choose-email-box">
+            <div class="choose-email-box" tabindex="0">
                 <input type="hidden" name="email" value="{{ email }}" />
                 {% if avatar_urls[email] %}
                 <img src="{{ avatar_urls[email] }}" alt="" class="no-drag"/>

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -457,4 +457,11 @@ $(() => {
     $("#slack-access-token").on("input", () => {
         $("#update-slack-access-token").show();
     });
+
+    $(".choose-email-box").on("keydown", function (e) {
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            $(this).closest("form").trigger("submit");
+        }
+    });
 });


### PR DESCRIPTION
fix #34724: social_auth: Make email selection boxes keyboard accessible

social_auth: Fix keyboard navigation for email selection

Add tabindex="0" and Enter/Space key handlers to make email selection
boxes focusable and activatable via keyboard during social auth flow.

Previously Tab key could only reach header buttons, now users can
navigate to and select email options using keyboard only.