### PR TITLE
popovers: Fix thumb-up emoji alignment in the help modal.

### DIFF
--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -290,7 +290,7 @@
                     <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>S</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">
+                    <td class="definition rendered_markdown">
                         {{t 'React to selected message with' }}
                         <img alt=":thumbs_up:"
                           class="emoji"


### PR DESCRIPTION
This PR aligns the thumb-up emoji in the keyboard shortcuts tab to match the inline emoji style used in markdown areas.

Fixes part of #30781.
Completes the work done in the PR [#34206](https://github.com/zulip/zulip/pull/34206) by @kash2104.
<br />

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------------|-------------|
| ![image](https://github.com/user-attachments/assets/d08f89ec-8e4d-445d-be2c-5f7a3891061a) | ![image](https://github.com/user-attachments/assets/fd5b1456-a4f3-498f-a462-c213f0df8cd3) |
| ![image](https://github.com/user-attachments/assets/2916c18e-7a53-4fe4-844b-1e90338ffc28) | ![image](https://github.com/user-attachments/assets/be6a3697-a808-4f02-9eb6-36ecdd386823) |



---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
