### PR TITLE
Fix bugs in generating screenshots of integrations

### DIFF
--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -122,8 +122,8 @@ def get_fixture_info(fixture_path: str) -> tuple[Any, bool, bool, str]:
     return data, json_fixture, multipart_fixture, fixture_name
 
 
-def get_requests_headers(integration_name: str, fixture_name: str) -> dict[str, Any]:
-    headers = get_fixture_http_headers(integration_name, fixture_name)
+def get_requests_headers(integration_dir_name: str, fixture_name: str) -> dict[str, Any]:
+    headers = get_fixture_http_headers(integration_dir_name, fixture_name)
 
     def fix_name(header: str) -> str:
         return header.removeprefix("HTTP_").replace("_", "-")
@@ -153,7 +153,7 @@ def send_bot_payload_message(
     Message.objects.filter(realm_id=bot.realm_id, sender=bot).delete()
     data, json_fixture, multipart_fixture, fixture_name = get_fixture_info(fixture_path)
 
-    headers = get_requests_headers(integration.name, fixture_name)
+    headers = get_requests_headers(integration.dir_name, fixture_name)
     if config.custom_headers:
         headers.update(config.custom_headers)
     if config.use_basic_auth:

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -825,6 +825,7 @@ WEBHOOK_SCREENSHOT_CONFIG: dict[str, list[WebhookScreenshotConfig]] = {
                 "project": "Zulip Mobile",
                 "language": "en",
                 "resource": "file",
+                "event": "review_completed",
                 "reviewed": "100",
             },
         )

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -214,13 +214,13 @@ def validate_extract_webhook_http_header(
     return extracted_header
 
 
-def get_fixture_http_headers(integration_name: str, fixture_name: str) -> dict["str", "str"]:
+def get_fixture_http_headers(integration_dir_name: str, fixture_name: str) -> dict["str", "str"]:
     """For integrations that require custom HTTP headers for some (or all)
     of their test fixtures, this method will call a specially named
     function from the target integration module to determine what set
     of HTTP headers goes with the given test fixture.
     """
-    view_module_name = f"zerver.webhooks.{integration_name}.view"
+    view_module_name = f"zerver.webhooks.{integration_dir_name}.view"
     try:
         # TODO: We may want to migrate to a more explicit registration
         # strategy for this behavior rather than a try/except import.


### PR DESCRIPTION
I came across some failing integrations when I was working on the `generate-integration-docs-screenshot` script.
These integrations error out on running `./tools/screenshots/generate-integration-docs-screenshot --all` or  `./tools/screenshots/generate-integration-docs-screenshot --integration integ-name`.

#### GitHub Sponsors integration

Error message
```
{'result': 'error', 'msg': "Missing the HTTP event header 'X-GitHub-Event'", 'header': 'X-GitHub-Event', 'code': 'MISSING_HTTP_EVENT_HEADER'}
```

#### Transifex integration

Error message
```
{'result': 'error', 'msg': "Missing 'event' argument", 'var_name': 'event', 'code': 'REQUEST_VARIABLE_MISSING'}
```

---

Other integrations that raise errors when used with `generate-integration-docs-screenshot`:
- Slack - `{'result': 'error', 'msg': 'Internal server error'}`
- Dialogflow - `{'result': 'error', 'msg': 'Internal server error'}`
- Bitbucket - `{'result': 'error', 'msg': 'Malformed JSON', 'code': 'BAD_REQUEST'}`

Should I bother opening an issue for tracking these?

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
