### PR TITLE
demo-orgs: Delete expired demo organizations in archive_messages cron job.

### DIFF
--- a/zerver/lib/demo_organizations.py
+++ b/zerver/lib/demo_organizations.py
@@ -4,10 +4,14 @@ from zerver.lib.exceptions import JsonableError
 from zerver.models.realms import Realm
 
 
+def demo_organization_owner_email_exists(realm: Realm) -> bool:
+    human_owner_emails = set(realm.get_human_owner_users().values_list("delivery_email", flat=True))
+    return human_owner_emails != {""}
+
+
 def check_demo_organization_has_set_email(realm: Realm) -> None:
     # This should be called after checking that the realm has
     # a demo_organization_scheduled_deletion_date set.
     assert realm.demo_organization_scheduled_deletion_date is not None
-    human_owner_emails = set(realm.get_human_owner_users().values_list("delivery_email", flat=True))
-    if "" in human_owner_emails:
+    if not demo_organization_owner_email_exists(realm):
         raise JsonableError(_("Configure owner account email address."))

--- a/zerver/management/commands/archive_messages.py
+++ b/zerver/management/commands/archive_messages.py
@@ -2,7 +2,10 @@ from typing import Any
 
 from typing_extensions import override
 
-from zerver.actions.realm_settings import clean_deactivated_realm_data
+from zerver.actions.realm_settings import (
+    clean_deactivated_realm_data,
+    delete_expired_demo_organizations,
+)
 from zerver.lib.management import ZulipBaseCommand, abort_unless_locked
 from zerver.lib.retention import archive_messages, clean_archived_data
 
@@ -13,4 +16,12 @@ class Command(ZulipBaseCommand):
     def handle(self, *args: Any, **options: str) -> None:
         clean_archived_data()
         archive_messages()
-        clean_deactivated_realm_data()
+        scrub_realms()
+
+
+def scrub_realms() -> None:
+    # First, scrub currently deactivated realms that have an expired
+    # scheduled deletion date. Then, deactivate and scrub realms with
+    # an expired scheduled demo organization deletion date.
+    clean_deactivated_realm_data()
+    delete_expired_demo_organizations()


### PR DESCRIPTION
Adds `delete_expired_demo_organizations` to the `archive_messages` management command, which is run as a cron job.

**Notes**:
- Adds "demo_expired" as a `RealmDeactivationReasonType` to be used for this specific case of calling `do_deactivate_realm`.
- The function loops through non-deactivated realms that have a demo organization scheduled deletion datetime set that is less than the current datetime.
- `deletion_delay_days` is set to zero, so that `do_deactivate_realm` will push the `"scrub_deactivated_realm"` event to the deferred work queue.
- Extracts a helper function `demo_organization_owner_email_exists` that returns `True` if an empty string is not in the set of human owners' delivery email addresses for the demo organization.

**Questions**:
- Do we want this as part of `archive_messages`? I added this there as that's where the data deletion for deactivating reams is?
- And if we do want it there, do we want to think about renaming that management command?

[Relevant CZO discussion](https://chat.zulip.org/#narrow/channel/3-backend/topic/demo.20organizations.3A.20deactivation.20and.20data.20deletion/near/2182960)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
