### PR TITLE
message_live_update: Live update user full-name in personal mentions.

### DIFF
--- a/web/src/message_live_update.ts
+++ b/web/src/message_live_update.ts
@@ -75,7 +75,7 @@ export function update_stream_name(stream_id: number, new_name: string): void {
 
 export function update_user_full_name(user_id: number, full_name: string): void {
     message_store.update_sender_full_name(user_id, full_name);
-    rerender_messages_view_for_user(user_id);
+    rerender_messages_view();
 }
 
 export function update_avatar(user_id: number, avatar_url: string | null): void {


### PR DESCRIPTION
[CZO bug report](https://chat.zulip.org/#narrow/channel/137-feedback/topic/Display.20name.2C.20full.20name.20and.20role.2Ftitle.20for.20users/near/2185098)
> Another thing, when a user changes his name, the mentions of him in previous chats stay with his previous name. But in Slack/Discord, I saw the mentions also change dynamically based on display name changes.

> Let's say, I mention you here: `@Tim Abbott` .
Now, if you change your name, will the change visually affect here in this reply of mine?


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Desdemona renamed to Desdemona-1

Name updated in right sidebar. Message view has stale name. | Message view live-updated. |
|-------|------|
 | <img width="1082" alt="Screenshot 2025-06-04 at 12 21 15 PM" src="https://github.com/user-attachments/assets/4ce726b8-441c-4dc0-b554-6fb01e497dfd" /> | <img width="1280" alt="Screenshot 2025-06-04 at 12 13 20 PM" src="https://github.com/user-attachments/assets/bcf1f709-33f6-4aed-a55c-8afd4da382d0" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
