### PR TITLE
app: Disallow overscroll on x-axis.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1,6 +1,6 @@
 html {
     overflow: hidden scroll;
-    overscroll-behavior-y: none;
+    overscroll-behavior: none;
     width: calc(100% - var(--disabled-scrollbar-width));
 }
 


### PR DESCRIPTION
This corrects a bug in current versions of Safari where it's possible to use a trackpad or touchscreen to scroll the message area under the left sidebar (and off the screen).

I'm not aware of any side-effects to this, and it seems like we wouldn't want overscroll on the x-axis (whereby, when things are working as expected, the whole UI jogs and slides back into position). The original style for prohibiting y-axis overscroll dates back to a78dc4a2bd5ae8735276d6e650bb2ec6de8440c4

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/Sliding.20of.20message_feed_container.20over.20the.20left-sidebar/with/2184913)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


| Before | After |
| --- | --- |
| ![overscroll-x-before](https://github.com/user-attachments/assets/7829b3ef-0a4d-4301-9c32-66575c090ada) | ![overscroll-x-after](https://github.com/user-attachments/assets/937648c1-0bca-4f35-8864-58f81f822573) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>