### PR TITLE
compose_paste: Don't paste formatted text at md link marker.

### DIFF
--- a/web/src/compose_paste.ts
+++ b/web/src/compose_paste.ts
@@ -628,6 +628,13 @@ export function paste_handler(this: HTMLTextAreaElement, event: JQuery.Triggered
         // Only intervene to generate formatted links when dealing
         // with a URL and a URL-safe range selection.
         if (isUrl(trimmed_paste_text)) {
+            if (cursor_at_markdown_link_marker($textarea)) {
+                // When pasting a link after the link marker syntax, we want to
+                // avoid inserting markdown syntax text and instead just paste
+                // the raw text, possibly replacing any selection. In other words,
+                // let the browser handle it.
+                return;
+            }
             if (is_safe_url_paste_target($textarea)) {
                 event.preventDefault();
                 event.stopPropagation();
@@ -635,12 +642,7 @@ export function paste_handler(this: HTMLTextAreaElement, event: JQuery.Triggered
                 compose_ui.format_text($textarea, "linked", url);
                 return;
             }
-
-            if (
-                !compose_ui.cursor_inside_code_block($textarea) &&
-                !cursor_at_markdown_link_marker($textarea) &&
-                !compose_ui.shift_pressed
-            ) {
+            if (!compose_ui.cursor_inside_code_block($textarea) && !compose_ui.shift_pressed) {
                 // Try to transform the url to #**stream>topic** syntax
                 // if it is a valid url.
                 const syntax_text = try_stream_topic_syntax_text(trimmed_paste_text);

--- a/web/src/compose_paste.ts
+++ b/web/src/compose_paste.ts
@@ -505,7 +505,7 @@ export function paste_handler_converter(
     return markdown_text;
 }
 
-function is_safe_url_paste_target($textarea: JQuery<HTMLTextAreaElement>): boolean {
+function can_paste_url_over_range($textarea: JQuery<HTMLTextAreaElement>): boolean {
     const range = $textarea.range();
 
     if (!range.text) {
@@ -515,19 +515,6 @@ function is_safe_url_paste_target($textarea: JQuery<HTMLTextAreaElement>): boole
 
     if (isUrl(range.text.trim())) {
         // Don't engage our URL paste logic over existing URLs
-        return false;
-    }
-
-    if (range.start <= 2) {
-        // The range opens too close to the start of the textarea
-        // to have to worry about Markdown link syntax
-        return true;
-    }
-
-    // Look at the two characters before the start of the original
-    // range in search of the tell-tale `](` from existing Markdown
-    // link syntax
-    if (cursor_at_markdown_link_marker($textarea)) {
         return false;
     }
 
@@ -635,7 +622,7 @@ export function paste_handler(this: HTMLTextAreaElement, event: JQuery.Triggered
                 // let the browser handle it.
                 return;
             }
-            if (is_safe_url_paste_target($textarea)) {
+            if (can_paste_url_over_range($textarea)) {
                 event.preventDefault();
                 event.stopPropagation();
                 const url = trimmed_paste_text;


### PR DESCRIPTION
This prevents the case when we have text like
`[abcd](url)` in the compose box and the "url" part
is selected, and we paste a link copied from message actions popover.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
