### PR TITLE
search: Prevent terms from being duplicated in typeahead or pill input.

### DIFF
--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -178,9 +178,13 @@ export function set_search_bar_contents(
     let partial_pill = "";
     const invalid_inputs = [];
     const search_operator_strings = [];
+    const added_pills_as_input_strings = new Set(); // to prevent duplicating terms
 
     for (const term of search_terms) {
         const input = Filter.unparse([term]);
+        if (added_pills_as_input_strings.has(input)) {
+            return;
+        }
 
         // If the last term looks something like `dm:`, we
         // don't want to make it a pill, since it isn't isn't
@@ -215,10 +219,13 @@ export function set_search_bar_contents(
                 return user;
             });
             append_user_pill(users, pill_widget, term.operator, term.negated ?? false);
+            added_pills_as_input_strings.add(input);
         } else if (term.operator === "search") {
+            // This isn't a pill, so we don't add it to `added_pills_as_input_strings`
             search_operator_strings.push(input);
         } else {
             pill_widget.appendValue(input);
+            added_pills_as_input_strings.add(input);
         }
     }
     pill_widget.clear_text();

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -421,7 +421,16 @@ function get_default_suggestion_line(terms: NarrowTerm[]): SuggestionLine {
     if (terms.length === 0) {
         return [{description_html: "", search_string: "", is_people: false}];
     }
-    return terms.map((term) => format_as_suggestion([term]));
+    const suggestion_line = [];
+    const suggestion_strings = new Set();
+    for (const term of terms) {
+        const suggestion = format_as_suggestion([term]);
+        if (!suggestion_strings.has(suggestion.search_string)) {
+            suggestion_line.push(suggestion);
+            suggestion_strings.add(suggestion.search_string);
+        }
+    }
+    return suggestion_line;
 }
 
 export function get_topic_suggestions_from_candidates({

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -384,3 +384,32 @@ run_test("initiate_search", ({override_rewire}) => {
     assert.ok(search_bar_opened);
     assert.equal($("#search_query").text(), "");
 });
+
+run_test("set_search_bar_contents with duplicate pills", () => {
+    const duplicate_attachment_terms = [
+        {
+            negated: false,
+            operator: "has",
+            operand: "attachment",
+        },
+        {
+            negated: false,
+            operator: "has",
+            operand: "attachment",
+        },
+    ];
+    search_pill.set_search_bar_contents(
+        duplicate_attachment_terms,
+        search.search_pill_widget,
+        false,
+        noop,
+    );
+    const pills = search.search_pill_widget._get_pills_for_testing();
+    assert.equal(pills.length, 1);
+    assert.deepEqual(pills[0].item, {
+        type: "search",
+        operator: "has",
+        operand: "attachment",
+        negated: false,
+    });
+});

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -117,6 +117,18 @@ test("basic_get_suggestions_for_spectator", () => {
     page_params.is_spectator = false;
 });
 
+test("get_suggestions deduplication", () => {
+    let query = "has:attachment";
+    let suggestions = get_suggestions(query, query);
+    let expected = ["has:attachment"];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = "has:attachment has:attachment";
+    suggestions = get_suggestions(query);
+    expected = ["has:attachment"];
+    assert.deepEqual(suggestions.strings, expected);
+});
+
 test("get_is_suggestions_for_spectator", () => {
     page_params.is_spectator = true;
 


### PR DESCRIPTION
Prevents this from being possible:

<img width="724" alt="image" src="https://github.com/user-attachments/assets/4483261e-17a6-4bfe-8beb-c9234850e16b" />
