### PR TITLE
move_topic_modal: Only include senders of the messages being moved in warning banner.

### DIFF
--- a/web/templates/modal_banner/unsubscribed_participants_warning_banner.hbs
+++ b/web/templates/modal_banner/unsubscribed_participants_warning_banner.hbs
@@ -9,7 +9,7 @@
 
         {{else}}
             {{#tr}}
-                {n_unsubscribed_participants} topic participants are not subscribed to &nbsp;<z-stream></z-stream>.
+                {unsubscribed_participants_count} topic participants are not subscribed to &nbsp;<z-stream></z-stream>.
                 {{#*inline "z-stream"}}<strong>{{> ../inline_decorated_channel_name stream=stream show_colored_icon=true}}</strong>{{/inline}}
             {{/tr}}
         {{/if}}

--- a/web/templates/modal_banner/unsubscribed_participants_warning_banner.hbs
+++ b/web/templates/modal_banner/unsubscribed_participants_warning_banner.hbs
@@ -1,6 +1,13 @@
 {{#> modal_banner . }}
     <p class="banner_message">
-        {{#if few_unsubscribed_participants}}
+        {{#if (eq selected_propagate_mode "change_one")}}
+            {{#tr}}
+                Message sender <z-user-names></z-user-names> is not subscribed to &nbsp;<z-stream></z-stream>.
+                {{#*inline "z-user-names"}}({{{unsubscribed_participant_formatted_names_list}}}){{/inline}}
+                {{#*inline "z-stream"}}<strong>{{> ../inline_decorated_channel_name stream=stream show_colored_icon=true}}</strong>{{/inline}}
+            {{/tr}}
+
+        {{else if few_unsubscribed_participants}}
             {{#tr}}
                 Some topic participants <z-user-names></z-user-names> are not subscribed to &nbsp;<z-stream></z-stream>.
                 {{#*inline "z-user-names"}}({{{unsubscribed_participant_formatted_names_list}}}){{/inline}}


### PR DESCRIPTION
[CZO discussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/Some.20topic.20participants.20banner.20when.20moving.20one.20message/with/2183841)

### Only participants who sent the messages being moved should appear in the warning banner.

For example, in a topic which has many participants unsubscribed to the destination stream, but we are only moving a single message sent by "Prospero", the following banner appears

![moving_single_message_warning_banner](https://github.com/user-attachments/assets/215c5362-8d5f-4daf-880b-f8ea7d494c3d)
