### PR TITLE
Optimize is_person_active

### DIFF
--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1536,9 +1536,14 @@ export function add_active_user(person: User, source = "inital_fetch"): void {
 
 export const is_person_active = (
     user_id: number,
-    allow_missing_user = !settings_data.user_can_access_all_other_users(),
+    allow_missing_user: boolean | undefined = undefined,
 ): boolean => {
     if (!people_by_user_id_dict.has(user_id)) {
+        // settings_data.user_can_access_all_other_users can be
+        // cheap, so we avoid computing it unless it's actually
+        // required.
+        allow_missing_user ??= !settings_data.user_can_access_all_other_users();
+
         if (allow_missing_user) {
             // We consider all inaccessible users as active.
             return true;

--- a/web/src/settings_data.ts
+++ b/web/src/settings_data.ts
@@ -356,6 +356,14 @@ export function user_can_access_all_other_users(): boolean {
         return true;
     }
 
+    if (!current_user.is_guest) {
+        // The only valid values for this setting are role:members and
+        // role:everyone, both of which are always true for non-guest
+        // users. This is an important optimization for code that may
+        // call this function in a loop.
+        return true;
+    }
+
     return user_has_permission_for_group_setting(
         realm.realm_can_access_all_users_group,
         "can_access_all_users_group",

--- a/web/tests/activity.test.cjs
+++ b/web/tests/activity.test.cjs
@@ -251,8 +251,6 @@ test("presence_list_full_update", ({override, mock_template}) => {
         return "<presence-rows-stub>";
     });
 
-    settings_data.user_can_access_all_other_users = () => true;
-
     $("input.user-list-filter").trigger("focus");
 
     const user_ids = activity_ui.build_user_sidebar();

--- a/web/tests/buddy_list.test.cjs
+++ b/web/tests/buddy_list.test.cjs
@@ -19,10 +19,6 @@ const $ = require("./lib/zjquery.cjs");
 const padded_widget = mock_esm("../src/padded_widget");
 const message_viewport = mock_esm("../src/message_viewport");
 
-mock_esm("../src/settings_data", {
-    user_can_access_all_other_users: () => true,
-});
-
 const buddy_data = zrequire("buddy_data");
 const {BuddyList} = zrequire("buddy_list");
 const people = zrequire("people");

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -50,7 +50,6 @@ const upload = mock_esm("../src/upload");
 const onboarding_steps = mock_esm("../src/onboarding_steps");
 mock_esm("../src/settings_data", {
     user_has_permission_for_group_setting: () => true,
-    user_can_access_all_other_users: () => true,
 });
 
 const compose_ui = zrequire("compose_ui");

--- a/web/tests/compose_pm_pill.test.cjs
+++ b/web/tests/compose_pm_pill.test.cjs
@@ -6,10 +6,6 @@ const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 const $ = require("./lib/zjquery.cjs");
 
-mock_esm("../src/settings_data", {
-    user_can_access_all_other_users: () => true,
-});
-
 const input_pill = mock_esm("../src/input_pill");
 const people = zrequire("people");
 

--- a/web/tests/conversation_participants.test.cjs
+++ b/web/tests/conversation_participants.test.cjs
@@ -5,15 +5,11 @@ const assert = require("node:assert/strict");
 const _ = require("lodash");
 
 const {make_user, make_bot} = require("./lib/example_user.cjs");
-const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 
 const people = zrequire("people");
 const {ConversationParticipants} = zrequire("../src/conversation_participants.ts");
-
-mock_esm("../src/settings_data", {
-    user_can_access_all_other_users: () => true,
-});
 
 const user1 = make_user();
 const user2 = make_user();

--- a/web/tests/settings_data.test.cjs
+++ b/web/tests/settings_data.test.cjs
@@ -558,6 +558,10 @@ run_test("user_can_access_all_other_users", ({override}) => {
 
     page_params.is_spectator = false;
     override(current_user, "user_id", member_user_id);
+    override(current_user, "is_guest", false);
+    assert.ok(settings_data.user_can_access_all_other_users());
+    override(current_user, "is_guest", true);
+    // For coverage only: Here the is_guest optimization is skipped.
     assert.ok(settings_data.user_can_access_all_other_users());
 
     override(current_user, "user_id", guest_user_id);

--- a/web/tests/stream_events.test.cjs
+++ b/web/tests/stream_events.test.cjs
@@ -35,9 +35,6 @@ const message_view_header = mock_esm("../src/message_view_header", {
 mock_esm("../src/recent_view_ui", {
     complete_rerender() {},
 });
-mock_esm("../src/settings_data", {
-    user_can_access_all_other_users: () => true,
-});
 mock_esm("../src/settings_notifications", {
     update_page() {},
     user_settings_panel: "stub", // Not used, but can't be undefined

--- a/web/tests/user_events.test.cjs
+++ b/web/tests/user_events.test.cjs
@@ -46,9 +46,6 @@ mock_esm("../src/pm_list", {
 mock_esm("../src/settings", {
     update_lock_icon_in_sidebar() {},
 });
-mock_esm("../src/settings_data", {
-    user_can_access_all_other_users: () => true,
-});
 mock_esm("../src/settings_linkifiers", {
     maybe_disable_widgets() {},
 });

--- a/web/tests/user_group_pill.test.cjs
+++ b/web/tests/user_group_pill.test.cjs
@@ -2,16 +2,12 @@
 
 const assert = require("node:assert/strict");
 
-const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 
 const user_groups = zrequire("user_groups");
 const user_group_pill = zrequire("user_group_pill");
 const people = zrequire("people");
-
-mock_esm("../src/settings_data", {
-    user_can_access_all_other_users: () => true,
-});
 
 const user1 = {
     user_id: 10,

--- a/web/tests/user_search.test.cjs
+++ b/web/tests/user_search.test.cjs
@@ -23,9 +23,6 @@ const fake_buddy_list = {
 mock_esm("../src/buddy_list", {
     buddy_list: fake_buddy_list,
 });
-mock_esm("../src/settings_data", {
-    user_can_access_all_other_users: () => true,
-});
 
 function mock_setTimeout() {
     set_global("setTimeout", (func) => {

--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -730,6 +730,8 @@ class Realm(models.Model):  # type: ignore[django-manager-missing] # django-stub
             allow_nobody_group=False,
             allow_everyone_group=True,
             default_group_name=SystemGroups.EVERYONE,
+            # Note that user_can_access_all_other_users in the web
+            # app is relying on members always have access.
             allowed_system_groups=[SystemGroups.EVERYONE, SystemGroups.MEMBERS],
         ),
         can_add_subscribers_group=GroupPermissionSetting(


### PR DESCRIPTION
See [#issues > buddy list performance issue @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/buddy.20list.20performance.20issue/near/2183130) for background.

@evykassirer @amanagr FYI. I think it's possible the second commit might need to be replaced with caching the value (and invalidating when settings/group memberships change) with the deferred user loading functionality, but am not sure.