### PR TITLE
Change top feed notice.

### DIFF
--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -197,7 +197,7 @@ async function search_silent_user(page: Page, str: string, item: string): Promis
     await page.waitForSelector(".empty_feed_notice", {visible: true});
     const expect_message = "You haven't received any messages sent by Email Gateway yet.";
     assert.strictEqual(
-        await common.get_text_from_selector(page, ".empty_feed_notice"),
+        await common.get_text_from_selector(page, ".empty-feed-notice-title"),
         expect_message,
     );
     await common.get_current_msg_list_id(page, true);

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -528,6 +528,15 @@ export function initialize(): void {
         open_scroll_to_time_popover(this, message_id);
     });
 
+    $("body").on("click", ".search-shared-history", function (this: HTMLElement, e) {
+        e.preventDefault();
+        e.stopPropagation();
+        const url = $(this).attr("data-url");
+        if (url) {
+            browser_history.go_to_location(url);
+        }
+    });
+
     // RESOLVED TOPICS
     $("body").on("click", ".message_header .on_hover_topic_resolve", (e) => {
         e.stopPropagation();

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -133,31 +133,22 @@ export function get_recipient_label(
 
 // Exported for tests
 export let update_reply_button_state = (disable = false): void => {
+    const $compose_reply_button_wrapper = $(
+        "#legacy-closed-compose-box .compose-reply-button-wrapper",
+    );
     $(".compose_reply_button").attr("disabled", disable ? "disabled" : null);
     if (disable) {
         if (maybe_get_selected_message_stream_id() !== undefined) {
-            $("#legacy-closed-compose-box .compose-reply-button-wrapper").attr(
-                "data-reply-button-type",
-                "stream_disabled",
-            );
+            $compose_reply_button_wrapper.attr("data-reply-button-type", "stream_disabled");
         } else {
-            $("#legacy-closed-compose-box .compose-reply-button-wrapper").attr(
-                "data-reply-button-type",
-                "direct_disabled",
-            );
+            $compose_reply_button_wrapper.attr("data-reply-button-type", "direct_disabled");
         }
         return;
     }
     if (narrow_state.is_message_feed_visible()) {
-        $("#legacy-closed-compose-box .compose-reply-button-wrapper").attr(
-            "data-reply-button-type",
-            "selected_message",
-        );
+        $compose_reply_button_wrapper.attr("data-reply-button-type", "selected_message");
     } else {
-        $("#legacy-closed-compose-box .compose-reply-button-wrapper").attr(
-            "data-reply-button-type",
-            "selected_conversation",
-        );
+        $compose_reply_button_wrapper.attr("data-reply-button-type", "selected_conversation");
     }
 };
 

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -132,13 +132,25 @@ export function get_recipient_label(
 }
 
 // Exported for tests
-export let update_reply_button_state = (disable = false): void => {
+export let update_reply_button_state = (): void => {
     const $compose_reply_button_wrapper = $(
         "#legacy-closed-compose-box .compose-reply-button-wrapper",
     );
+    const stream_id_str = $compose_reply_button_wrapper.attr("data-stream-id");
+    const user_ids_string = $compose_reply_button_wrapper.attr("data-user-ids-string");
+
+    let disable = false;
+    if (stream_id_str !== undefined) {
+        disable = should_disable_compose_reply_button_for_stream(
+            Number.parseInt(stream_id_str, 10),
+        );
+    } else if (user_ids_string !== undefined) {
+        disable = should_disable_compose_reply_button_for_direct_message(user_ids_string);
+    }
+
     $(".compose_reply_button").attr("disabled", disable ? "disabled" : null);
     if (disable) {
-        if (maybe_get_selected_message_stream_id() !== undefined) {
+        if (stream_id_str !== undefined) {
             $compose_reply_button_wrapper.attr("data-reply-button-type", "stream_disabled");
         } else {
             $compose_reply_button_wrapper.attr("data-reply-button-type", "direct_disabled");
@@ -160,51 +172,22 @@ function update_new_conversation_button(data_attribute_string: "stream" | "non-s
     $("#new_conversation_button").attr("data-conversation-type", data_attribute_string);
 }
 
-function maybe_get_selected_message_stream_id(): number | undefined {
-    if (message_lists.current?.visibly_empty()) {
-        return undefined;
+function should_disable_compose_reply_button_for_stream(stream_id: number): boolean {
+    if (page_params.is_spectator) {
+        return false;
     }
-    const selected_message = message_lists.current?.selected_message();
-    if (!selected_message?.is_stream) {
-        return undefined;
-    }
-    return selected_message.stream_id;
-}
-
-function should_disable_compose_reply_button_for_stream(): boolean {
-    const stream_id = maybe_get_selected_message_stream_id();
-    if (stream_id !== undefined && !page_params.is_spectator) {
-        const stream = stream_data.get_sub_by_id(stream_id);
-        if (stream && !stream_data.can_post_messages_in_stream(stream)) {
-            return true;
-        }
-    }
-    return false;
+    const stream = stream_data.get_sub_by_id(stream_id);
+    return stream !== undefined && !stream_data.can_post_messages_in_stream(stream);
 }
 
 // Exported for tests
-export function should_disable_compose_reply_button_for_direct_message(): boolean {
-    const pm_ids_string = narrow_state.pm_ids_string();
-    // If we can identify a direct message recipient, and the user can't
-    // reply to that recipient, then we disable the compose_reply_button.
-    if (pm_ids_string && !message_util.user_can_send_direct_message(pm_ids_string)) {
-        return true;
-    }
-    return false;
+export function should_disable_compose_reply_button_for_direct_message(
+    user_ids_string: string,
+): boolean {
+    return !message_util.user_can_send_direct_message(user_ids_string);
 }
 
 export function update_buttons(update_type?: string): void {
-    let disable_reply_button = false;
-    if (update_type === "direct") {
-        // Based on whether there's a direct message recipient for
-        // the current narrow_state.
-        disable_reply_button = should_disable_compose_reply_button_for_direct_message();
-    } else if (update_type === "stream") {
-        // Based on whether there's a selected channel message in
-        // the current message list.
-        disable_reply_button = should_disable_compose_reply_button_for_stream();
-    }
-
     update_new_conversation_button(update_type === "stream" ? "stream" : "non-specific");
     // We omit recipient_information here, so update_reply_button_with_recipient_context
     // derives the reply target from the current message list: the selected
@@ -212,7 +195,7 @@ export function update_buttons(update_type?: string): void {
     // and Recent Conversations views instead pass the reply target from
     // their focused row.)
     update_reply_button_with_recipient_context();
-    update_reply_button_state(disable_reply_button);
+    update_reply_button_state();
 }
 
 export function maybe_update_buttons_for_dm_recipient(): void {
@@ -235,6 +218,9 @@ export function set_standard_text_for_reply_button(): void {
     $compose_reply_button_wrapper.removeAttr("data-stream-id");
     $compose_reply_button_wrapper.removeAttr("data-user-ids-string");
     $compose_reply_button_wrapper.removeAttr("data-reply-button-type");
+    // Reset the stale disabled state if the reply button was
+    // previously disabled.
+    $(".compose_reply_button").attr("disabled", null);
 }
 
 export function update_reply_button_with_recipient_context(
@@ -286,18 +272,6 @@ export function update_reply_button_with_recipient_context(
     }
 }
 
-function can_user_reply_to_message(message_id: number): boolean {
-    const selected_message = message_store.get(message_id);
-    if (selected_message === undefined) {
-        return false;
-    }
-    if (selected_message.is_stream) {
-        return !should_disable_compose_reply_button_for_stream();
-    }
-    assert(selected_message.is_private);
-    return message_util.user_can_send_direct_message(selected_message.to_user_ids);
-}
-
 export function initialize(): void {
     // When the message selection changes, change the label on the Reply button.
     $(document).on("message_selected.zulip", () => {
@@ -306,9 +280,7 @@ export function initialize(): void {
             // open due to the combined feed view loading in the background,
             // so we only update if message feed is visible.
             update_reply_button_with_recipient_context();
-            update_reply_button_state(
-                !can_user_reply_to_message(message_lists.current!.selected_id()),
-            );
+            update_reply_button_state();
         }
     });
 

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -163,9 +163,7 @@ export function rewire_update_reply_button_state(value: typeof update_reply_butt
     update_reply_button_state = value;
 }
 
-function update_new_conversation_button(
-    data_attribute_string: "direct" | "stream" | "non-specific",
-): void {
+function update_new_conversation_button(data_attribute_string: "stream" | "non-specific"): void {
     $("#new_conversation_button").attr("data-conversation-type", data_attribute_string);
 }
 
@@ -203,27 +201,22 @@ export function should_disable_compose_reply_button_for_direct_message(): boolea
 }
 
 export function update_buttons(update_type?: string): void {
-    let disable_reply_button;
+    let disable_reply_button = false;
     if (update_type === "direct") {
         // Based on whether there's a direct message recipient for
         // the current narrow_state.
         disable_reply_button = should_disable_compose_reply_button_for_direct_message();
-    } else {
+    } else if (update_type === "stream") {
         // Based on whether there's a selected channel message in
         // the current message list.
         disable_reply_button = should_disable_compose_reply_button_for_stream();
+    } else {
+        // Default case for most views.
+        set_standard_text_for_reply_button();
     }
 
-    if (update_type === "direct" || update_type === "stream") {
-        update_new_conversation_button(update_type);
-        update_reply_button_state(disable_reply_button);
-        return;
-    }
-
-    // Default case for most views.
-    update_new_conversation_button("non-specific");
+    update_new_conversation_button(update_type === "stream" ? "stream" : "non-specific");
     update_reply_button_state(disable_reply_button);
-    set_standard_text_for_reply_button();
 }
 
 export function maybe_update_buttons_for_dm_recipient(): void {

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -23,6 +23,7 @@ type RecipientLabel = {
     stream?: StreamSubscription;
     topic_display_name?: string;
     is_dm_with_self?: boolean;
+    user_ids?: number[];
 };
 
 function get_stream_recipient_label(stream_id: number, topic: string): RecipientLabel | undefined {
@@ -50,6 +51,7 @@ function get_direct_message_recipient_label(user_ids: number[]): RecipientLabel 
     const recipient_label: RecipientLabel = {
         label_text,
         is_dm_with_self,
+        user_ids,
     };
     return recipient_label;
 }
@@ -210,12 +212,15 @@ export function update_buttons(update_type?: string): void {
         // Based on whether there's a selected channel message in
         // the current message list.
         disable_reply_button = should_disable_compose_reply_button_for_stream();
-    } else {
-        // Default case for most views.
-        set_standard_text_for_reply_button();
     }
 
     update_new_conversation_button(update_type === "stream" ? "stream" : "non-specific");
+    // We omit recipient_information here, so update_reply_button_with_recipient_context
+    // derives the reply target from the current message list: the selected
+    // message, or the narrowed conversation in an empty view. (The Inbox
+    // and Recent Conversations views instead pass the reply target from
+    // their focused row.)
+    update_reply_button_with_recipient_context();
     update_reply_button_state(disable_reply_button);
 }
 
@@ -232,12 +237,22 @@ function set_reply_button_label(label: string): void {
 
 export function set_standard_text_for_reply_button(): void {
     set_reply_button_label($t({defaultMessage: "Compose message"}));
+    const $compose_reply_button_wrapper = $(
+        "#legacy-closed-compose-box .compose-reply-button-wrapper",
+    );
+    // Clear any stale recipient context from a previous reply target.
+    $compose_reply_button_wrapper.removeAttr("data-stream-id");
+    $compose_reply_button_wrapper.removeAttr("data-user-ids-string");
+    $compose_reply_button_wrapper.removeAttr("data-reply-button-type");
 }
 
-export function update_recipient_text_for_reply_button(
+export function update_reply_button_with_recipient_context(
     recipient_information?: ReplyRecipientInformation,
 ): void {
     const recipient_label = get_recipient_label(recipient_information);
+    const $compose_reply_button_wrapper = $(
+        "#legacy-closed-compose-box .compose-reply-button-wrapper",
+    );
     if (recipient_label !== undefined) {
         const empty_string_topic_display_name = util.get_final_topic_display_name("");
         const rendered_recipient_label = render_reply_recipient_label({
@@ -248,6 +263,32 @@ export function update_recipient_text_for_reply_button(
             empty_string_topic_display_name,
             label_text: recipient_label.label_text,
         });
+        // We store the recipient state so that update_reply_button_state
+        // can use that information without re-examining the message list
+        // or narrow state. The state is reset/unset by
+        // set_standard_text_for_reply_button().
+        if (recipient_label.stream) {
+            // Channel message recipient.
+            $compose_reply_button_wrapper.removeAttr("data-user-ids-string");
+            $compose_reply_button_wrapper.attr(
+                "data-stream-id",
+                recipient_label.stream.stream_id.toString(),
+            );
+        } else if (recipient_label.user_ids) {
+            // Direct message recipient.
+            $compose_reply_button_wrapper.removeAttr("data-stream-id");
+            $compose_reply_button_wrapper.attr(
+                "data-user-ids-string",
+                recipient_label.user_ids.join(","),
+            );
+        } else {
+            // Fallback case: recipient label from display_reply_to
+            // text when we couldn't decode user IDs from the narrow
+            // URL. We can't check permissions, so we leave the
+            // button enabled.
+            $compose_reply_button_wrapper.removeAttr("data-stream-id");
+            $compose_reply_button_wrapper.removeAttr("data-user-ids-string");
+        }
         $("#left_bar_compose_reply_button_big").html(rendered_recipient_label);
     } else {
         set_standard_text_for_reply_button();
@@ -273,7 +314,7 @@ export function initialize(): void {
             // message_selected events can occur with Recent Conversations
             // open due to the combined feed view loading in the background,
             // so we only update if message feed is visible.
-            update_recipient_text_for_reply_button();
+            update_reply_button_with_recipient_context();
             update_reply_button_state(
                 !can_user_reply_to_message(message_lists.current!.selected_id()),
             );

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -275,8 +275,8 @@ export function update_reply_button_with_recipient_context(
 // update_reply_button_with_recipient_context() runs before
 // update_reply_button_state(), ensuring that the button wrapper
 // contains the relevant recipient metadata.
-export function update_reply_button(): void {
-    update_reply_button_with_recipient_context();
+export function update_reply_button(recipient_information?: ReplyRecipientInformation): void {
+    update_reply_button_with_recipient_context(recipient_information);
     update_reply_button_state();
 }
 

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -189,13 +189,12 @@ export function should_disable_compose_reply_button_for_direct_message(
 
 export function update_buttons(update_type?: string): void {
     update_new_conversation_button(update_type === "stream" ? "stream" : "non-specific");
-    // We omit recipient_information here, so update_reply_button_with_recipient_context
-    // derives the reply target from the current message list: the selected
+    // We omit recipient_information here, so update_reply_button derives
+    // the reply target from the current message list: the selected
     // message, or the narrowed conversation in an empty view. (The Inbox
     // and Recent Conversations views instead pass the reply target from
     // their focused row.)
-    update_reply_button_with_recipient_context();
-    update_reply_button_state();
+    update_reply_button();
 }
 
 export function maybe_update_buttons_for_dm_recipient(): void {
@@ -272,6 +271,15 @@ export function update_reply_button_with_recipient_context(
     }
 }
 
+// This should be called when updating the reply button so that
+// update_reply_button_with_recipient_context() runs before
+// update_reply_button_state(), ensuring that the button wrapper
+// contains the relevant recipient metadata.
+export function update_reply_button(): void {
+    update_reply_button_with_recipient_context();
+    update_reply_button_state();
+}
+
 export function initialize(): void {
     // When the message selection changes, change the label on the Reply button.
     $(document).on("message_selected.zulip", () => {
@@ -279,8 +287,7 @@ export function initialize(): void {
             // message_selected events can occur with Recent Conversations
             // open due to the combined feed view loading in the background,
             // so we only update if message feed is visible.
-            update_reply_button_with_recipient_context();
-            update_reply_button_state();
+            update_reply_button();
         }
     });
 

--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -11,7 +11,6 @@ import * as blueslip from "./blueslip.ts";
 import * as compose_state from "./compose_state.ts";
 import * as compose_validate from "./compose_validate.ts";
 import {$t} from "./i18n.ts";
-import {pick_empty_narrow_banner} from "./narrow_banner.ts";
 import * as narrow_state from "./narrow_state.ts";
 import * as onboarding_steps from "./onboarding_steps.ts";
 import * as popover_menus from "./popover_menus.ts";
@@ -165,9 +164,11 @@ export function initialize(): void {
             const button_type = $elem.attr("data-reply-button-type");
             switch (button_type) {
                 case "direct_disabled": {
-                    const narrow_filter = narrow_state.filter();
-                    assert(narrow_filter !== undefined);
-                    instance.setContent(pick_empty_narrow_banner(narrow_filter).title);
+                    const user_ids_string = $elem.attr("data-user-ids-string");
+                    assert(user_ids_string !== undefined);
+                    instance.setContent(
+                        compose_validate.check_dm_permissions_and_get_error_string(user_ids_string),
+                    );
                     return;
                 }
                 case "stream_disabled": {

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1724,10 +1724,10 @@ export class Filter {
         );
     }
 
-    may_have_incomplete_message_history(): boolean {
+    may_have_incomplete_message_history(treat_combined_feed_as_complete = true): boolean {
         // Whether the filter may not include all messages.
         return (
-            !this.is_in_home() &&
+            (!treat_combined_feed_as_complete || !this.is_in_home()) &&
             !this.contains_only_private_messages() &&
             !this.includes_full_stream_history() &&
             !this.is_personal_filter() &&

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1724,6 +1724,20 @@ export class Filter {
         );
     }
 
+    may_have_incomplete_message_history(): boolean {
+        // Whether the filter may not include all messages.
+        return (
+            !this.is_in_home() &&
+            !this.contains_only_private_messages() &&
+            !this.includes_full_stream_history() &&
+            !this.is_personal_filter() &&
+            !(
+                _.isEqual(this.sorted_term_types(), ["sender", "has-reaction"]) &&
+                this.terms_with_operator("sender")[0]!.operand === people.my_current_user_id()
+            )
+        );
+    }
+
     contains_only_private_messages(): boolean {
         return (
             (this.has_operator("is") && this.terms_with_operator("is")[0]!.operand === "dm") ||

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -513,7 +513,11 @@ export function decode_dm_recipient_user_ids_from_narrow_url(narrow_url: string)
             return null;
         }
 
-        if (terms[1]?.operator !== "with" && terms[1]?.operator !== "near") {
+        if (
+            terms[1] !== undefined &&
+            terms[1].operator !== "with" &&
+            terms[1].operator !== "near"
+        ) {
             return null;
         }
 

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1547,6 +1547,7 @@ function focus_current_id(): void {
 export function focus_inbox_search(): void {
     current_navigated_id = INBOX_SEARCH_ID;
     focus_current_id();
+    compose_closed_ui.set_standard_text_for_reply_button();
 }
 
 function is_navigated_to_list(): boolean {
@@ -1630,9 +1631,19 @@ function update_closed_compose_text($row: JQuery, is_header_row: boolean): void 
             };
         }
     } else {
-        const $topic_menu_elt = $row.find(".inbox-topic-menu");
+        let stream_id: number;
+        // In the "list of topics" channel view, we get the stream_id
+        // from the current filter via get_channel_id(). For the general inbox
+        // view (#inbox), we get the stream_id from the inbox header's
+        // data-stream-id attribute.
+        if (inbox_util.is_channel_view()) {
+            stream_id = inbox_util.get_channel_id();
+        } else {
+            const $topic_menu_elt = $row.find(".inbox-topic-menu");
+            stream_id = Number($topic_menu_elt.attr("data-stream-id"));
+        }
         reply_recipient_information = {
-            stream_id: Number($topic_menu_elt.attr("data-stream-id")),
+            stream_id,
             topic: $row.find(".inbox-topic-name a").text(),
         };
     }
@@ -1795,6 +1806,7 @@ function set_list_focus(input_key?: string): void {
 function focus_filters_dropdown(): void {
     current_navigated_id = INBOX_FILTERS_DROPDOWN_ID;
     $(`#${CSS.escape(INBOX_FILTERS_DROPDOWN_ID)}`).trigger("focus");
+    compose_closed_ui.set_standard_text_for_reply_button();
 }
 
 export function is_search_focused(): boolean {

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1630,9 +1630,9 @@ function update_closed_compose_text($row: JQuery, is_header_row: boolean): void 
             };
         }
     } else {
-        const $stream = $row.parent(".inbox-topic-container").prev(".inbox-header");
+        const $topic_menu_elt = $row.find(".inbox-topic-menu");
         reply_recipient_information = {
-            stream_id: Number($stream.attr("data-stream-id")),
+            stream_id: Number($topic_menu_elt.attr("data-stream-id")),
             topic: $row.find(".inbox-topic-name a").text(),
         };
     }

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1647,7 +1647,7 @@ function update_closed_compose_text($row: JQuery, is_header_row: boolean): void 
             topic: $row.find(".inbox-topic-name a").text(),
         };
     }
-    compose_closed_ui.update_reply_button_with_recipient_context(reply_recipient_information);
+    compose_closed_ui.update_reply_button(reply_recipient_information);
 }
 
 export function get_focused_row_message(): {message?: Message | undefined} & (

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1647,7 +1647,7 @@ function update_closed_compose_text($row: JQuery, is_header_row: boolean): void 
             topic: $row.find(".inbox-topic-name a").text(),
         };
     }
-    compose_closed_ui.update_recipient_text_for_reply_button(reply_recipient_information);
+    compose_closed_ui.update_reply_button_with_recipient_context(reply_recipient_information);
 }
 
 export function get_focused_row_message(): {message?: Message | undefined} & (

--- a/web/src/message_feed_top_notices.ts
+++ b/web/src/message_feed_top_notices.ts
@@ -1,5 +1,4 @@
 import $ from "jquery";
-import _ from "lodash";
 import assert from "minimalistic-assert";
 
 import * as hash_util from "./hash_util.ts";
@@ -7,7 +6,6 @@ import type {MessageList} from "./message_list.ts";
 import * as message_lists from "./message_lists.ts";
 import * as narrow_banner from "./narrow_banner.ts";
 import * as narrow_state from "./narrow_state.ts";
-import * as people from "./people.ts";
 
 function show_history_limit_notice(): void {
     $(".top-messages-logo").hide();
@@ -51,17 +49,7 @@ export function update_top_of_narrow_notices(msg_list: MessageList): void {
         // conditions, but there's a very legitimate use case
         // for moderation of searching for all messages sent
         // by a potential spammer user.
-        if (
-            filter &&
-            !filter.is_in_home() &&
-            !filter.contains_only_private_messages() &&
-            !filter.includes_full_stream_history() &&
-            !filter.is_personal_filter() &&
-            !(
-                _.isEqual(filter.sorted_term_types(), ["sender", "has-reaction"]) &&
-                filter.terms_with_operator("sender")[0]!.operand === people.my_current_user_id()
-            )
-        ) {
+        if (filter?.may_have_incomplete_message_history()) {
             show_end_of_results_notice();
         }
     }

--- a/web/src/message_feed_top_notices.ts
+++ b/web/src/message_feed_top_notices.ts
@@ -58,7 +58,7 @@ export function update_top_of_narrow_notices(msg_list: MessageList): void {
             !filter.includes_full_stream_history() &&
             !filter.is_personal_filter() &&
             !(
-                _.isEqual(filter._sorted_term_types, ["sender", "has-reaction"]) &&
+                _.isEqual(filter.sorted_term_types(), ["sender", "has-reaction"]) &&
                 filter.terms_with_operator("sender")[0]!.operand === people.my_current_user_id()
             )
         ) {

--- a/web/src/message_feed_top_notices.ts
+++ b/web/src/message_feed_top_notices.ts
@@ -5,6 +5,7 @@ import * as hash_util from "./hash_util.ts";
 import type {MessageList} from "./message_list.ts";
 import * as message_lists from "./message_lists.ts";
 import * as narrow_state from "./narrow_state.ts";
+import {page_params} from "./page_params.ts";
 
 function show_history_limit_notice(): void {
     $(".top-messages-logo").hide();
@@ -26,6 +27,13 @@ function hide_end_of_results_notice(): void {
 }
 
 function show_end_of_results_notice(): void {
+    // end-of-results notices are hidden for spectators, so leave the
+    // top-of-feed logo in place for them rather than hiding it and showing
+    // nothing.
+    if (page_params.is_spectator) {
+        return;
+    }
+    $(".top-messages-logo").hide();
     $(".all-messages-search-caution").show();
 
     // Set the link to point to this search with streams:public added.
@@ -34,7 +42,7 @@ function show_end_of_results_notice(): void {
     assert(narrow_filter !== undefined);
     const terms = narrow_filter.terms();
     const update_hash = hash_util.search_public_streams_notice_url(terms);
-    $(".all-messages-search-caution a.search-shared-history").attr("href", update_hash);
+    $(".all-messages-search-caution .search-shared-history").attr("data-url", update_hash);
 }
 
 export function update_top_of_narrow_notices(msg_list: MessageList): void {

--- a/web/src/message_feed_top_notices.ts
+++ b/web/src/message_feed_top_notices.ts
@@ -24,24 +24,30 @@ function hide_history_limit_notice(): void {
 
 function hide_end_of_results_notice(): void {
     $(".all-messages-search-caution").hide();
+    $(".combined-feed-notice").hide();
 }
 
 function show_end_of_results_notice(): void {
-    // end-of-results notices are hidden for spectators, so leave the
+    // Both end-of-results notices are hidden for spectators, so leave the
     // top-of-feed logo in place for them rather than hiding it and showing
     // nothing.
     if (page_params.is_spectator) {
         return;
     }
     $(".top-messages-logo").hide();
-    $(".all-messages-search-caution").show();
 
-    // Set the link to point to this search with streams:public added.
-    // Note that element we adjust is not visible to spectators.
     const narrow_filter = narrow_state.filter();
     assert(narrow_filter !== undefined);
+
+    if (narrow_filter.is_in_home()) {
+        $(".combined-feed-notice").show();
+        return;
+    }
     const terms = narrow_filter.terms();
+    // Set the link to point to this search with streams:public added.
+    // Note that element we adjust is not visible to spectators.
     const update_hash = hash_util.search_public_streams_notice_url(terms);
+    $(".all-messages-search-caution").show();
     $(".all-messages-search-caution .search-shared-history").attr("data-url", update_hash);
 }
 
@@ -60,7 +66,7 @@ export function update_top_of_narrow_notices(msg_list: MessageList): void {
         // conditions, but there's a very legitimate use case
         // for moderation of searching for all messages sent
         // by a potential spammer user.
-        if (filter?.may_have_incomplete_message_history()) {
+        if (filter?.may_have_incomplete_message_history(false)) {
             show_end_of_results_notice();
         }
     }

--- a/web/src/message_feed_top_notices.ts
+++ b/web/src/message_feed_top_notices.ts
@@ -4,13 +4,16 @@ import assert from "minimalistic-assert";
 import * as hash_util from "./hash_util.ts";
 import type {MessageList} from "./message_list.ts";
 import * as message_lists from "./message_lists.ts";
-import * as narrow_banner from "./narrow_banner.ts";
 import * as narrow_state from "./narrow_state.ts";
 
 function show_history_limit_notice(): void {
     $(".top-messages-logo").hide();
     $(".history-limited-box").show();
-    narrow_banner.hide_empty_narrow_message();
+    // The history-limit notice and the empty-narrow banner are mutually
+    // exclusive top-of-feed states; clear the latter when showing this.
+    // We do this inline rather than calling narrow_banner, which imports
+    // this module, to avoid an import cycle.
+    $(".empty_feed_notice_main").empty();
 }
 
 function hide_history_limit_notice(): void {

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -479,7 +479,11 @@ export function load_messages(opts: MessageFetchOptions, attempt = 1): void {
                     !opts.msg_list.is_combined_feed_view &&
                     opts.msg_list.visibly_empty()
                 ) {
-                    narrow_banner.show_empty_narrow_message(opts.msg_list.data.filter);
+                    const invalid_narrow = true;
+                    narrow_banner.show_empty_narrow_message(
+                        opts.msg_list.data.filter,
+                        invalid_narrow,
+                    );
                 }
 
                 // TODO: This should probably do something explicit with

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1623,7 +1623,6 @@ function handle_post_view_change(
     } else {
         compose_closed_ui.update_buttons();
     }
-    compose_closed_ui.update_reply_button_with_recipient_context();
 
     message_view_header.render_title_area();
 

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1623,7 +1623,7 @@ function handle_post_view_change(
     } else {
         compose_closed_ui.update_buttons();
     }
-    compose_closed_ui.update_recipient_text_for_reply_button();
+    compose_closed_ui.update_reply_button_with_recipient_context();
 
     message_view_header.render_title_area();
 

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -333,6 +333,10 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                             defaultMessage: "You have no messages in muted topics and channels.",
                         }),
                     };
+                case "alerted":
+                    return {
+                        title_html: NO_SEARCH_RESULTS_TITLE_HTML,
+                    };
             }
             // fallthrough to default case if no match is found
             break;

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -539,12 +539,6 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
             // mentions:me is redirected to is:mentioned in Filter.parse(),
             // so mentioned_user will never be the current user here.
             return {
-                title: $t(
-                    {
-                        defaultMessage: "No messages in your message history mention {person} yet.",
-                    },
-                    {person: mentioned_user.full_name},
-                ),
                 title_html: $t_html(
                     {
                         defaultMessage:

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -320,7 +320,18 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                     };
                 case "resolved":
                     return {
-                        title: $t({defaultMessage: "No topics are marked as resolved."}),
+                        title_html: $t_html(
+                            {
+                                defaultMessage:
+                                    "No topics in <z-link>your history</z-link> are marked as resolved.",
+                            },
+                            {
+                                "z-link": (content_html) =>
+                                    `<a href="/help/search-for-messages#search-shared-history" target="_blank" rel="noopener noreferrer">${content_html.join(
+                                        "",
+                                    )}</a>`,
+                            },
+                        ),
                     };
                 case "followed":
                     return {

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -80,6 +80,17 @@ const MUTED_TOPICS_IN_CHANNEL_EMPTY_BANNER = {
 };
 
 const NO_SEARCH_RESULTS_TITLE = $t({defaultMessage: "No search results."});
+const NO_SEARCH_RESULTS_TITLE_HTML = $t_html(
+    {
+        defaultMessage: "No search results from <z-link>your message history</z-link>.",
+    },
+    {
+        "z-link": (content_html) =>
+            `<a href="/help/search-for-messages#search-shared-history" target="_blank" rel="noopener noreferrer">${content_html.join(
+                "",
+            )}</a>`,
+    },
+);
 
 function empty_search_query_banner(current_filter: Filter): NarrowBannerData {
     const search_query = current_filter.terms_with_operator("search")[0]!.operand;
@@ -550,6 +561,12 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                         person: mentioned_user.full_name,
                     },
                 ),
+            };
+        }
+
+        case "has": {
+            return {
+                title_html: NO_SEARCH_RESULTS_TITLE_HTML,
             };
         }
     }

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -4,7 +4,9 @@ import assert from "minimalistic-assert";
 
 import * as compose_validate from "./compose_validate.ts";
 import type {Filter} from "./filter.ts";
+import * as hash_util from "./hash_util.ts";
 import {$t, $t_html} from "./i18n.ts";
+import * as message_feed_top_notices from "./message_feed_top_notices.ts";
 import * as message_lists from "./message_lists.ts";
 import type {NarrowBannerData, SearchData} from "./narrow_error.ts";
 import {narrow_error} from "./narrow_error.ts";
@@ -92,7 +94,32 @@ const NO_SEARCH_RESULTS_TITLE_HTML = $t_html(
     },
 );
 
-function empty_search_query_banner(current_filter: Filter): NarrowBannerData {
+function should_show_search_shared_history_action(
+    current_filter: Filter,
+    invalid_narrow: boolean,
+): boolean {
+    return current_filter.may_have_incomplete_message_history() && !invalid_narrow;
+}
+
+// When we're offering the search shared history in banner, the title
+// links to the relevant help center page; otherwise it's plain text.
+function get_no_search_results_title(
+    show_search_shared_history: boolean,
+): {title: string} | {title_html: string} {
+    if (show_search_shared_history) {
+        return {
+            title_html: NO_SEARCH_RESULTS_TITLE_HTML,
+        };
+    }
+
+    return {title: NO_SEARCH_RESULTS_TITLE};
+}
+
+function empty_search_query_banner(
+    current_filter: Filter,
+    show_search_shared_history: boolean,
+): NarrowBannerData {
+    const no_search_results = get_no_search_results_title(show_search_shared_history);
     const search_query = current_filter.terms_with_operator("search")[0]!.operand;
     const query_words = search_query.split(" ");
 
@@ -121,11 +148,12 @@ function empty_search_query_banner(current_filter: Filter): NarrowBannerData {
     // when there are excluded stop words.
     if (search_string_result.has_stop_word) {
         return {
-            title: NO_SEARCH_RESULTS_TITLE,
+            ...no_search_results,
+            show_action: show_search_shared_history,
             search_data: search_string_result,
         };
     }
-    return {title: NO_SEARCH_RESULTS_TITLE};
+    return {...no_search_results, show_action: show_search_shared_history};
 }
 
 // Returns a banner describing why direct messages to these users are
@@ -150,7 +178,20 @@ function dm_permission_error_banner(user_ids_string: string): NarrowBannerData |
     };
 }
 
-export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerData {
+export function pick_empty_narrow_banner(
+    current_filter: Filter,
+    invalid_narrow = false,
+): NarrowBannerData {
+    // Show the "search shared history" help link and action button only for
+    // banners where the user's message history may be incomplete in a valid
+    // narrow. Some compatible banners do not show them because the user lacks
+    // permission to search shared history or the corresponding view is not
+    // available.
+    const show_search_shared_history = should_show_search_shared_history_action(
+        current_filter,
+        invalid_narrow,
+    );
+    const no_search_results = get_no_search_results_title(show_search_shared_history);
     const default_banner = {
         title: $t({defaultMessage: "There are no messages here."}),
         // Spectators cannot start a conversation.
@@ -230,7 +271,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
 
         // For empty search queries, we display excluded stop words
         if (current_filter.terms_with_operator("search").length > 0) {
-            return empty_search_query_banner(current_filter);
+            return empty_search_query_banner(current_filter, show_search_shared_history);
         }
 
         if (
@@ -284,7 +325,8 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
 
         // For other multi-operator narrows, we just use the default banner
         return {
-            title: NO_SEARCH_RESULTS_TITLE,
+            ...no_search_results,
+            show_action: show_search_shared_history,
         };
     }
 
@@ -332,6 +374,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                                     )}</a>`,
                             },
                         ),
+                        show_action: show_search_shared_history,
                     };
                 case "followed":
                     return {
@@ -347,6 +390,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                 case "alerted":
                     return {
                         title_html: NO_SEARCH_RESULTS_TITLE_HTML,
+                        show_action: show_search_shared_history,
                     };
             }
             // fallthrough to default case if no match is found
@@ -400,7 +444,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
         }
         case "search": {
             // You are narrowed to empty search results.
-            return empty_search_query_banner(current_filter);
+            return empty_search_query_banner(current_filter, show_search_shared_history);
         }
         case "dm": {
             if (!people.is_valid_bulk_user_ids_for_compose(first_term.operand, true)) {
@@ -496,6 +540,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                         },
                         {person: sender.full_name},
                     ),
+                    show_action: show_search_shared_history,
                 };
             }
             return {
@@ -576,22 +621,40 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                         person: mentioned_user.full_name,
                     },
                 ),
+                show_action: show_search_shared_history,
             };
         }
 
         case "has": {
             return {
                 title_html: NO_SEARCH_RESULTS_TITLE_HTML,
+                show_action: show_search_shared_history,
             };
         }
     }
     return default_banner;
 }
 
-export function show_empty_narrow_message(current_filter: Filter): void {
+export function show_empty_narrow_message(current_filter: Filter, invalid_narrow = false): void {
     $(".empty_feed_notice_main").empty();
-    const rendered_narrow_banner = narrow_error(pick_empty_narrow_banner(current_filter));
+    const rendered_narrow_banner = narrow_error(
+        pick_empty_narrow_banner(current_filter, invalid_narrow),
+    );
     $(".empty_feed_notice_main").html(rendered_narrow_banner);
+
+    // Removing messages from the current narrow can leave a stale
+    // top-of-feed notice visible, so hide all of them before showing
+    // the empty-narrow banner.
+    message_feed_top_notices.hide_top_of_narrow_notices();
+
+    if (current_filter.may_have_incomplete_message_history()) {
+        $(".empty_feed_notice .empty-feed-notice-action").show();
+
+        const terms = current_filter.terms();
+        const update_hash = hash_util.search_public_streams_notice_url(terms);
+
+        $(".empty_feed_notice .search-shared-history").attr("data-url", update_hash);
+    }
 }
 
 export function hide_empty_narrow_message(): void {

--- a/web/src/narrow_error.ts
+++ b/web/src/narrow_error.ts
@@ -12,6 +12,7 @@ export type SearchData = {
 
 export type NarrowBannerData = {
     html?: string;
+    show_action?: boolean;
     search_data?: SearchData;
 } & ({title: string} | {title_html: string});
 

--- a/web/src/narrow_error.ts
+++ b/web/src/narrow_error.ts
@@ -11,23 +11,13 @@ export type SearchData = {
 };
 
 export type NarrowBannerData = {
-    title: string;
-    title_html?: string;
     html?: string;
     search_data?: SearchData;
-};
+} & ({title: string} | {title_html: string});
 
 export function narrow_error(narrow_banner_data: NarrowBannerData): string {
-    const title = narrow_banner_data.title;
-    const title_html = narrow_banner_data.title_html;
-    const notice_html = narrow_banner_data.html;
-    const search_data = narrow_banner_data.search_data;
-
-    const empty_feed_notice = render_empty_feed_notice({
-        title,
-        title_html,
-        notice_html,
-        search_data,
+    return render_empty_feed_notice({
+        ...narrow_banner_data,
+        notice_html: narrow_banner_data.html,
     });
-    return empty_feed_notice;
 }

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -503,7 +503,7 @@ function set_table_focus(row: number, col: number, using_keyboard = false): bool
             topic: $topic_row.find(".recent-view-conversation-link").text(),
         };
     }
-    compose_closed_ui.update_recipient_text_for_reply_button(reply_recipient_information);
+    compose_closed_ui.update_reply_button_with_recipient_context(reply_recipient_information);
     return true;
 }
 

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -503,7 +503,7 @@ function set_table_focus(row: number, col: number, using_keyboard = false): bool
             topic: $topic_row.find(".recent-view-conversation-link").text(),
         };
     }
-    compose_closed_ui.update_reply_button_with_recipient_context(reply_recipient_information);
+    compose_closed_ui.update_reply_button(reply_recipient_information);
     return true;
 }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -91,6 +91,10 @@
             flex-grow: 1;
             display: flex;
             overflow: hidden;
+
+            .compose_reply_button:disabled {
+                cursor: default;
+            }
         }
 
         #left_bar_compose_reply_button_big {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -215,8 +215,7 @@
         opacity: 0.7;
     }
 
-    .history-limited-box,
-    .all-messages-search-caution {
+    .history-limited-box {
         background-color: hsl(0deg 0% 0% / 20%);
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -195,10 +195,12 @@ p.n-margin {
     margin: 0;
 }
 
-.all-messages-search-caution {
+.all-messages-search-caution,
+.combined-feed-notice {
     display: none;
 
-    .all-messages-search-caution-info {
+    .all-messages-search-caution-info,
+    .combined-feed-notice-info {
         display: flex;
         flex-wrap: wrap;
         align-items: center;
@@ -219,7 +221,8 @@ p.n-margin {
 }
 
 .history-limited-box,
-.all-messages-search-caution {
+.all-messages-search-caution,
+.combined-feed-notice {
     margin: 0 auto 12px;
     padding: 5px;
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -195,31 +195,33 @@ p.n-margin {
     margin: 0;
 }
 
+.all-messages-search-caution {
+    display: none;
+
+    .all-messages-search-caution-info {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 6px;
+    }
+}
+
 .history-limited-box {
+    border-radius: 4px;
+    display: none;
+    /* Difference should be 16px to accommodate the icon. */
+    /* This emulates hanging indent. */
+    padding-left: 26px;
+    text-indent: -10px;
     color: hsl(16deg 60% 45%);
     border: 1px solid hsl(16deg 60% 45%);
     box-shadow: 0 0 2px hsl(16deg 60% 45%);
 }
 
-.all-messages-search-caution {
-    border: 1px solid hsl(192deg 19% 75% / 20%);
-    box-shadow: 0 0 2px hsl(192deg 19% 75% / 20%);
-}
-
 .history-limited-box,
 .all-messages-search-caution {
-    border-radius: 4px;
-    display: none;
     margin: 0 auto 12px;
     padding: 5px;
-    /* Difference should be 16px to accommodate the icon. */
-    /* This emulates hanging indent. */
-    padding-left: 26px;
-    text-indent: -10px;
-
-    .all-messages-search-caution-icon {
-        margin: 0 3px 0 1px;
-    }
 
     & p {
         margin: 0;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1422,6 +1422,16 @@ div.topic_edit_spinner .loading_indicator_spinner {
     }
 }
 
+.empty-feed-notice-action {
+    display: none;
+    font-size: 1.1em;
+
+    .search-shared-history {
+        display: inline-block;
+        margin-top: 10px;
+    }
+}
+
 .message-fade,
 .user_sidebar_entry.user-fade {
     opacity: 0.4;

--- a/web/templates/empty_feed_notice.hbs
+++ b/web/templates/empty_feed_notice.hbs
@@ -18,4 +18,13 @@
             {{{ notice_html }}}
         </div>
     {{/if}}
+    {{#if show_action}}
+    <div class="empty-feed-notice-action">
+        <button
+          class="search-shared-history hidden-for-spectators action-button action-button-subtle-neutral"
+          type="button">
+            {{t 'Search all public channels'}}
+        </button>
+    </div>
+    {{/if}}
 </div>

--- a/web/templates/message_feed_errors.hbs
+++ b/web/templates/message_feed_errors.hbs
@@ -9,29 +9,32 @@
         {{/tr}}
     </p>
 </div>
-<div class="all-messages-search-caution hidden-for-spectators" hidden>
-    <p>
-        <i class="all-messages-search-caution-icon fa fa-exclamation-circle" aria-hidden="true"></i>
-        {{#tr}}
-        End of results from your
-        <z-link>history</z-link>.
-        {{#*inline "z-link"}}<a href="/help/search-for-messages#search-shared-history"
-          target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-        {{/tr}}
-        &nbsp;
-        <span>
+<div class="all-messages-search-caution hidden-for-spectators">
+    <div class="all-messages-search-caution-info">
+        <p>
             {{#if is_guest}}
                 {{#tr}}
-                    Consider <z-link>searching all public channels that you can view</z-link>.
-                    {{#*inline "z-link"}}<a class="search-shared-history" href="">{{> @partial-block}}</a>{{/inline}}
+                    End of results from
+                    <z-link>your message history</z-link>. Include messages in your public channels
+                    sent when you weren't subscribed?
+                    {{#*inline "z-link"}}<a href="/help/search-for-messages#search-shared-history"
+                    target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
                 {{/tr}}
             {{else}}
                 {{#tr}}
-                    Consider <z-link>searching all public channels</z-link>.
-                    {{#*inline "z-link"}}<a class="search-shared-history" href="">{{> @partial-block}}</a>{{/inline}}
+                    End of results from
+                    <z-link>your message history</z-link>. Include messages in public channels
+                    sent when you weren't subscribed?
+                    {{#*inline "z-link"}}<a href="/help/search-for-messages#search-shared-history"
+                    target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
                 {{/tr}}
             {{/if}}
-        </span>
-    </p>
+        </p>
+        <button
+          class="search-shared-history action-button action-button-subtle-neutral"
+          type="button">
+            {{t 'Expand search'}}
+        </button>
+    </div>
 </div>
 <div class="empty_feed_notice_main"></div>

--- a/web/templates/message_feed_errors.hbs
+++ b/web/templates/message_feed_errors.hbs
@@ -37,4 +37,26 @@
         </button>
     </div>
 </div>
+<div class="combined-feed-notice hidden-for-spectators">
+    <div class="combined-feed-notice-info">
+        <p>
+            {{#tr}}
+            End of messages in your
+            <z-link>combined feed</z-link>.
+            {{#*inline "z-link"}}<a href="/help/combined-feed"
+            target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        </p>
+        <button
+          class="search-shared-history action-button action-button-subtle-neutral"
+          type="button"
+          data-url="#narrow/channels/public">
+            {{#if is_guest}}
+                {{t 'View all messages in your public channels'}}
+            {{else}}
+                {{t 'View all messages in public channels'}}
+            {{/if}}
+        </button>
+    </div>
+</div>
 <div class="empty_feed_notice_main"></div>

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -857,10 +857,11 @@ test_ui("DM policy disabled", ({override}) => {
     reply_disabled = compose_closed_ui.should_disable_compose_reply_button_for_direct_message();
     assert.ok(!reply_disabled);
     // For human user, Alice, the "Message X" button is disabled
-    override(narrow_state, "pm_ids_string", () => "31,33");
+    override(narrow_state, "pm_ids_string", () => "31");
     reply_disabled = compose_closed_ui.should_disable_compose_reply_button_for_direct_message();
     assert.ok(reply_disabled);
     // For human user and bot user, the "Message X" button is disabled
+    override(narrow_state, "pm_ids_string", () => "31,33");
     reply_disabled = compose_closed_ui.should_disable_compose_reply_button_for_direct_message();
     assert.ok(reply_disabled);
 });

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -847,21 +847,15 @@ test_ui("DM policy disabled", ({override}) => {
     // Disable sending direct messages in the organisation
     override(realm, "realm_direct_message_permission_group", nobody.id);
     override(realm, "realm_direct_message_initiator_group", everyone.id);
-    // For no specified direct message recipient, the "Message X"button
-    // is not disabled
-    override(narrow_state, "pm_ids_string", () => undefined);
-    let reply_disabled = compose_closed_ui.should_disable_compose_reply_button_for_direct_message();
-    assert.ok(!reply_disabled);
     // For single bot recipient, Bot, the "Message X" button is not disabled
-    override(narrow_state, "pm_ids_string", () => "33");
-    reply_disabled = compose_closed_ui.should_disable_compose_reply_button_for_direct_message();
+    let reply_disabled =
+        compose_closed_ui.should_disable_compose_reply_button_for_direct_message("33");
     assert.ok(!reply_disabled);
     // For human user, Alice, the "Message X" button is disabled
-    override(narrow_state, "pm_ids_string", () => "31");
-    reply_disabled = compose_closed_ui.should_disable_compose_reply_button_for_direct_message();
+    reply_disabled = compose_closed_ui.should_disable_compose_reply_button_for_direct_message("31");
     assert.ok(reply_disabled);
     // For human user and bot user, the "Message X" button is disabled
-    override(narrow_state, "pm_ids_string", () => "31,33");
-    reply_disabled = compose_closed_ui.should_disable_compose_reply_button_for_direct_message();
+    reply_disabled =
+        compose_closed_ui.should_disable_compose_reply_button_for_direct_message("31,33");
     assert.ok(reply_disabled);
 });

--- a/web/tests/compose_closed_ui.test.cjs
+++ b/web/tests/compose_closed_ui.test.cjs
@@ -9,6 +9,7 @@ const {make_user} = require("./lib/example_user.cjs");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
 const $ = require("./lib/zjquery.cjs");
+const {page_params} = require("./lib/zpage_params.cjs");
 
 // Mocking and stubbing things
 set_global("document", "document-stub");
@@ -27,6 +28,10 @@ mock_esm("../src/message_list_view", {
 });
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => true,
+    user_has_permission_for_group_setting: () => true,
+});
+const message_util = mock_esm("../src/message_util", {
+    user_can_send_direct_message: () => true,
 });
 
 const stream_data = zrequire("stream_data");
@@ -244,4 +249,96 @@ run_test("test_non_message_list_input", ({mock_template}) => {
     });
     label = $("#left_bar_compose_reply_button_big").text();
     assert.equal(label, "translated: Compose message");
+});
+
+run_test("update_reply_button_state", ({override, override_rewire}) => {
+    const $compose_reply_wrapper = $("#legacy-closed-compose-box .compose-reply-button-wrapper");
+    const $reply_button = $(".compose_reply_button");
+
+    const postable_stream = make_stream({
+        subscribed: true,
+        name: "postable_stream",
+        stream_id: 20,
+    });
+    stream_data.add_sub_for_tests(postable_stream);
+
+    const restricted_stream = make_stream({
+        subscribed: true,
+        name: "restricted_stream",
+        stream_id: 21,
+    });
+    stream_data.add_sub_for_tests(restricted_stream);
+    override_rewire(
+        stream_data,
+        "can_post_messages_in_stream",
+        (stream) => stream.stream_id !== restricted_stream.stream_id,
+    );
+
+    // Reply button is enabled for stream where user can post.
+    message_lists.current = {};
+    $compose_reply_wrapper.attr("data-stream-id", postable_stream.stream_id.toString());
+    $compose_reply_wrapper.removeAttr("data-user-ids-string");
+    compose_closed_ui.update_reply_button_state();
+    assert.notEqual($reply_button.attr("disabled"), "disabled");
+    assert.equal($compose_reply_wrapper.attr("data-reply-button-type"), "selected_message");
+
+    // Reply button is disabled for stream where user cannot post.
+    $compose_reply_wrapper.attr("data-stream-id", restricted_stream.stream_id.toString());
+    compose_closed_ui.update_reply_button_state();
+    assert.equal($reply_button.attr("disabled"), "disabled");
+    assert.equal($compose_reply_wrapper.attr("data-reply-button-type"), "stream_disabled");
+
+    // Reply button is enabled for DM where user can send.
+    override(message_util, "user_can_send_direct_message", () => true);
+    $compose_reply_wrapper.removeAttr("data-stream-id");
+    $compose_reply_wrapper.attr("data-user-ids-string", "2");
+    compose_closed_ui.update_reply_button_state();
+    assert.notEqual($reply_button.attr("disabled"), "disabled");
+    assert.equal($compose_reply_wrapper.attr("data-reply-button-type"), "selected_message");
+
+    // Reply button is disabled for DM where user cannot send.
+    override(message_util, "user_can_send_direct_message", () => false);
+    compose_closed_ui.update_reply_button_state();
+    assert.equal($reply_button.attr("disabled"), "disabled");
+    assert.equal($compose_reply_wrapper.attr("data-reply-button-type"), "direct_disabled");
+
+    // No data attributes leads to enabled reply button.
+    message_lists.current = undefined;
+    $compose_reply_wrapper.removeAttr("data-stream-id");
+    $compose_reply_wrapper.removeAttr("data-user-ids-string");
+    compose_closed_ui.update_reply_button_state();
+    assert.notEqual($reply_button.attr("disabled"), "disabled");
+
+    // Button is not disabled for spectators.
+    page_params.is_spectator = true;
+    message_lists.current = {};
+    $compose_reply_wrapper.attr("data-stream-id", restricted_stream.stream_id.toString());
+    compose_closed_ui.update_reply_button_state();
+    assert.notEqual($reply_button.attr("disabled"), "disabled");
+    assert.equal($compose_reply_wrapper.attr("data-reply-button-type"), "selected_message");
+    page_params.is_spectator = false;
+});
+
+run_test("set_standard_text_resets_stale_state", ({override}) => {
+    const $compose_reply_wrapper = $("#legacy-closed-compose-box .compose-reply-button-wrapper");
+    const $reply_button = $(".compose_reply_button");
+
+    // Put the button in the "direct_disabled" state, with a recipient the
+    // user cannot message, so it carries a data-user-ids-string attribute.
+    override(message_util, "user_can_send_direct_message", () => false);
+    message_lists.current = {};
+    $compose_reply_wrapper.removeAttr("data-stream-id");
+    $compose_reply_wrapper.attr("data-user-ids-string", "2");
+    compose_closed_ui.update_reply_button_state();
+    assert.equal($reply_button.attr("disabled"), "disabled");
+    assert.equal($compose_reply_wrapper.attr("data-reply-button-type"), "direct_disabled");
+
+    // Resetting to the standard text must clear the recipient context along
+    // with the stale button type and disabled state, so the hover tooltip
+    // never sees "direct_disabled" without a data-user-ids-string attribute.
+    compose_closed_ui.set_standard_text_for_reply_button();
+    assert.equal($("#left_bar_compose_reply_button_big").text(), "translated: Compose message");
+    assert.equal($compose_reply_wrapper.attr("data-user-ids-string"), undefined);
+    assert.equal($compose_reply_wrapper.attr("data-reply-button-type"), undefined);
+    assert.notEqual($reply_button.attr("disabled"), "disabled");
 });

--- a/web/tests/compose_closed_ui.test.cjs
+++ b/web/tests/compose_closed_ui.test.cjs
@@ -204,7 +204,7 @@ run_test("reply_label", ({mock_template}) => {
 
 run_test("empty_narrow", () => {
     message_lists.current.visibly_empty = () => true;
-    compose_closed_ui.update_recipient_text_for_reply_button();
+    compose_closed_ui.update_reply_button_with_recipient_context();
     const label = $("#left_bar_compose_reply_button_big").text();
     assert.equal(label, "translated: Compose message");
 });
@@ -225,21 +225,21 @@ run_test("test_non_message_list_input", ({mock_template}) => {
     stream_data.add_sub_for_tests(stream);
 
     // Channel and topic row.
-    compose_closed_ui.update_recipient_text_for_reply_button({
+    compose_closed_ui.update_reply_button_with_recipient_context({
         stream_id: stream.stream_id,
         topic: "topic test",
     });
     test_reply_label("<rendered-channel-stub:stream test> &gt; topic test");
 
     // Direct message conversation with current user row.
-    compose_closed_ui.update_recipient_text_for_reply_button({
+    compose_closed_ui.update_reply_button_with_recipient_context({
         user_ids: [current_user.user_id],
     });
     let label = $("#left_bar_compose_reply_button_big").html();
     assert.equal(label, "translated: Write yourself a note");
 
     // Invalid data for a the reply button text.
-    compose_closed_ui.update_recipient_text_for_reply_button({
+    compose_closed_ui.update_reply_button_with_recipient_context({
         invalid_field: "something unexpected",
     });
     label = $("#left_bar_compose_reply_button_big").text();

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -189,6 +189,7 @@ test("basics", () => {
     assert.ok(!filter.is_keyword_search());
     assert.ok(!filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.allow_use_first_unread_when_narrowing());
     assert.ok(filter.includes_full_stream_history());
@@ -239,6 +240,7 @@ test("basics", () => {
     assert.ok(!filter.is_keyword_search());
     assert.ok(!filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.allow_use_first_unread_when_narrowing());
     assert.ok(filter.includes_full_stream_history());
@@ -259,6 +261,7 @@ test("basics", () => {
     assert.ok(filter.is_keyword_search());
     assert.ok(!filter.can_mark_messages_read());
     assert.ok(!filter.contains_no_partial_conversations());
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.allow_use_first_unread_when_narrowing());
     assert.ok(!filter.can_apply_locally());
@@ -280,6 +283,7 @@ test("basics", () => {
     assert.ok(!filter.is_keyword_search());
     assert.ok(filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.allow_use_first_unread_when_narrowing());
     assert.ok(filter.can_apply_locally());
@@ -299,6 +303,7 @@ test("basics", () => {
     // want to have the channel in the tab bar or unsubscribe messaging, etc.
     terms = [{operator: "channel", operand: invalid_sub_id.toString(), negated: true}];
     filter = new Filter(terms);
+    assert.ok(filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.has_operator("channel"));
     assert.ok(!filter.can_mark_messages_read());
@@ -314,6 +319,7 @@ test("basics", () => {
     // be false, and we want "Search results" in the tab bar.
     terms = [{operator: "search", operand: "stop_word", negated: true}];
     filter = new Filter(terms);
+    assert.ok(filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(filter.has_operator("search"));
     assert.ok(!filter.can_apply_locally());
@@ -344,6 +350,7 @@ test("basics", () => {
 
     terms = [{operator: "channels", operand: "public", negated: true}];
     filter = new Filter(terms);
+    assert.ok(filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.has_operator("channels"));
     assert.ok(!filter.can_mark_messages_read());
@@ -358,6 +365,7 @@ test("basics", () => {
 
     terms = [{operator: "channels", operand: "public"}];
     filter = new Filter(terms);
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(filter.has_operator("channels"));
     assert.ok(!filter.can_mark_messages_read());
@@ -410,6 +418,7 @@ test("basics", () => {
 
     terms = [{operator: "is", operand: "dm"}];
     filter = new Filter(terms);
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(filter.contains_only_private_messages());
     assert.ok(filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
@@ -425,6 +434,7 @@ test("basics", () => {
 
     terms = [{operator: "is", operand: "dm", negated: true}];
     filter = new Filter(terms);
+    assert.ok(filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
@@ -450,6 +460,7 @@ test("basics", () => {
 
     terms = [{operator: "is", operand: "mentioned"}];
     filter = new Filter(terms);
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.can_mark_messages_read());
     assert.ok(!filter.contains_no_partial_conversations());
@@ -465,6 +476,7 @@ test("basics", () => {
 
     terms = [{operator: "is", operand: "starred"}];
     filter = new Filter(terms);
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.can_mark_messages_read());
     assert.ok(!filter.contains_no_partial_conversations());
@@ -479,6 +491,7 @@ test("basics", () => {
     terms = [{operator: "dm", operand: [joe.user_id]}];
     filter = new Filter(terms);
     assert.ok(filter.is_search_for_specific_group_or_user());
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(filter.contains_only_private_messages());
     assert.ok(filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
@@ -497,6 +510,7 @@ test("basics", () => {
     ];
     filter = new Filter(terms);
     assert.ok(filter.is_search_for_specific_group_or_user());
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(filter.contains_only_private_messages());
     assert.ok(filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
@@ -512,6 +526,7 @@ test("basics", () => {
     terms = [{operator: "dm", operand: [joe.user_id, steve.user_id]}];
     filter = new Filter(terms);
     assert.ok(filter.is_search_for_specific_group_or_user());
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(filter.contains_only_private_messages());
     assert.ok(filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
@@ -528,6 +543,7 @@ test("basics", () => {
         {operator: "with", operand: "12"},
     ];
     filter = new Filter(terms);
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(filter.contains_only_private_messages());
     assert.ok(filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
@@ -550,6 +566,7 @@ test("basics", () => {
     terms = [{operator: "dm-including", operand: [joe.user_id]}];
     filter = new Filter(terms);
     assert.ok(filter.is_search_for_specific_group_or_user());
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(filter.contains_only_private_messages());
     assert.ok(!filter.has_operator("search"));
     assert.ok(!filter.can_mark_messages_read());
@@ -571,6 +588,7 @@ test("basics", () => {
 
     terms = [{operator: "is", operand: "resolved"}];
     filter = new Filter(terms);
+    assert.ok(filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.has_operator("search"));
     assert.ok(filter.can_mark_messages_read());
@@ -595,6 +613,7 @@ test("basics", () => {
         {operator: "in", operand: "all"},
     ];
     filter = new Filter(terms);
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.has_operator("search"));
     assert.ok(!filter.can_mark_messages_read());
@@ -617,6 +636,7 @@ test("basics", () => {
     assert.ok(!filter.is_keyword_search());
     assert.ok(filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(filter.allow_use_first_unread_when_narrowing());
     assert.ok(filter.includes_full_stream_history());
@@ -638,6 +658,7 @@ test("basics", () => {
     assert.ok(!filter.is_keyword_search());
     assert.ok(filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(filter.allow_use_first_unread_when_narrowing());
     assert.ok(filter.includes_full_stream_history());
@@ -660,6 +681,7 @@ test("basics", () => {
     assert.ok(!filter.is_keyword_search());
     assert.ok(filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(filter.allow_use_first_unread_when_narrowing());
     assert.ok(filter.includes_full_stream_history());
@@ -679,6 +701,7 @@ test("basics", () => {
     assert.ok(!filter.is_keyword_search());
     assert.ok(!filter.can_mark_messages_read());
     assert.ok(filter.contains_no_partial_conversations());
+    assert.ok(!filter.may_have_incomplete_message_history());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.allow_use_first_unread_when_narrowing());
     assert.ok(filter.includes_full_stream_history());

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -61,12 +61,13 @@ mock_esm("../src/spectators", {
     login_to_access() {},
 });
 
-function empty_narrow_html(title, title_html, notice_html, search_data) {
+function empty_narrow_html(title, title_html, notice_html, search_data, show_action) {
     const opts = {
         title,
         title_html,
         notice_html,
         search_data,
+        show_action,
     };
     return require("../templates/empty_feed_notice.hbs")(opts);
 }
@@ -148,6 +149,42 @@ run_test("empty_narrow_html", ({mock_template}) => {
             <h1> This is the html </h1>
         </div>
     </div>
+`,
+    );
+
+    // Title, html and action
+    actual_html = empty_narrow_html(
+        "This is a title",
+        undefined,
+        "<h1> This is the html </h1>",
+        undefined,
+        true,
+    );
+    assert.equal(
+        actual_html,
+        `<div class="empty_feed_notice">
+    <h4 class="empty-feed-notice-title"> This is a title </h4>
+        <div class="empty-feed-notice-description">
+            <h1> This is the html </h1>
+        </div>
+        <div class="empty-feed-notice-action">
+        <button
+          class="search-shared-history hidden-for-spectators action-button action-button-subtle-neutral"
+          type="button">
+            translated: Search all public channels
+        </button>
+    </div>
+</div>
+`,
+    );
+
+    // title_html
+    actual_html = empty_narrow_html("Plain text title", "<h1> This is the title html </h1>");
+    assert.equal(
+        actual_html,
+        `<div class="empty_feed_notice">
+    <h4 class="empty-feed-notice-title"> <h1> This is the title html </h1> </h4>
+</div>
 `,
     );
 
@@ -406,6 +443,9 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         empty_narrow_html(
             undefined,
             `translated: No topics in <a href="/help/search-for-messages#search-shared-history" target="_blank" rel="noopener noreferrer">your history</a> are marked as resolved.`,
+            undefined,
+            undefined,
+            true,
         ),
     );
 
@@ -605,7 +645,13 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: You haven't received any messages sent by Raymond yet."),
+        empty_narrow_html(
+            "translated: You haven't received any messages sent by Raymond yet.",
+            undefined,
+            undefined,
+            undefined,
+            true,
+        ),
     );
 
     current_filter = set_filter([["sender", 9999]]);
@@ -634,6 +680,9 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         empty_narrow_html(
             "translated: No messages in your message history mention Alice Smith yet.",
             'translated: No messages in <a href="/help/search-for-messages#search-shared-history" target="_blank" rel="noopener noreferrer">your message history</a> mention Alice Smith yet.',
+            undefined,
+            undefined,
+            true,
         ),
     );
 
@@ -712,6 +761,9 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         empty_narrow_html(
             undefined,
             `translated: No search results from <a href="/help/search-for-messages#search-shared-history" target="_blank" rel="noopener noreferrer">your message history</a>.`,
+            undefined,
+            undefined,
+            true,
         ),
     );
     current_filter = set_filter([
@@ -766,7 +818,13 @@ run_test("show_empty_narrow_message_with_search", ({mock_template, override}) =>
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No search results."),
+        empty_narrow_html(
+            undefined,
+            `translated: No search results from <a href="/help/search-for-messages#search-shared-history" target="_blank" rel="noopener noreferrer">your message history</a>.`,
+            undefined,
+            undefined,
+            true,
+        ),
     );
 });
 
@@ -793,10 +851,11 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: No search results.",
             undefined,
+            `translated: No search results from <a href="/help/search-for-messages#search-shared-history" target="_blank" rel="noopener noreferrer">your message history</a>.`,
             undefined,
             expected_search_data,
+            true,
         ),
     );
 

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -403,7 +403,10 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No topics are marked as resolved."),
+        empty_narrow_html(
+            undefined,
+            `translated: No topics in <a href="/help/search-for-messages#search-shared-history" target="_blank" rel="noopener noreferrer">your history</a> are marked as resolved.`,
+        ),
     );
 
     current_filter = set_filter([["is", "followed"]]);

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -419,6 +419,16 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: You have no messages in muted topics and channels."),
     );
+
+    current_filter = set_filter([["is", "alerted"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html(
+            undefined,
+            `translated: No search results from <a href="/help/search-for-messages#search-shared-history" target="_blank" rel="noopener noreferrer">your message history</a>.`,
+        ),
+    );
     // organization has disabled sending direct messages
     override(realm, "realm_direct_message_permission_group", nobody.id);
 

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -61,7 +61,7 @@ mock_esm("../src/spectators", {
     login_to_access() {},
 });
 
-function empty_narrow_html(title, notice_html, search_data, title_html) {
+function empty_narrow_html(title, title_html, notice_html, search_data) {
     const opts = {
         title,
         title_html,
@@ -134,7 +134,12 @@ run_test("empty_narrow_html", ({mock_template}) => {
     );
 
     // Title and html
-    actual_html = empty_narrow_html("This is a title", "<h1> This is the html </h1>", undefined);
+    actual_html = empty_narrow_html(
+        "This is a title",
+        undefined,
+        "<h1> This is the html </h1>",
+        undefined,
+    );
     assert.equal(
         actual_html,
         `<div class="empty_feed_notice">
@@ -154,7 +159,12 @@ run_test("empty_narrow_html", ({mock_template}) => {
             {query_word: "search", is_stop_word: false},
         ],
     };
-    actual_html = empty_narrow_html("This is a title", undefined, search_data_with_stop_word);
+    actual_html = empty_narrow_html(
+        "This is a title",
+        undefined,
+        undefined,
+        search_data_with_stop_word,
+    );
     assert.equal(
         actual_html,
         `<div class="empty_feed_notice">
@@ -177,7 +187,12 @@ run_test("empty_narrow_html", ({mock_template}) => {
             {query_word: "return", is_stop_word: false},
         ],
     };
-    actual_html = empty_narrow_html("This is a title", undefined, search_data_with_stop_words);
+    actual_html = empty_narrow_html(
+        "This is a title",
+        undefined,
+        undefined,
+        search_data_with_stop_words,
+    );
     assert.equal(
         actual_html,
         `<div class="empty_feed_notice">
@@ -197,7 +212,12 @@ run_test("empty_narrow_html", ({mock_template}) => {
         has_stop_word: false,
         query_words: [{query_word: "search", is_stop_word: false}],
     };
-    actual_html = empty_narrow_html("This is a title", undefined, search_data_without_stop_words);
+    actual_html = empty_narrow_html(
+        "This is a title",
+        undefined,
+        undefined,
+        search_data_without_stop_words,
+    );
     assert.equal(
         actual_html,
         `<div class="empty_feed_notice">
@@ -246,6 +266,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: There are no messages in your combined feed.",
+            undefined,
             'translated: Would you like to <a href="#narrow/channels/public">view messages in all public channels</a>?',
         ),
     );
@@ -284,6 +305,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: There are no messages here.",
+            undefined,
             'translated: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
         ),
     );
@@ -296,6 +318,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "",
+            undefined,
             'translated: This is not a <a target="_blank" rel="noopener noreferrer" href="/help/public-access-option">publicly accessible</a> conversation.',
         ),
     );
@@ -309,6 +332,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "",
+            undefined,
             'translated: This is not a <a target="_blank" rel="noopener noreferrer" href="/help/public-access-option">publicly accessible</a> conversation.',
         ),
     );
@@ -339,6 +363,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: You have no starred messages.",
+            undefined,
             'translated: Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, hover over a message and click the <i class="zulip-icon zulip-icon-star" aria-hidden="true"></i>. <a target="_blank" rel="noopener noreferrer" href="/help/star-a-message">Learn more</a>',
         ),
     );
@@ -349,6 +374,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: This view will show messages where you are mentioned.",
+            undefined,
             'translated: To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a channel. Type @ in the compose box, and choose who you\'d like to mention from the list of suggestions. <a target="_blank" rel="noopener noreferrer" href="/help/mention-a-user-or-group">Learn more</a>',
         ),
     );
@@ -361,6 +387,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: You have no direct messages yet!",
+            undefined,
             'translated: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
@@ -416,6 +443,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: Direct messages are disabled in this organization.",
+            undefined,
             'translated: <a target="_blank" rel="noopener noreferrer" href="/help/restrict-direct-messages">Learn more.</a>',
         ),
     );
@@ -429,6 +457,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: You have no direct messages with Example Bot yet.",
+            undefined,
             'translated: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
@@ -441,6 +470,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: Direct messages are disabled in this organization.",
+            undefined,
             'translated: <a target="_blank" rel="noopener noreferrer" href="/help/restrict-direct-messages">Learn more.</a>',
         ),
     );
@@ -453,6 +483,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: You have no direct messages with Alice Smith yet.",
+            undefined,
             'translated: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
@@ -476,6 +507,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: You haven't sent yourself any notes yet!",
+            undefined,
             "translated: Use this space for personal notes, or to test out Zulip features.",
         ),
     );
@@ -486,6 +518,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: You have no direct messages with these users yet.",
+            undefined,
             'translated: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
@@ -524,6 +557,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: Direct messages are disabled in this organization.",
+            undefined,
             'translated: <a target="_blank" rel="noopener noreferrer" href="/help/restrict-direct-messages">Learn more.</a>',
         ),
     );
@@ -586,8 +620,6 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: No messages in your message history mention Alice Smith yet.",
-            undefined,
-            undefined,
             'translated: No messages in <a href="/help/search-for-messages#search-shared-history" target="_blank" rel="noopener noreferrer">your message history</a> mention Alice Smith yet.',
         ),
     );
@@ -605,6 +637,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: There are no messages here.",
+            undefined,
             'translated: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
         ),
     );
@@ -634,6 +667,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: You have muted all the topics in this channel.",
+            undefined,
             'translated: To view a muted topic, click <b>show all topics</b> in the left sidebar, and select one from the list. <a target="_blank" rel="noopener noreferrer" href="/help/mute-a-topic">Learn more</a>',
         ),
     );
@@ -644,6 +678,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: There are no messages here.",
+            undefined,
             'translated: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
         ),
     );
@@ -657,6 +692,15 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         ),
     );
 
+    current_filter = set_filter([["has", "images"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html(
+            undefined,
+            `translated: No search results from <a href="/help/search-for-messages#search-shared-history" target="_blank" rel="noopener noreferrer">your message history</a>.`,
+        ),
+    );
     current_filter = set_filter([
         ["has", "reaction"],
         ["sender", me.user_id],
@@ -666,6 +710,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: None of your messages have emoji reactions yet.",
+            undefined,
             'translated: Learn more about emoji reactions <a target="_blank" rel="noopener noreferrer" href="/help/emoji-reactions">here</a>.',
         ),
     );
@@ -734,7 +779,12 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No search results.", undefined, expected_search_data),
+        empty_narrow_html(
+            "translated: No search results.",
+            undefined,
+            undefined,
+            expected_search_data,
+        ),
     );
 
     const streamA_id = 88;
@@ -746,7 +796,12 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No search results.", undefined, expected_search_data),
+        empty_narrow_html(
+            "translated: No search results.",
+            undefined,
+            undefined,
+            expected_search_data,
+        ),
     );
 
     current_filter = set_filter([
@@ -757,7 +812,12 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No search results.", undefined, expected_search_data),
+        empty_narrow_html(
+            "translated: No search results.",
+            undefined,
+            undefined,
+            expected_search_data,
+        ),
     );
 });
 
@@ -778,6 +838,7 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: No search results.",
+            undefined,
             "translated: <p>You are searching for messages that belong to more than one channel, which is not possible.</p>",
         ),
     );
@@ -791,6 +852,7 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: No search results.",
+            undefined,
             "translated: <p>You are searching for messages that belong to more than one topic, which is not possible.</p>",
         ),
     );
@@ -807,6 +869,7 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: No search results.",
+            undefined,
             "translated: <p>You are searching for messages that are sent by more than one person, which is not possible.</p>",
         ),
     );


### PR DESCRIPTION
This fixes the wrong compose tooltip when compose is disabled. Disables compose reply button in non message list view.

This PR also changes top notice/narrow banner in:

## No search results
- Removes top of feed notice
- adds `Search all public channels` button with same href as top feed text link.

## Search results
- At the top of the message feed, when message feed notice is shown, removes `!` icon, background/border and changes text to 
> End of results from [your message history](https://github.com/help/search-for-messages#searching-shared-history).`
- Adds `Search all public channels` button aligned right

## Combined feed
At the top of the combined feed
- Adds notice text aligned left
- adds `View all messages in public channels` button to `#narrow/channels/public` aligned right

<details>
<summary>Commit description</summary>

Commit 1-7:

Refactors how the closed compose reply button tracks and updates its recipient context, label, and disabled state. Previously, the reply button label and compose permission state were derived through separate code paths. The label was updated from `recipient_information` passed to `get_recipient_label`(handling various other cases) by callers, while the disabled state was calculated with the reply target from the selected message or current narrow state only. This made compose disabled state to not work for inbox view and recent conversation view. Now, we store recipient metadata from `RecipientLabel` in reply button element wrapper and use it to compute disabled state.

Commit 8: We can now disable and update tooltip for compose button in recent view/inbox view using this metadata.

commit 9-10: Simple refactor into object.

Commit 11-14: Banner text html for some narrows.

Commit 16-18:

Redesign top of feed notice, empty narrow banner and make them mutually exclusive.

</details>


Fixes: zulip#33287
Fixes: zulip#32597

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Feed notice screenshots</summary>

|Before|After|
|-|-|
|`No search results`||
|<img width="929" height="254" alt="image" src="https://github.com/user-attachments/assets/27c5334f-c407-4010-9e96-3a284f03ebf4" />|<img width="906" height="404" alt="image" src="https://github.com/user-attachments/assets/1b474a02-6ca6-43dc-ba05-1c37ba58b398" />|
|`Top of search results`||
|<img width="940" height="233" alt="image" src="https://github.com/user-attachments/assets/f236e03c-1a59-4772-a639-835debbe85aa" />|<img width="936" height="436" alt="image" src="https://github.com/user-attachments/assets/b7965b66-bc28-4368-b19e-483572716de6" />|
||<img width="555" height="436" alt="image" src="https://github.com/user-attachments/assets/affdd767-d693-4159-81d8-b7a174789d63" />|
|`Top of combined feed`||
|<img width="940" height="184" alt="image" src="https://github.com/user-attachments/assets/ed780309-2507-463a-8899-7733a5970c4c" />|<img width="937" height="204" alt="image" src="https://github.com/user-attachments/assets/0393b5d2-ad05-422d-bfdf-25497c6b2a1b" />|
||<img width="495" height="254" alt="image" src="https://github.com/user-attachments/assets/9e787f91-864c-41d7-a258-f87b023517c3" />|


|Before|After|
|-|-|
|`has:`||
|<img width="929" height="254" alt="image" src="https://github.com/user-attachments/assets/7b646aa3-da49-46af-8152-48b588733c2f" />|<img width="938" height="300" alt="image" src="https://github.com/user-attachments/assets/c34bcf39-12eb-42e0-ab15-6e0b1ba16648" />|
|`sender:`||
|<img width="929" height="254" alt="image" src="https://github.com/user-attachments/assets/01af3040-caae-4f5c-ae44-d6b59f6cac1c" />|<img width="584" height="254" alt="image" src="https://github.com/user-attachments/assets/ab944fe9-f02d-4eab-ba81-217312148cad" />|
|`is:resolved`||
|<img width="929" height="254" alt="image" src="https://github.com/user-attachments/assets/50f4056c-bd8b-4df1-aba1-df85d68f0195" />|<img width="929" height="297" alt="image" src="https://github.com/user-attachments/assets/4b7637f7-72e7-4f7e-8d37-31e82a00c94d" />|
</details>

<details>
<summary>Compose reply button screenshot</summary>

|Before|After|
|-|-|
|<img width="934" height="626" alt="image" src="https://github.com/user-attachments/assets/6c78e76e-fb26-4a3a-a2c3-e374168345c2" />|<img width="934" height="626" alt="Screenshot from 2026-03-23 22-18-57" src="https://github.com/user-attachments/assets/7546008b-20c1-45e7-b163-5df8a264a680" />|
|<img width="754" height="399" alt="image" src="https://github.com/user-attachments/assets/86e7f1dd-ab1f-4409-a70d-c38bf773b166" />|<img width="754" height="399" alt="image" src="https://github.com/user-attachments/assets/5fab5330-0eb6-4fba-99e7-9fc63fc78d33" />|
|<img width="754" height="399" alt="image" src="https://github.com/user-attachments/assets/946ff3ac-899c-48e5-80b6-471f8f14dfcd" />|<img width="754" height="399" alt="image" src="https://github.com/user-attachments/assets/ffc6ae89-196e-478c-8120-34938bae0a7e" />|
|<img width="754" height="399" alt="image" src="https://github.com/user-attachments/assets/a962d0ef-d509-4e8b-831a-ef68a4e92db5" />|<img width="754" height="399" alt="image" src="https://github.com/user-attachments/assets/5ddaa639-ebec-4c76-8f55-c6ca026533ae" />|
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
