### PR TITLE
popover_menus: Allow focusing an item when none is focused

### DIFF
--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -77,14 +77,14 @@ export function popover_items_handle_keyboard(key: string, $items?: JQuery): voi
         return;
     }
 
-    if ((key === "down_arrow" || key === "vim_down") && index !== -1) {
+    if (key === "down_arrow" || key === "vim_down") {
         [...$items]
-            .slice(index + 1)
+            .slice(index === -1 ? 0 : index + 1)
             .find((item) => item.getClientRects().length)
             ?.focus();
-    } else if ((key === "up_arrow" || key === "vim_up") && index !== -1) {
+    } else if (key === "up_arrow" || key === "vim_up") {
         [...$items]
-            .slice(0, index)
+            .slice(0, index === -1 ? $items.length : index)
             .findLast((item) => item.getClientRects().length)
             ?.focus();
     }


### PR DESCRIPTION
Commit 71fbc93c035df262d29607b3786bbfd2eeb402d8 (#34685) incorrectly removed this behavior.

[Discussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/keyboard.20navigation.20in.20gear.20menu/near/2181400).