### PR TITLE
demo-orgs: Update gear menu for demo organizations.

### DIFF
--- a/web/src/gear_menu.ts
+++ b/web/src/gear_menu.ts
@@ -8,6 +8,7 @@ import render_navbar_gear_menu_popover from "../templates/popovers/navbar/navbar
 
 import * as blueslip from "./blueslip.ts";
 import * as channel from "./channel.ts";
+import * as demo_organizations_ui from "./demo_organizations_ui.ts";
 import * as information_density from "./information_density.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as popover_menus_data from "./popover_menus_data.ts";
@@ -172,6 +173,13 @@ export function initialize(): void {
                 popover_menus.hide_current_popover_if_visible(instance);
                 e.preventDefault();
                 e.stopPropagation();
+            });
+
+            $popper.on("click", ".convert-demo-organization", (e) => {
+                popover_menus.hide_current_popover_if_visible(instance);
+                e.preventDefault();
+                e.stopPropagation();
+                demo_organizations_ui.do_convert_demo_organization();
             });
 
             $popper.on("click", ".change-language-spectator", (e) => {

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -109,6 +109,7 @@ type GearMenuContext = {
     is_spectator: boolean;
     is_self_hosted: boolean;
     is_development_environment: boolean;
+    is_demo_organization: boolean;
     is_plan_limited: boolean;
     is_plan_standard: boolean;
     is_plan_standard_sponsored_for_free: boolean;
@@ -387,6 +388,7 @@ export function get_gear_menu_content_context(): GearMenuContext {
         is_spectator: page_params.is_spectator,
         is_self_hosted: realm.realm_plan_type === settings_config.realm_plan_types.self_hosted.code,
         is_development_environment: page_params.development_environment,
+        is_demo_organization: realm.demo_organization_scheduled_deletion_date !== undefined,
         is_plan_limited: realm.realm_plan_type === settings_config.realm_plan_types.limited.code,
         is_plan_standard,
         is_plan_standard_sponsored_for_free:

--- a/web/templates/popovers/navbar/navbar_gear_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_gear_menu_popover.hbs
@@ -13,7 +13,9 @@
         {{/if}}
         {{else}}
         <div class="org-info org-plan hidden-for-spectators">
-            {{#if is_plan_limited }}
+            {{#if is_demo_organization }}
+            <a href="/help/demo-organizations" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">{{t "Demo organization" }}</a>
+            {{else if is_plan_limited }}
             <a href="/plans/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">Zulip Cloud Free</a>
             {{else if is_plan_standard}}
             <a href="/plans/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">Zulip Cloud Standard</a>
@@ -30,12 +32,17 @@
             <a href="/sponsorship/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">{{t "Sponsorship request pending" }}</a>
         </div>
         {{else}}
-        {{#if is_plan_limited }}
+        {{#if (and is_demo_organization is_owner) }}
+        <div class="org-info org-upgrade">
+            <a class="convert-demo-organization popover-menu-link">{{t "Convert into permanent organization" }}</a>
+        </div>
+        {{/if}}
+        {{#if (and is_plan_limited (not is_demo_organization))}}
         <div class="org-info org-upgrade">
             <a href="/upgrade/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">{{t "Upgrade to {standard_plan_name}" }}</a>
         </div>
         {{/if}}
-        {{#unless is_org_on_paid_plan}}
+        {{#unless (or is_org_on_paid_plan is_demo_organization)}}
         {{#if is_education_org }}
         <div class="org-info org-upgrade">
             <a href="/sponsorship/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">{{t 'Request education pricing' }}</a>


### PR DESCRIPTION
From [relevant CZO conversation](https://chat.zulip.org/#narrow/channel/101-design/topic/demo.20organizations.20gear.20menu/near/1658826):

> We should change the info/links for demo organizations in the gear menu. Something like:
> - Zulip Cloud Free -> Demo organization (linking to help center)
> - Upgrade to Zulip Cloud Standard -> Convert into a permanent organization (if it's not too long; otherwise, we can adjust)
> - no "Request sponsorship" link

---

**Screenshots and screen captures:**

### Demo organization owner account:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-06-03 17-27-35](https://github.com/user-attachments/assets/ad89efab-14e6-4aae-b969-d90cd71105fd) | ![Screenshot from 2025-06-03 17-28-10](https://github.com/user-attachments/assets/26609164-7cf2-43d5-ae3d-b03f45dff1db)

### Demo organization member account:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-06-03 17-27-19](https://github.com/user-attachments/assets/fb800c83-789c-4465-8368-1381e52ccff9) | ![Screenshot from 2025-06-03 17-26-25](https://github.com/user-attachments/assets/e6904b29-9acf-4752-a292-99141c2400f3)

### Regular new organization owner account (NO CHANGE):
| Before | After |
| --- | --- |
| ![Screenshot from 2025-06-03 17-30-43](https://github.com/user-attachments/assets/b25c4937-d6c4-4a51-847d-c2b1fd2b1785) | ![Screenshot from 2025-06-03 17-30-03](https://github.com/user-attachments/assets/8886dedd-e558-4590-98d3-cd3d7b4e8ba2)

### Regular new organization member account (NO CHANGE):
| Before | After |
| --- | --- |
| ![Screenshot from 2025-06-03 17-31-17](https://github.com/user-attachments/assets/c4188650-b204-4f36-9035-354b1988df04) | ![Screenshot from 2025-06-03 17-31-03](https://github.com/user-attachments/assets/600dda9e-ab68-4afb-8a3b-f78ae5440004)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
