### PR TITLE
navigation_views: Add frontend of navigation views.

### DIFF
--- a/web/src/navigation_views.ts
+++ b/web/src/navigation_views.ts
@@ -1,6 +1,6 @@
 import * as blueslip from "./blueslip.ts";
 import {$t} from "./i18n.ts";
-import type {StateData} from "./state_data.ts";
+import type {NavigationView, StateData} from "./state_data.ts";
 import {user_settings} from "./user_settings.ts";
 
 export type BuiltInViewBasicMetadata = {
@@ -167,11 +167,6 @@ export const built_in_views_meta_data: Record<string, BuiltInViewBasicMetadata> 
     },
 };
 
-export type NavigationView = {
-    fragment: string;
-    is_pinned: boolean;
-    name: string | null;
-};
 
 let navigation_views_dict: Map<string, NavigationView>;
 

--- a/web/src/navigation_views.ts
+++ b/web/src/navigation_views.ts
@@ -1,4 +1,5 @@
 import * as blueslip from "./blueslip.ts";
+import * as channel from "./channel.ts";
 import {$t} from "./i18n.ts";
 import type {NavigationView, StateData} from "./state_data.ts";
 import {user_settings} from "./user_settings.ts";
@@ -20,7 +21,7 @@ export type BuiltInViewBasicMetadata = {
     prioritize_in_condensed_view: boolean;
 };
 
-export const built_in_views_meta_data: Record<string, BuiltInViewBasicMetadata> = {
+export const built_in_views_meta_data = {
     inbox: {
         fragment: "inbox",
         name: $t({defaultMessage: "Inbox"}),
@@ -80,8 +81,8 @@ export const built_in_views_meta_data: Record<string, BuiltInViewBasicMetadata> 
         unread_count_type: "normal-count",
         supports_masked_unread: false,
         hidden_for_spectators: true,
-        menu_icon_class: "",
-        menu_aria_label: "",
+        menu_icon_class: "mentions-sidebar-menu-icon",
+        menu_aria_label: $t({defaultMessage: "Mentions options"}),
         home_view_code: "",
         prioritize_in_condensed_view: true,
     },
@@ -96,8 +97,8 @@ export const built_in_views_meta_data: Record<string, BuiltInViewBasicMetadata> 
         unread_count_type: "",
         supports_masked_unread: false,
         hidden_for_spectators: true,
-        menu_icon_class: "",
-        menu_aria_label: "",
+        menu_icon_class: "reactions-sidebar-menu-icon",
+        menu_aria_label: $t({defaultMessage: "Reactions options"}),
         home_view_code: "",
         prioritize_in_condensed_view: false,
     },
@@ -144,8 +145,8 @@ export const built_in_views_meta_data: Record<string, BuiltInViewBasicMetadata> 
         unread_count_type: "quiet-count",
         supports_masked_unread: false,
         hidden_for_spectators: true,
-        menu_icon_class: "",
-        menu_aria_label: "",
+        menu_icon_class: "scheduled-messages-sidebar-menu-icon",
+        menu_aria_label: $t({defaultMessage: "Scheduled messages options"}),
         home_view_code: "",
         prioritize_in_condensed_view: false,
     },
@@ -160,13 +161,18 @@ export const built_in_views_meta_data: Record<string, BuiltInViewBasicMetadata> 
         unread_count_type: "quiet-count",
         supports_masked_unread: false,
         hidden_for_spectators: true,
-        menu_icon_class: "",
-        menu_aria_label: "",
+        menu_icon_class: "reminders-sidebar-menu-icon",
+        menu_aria_label: $t({defaultMessage: "Reminders options"}),
         home_view_code: "",
         prioritize_in_condensed_view: false,
     },
-};
+} satisfies Record<string, BuiltInViewBasicMetadata>;
 
+export type BuiltInViewKey = keyof typeof built_in_views_meta_data;
+
+export function is_built_in_view_key(key: string): key is BuiltInViewKey {
+    return key in built_in_views_meta_data;
+}
 
 let navigation_views_dict: Map<string, NavigationView>;
 
@@ -174,13 +180,24 @@ export function add_navigation_view(navigation_view: NavigationView): void {
     navigation_views_dict.set(navigation_view.fragment, navigation_view);
 }
 
-export function update_navigation_view(fragment: string, data: Partial<NavigationView>): void {
+function apply_navigation_view_update(view: NavigationView, data: Partial<NavigationView>): void {
+    navigation_views_dict.set(view.fragment, {
+        ...view,
+        ...data,
+    });
+}
+
+export function update_navigation_view(view: NavigationView, data: Partial<NavigationView>): void {
+    apply_navigation_view_update(view, data);
+}
+
+export function update_navigation_view_by_fragment(
+    fragment: string,
+    data: Partial<NavigationView>,
+): void {
     const view = get_navigation_view_by_fragment(fragment);
     if (view) {
-        navigation_views_dict.set(fragment, {
-            ...view,
-            ...data,
-        });
+        apply_navigation_view_update(view, data);
     } else {
         blueslip.error("Cannot find navigation view to update");
     }
@@ -192,6 +209,14 @@ export function remove_navigation_view(fragment: string): void {
 
 export function get_navigation_view_by_fragment(fragment: string): NavigationView | undefined {
     return navigation_views_dict.get(fragment);
+}
+
+export function is_view_pinned(fragment: string): boolean {
+    return (
+        get_navigation_view_by_fragment(fragment)?.is_pinned ??
+        Object.values(built_in_views_meta_data).find((v) => v.fragment === fragment)?.is_pinned ??
+        false
+    );
 }
 
 export type BuiltInViewMetadata = BuiltInViewBasicMetadata & {
@@ -222,6 +247,51 @@ export function get_all_navigation_views(): NavigationView[] {
     );
 
     return [...built_in_views, ...custom_views];
+}
+
+export function set_view_pinned_status(
+    fragment: string,
+    is_pinned: boolean,
+    success_callback?: () => void,
+    error_callback?: () => void,
+): void {
+    const existing_view = get_navigation_view_by_fragment(fragment);
+
+    if (existing_view) {
+        void channel.patch({
+            url: `/json/navigation_views/${encodeURIComponent(fragment)}`,
+            data: {is_pinned},
+            success() {
+                update_navigation_view(existing_view, {is_pinned});
+                success_callback?.();
+            },
+            error() {
+                blueslip.error("Failed to update navigation view", {fragment, is_pinned});
+                error_callback?.();
+            },
+        });
+    } else {
+        void channel.post({
+            url: "/json/navigation_views",
+            data: {
+                fragment,
+                is_pinned,
+            },
+            success() {
+                const new_view: NavigationView = {
+                    fragment,
+                    is_pinned,
+                    name: null,
+                };
+                add_navigation_view(new_view);
+                success_callback?.();
+            },
+            error() {
+                blueslip.error("Failed to create navigation view", {fragment, is_pinned});
+                error_callback?.();
+            },
+        });
+    }
 }
 
 export const initialize = (params: StateData["navigation_views"]): void => {

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -20,6 +20,11 @@ type PopoverName =
     | "left_sidebar_inbox_popover"
     | "left_sidebar_all_messages_popover"
     | "left_sidebar_recent_view_popover"
+    | "left_sidebar_mentions_popover"
+    | "left_sidebar_reactions_popover"
+    | "left_sidebar_drafts_popover"
+    | "left_sidebar_scheduled_messages_popover"
+    | "left_sidebar_reminders_popover"
     | "top_left_sidebar"
     | "message_actions"
     | "stream_card_popover"
@@ -44,6 +49,11 @@ export const popover_instances: Record<PopoverName, tippy.Instance | null> = {
     left_sidebar_inbox_popover: null,
     left_sidebar_all_messages_popover: null,
     left_sidebar_recent_view_popover: null,
+    left_sidebar_mentions_popover: null,
+    left_sidebar_reactions_popover: null,
+    left_sidebar_drafts_popover: null,
+    left_sidebar_scheduled_messages_popover: null,
+    left_sidebar_reminders_popover: null,
     top_left_sidebar: null,
     message_actions: null,
     stream_card_popover: null,

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -219,12 +219,15 @@ export function dispatch_normal_event(event) {
             switch (event.op) {
                 case "add":
                     navigation_views.add_navigation_view(event.navigation_view);
+                    left_sidebar_navigation_area.update_sidebar_for_navigation_views();
                     break;
                 case "update":
-                    navigation_views.update_navigation_view(event.fragment, event.data);
+                    navigation_views.update_navigation_view_by_fragment(event.fragment, event.data);
+                    left_sidebar_navigation_area.update_sidebar_for_navigation_views();
                     break;
                 case "remove":
                     navigation_views.remove_navigation_view(event.fragment);
+                    left_sidebar_navigation_area.update_sidebar_for_navigation_views();
                     break;
             }
             break;
@@ -665,6 +668,7 @@ export function dispatch_normal_event(event) {
                     scheduled_messages_feed_ui.update_schedule_message_indicator();
                     scheduled_messages_overlay_ui.rerender();
                     left_sidebar_navigation_area.update_scheduled_messages_row();
+                    left_sidebar_navigation_area.update_sidebar_for_navigation_views();
                     break;
                 }
                 case "remove": {
@@ -677,12 +681,14 @@ export function dispatch_normal_event(event) {
                         event.scheduled_message_id,
                     );
                     left_sidebar_navigation_area.update_scheduled_messages_row();
+                    left_sidebar_navigation_area.update_sidebar_for_navigation_views();
                     break;
                 }
                 case "update": {
                     scheduled_messages.update_scheduled_message(event.scheduled_message);
                     scheduled_messages_overlay_ui.rerender();
                     left_sidebar_navigation_area.update_scheduled_messages_row();
+                    left_sidebar_navigation_area.update_sidebar_for_navigation_views();
                     break;
                 }
                 // No default
@@ -695,12 +701,14 @@ export function dispatch_normal_event(event) {
                     message_reminder.add_reminders(event.reminders);
                     reminders_overlay_ui.rerender();
                     left_sidebar_navigation_area.update_reminders_row();
+                    left_sidebar_navigation_area.update_sidebar_for_navigation_views();
                     break;
                 }
                 case "remove": {
                     message_reminder.remove_reminder(event.reminder_id);
                     reminders_overlay_ui.remove_reminder_id(event.reminder_id);
                     left_sidebar_navigation_area.update_reminders_row();
+                    left_sidebar_navigation_area.update_sidebar_for_navigation_views();
                     break;
                 }
                 // No default

--- a/web/src/settings.ts
+++ b/web/src/settings.ts
@@ -10,6 +10,7 @@ import * as common from "./common.ts";
 import * as flatpickr from "./flatpickr.ts";
 import {$t} from "./i18n.ts";
 import * as information_density from "./information_density.ts";
+import * as navigation_views from "./navigation_views.ts";
 import * as overlays from "./overlays.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
@@ -151,6 +152,10 @@ export function build_page(): void {
                 user_settings.web_line_height_percent,
             ),
         max_user_name_length: people.MAX_USER_NAME_LENGTH,
+        navigation_views: navigation_views.get_all_navigation_views().map((view) => ({
+            ...view,
+            setting_name: `navigation_view_${view.fragment}`,
+        })),
     });
 
     $(".settings-box").html(rendered_settings_tab);

--- a/web/src/settings_preferences.ts
+++ b/web/src/settings_preferences.ts
@@ -13,6 +13,7 @@ import * as emojisets from "./emojisets.ts";
 import {$t_html, get_language_list_columns} from "./i18n.ts";
 import * as information_density from "./information_density.ts";
 import * as loading from "./loading.ts";
+import * as navigation_views from "./navigation_views.ts";
 import * as overlays from "./overlays.ts";
 import {page_params} from "./page_params.ts";
 import type {RealmDefaultSettings} from "./realm_user_settings_defaults.ts";
@@ -170,6 +171,18 @@ export function set_up(settings_panel: SettingsPanel): void {
         // settings_org.ts handlers, so we can return early here.
         return;
     }
+
+    $container.on("change", "input[name^='navigation_view_']", (e) => {
+        const $input_elem = $(e.currentTarget);
+        const setting = $input_elem.attr("name")!;
+        const fragment = setting.replace("navigation_view_", "");
+        const is_pinned = Boolean($input_elem.prop("checked"));
+        navigation_views.set_view_pinned_status(fragment, is_pinned, undefined, () => {
+            $input_elem.prop("checked", !is_pinned);
+        });
+
+        e.stopPropagation();
+    });
 
     // Common handler for sending requests to the server when an input
     // element is changed.

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -331,13 +331,6 @@ export function initialize_left_sidebar(): void {
 
     const rendered_sidebar = render_left_sidebar({
         is_guest: current_user.is_guest,
-        development_environment: page_params.development_environment,
-        is_inbox_home_view:
-            user_settings.web_home_view === settings_config.web_home_view_values.inbox.code,
-        is_all_messages_home_view:
-            user_settings.web_home_view === settings_config.web_home_view_values.all_messages.code,
-        is_recent_view_home_view:
-            user_settings.web_home_view === settings_config.web_home_view_values.recent_topics.code,
         is_spectator: page_params.is_spectator,
         primary_condensed_views,
         expanded_views,

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -302,7 +302,7 @@ export function update_expanded_views_for_search(search_value: string): void {
     }
 
     let any_view_visible = false;
-    const expanded_views = left_sidebar_navigation_area.get_built_in_views();
+    const expanded_views = left_sidebar_navigation_area.get_built_in_pinned_views();
     for (const view of expanded_views) {
         let show_view = search_util.vanilla_match({
             val: view.name,
@@ -325,15 +325,22 @@ export function update_expanded_views_for_search(search_value: string): void {
 }
 
 export function initialize_left_sidebar(): void {
-    const primary_condensed_views =
-        left_sidebar_navigation_area.get_built_in_primary_condensed_views();
-    const expanded_views = left_sidebar_navigation_area.get_built_in_views();
+    const pinned_views = left_sidebar_navigation_area.get_built_in_pinned_views();
+    const unpinned_views = left_sidebar_navigation_area.get_built_in_unpinned_views();
+    const primary_condensed_views = left_sidebar_navigation_area.get_primary_condensed_views();
+    const has_unpinned_views = unpinned_views.length > 0;
+    const is_condensed = left_sidebar_navigation_area.is_condensed();
+    const should_hide_menu = !is_condensed && !has_unpinned_views;
+    const show_empty_state = !is_condensed && pinned_views.length === 0;
 
     const rendered_sidebar = render_left_sidebar({
         is_guest: current_user.is_guest,
+        development_environment: page_params.development_environment,
         is_spectator: page_params.is_spectator,
         primary_condensed_views,
-        expanded_views,
+        expanded_views: pinned_views,
+        should_hide_menu,
+        show_empty_state,
     });
 
     $("#left-sidebar-container").html(rendered_sidebar);

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -163,7 +163,7 @@ export const channel_folder_schema = z.object({
 
 export const navigation_view_schema = z.object({
     fragment: z.string(),
-    name: z.string(),
+    name: z.nullable(z.string()),
     is_pinned: z.boolean(),
 });
 

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -167,6 +167,8 @@ export const navigation_view_schema = z.object({
     is_pinned: z.boolean(),
 });
 
+export type NavigationView = z.infer<typeof navigation_view_schema>;
+
 export const user_topic_schema = z.object({
     stream_id: z.number(),
     topic_name: z.string(),

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1217,6 +1217,10 @@ li.active-sub-filter {
        only apply in the expanded-navigation view. */
     grid-auto-rows: var(--line-height-sidebar-row);
 
+    li.left-sidebar-navigation-empty {
+        text-align: center;
+    }
+
     .left-sidebar-navigation-label-container {
         .left-sidebar-navigation-label {
             overflow: hidden;
@@ -1498,8 +1502,7 @@ li.active-sub-filter {
     &.showing-expanded-navigation {
         /* When the expanded navigation is visible,
            hide the condensed navigation's controls. */
-        #left-sidebar-navigation-list-condensed,
-        .left-sidebar-navigation-menu-icon {
+        #left-sidebar-navigation-list-condensed {
             display: none;
         }
         /* Give the sidebar title through the end of the markers
@@ -1520,6 +1523,10 @@ li.active-sub-filter {
             /* When the navigation area is condensed, hide all
                the rows in the full navigation list... */
             & .top_left_row {
+                display: none;
+            }
+
+            & .left-sidebar-navigation-empty {
                 display: none;
             }
             /* ...except when there is an active filter in place:
@@ -1591,6 +1598,10 @@ li.active-sub-filter {
         &:hover {
             color: var(--color-vdots-hover);
             background-color: var(--color-background-sidebar-action-hover);
+        }
+
+        &.hide {
+            display: none;
         }
     }
 }

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -28,12 +28,14 @@
                     <span class="unread_count normal-count"></span>
                 </li>
             </ul>
-            <div class="left-sidebar-navigation-menu-icon">
+            {{#unless is_spectator}}
+            <div class="left-sidebar-navigation-menu-icon {{#if should_hide_menu}}hide{{/if}}">
                 <i class="zulip-icon zulip-icon-more-vertical" aria-label="{{t 'Other views'}}"></i>
             </div>
+            {{/unless}}
         </div>
         <ul id="left-sidebar-navigation-list" class="left-sidebar-navigation-list filters">
-            {{> left_sidebar_expanded_view_items_list expanded_views=expanded_views}}
+            {{> left_sidebar_expanded_view_items_list expanded_views=expanded_views show_empty_state=show_empty_state}}
         </ul>
     </div>
 

--- a/web/templates/left_sidebar_expanded_view_items_list.hbs
+++ b/web/templates/left_sidebar_expanded_view_items_list.hbs
@@ -1,3 +1,7 @@
-{{#each expanded_views}}
-    {{> left_sidebar_expanded_view_item . }}
-{{/each}}
+{{#if show_empty_state}}
+    <li class="left-sidebar-navigation-empty">{{t 'No pinned views currently.'}}</li>
+{{else}}
+    {{#each expanded_views}}
+        {{> left_sidebar_expanded_view_item . }}
+    {{/each}}
+{{/if}}

--- a/web/templates/popovers/left_sidebar/left_sidebar_all_messages_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_all_messages_popover.hbs
@@ -33,5 +33,6 @@
             </a>
         </li>
         {{/if}}
+        {{> left_sidebar_toggle_navigation_view_popover_item fragment=fragment is_currently_active_unpinned_view=is_currently_active_unpinned_view}}
     </ul>
 </div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_drafts_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_drafts_popover.hbs
@@ -6,5 +6,6 @@
                 <span class="popover-menu-label">{{t "Delete all drafts" }}</span>
             </a>
         </li>
+        {{> left_sidebar_toggle_navigation_view_popover_item fragment=fragment is_currently_active_unpinned_view=is_currently_active_unpinned_view}}
     </ul>
 </div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_hide_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_hide_popover.hbs
@@ -1,0 +1,5 @@
+<div class="popover-menu" data-simplebar data-simplebar-tab-index="-1">
+    <ul role="menu" class="popover-menu-list">
+        {{> left_sidebar_toggle_navigation_view_popover_item fragment=fragment is_currently_active_unpinned_view=is_currently_active_unpinned_view}}
+    </ul>
+</div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_inbox_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_inbox_popover.hbs
@@ -33,5 +33,6 @@
             </a>
         </li>
         {{/if}}
+        {{> left_sidebar_toggle_navigation_view_popover_item fragment=fragment is_currently_active_unpinned_view=is_currently_active_unpinned_view}}
     </ul>
 </div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_recent_view_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_recent_view_popover.hbs
@@ -33,5 +33,6 @@
             </a>
         </li>
         {{/if}}
+        {{> left_sidebar_toggle_navigation_view_popover_item fragment=fragment is_currently_active_unpinned_view=is_currently_active_unpinned_view}}
     </ul>
 </div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_starred_messages_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_starred_messages_popover.hbs
@@ -19,5 +19,6 @@
                 {{/if}}
             </a>
         </li>
+        {{> left_sidebar_toggle_navigation_view_popover_item fragment=fragment is_currently_active_unpinned_view=is_currently_active_unpinned_view}}
     </ul>
 </div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_toggle_navigation_view_popover_item.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_toggle_navigation_view_popover_item.hbs
@@ -1,0 +1,14 @@
+<li role="none" class="link-item popover-menu-list-item">
+    {{#if is_currently_active_unpinned_view}}
+    <a role="menuitem" class="show-navigation-view popover-menu-link" data-fragment="{{fragment}}" tabindex="0">
+        <i class="popover-menu-icon zulip-icon zulip-icon-eye" aria-hidden="true"></i>
+        <span class="popover-menu-label">{{t "Show in left sidebar" }}</span>
+    </a>
+    {{else}}
+    <a role="menuitem" class="hide-navigation-view popover-menu-link" data-fragment="{{fragment}}" tabindex="0">
+        <i class="popover-menu-icon zulip-icon zulip-icon-hide" aria-hidden="true"></i>
+        <span class="popover-menu-label">{{t "Hide from left sidebar" }}</span>
+    </a>
+    {{/if}}
+</li>
+

--- a/web/templates/settings/preferences.hbs
+++ b/web/templates/settings/preferences.hbs
@@ -10,4 +10,6 @@
     {{>preferences_information .}}
 
     {{>preferences_left_sidebar .}}
+
+    {{>preferences_view .}}
 </form>

--- a/web/templates/settings/preferences_view.hbs
+++ b/web/templates/settings/preferences_view.hbs
@@ -1,0 +1,19 @@
+<div
+  class="{{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
+    <div class="subsection-header">
+        <h3>{{t "Views in left sidebar" }}</h3>
+        {{> settings_save_discard_widget section_name="navigation-view-settings" show_only_indicator=(not
+          for_realm_settings) }}
+    </div>
+    <p>{{t "Configure which views appear directly in the left sidebar. Unchecked views will be available in the 'More
+        views' menu." }}</p>
+    <div>
+        {{#each navigation_views}}
+            {{> settings_checkbox
+              setting_name=this.setting_name
+              prefix="id_"
+              is_checked=this.is_pinned
+              label=this.name}}
+        {{/each}}
+    </div>
+</div>

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -99,6 +99,7 @@ mock_esm("../src/left_sidebar_navigation_area", {
     update_scheduled_messages_row() {},
     update_reminders_row() {},
     handle_home_view_changed() {},
+    update_sidebar_for_navigation_views() {},
 });
 const typing_events = mock_esm("../src/typing_events");
 const unread_ops = mock_esm("../src/unread_ops");
@@ -218,11 +219,13 @@ run_test("navigation_views", ({override}) => {
     const update_event = event_fixtures.navigation_view__update;
     {
         const stub = make_stub();
-        override(navigation_views, "update_navigation_view", stub.f);
+        override(navigation_views, "update_navigation_view_by_fragment", stub.f);
 
         dispatch(update_event);
         assert.equal(stub.num_calls, 1);
-        assert_same(stub.get_args("event").event, update_event.fragment);
+        const {fragment, data} = stub.get_args("fragment", "data");
+        assert_same(fragment, update_event.fragment);
+        assert_same(data, update_event.data);
     }
 
     const remove_event = event_fixtures.navigation_view__remove;


### PR DESCRIPTION
This PR adds frontend of navigation views for builin views only.

Fixes: #32077.


**Screenshots and screen captures:**
[Watch the video](https://drive.google.com/file/d/1gqz6Uu8pf2ukUUTnhRBzoWSqyB9NhV9v/view?usp=sharing)

|  |  |  |
|--------------|--------------|--------------|
| ![img1](https://github.com/user-attachments/assets/e5ddc70c-97b6-4eb6-9297-9cc9a4642eff) | ![img2](https://github.com/user-attachments/assets/3a079a9a-6bbe-4124-9912-a722be15f5b5) | ![img3](https://github.com/user-attachments/assets/e4a3aab4-6381-47e6-bb37-b030c2ec745a) |
| ![img4](https://github.com/user-attachments/assets/c6505091-f5f0-4e6c-a6fb-5c22d1f21989) | ![img5](https://github.com/user-attachments/assets/9629a181-7e2b-448b-903c-34864886b59f) | ![img6](https://github.com/user-attachments/assets/20b51628-e4d6-4068-9c6c-09c043291acb) |

|  |
|--------------|
| ![img7](https://github.com/user-attachments/assets/0b4b38dc-e605-4a40-b6bd-8c70643a877d) |


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
