### PR TITLE
left_sidebar: Show sidebar menu icon for muted unread messages.

### DIFF
--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -76,7 +76,9 @@ export function update_dom_with_unread_counts(
     ui_util.update_unread_count_in_dom($streams_header, counts.stream_unread_messages);
     ui_util.update_unread_count_in_dom($back_to_streams, counts.stream_unread_messages);
 
-    if (counts.home_unread_messages === 0) {
+    const show_sidebar_menu_icon =
+        counts.home_unread_messages + counts.muted_topic_unread_messages_count > 0;
+    if (!show_sidebar_menu_icon) {
         $home_view_li.find(".sidebar-menu-icon").addClass("hide");
     } else {
         $home_view_li.find(".sidebar-menu-icon").removeClass("hide");

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -912,6 +912,7 @@ export type FullUnreadCountsData = {
     stream_unread_messages: number;
     followed_topic_unread_messages_count: number;
     followed_topic_unread_messages_with_mention_count: number;
+    muted_topic_unread_messages_count: number;
     stream_count: Map<number, StreamCountInfo>;
     streams_with_mentions: number[];
     streams_with_unmuted_mentions: number[];
@@ -938,6 +939,8 @@ export function get_counts(): FullUnreadCountsData {
         followed_topic_unread_messages_count: topic_res.followed_topic_unread_messages,
         followed_topic_unread_messages_with_mention_count:
             unread_topic_counter.get_followed_topic_unread_mentions(),
+        muted_topic_unread_messages_count:
+            unread_messages.size - topic_res.stream_unread_messages - pm_res.total_count,
         stream_count: topic_res.stream_count,
         streams_with_mentions: [...unread_topic_counter.get_streams_with_unread_mentions()],
         streams_with_unmuted_mentions: [


### PR DESCRIPTION
It was reported that there was no option to mark messages as read when only unread messages in muted streams and topics remained.

This happened because the logic to show or hide the sidebar menu icon relied solely on the home view count, which excludes unread messages in muted streams and topics.

This PR fixes the issue by including the count of unread messages in muted streams and topics when determining whether to show or hide the sidebar menu icon.

## Screenshots showing the sidebar menu icon when there are messages in muted streams only

![image](https://github.com/user-attachments/assets/9f60a3ce-978c-4424-b0b3-481da3e5635c)


Fixes: #34682



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
