### PR TITLE
composebox_typeahead: Focus composebox when topic is selected.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1535,6 +1535,11 @@ export function initialize({
             }
             return sorted;
         },
+        updater(item: string, _query: string): string {
+            $("textarea#compose-textarea").trigger("focus");
+            $nextFocus = undefined;
+            return item;
+        },
         option_label(matching_items: string[], item: string): string | false {
             if (!matching_items.includes(item)) {
                 return `<em>${$t({defaultMessage: "New"})}</em>`;


### PR DESCRIPTION
Fixes bug reported here:
https://chat.zulip.org/#narrow/channel/9-issues/topic/focus.20after.20choosing.20from.20topic.20typeahead/near/2180336
