### PR TITLE
Support generating screenshots of fixtureless integrations

### DIFF
--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -42,7 +42,8 @@ from zerver.lib.integrations import (
     Integration,
     WebhookIntegration,
     WebhookScreenshotConfig,
-    get_fixture_and_image_paths,
+    get_fixture_path,
+    get_image_path,
     split_fixture_path,
 )
 from zerver.lib.storage import static_path
@@ -220,7 +221,8 @@ def generate_screenshot_from_config(
 ) -> None:
     integration = INTEGRATIONS[integration_name]
     assert isinstance(integration, WebhookIntegration)
-    fixture_path, image_path = get_fixture_and_image_paths(integration, screenshot_config)
+    fixture_path = get_fixture_path(integration, screenshot_config)
+    image_path = get_image_path(integration, screenshot_config)
     bot = create_integration_bot(integration, screenshot_config.bot_name)
     create_integration_stream(integration, bot)
     if send_bot_payload_message(bot, integration, fixture_path, screenshot_config):

--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -9,6 +9,8 @@ import sys
 from typing import Any
 from urllib.parse import parse_qsl, urlencode
 
+import zulip
+
 SCREENSHOTS_DIR = os.path.abspath(os.path.dirname(__file__))
 TOOLS_DIR = os.path.abspath(os.path.dirname(SCREENSHOTS_DIR))
 ROOT_DIR = os.path.dirname(TOOLS_DIR)
@@ -39,6 +41,7 @@ from zerver.actions.user_settings import do_change_avatar_fields
 from zerver.lib.integrations import (
     DOC_SCREENSHOT_CONFIG,
     INTEGRATIONS,
+    FixturelessScreenshotConfig,
     Integration,
     WebhookIntegration,
     WebhookScreenshotConfig,
@@ -205,6 +208,17 @@ def send_bot_payload_message(
         return True
 
 
+def send_bot_mock_message(bot: UserProfile, channel: str, topic: str, message: str) -> None:
+    # Delete all messages, so that the new message is the only one in its message group
+    Message.objects.filter(realm_id=bot.realm_id, sender=bot).delete()
+    assert bot.bot_owner is not None
+    url = f"{bot.bot_owner.realm.url}"
+    client = zulip.Client(email=bot.email, api_key=bot.api_key, site=url)
+
+    request = {"type": "stream", "to": channel, "topic": topic, "content": message}
+    client.send_message(request)
+
+
 def capture_last_message_screenshot(bot: UserProfile, image_path: str) -> None:
     message = Message.objects.filter(realm_id=bot.realm_id, sender=bot).last()
     realm = get_realm("zulip")
@@ -217,15 +231,29 @@ def capture_last_message_screenshot(bot: UserProfile, image_path: str) -> None:
 
 
 def generate_screenshot_from_config(
-    integration_name: str, screenshot_config: WebhookScreenshotConfig
+    integration_name: str, screenshot_config: WebhookScreenshotConfig | FixturelessScreenshotConfig
 ) -> None:
     integration = INTEGRATIONS[integration_name]
-    assert isinstance(integration, WebhookIntegration)
-    fixture_path = get_fixture_path(integration, screenshot_config)
-    image_path = get_image_path(integration, screenshot_config)
     bot = create_integration_bot(integration, screenshot_config.bot_name)
     create_integration_stream(integration, bot)
-    if send_bot_payload_message(bot, integration, fixture_path, screenshot_config):
+    image_path = get_image_path(integration, screenshot_config)
+
+    if isinstance(integration, WebhookIntegration):
+        assert isinstance(screenshot_config, WebhookScreenshotConfig)
+        fixture_path = get_fixture_path(integration, screenshot_config)
+        message_sent = send_bot_payload_message(bot, integration, fixture_path, screenshot_config)
+    else:
+        assert isinstance(screenshot_config, FixturelessScreenshotConfig)
+        create_integration_stream(integration, bot)
+        send_bot_mock_message(
+            bot,
+            channel=screenshot_config.channel or integration.stream_name,
+            topic=screenshot_config.topic,
+            message=screenshot_config.message,
+        )
+        message_sent = True
+
+    if message_sent:
         capture_last_message_screenshot(bot, image_path)
         print(f"Screenshot captured to: {BOLDRED}{image_path}{ENDC}")
 

--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -40,8 +40,8 @@ from zerver.lib.integrations import (
     DOC_SCREENSHOT_CONFIG,
     INTEGRATIONS,
     Integration,
-    ScreenshotConfig,
     WebhookIntegration,
+    WebhookScreenshotConfig,
     get_fixture_and_image_paths,
     split_fixture_path,
 )
@@ -138,7 +138,10 @@ def custom_headers(headers_json: str) -> dict[str, str]:
 
 
 def send_bot_payload_message(
-    bot: UserProfile, integration: WebhookIntegration, fixture_path: str, config: ScreenshotConfig
+    bot: UserProfile,
+    integration: WebhookIntegration,
+    fixture_path: str,
+    config: WebhookScreenshotConfig,
 ) -> bool:
     # Delete all messages, so new message is the only one it's message group
     Message.objects.filter(realm_id=bot.realm_id, sender=bot).delete()
@@ -213,7 +216,7 @@ def capture_last_message_screenshot(bot: UserProfile, image_path: str) -> None:
 
 
 def generate_screenshot_from_config(
-    integration_name: str, screenshot_config: ScreenshotConfig
+    integration_name: str, screenshot_config: WebhookScreenshotConfig
 ) -> None:
     integration = INTEGRATIONS[integration_name]
     assert isinstance(integration, WebhookIntegration)
@@ -312,7 +315,7 @@ elif options.fixture_name:
     webhook_options = [action.dest for action in webhook_group._group_actions]
     common_options = [action.dest for action in common_group._group_actions]
     config = build_config(options, webhook_options + common_options)
-    screenshot_config = ScreenshotConfig(**config)
+    screenshot_config = WebhookScreenshotConfig(**config)
     generate_screenshot_from_config(options.integration[0], screenshot_config)
 
 elif options.integration:

--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -295,6 +295,15 @@ webhook_group.add_argument(
     help="Any additional headers to be sent with the request.",
 )
 
+fixtureless_group = parser.add_argument_group("Fixtureless non-webhook integrations options")
+fixtureless_group.add_argument("-T", "--topic", help="Topic to use for the mock message")
+fixtureless_group.add_argument("-M", "--message", help="Message to use for the mock message")
+fixtureless_group.add_argument(
+    "-C",
+    "--channel",
+    help="Channel name to use for the mock message. Defaults to stream name. Ignored if --topic and --message are not specified.",
+)
+
 options = parser.parse_args()
 prepare_puppeteer_run()
 
@@ -347,6 +356,16 @@ elif options.fixture_name:
     config = build_config(options, webhook_options + common_options)
     screenshot_config = WebhookScreenshotConfig(**config)
     generate_screenshot_from_config(options.integration[0], screenshot_config)
+
+elif options.topic or options.message:
+    if not options.topic or not options.message:
+        parser.error("Both --topic and --message must be specified together")
+    validate_integration_count(options, parser, "topic")
+    fixtureless_options = [action.dest for action in webhook_group._group_actions]
+    common_options = [action.dest for action in common_group._group_actions]
+    config = build_config(options, fixtureless_options + common_options)
+    fixtureless_screenshot_config = FixturelessScreenshotConfig(**config)
+    generate_screenshot_from_config(options.integration[0], fixtureless_screenshot_config)
 
 elif options.integration:
     for integration in options.integration:

--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -30,7 +30,6 @@ django.setup()
 
 import orjson
 import requests
-import zulip
 
 from scripts.lib.zulip_tools import BOLDRED, ENDC
 from tools.lib.test_script import prepare_puppeteer_run
@@ -40,7 +39,6 @@ from zerver.actions.user_settings import do_change_avatar_fields
 from zerver.lib.integrations import (
     DOC_SCREENSHOT_CONFIG,
     INTEGRATIONS,
-    BaseScreenshotConfig,
     Integration,
     ScreenshotConfig,
     WebhookIntegration,
@@ -118,11 +116,6 @@ def get_fixture_info(fixture_path: str) -> tuple[Any, bool, bool, str]:
     return data, json_fixture, multipart_fixture, fixture_name
 
 
-def get_integration(integration_name: str) -> Integration:
-    integration = INTEGRATIONS[integration_name]
-    return integration
-
-
 def get_requests_headers(integration_name: str, fixture_name: str) -> dict[str, Any]:
     headers = get_fixture_http_headers(integration_name, fixture_name)
 
@@ -142,31 +135,6 @@ def custom_headers(headers_json: str) -> dict[str, str]:
             f"Encountered an error while attempting to parse custom headers: {ve}\n"
             "Note: all strings must be enclosed within \"\" instead of ''"
         )
-
-
-def send_bot_mock_message(bot: UserProfile, integration: Integration, fixture_path: str) -> None:
-    # Delete all messages, so new message is the only one it's message group
-    Message.objects.filter(realm_id=bot.realm_id, sender=bot).delete()
-    data, _, _, _ = get_fixture_info(fixture_path)
-
-    assert bot.bot_owner is not None
-    url = f"{bot.bot_owner.realm.url}"
-    client = zulip.Client(email=bot.email, api_key=bot.api_key, site=url)
-
-    try:
-        request = {
-            "type": "stream",
-            "to": integration.stream_name,
-            "topic": data["subject"],
-            "content": data["body"],
-        }
-        client.send_message(request)
-    except KeyError:
-        print(
-            f"{fixture_path} contains invalid configuration. "
-            'Fields "subject" and "body" are required for non-webhook integrations.'
-        )
-        sys.exit(1)
 
 
 def send_bot_payload_message(
@@ -245,21 +213,14 @@ def capture_last_message_screenshot(bot: UserProfile, image_path: str) -> None:
 
 
 def generate_screenshot_from_config(
-    integration_name: str, screenshot_config: BaseScreenshotConfig
+    integration_name: str, screenshot_config: ScreenshotConfig
 ) -> None:
-    integration = get_integration(integration_name)
+    integration = INTEGRATIONS[integration_name]
+    assert isinstance(integration, WebhookIntegration)
     fixture_path, image_path = get_fixture_and_image_paths(integration, screenshot_config)
     bot = create_integration_bot(integration, screenshot_config.bot_name)
     create_integration_stream(integration, bot)
-    if isinstance(integration, WebhookIntegration):
-        assert isinstance(screenshot_config, ScreenshotConfig), (
-            "Webhook integrations require ScreenshotConfig"
-        )
-        message_sent = send_bot_payload_message(bot, integration, fixture_path, screenshot_config)
-    else:
-        send_bot_mock_message(bot, integration, fixture_path)
-        message_sent = True
-    if message_sent:
+    if send_bot_payload_message(bot, integration, fixture_path, screenshot_config):
         capture_last_message_screenshot(bot, image_path)
         print(f"Screenshot captured to: {BOLDRED}{image_path}{ENDC}")
 

--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -40,7 +40,9 @@ from zerver.actions.streams import bulk_add_subscriptions
 from zerver.actions.user_settings import do_change_avatar_fields
 from zerver.lib.integrations import (
     DOC_SCREENSHOT_CONFIG,
+    FIXTURELESS_SCREENSHOT_CONFIG,
     INTEGRATIONS,
+    WEBHOOK_SCREENSHOT_CONFIG,
     FixturelessScreenshotConfig,
     Integration,
     WebhookIntegration,
@@ -262,6 +264,8 @@ parser = argparse.ArgumentParser()
 
 batch_group = parser.add_mutually_exclusive_group(required=True)
 batch_group.add_argument("--all", action="store_true")
+batch_group.add_argument("--all-webhook", action="store_true")
+batch_group.add_argument("--all-fixtureless", action="store_true")
 batch_group.add_argument(
     "--skip-until",
     help="Name of the integration to start processing from, including all that follow in alphabetical order. Similar to --all",
@@ -324,15 +328,32 @@ def build_config(options: argparse.Namespace, config_keys: list[str]) -> dict[st
     return config
 
 
-if options.all:
+def generate_full_batch_screenshots(
+    option_key: str,
+    config_dict: dict[str, list[WebhookScreenshotConfig]]
+    | dict[str, list[FixturelessScreenshotConfig]]
+    | dict[str, list[WebhookScreenshotConfig] | list[FixturelessScreenshotConfig]],
+    batch_type: str,
+) -> None:
     for key, value in vars(options).items():
-        if key != "all" and value:
-            print("Generating screenshots for all integrations. Ignoring all command-line options")
+        if key != option_key and value:
+            print(f"Generating screenshots for {batch_type}. Ignoring all command-line options")
             break
-    for integration_name, screenshot_configs in DOC_SCREENSHOT_CONFIG.items():
+    for integration_name, screenshot_configs in config_dict.items():
         for screenshot_config in screenshot_configs:
             generate_screenshot_from_config(integration_name, screenshot_config)
 
+
+if options.all:
+    generate_full_batch_screenshots("all", DOC_SCREENSHOT_CONFIG, "all integrations")
+elif options.all_webhook:
+    generate_full_batch_screenshots(
+        "all_webhook", WEBHOOK_SCREENSHOT_CONFIG, "all webhook integrations"
+    )
+elif options.all_fixtureless:
+    generate_full_batch_screenshots(
+        "all_fixtureless", FIXTURELESS_SCREENSHOT_CONFIG, "all fixtureless integrations"
+    )
 elif options.skip_until:
     for key, value in vars(options).items():
         if key != "skip_until" and value:

--- a/zerver/integration_fixtures/nagios/service_notify.json
+++ b/zerver/integration_fixtures/nagios/service_notify.json
@@ -1,4 +1,0 @@
-{
-    "subject": "service remote load on postgres.humbughq.com",
-    "body": "**PROBLEM**: service is CRITICAL\n> CRITICAL - load average: 7.49, 8.20, 4.72"
-}

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -771,7 +771,6 @@ DOC_SCREENSHOT_CONFIG: dict[str, list[BaseScreenshotConfig]] = {
     "lidarr": [ScreenshotConfig("lidarr_album_grabbed.json")],
     "linear": [ScreenshotConfig("issue_create_complex.json")],
     "mention": [ScreenshotConfig("webfeeds.json")],
-    "nagios": [BaseScreenshotConfig("service_notify.json")],
     "netlify": [ScreenshotConfig("deploy_building.json")],
     "newrelic": [ScreenshotConfig("incident_activated_new_default_payload.json")],
     "opencollective": [ScreenshotConfig("one_time_donation.json")],

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -314,15 +314,19 @@ class WebhookScreenshotConfig:
     custom_headers: dict[str, str] = field(default_factory=dict)
 
 
-def get_fixture_and_image_paths(
+def get_fixture_path(
     integration: WebhookIntegration, screenshot_config: WebhookScreenshotConfig
-) -> tuple[str, str]:
+) -> str:
     fixture_dir = os.path.join("zerver", "webhooks", integration.dir_name, "fixtures")
     fixture_path = os.path.join(fixture_dir, screenshot_config.fixture_name)
+    return fixture_path
+
+
+def get_image_path(integration: Integration, screenshot_config: WebhookScreenshotConfig) -> str:
     image_dir = screenshot_config.image_dir or integration.name
     image_name = screenshot_config.image_name
     image_path = os.path.join("static/images/integrations", image_dir, image_name)
-    return fixture_path, image_path
+    return image_path
 
 
 class HubotIntegration(Integration):

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -302,15 +302,11 @@ def split_fixture_path(path: str) -> tuple[str, str]:
 
 
 @dataclass
-class BaseScreenshotConfig:
+class ScreenshotConfig:
     fixture_name: str
     image_name: str = "001.png"
     image_dir: str | None = None
     bot_name: str | None = None
-
-
-@dataclass
-class ScreenshotConfig(BaseScreenshotConfig):
     payload_as_query_param: bool = False
     payload_param_name: str = "payload"
     extra_params: dict[str, str] = field(default_factory=dict)
@@ -319,12 +315,9 @@ class ScreenshotConfig(BaseScreenshotConfig):
 
 
 def get_fixture_and_image_paths(
-    integration: Integration, screenshot_config: BaseScreenshotConfig
+    integration: WebhookIntegration, screenshot_config: ScreenshotConfig
 ) -> tuple[str, str]:
-    if isinstance(integration, WebhookIntegration):
-        fixture_dir = os.path.join("zerver", "webhooks", integration.dir_name, "fixtures")
-    else:
-        fixture_dir = os.path.join("zerver", "integration_fixtures", integration.name)
+    fixture_dir = os.path.join("zerver", "webhooks", integration.dir_name, "fixtures")
     fixture_path = os.path.join(fixture_dir, screenshot_config.fixture_name)
     image_dir = screenshot_config.image_dir or integration.name
     image_name = screenshot_config.image_name
@@ -695,7 +688,7 @@ NO_SCREENSHOT_WEBHOOKS = {
 }
 
 
-DOC_SCREENSHOT_CONFIG: dict[str, list[BaseScreenshotConfig]] = {
+DOC_SCREENSHOT_CONFIG: dict[str, list[ScreenshotConfig]] = {
     "airbrake": [ScreenshotConfig("error_message.json")],
     "airbyte": [ScreenshotConfig("airbyte_job_payload_success.json")],
     "alertmanager": [

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -302,7 +302,7 @@ def split_fixture_path(path: str) -> tuple[str, str]:
 
 
 @dataclass
-class ScreenshotConfig:
+class WebhookScreenshotConfig:
     fixture_name: str
     image_name: str = "001.png"
     image_dir: str | None = None
@@ -315,7 +315,7 @@ class ScreenshotConfig:
 
 
 def get_fixture_and_image_paths(
-    integration: WebhookIntegration, screenshot_config: ScreenshotConfig
+    integration: WebhookIntegration, screenshot_config: WebhookScreenshotConfig
 ) -> tuple[str, str]:
     fixture_dir = os.path.join("zerver", "webhooks", integration.dir_name, "fixtures")
     fixture_path = os.path.join(fixture_dir, screenshot_config.fixture_name)
@@ -688,111 +688,121 @@ NO_SCREENSHOT_WEBHOOKS = {
 }
 
 
-DOC_SCREENSHOT_CONFIG: dict[str, list[ScreenshotConfig]] = {
-    "airbrake": [ScreenshotConfig("error_message.json")],
-    "airbyte": [ScreenshotConfig("airbyte_job_payload_success.json")],
+DOC_SCREENSHOT_CONFIG: dict[str, list[WebhookScreenshotConfig]] = {
+    "airbrake": [WebhookScreenshotConfig("error_message.json")],
+    "airbyte": [WebhookScreenshotConfig("airbyte_job_payload_success.json")],
     "alertmanager": [
-        ScreenshotConfig("alert.json", extra_params={"name": "topic", "desc": "description"})
+        WebhookScreenshotConfig("alert.json", extra_params={"name": "topic", "desc": "description"})
     ],
-    "ansibletower": [ScreenshotConfig("job_successful_multiple_hosts.json")],
-    "appfollow": [ScreenshotConfig("review.json")],
-    "appveyor": [ScreenshotConfig("appveyor_build_success.json")],
-    "azuredevops": [ScreenshotConfig("code_push.json")],
-    "basecamp": [ScreenshotConfig("doc_active.json")],
+    "ansibletower": [WebhookScreenshotConfig("job_successful_multiple_hosts.json")],
+    "appfollow": [WebhookScreenshotConfig("review.json")],
+    "appveyor": [WebhookScreenshotConfig("appveyor_build_success.json")],
+    "azuredevops": [WebhookScreenshotConfig("code_push.json")],
+    "basecamp": [WebhookScreenshotConfig("doc_active.json")],
     "beanstalk": [
-        ScreenshotConfig("git_multiple.json", use_basic_auth=True, payload_as_query_param=True)
+        WebhookScreenshotConfig(
+            "git_multiple.json", use_basic_auth=True, payload_as_query_param=True
+        )
     ],
-    # 'beeminder': [ScreenshotConfig('derail_worried.json')],
+    # 'beeminder': [WebhookScreenshotConfig('derail_worried.json')],
     "bitbucket": [
-        ScreenshotConfig("push.json", "002.png", use_basic_auth=True, payload_as_query_param=True)
+        WebhookScreenshotConfig(
+            "push.json", "002.png", use_basic_auth=True, payload_as_query_param=True
+        )
     ],
     "bitbucket2": [
-        ScreenshotConfig("issue_created.json", "003.png", "bitbucket", bot_name="Bitbucket Bot")
+        WebhookScreenshotConfig(
+            "issue_created.json", "003.png", "bitbucket", bot_name="Bitbucket Bot"
+        )
     ],
     "bitbucket3": [
-        ScreenshotConfig(
+        WebhookScreenshotConfig(
             "repo_push_update_single_branch.json",
             "004.png",
             "bitbucket",
             bot_name="Bitbucket Server Bot",
         )
     ],
-    "buildbot": [ScreenshotConfig("started.json")],
-    "canarytoken": [ScreenshotConfig("canarytoken_real.json")],
-    "circleci": [ScreenshotConfig("github_job_completed.json")],
-    "clubhouse": [ScreenshotConfig("story_create.json")],
-    "codeship": [ScreenshotConfig("error_build.json")],
-    "crashlytics": [ScreenshotConfig("issue_message.json")],
-    "delighted": [ScreenshotConfig("survey_response_updated_promoter.json")],
-    "dialogflow": [ScreenshotConfig("weather_app.json", extra_params={"email": "iago@zulip.com"})],
-    "dropbox": [ScreenshotConfig("file_updated.json")],
-    "errbit": [ScreenshotConfig("error_message.json")],
-    "flock": [ScreenshotConfig("messages.json")],
-    "freshdesk": [
-        ScreenshotConfig("ticket_created.json", image_name="004.png", use_basic_auth=True)
+    "buildbot": [WebhookScreenshotConfig("started.json")],
+    "canarytoken": [WebhookScreenshotConfig("canarytoken_real.json")],
+    "circleci": [WebhookScreenshotConfig("github_job_completed.json")],
+    "clubhouse": [WebhookScreenshotConfig("story_create.json")],
+    "codeship": [WebhookScreenshotConfig("error_build.json")],
+    "crashlytics": [WebhookScreenshotConfig("issue_message.json")],
+    "delighted": [WebhookScreenshotConfig("survey_response_updated_promoter.json")],
+    "dialogflow": [
+        WebhookScreenshotConfig("weather_app.json", extra_params={"email": "iago@zulip.com"})
     ],
-    "freshping": [ScreenshotConfig("freshping_check_unreachable.json")],
-    "freshstatus": [ScreenshotConfig("freshstatus_incident_open.json")],
-    "front": [ScreenshotConfig("inbound_message.json")],
-    "gitea": [ScreenshotConfig("pull_request__merged.json")],
-    "github": [ScreenshotConfig("push__1_commit.json")],
-    "githubsponsors": [ScreenshotConfig("created.json")],
-    "gitlab": [ScreenshotConfig("push_hook__push_local_branch_without_commits.json")],
-    "gocd": [ScreenshotConfig("pipeline_with_mixed_job_result.json")],
-    "gogs": [ScreenshotConfig("pull_request__opened.json")],
-    "gosquared": [ScreenshotConfig("traffic_spike.json")],
-    "grafana": [ScreenshotConfig("alert_values_v11.json")],
-    "greenhouse": [ScreenshotConfig("candidate_stage_change.json")],
-    "groove": [ScreenshotConfig("ticket_started.json")],
-    "harbor": [ScreenshotConfig("scanning_completed.json")],
+    "dropbox": [WebhookScreenshotConfig("file_updated.json")],
+    "errbit": [WebhookScreenshotConfig("error_message.json")],
+    "flock": [WebhookScreenshotConfig("messages.json")],
+    "freshdesk": [
+        WebhookScreenshotConfig("ticket_created.json", image_name="004.png", use_basic_auth=True)
+    ],
+    "freshping": [WebhookScreenshotConfig("freshping_check_unreachable.json")],
+    "freshstatus": [WebhookScreenshotConfig("freshstatus_incident_open.json")],
+    "front": [WebhookScreenshotConfig("inbound_message.json")],
+    "gitea": [WebhookScreenshotConfig("pull_request__merged.json")],
+    "github": [WebhookScreenshotConfig("push__1_commit.json")],
+    "githubsponsors": [WebhookScreenshotConfig("created.json")],
+    "gitlab": [WebhookScreenshotConfig("push_hook__push_local_branch_without_commits.json")],
+    "gocd": [WebhookScreenshotConfig("pipeline_with_mixed_job_result.json")],
+    "gogs": [WebhookScreenshotConfig("pull_request__opened.json")],
+    "gosquared": [WebhookScreenshotConfig("traffic_spike.json")],
+    "grafana": [WebhookScreenshotConfig("alert_values_v11.json")],
+    "greenhouse": [WebhookScreenshotConfig("candidate_stage_change.json")],
+    "groove": [WebhookScreenshotConfig("ticket_started.json")],
+    "harbor": [WebhookScreenshotConfig("scanning_completed.json")],
     "hellosign": [
-        ScreenshotConfig(
+        WebhookScreenshotConfig(
             "signatures_signed_by_one_signatory.json",
             payload_as_query_param=True,
             payload_param_name="json",
         )
     ],
-    "helloworld": [ScreenshotConfig("hello.json")],
-    "heroku": [ScreenshotConfig("deploy.txt")],
-    "homeassistant": [ScreenshotConfig("reqwithtitle.json")],
-    "insping": [ScreenshotConfig("website_state_available.json")],
-    "intercom": [ScreenshotConfig("conversation_admin_replied.json")],
-    "jira": [ScreenshotConfig("created_v1.json")],
-    "jotform": [ScreenshotConfig("screenshot_response.multipart")],
-    "json": [ScreenshotConfig("json_github_push__1_commit.json")],
-    "librato": [ScreenshotConfig("three_conditions_alert.json", payload_as_query_param=True)],
-    "lidarr": [ScreenshotConfig("lidarr_album_grabbed.json")],
-    "linear": [ScreenshotConfig("issue_create_complex.json")],
-    "mention": [ScreenshotConfig("webfeeds.json")],
-    "netlify": [ScreenshotConfig("deploy_building.json")],
-    "newrelic": [ScreenshotConfig("incident_activated_new_default_payload.json")],
-    "opencollective": [ScreenshotConfig("one_time_donation.json")],
-    "openproject": [ScreenshotConfig("project_created__without_parent.json")],
-    "opensearch": [ScreenshotConfig("example_template.txt")],
-    "opsgenie": [ScreenshotConfig("addrecipient.json")],
-    "pagerduty": [ScreenshotConfig("trigger_v2.json")],
-    "papertrail": [ScreenshotConfig("short_post.json", payload_as_query_param=True)],
-    "patreon": [ScreenshotConfig("members_pledge_create.json")],
-    "pingdom": [ScreenshotConfig("http_up_to_down.json")],
-    "pivotal": [ScreenshotConfig("v5_type_changed.json")],
-    "radarr": [ScreenshotConfig("radarr_movie_grabbed.json")],
-    "raygun": [ScreenshotConfig("new_error.json")],
-    "reviewboard": [ScreenshotConfig("review_request_published.json")],
-    "rhodecode": [ScreenshotConfig("push.json")],
-    "rundeck": [ScreenshotConfig("start.json")],
-    "semaphore": [ScreenshotConfig("pull_request.json")],
-    "sentry": [ScreenshotConfig("event_for_exception_python.json")],
-    "slack": [ScreenshotConfig("message_with_normal_text.json")],
-    "sonarqube": [ScreenshotConfig("error.json")],
-    "sonarr": [ScreenshotConfig("sonarr_episode_grabbed.json")],
-    "splunk": [ScreenshotConfig("search_one_result.json")],
-    "statuspage": [ScreenshotConfig("incident_created.json")],
-    "stripe": [ScreenshotConfig("charge_succeeded__card.json")],
-    "taiga": [ScreenshotConfig("userstory_changed_status.json")],
-    "teamcity": [ScreenshotConfig("success.json")],
-    "thinkst": [ScreenshotConfig("canary_consolidated_port_scan.json")],
+    "helloworld": [WebhookScreenshotConfig("hello.json")],
+    "heroku": [WebhookScreenshotConfig("deploy.txt")],
+    "homeassistant": [WebhookScreenshotConfig("reqwithtitle.json")],
+    "insping": [WebhookScreenshotConfig("website_state_available.json")],
+    "intercom": [WebhookScreenshotConfig("conversation_admin_replied.json")],
+    "jira": [WebhookScreenshotConfig("created_v1.json")],
+    "jotform": [WebhookScreenshotConfig("screenshot_response.multipart")],
+    "json": [WebhookScreenshotConfig("json_github_push__1_commit.json")],
+    "librato": [
+        WebhookScreenshotConfig("three_conditions_alert.json", payload_as_query_param=True)
+    ],
+    "lidarr": [WebhookScreenshotConfig("lidarr_album_grabbed.json")],
+    "linear": [WebhookScreenshotConfig("issue_create_complex.json")],
+    "mention": [WebhookScreenshotConfig("webfeeds.json")],
+    "netlify": [WebhookScreenshotConfig("deploy_building.json")],
+    "newrelic": [WebhookScreenshotConfig("incident_activated_new_default_payload.json")],
+    "opencollective": [WebhookScreenshotConfig("one_time_donation.json")],
+    "openproject": [WebhookScreenshotConfig("project_created__without_parent.json")],
+    "opensearch": [WebhookScreenshotConfig("example_template.txt")],
+    "opsgenie": [WebhookScreenshotConfig("addrecipient.json")],
+    "pagerduty": [WebhookScreenshotConfig("trigger_v2.json")],
+    "papertrail": [WebhookScreenshotConfig("short_post.json", payload_as_query_param=True)],
+    "patreon": [WebhookScreenshotConfig("members_pledge_create.json")],
+    "pingdom": [WebhookScreenshotConfig("http_up_to_down.json")],
+    "pivotal": [WebhookScreenshotConfig("v5_type_changed.json")],
+    "radarr": [WebhookScreenshotConfig("radarr_movie_grabbed.json")],
+    "raygun": [WebhookScreenshotConfig("new_error.json")],
+    "reviewboard": [WebhookScreenshotConfig("review_request_published.json")],
+    "rhodecode": [WebhookScreenshotConfig("push.json")],
+    "rundeck": [WebhookScreenshotConfig("start.json")],
+    "semaphore": [WebhookScreenshotConfig("pull_request.json")],
+    "sentry": [WebhookScreenshotConfig("event_for_exception_python.json")],
+    "slack": [WebhookScreenshotConfig("message_with_normal_text.json")],
+    "sonarqube": [WebhookScreenshotConfig("error.json")],
+    "sonarr": [WebhookScreenshotConfig("sonarr_episode_grabbed.json")],
+    "splunk": [WebhookScreenshotConfig("search_one_result.json")],
+    "statuspage": [WebhookScreenshotConfig("incident_created.json")],
+    "stripe": [WebhookScreenshotConfig("charge_succeeded__card.json")],
+    "taiga": [WebhookScreenshotConfig("userstory_changed_status.json")],
+    "teamcity": [WebhookScreenshotConfig("success.json")],
+    "thinkst": [WebhookScreenshotConfig("canary_consolidated_port_scan.json")],
     "transifex": [
-        ScreenshotConfig(
+        WebhookScreenshotConfig(
             "",
             extra_params={
                 "project": "Zulip Mobile",
@@ -802,15 +812,15 @@ DOC_SCREENSHOT_CONFIG: dict[str, list[ScreenshotConfig]] = {
             },
         )
     ],
-    "travis": [ScreenshotConfig("build.json", payload_as_query_param=True)],
-    "trello": [ScreenshotConfig("adding_comment_to_card.json")],
-    "updown": [ScreenshotConfig("check_multiple_events.json")],
-    "uptimerobot": [ScreenshotConfig("uptimerobot_monitor_up.json")],
-    "wekan": [ScreenshotConfig("add_comment.json")],
-    "wordpress": [ScreenshotConfig("publish_post.txt", "wordpress_post_created.png")],
-    "zabbix": [ScreenshotConfig("zabbix_alert.json")],
+    "travis": [WebhookScreenshotConfig("build.json", payload_as_query_param=True)],
+    "trello": [WebhookScreenshotConfig("adding_comment_to_card.json")],
+    "updown": [WebhookScreenshotConfig("check_multiple_events.json")],
+    "uptimerobot": [WebhookScreenshotConfig("uptimerobot_monitor_up.json")],
+    "wekan": [WebhookScreenshotConfig("add_comment.json")],
+    "wordpress": [WebhookScreenshotConfig("publish_post.txt", "wordpress_post_created.png")],
+    "zabbix": [WebhookScreenshotConfig("zabbix_alert.json")],
     "zendesk": [
-        ScreenshotConfig(
+        WebhookScreenshotConfig(
             "",
             use_basic_auth=True,
             extra_params={

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -314,6 +314,16 @@ class WebhookScreenshotConfig:
     custom_headers: dict[str, str] = field(default_factory=dict)
 
 
+@dataclass
+class FixturelessScreenshotConfig:
+    message: str
+    topic: str
+    channel: str | None = None
+    image_name: str = "001.png"
+    image_dir: str | None = None
+    bot_name: str | None = None
+
+
 def get_fixture_path(
     integration: WebhookIntegration, screenshot_config: WebhookScreenshotConfig
 ) -> str:
@@ -322,7 +332,10 @@ def get_fixture_path(
     return fixture_path
 
 
-def get_image_path(integration: Integration, screenshot_config: WebhookScreenshotConfig) -> str:
+def get_image_path(
+    integration: Integration,
+    screenshot_config: WebhookScreenshotConfig | FixturelessScreenshotConfig,
+) -> str:
     image_dir = screenshot_config.image_dir or integration.name
     image_name = screenshot_config.image_name
     image_path = os.path.join("static/images/integrations", image_dir, image_name)

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -705,7 +705,7 @@ NO_SCREENSHOT_WEBHOOKS = {
 }
 
 
-DOC_SCREENSHOT_CONFIG: dict[str, list[WebhookScreenshotConfig]] = {
+WEBHOOK_SCREENSHOT_CONFIG: dict[str, list[WebhookScreenshotConfig]] = {
     "airbrake": [WebhookScreenshotConfig("error_message.json")],
     "airbyte": [WebhookScreenshotConfig("airbyte_job_payload_success.json")],
     "alertmanager": [
@@ -847,6 +847,15 @@ DOC_SCREENSHOT_CONFIG: dict[str, list[WebhookScreenshotConfig]] = {
             },
         )
     ],
+}
+
+FIXTURELESS_SCREENSHOT_CONFIG: dict[str, list[FixturelessScreenshotConfig]] = {}
+
+DOC_SCREENSHOT_CONFIG: dict[
+    str, list[WebhookScreenshotConfig] | list[FixturelessScreenshotConfig]
+] = {
+    **WEBHOOK_SCREENSHOT_CONFIG,
+    **FIXTURELESS_SCREENSHOT_CONFIG,
 }
 
 

--- a/zerver/tests/test_integrations.py
+++ b/zerver/tests/test_integrations.py
@@ -1,10 +1,10 @@
 import os
 
 from zerver.lib.integrations import (
-    DOC_SCREENSHOT_CONFIG,
     INTEGRATIONS,
     NO_SCREENSHOT_WEBHOOKS,
     WEBHOOK_INTEGRATIONS,
+    WEBHOOK_SCREENSHOT_CONFIG,
     WebhookIntegration,
     WebhookScreenshotConfig,
     get_fixture_path,
@@ -42,7 +42,7 @@ class IntegrationsTestCase(ZulipTestCase):
 
     def test_no_missing_doc_screenshot_config(self) -> None:
         webhook_names = {webhook.name for webhook in WEBHOOK_INTEGRATIONS}
-        webhooks_with_screenshot_config = set(DOC_SCREENSHOT_CONFIG.keys())
+        webhooks_with_screenshot_config = set(WEBHOOK_SCREENSHOT_CONFIG.keys())
         missing_webhooks = webhook_names - webhooks_with_screenshot_config - NO_SCREENSHOT_WEBHOOKS
         message = (
             f"These webhooks are missing screenshot config: {missing_webhooks}.\n"
@@ -56,8 +56,8 @@ class IntegrationsTestCase(ZulipTestCase):
             "Consider updating zerver.lib.integrations.DOC_SCREENSHOT_CONFIG\n"
             'and running "tools/screenshots/generate-integration-docs-screenshot" to keep the screenshots up-to-date.'
         )
-        for integration_name in DOC_SCREENSHOT_CONFIG:
-            configs = DOC_SCREENSHOT_CONFIG[integration_name]
+        for integration_name in WEBHOOK_SCREENSHOT_CONFIG:
+            configs = WEBHOOK_SCREENSHOT_CONFIG[integration_name]
             for screenshot_config in configs:
                 integration = INTEGRATIONS[integration_name]
                 assert isinstance(integration, WebhookIntegration)

--- a/zerver/tests/test_integrations.py
+++ b/zerver/tests/test_integrations.py
@@ -7,7 +7,8 @@ from zerver.lib.integrations import (
     WEBHOOK_INTEGRATIONS,
     WebhookIntegration,
     WebhookScreenshotConfig,
-    get_fixture_and_image_paths,
+    get_fixture_path,
+    get_image_path,
     split_fixture_path,
 )
 from zerver.lib.test_classes import ZulipTestCase
@@ -24,7 +25,8 @@ class IntegrationsTestCase(ZulipTestCase):
         integration = INTEGRATIONS["airbrake"]
         assert isinstance(integration, WebhookIntegration)
         screenshot_config = WebhookScreenshotConfig("error_message.json", "002.png", "ci")
-        fixture_path, image_path = get_fixture_and_image_paths(integration, screenshot_config)
+        fixture_path = get_fixture_path(integration, screenshot_config)
+        image_path = get_image_path(integration, screenshot_config)
         self.assertEqual(fixture_path, "zerver/webhooks/airbrake/fixtures/error_message.json")
         self.assertEqual(image_path, "static/images/integrations/ci/002.png")
 
@@ -63,13 +65,12 @@ class IntegrationsTestCase(ZulipTestCase):
                     # Such screenshot configs only use a placeholder
                     # fixture_name.
                     continue
-                fixture_path, image_path = get_fixture_and_image_paths(
-                    integration, screenshot_config
-                )
+                fixture_path = get_fixture_path(integration, screenshot_config)
                 self.assertTrue(
                     os.path.isfile(fixture_path),
                     message.format(path=fixture_path, webhook_name=integration_name),
                 )
+                image_path = get_image_path(integration, screenshot_config)
                 self.assertTrue(
                     os.path.isfile(image_path),
                     message.format(path=image_path, webhook_name=integration_name),

--- a/zerver/tests/test_integrations.py
+++ b/zerver/tests/test_integrations.py
@@ -5,8 +5,8 @@ from zerver.lib.integrations import (
     INTEGRATIONS,
     NO_SCREENSHOT_WEBHOOKS,
     WEBHOOK_INTEGRATIONS,
-    ScreenshotConfig,
     WebhookIntegration,
+    WebhookScreenshotConfig,
     get_fixture_and_image_paths,
     split_fixture_path,
 )
@@ -23,7 +23,7 @@ class IntegrationsTestCase(ZulipTestCase):
     def test_get_fixture_and_image_paths(self) -> None:
         integration = INTEGRATIONS["airbrake"]
         assert isinstance(integration, WebhookIntegration)
-        screenshot_config = ScreenshotConfig("error_message.json", "002.png", "ci")
+        screenshot_config = WebhookScreenshotConfig("error_message.json", "002.png", "ci")
         fixture_path, image_path = get_fixture_and_image_paths(integration, screenshot_config)
         self.assertEqual(fixture_path, "zerver/webhooks/airbrake/fixtures/error_message.json")
         self.assertEqual(image_path, "static/images/integrations/ci/002.png")

--- a/zerver/tests/test_integrations.py
+++ b/zerver/tests/test_integrations.py
@@ -5,8 +5,6 @@ from zerver.lib.integrations import (
     INTEGRATIONS,
     NO_SCREENSHOT_WEBHOOKS,
     WEBHOOK_INTEGRATIONS,
-    BaseScreenshotConfig,
-    Integration,
     ScreenshotConfig,
     WebhookIntegration,
     get_fixture_and_image_paths,
@@ -29,14 +27,6 @@ class IntegrationsTestCase(ZulipTestCase):
         fixture_path, image_path = get_fixture_and_image_paths(integration, screenshot_config)
         self.assertEqual(fixture_path, "zerver/webhooks/airbrake/fixtures/error_message.json")
         self.assertEqual(image_path, "static/images/integrations/ci/002.png")
-
-    def test_get_fixture_and_image_paths_non_webhook(self) -> None:
-        integration = INTEGRATIONS["nagios"]
-        assert isinstance(integration, Integration)
-        screenshot_config = BaseScreenshotConfig("service_notify.json", "001.png")
-        fixture_path, image_path = get_fixture_and_image_paths(integration, screenshot_config)
-        self.assertEqual(fixture_path, "zerver/integration_fixtures/nagios/service_notify.json")
-        self.assertEqual(image_path, "static/images/integrations/nagios/001.png")
 
     def test_get_bot_avatar_path(self) -> None:
         integration = INTEGRATIONS["alertmanager"]
@@ -68,6 +58,7 @@ class IntegrationsTestCase(ZulipTestCase):
             configs = DOC_SCREENSHOT_CONFIG[integration_name]
             for screenshot_config in configs:
                 integration = INTEGRATIONS[integration_name]
+                assert isinstance(integration, WebhookIntegration)
                 if screenshot_config.fixture_name == "":
                     # Such screenshot configs only use a placeholder
                     # fixture_name.


### PR DESCRIPTION
Continued from #34780. The first 8 commits with the prefix "generate-integration-docs-screenshot" are from the other PR, and can be ignored for the review here.

1. Removes the existing infrastructure for fixtureless integrations in the screenshot script, and performs refactors.
2. Adds the new framework.

**Previous system**: Each fixtureless integration has its screenshot config in its own file in `zerver/integration_fixtures/<integration_name>/<fixture_file_name>`. These fixtures are used only for generating screenshots, and only contain - topic and message, in a JSON format.
**New system**: The screenshot configs of all the fixtureless integrations are tracked in a single dictionary (like the existing `WebhookScreenshotConfig`) in `integrations.py`. This simplifies the code logic by making the system more in sync with the system for the webhook integrations.

### Decisions to consider
- We could consider splitting out the screenshot configs into their own independent file, as we have a lot of this config type of content in `integrations.py`.

### Observations
- The only non-webhook integration that supports the generation of screenshots prior to this PR is Nagios.
- I have used the term "Fixtureless" to refer to all the non-webhook integrations. None of the non-webhook integrations have a fixture. But, there are two webhook integrations that do not have fixtures either (Transifex and Zendesk), but `WebhookScreenshotConfig` allows empty fixture names ("") and supports webhook integrations without fixtures.
- This commit only adds support for generating screenshot of single messages. Support for thread screenshots is needed for some integrations like Hubot, Errbot, GitHub Detail, IRC. That is planned to be added later in a separate PR.
- This PR adds the new framework, but does not add the screenshot configs, as they're likely to be heavily reviewed. The tests are also not added because they'd fail until the screenshot configs are added, and hence need to be added after all the configs.

<details>
<summary><h3>Screenshot of --help</h3></summary>

Before adding support for fixtureless integrations (but after the refactors to the screenshot script in the previous PR)
![449710731-cf8637c9-5dad-44d0-8c78-819244bafff5](https://github.com/user-attachments/assets/9abb0824-4765-4c47-9bfb-1f562f7d7261)

After:
![image](https://github.com/user-attachments/assets/a5574d9f-0fb4-4f82-af29-4eac50e6610f)


</details>
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
