### PR TITLE
templates: Update deactivated organization template for deleted data.

### DIFF
--- a/templates/zerver/deactivated.html
+++ b/templates/zerver/deactivated.html
@@ -16,23 +16,24 @@
         <div class="inline-block">
 
             <div class="get-started">
-                {% if deactivated_redirect %}
-                    <h1>{{ _("Organization moved") }}</h1>
-                {% else %}
-                    <h1>{{ _("Deactivated organization") }}</h1>
-                {% endif %}
+                <h1>{{ _("Deactivated organization") }}</h1>
             </div>
 
             <div class="white-box deactivated-realm-container">
                 <p>
-                    {% if deactivated_redirect %}
-                        {% trans %}
-                        This organization has moved to <a href="{{ deactivated_redirect }}">{{ deactivated_redirect }}</a>.
-                        {% endtrans %}
+                    {% if realm_data_deleted %}
+                        {{ _("This organization has been deactivated, and all organization data has been deleted.") }}
+                        {% if corporate_enabled %}
+                            {% trans %}
+                            You can <a href="mailto:{{ support_email }}">contact Zulip support</a> to inquire about reusing this URL for a new organization.
+                            {% endtrans %}
+                        {% else %}
+                            {% trans %}
+                            You can <a href="mailto:{{ support_email }}">contact this Zulip server's administrators</a> to inquire about reusing this URL for a new organization.
+                            {% endtrans %}
+                        {% endif %}
                     {% else %}
-                        {% trans %}
-                        This organization has been deactivated.
-                        {% endtrans %}
+                        {{ _("This organization has been deactivated.") }}
                         {% if corporate_enabled %}
                             {% trans %}
                             If you are an owner of this organization, you can <a href="mailto:{{ support_email }}">contact Zulip support</a> to reactivate it.


### PR DESCRIPTION
If a realm's data has been scrubbed, update the deactivated realm to note the URL can be reused, but not that the realm can be reactivated.

**Notes**:
- Updates the template for context variables that are no longer used:
  - `"deactivated_redirect"`  removed from context dict in #34072.
  - `"deactivated_domain_name"` removed from template in #30057.
- The test could potentially be moved to `zerver/tests/test_realm.ScrubRealmTest`.

---

**Screenshots and screen captures:**

### Zulip Cloud:
| Context | Image |
| --- | --- |
| Data not deleted | ![Screenshot from 2025-05-28 13-03-12](https://github.com/user-attachments/assets/76258c3d-a4a6-40da-b8c2-7028fb63e352) |
| Data deleted | ![Screenshot from 2025-05-28 18-07-13](https://github.com/user-attachments/assets/3bde9e01-6898-4c53-9147-471ff21d81af)


### self-hosted server:
| Context | Image |
| --- | --- |
| Data not deleted | ![Screenshot from 2025-05-28 18-17-44](https://github.com/user-attachments/assets/5a5d7cdf-b871-4946-af28-bb7e35592942)
| Data deleted | ![Screenshot from 2025-05-28 18-18-17](https://github.com/user-attachments/assets/bc98d711-9fb2-4e24-8d9f-5ef64039a01c)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
