### PR TITLE
 Add "channels:archived" search filter.

### DIFF
--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -84,6 +84,12 @@ Zulip offers the following filters based on the location of the message.
   between you, Bo, and Elena.
 * `dm-including:Bo Lin`: Search all direct message conversations
   (1-on-1 and group) that include you and Bo, as well as any other users.
+* `channels:public`: Search the history of all [public
+  channels](/help/change-the-privacy-of-a-channel) in the organization, including
+  channels you are not subscribed to; see details
+  [below](#search-shared-history).
+* `channels:archived`: Search the history of [archived
+  channels](/help/archive-a-channel#archive-a-channel_1) in the organization.
 
 ### Search shared history
 

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -661,6 +661,33 @@ function get_public_channels_filter_suggestions(
     return get_special_filter_suggestions(last, terms, suggestions);
 }
 
+function get_archived_channel_filter_suggestions(
+    last: NarrowTerm,
+    terms: NarrowTerm[],
+): Suggestion[] {
+    let search_string = "channels:archived";
+    // show "channels:archived" option for users who
+    // have "streams" in their muscle memory
+    if (last.operator === "search" && common.phrase_match(last.operand, "streams")) {
+        search_string = "streams:archived";
+    }
+    let description_html = Filter.describe_archived_channels(last.negated ?? false);
+    description_html = description_html.charAt(0).toUpperCase() + description_html.slice(1);
+    const suggestions: SuggestionAndIncompatiblePatterns[] = [
+        {
+            search_string,
+            description_html,
+            incompatible_patterns: [
+                {operator: "is", operand: "dm"},
+                {operator: "channel"},
+                {operator: "dm-including"},
+                {operator: "dm"},
+            ],
+        },
+    ];
+    return get_special_filter_suggestions(last, terms, suggestions);
+}
+
 function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestion[] {
     let suggestions: SuggestionAndIncompatiblePatterns[];
     if (page_params.is_spectator) {
@@ -1079,6 +1106,7 @@ export function get_search_result(
         // searching user probably is looking to make a group DM.
         get_group_suggestions,
         get_public_channels_filter_suggestions,
+        get_archived_channel_filter_suggestions,
         get_operator_suggestions,
         get_is_filter_suggestions,
         get_sent_by_me_suggestions,

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -71,6 +71,12 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">channels:archived</td>
+                        <td class="definition">
+                            {{t 'Search archived channels.'}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">channels:web-public</td>
                         <td class="definition">
                             {{t 'Search all web-public channels.'}}

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -302,7 +302,7 @@ test("basics", () => {
     assert.ok(!filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
     assert.ok(filter.has_negated_operand("channels", "public"));
-    assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
     assert.ok(!filter.is_channel_view());
@@ -316,7 +316,34 @@ test("basics", () => {
     assert.ok(!filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
     assert.ok(!filter.has_negated_operand("channels", "public"));
-    assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.can_apply_locally());
+    assert.ok(filter.includes_full_stream_history());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.is_channel_view());
+    assert.ok(filter.may_contain_multiple_conversations());
+    assert.ok(!filter.has_exactly_channel_topic_operators());
+
+    terms = [{operator: "channels", operand: "archived", negated: true}];
+    filter = new Filter(terms);
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.has_operator("channels"));
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.has_negated_operand("channels", "archived"));
+    assert.ok(!filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.is_channel_view());
+    assert.ok(filter.may_contain_multiple_conversations());
+    assert.ok(!filter.has_exactly_channel_topic_operators());
+
+    terms = [{operator: "channels", operand: "archived"}];
+    filter = new Filter(terms);
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(filter.has_operator("channels"));
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(!filter.has_negated_operand("channels", "archived"));
+    assert.ok(!filter.can_apply_locally());
     assert.ok(filter.includes_full_stream_history());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
@@ -515,6 +542,7 @@ test("basics", () => {
         {operator: "channel", operand: "channel_name", negated: true},
         {operator: "channels", operand: "web-public", negated: true},
         {operator: "channels", operand: "public"},
+        {operator: "channels", operand: "archived"},
         {operator: "topic", operand: "patience", negated: true},
         {operator: "in", operand: "all"},
     ];
@@ -525,7 +553,7 @@ test("basics", () => {
     assert.ok(filter.contains_no_partial_conversations());
     // This next check verifies what is probably a bug; see the
     // comment in the can_apply_locally implementation.
-    assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
     assert.ok(filter.may_contain_multiple_conversations());
@@ -606,7 +634,7 @@ test("basics", () => {
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.allow_use_first_unread_when_narrowing());
     assert.ok(filter.includes_full_stream_history());
-    assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
     assert.ok(!filter.may_contain_multiple_conversations());
@@ -1137,15 +1165,18 @@ test("predicate_basics", ({override}) => {
 
     predicate = get_predicate([["channels", "public"]]);
     assert.ok(predicate({type: stream_message, stream_id: old_sub_id}));
-    assert.ok(!predicate({type: stream_message, stream_id: private_sub_id}));
+    assert.ok(predicate({type: stream_message, stream_id: private_sub_id}));
     assert.ok(predicate({type: stream_message, stream_id: web_public_sub_id}));
 
     predicate = get_predicate([["channels", "web-public"]]);
     assert.ok(predicate({type: stream_message, stream_id: web_public_sub_id}));
-    assert.ok(!predicate({type: stream_message, stream_id: old_sub_id}));
+    assert.ok(predicate({type: stream_message, stream_id: old_sub_id}));
 
     predicate = get_predicate([["channels", "bogus"]]);
-    assert.ok(!predicate({type: stream_message, stream_id: old_sub_id}));
+    assert.ok(predicate({type: stream_message, stream_id: old_sub_id}));
+
+    predicate = get_predicate([["channels", "archived"]]);
+    assert.ok(predicate({}));
 
     predicate = get_predicate([["is", "starred"]]);
     assert.ok(predicate({starred: true}));
@@ -1431,6 +1462,10 @@ test("negated_predicates", () => {
     narrow = [{operator: "channels", operand: "public", negated: true}];
     predicate = new Filter(narrow).predicate();
     assert.ok(predicate({}));
+
+    narrow = [{operator: "channels", operand: "archived", negated: true}];
+    predicate = new Filter(narrow).predicate();
+    assert.ok(predicate({}));
 });
 
 function test_mit_exceptions() {
@@ -1531,6 +1566,14 @@ test("parse", () => {
         {operator: "topic", operand: "bar"},
         {operator: "search", operand: "yo"},
     ];
+    _test();
+
+    string = "channels:archived";
+    terms = [{operator: "channels", operand: "archived"}];
+    _test();
+
+    string = "-channels:archived";
+    terms = [{operator: "channels", operand: "archived", negated: true}];
     _test();
 
     // "stream" was renamed to "channel"
@@ -1670,7 +1713,23 @@ test("unparse", () => {
     string = "-channels:public";
     assert.deepEqual(Filter.unparse(terms), string);
 
-    terms = [{operator: "id", operand: "50"}];
+    terms = [
+        {operator: "channels", operand: "archived"},
+        {operator: "search", operand: "text"},
+    ];
+
+    string = "channels:archived text";
+    assert.deepEqual(Filter.unparse(terms), string);
+
+    terms = [{operator: "channels", operand: "archived"}];
+    string = "channels:archived";
+    assert.deepEqual(Filter.unparse(terms), string);
+
+    terms = [{operator: "channels", operand: "archived", negated: true}];
+    string = "-channels:archived";
+    assert.deepEqual(Filter.unparse(terms), string);
+
+    terms = [{operator: "id", operand: 50}];
     string = "id:50";
     assert.deepEqual(Filter.unparse(terms), string);
 
@@ -1734,6 +1793,14 @@ test("describe", ({mock_template, override}) => {
     string = "exclude all web-public channels";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
     page_params.is_spectator = false;
+
+    narrow = [{operator: "channels", operand: "archived"}];
+    string = "archived channels";
+    assert.equal(Filter.search_description_as_html(narrow), string);
+
+    narrow = [{operator: "channels", operand: "archived", negated: true}];
+    string = "exclude archived channels";
+    assert.equal(Filter.search_description_as_html(narrow), string);
 
     const devel_id = new_stream_id();
     make_sub("devel", devel_id);
@@ -1997,6 +2064,7 @@ test("term_type", () => {
     }
 
     assert_term_type(term("channels", "public"), "channels-public");
+    assert_term_type(term("channels", "archived"), "channels-archived");
     assert_term_type(term("channel", "whatever"), "channel");
     assert_term_type(term("dm", "whomever"), "dm");
     assert_term_type(term("dm", "whomever", true), "not-dm");
@@ -2023,6 +2091,7 @@ test("term_type", () => {
     assert_term_sort(["channel", "topic", "channel"], ["channel", "channel", "topic"]);
 
     assert_term_sort(["search", "channels-public"], ["channels-public", "search"]);
+    assert_term_sort(["search", "channels-archived"], ["channels-archived", "search"]);
 
     const terms = [
         {operator: "topic", operand: "lunch"},
@@ -2097,6 +2166,7 @@ test("is_valid_search_term", () => {
         ["channel:" + denmark.stream_id, true],
         [`channel:${invalid_sub_id}`, false],
         ["channels:public", true],
+        ["channels:archived", true],
         ["channels:private", false],
         ["topic:GhostTown", true],
         ["dm-including:alice@example.com", true],
@@ -2382,6 +2452,7 @@ test("navbar_helpers", ({override}) => {
     const is_resolved = [{operator: "is", operand: "resolved"}];
     const is_followed = [{operator: "is", operand: "followed"}];
     const channels_public = [{operator: "channels", operand: "public"}];
+    const channels_archived = [{operator: "channels", operand: "archived"}];
     const channels_web_public = [{operator: "channels", operand: "web-public"}];
     const channel_topic_terms = [
         {operator: "channel", operand: foo_stream_id.toString()},
@@ -2538,6 +2609,13 @@ test("navbar_helpers", ({override}) => {
             icon: undefined,
             title: "translated: Messages in all public channels",
             redirect_url_with_search: "/#narrow/channels/public",
+        },
+        {
+            terms: channels_archived,
+            is_common_narrow: true,
+            icon: undefined,
+            title: "translated: Messages in archived channels",
+            redirect_url_with_search: "/#narrow/channels/archived",
         },
         {
             terms: channels_web_public,
@@ -2860,6 +2938,7 @@ run_test("is_spectator_compatible", () => {
     assert.ok(!Filter.is_spectator_compatible([{operator: "is", operand: "starred"}]));
     assert.ok(!Filter.is_spectator_compatible([{operator: "is", operand: "dm"}]));
     assert.ok(Filter.is_spectator_compatible([{operator: "channels", operand: "public"}]));
+    assert.ok(Filter.is_spectator_compatible([{operator: "channels", operand: "archived"}]));
 
     // Malformed input not allowed
     assert.ok(!Filter.is_spectator_compatible([{operator: "has"}]));

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -404,6 +404,7 @@ test("empty_query_suggestions", () => {
     const suggestions = get_suggestions(query);
 
     const expected = [
+        "channels:archived",
         "channels:",
         "channel:",
         "is:dm",
@@ -592,7 +593,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
     // but shows html description used for "channels:public"
     query = "st";
     suggestions = get_suggestions(query);
-    expected = ["st", "channels:", "channel:", "is:starred"];
+    expected = ["st", "streams:archived", "channels:", "channel:", "is:starred"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "channel:66 has:link is:sta";
@@ -1006,7 +1007,7 @@ test("operator_suggestions", ({override, mock_template}) => {
 
     query = "ch";
     suggestions = get_suggestions(query);
-    expected = ["ch", "channels:", "channel:"];
+    expected = ["ch", "channels:archived", "channels:", "channel:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-s";

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -45,6 +45,7 @@ from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
 from zerver.lib.streams import (
     can_access_stream_history_by_id,
     can_access_stream_history_by_name,
+    get_archived_streams_queryset,
     get_public_streams_queryset,
     get_stream_by_narrow_operand_access_unchecked,
     get_web_public_streams_queryset,
@@ -523,6 +524,8 @@ class NarrowBuilder:
             # Get all both subscribed and non-subscribed public channels
             # but exclude any private subscribed channels.
             recipient_queryset = get_public_streams_queryset(self.realm)
+        elif operand == "archived":
+            recipient_queryset = get_archived_streams_queryset(self.realm)
         elif operand == "web-public":
             recipient_queryset = get_web_public_streams_queryset(self.realm)
         else:

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -976,6 +976,10 @@ def get_public_streams_queryset(realm: Realm) -> QuerySet[Stream]:
     return Stream.objects.filter(realm=realm, invite_only=False, history_public_to_subscribers=True)
 
 
+def get_archived_streams_queryset(realm: Realm) -> QuerySet[Stream]:
+    return Stream.objects.filter(realm=realm, deactivated=True)
+
+
 def get_web_public_streams_queryset(realm: Realm) -> QuerySet[Stream]:
     # This should match the include_web_public code path in do_get_streams.
     return Stream.objects.filter(

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -17,6 +17,7 @@ from analytics.models import RealmCount
 from zerver.actions.message_edit import build_message_edit_request, do_update_message
 from zerver.actions.reactions import check_add_reaction
 from zerver.actions.realm_settings import do_set_realm_property
+from zerver.actions.streams import do_deactivate_stream
 from zerver.actions.uploads import do_claim_attachments
 from zerver.actions.user_settings import do_change_user_setting
 from zerver.actions.users import do_deactivate_user
@@ -217,6 +218,57 @@ class NarrowBuilderTest(ZulipTestCase):
         # Number of recipient ids will increase by 1 and not 3
         self._do_add_term_test(
             term,
+            "WHERE (recipient_id NOT IN (__[POSTCOMPILE_recipient_id_1]))",
+        )
+
+    def test_add_term_using_channels_operator_and_archived_operand_and_negation(self) -> None:
+        term = NarrowParameter(operator="channels", operand="archived")
+        term_negated = NarrowParameter(operator="channels", operand="archived", negated=True)
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id IN (__[POSTCOMPILE_recipient_id_1])",
+        )
+        self._do_add_term_test(
+            term_negated,
+            "WHERE (recipient_id NOT IN (__[POSTCOMPILE_recipient_id_1]))",
+        )
+
+        # Add new channels
+        channel_dicts: list[StreamDict] = [
+            {
+                "name": "public-channel",
+                "description": "Public channel with public history",
+            },
+            {
+                "name": "private-channel",
+                "description": "Private channel with non-public history",
+                "invite_only": True,
+            },
+            {
+                "name": "private-channel-with-history",
+                "description": "Private channel with public history",
+                "invite_only": True,
+                "history_public_to_subscribers": True,
+            },
+        ]
+        realm = get_realm("zulip")
+        created, existing = create_streams_if_needed(realm, channel_dicts)
+        self.assert_length(created, 3)
+        self.assert_length(existing, 0)
+
+        # Archive the streams in the created list
+        for archived_stream in created:
+            do_deactivate_stream(archived_stream, acting_user=None)
+
+        # Verify the term behavior after archiving streams
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id IN (__[POSTCOMPILE_recipient_id_1])",
+        )
+
+        # Verify the term behavior with negation after archiving streams
+        self._do_add_term_test(
+            term_negated,
             "WHERE (recipient_id NOT IN (__[POSTCOMPILE_recipient_id_1]))",
         )
 
@@ -763,6 +815,20 @@ class NarrowBuilderTest(ZulipTestCase):
             "WHERE (recipient_id NOT IN (__[POSTCOMPILE_recipient_id_1]))",
         )
 
+    def test_add_term_using_streams_operator_and_archived_operand(self) -> None:
+        term = NarrowParameter(operator="streams", operand="archived")
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id IN (__[POSTCOMPILE_recipient_id_1])",
+        )
+
+    def test_add_term_using_streams_operator_and_archived_operand_negated(self) -> None:
+        term = NarrowParameter(operator="streams", operand="archived", negated=True)
+        self._do_add_term_test(
+            term,
+            "WHERE (recipient_id NOT IN (__[POSTCOMPILE_recipient_id_1]))",
+        )
+
     def _do_add_term_test(
         self, term: NarrowParameter, where_clause: str, params: dict[str, Any] | None = None
     ) -> None:
@@ -1106,6 +1172,9 @@ class NarrowLibraryTest(ZulipTestCase):
         self.assertTrue(
             is_spectator_compatible([NarrowParameter(operator="channels", operand="public")])
         )
+        self.assertTrue(
+            is_spectator_compatible([NarrowParameter(operator="channels", operand="archived")])
+        )
 
         # "is:private" is a legacy alias for "is:dm".
         self.assertFalse(
@@ -1139,6 +1208,9 @@ class NarrowLibraryTest(ZulipTestCase):
         self.assertTrue(
             is_spectator_compatible([NarrowParameter(operator="streams", operand="public")])
         )
+        self.assertTrue(
+            is_spectator_compatible([NarrowParameter(operator="streams", operand="archived")])
+        )
 
 
 class IncludeHistoryTest(ZulipTestCase):
@@ -1161,6 +1233,18 @@ class IncludeHistoryTest(ZulipTestCase):
         # Negated -channels:public searches should not include history.
         narrow = [
             NarrowParameter(operator="channels", operand="public", negated=True),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+
+        # channels:archived searches should not include history for non-guest members.
+        narrow = [
+            NarrowParameter(operator="channels", operand="archived"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+
+        # Negated -channels:archived searches should not include history.
+        narrow = [
+            NarrowParameter(operator="channels", operand="archived", negated=True),
         ]
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
 
@@ -1237,6 +1321,36 @@ class IncludeHistoryTest(ZulipTestCase):
         ]
         self.assertTrue(ok_to_include_history(narrow, user_profile, False))
 
+        narrow = [
+            NarrowParameter(operator="channels", operand="archived"),
+            NarrowParameter(operator="is", operand="mentioned"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+
+        narrow = [
+            NarrowParameter(operator="channels", operand="archived"),
+            NarrowParameter(operator="is", operand="unread"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+
+        narrow = [
+            NarrowParameter(operator="channels", operand="archived"),
+            NarrowParameter(operator="is", operand="alerted"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+
+        narrow = [
+            NarrowParameter(operator="channels", operand="archived"),
+            NarrowParameter(operator="is", operand="resolved"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+
+        narrow = [
+            NarrowParameter(operator="channels", operand="public"),
+            NarrowParameter(operator="channels", operand="archived"),
+        ]
+        self.assertTrue(ok_to_include_history(narrow, user_profile, False))
+
         # simple True case
         narrow = [
             NarrowParameter(operator="channel", operand="public_channel"),
@@ -1258,6 +1372,11 @@ class IncludeHistoryTest(ZulipTestCase):
         # channels:public searches should not include history for guest members.
         narrow = [
             NarrowParameter(operator="channels", operand="public"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
+        # channels:archived searches should not include history for guest members.
+        narrow = [
+            NarrowParameter(operator="channels", operand="archived"),
         ]
         self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
 


### PR DESCRIPTION
This PR adds "channels:archived" search filter to make search in archived channels easy.

## Screenshots

<img width="1074" height="380" alt="image" src="https://github.com/user-attachments/assets/1db3fcb2-534c-4474-8320-5f778b64a70e" />

![image](https://github.com/user-attachments/assets/530f5a9a-4231-4a81-8b2f-eac89362dd1b)

![image](https://github.com/user-attachments/assets/1a1e42a6-fd3c-4f37-b2d4-c09a61452cc8)

<img width="814" height="463" alt="image" src="https://github.com/user-attachments/assets/80b92e7d-53c4-4b2c-a0d8-5b5702ab0fce" />


Fixes: #32506

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
