### PR TITLE
UI: Fix cluttered title for channel and group setting modals.

### DIFF
--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -259,6 +259,19 @@ export function resize_settings_creation_overlay($container: JQuery): void {
         );
 }
 
+export function resize_settings_overlay_list_toggler_container($container: JQuery): void {
+    if ($container.find(".display-type").length === 0) {
+        return;
+    }
+    // Make list-toggler-container in left panel equal to the title container
+    // in the right panel.
+    $container
+        .find(".list-toggler-container")
+        .css("height", `${$container.find(".display-type").height()}px`);
+
+    resize_settings_overlay($container);
+}
+
 export function resize_page_components(): void {
     resize_navbar_alerts();
     resize_sidebars();
@@ -268,4 +281,6 @@ export function resize_page_components(): void {
     resize_settings_overlay($("#channels_overlay_container"));
     resize_settings_creation_overlay($("#groups_overlay_container"));
     resize_settings_creation_overlay($("#channels_overlay_container"));
+    resize_settings_overlay_list_toggler_container($("#groups_overlay_container"));
+    resize_settings_overlay_list_toggler_container($("#channels_overlay_container"));
 }

--- a/web/src/stream_settings_components.ts
+++ b/web/src/stream_settings_components.ts
@@ -13,6 +13,7 @@ import {$t, $t_html} from "./i18n.ts";
 import * as loading from "./loading.ts";
 import * as overlays from "./overlays.ts";
 import * as peer_data from "./peer_data.ts";
+import * as resize from "./resize.ts";
 import * as settings_data from "./settings_data.ts";
 import {current_user} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
@@ -42,11 +43,13 @@ export const show_subs_pane = {
         $("#subscription_overlay .stream-info-title").text(
             $t({defaultMessage: "Channel settings"}),
         );
+        resize.resize_settings_overlay_list_toggler_container($("#channels_overlay_container"));
     },
     settings(sub: StreamSubscription): void {
         $(".settings, #stream-creation").hide();
         $(".settings").show();
         set_right_panel_title(sub);
+        resize.resize_settings_overlay_list_toggler_container($("#channels_overlay_container"));
     },
     create_stream(
         container_name = "configure_channel_settings",
@@ -72,6 +75,7 @@ export const show_subs_pane = {
                 }),
             );
         }
+        resize.resize_settings_overlay_list_toggler_container($("#channels_overlay_container"));
         update_footer_buttons(container_name);
         $(`.${CSS.escape(container_name)}`).show();
         $(".nothing-selected, .settings, #stream-creation").hide();

--- a/web/src/user_group_components.ts
+++ b/web/src/user_group_components.ts
@@ -3,6 +3,7 @@ import $ from "jquery";
 import {$t_html} from "./i18n.ts";
 import * as people from "./people.ts";
 import type {User} from "./people.ts";
+import * as resize from "./resize.ts";
 import * as user_groups from "./user_groups.ts";
 import type {UserGroup} from "./user_groups.ts";
 import * as user_sort from "./user_sort.ts";
@@ -27,6 +28,7 @@ export const show_user_group_settings_pane = {
             $t_html({defaultMessage: "User group settings"}),
         );
         $("#groups_overlay .deactivated-user-group-icon-right").hide();
+        resize.resize_settings_overlay_list_toggler_container($("#groups_overlay_container"));
     },
     settings(group: UserGroup) {
         $("#groups_overlay .nothing-selected, #user-group-creation").hide();
@@ -39,6 +41,7 @@ export const show_user_group_settings_pane = {
         } else {
             $("#groups_overlay .deactivated-user-group-icon-right").hide();
         }
+        resize.resize_settings_overlay_list_toggler_container($("#groups_overlay_container"));
     },
     create_user_group(container_name = "configure_user_group_settings", group_name?: string) {
         $(".user_group_creation").hide();
@@ -51,6 +54,7 @@ export const show_user_group_settings_pane = {
                 .text($t_html({defaultMessage: "Add members to {group_name}"}, {group_name}))
                 .addClass("showing-info-title");
         }
+        resize.resize_settings_overlay_list_toggler_container($("#groups_overlay_container"));
         update_footer_buttons(container_name);
         $(`.${CSS.escape(container_name)}`).show();
         $("#groups_overlay .nothing-selected, #groups_overlay .settings").hide();

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -2000,6 +2000,11 @@ export function initialize(): void {
                         .addClass("save-button")
                         .attr("data-group-id", user_group_id);
                 },
+                on_hidden() {
+                    resize.resize_settings_overlay_list_toggler_container(
+                        $("#groups_overlay_container"),
+                    );
+                },
                 update_submit_disabled_state_on_change: true,
             });
         },

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -68,6 +68,7 @@
 
 #add_new_user_group {
     height: var(--settings-overlay-header-button-height);
+    margin-top: 0.5em; /* 8px at 16px/em */
 }
 
 .two-pane-settings-plus-button {
@@ -356,7 +357,7 @@ h4.user_group_setting_subsection_title {
    differentiating from the main container styles below. */
 .two-pane-settings-container.overlay-container {
     .list-toggler-container {
-        align-items: center;
+        align-items: flex-start;
         padding: 0 8px;
         border-bottom: 1px solid var(--color-border-modal-bar);
         display: flex;
@@ -370,10 +371,11 @@ h4.user_group_setting_subsection_title {
 
     #add_new_subscription {
         height: var(--settings-overlay-header-button-height);
+        margin-top: 0.5em; /* 8px at 16px/em */
     }
 
     .display-type {
-        height: var(--settings-overlay-subheader-height);
+        min-height: var(--settings-overlay-subheader-height);
         display: flex;
         justify-content: center;
         align-items: center;
@@ -408,6 +410,7 @@ h4.user_group_setting_subsection_title {
             -webkit-line-clamp: 2;
             -webkit-box-orient: vertical;
             overflow: hidden;
+            margin: 0.4em; /* 7px at 16px/em */
 
             &.showing-info-title {
                 display: -webkit-box;
@@ -452,6 +455,7 @@ h4.user_group_setting_subsection_title {
 
             .tab-switcher {
                 margin-right: 0;
+                margin-top: 0.1875em; /* 3px at 16px/em */
             }
 
             .tab-switcher:first-child {
@@ -459,6 +463,11 @@ h4.user_group_setting_subsection_title {
                 width: 100%;
                 display: flex;
                 justify-content: end;
+            }
+
+            .stream_sorter_toggle,
+            #add_new_subscription {
+                margin-top: 0.125em; /* 2px at 16px/em */
             }
         }
 
@@ -674,7 +683,7 @@ h4.user_group_setting_subsection_title {
 }
 
 .deactivated-user-group-icon-right {
-    margin-left: 3px;
+    margin: 0 3px;
     opacity: 0.6;
 }
 
@@ -930,6 +939,7 @@ h4.user_group_setting_subsection_title {
     .tab-switcher {
         display: flex;
         flex-wrap: nowrap;
+        margin-top: 0.5em; /* 8px at 16px/em */
         height: var(--settings-overlay-header-button-height);
     }
 

--- a/web/tests/stream_settings_ui.test.cjs
+++ b/web/tests/stream_settings_ui.test.cjs
@@ -32,6 +32,10 @@ mock_esm("../src/group_permission_settings", {
     },
 });
 
+mock_esm("../src/resize", {
+    resize_settings_overlay_list_toggler_container() {},
+});
+
 set_global("page_params", {});
 
 const {set_current_user, set_realm} = zrequire("state_data");


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Currently the long titles in the channel and groups two panel windows look too cluttered and tight. This PR fixes that UI issue.
Earlier attempt to fix this issue: #34147

CZO discussion: [#design > cluttered title for stream settings and user groups](https://chat.zulip.org/#narrow/channel/101-design/topic/cluttered.20title.20for.20stream.20settings.20and.20user.20groups) 

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/a3bbf379-069f-4688-b0b4-6b496e3e9440) | ![image](https://github.com/user-attachments/assets/09b2839b-6265-4940-9a0b-d10b08a4e472) |
| ![image](https://github.com/user-attachments/assets/5ef78478-224b-4233-8623-4410b3ac7926) | ![image](https://github.com/user-attachments/assets/e70fc3fd-a0ae-40aa-b017-8bcd741f01a1) |
| ![image](https://github.com/user-attachments/assets/aba9da57-b7e6-476d-a438-d91efd9fe9fe) | ![image](https://github.com/user-attachments/assets/6df5dbd9-793a-42b7-985c-6e911c21cfff) |
| ![image](https://github.com/user-attachments/assets/52756765-bdb5-4a0e-aa19-c2cd48856e95) | ![image](https://github.com/user-attachments/assets/a6229110-037b-46bb-82f5-8b9b1c2dbdbf) |


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
