### PR TITLE
Top_notice: Improve top-of-feed notices

### DIFF
--- a/web/src/message_feed_top_notices.ts
+++ b/web/src/message_feed_top_notices.ts
@@ -20,6 +20,14 @@ function hide_history_limit_notice(): void {
     $(".history-limited-box").hide();
 }
 
+function show_end_of_combined_feed_notice(): void {
+    $(".end-of-combined-feed").show();
+}
+
+function hide_end_of_combined_feed_notice(): void {
+    $(".end-of-combined-feed").hide();
+}
+
 function hide_end_of_results_notice(): void {
     $(".all-messages-search-caution").hide();
 }
@@ -64,6 +72,11 @@ export function update_top_of_narrow_notices(msg_list: MessageList): void {
         ) {
             show_end_of_results_notice();
         }
+
+        // Display the notice for combined feed view
+        if (filter?.is_in_home()) {
+            show_end_of_combined_feed_notice();
+        }
     }
 
     if (msg_list.data.fetch_status.history_limited()) {
@@ -74,4 +87,5 @@ export function update_top_of_narrow_notices(msg_list: MessageList): void {
 export function hide_top_of_narrow_notices(): void {
     hide_end_of_results_notice();
     hide_history_limit_notice();
+    hide_end_of_combined_feed_notice();
 }

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -126,6 +126,7 @@ export function fetch_more_if_required_for_current_msg_list(
     if (has_found_oldest && has_found_newest && message_lists.current.visibly_empty()) {
         // Even after loading more messages, we have
         // no messages to display in this narrow.
+        message_feed_top_notices.hide_top_of_narrow_notices();
         narrow_banner.show_empty_narrow_message(message_lists.current.data.filter);
         message_lists.current.update_trailing_bookend();
         compose_closed_ui.update_buttons_for_private();

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -4,6 +4,7 @@ import assert from "minimalistic-assert";
 
 import * as compose_validate from "./compose_validate.ts";
 import type {Filter} from "./filter.ts";
+import * as hash_util from "./hash_util.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as message_lists from "./message_lists.ts";
 import type {NarrowBannerData, SearchData} from "./narrow_error.ts";
@@ -344,9 +345,11 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
         }
         case "search": {
             // You are narrowed to empty search results.
+            const update_hash = hash_util.search_public_streams_notice_url(current_filter.terms());
             return {
                 title: $t({defaultMessage: "No search results."}),
                 search_data: retrieve_search_query_data(current_filter),
+                update_hash,
             };
         }
         case "dm": {

--- a/web/src/narrow_error.ts
+++ b/web/src/narrow_error.ts
@@ -17,13 +17,15 @@ export type NarrowBannerData = {
     title: string;
     html?: string;
     search_data?: SearchData;
+    update_hash?: string;
 };
 
 export function narrow_error(narrow_banner_data: NarrowBannerData): string {
     const title = narrow_banner_data.title;
     const html = narrow_banner_data.html;
     const search_data = narrow_banner_data.search_data;
+    const update_hash = narrow_banner_data.update_hash;
 
-    const empty_feed_notice = render_empty_feed_notice({title, html, search_data});
+    const empty_feed_notice = render_empty_feed_notice({title, html, search_data, update_hash});
     return empty_feed_notice;
 }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -389,8 +389,7 @@
         opacity: 0.7;
     }
 
-    .history-limited-box,
-    .all-messages-search-caution {
+    .history-limited-box {
         background-color: hsl(0deg 0% 0% / 20%);
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -208,29 +208,26 @@ p.n-margin {
     box-shadow: 0 0 2px hsl(16deg 60% 45%);
 }
 
-.all-messages-search-caution {
-    border: 1px solid hsl(192deg 19% 75% / 20%);
-    box-shadow: 0 0 2px hsl(192deg 19% 75% / 20%);
-}
-
 .history-limited-box,
 .all-messages-search-caution {
-    border-radius: 4px;
     display: none;
     margin: 0 auto 12px;
     padding: 5px;
-    /* Difference should be 16px to accommodate the icon. */
-    /* This emulates hanging indent. */
-    padding-left: 26px;
-    text-indent: -10px;
-
-    .all-messages-search-caution-icon {
-        margin: 0 3px 0 1px;
-    }
 
     & p {
         margin: 0;
         padding: 4px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+}
+
+.search-all-channels-button {
+    & a {
+        &:hover {
+            text-decoration: none;
+        }
     }
 }
 
@@ -1384,6 +1381,13 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
 
     .search-query-word {
         word-wrap: break-word;
+    }
+
+    .search-all-channels-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-top: 5px;
     }
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -209,7 +209,8 @@ p.n-margin {
 }
 
 .history-limited-box,
-.all-messages-search-caution {
+.all-messages-search-caution,
+.end-of-combined-feed {
     display: none;
     margin: 0 auto 12px;
     padding: 5px;

--- a/web/templates/empty_feed_notice.hbs
+++ b/web/templates/empty_feed_notice.hbs
@@ -20,6 +20,15 @@
                 <span class="search-query-word">{{query_word}}</span>
                 {{/if}}
             {{/each}}
+            {{#if update_hash}}
+            <span class="search-all-channels-button">
+                <a class="search-shared-history" href="{{update_hash}}">
+                    <button class="action-button action-button-quiet-neutral">
+                        <span class="action-button-label">{{t "Search all public channels" }}</span>
+                    </button>
+                </a>
+            </span>
+            {{/if}}
         {{else}}
             {{{ html }}}
         {{/if}}

--- a/web/templates/message_feed_errors.hbs
+++ b/web/templates/message_feed_errors.hbs
@@ -11,26 +11,21 @@
 </div>
 <div class="all-messages-search-caution hidden-for-spectators" hidden>
     <p>
-        <i class="all-messages-search-caution-icon fa fa-exclamation-circle" aria-hidden="true"></i>
-        {{#tr}}
-        End of results from your
-        <z-link>history</z-link>.
-        {{#*inline "z-link"}}<a href="/help/search-for-messages#searching-shared-history"
-          target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-        {{/tr}}
-        &nbsp;
         <span>
-            {{#if is_guest}}
-                {{#tr}}
-                    Consider <z-link>searching all public channels that you can view</z-link>.
-                    {{#*inline "z-link"}}<a class="search-shared-history" href="">{{> @partial-block}}</a>{{/inline}}
-                {{/tr}}
-            {{else}}
-                {{#tr}}
-                    Consider <z-link>searching all public channels</z-link>.
-                    {{#*inline "z-link"}}<a class="search-shared-history" href="">{{> @partial-block}}</a>{{/inline}}
-                {{/tr}}
-            {{/if}}
+            {{#tr}}
+            End of results from
+            <z-link> your message history</z-link>.
+            {{#*inline "z-link"}}<a href="/help/search-for-messages#searching-shared-history"
+        target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        </span>
+        &nbsp;
+        <span class="search-all-channels-button banner-action-buttons">
+            <a class="search-shared-history">
+                <button class="action-button action-button-quiet-neutral">
+                    <span class="action-button-label">{{t "Search all public channels" }}</span>
+                </button>
+            </a>
         </span>
     </p>
 </div>

--- a/web/templates/message_feed_errors.hbs
+++ b/web/templates/message_feed_errors.hbs
@@ -29,4 +29,24 @@
         </span>
     </p>
 </div>
+<div class="end-of-combined-feed hidden-for-spectators" hidden>
+    <p>
+        <span>
+            {{#tr}}
+            End of messages in your
+            <z-link>combined feed</z-link>.
+            {{#*inline "z-link"}}<a href="/help/combined-feed"
+            target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        </span>
+        &nbsp;
+        <span class="search-all-channels-button banner-action-buttons">
+            <a href="#narrow/channels/public">
+                <button class="action-button action-button-quiet-neutral">
+                    <span class="action-button-label">{{t "View all messages in public channels" }}</span>
+                </button>
+            </a>
+        </span>
+    </p>
+</div>
 <div class="empty_feed_notice_main"></div>

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -54,11 +54,12 @@ mock_esm("../src/spectators", {
     login_to_access() {},
 });
 
-function empty_narrow_html(title, html, search_data) {
+function empty_narrow_html(title, html, search_data, update_hash) {
     const opts = {
         title,
         html,
         search_data,
+        update_hash,
     };
     return require("../templates/empty_feed_notice.hbs")(opts);
 }
@@ -674,9 +675,15 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
     };
     let current_filter = set_filter([["search", "what about grail"]]);
     narrow_banner.show_empty_narrow_message(current_filter);
+    const update_hash = hash_util.search_public_streams_notice_url(current_filter.terms());
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No search results.", undefined, expected_search_data),
+        empty_narrow_html(
+            "translated: No search results.",
+            undefined,
+            expected_search_data,
+            update_hash,
+        ),
     );
 
     const streamA_id = 88;


### PR DESCRIPTION
## Search Results
Removed the exclamation mark and the outline around the message at the top of search results. Added a button with the label 'Search all public channels.' When there are no search results, we hide the top-of-feed notice and add a 'Search all public channels' button below the 'You searched...' line.

| Font Size | Light Theme | Dark Theme |
| ---- | ---- | ---- |
| 12px | <img width="769" alt="image" src="https://github.com/user-attachments/assets/db03db5d-0d27-491f-b36c-86e13b49e596" /> | <img width="576" alt="image" src="https://github.com/user-attachments/assets/de096889-8811-4bbb-8d28-2a1cff19be3e" /> |
| 16px | <img width="718" alt="image" src="https://github.com/user-attachments/assets/569750a9-b942-4a09-87bf-b7fdb29ffbcb" /> | <img width="714" alt="image" src="https://github.com/user-attachments/assets/4894e69f-746e-42ba-8a20-cc4fec98d97a" /> |
| 20px | <img width="814" alt="image" src="https://github.com/user-attachments/assets/72e5486f-d14e-4805-868d-c272d01d6f73" /> | <img width="800" alt="image" src="https://github.com/user-attachments/assets/1b797455-a9ef-4fd7-a13f-7f8e4796619e" /> | 

### No search results

| Font Size | Light Theme | Dark Theme |
| ---- | ---- | ---- |
| 12px | <img width="316" alt="image" src="https://github.com/user-attachments/assets/8587342a-ec18-46f5-aff4-968b488c2425" /> | <img width="348" alt="image" src="https://github.com/user-attachments/assets/0ef4e1a7-d831-42e1-a643-704c3399a44a" /> | 
| 16px | <img width="329" alt="image" src="https://github.com/user-attachments/assets/b5ce4960-bc9a-4f85-8ae7-b622ce65e4e8" /> | <img width="356" alt="image" src="https://github.com/user-attachments/assets/e6023776-f1a1-4472-8f8b-860511962a3a" /> |
| 20px | <img width="352" alt="image" src="https://github.com/user-attachments/assets/4bc94293-305f-4c83-8c4a-9243cca1825f" /> | <img width="343" alt="image" src="https://github.com/user-attachments/assets/ae873183-088f-4c13-83df-201d512be3d5" /> |

## Combined Feed
Added a similar notice at the top of the combined feed. 

| Font Size | Light Theme | Dark Theme |
| ---- | ---- | ---- |
| 12px | <img width="599" alt="image" src="https://github.com/user-attachments/assets/36eb9093-fde2-44ab-b304-88d545ced6bd" /> | <img width="597" alt="image" src="https://github.com/user-attachments/assets/fb1cfc8c-3e19-4b3e-91de-8fb441905a98" /> |
| 16px | <img width="733" alt="image" src="https://github.com/user-attachments/assets/c42fb804-accd-4784-984e-d30b4093b7e2" /> | <img width="766" alt="image" src="https://github.com/user-attachments/assets/ecfab549-571e-4156-ab49-2e68da849852" /> |
| 20px | <img width="801" alt="image" src="https://github.com/user-attachments/assets/97d00763-d3b9-4977-ba47-e476f9501868" /> | <img width="840" alt="image" src="https://github.com/user-attachments/assets/0de646c0-61bd-45b6-89a8-e5efa707b07a" /> | 

<!-- Describe your pull request here.-->

Fixes: #33287 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<!--**Screenshots and screen captures:**-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
