### PR TITLE
generate-integration-docs-screenshot script improvements

### DIFF
--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -140,9 +140,7 @@ def custom_headers(headers_json: str) -> dict[str, str]:
         )
 
 
-def send_bot_mock_message(
-    bot: UserProfile, integration: Integration, fixture_path: str, config: BaseScreenshotConfig
-) -> None:
+def send_bot_mock_message(bot: UserProfile, integration: Integration, fixture_path: str) -> None:
     # Delete all messages, so new message is the only one it's message group
     Message.objects.filter(realm_id=bot.realm_id, sender=bot).delete()
     data, _, _, _ = get_fixture_info(fixture_path)
@@ -255,7 +253,7 @@ def generate_screenshot_from_config(
         )
         message_sent = send_bot_payload_message(bot, integration, fixture_path, screenshot_config)
     else:
-        send_bot_mock_message(bot, integration, fixture_path, screenshot_config)
+        send_bot_mock_message(bot, integration, fixture_path)
         message_sent = True
     if message_sent:
         capture_last_message_screenshot(bot, image_path)

--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -300,6 +300,23 @@ webhook_group.add_argument(
 options = parser.parse_args()
 prepare_puppeteer_run()
 
+
+def validate_integration_count(
+    options: argparse.Namespace, parser: argparse.ArgumentParser, option_name: str
+) -> None:
+    if len(options.integration) != 1:
+        parser.error(
+            f"Exactly one integration should be specified with --integration when --{option_name} is provided"
+        )
+
+
+def build_config(options: argparse.Namespace, config_keys: list[str]) -> dict[str, Any]:
+    config = {
+        key: getattr(options, key) for key in config_keys if getattr(options, key) is not None
+    }
+    return config
+
+
 if options.all:
     for key, value in vars(options).items():
         if key != "all" and value:
@@ -326,24 +343,10 @@ elif options.skip_until:
             generate_screenshot_from_config(integration_name, screenshot_config)
 
 elif options.fixture_name:
-    if len(options.integration) != 1:
-        parser.error(
-            "Exactly one integration should be specified for --integration when --fixture is provided"
-        )
-    config = dict(
-        fixture_name=options.fixture,
-        use_basic_auth=options.use_basic_auth,
-        custom_headers=options.custom_headers,
-        payload_as_query_param=options.payload_as_query_param,
-    )
-    if options.image_name:
-        config["image_name"] = options.image_name
-    if options.image_dir:
-        config["image_dir"] = options.image_dir
-    if options.bot_name:
-        config["bot_name"] = options.bot_name
-    if options.payload_param_name:
-        config["payload_param_name"] = options.payload_param_name
+    validate_integration_count(options, parser, "fixture-name")
+    webhook_options = [action.dest for action in webhook_group._group_actions]
+    common_options = [action.dest for action in common_group._group_actions]
+    config = build_config(options, webhook_options + common_options)
     screenshot_config = ScreenshotConfig(**config)
     generate_screenshot_from_config(options.integration[0], screenshot_config)
 

--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -267,7 +267,6 @@ group.add_argument(
     "--skip-until", help="Name of the integration whose predecessor are skipped. Similar to --all"
 )
 group.add_argument("--integration", nargs="+", help="Names of the integrations")
-fixture_group = parser.add_argument_group("integration")
 parser.add_argument("--fixture", help="Name of the fixture file to use")
 parser.add_argument("--image-name", help="Name for the screenshot image")
 parser.add_argument("--image-dir", help="Directory name where to save the screenshot image")

--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -271,7 +271,7 @@ batch_group.add_argument(
 batch_group.add_argument("--integration", nargs="+", help="Names of specific integrations")
 
 parser.add_argument(
-    "--fixture",
+    "--fixture-name",
     help="Name of the fixture file to use. All other webhook options are ignored if the fixture is not specified.",
 )
 parser.add_argument("--image-name", help="Name for the screenshot image")
@@ -322,7 +322,7 @@ elif options.skip_until:
         for screenshot_config in screenshot_configs:
             generate_screenshot_from_config(integration_name, screenshot_config)
 
-elif options.fixture:
+elif options.fixture_name:
     if len(options.integration) != 1:
         parser.error(
             "Exactly one integration should be specified for --integration when --fixture is provided"

--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -100,6 +100,10 @@ def get_fixture_info(fixture_path: str) -> tuple[Any, bool, bool, str]:
     _, fixture_name = split_fixture_path(fixture_path)
 
     if fixture_name:
+        if not os.path.exists(fixture_path):
+            raise FileNotFoundError(
+                f"{BOLDRED}The fixture '{fixture_path}' does not exist. Please check the fixture file name and try again.{ENDC}"
+            )
         if json_fixture:
             with open(fixture_path, "rb") as fb:
                 data = orjson.loads(fb.read())

--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -270,24 +270,27 @@ batch_group.add_argument(
 )
 batch_group.add_argument("--integration", nargs="+", help="Names of specific integrations")
 
-parser.add_argument(
+common_group = parser.add_argument_group()
+common_group.add_argument("--image-name", help="Name for the screenshot image")
+common_group.add_argument("--image-dir", help="Directory name where to save the screenshot image")
+common_group.add_argument("--bot-name", help="Name to use for the bot")
+
+webhook_group = parser.add_argument_group("Webhook integrations options")
+webhook_group.add_argument(
     "--fixture-name",
     help="Name of the fixture file to use. All other webhook options are ignored if the fixture is not specified.",
 )
-parser.add_argument("--image-name", help="Name for the screenshot image")
-parser.add_argument("--image-dir", help="Directory name where to save the screenshot image")
-parser.add_argument("--bot-name", help="Name to use for the bot")
-parser.add_argument(
+webhook_group.add_argument(
     "-A", "--use-basic-auth", action="store_true", help="Add basic auth headers to the request"
 )
-parser.add_argument(
+webhook_group.add_argument(
     "-Q",
     "--payload-as-query-param",
     action="store_true",
     help="Send payload as query param instead of body",
 )
-parser.add_argument("-P", "--payload-param-name", help="Param name to use for the payload")
-parser.add_argument(
+webhook_group.add_argument("-P", "--payload-param-name", help="Param name to use for the payload")
+webhook_group.add_argument(
     "-H",
     "--custom-headers",
     type=custom_headers,

--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -265,11 +265,15 @@ parser = argparse.ArgumentParser()
 batch_group = parser.add_mutually_exclusive_group(required=True)
 batch_group.add_argument("--all", action="store_true")
 batch_group.add_argument(
-    "--skip-until", help="Name of the integration whose predecessor are skipped. Similar to --all"
+    "--skip-until",
+    help="Name of the integration to start processing from, including all that follow in alphabetical order. Similar to --all",
 )
-batch_group.add_argument("--integration", nargs="+", help="Names of the integrations")
+batch_group.add_argument("--integration", nargs="+", help="Names of specific integrations")
 
-parser.add_argument("--fixture", help="Name of the fixture file to use")
+parser.add_argument(
+    "--fixture",
+    help="Name of the fixture file to use. All other webhook options are ignored if the fixture is not specified.",
+)
 parser.add_argument("--image-name", help="Name for the screenshot image")
 parser.add_argument("--image-dir", help="Directory name where to save the screenshot image")
 parser.add_argument("--bot-name", help="Name to use for the bot")
@@ -306,7 +310,7 @@ elif options.skip_until:
     for key, value in vars(options).items():
         if key != "skip_until" and value:
             print(
-                f"Generating screenshots for all integrations skipping until {options.skip_until}. Ignoring all command-line options"
+                f"Generating screenshots for all integrations starting from {options.skip_until}. Ignoring all command-line options"
             )
             break
     skip = True

--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -261,12 +261,14 @@ def generate_screenshot_from_config(
 
 
 parser = argparse.ArgumentParser()
-group = parser.add_mutually_exclusive_group(required=True)
-group.add_argument("--all", action="store_true")
-group.add_argument(
+
+batch_group = parser.add_mutually_exclusive_group(required=True)
+batch_group.add_argument("--all", action="store_true")
+batch_group.add_argument(
     "--skip-until", help="Name of the integration whose predecessor are skipped. Similar to --all"
 )
-group.add_argument("--integration", nargs="+", help="Names of the integrations")
+batch_group.add_argument("--integration", nargs="+", help="Names of the integrations")
+
 parser.add_argument("--fixture", help="Name of the fixture file to use")
 parser.add_argument("--image-name", help="Name for the screenshot image")
 parser.add_argument("--image-dir", help="Directory name where to save the screenshot image")


### PR DESCRIPTION
This PR refactors the script in preparation for adding support for generating screenshots of integrations without fixtures (all non-webhook integrations) in the following PRs.

<details>
<summary><h3>Screenshot of `--help`</h3></summary>

Old:
![image](https://github.com/user-attachments/assets/0de3576f-27ce-4336-ab31-0dae46659e86)

New:
![image](https://github.com/user-attachments/assets/cf8637c9-5dad-44d0-8c78-819244bafff5)


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
