### PR TITLE
search: Show correct description string for public channels.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -807,6 +807,12 @@ export class Filter {
                     };
                 }
             }
+            if (canonicalized_operator === "channels" && operand === "public") {
+                return {
+                    type: "plain_text",
+                    content: this.describe_public_channels(term.negated ?? false),
+                };
+            }
             const prefix_for_operator = Filter.operator_to_prefix(
                 canonicalized_operator,
                 term.negated,
@@ -865,6 +871,14 @@ export class Filter {
             };
         });
         return [...parts, ...more_parts];
+    }
+
+    static describe_public_channels(negated: boolean): string {
+        const possible_prefix = negated ? "exclude " : "";
+        if (page_params.is_spectator || current_user.is_guest) {
+            return possible_prefix + "all public channels that you can view";
+        }
+        return possible_prefix + "all public channels";
     }
 
     static search_description_as_html(

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -11,7 +11,7 @@ import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import type {User} from "./people.ts";
-import {type NarrowTerm, current_user} from "./state_data.ts";
+import {type NarrowTerm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_topic_history from "./stream_topic_history.ts";
 import * as stream_topic_history_util from "./stream_topic_history_util.ts";
@@ -646,12 +646,8 @@ function get_channels_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]):
     if (last.operator === "search" && common.phrase_match(last.operand, "streams")) {
         search_string = "streams:public";
     }
-    let description_html;
-    if (page_params.is_spectator || current_user.is_guest) {
-        description_html = "All public channels that you can view";
-    } else {
-        description_html = "All public channels";
-    }
+    let description_html = Filter.describe_public_channels(last.negated ?? false);
+    description_html = description_html.charAt(0).toUpperCase() + description_html.slice(1);
     const suggestions: SuggestionAndIncompatiblePatterns[] = [
         {
             search_string,

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1658,12 +1658,18 @@ test("describe", ({mock_template, override}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
 
     narrow = [{operator: "channels", operand: "public"}];
-    string = "channels public";
+    string = "all public channels";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "channels", operand: "public", negated: true}];
-    string = "exclude channels public";
+    string = "exclude all public channels";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
+
+    page_params.is_spectator = true;
+    narrow = [{operator: "channels", operand: "public"}];
+    string = "all public channels that you can view";
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
+    page_params.is_spectator = false;
 
     const devel_id = new_stream_id();
     make_sub("devel", devel_id);


### PR DESCRIPTION
Previously, typing "channels: public" would show "Channels public" in the typeahead, which was especially confusing because we'd show "All public channels" until the term was completely typed out.

