### PR TITLE
Make the example Zulip URLs uniform in docs

### DIFF
--- a/api_docs/running-bots.md
+++ b/api_docs/running-bots.md
@@ -13,7 +13,7 @@ You'll need:
 
 * An account in a Zulip organization
   (e.g., [the Zulip development community](https://zulip.com/development-community/),
-  `<yourSubdomain>.zulipchat.com`, or a Zulip organization on your own
+  `{{ display_host }}`, or a Zulip organization on your own
   [development](https://zulip.readthedocs.io/en/latest/development/overview.html) or
   [production](https://zulip.readthedocs.io/en/latest/production/install.html) server).
 * A computer where you're running the bot from.

--- a/docs/documentation/integrations.md
+++ b/docs/documentation/integrations.md
@@ -142,7 +142,7 @@ Here are a few common macros used to document Zulip's integrations:
   to generate URLs of the form:
 
   ```text
-  https://bot_email:bot_api_key@yourZulipDomain.zulipchat.com/api/v1/external/beanstalk
+  https://bot_email:bot_api_key@your-org.zulipchat.com/api/v1/external/beanstalk
   ```
 
   For an example rendering, see

--- a/help/include/how-to-invite-users-to-join.md
+++ b/help/include/how-to-invite-users-to-join.md
@@ -19,7 +19,7 @@
    for your organization.
 
 1. Share a link to your registration page, which is
-   https://organization.zulipchat.com for Zulip Cloud organizations.
+   https://your-org.zulipchat.com for Zulip Cloud organizations.
 
 {tab|imported-organizations}
 
@@ -31,7 +31,7 @@
    a password.
 
 1. Share a link to your Zulip organization, which is
-   https://organization.zulipchat.com on Zulip Cloud.
+   https://your-org.zulipchat.com on Zulip Cloud.
 
 1. *(optional)* To log in with an email/password, users will need to set their
    initial password. You can:

--- a/help/scim.md
+++ b/help/scim.md
@@ -50,7 +50,7 @@ Zulip's SCIM integration has the following limitations:
 
 1. In the **Provisioning** tab, click **Configure API Integration**, check the
    **Enable API integration** checkbox, and specify the following fields:
-     * **Base URL**: `yourorganization.zulipchat.com/scim/v2`
+     * **Base URL**: `{{ display_host }}/scim/v2`
      * **API token**: `Bearer <token>` (given to you by Zulip support)
 
     When you proceed to the next step, Okta will verify that these details are
@@ -109,7 +109,7 @@ Zulip's SCIM integration has the following limitations:
 1. Continue to the app's management screen and click **Provisioning** in the left panel.
 
 1. In the **Provisioning Mode** menu, select **Automatic**  and specify the following fields:
-    * **Tenant URL**: `http://yourorganization.zulipchat.com/scim/v2/?aadOptscim062020`.
+    * **Tenant URL**: `{{ display_host }}/scim/v2/?aadOptscim062020`.
       The `?aadOptscim062020` part of it is a [feature flag][feature-flag]
       that needs to be added to ensure SCIM compliance by Entra ID.
     * **Secret Token**: `<token>` (given to you by Zulip support)

--- a/templates/zerver/integrations/capistrano.md
+++ b/templates/zerver/integrations/capistrano.md
@@ -20,8 +20,8 @@ Get Zulip notifications for your Capistrano deploys!
           desc "Post a message to Zulip after deploy"
           task :humbug do
             run_locally "echo 'I just deployed to #{stage}! :tada:' | zulip-send \
-            --user capistrano-bot@example.com --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5 \
-            --site={{ api_url }} \
+            --user capistrano-bot@{{ display_host }} --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5 \
+            --site={{ zulip_url }} \
             --stream commits --subject deployments || true"
           end
         end

--- a/templates/zerver/integrations/hubot.md
+++ b/templates/zerver/integrations/hubot.md
@@ -18,8 +18,8 @@ Use Hubot to execute scripts and commands within Zulip!
    information of the bot you created, by running:
 
     ```
-    export HUBOT_ZULIP_SITE="{{ api_url }}"
-    export HUBOT_ZULIP_BOT="hubot-bot@example.com"
+    export HUBOT_ZULIP_SITE="{{ zulip_url }}"
+    export HUBOT_ZULIP_BOT="hubot-bot@{{ zulip_url }}"
     export HUBOT_ZULIP_API_KEY="<your_key>"
     ```
 

--- a/templates/zerver/integrations/hubot.md
+++ b/templates/zerver/integrations/hubot.md
@@ -20,7 +20,7 @@ Use Hubot to execute scripts and commands within Zulip!
     ```
     export HUBOT_ZULIP_SITE="{{ zulip_url }}"
     export HUBOT_ZULIP_BOT="hubot-bot@{{ zulip_url }}"
-    export HUBOT_ZULIP_API_KEY="<your_key>"
+    export HUBOT_ZULIP_API_KEY="0123456789abcdef0123456789abcdef"
     ```
 
 1. Run Hubot:

--- a/templates/zerver/integrations/include/change-zulip-config-file.md
+++ b/templates/zerver/integrations/include/change-zulip-config-file.md
@@ -3,7 +3,7 @@ following lines to specify the email address and API key for your
 {{ integration_display_name }} bot:
 
 ```
-ZULIP_USER = "{{ integration_name }}-bot@example.com"
+ZULIP_USER = "{{ integration_name }}-bot@{{ display_host }}"
 ZULIP_API_KEY = "0123456789abcdef0123456789abcdef"
 ZULIP_SITE = "{{ zulip_url }}"
 ```

--- a/templates/zerver/integrations/redmine.md
+++ b/templates/zerver/integrations/redmine.md
@@ -32,7 +32,7 @@ corner, then click on **Plugins**.
 3. Find the **Redmine Zulip** plugin, and click **Configure**. Fill
 out the following fields:
 
-    * Zulip URL (e.g `https://yourZulipDomain.zulipchat.com/`)
+    * Zulip URL (e.g `{{ zulip_url }}`)
     * Zulip Bot E-mail
     * Zulip Bot API key
     * Stream name __*__

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -521,8 +521,8 @@ class IntegrationTest(ZulipTestCase):
     def test_api_url_view_subdomains_homepage_base(self) -> None:
         context: dict[str, Any] = {}
         add_api_url_context(context, HostRequestMock())
-        self.assertEqual(context["api_url_scheme_relative"], "yourZulipDomain.testserver/api")
-        self.assertEqual(context["api_url"], "http://yourZulipDomain.testserver/api")
+        self.assertEqual(context["api_url_scheme_relative"], "your-org.testserver/api")
+        self.assertEqual(context["api_url"], "http://your-org.testserver/api")
         self.assertFalse(context["html_settings_links"])
 
     def test_api_url_view_subdomains_full(self) -> None:

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -59,6 +59,8 @@ def add_api_url_context(context: dict[str, Any], request: HttpRequest) -> None:
     api_url = settings.EXTERNAL_URI_SCHEME + api_url_scheme_relative
     zulip_url = settings.EXTERNAL_URI_SCHEME + display_host
 
+    context["display_subdomain"] = display_subdomain
+    context["display_host"] = display_host
     context["external_url_scheme"] = settings.EXTERNAL_URI_SCHEME
     context["api_url"] = api_url
     context["api_url_scheme_relative"] = api_url_scheme_relative

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -51,7 +51,7 @@ def add_api_url_context(context: dict[str, Any], request: HttpRequest) -> None:
         display_subdomain = subdomain
         html_settings_links = True
     else:
-        display_subdomain = "yourZulipDomain"
+        display_subdomain = "your-org"
         html_settings_links = False
 
     display_host = Realm.host_for_subdomain(display_subdomain)

--- a/zerver/webhooks/helloworld/doc.md
+++ b/zerver/webhooks/helloworld/doc.md
@@ -23,13 +23,13 @@ integration](/api/incoming-webhooks-walkthrough).
         (zulip-server) vagrant@vagrant:/srv/zulip$
         ./manage.py send_webhook_fixture_message \
         > --fixture=zerver/tests/fixtures/helloworld/hello.json \
-        > '--url=http://localhost:9991/api/v1/external/helloworld?api_key=abcdefgh&stream=channel%20name;'
+        > '--url=http://localhost:9991/api{{ integration_url }}?api_key=abcdefgh&stream=channel%20name;'
     ```
 
     Or, use curl:
 
     ```
-    curl -X POST -H "Content-Type: application/json" -d '{ "featured_title":"Marilyn Monroe", "featured_url":"https://en.wikipedia.org/wiki/Marilyn_Monroe" }' http://localhost:9991/api/v1/external/helloworld\?api_key=abcdefgh&stream=channel%20name;
+    curl -X POST -H "Content-Type: application/json" -d '{ "featured_title":"Marilyn Monroe", "featured_url":"https://en.wikipedia.org/wiki/Marilyn_Monroe" }' http://localhost:9991/api{{ integration_url }}?api_key=abcdefgh&stream=channel%20name;
     ```
 
 {end_tabs}

--- a/zerver/webhooks/zapier/doc.md
+++ b/zerver/webhooks/zapier/doc.md
@@ -38,7 +38,7 @@ sent by Zapier directly in Zulip.
         enter the email associated with your Zulip account in the
         **Recipients** field. Otherwise, enter `user` +
         [your user ID](/help/view-someones-profile) +
-        `@` + your Zulip domain, e.g., `user123@acme.zulipchat.com`.
+        `@` + your Zulip domain, e.g., `user123@{{ display_host }}`.
 
 1. Click **Publish** to enable your Zap.
 


### PR DESCRIPTION
Major steps:
1. Update the subdomain value used in the context property `zulip_url` from "yourZulipDomain" to "your-org".
2. Add new context properties for just the subdomain and the host, and use them.
3. (Commits 3 and 4) Make manual replacements for scenarios where we can't use the context property - Zulip Cloud examples, and the RTD docs.
4. Update sample URLs and bot emails in integration docs (does not include docs that are pending an update, because some of them have pretty repetitive occurrences, which are planned to be removed during their update).

Only help, API docs and policies can use the documentation context properties. RTD docs cannot.

This PR also includes a commit that updates one sample API key in the Hubot doc. It only updates 1 doc because all the other integration docs (excluding the ones pending updates) already seem to be using some sort of sample value, Hubot's the one with a placeholder. I've not attempted to make the sample values uniform.

### String occurrences

Only occurrences of `.zulipchat.com` in `*.md` files have been updated.

Occurrences in the following files have not been updated, assuming that the current values look better even if they do not currently match the convention of "your-org".
- `help/mobile-notifications.md`
- `help/logging-in.md`
- `help/move-to-zulip-cloud.md`
- `help/include/import-into-a-zulip-cloud-organization`
- `docs/production/authentication-methods.md`

<details>
<summary><h3>Screenshots</h3></summary>

#### Commit 1: Updating the subdomain value of `zulip_url`

[Discourse Doc](https://zulip.com/integrations/doc/discourse)
![img](https://github.com/user-attachments/assets/bcaf0a2d-39b9-41f6-9bb2-0b2639642c87)

The actual URL would be "your-org.zulipchat.com". This one's a screenshot from the dev env.

Other files affected include: The Onyx doc, several script integration docs.

---

**Commit 2: New context properties**

This includes all the files affected in this commit, to verify their rendering.

[Redmine Doc](https://zulip.com/integrations/doc/redmine)
![img1](https://github.com/user-attachments/assets/723cbd1e-5713-4c3b-8048-d73a6f6dd8c7)

[SCIM Doc](https://zulip.com/help/scim)
![img2](https://github.com/user-attachments/assets/ddebb60f-e5c5-46eb-b4f2-ac002cf3e834)
![img3](https://github.com/user-attachments/assets/12b3923b-5e8e-4af9-9fe8-c1c2fe9682b8)

[Zapier Doc](https://zulip.com/integrations/doc/zapier)
![img4](https://github.com/user-attachments/assets/577acced-b504-4db3-a761-eab4c72eaa23)

[Running-bots Doc](https://zulip.com/api/running-bots)
![Pasted image 20250526041916](https://github.com/user-attachments/assets/25598acf-639f-4b14-ae34-4e8afcb116f6)

---

**Commit 5: Updating sample site URLs and bot emails in integ docs**

[HelloWorld doc](https://zulip.com/integrations/doc/helloworld)
![Pasted image 20250526053553](https://github.com/user-attachments/assets/9664920f-7232-4c41-940d-2e93e6e09134)

[Capistrano doc](https://zulip.com/integrations/doc/capistrano)
![Pasted image 20250526053711](https://github.com/user-attachments/assets/f812e73f-e729-433c-b6c9-0fbdcaa15cc2)

[Hubot doc](https://zulip.com/integrations/doc/hubot)
![Pasted image 20250526053756](https://github.com/user-attachments/assets/f9c78ed6-76d4-4b4d-a23d-ccf266d56be3)

[Git doc](https://zulip.com/integrations/doc/hubot) for demonstrating the `change-zulip-config-file` macro.
![Pasted image 20250526053903](https://github.com/user-attachments/assets/9be73713-5504-4d38-a417-81af2e11bd40)

---

I'm not attaching any screenshots for manual replacements.

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
