### PR TITLE
Keep focus on dropdown input in integration URL modal.

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -304,7 +304,6 @@ export function initialize(): void {
         tippy_props: {
             offset: [-10, 5],
         },
-        keep_focus_on_search: true,
         tab_moves_focus_to_target() {
             if (compose_state.get_message_type() === "stream") {
                 return "#stream_message_recipient_topic";

--- a/web/src/dropdown_widget.ts
+++ b/web/src/dropdown_widget.ts
@@ -78,8 +78,6 @@ export type DropdownWidgetOptions = {
     // Boolean variable to check whether the dropdown is opened
     // with a keyboard trigger or not.
     dropdown_triggered_via_keyboard?: boolean;
-    // Keep focus on search box while navigation.
-    keep_focus_on_search?: boolean;
     // When this is set, pressing tab will move focus to the target element.
     tab_moves_focus_to_target?: string | (() => string);
 };
@@ -154,7 +152,7 @@ export class DropdownWidget {
             options.dropdown_input_visible_selector ?? this.widget_selector;
         this.prefer_top_start_placement = options.prefer_top_start_placement ?? false;
         this.dropdown_triggered_via_keyboard = false;
-        this.keep_focus_on_search = options.keep_focus_on_search ?? false;
+        this.keep_focus_on_search = !this.hide_search_box;
         this.tab_moves_focus_to_target = options.tab_moves_focus_to_target;
         this.current_hover_index = 0;
     }


### PR DESCRIPTION
This PR keeps the focus on the dropdown input in the integration URL modal (for both the integration picker and channel picker dropdowns).

Fixes: Follow-up of #33777 ([comment](https://github.com/zulip/zulip/pull/33777#issuecomment-2923422748)).

**Screenshots and screen captures:**

| Integration Picker                                                                              | Channel Picker                                                                              | Move Topic Modal                                                                               | Saved Snippet                                                                                     | User-Channel Subscription                                                                                  |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
| ![Integration](https://github.com/user-attachments/assets/94011567-c744-4c45-abc6-6ecfd3c3f3d4) | ![Channel](https://github.com/user-attachments/assets/82757c9f-ee3a-4495-958a-b0c1514fc91d) | ![Move Topic](https://github.com/user-attachments/assets/fb2aa8d1-4191-4754-9f7f-f2dc5115cad3) | ![Saved Snippet](https://github.com/user-attachments/assets/1548db8f-6655-44eb-bc80-4771320e5063) | ![User-Channel Subscribe](https://github.com/user-attachments/assets/66ad1ae3-460c-467e-9a3f-2267abd0d83b) |

<br>

| Bot Owner Picker                                                                              | Role Filter Dropdown                                                                                   | Default Channel                                                                                     | Organization Settings                                                                            | Export Filter                                                                                     |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
| ![Bot Owner](https://github.com/user-attachments/assets/74aef6d8-0612-4466-af0e-1f300e5a450f) | ![Select Role Filter](https://github.com/user-attachments/assets/9d255b04-b955-4e87-bd10-2b4a27a24944) | ![Default Channel](https://github.com/user-attachments/assets/1566db7b-11a7-4082-8e2e-b88c1652a526) | ![Org Settings](https://github.com/user-attachments/assets/b7828fd8-b1fb-4075-86df-d8d398355db6) | ![Export Filter](https://github.com/user-attachments/assets/715a06ab-1895-4e66-bd3e-3b06cdbb9dd3) |


| Compose Stream Picker                                                                              | 
| ------------------------------------------------------------------------------------------------- |
![Compose Stream Picker](https://github.com/user-attachments/assets/d99b36cb-146b-42d8-ab0f-401d67a9ea09) |

---



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
