### PR TITLE
Use pills in search typeahead

### DIFF
--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -209,7 +209,7 @@ async function search_tests(page: Page): Promise<void> {
     await search_and_check(
         page,
         "Verona",
-        "Channel",
+        "#Verona",
         expect_verona_stream,
         "#Verona - Zulip Dev - Zulip",
     );
@@ -217,7 +217,7 @@ async function search_tests(page: Page): Promise<void> {
     await search_and_check(
         page,
         "Cordelia",
-        "Direct",
+        "dm:",
         expect_cordelia_direct_messages,
         "Cordelia, Lear's daughter - Zulip Dev - Zulip",
     );

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -46,6 +46,11 @@ type Part =
           is_empty_string_topic: boolean;
       }
     | {
+          type: "channel";
+          prefix_for_operator: string;
+          operand: string;
+      }
+    | {
           type: "is_operator";
           verb: string;
           operand: string;
@@ -694,7 +699,7 @@ export class Filter {
 
         switch (operator) {
             case "channel":
-                return verb + "channel";
+                return verb + "messages in #";
             case "channels":
                 return verb + "channels";
             case "near":
@@ -839,7 +844,7 @@ export class Filter {
                     const stream = stream_data.get_sub_by_id_string(operand);
                     if (stream) {
                         return {
-                            type: "prefix_for_operator",
+                            type: "channel",
                             prefix_for_operator,
                             operand: stream.name,
                         };

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -1,8 +1,6 @@
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
-import render_search_list_item from "../templates/search_list_item.hbs";
-
 import {Typeahead} from "./bootstrap_typeahead.ts";
 import type {TypeaheadInputElement} from "./bootstrap_typeahead.ts";
 import {Filter} from "./filter.ts";
@@ -195,7 +193,8 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
         requireHighlight: false,
         item_html(item: string): string {
             const obj = search_map.get(item);
-            return render_search_list_item(obj);
+            assert(obj !== undefined);
+            return search_pill.generate_pills_html(obj);
         },
         // When the user starts typing new search operands,
         // we want to highlight the first typeahead row by default

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -2,6 +2,7 @@ import $ from "jquery";
 import assert from "minimalistic-assert";
 
 import render_input_pill from "../templates/input_pill.hbs";
+import render_search_list_item from "../templates/search_list_item.hbs";
 import render_search_user_pill from "../templates/search_user_pill.hbs";
 
 import {Filter} from "./filter.ts";
@@ -9,6 +10,7 @@ import * as input_pill from "./input_pill.ts";
 import type {InputPill, InputPillContainer} from "./input_pill.ts";
 import * as people from "./people.ts";
 import type {User} from "./people.ts";
+import {type Suggestion, search_term_description_html} from "./search_suggestion.ts";
 import type {NarrowTerm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as user_status from "./user_status.ts";
@@ -112,6 +114,73 @@ function on_pill_exit(
     $user_pill.remove();
 }
 
+// TODO: We're calculating `description_html` every time, even though
+// we only show it (in `generate_pills_html`) for lines with only one
+// pill. We can probably simplify things by separating out a function
+// that generates `description_html` from the information in a single
+// search pill, and remove `description_html` from the `Suggestion` type.
+export function generate_pills_html(suggestion: Suggestion): string {
+    const search_terms = Filter.parse(suggestion.search_string);
+
+    const pill_render_data = search_terms.map((term, index) => {
+        if (user_pill_operators.has(term.operator) && term.operand !== "") {
+            return search_user_pill_data_from_term(term);
+        }
+        const search_pill: SearchPill = {
+            type: "generic_operator",
+            operator: term.operator,
+            operand: term.operand,
+            negated: term.negated,
+        };
+
+        if (search_pill.operator === "topic" && search_pill.operand === "") {
+            return {
+                ...search_pill,
+                is_empty_string_topic: true,
+                sign: search_pill.negated ? "-" : "",
+                topic_display_name: util.get_final_topic_display_name(""),
+            };
+        }
+        if (search_pill.operator === "search") {
+            let description_html = search_term_description_html(search_pill);
+            // We capitalize the beginning of the suggestion line if it's text (not
+            // pills), which is only relevant for suggestions with search operators.
+            if (index === 0) {
+                const capitalized_first_letter = description_html.charAt(0).toUpperCase();
+                description_html = capitalized_first_letter + description_html.slice(1);
+            }
+            return {
+                ...search_pill,
+                description_html,
+            };
+        }
+        return {
+            ...search_pill,
+            display_value: get_search_string_from_item(search_pill),
+        };
+    });
+
+    // When there's a single pill on a suggestion line, we have space
+    // to provide help text (description_html) explaining what the
+    // operator does. When there's more than one pill we don't show it.
+    if (pill_render_data.length === 1) {
+        const render_data = util.the(pill_render_data);
+        // Don't add description html for search terms, since those "pills"
+        // are already set up to only display text and no pill. We also
+        // don't show it for any user pills.
+        if (render_data.type === "generic_operator" && render_data.operator !== "search") {
+            return render_search_list_item({
+                pills: pill_render_data,
+                description_html: suggestion.description_html,
+            });
+        }
+    }
+
+    return render_search_list_item({
+        pills: pill_render_data,
+    });
+}
+
 export function create_pills($pill_container: JQuery): SearchPillWidget {
     const pills = input_pill.create({
         $container: $pill_container,
@@ -142,6 +211,16 @@ export function create_pills($pill_container: JQuery): SearchPillWidget {
     // presses enter, we validate the input then.
     pills.createPillonPaste(() => false);
     return pills;
+}
+
+function search_user_pill_data_from_term(term: NarrowTerm): SearchUserPill {
+    const emails = term.operand.split(",");
+    const users = emails.map((email) => {
+        const person = people.get_by_email(email);
+        assert(person !== undefined);
+        return person;
+    });
+    return search_user_pill_data(users, term.operator, term.negated ?? false);
 }
 
 function search_user_pill_data(users: User[], operator: string, negated: boolean): SearchUserPill {
@@ -248,11 +327,17 @@ function get_search_operand(item: SearchPill, for_display: boolean): string {
     if (item.type === "search_user") {
         return item.users.map((user) => user.email).join(",");
     }
-    if (for_display && item.operator === "channel") {
-        return stream_data.get_valid_sub_by_id_string(item.operand).name;
-    }
-    if (for_display && item.operator === "topic") {
-        return util.get_final_topic_display_name(item.operand);
+    // When we're displaying the operand in a pill, we sometimes want to make
+    // it more human readable. We do this for channel pills (with channels
+    // specified) and topic pills only.
+    if (for_display) {
+        if (item.operator === "channel" && item.operand !== "") {
+            return stream_data.get_valid_sub_by_id_string(item.operand).name;
+        }
+        if (item.operator === "topic") {
+            return util.get_final_topic_display_name(item.operand);
+        }
+        // For all other `for_display=true` cases, we just show the default operand.
     }
     return item.operand;
 }

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -144,13 +144,8 @@ export function create_pills($pill_container: JQuery): SearchPillWidget {
     return pills;
 }
 
-function append_user_pill(
-    users: User[],
-    pill_widget: SearchPillWidget,
-    operator: string,
-    negated: boolean,
-): void {
-    const pill_data: SearchUserPill = {
+function search_user_pill_data(users: User[], operator: string, negated: boolean): SearchUserPill {
+    return {
         type: "search_user",
         operator,
         negated,
@@ -164,7 +159,15 @@ function append_user_pill(
             deactivated: !people.is_person_active(user.user_id) && !user.is_inaccessible_user,
         })),
     };
+}
 
+function append_user_pill(
+    users: User[],
+    pill_widget: SearchPillWidget,
+    operator: string,
+    negated: boolean,
+): void {
+    const pill_data = search_user_pill_data(users, operator, negated);
     pill_widget.appendValidatedData(pill_data);
     pill_widget.clear_text();
 }

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -32,7 +32,7 @@ export type SearchUserPill = {
 
 type SearchPill =
     | {
-          type: "search";
+          type: "generic_operator";
           operator: string;
           operand: string;
           negated: boolean | undefined;
@@ -51,7 +51,7 @@ export function create_item_from_search_string(search_string: string): SearchPil
         return undefined;
     }
     return {
-        type: "search",
+        type: "generic_operator",
         operator: search_term.operator,
         operand: search_term.operand,
         negated: search_term.negated,

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -703,7 +703,7 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
             },
             {
                 search_string: "is:mentioned",
-                description_html: "@-mentions",
+                description_html: "messages that mention you",
                 is_people: false,
                 incompatible_patterns: [{operator: "is", operand: "mentioned"}],
             },

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -157,10 +157,9 @@ function get_channel_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggest
     channels = typeahead_helper.sorter(query, channels, (x) => x);
 
     return channels.map((channel_name) => {
-        const prefix = "channel";
+        const prefix = "messages in #";
         const verb = last.negated ? "exclude " : "";
-        const description_html =
-            verb + prefix + " " + Handlebars.Utils.escapeExpression(channel_name);
+        const description_html = verb + prefix + Handlebars.Utils.escapeExpression(channel_name);
         const channel = stream_data.get_sub_by_name(channel_name);
         assert(channel !== undefined);
         const term = {

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -1,12 +1,10 @@
 import Handlebars from "handlebars/runtime.js";
 import assert from "minimalistic-assert";
 
-import render_user_pill from "../templates/user_pill.hbs";
-
 import {MAX_ITEMS} from "./bootstrap_typeahead.ts";
 import * as common from "./common.ts";
 import * as direct_message_group_data from "./direct_message_group_data.ts";
-import {Filter, create_user_pill_context} from "./filter.ts";
+import {Filter} from "./filter.ts";
 import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
@@ -29,19 +27,13 @@ export type UserPillItem = {
 type TermPattern = Omit<NarrowTerm, "operand"> & Partial<Pick<NarrowTerm, "operand">>;
 
 export type Suggestion = {
-    description_html: string;
+    // When there's a single pill on a suggestion line, we have space to provide
+    // help text (description_html) explaining what the operator does. If a
+    // suggestion will be parsed into multiple pills, then we don't include
+    // `description_html`.
+    description_html: string | undefined;
     search_string: string;
-} & (
-    | {
-          is_people: false;
-      }
-    | {
-          is_people: true;
-          users: {
-              user_pill_context: UserPillItem;
-          }[];
-      }
-);
+};
 
 export let max_num_of_search_results = MAX_ITEMS;
 export function rewire_max_num_of_search_results(value: typeof max_num_of_search_results): void {
@@ -50,16 +42,6 @@ export function rewire_max_num_of_search_results(value: typeof max_num_of_search
 
 function channel_matches_query(channel_name: string, q: string): boolean {
     return common.phrase_match(q, channel_name);
-}
-
-function user_pill_item(person: User): UserPillItem {
-    return {
-        id: person.user_id,
-        display_value: person.full_name,
-        has_image: true,
-        img_src: people.small_avatar_url_for_person(person),
-        should_add_guest_user_indicator: people.should_add_guest_user_indicator(person.user_id),
-    };
 }
 
 function match_criteria(terms: NarrowTerm[], criteria: TermPattern[]): boolean {
@@ -93,10 +75,6 @@ function format_as_suggestion(terms: NarrowTerm[], is_operator_suggestion = fals
     return {
         description_html: Filter.search_description_as_html(terms, is_operator_suggestion),
         search_string: Filter.unparse(terms),
-        // TODO: This isn't actually always false. We should
-        // treat terms with emails (dm, sender, etc) as `is_people`
-        // and show user pills for those.
-        is_people: false,
     };
 }
 
@@ -168,7 +146,7 @@ function get_channel_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggest
             negated: last.negated,
         };
         const search_string = Filter.unparse([term]);
-        return {description_html, search_string, is_people: false};
+        return {description_html, search_string};
     });
 }
 
@@ -247,9 +225,6 @@ function get_group_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
         }
         all_users_but_last_part.push(user);
     }
-    const user_pill_contexts = all_users_but_last_part.map((person) =>
-        create_user_pill_context(person),
-    );
 
     const person_matcher = people.build_person_matcher(last_part);
     let persons = people.filter_all_persons((person) => {
@@ -278,13 +253,9 @@ function get_group_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
             terms = [{operator: "is", operand: "dm"}, term];
         }
 
-        const all_user_pill_contexts = [...user_pill_contexts, user_pill_item(person)];
-
         return {
             description_html: prefix,
             search_string: Filter.unparse(terms),
-            is_people: true,
-            users: all_user_pill_contexts.map((user_pill_context) => ({user_pill_context})),
         };
     });
 }
@@ -386,19 +357,13 @@ function get_person_suggestions(
         return {
             description_html: prefix,
             search_string: Filter.unparse(terms),
-            is_people: true,
-            users: [
-                {
-                    user_pill_context: user_pill_item(person),
-                },
-            ],
         };
     });
 }
 
 function get_default_suggestion_line(terms: NarrowTerm[]): SuggestionLine {
     if (terms.length === 0) {
-        return [{description_html: "", search_string: "", is_people: false}];
+        return [{description_html: "", search_string: ""}];
     }
     const suggestion_line = [];
     const suggestion_strings = new Set();
@@ -578,6 +543,7 @@ function get_special_filter_suggestions(
     // suggesting negated terms.
     if (last.negated === true || is_search_operand_negated) {
         suggestions = suggestions
+            .filter((suggestion) => suggestion.search_string !== "-is:resolved")
             .map((suggestion) => {
                 // If the search_string is "is:resolved", we want to suggest "Unresolved topics"
                 // instead of "Exclude resolved topics".
@@ -587,19 +553,13 @@ function get_special_filter_suggestions(
                         search_string: "-" + suggestion.search_string,
                         description_html: "unresolved topics",
                     };
-                } else if (suggestion.search_string === "-is:resolved") {
-                    return null;
                 }
                 return {
                     ...suggestion,
                     search_string: "-" + suggestion.search_string,
                     description_html: "exclude " + suggestion.description_html,
                 };
-            })
-            .filter(
-                (suggestion): suggestion is SuggestionAndIncompatiblePatterns =>
-                    suggestion !== null,
-            );
+            });
     }
 
     const last_string = Filter.unparse([last]).toLowerCase();
@@ -619,7 +579,7 @@ function get_special_filter_suggestions(
         return (
             s.search_string.toLowerCase().startsWith(last_string) ||
             show_operator_suggestions ||
-            s.description_html.toLowerCase().startsWith(last_string)
+            s.description_html?.toLowerCase().startsWith(last_string)
         );
     });
     const filtered_suggestions = suggestions.map(({incompatible_patterns, ...s}) => s);
@@ -640,7 +600,6 @@ function get_channels_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]):
         {
             search_string,
             description_html,
-            is_people: false,
             incompatible_patterns: [
                 {operator: "is", operand: "dm"},
                 {operator: "channel"},
@@ -660,7 +619,6 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
             {
                 search_string: "is:resolved",
                 description_html: "resolved topics",
-                is_people: false,
                 incompatible_patterns: [
                     {operator: "is", operand: "resolved"},
                     {operator: "is", operand: "dm"},
@@ -671,7 +629,6 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
             {
                 search_string: "-is:resolved",
                 description_html: "unresolved topics",
-                is_people: false,
                 incompatible_patterns: [
                     {operator: "is", operand: "resolved"},
                     {operator: "is", operand: "dm"},
@@ -685,7 +642,6 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
             {
                 search_string: "is:dm",
                 description_html: "direct messages",
-                is_people: false,
                 incompatible_patterns: [
                     {operator: "is", operand: "dm"},
                     {operator: "is", operand: "resolved"},
@@ -698,19 +654,16 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
             {
                 search_string: "is:starred",
                 description_html: "starred messages",
-                is_people: false,
                 incompatible_patterns: [{operator: "is", operand: "starred"}],
             },
             {
                 search_string: "is:mentioned",
                 description_html: "messages that mention you",
-                is_people: false,
                 incompatible_patterns: [{operator: "is", operand: "mentioned"}],
             },
             {
                 search_string: "is:followed",
                 description_html: "followed topics",
-                is_people: false,
                 incompatible_patterns: [
                     {operator: "is", operand: "followed"},
                     {operator: "is", operand: "dm"},
@@ -721,19 +674,16 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
             {
                 search_string: "is:alerted",
                 description_html: "alerted messages",
-                is_people: false,
                 incompatible_patterns: [{operator: "is", operand: "alerted"}],
             },
             {
                 search_string: "is:unread",
                 description_html: "unread messages",
-                is_people: false,
                 incompatible_patterns: [{operator: "is", operand: "unread"}],
             },
             {
                 search_string: "is:muted",
                 description_html: "muted messages",
-                is_people: false,
                 incompatible_patterns: [
                     {operator: "is", operand: "muted"},
                     {operator: "in", operand: "home"},
@@ -742,7 +692,6 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
             {
                 search_string: "is:resolved",
                 description_html: "resolved topics",
-                is_people: false,
                 incompatible_patterns: [
                     {operator: "is", operand: "resolved"},
                     {operator: "is", operand: "dm"},
@@ -753,7 +702,6 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
             {
                 search_string: "-is:resolved",
                 description_html: "unresolved topics",
-                is_people: false,
                 incompatible_patterns: [
                     {operator: "is", operand: "resolved"},
                     {operator: "is", operand: "dm"},
@@ -785,25 +733,21 @@ function get_has_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugg
         {
             search_string: "has:link",
             description_html: "messages with links",
-            is_people: false,
             incompatible_patterns: [{operator: "has", operand: "link"}],
         },
         {
             search_string: "has:image",
             description_html: "messages with images",
-            is_people: false,
             incompatible_patterns: [{operator: "has", operand: "image"}],
         },
         {
             search_string: "has:attachment",
             description_html: "messages with attachments",
-            is_people: false,
             incompatible_patterns: [{operator: "has", operand: "attachment"}],
         },
         {
             search_string: "has:reaction",
             description_html: "messages with reactions",
-            is_people: false,
             incompatible_patterns: [{operator: "has", operand: "reaction"}],
         },
     ];
@@ -840,7 +784,6 @@ function get_sent_by_me_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugg
             {
                 search_string: sender_query,
                 description_html,
-                is_people: false,
             },
         ];
     }
@@ -996,33 +939,19 @@ class Attacher {
             const description_htmls = [];
             const search_strings = [];
             for (const suggestion of suggestion_line) {
-                if (suggestion.description_html !== "") {
-                    // To be able to render multiple user pills per suggestion,
-                    // we generate the user pill html here and concatenate it
-                    // together with other parts of the suggestion for the
-                    // Suggestion html.
-                    if (suggestion.is_people) {
-                        const user_pills_html = suggestion.users
-                            .map((user) => render_user_pill(user))
-                            .join(" ");
-                        description_htmls.push(suggestion.description_html + user_pills_html);
-                    } else {
-                        description_htmls.push(suggestion.description_html);
-                    }
+                if (suggestion.description_html && suggestion.description_html !== "") {
+                    description_htmls.push(suggestion.description_html);
                 }
-
                 if (suggestion.search_string !== "") {
                     search_strings.push(suggestion.search_string);
                 }
             }
             return {
-                description_html: description_htmls.join(", "),
+                // We only display description_html for suggestion lines
+                // with only one suggestion.
+                description_html:
+                    description_htmls.length === 1 ? util.the(description_htmls) : undefined,
                 search_string: search_strings.join(" "),
-                // This is a full suggestion line of multiple suggestions,
-                // some of which might be people, but people can be suggested
-                // alongside non-people, so we do the html conversion for user
-                // suggestions already by this point.
-                is_people: false,
             };
         });
     }
@@ -1087,7 +1016,6 @@ export function get_search_result(
             {
                 search_string: last.operand,
                 description_html: search_term_description_html(last),
-                is_people: false,
             },
         ];
         attacher.push([...attacher.base, ...suggestion_line]);
@@ -1180,8 +1108,10 @@ export function finalize_search_result(result: Suggestion[]): {
     lookup_table: Map<string, Suggestion>;
 } {
     for (const sug of result) {
-        const first = sug.description_html.charAt(0).toUpperCase();
-        sug.description_html = first + sug.description_html.slice(1);
+        if (sug.description_html) {
+            const first = sug.description_html.charAt(0).toUpperCase();
+            sug.description_html = first + sug.description_html.slice(1);
+        }
     }
 
     // Typeahead expects us to give it strings, not objects,

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -259,69 +259,69 @@
         &.focused .user-pill-container {
             flex-flow: row wrap;
         }
+    }
 
-        .user-pill-container {
-            gap: 2px 5px;
-            /* Don't enforce a height, as user-pill containers
-               can contain multiple user pills that wrap onto
-               new lines. */
-            height: unset;
-            border: 1px solid transparent;
+    .user-pill-container {
+        gap: 2px 5px;
+        /* Don't enforce a height, as user-pill containers
+            can contain multiple user pills that wrap onto
+            new lines. */
+        height: unset;
+        border: 1px solid transparent;
 
-            /* Not focus-visible, because we want to support mouse+backpace
-               to delete pills */
-            &:focus {
-                /* Unlike regular `.pill` this multi-user pill has a border,
-                   so we use border instead of box-shadow on focus. */
-                box-shadow: none;
-                border-color: var(--color-focus-outline-input-pill);
+        /* Not focus-visible, because we want to support mouse+backpace
+            to delete pills */
+        &:focus {
+            /* Unlike regular `.pill` this multi-user pill has a border,
+                so we use border instead of box-shadow on focus. */
+            box-shadow: none;
+            border-color: var(--color-focus-outline-input-pill);
+        }
+
+        > .pill-label {
+            min-width: fit-content;
+            white-space: nowrap;
+            width: fit-content;
+            /* Replaced by the 5px gap. */
+            margin-right: 0;
+            /* Don't inherit large line-height for user pill labels. */
+            line-height: 1.1;
+        }
+
+        .pill {
+            /* Reduce user pill height by 2px to
+                preserve an apparent border around
+                them even under `box-sizing: border-box`
+                in the area. */
+            height: calc(var(--height-input-pill) - 2px);
+            border: none;
+            /* Match border radius to image */
+            border-radius: 4px;
+            max-width: none;
+            /* Set the minimum width on the pill container;
+                this accommodates the avatar, a minimum
+                two-character username, and the closing X.
+                90px at 20px/1em */
+            min-width: 4.5em;
+            display: grid;
+            grid-template-columns:
+                var(--length-search-input-pill-image) minmax(0, 1fr)
+                var(--length-input-pill-exit);
+            align-content: center;
+            /* Don't inherit large line-height for user pills themselves, either. */
+            line-height: 1.1;
+
+            .pill-image {
+                height: var(--length-search-input-pill-image);
+                width: var(--length-search-input-pill-image);
             }
 
-            > .pill-label {
-                min-width: fit-content;
-                white-space: nowrap;
-                width: fit-content;
-                /* Replaced by the 5px gap. */
-                margin-right: 0;
-                /* Don't inherit large line-height for user pill labels. */
-                line-height: 1.1;
-            }
-
-            .pill {
-                /* Reduce user pill height by 2px to
-                   preserve an apparent border around
-                   them even under `box-sizing: border-box`
-                   in the area. */
-                height: calc(var(--height-input-pill) - 2px);
+            .pill-image-border {
                 border: none;
-                /* Match border radius to image */
-                border-radius: 4px;
-                max-width: none;
-                /* Set the minimum width on the pill container;
-                   this accommodates the avatar, a minimum
-                   two-character username, and the closing X.
-                   90px at 20px/1em */
-                min-width: 4.5em;
-                display: grid;
-                grid-template-columns:
-                    var(--length-search-input-pill-image) minmax(0, 1fr)
-                    var(--length-input-pill-exit);
-                align-content: center;
-                /* Don't inherit large line-height for user pills themselves, either. */
-                line-height: 1.1;
+            }
 
-                .pill-image {
-                    height: var(--length-search-input-pill-image);
-                    width: var(--length-search-input-pill-image);
-                }
-
-                .pill-image-border {
-                    border: none;
-                }
-
-                &:not(.deactivated-pill) {
-                    background-color: var(--color-background-user-pill);
-                }
+            &:not(.deactivated-pill) {
+                background-color: var(--color-background-user-pill);
             }
         }
     }
@@ -382,10 +382,13 @@
 
         .search_list_item {
             max-width: 100%;
+            display: flex;
+            gap: 5px;
+            align-items: center;
         }
 
         .search_list_item .pill-container {
-            margin: 1px 5px;
+            margin: 2px 0;
             /* This contains only one pill, which handles its own border */
             border: none;
             cursor: pointer;

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -4,10 +4,14 @@
         {{~this.content~}}
     {{else if (eq this.type "channel_topic")}}
         {{~#if is_empty_string_topic~}}
-        channel {{this.channel}} > <span class="empty-topic-display">{{this.topic_display_name}}</span>
+        messages in #{{this.channel}} > <span class="empty-topic-display">{{this.topic_display_name}}</span>
         {{~else~}}
-        channel {{this.channel}} > {{this.topic_display_name}}
+        messages in #{{this.channel}} > {{this.topic_display_name}}
         {{~/if~}}
+    {{else if (eq this.type "channel")}}
+        {{~!-- squash whitespace --~}}
+        {{this.prefix_for_operator}}{{this.operand}}
+        {{~!-- squash whitespace --~}}
     {{else if (eq this.type "invalid_has")}}
         {{~!-- squash whitespace --~}}
         invalid {{this.operand}} operand for has operator

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -36,7 +36,7 @@
     {{else if (eq this.type "is_operator")}}
         {{#if (eq this.operand "mentioned")}}
             {{~!-- squash whitespace --~}}
-            {{this.verb}}@-mentions
+            {{this.verb}}messages that mention you
             {{~!-- squash whitespace --~}}
         {{else if (or (eq this.operand "starred") (eq this.operand "alerted") (eq this.operand "unread"))}}
             {{~!-- squash whitespace --~}}

--- a/web/templates/search_list_item.hbs
+++ b/web/templates/search_list_item.hbs
@@ -1,10 +1,14 @@
 <div class="search_list_item">
-    <span>{{{ description_html }}}</span>
-    {{#if is_people}}
-    {{#each users}}
+    {{#each pills}}
         <span class="pill-container">
-            {{> input_pill user_pill_context}}
+            {{#if (eq this.type "search_user")}}
+                {{> search_user_pill this}}
+            {{else if (eq this.operator "search")}}
+                {{{this.description_html}}}
+            {{else}}
+                {{> input_pill this}}
+            {{/if}}
         </span>
     {{/each}}
-    {{/if}}
+    {{#if description_html}}<div class="description">{{{description_html}}}</div>{{/if}}
 </div>

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1682,7 +1682,7 @@ test("describe", ({mock_template, override}) => {
         {operator: "channel", operand: devel_id.toString()},
         {operator: "is", operand: "starred"},
     ];
-    string = "channel devel, starred messages";
+    string = "messages in #devel, starred messages";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     const river_id = new_stream_id();
@@ -1691,14 +1691,14 @@ test("describe", ({mock_template, override}) => {
         {operator: "channel", operand: river_id.toString()},
         {operator: "is", operand: "unread"},
     ];
-    string = "channel river, unread messages";
+    string = "messages in #river, unread messages";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "channel", operand: devel_id.toString()},
         {operator: "topic", operand: "JS"},
     ];
-    string = "channel devel > JS";
+    string = "messages in #devel > JS";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
@@ -1754,7 +1754,7 @@ test("describe", ({mock_template, override}) => {
         {operator: "channel", operand: devel_id.toString()},
         {operator: "topic", operand: "JS", negated: true},
     ];
-    string = "channel devel, exclude topic JS";
+    string = "messages in #devel, exclude topic JS";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
@@ -1768,28 +1768,28 @@ test("describe", ({mock_template, override}) => {
         {operator: "channel", operand: devel_id.toString()},
         {operator: "is", operand: "starred", negated: true},
     ];
-    string = "channel devel, exclude starred messages";
+    string = "messages in #devel, exclude starred messages";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "channel", operand: devel_id.toString()},
         {operator: "has", operand: "image", negated: true},
     ];
-    string = "channel devel, exclude messages with images";
+    string = "messages in #devel, exclude messages with images";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "has", operand: "abc", negated: true},
         {operator: "channel", operand: devel_id.toString()},
     ];
-    string = "invalid abc operand for has operator, channel devel";
+    string = "invalid abc operand for has operator, messages in #devel";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "has", operand: "image", negated: true},
         {operator: "channel", operand: devel_id.toString()},
     ];
-    string = "exclude messages with images, channel devel";
+    string = "exclude messages with images, messages in #devel";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [];
@@ -1801,7 +1801,7 @@ test("describe", ({mock_template, override}) => {
         {operator: "stream", operand: devel_id.toString()},
         {operator: "subject", operand: "JS", negated: true},
     ];
-    string = "channel devel, exclude topic JS";
+    string = "messages in #devel, exclude topic JS";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     // Empty string topic involved.
@@ -1810,7 +1810,8 @@ test("describe", ({mock_template, override}) => {
         {operator: "channel", operand: devel_id.toString()},
         {operator: "topic", operand: ""},
     ];
-    string = 'channel devel > <span class="empty-topic-display">translated: general chat</span>';
+    string =
+        'messages in #devel > <span class="empty-topic-display">translated: general chat</span>';
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1717,7 +1717,7 @@ test("describe", ({mock_template, override}) => {
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "is", operand: "mentioned"}];
-    string = "@-mentions";
+    string = "messages that mention you";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "is", operand: "alerted"}];

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -12,9 +12,11 @@ const people = zrequire("people");
 const search = zrequire("search");
 const search_pill = zrequire("search_pill");
 const search_suggestion = zrequire("search_suggestion");
-const {set_realm} = zrequire("state_data");
+const {set_current_user, set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 
+const current_user = {};
+set_current_user(current_user);
 const realm = {};
 set_realm(realm);
 

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -8,10 +8,15 @@ const $ = require("./lib/zjquery.cjs");
 
 const bootstrap_typeahead = mock_esm("../src/bootstrap_typeahead");
 
+const people = zrequire("people");
 const search = zrequire("search");
 const search_pill = zrequire("search_pill");
 const search_suggestion = zrequire("search_suggestion");
+const {set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
+
+const realm = {};
+set_realm(realm);
 
 function stub_pills() {
     const $pill_container = $("#searchbox-input-container.pill-container");
@@ -40,7 +45,6 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
     stub_pills();
 
     mock_template("search_list_item.hbs", true, (data, html) => {
-        assert.equal(typeof data.description_html, "string");
         if (data.is_people) {
             for (const user of data.users) {
                 assert.equal(typeof user.user_pill_context.id, "number");
@@ -117,11 +121,14 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             const source = opts.source("ver");
             assert.deepStrictEqual(source, expected_source_value);
 
-            /* Test item_html */
-            let expected_value = `<div class="search_list_item">\n    <span>Search for ver</span>\n</div>\n`;
+            /* Test highlighter */
+            let description_html = "Search for ver";
+            let expected_value = `<div class="search_list_item">\n        <span class="pill-container">\n                ${description_html}\n        </span>\n    \n</div>\n`;
             assert.equal(opts.item_html(source[0]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>Stream Verona</span>\n</div>\n`;
+            const search_string = "channel: Verona";
+            description_html = "Stream Verona";
+            expected_value = `<div class="search_list_item">\n        <span class="pill-container">\n                <div class='pill ' tabindex=0>\n    <span class="pill-label">\n        <span class="pill-value">\n            ${search_string}\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n                    </span>\n    <div class="description">${description_html}</div>\n</div>\n`;
             assert.equal(opts.item_html(source[1]), expected_value);
 
             /* Test sorter */
@@ -205,17 +212,24 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             const source = opts.source("zo");
             assert.deepStrictEqual(source, expected_source_value);
 
-            /* Test item_html */
-            let expected_value = `<div class="search_list_item">\n    <span>Search for zo</span>\n</div>\n`;
+            /* Test highlighter */
+            const description_html = "Search for zo";
+            let expected_value = `<div class="search_list_item">\n        <span class="pill-container">\n                ${description_html}\n        </span>\n    \n</div>\n`;
             assert.equal(opts.item_html(source[0]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>sent by</span>\n        <span class="pill-container">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1" />\n    <div class="pill-image-border"></div>\n    <span class="pill-label">\n        <span class="pill-value">\n            Zoe\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n        </span>\n</div>\n`;
+            people.add_active_user({
+                email: "user7@zulipdev.com",
+                user_id: 3,
+                full_name: "Zoe",
+            });
+            override(realm, "realm_enable_guest_user_indicator", true);
+            expected_value = `<div class="search_list_item">\n        <span class="pill-container">\n                <div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">sender:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n        </span>\n    \n</div>\n`;
             assert.equal(opts.item_html(source[1]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>direct messages with</span>\n        <span class="pill-container">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1" />\n    <div class="pill-image-border"></div>\n    <span class="pill-label">\n        <span class="pill-value">\n            Zoe\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n        </span>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n        <span class="pill-container">\n                <div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">dm:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n        </span>\n    \n</div>\n`;
             assert.equal(opts.item_html(source[2]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>group direct messages including</span>\n        <span class="pill-container">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1" />\n    <div class="pill-image-border"></div>\n    <span class="pill-label">\n        <span class="pill-value">\n            Zoe\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n        </span>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n        <span class="pill-container">\n                <div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">dm-including:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n        </span>\n    \n</div>\n`;
             assert.equal(opts.item_html(source[3]), expected_value);
 
             /* Test sorter */

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -407,7 +407,7 @@ run_test("set_search_bar_contents with duplicate pills", () => {
     const pills = search.search_pill_widget._get_pills_for_testing();
     assert.equal(pills.length, 1);
     assert.deepEqual(pills[0].item, {
-        type: "search",
+        type: "generic_operator",
         operator: "has",
         operand: "attachment",
         negated: false,

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -46,17 +46,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
     const $searchbox_form = $("#searchbox_form");
     stub_pills();
 
-    mock_template("search_list_item.hbs", true, (data, html) => {
-        if (data.is_people) {
-            for (const user of data.users) {
-                assert.equal(typeof user.user_pill_context.id, "number");
-                assert.equal(typeof user.user_pill_context.display_value, "string");
-                assert.equal(typeof user.user_pill_context.has_image, "boolean");
-                assert.equal(typeof user.user_pill_context.img_src, "string");
-            }
-        }
-        return html;
-    });
+    mock_template("search_list_item.hbs", true, (_data, html) => html);
 
     let expected_pill_display_value = "";
     let input_pill_displayed = false;
@@ -144,57 +134,21 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
                         "dm-including:zo",
                         {
                             description_html: "group direct messages including",
-                            is_people: true,
                             search_string: "dm-including:user7@zulipdev.com",
-                            users: [
-                                {
-                                    user_pill_context: {
-                                        display_value: "Zoe",
-                                        has_image: true,
-                                        id: 7,
-                                        img_src:
-                                            "https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d=identicon&version=1",
-                                    },
-                                },
-                            ],
                         },
                     ],
                     [
                         "dm:zo",
                         {
                             description_html: "direct messages with",
-                            is_people: true,
                             search_string: "dm:user7@zulipdev.com",
-                            users: [
-                                {
-                                    user_pill_context: {
-                                        display_value: "Zoe",
-                                        has_image: true,
-                                        id: 7,
-                                        img_src:
-                                            "https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d=identicon&version=1",
-                                    },
-                                },
-                            ],
                         },
                     ],
                     [
                         "sender:zo",
                         {
                             description_html: "sent by",
-                            is_people: true,
                             search_string: "sender:user7@zulipdev.com",
-                            users: [
-                                {
-                                    user_pill_context: {
-                                        display_value: "Zoe",
-                                        has_image: true,
-                                        id: 7,
-                                        img_src:
-                                            "https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d=identicon&version=1",
-                                    },
-                                },
-                            ],
                         },
                     ],
                     [

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -160,7 +160,6 @@ test("subset_suggestions", ({mock_template}) => {
 
 test("dm_suggestions", ({override, mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
-    mock_template("user_pill.hbs", true, (_data, html) => html);
 
     let query = "is:dm";
     let suggestions = get_suggestions(query);
@@ -300,7 +299,6 @@ test("dm_suggestions", ({override, mock_template}) => {
 
 test("group_suggestions", ({mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
-    mock_template("user_pill.hbs", true, (_data, html) => html);
 
     // If there's an existing completed user pill right before
     // the input string, we suggest a user group as one of the
@@ -489,7 +487,6 @@ test("has_suggestions", ({override, mock_template}) => {
 
 test("check_is_suggestions", ({override, mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
-    mock_template("user_pill.hbs", true, (_data, html) => html);
 
     override(narrow_state, "stream_id", noop);
 
@@ -662,7 +659,6 @@ test("sent_by_me_suggestions", ({override, mock_template}) => {
 
 test("topic_suggestions", ({override, mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
-    mock_template("user_pill.hbs", true, (_data, html) => html);
     let suggestions;
     let expected;
 
@@ -856,7 +852,6 @@ test("channel_completion", ({override}) => {
 
 test("people_suggestions", ({override, mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
-    mock_template("user_pill.hbs", true, (_data, html) => html);
 
     let query = "te";
 
@@ -933,20 +928,6 @@ test("people_suggestions", ({override, mock_template}) => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
-    function is_person(q) {
-        return suggestions.lookup_table.get(q).description_html.includes(`class="user-pill`);
-    }
-    assert.equal(is_person("dm:ted@zulip.com"), true);
-    assert.equal(is_person("sender:ted@zulip.com"), true);
-    assert.equal(is_person("dm-including:ted@zulip.com"), true);
-
-    function has_image(q) {
-        return suggestions.lookup_table.get(q).description_html.includes(`class="pill-image"`);
-    }
-    assert.equal(has_image("dm:bob@zulip.com"), true);
-    assert.equal(has_image("sender:bob@zulip.com"), true);
-    assert.equal(has_image("dm-including:bob@zulip.com"), true);
-
     function test_describe(q, description_html_start) {
         assert.ok(
             suggestions.lookup_table.get(q).description_html.startsWith(description_html_start),
@@ -973,37 +954,6 @@ test("people_suggestions", ({override, mock_template}) => {
     test_avatar_url("dm:bob@zulip.com", expectedString);
     test_avatar_url("sender:bob@zulip.com", expectedString);
     test_avatar_url("dm-including:bob@zulip.com", expectedString);
-
-    const guest_html = "<i>(guest)</i>";
-    function test_guest_user_indicator(q, should_have_guest_indicator) {
-        const description_html = suggestions.lookup_table.get(q).description_html;
-        if (should_have_guest_indicator) {
-            assert.ok(description_html.includes(guest_html));
-        } else {
-            assert.ok(!description_html.includes(guest_html));
-        }
-    }
-
-    override(realm, "realm_enable_guest_user_indicator", true);
-    suggestions = get_suggestions(query);
-
-    test_guest_user_indicator("dm:bob@zulip.com", false);
-    test_guest_user_indicator("sender:bob@zulip.com", false);
-    test_guest_user_indicator("dm-including:bob@zulip.com", false);
-
-    bob.is_guest = true;
-    suggestions = get_suggestions(query);
-
-    test_guest_user_indicator("dm:bob@zulip.com", true);
-    test_guest_user_indicator("sender:bob@zulip.com", true);
-    test_guest_user_indicator("dm-including:bob@zulip.com", true);
-
-    override(realm, "realm_enable_guest_user_indicator", false);
-    suggestions = get_suggestions(query);
-
-    test_guest_user_indicator("dm:bob@zulip.com", false);
-    test_guest_user_indicator("sender:bob@zulip.com", false);
-    test_guest_user_indicator("dm-including:bob@zulip.com", false);
 
     suggestions = get_suggestions("Ted "); // note space
 

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -417,7 +417,7 @@ test("empty_query_suggestions", () => {
     }
     assert.equal(describe("is:dm"), "Direct messages");
     assert.equal(describe("is:starred"), "Starred messages");
-    assert.equal(describe("is:mentioned"), "@-mentions");
+    assert.equal(describe("is:mentioned"), "Messages that mention you");
     assert.equal(describe("is:alerted"), "Alerted messages");
     assert.equal(describe("is:unread"), "Unread messages");
     assert.equal(describe("is:resolved"), "Resolved topics");
@@ -518,7 +518,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
 
     assert.equal(describe("is:dm"), "Direct messages");
     assert.equal(describe("is:starred"), "Starred messages");
-    assert.equal(describe("is:mentioned"), "@-mentions");
+    assert.equal(describe("is:mentioned"), "Messages that mention you");
     assert.equal(describe("is:alerted"), "Alerted messages");
     assert.equal(describe("is:unread"), "Unread messages");
     assert.equal(describe("is:resolved"), "Resolved topics");
@@ -542,7 +542,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
 
     assert.equal(describe("-is:dm"), "Exclude direct messages");
     assert.equal(describe("-is:starred"), "Exclude starred messages");
-    assert.equal(describe("-is:mentioned"), "Exclude @-mentions");
+    assert.equal(describe("-is:mentioned"), "Exclude messages that mention you");
     assert.equal(describe("-is:alerted"), "Exclude alerted messages");
     assert.equal(describe("-is:unread"), "Exclude unread messages");
     assert.equal(describe("-is:resolved"), "Unresolved topics");

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -706,7 +706,7 @@ test("topic_suggestions", ({override, mock_template}) => {
         return suggestions.lookup_table.get(q).description_html;
     }
     assert.equal(describe("te"), "Search for te");
-    assert.equal(describe(`channel:${office_id} topic:team`), "Channel office > team");
+    assert.equal(describe(`channel:${office_id} topic:team`), "Messages in #office > team");
 
     suggestions = get_suggestions(`topic:staplers channel:${office_id}`);
     expected = [`topic:staplers channel:${office_id}`, "topic:staplers"];
@@ -826,7 +826,7 @@ test("xss_channel_name", () => {
     const suggestions = get_suggestions(query);
     assert.deepEqual(
         suggestions.lookup_table.get(`channel:${stream_id}`).description_html,
-        "Channel &lt;em&gt; Italics &lt;/em&gt;",
+        "Messages in #&lt;em&gt; Italics &lt;/em&gt;",
     );
 });
 


### PR DESCRIPTION
Fixes #34750.

Note that this change removes query highlighting for users, see [CZO](https://chat.zulip.org/#narrow/channel/101-design/topic/search.20typeahead.20highlighting/near/2187269) for context discussion on that and [#34832](https://github.com/zulip/zulip/pull/34832) for a PR removing all highlighting (which we'll probably merge first).


| before | after |
| --- | --- |
| <img width="628" alt="image" src="https://github.com/user-attachments/assets/f624ef1c-2764-4234-bbab-eb714bfe6e8b" /> | <img width="629" alt="image" src="https://github.com/user-attachments/assets/36f43483-d015-4f33-8cad-4d7e57d9d8fc" /> |
| <img width="639" alt="image" src="https://github.com/user-attachments/assets/d7d9fec3-ae7d-4f3d-ad36-ab4b58a1c423" /> | <img width="628" alt="image" src="https://github.com/user-attachments/assets/b3a974cf-8a2f-4ecc-9672-a05f7018f919" /> |
| <img width="631" alt="image" src="https://github.com/user-attachments/assets/f38a1bc5-77df-4457-b546-db4972bdd375" /> | <img width="627" alt="image" src="https://github.com/user-attachments/assets/c15df918-1a7f-4364-b397-c7d81ba772d0" /> |
| <img width="628" alt="image" src="https://github.com/user-attachments/assets/08e9099f-ba28-4a21-a045-66c8a9bbdff0" /> | <img width="627" alt="image" src="https://github.com/user-attachments/assets/2479586b-697b-472a-87c4-e1a66e7c9b1c" /> |
| <img width="627" alt="image" src="https://github.com/user-attachments/assets/abfa47b4-6139-443e-86c4-40f7c8a9c4fd" /> | <img width="630" alt="image" src="https://github.com/user-attachments/assets/5c4cf5fd-cbb1-4bbf-92ef-f45fbfbdadd3" /> |
| <img width="630" alt="image" src="https://github.com/user-attachments/assets/6d775cfd-9e6e-4873-8a9c-5c6ac8aeaa3d" /> | <img width="626" alt="image" src="https://github.com/user-attachments/assets/2f10ce28-9a16-461e-90de-98978037b022" /> |
| <img width="627" alt="image" src="https://github.com/user-attachments/assets/a3f227c9-000c-49dc-a6cb-8389930d1c64" /> | <img width="628" alt="image" src="https://github.com/user-attachments/assets/848d97bd-e036-4a1e-ba67-fdab5b580a5c" /> |
