### PR TITLE
cleanup: Remove copy-paste-text spans, styles.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -855,14 +855,6 @@ strong {
     }
 }
 
-.copy-paste-text {
-    /* Hide the text that we want copy paste to capture */
-    position: absolute;
-    text-indent: -99999px;
-    float: left;
-    width: 0;
-}
-
 @keyframes rotate {
     from {
         transform: rotate(0deg);

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -27,9 +27,6 @@
 </span>
 
 <a {{#unless msg/locally_echoed}}href="{{ msg/url }}"{{/unless}} class="message-time">
-    {{#unless include_sender}}
-    <span class="copy-paste-text">&nbsp;</span>
-    {{/unless}}
     {{timestr}}
 </a>
 

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -19,9 +19,6 @@
         </a>
         <span class="stream_topic_separator"><i class="zulip-icon zulip-icon-chevron-right"></i></span>
 
-        {{! hidden narrow icon for copy-pasting }}
-        <span class="copy-paste-text">&gt;</span>
-
         {{! topic stuff }}
         <span class="stream_topic">
             {{! topic link }}


### PR DESCRIPTION
This PR removes what appear to be unnecessary `<span>` elements and styles that, while largely harmless, were causing a minor but irritating text-selection bug on messages without a sender.

[#issues > Timestamp selection area](https://chat.zulip.org/#narrow/channel/9-issues/topic/Timestamp.20selection.20area/with/2183111)

**Screenshots and screen captures:**

Selecting the entire topic, as shown in the screenshots below, results in this pasted output from `main`:

```
King Hamlet: This is just a quick test for copying and pasting an entire topic. This message has a sender...
King Hamlet: However, this message does not.
```

And here, with no change, from the PR:

```
King Hamlet: This is just a quick test for copying and pasting an entire topic. This message has a sender...
King Hamlet: However, this message does not.
```

| Before | After |
| --- | --- |
| ![selected-text-before](https://github.com/user-attachments/assets/299b70da-1a69-4c91-92e3-f7505ac2f8ea) | ![selected-text-after](https://github.com/user-attachments/assets/c3f4649c-8a8a-4eba-8f8e-c324b7918c2c) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>