### PR TITLE
copy_paste: Remove .copy-paste-text from document flow.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -858,9 +858,7 @@ strong {
 .copy-paste-text {
     /* Hide the text that we want copy paste to capture */
     position: absolute;
-    text-indent: -99999px;
-    float: left;
-    width: 0;
+    right: -99999px;
 }
 
 @keyframes rotate {


### PR DESCRIPTION
This improves removing the `.copy-paste-text` from the document flow, correcting a weird highlighting bug without (apparently, based on my non-Linux testing) impacting pastable output.

[#issues > Timestamp selection area](https://chat.zulip.org/#narrow/channel/9-issues/topic/Timestamp.20selection.20area/with/2183111)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![selected-text-highlight-before](https://github.com/user-attachments/assets/bb82007d-aa80-4592-a26f-61155eb8c444) | ![selected-text-highlight-after](https://github.com/user-attachments/assets/d9ea5a75-c2f8-4b3d-8cb3-6b0ac80438d3) |

