### PR TITLE
tests: Add more tests for using DM groups for 1:1 or self DMs.

### DIFF
--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -311,6 +311,7 @@ from zerver.models.bots import get_bot_services
 from zerver.models.clients import get_client
 from zerver.models.groups import SystemGroups
 from zerver.models.realm_audit_logs import AuditLogEventType
+from zerver.models.recipients import get_or_create_direct_message_group
 from zerver.models.streams import StreamTopicsPolicyEnum, get_stream
 from zerver.models.users import get_user_by_delivery_email
 from zerver.openapi.openapi import validate_against_openapi_schema
@@ -706,6 +707,21 @@ class NormalActionsTest(BaseAction):
             has_new_stream_id=False,
             is_embedded_update_only=False,
         )
+
+    def test_pm_send_message_events_via_direct_message_group(self) -> None:
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+
+        # Create a direct message group with hamlet and cordelia
+        get_or_create_direct_message_group(id_list=[hamlet.id, cordelia.id])
+
+        with self.verify_action():
+            self.send_group_direct_message(
+                from_user=hamlet,
+                to_users=[hamlet, cordelia],
+                content="hola",
+                skip_capture_on_commit_callbacks=True,
+            )
 
     def test_direct_message_group_send_message_events(self) -> None:
         direct_message_group = [

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -425,6 +425,18 @@ class NarrowBuilderTest(ZulipTestCase):
             "WHERE NOT ((flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s)",
         )
 
+    def test_add_term_using_dm_operator_the_same_user_as_operand_when_direct_message_group_exists(
+        self,
+    ) -> None:
+        hamlet = self.example_user("hamlet")
+
+        # Make the direct message group for self messages
+        direct_message_group = get_or_create_direct_message_group(id_list=[hamlet.id])
+
+        term = NarrowParameter(operator="dm", operand=hamlet.email)
+        params = {"recipient_id_1": direct_message_group.recipient_id}
+        self._do_add_term_test(term, "WHERE recipient_id = %(recipient_id_1)s", params)
+
     def test_add_term_using_dm_operator_and_self_and_user_as_operand(self) -> None:
         myself_and_other = (
             f"{self.example_user('hamlet').email},{self.example_user('othello').email}"
@@ -434,6 +446,19 @@ class NarrowBuilderTest(ZulipTestCase):
             term,
             "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s)",
         )
+
+    def test_add_term_using_dm_operator_and_self_and_user_as_operand_when_direct_message_group_exists(
+        self,
+    ) -> None:
+        hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+
+        # Make the direct message group for 1:1 messages between hamlet and othello
+        direct_message_group = get_or_create_direct_message_group(id_list=[hamlet.id, othello.id])
+
+        term = NarrowParameter(operator="dm", operand=f"{hamlet.email},{othello.email}")
+        params = {"recipient_id_1": direct_message_group.recipient_id}
+        self._do_add_term_test(term, "WHERE recipient_id = %(recipient_id_1)s", params)
 
     def test_add_term_using_dm_operator_more_than_one_user_as_operand_no_direct_message_group(
         self,

--- a/zerver/tests/test_scheduled_messages.py
+++ b/zerver/tests/test_scheduled_messages.py
@@ -193,6 +193,54 @@ class ScheduledMessageTest(ZulipTestCase):
         )
         self.assert_json_error(updated_response, "Scheduled message was already sent")
 
+    def test_successful_deliver_personal_scheduled_message_using_direct_message_group(self) -> None:
+        # No scheduled message
+        self.assertFalse(try_deliver_one_scheduled_message())
+
+        content = "Test message"
+        scheduled_delivery_datetime = timezone_now() + timedelta(minutes=5)
+        scheduled_delivery_timestamp = int(scheduled_delivery_datetime.timestamp())
+        sender = self.example_user("hamlet")
+        othello = self.example_user("othello")
+
+        # Create a direct message group for the sender and othello.
+        direct_message_group = get_or_create_direct_message_group(id_list=[sender.id, othello.id])
+
+        response = self.do_schedule_message(
+            "direct", [othello.id], f"{content} 4", scheduled_delivery_timestamp
+        )
+        self.assert_json_success(response)
+        scheduled_message = self.last_scheduled_message()
+
+        # mock current time to be greater than the scheduled time.
+        more_than_scheduled_delivery_datetime = scheduled_delivery_datetime + timedelta(minutes=1)
+
+        with (
+            time_machine.travel(more_than_scheduled_delivery_datetime, tick=False),
+            self.assertLogs(level="INFO") as logs,
+        ):
+            result = try_deliver_one_scheduled_message()
+            self.assertTrue(result)
+            self.assertEqual(
+                logs.output,
+                [
+                    f"INFO:root:Sending scheduled message {scheduled_message.id} with date {scheduled_message.scheduled_timestamp} (sender: {scheduled_message.sender_id})"
+                ],
+            )
+            scheduled_message.refresh_from_db()
+            assert isinstance(scheduled_message.delivered_message_id, int)
+            self.assertEqual(scheduled_message.delivered, True)
+            self.assertEqual(scheduled_message.failed, False)
+            delivered_message = Message.objects.get(id=scheduled_message.delivered_message_id)
+            self.assertEqual(delivered_message.content, scheduled_message.content)
+            self.assertEqual(delivered_message.recipient, direct_message_group.recipient)
+            self.assertEqual(delivered_message.rendered_content, scheduled_message.rendered_content)
+            self.assertEqual(delivered_message.date_sent, more_than_scheduled_delivery_datetime)
+            sender_user_message = UserMessage.objects.get(
+                message_id=scheduled_message.delivered_message_id, user_profile_id=sender.id
+            )
+            self.assertTrue(sender_user_message.flags.read)
+
     def test_successful_deliver_direct_scheduled_message_to_self(self) -> None:
         # No scheduled message
         self.assertFalse(try_deliver_one_scheduled_message())


### PR DESCRIPTION
In https://github.com/zulip/zulip/pull/34307, we supported using direct message groups for 1:1 or self DMs if present. That was toward addressing part of https://github.com/zulip/zulip/issues/25713 for migrating from the legacy `PERSONAL` recipient type to `DIRECT_GROUP_MESSAGE`.

Following up on [Tim's comment](https://github.com/zulip/zulip/pull/34307#issuecomment-2889737240), this PR adds more tests for the following code paths to ensure that direct message group is a safe alternative to be used for 1:1 or self DMs if present:
* Narrow/message_fetch/search
* Events
* Scheduled messages
* Reminders

Conclusion: `get_recipient_from_user_profiles` was a key function that different functionalities rely on, and we don't need to add this support explicitly for most of the other domains.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
