### PR TITLE
css: Fix overflow and color issues in GIF popover (#34772).

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -763,11 +763,6 @@ ul.popover-group-menu-member-list {
     border: 0;
     padding: 0;
 
-    .giphy-content {
-        position: relative;
-        left: 1px;
-    }
-
     .giphy-gif {
         cursor: pointer;
     }
@@ -780,9 +775,9 @@ ul.popover-group-menu-member-list {
     }
 
     .giphy-scrolling-container {
-        overflow: auto;
+        overflow: hidden auto;
         height: 200px;
-        margin: 2px;
+        margin: 2px 3px;
         padding: 5px 0;
     }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -111,6 +111,12 @@
     }
 }
 
+.giphy-popover .tippy-box .tippy-arrow {
+    /* Since the GIPHY banner at the popover is black,
+       match the arrow color with the banner. */
+    color: hsl(0deg 0% 0%);
+}
+
 .tippy-box[data-theme="popover-menu"]:has(#gear-menu-dropdown) {
     --box-shadow-popover-menu: var(--box-shadow-gear-menu);
 }


### PR DESCRIPTION
Fixes #34772  
Adjusted the overflow properties of the GIF container.  
Changed the color of the triangular tip at the bottom to match the color of the GIPHY logo bar just above it.

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/f1b5a32f-c7d8-438f-a070-a77480f4e8a9) | ![image](https://github.com/user-attachments/assets/02941e32-06cf-482c-a3aa-09b649bef128) |

---

<details>
<summary><strong>Self-review checklist</strong></summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).

**Communicate decisions, questions, and potential concerns**
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

**Individual commits are ready for review** ([commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html))
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

**Completed manual review and testing of the following:**
- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
