### PR TITLE
markdown: Permit time elements to display inline.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -320,7 +320,6 @@
         background: hsl(0deg 0% 93%);
         border-radius: 3px;
         box-shadow: 0 0 0 1px hsl(0deg 0% 80%);
-        white-space: nowrap;
         margin: 0 2px;
         /* Reduce the font-size to reduce the
            footprint of the timestamp block. */
@@ -332,13 +331,15 @@
                for the icon. */
             font-size: 1.0526em;
             padding: 0 0.2em;
-            display: inline-flex;
-            align-items: baseline;
-            gap: 3px;
         }
 
         .markdown-timestamp-icon {
-            align-self: center;
+            display: inline-block;
+            /* 3px at 16px/1em */
+            vertical-align: -0.1875em;
+            /* Match space to the right of the icon
+               with the lefthand padding on the wrapper. */
+            margin-right: 0.2em;
         }
     }
 


### PR DESCRIPTION
This PR finally does the right thing and allows `<time>` elements to behave as the natively inline critters they are, ensuring that even at mobile scale, the full content will be visible.

[#issues > Impossible to see the full precision of time in mobile web](https://chat.zulip.org/#narrow/channel/9-issues/topic/Impossible.20to.20see.20the.20full.20precision.20of.20time.20in.20mobile.20web/with/2182873)

Fixes:  #33916 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![narrow-timestamp-before](https://github.com/user-attachments/assets/df65dd65-f4f0-4196-adee-adcdc2f81833) | ![narrow-timestamp-after](https://github.com/user-attachments/assets/bf4ef030-40c0-4d53-927a-e49190d6051f) |
| ![ordinary-timestamp-before](https://github.com/user-attachments/assets/52f65d34-fd51-4ab9-b3b2-48e0b7b1363b) | ![ordinary-timestamp-after](https://github.com/user-attachments/assets/b1ad4f8d-43f3-4936-82c0-6210e7912211) |
| ![message-formatting-before](https://github.com/user-attachments/assets/5ccff01d-5675-4c8a-b75e-a38e4341d93a) | ![message-formatting-after](https://github.com/user-attachments/assets/75f0e112-9537-487d-bab0-d0f3f8c254d0) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>