### PR TITLE
buddy_list: Use class to show/hide view all users instead of append.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -367,7 +367,7 @@ export class BuddyList extends BuddyListConf {
 
         // This must happen after `fill_screen_with_content`
         $("#buddy-list-users-matching-view-container .view-all-subscribers-link").remove();
-        $("#buddy-list-other-users-container .view-all-users-link").remove();
+        $("#buddy-list-other-users-container .view-all-users-link").empty();
         void this.render_view_user_list_links();
         this.display_or_hide_sections();
         void this.update_empty_list_placeholders();
@@ -758,7 +758,9 @@ export class BuddyList extends BuddyListConf {
         // We give a link to view the list of all users to help reduce confusion about
         // there being hidden (inactive) "other" users.
         if (has_inactive_other_users) {
-            $("#buddy-list-other-users-container").append($(render_view_all_users()));
+            $("#buddy-list-other-users-container .view-all-users-link").html(
+                render_view_all_users(),
+            );
         }
 
         // Note that we don't show a link for the participants list because we expect

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -366,7 +366,7 @@ export class BuddyList extends BuddyListConf {
         this.fill_screen_with_content();
 
         // This must happen after `fill_screen_with_content`
-        $("#buddy-list-users-matching-view-container .view-all-subscribers-link").remove();
+        $("#buddy-list-users-matching-view-container .view-all-subscribers-link").empty();
         $("#buddy-list-other-users-container .view-all-users-link").empty();
         void this.render_view_user_list_links();
         this.display_or_hide_sections();
@@ -746,12 +746,10 @@ export class BuddyList extends BuddyListConf {
                 current_sub,
                 "subscribers",
             );
-            $("#buddy-list-users-matching-view-container").append(
-                $(
-                    render_view_all_subscribers({
-                        stream_edit_hash,
-                    }),
-                ),
+            $("#buddy-list-users-matching-view-container .view-all-subscribers-link").html(
+                render_view_all_subscribers({
+                    stream_edit_hash,
+                }),
             );
         }
 

--- a/web/templates/buddy_list/view_all_subscribers.hbs
+++ b/web/templates/buddy_list/view_all_subscribers.hbs
@@ -1,7 +1,5 @@
-<div class="buddy-list-user-link view-all-subscribers-link">
-    <a class="right-sidebar-wrappable-text-container" href="{{stream_edit_hash}}">
-        <span class="right-sidebar-wrappable-text-inner">
-            {{t "View all subscribers" }}
-        </span>
-    </a>
-</div>
+<a class="right-sidebar-wrappable-text-container" href="{{stream_edit_hash}}">
+    <span class="right-sidebar-wrappable-text-inner">
+        {{t "View all subscribers" }}
+    </span>
+</a>

--- a/web/templates/buddy_list/view_all_users.hbs
+++ b/web/templates/buddy_list/view_all_users.hbs
@@ -1,7 +1,5 @@
-<div class="buddy-list-user-link view-all-users-link">
-    <a class="right-sidebar-wrappable-text-container" href="#organization/users">
-        <span class="right-sidebar-wrappable-text-inner">
-            {{t "View all users" }}
-        </span>
-    </a>
-</div>
+<a class="right-sidebar-wrappable-text-container" href="#organization/users">
+    <span class="right-sidebar-wrappable-text-inner">
+        {{t "View all users" }}
+    </span>
+</a>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -24,6 +24,7 @@
                 <div id="buddy-list-other-users-container" class="buddy-list-section-container">
                     <div class="buddy-list-subsection-header"></div>
                     <ul id="buddy-list-other-users" class="buddy-list-section"></ul>
+                    <div class="buddy-list-user-link view-all-users-link"></div>
                 </div>
                 <div id="buddy_list_wrapper_padding"></div>
                 <div class="invite-user-shortcut">

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -20,6 +20,7 @@
                 <div id="buddy-list-users-matching-view-container" class="buddy-list-section-container">
                     <div class="buddy-list-subsection-header"></div>
                     <ul id="buddy-list-users-matching-view" class="buddy-list-section"></ul>
+                    <div class="buddy-list-user-link view-all-subscribers-link"></div>
                 </div>
                 <div id="buddy-list-other-users-container" class="buddy-list-section-container">
                     <div class="buddy-list-subsection-header"></div>

--- a/web/tests/lib/buddy_list.cjs
+++ b/web/tests/lib/buddy_list.cjs
@@ -41,7 +41,7 @@ exports.stub_buddy_list_elements = () => {
     $("#buddy-list-users-matching-view .empty-list-message").length = 0;
     $("#buddy-list-other-users .empty-list-message").length = 0;
     $("#buddy-list-other-users-container .view-all-users-link").length = 0;
-    $("#buddy-list-users-matching-view-container .view-all-subscribers-link").remove = noop;
+    $("#buddy-list-users-matching-view-container .view-all-subscribers-link").empty = noop;
     $("#buddy-list-other-users-container .view-all-users-link").empty = noop;
     $(`#buddy-list-users-matching-view .empty-list-message`).remove = noop;
     $(`#buddy-list-other-users .empty-list-message`).remove = noop;

--- a/web/tests/lib/buddy_list.cjs
+++ b/web/tests/lib/buddy_list.cjs
@@ -42,7 +42,7 @@ exports.stub_buddy_list_elements = () => {
     $("#buddy-list-other-users .empty-list-message").length = 0;
     $("#buddy-list-other-users-container .view-all-users-link").length = 0;
     $("#buddy-list-users-matching-view-container .view-all-subscribers-link").remove = noop;
-    $("#buddy-list-other-users-container .view-all-users-link").remove = noop;
+    $("#buddy-list-other-users-container .view-all-users-link").empty = noop;
     $(`#buddy-list-users-matching-view .empty-list-message`).remove = noop;
     $(`#buddy-list-other-users .empty-list-message`).remove = noop;
     $(`#buddy-list-participants .empty-list-message`).remove = noop;


### PR DESCRIPTION
Fixes https://chat.zulip.org/#narrow/channel/9-issues/topic/buddy.20list.20view.20all.20users.20appears.20twice. Earlier, we were appending view all users link using JQuery.append, so when `render_view_user_list_links` is called twice, `view all users` appears twice. It is better show the link using the `hide` since that will make the link appear once regardless of how many times `render_view_user_list_links` is called.

`view_all_users.hbs` is only used once, but we should still keep it around as a partial in order to not make the right sidebar hbs cluttered to read

NOTE: If this exact approach (using the `hide` class) looks good, we should also replace appends in the same file with similar approach.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="269" alt="Screenshot 2025-06-02 at 1 40 23 PM" src="https://github.com/user-attachments/assets/c682565f-8e5c-4c65-9f5c-3381b0f96c8e" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
