### PR TITLE
docs: Update comment, docs links to Format.JS.

### DIFF
--- a/docs/translating/internationalization.md
+++ b/docs/translating/internationalization.md
@@ -394,8 +394,8 @@ their style guidelines.
 [jinja2]: http://jinja.pocoo.org/
 [handlebars]: https://handlebarsjs.com/
 [trans]: https://jinja.palletsprojects.com/en/3.0.x/extensions/#i18n-extension
-[formatjs]: https://formatjs.io/
-[icu messageformat]: https://formatjs.io/docs/intl-messageformat
+[formatjs]: https://formatjs.github.io/
+[icu messageformat]: https://formatjs.github.io/docs/core-concepts/icu-syntax#plural-format
 [helpers]: https://handlebarsjs.com/guide/block-helpers.html
 [transifex]: https://www.transifex.com
 [transifex-api-token]: https://app.transifex.com/user/settings/api/

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -579,7 +579,7 @@ function get_avatars_context(all_senders: number[]): AvatarsContext {
         // and just display remaining number of senders.
         const remaining_senders = extra_sender_ids.length - MAX_EXTRA_SENDERS;
         // Pluralization syntax from:
-        // https://formatjs.io/docs/core-concepts/icu-syntax/#plural-format
+        // https://formatjs.github.io/docs/core-concepts/icu-syntax#plural-format
         displayed_other_names.push(
             $t(
                 {


### PR DESCRIPTION
Noticed while reviewing #34693 that old FormatJS links are not redirected correctly from the `formatjs.io` URL.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

