### PR TITLE
bot_settings: Add status based filter in SETTINGS/BOTS.

### DIFF
--- a/web/src/admin.ts
+++ b/web/src/admin.ts
@@ -258,6 +258,7 @@ export function build_page(): void {
             settings_users.deactivated_user_list_dropdown_widget_name,
         giphy_help_link,
         ...get_realm_level_notification_settings(),
+        all_bots_list_dropdown_widget_name: settings_users.all_bots_list_dropdown_widget_name,
         group_setting_labels: settings_config.all_group_setting_labels.realm,
         server_can_summarize_topics: realm.server_can_summarize_topics,
         is_plan_self_hosted:

--- a/web/src/settings_users.ts
+++ b/web/src/settings_users.ts
@@ -31,6 +31,7 @@ import * as util from "./util.ts";
 
 export const active_user_list_dropdown_widget_name = "active_user_list_select_user_role";
 export const deactivated_user_list_dropdown_widget_name = "deactivated_user_list_select_user_role";
+export const all_bots_list_dropdown_widget_name = "all_bots_list_select_bot_status";
 
 let should_redraw_active_users_list = false;
 let should_redraw_deactivated_users_list = false;
@@ -47,6 +48,17 @@ type UserSettingsSection = {
     handle_events: () => void;
     create_table: (active_users: number[]) => void;
     list_widget: ListWidgetType<number, User> | undefined;
+};
+
+type BotSettingsSection = {
+    dropdown_widget_name: string;
+    filters: {
+        text_search: string;
+        status_code: number;
+    };
+    handle_events: () => void;
+    create_table: () => void;
+    list_widget: ListWidgetType<number, BotInfo> | undefined;
 };
 
 const active_section: UserSettingsSection = {
@@ -73,9 +85,16 @@ const deactivated_section: UserSettingsSection = {
     list_widget: undefined,
 };
 
-const bots_section = {
+const bots_section: BotSettingsSection = {
+    dropdown_widget_name: all_bots_list_dropdown_widget_name,
+    filters: {
+        text_search: "",
+        // 0 status_code signifies Active status for our filter.
+        status_code: 0,
+    },
     handle_events: bots_handle_events,
     create_table: bots_create_table,
+    list_widget: undefined,
 };
 
 function sort_bot_email(a: BotInfo, b: BotInfo): number {
@@ -188,16 +207,19 @@ export function update_view_on_reactivate(user_id: number, is_bot: boolean): voi
 }
 
 function add_value_to_filters(
-    section: UserSettingsSection,
-    key: "role_code" | "text_search",
+    section: UserSettingsSection | BotSettingsSection,
+    key: "role_code" | "status_code" | "text_search",
     value: number | string,
 ): void {
-    if (key === "role_code") {
+    if (key === "role_code" && "role_code" in section.filters) {
         assert(typeof value === "number");
-        section.filters[key] = value;
+        section.filters.role_code = value;
+    } else if (key === "status_code" && "status_code" in section.filters) {
+        assert(typeof value === "number");
+        section.filters.status_code = value;
     } else {
         assert(typeof value === "string");
-        section.filters[key] = value;
+        section.filters.text_search = value;
     }
     // This hard_redraw will rerun the relevant predicate function
     // and in turn apply the new filters.
@@ -219,6 +241,21 @@ function role_selected_handler(
     } else if (widget.widget_name === deactivated_section.dropdown_widget_name) {
         add_value_to_filters(deactivated_section, "role_code", role_code);
     }
+
+    dropdown.hide();
+    widget.render();
+}
+
+function status_selected_handler(
+    event: JQuery.ClickEvent,
+    dropdown: tippy.Instance,
+    widget: dropdown_widget.DropdownWidget,
+): void {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const status_code = Number($(event.currentTarget).attr("data-unique-id"));
+    add_value_to_filters(bots_section, "status_code", status_code);
 
     dropdown.hide();
     widget.render();
@@ -305,6 +342,30 @@ function initialize_user_sections(active_user_ids: number[], deactivated_user_id
     deactivated_users_role_dropdown.setup();
 }
 
+function get_bot_status(): {unique_id: number; name: string}[] {
+    return [
+        {unique_id: 0, name: $t({defaultMessage: "Active"})},
+        {unique_id: 1, name: $t({defaultMessage: "Deactivated"})},
+    ];
+}
+
+function create_status_filter_dropdown(
+    $events_container: JQuery,
+    section: BotSettingsSection,
+): void {
+    new dropdown_widget.DropdownWidget({
+        widget_name: section.dropdown_widget_name,
+        unique_id_type: "number",
+        get_options: get_bot_status,
+        $events_container,
+        item_click_callback: status_selected_handler,
+        default_id: section.filters.status_code,
+        tippy_props: {
+            offset: [0, 0],
+        },
+    }).setup();
+}
+
 function populate_users(): void {
     const active_user_ids = people.get_realm_active_human_user_ids();
     const deactivated_user_ids = people.get_non_active_human_ids();
@@ -344,6 +405,7 @@ function bot_owner_full_name(owner_id: number | null): string | undefined {
 type BotInfo = {
     is_bot: boolean;
     role: number;
+    status_code: number;
     is_active: boolean;
     user_id: number;
     full_name: string;
@@ -379,6 +441,7 @@ function bot_info(bot_user_id: number): BotInfo {
         is_bot: true,
         role: bot_user.role,
         is_active: people.is_person_active(bot_user.user_id),
+        status_code: people.is_person_active(bot_user.user_id) ? 0 : 1,
         user_id: bot_user.user_id,
         full_name: bot_user.full_name,
         user_role_text: people.get_user_type(bot_user_id),
@@ -461,10 +524,8 @@ function human_info(person: User): {
 }
 
 function set_text_search_value($table: JQuery, value: string): void {
-    $table.closest(".user-settings-section").find(".search").val(value);
+    $table.find<HTMLInputElement>(".search").val(value);
 }
-
-let bot_list_widget: ListWidgetType<number, BotInfo>;
 
 function bots_create_table(): void {
     loading.make_indicator($("#admin_page_bots_loading_indicator"), {
@@ -474,18 +535,24 @@ function bots_create_table(): void {
     $bots_table.hide();
     const bot_user_ids = people.get_bot_ids();
 
-    bot_list_widget = ListWidget.create($bots_table, bot_user_ids, {
+    bots_section.list_widget = ListWidget.create($bots_table, bot_user_ids, {
         name: "admin_bot_list",
         get_item: bot_info,
         modifier_html: render_settings_user_list_row,
         html_selector: (item) => $(`tr[data-user-id='${CSS.escape(item.user_id.toString())}']`),
         filter: {
             $element: $bots_table.closest(".settings-section").find(".search"),
-            predicate(item, value) {
-                return (
-                    item.full_name.toLowerCase().includes(value) ||
-                    item.display_email.toLowerCase().includes(value)
-                );
+            predicate(item) {
+                if (!item) {
+                    return false;
+                }
+                const search_query = bots_section.filters.text_search.toLowerCase();
+                const filter_searches =
+                    item.full_name.toLowerCase().includes(search_query) ||
+                    item.display_email.toLowerCase().includes(search_query);
+
+                const filter_status = item.status_code === bots_section.filters.status_code;
+                return filter_searches && filter_status;
             },
             onupdate: reset_scrollbar($bots_table),
         },
@@ -499,6 +566,8 @@ function bots_create_table(): void {
         },
         $simplebar_container: $("#admin-bot-list .progressive-table-wrapper"),
     });
+    const $table = $bots_table.closest(".bot-settings-section");
+    set_text_search_value($table, bots_section.filters.text_search);
 
     loading.destroy_indicator($("#admin_page_bots_loading_indicator"));
     $bots_table.show();
@@ -533,12 +602,24 @@ function active_create_table(active_users: number[]): void {
         $simplebar_container: $("#admin-active-users-list .progressive-table-wrapper"),
     });
     loading.destroy_indicator($("#admin_page_users_loading_indicator"));
-    set_text_search_value($users_table, active_section.filters.text_search);
+    const $table = $users_table.closest(".user-settings-section");
+    set_text_search_value($table, active_section.filters.text_search);
     $("#admin_users_table").show();
 }
 
 function handle_clear_button_for_users($tbody: JQuery): void {
     const $container = $tbody.closest(".user-settings-section");
+    $container.on("click", ".clear-filter", (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        const $filter = $container.find(".search");
+        set_text_search_value($tbody, "");
+        $filter.trigger("input");
+    });
+}
+
+function handle_clear_button_for_bots($tbody: JQuery): void {
+    const $container = $tbody.closest(".bot-settings-section");
     $container.on("click", ".clear-filter", (e) => {
         e.stopPropagation();
         e.preventDefault();
@@ -583,16 +664,17 @@ function deactivated_create_table(deactivated_users: number[]): void {
         },
     );
     loading.destroy_indicator($("#admin_page_deactivated_users_loading_indicator"));
-    set_text_search_value($deactivated_users_table, deactivated_section.filters.text_search);
+    const $table = $deactivated_users_table.closest(".user-settings-section");
+    set_text_search_value($table, deactivated_section.filters.text_search);
     $("#admin_deactivated_users_table").show();
 }
 
 export function update_bot_data(bot_user_id: number): void {
-    if (!bot_list_widget) {
+    if (!bots_section.list_widget) {
         return;
     }
 
-    bot_list_widget.render_item(bot_info(bot_user_id));
+    bots_section.list_widget.render_item(bot_info(bot_user_id));
 }
 
 export function update_user_data(
@@ -619,15 +701,15 @@ export function update_user_data(
 }
 
 export function redraw_bots_list(): void {
-    if (!bot_list_widget) {
+    if (!bots_section.list_widget) {
         return;
     }
 
     // In order to properly redraw after a user may have been added,
-    // we need to update the bot_list_widget with the new set of bot
+    // we need to update the bots_section.list_widget with the new set of bot
     // user IDs to display.
     const bot_user_ids = people.get_bot_ids();
-    bot_list_widget.replace_list_data(bot_user_ids);
+    bots_section.list_widget.replace_list_data(bot_user_ids);
 }
 
 function redraw_users_list(user_section: UserSettingsSection, user_list: number[]): void {
@@ -760,13 +842,11 @@ function handle_edit_form($tbody: JQuery): void {
     });
 }
 
-function handle_filter_change($tbody: JQuery, section: UserSettingsSection): void {
-    // This duplicates the built-in search filter live-update logic in
-    // ListWidget for the input.list_widget_filter event type, but we
-    // can't use that, because we're also filtering on Role with our
-    // custom predicate.
-    $tbody
-        .closest(".user-settings-section")
+function handle_filter_change(
+    $section: JQuery,
+    section: UserSettingsSection | BotSettingsSection,
+): void {
+    $section
         .find<HTMLInputElement>(".search")
         .on("input.list_widget_filter", function (this: HTMLInputElement) {
             add_value_to_filters(section, "text_search", this.value.toLocaleLowerCase());
@@ -775,8 +855,9 @@ function handle_filter_change($tbody: JQuery, section: UserSettingsSection): voi
 
 function active_handle_events(): void {
     const $tbody = $("#admin_users_table").expectOne();
+    const $section = $tbody.closest(".user-settings-section");
 
-    handle_filter_change($tbody, active_section);
+    handle_filter_change($section, active_section);
     handle_deactivation($tbody);
     handle_reactivation($tbody);
     handle_edit_form($tbody);
@@ -785,8 +866,9 @@ function active_handle_events(): void {
 
 function deactivated_handle_events(): void {
     const $tbody = $("#admin_deactivated_users_table").expectOne();
+    const $section = $tbody.closest(".user-settings-section");
 
-    handle_filter_change($tbody, deactivated_section);
+    handle_filter_change($section, deactivated_section);
     handle_deactivation($tbody);
     handle_reactivation($tbody);
     handle_edit_form($tbody);
@@ -795,21 +877,24 @@ function deactivated_handle_events(): void {
 
 function bots_handle_events(): void {
     const $tbody = $("#admin_bots_table").expectOne();
+    const $section = $tbody.closest(".bot-settings-section");
 
+    handle_filter_change($section, bots_section);
     handle_bot_deactivation($tbody);
     handle_reactivation($tbody);
     handle_edit_form($tbody);
+    handle_clear_button_for_bots($tbody);
 }
 
 export function set_up_humans(): void {
     start_data_load();
-    active_section.handle_events();
-    deactivated_section.handle_events();
+    active_handle_events();
+    deactivated_handle_events();
     setting_invites.set_up();
 }
 
 export function set_up_bots(): void {
-    bots_section.handle_events();
+    bots_handle_events();
     bots_section.create_table();
 
     $("#admin-bot-list .add-a-new-bot").on("click", (e) => {
@@ -817,6 +902,7 @@ export function set_up_bots(): void {
         e.stopPropagation();
         settings_bots.add_a_new_bot();
     });
+    create_status_filter_dropdown($("#admin-bot-list"), bots_section);
 }
 
 type FetchPresenceUserSettingParams = {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -2077,7 +2077,8 @@ label.preferences-radio-choice-label {
         display: inline-block;
     }
 
-    .user_filters {
+    .user_filters,
+    .bot_filters {
         display: flex;
         flex-wrap: wrap;
         margin-top: auto;

--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -1,4 +1,4 @@
-<div id="admin-bot-list" class="settings-section" data-name="bot-list-admin">
+<div id="admin-bot-list" class="settings-section bot-settings-section" data-name="bot-list-admin">
     <div class="bot-settings-tip" id="admin-bot-settings-tip">
     </div>
     <div class="clear-float"></div>
@@ -21,7 +21,10 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Bots"}}</h3>
         <div class="alert-notification" id="bot-field-status"></div>
-        {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter bots')}}
+        <div class="bot_filters">
+            {{> ../dropdown_widget widget_name=all_bots_list_dropdown_widget_name}}
+            {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter bots')}}
+        </div>
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
@@ -47,7 +50,7 @@
                 {{/if}}
             </thead>
             <tbody id="admin_bots_table" class="admin_bot_table"
-              data-empty="{{t 'There are no bots.' }}" data-search-results-empty="{{t 'No bots match your current filter.' }}"></tbody>
+              data-empty="{{t 'There is no deactivated bot.' }}" data-search-results-empty="{{t 'No bots match your current filter.' }}"></tbody>
         </table>
     </div>
     <div id="admin_page_bots_loading_indicator"></div>


### PR DESCRIPTION
**Commit 1:**

- Added a status-based filter to the Bots list in the SETTINGS/BOTS section.
- Users can now filter bots by their status (Active or Deactivated) using a dropdown menu located to the left of the "Filter bots" field.
- The default selection for the filter is set to "Active" when the panel is opened.

Fixes part of #31156.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
