### PR TITLE
search: Remove highlighting in search typeahead.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -221,7 +221,7 @@ export class Typeahead<ItemType extends string | object> {
     items: number;
     matcher: (item: ItemType, query: string) => boolean;
     sorter: (items: ItemType[], query: string) => ItemType[];
-    highlighter_html: (item: ItemType, query: string) => string | undefined;
+    item_html: (item: ItemType, query: string) => string | undefined;
     updater: (
         item: ItemType,
         query: string,
@@ -281,7 +281,7 @@ export class Typeahead<ItemType extends string | object> {
         this.items = options.items ?? MAX_ITEMS;
         this.matcher = options.matcher ?? ((item, query) => this.defaultMatcher(item, query));
         this.sorter = options.sorter;
-        this.highlighter_html = options.highlighter_html;
+        this.item_html = options.item_html;
         this.updater = options.updater ?? ((items) => this.defaultUpdater(items));
         this.$container = $(CONTAINER_HTML);
         if (options.non_tippy_parent_element) {
@@ -544,7 +544,7 @@ export class Typeahead<ItemType extends string | object> {
         const $items: JQuery[] = final_items.map((item) => {
             const $i = $(ITEM_HTML);
             this.values.set(the($i), item);
-            const item_html = this.highlighter_html(item, this.query) ?? "";
+            const item_html = this.item_html(item, this.query) ?? "";
             const $item_html = $i.find("a").html(item_html);
 
             const option_label_html = this.option_label(matching_items, item);
@@ -894,7 +894,7 @@ export class Typeahead<ItemType extends string | object> {
  * =========================== */
 
 type TypeaheadOptions<ItemType> = {
-    highlighter_html: (item: ItemType, query: string) => string | undefined;
+    item_html: (item: ItemType, query: string) => string | undefined;
     items?: number;
     source: (query: string, input_element: TypeaheadInputElement) => ItemType[];
     // optional options

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -52,10 +52,10 @@ const MAX_LOOKBACK_FOR_TYPEAHEAD_COMPLETION = 60 + 6 + 20;
 // **********************************
 // They do not do any HTML escaping, at all.
 // And your input to them is rendered as though it were HTML by
-// the default highlighter.
+// the default `item_html`.
 //
 // So if you are not using trusted input, you MUST use a
-// highlighter that escapes (i.e. one that calls
+// custom `item_html` that escapes (i.e. one that calls
 // Handlebars.Utils.escapeExpression).
 
 // ---------------- TYPE DECLARATIONS ----------------
@@ -1109,7 +1109,7 @@ export function get_candidates(
     return [];
 }
 
-export function content_highlighter_html(item: TypeaheadSuggestion): string | undefined {
+export function content_item_html(item: TypeaheadSuggestion): string | undefined {
     switch (item.type) {
         case "emoji":
             return typeahead_helper.render_emoji(item);
@@ -1397,7 +1397,7 @@ export function initialize_topic_edit_typeahead(
     };
     return new Typeahead(bootstrap_typeahead_input, {
         dropup,
-        highlighter_html(item: string): string {
+        item_html(item: string): string {
             const is_empty_string_topic = item === "";
             const topic_display_name = util.get_final_topic_display_name(item);
             return typeahead_helper.render_typeahead_item({
@@ -1457,7 +1457,7 @@ export function initialize_compose_typeahead($element: JQuery<HTMLTextAreaElemen
             // O(n) behavior in the number of users in the organization
             // inside the typeahead library.
             source: get_candidates,
-            highlighter_html: content_highlighter_html,
+            item_html: content_item_html,
             matcher() {
                 return true;
             },
@@ -1529,7 +1529,7 @@ export function initialize({
             return topics_seen_for(compose_state.stream_id());
         },
         items: max_num_items,
-        highlighter_html(item: string): string {
+        item_html(item: string): string {
             const is_empty_string_topic = item === "";
             const topic_display_name = util.get_final_topic_display_name(item);
             return typeahead_helper.render_typeahead_item({
@@ -1572,7 +1572,7 @@ export function initialize({
         source: get_pm_people,
         items: max_num_items,
         dropup: true,
-        highlighter_html(item: UserGroupPillData | UserPillData) {
+        item_html(item: UserGroupPillData | UserPillData) {
             return typeahead_helper.render_person_or_user_group(item);
         },
         matcher(): boolean {

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -56,7 +56,7 @@ const MAX_LOOKBACK_FOR_TYPEAHEAD_COMPLETION = 60 + 6 + 20;
 //
 // So if you are not using trusted input, you MUST use a
 // highlighter that escapes (i.e. one that calls
-// typeahead_helper.highlight_with_escaping).
+// Handlebars.Utils.escapeExpression).
 
 // ---------------- TYPE DECLARATIONS ----------------
 // There are many types of suggestions that can show

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -375,7 +375,7 @@ export function initialize_custom_pronouns_type_fields(element_id: string): void
                 sorter(items, query) {
                     return bootstrap_typeahead.defaultSorter(items, query);
                 },
-                highlighter_html(item) {
+                item_html(item) {
                     return typeahead_helper.render_typeahead_item({primary: item});
                 },
             });

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1,4 +1,3 @@
-import Handlebars from "handlebars/runtime.js";
 import _ from "lodash";
 import assert from "minimalistic-assert";
 
@@ -261,7 +260,7 @@ export function create_user_pill_context(user: User): UserPillItem {
 
     return {
         id: user.user_id,
-        display_value: new Handlebars.SafeString(user.full_name),
+        display_value: user.full_name,
         has_image: true,
         img_src: avatar_url,
         should_add_guest_user_indicator: people.should_add_guest_user_indicator(user.user_id),

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -47,7 +47,7 @@ export function set_up_user(
         source(_query: string): UserPillData[] {
             return user_pill.typeahead_source(pills, exclude_bots);
         },
-        highlighter_html(item: UserPillData, _query: string): string {
+        item_html(item: UserPillData, _query: string): string {
             return typeahead_helper.render_person(item);
         },
         matcher(item: UserPillData, query: string): boolean {
@@ -96,7 +96,7 @@ export function set_up_stream(
         source(_query: string): StreamPillData[] {
             return stream_pill.typeahead_source(pills, opts.invite_streams);
         },
-        highlighter_html(item: StreamPillData, _query: string): string {
+        item_html(item: StreamPillData, _query: string): string {
             return typeahead_helper.render_stream(item);
         },
         matcher(item: StreamPillData, query: string): boolean {
@@ -147,7 +147,7 @@ export function set_up_user_group(
                 .user_group_source()
                 .map((user_group) => ({type: "user_group", ...user_group}));
         },
-        highlighter_html(item: UserGroupPillData, _query: string): string {
+        item_html(item: UserGroupPillData, _query: string): string {
             return typeahead_helper.render_user_group(item);
         },
         matcher(item: UserGroupPillData, query: string): boolean {
@@ -194,7 +194,7 @@ export function set_up_group_setting_typeahead(
 
             return source;
         },
-        highlighter_html(item: GroupSettingTypeaheadItem, _query: string): string {
+        item_html(item: GroupSettingTypeaheadItem, _query: string): string {
             if (item.type === "user_group") {
                 return typeahead_helper.render_user_group(item);
             }
@@ -320,7 +320,7 @@ export function set_up_combined(
             }
             return source;
         },
-        highlighter_html(item: TypeaheadItem, query: string): string {
+        item_html(item: TypeaheadItem, query: string): string {
             if (include_streams(query) && item.type === "stream") {
                 return typeahead_helper.render_stream(item);
             }

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -193,7 +193,7 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
         helpOnEmptyStrings: true,
         stopAdvance: true,
         requireHighlight: false,
-        highlighter_html(item: string): string {
+        item_html(item: string): string {
             const obj = search_map.get(item);
             return render_search_list_item(obj);
         },

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -20,7 +20,7 @@ import * as util from "./util.ts";
 
 export type UserPillItem = {
     id: number;
-    display_value: Handlebars.SafeString;
+    display_value: string;
     has_image: boolean;
     img_src: string;
     should_add_guest_user_indicator: boolean;
@@ -49,23 +49,12 @@ function channel_matches_query(channel_name: string, q: string): boolean {
     return common.phrase_match(q, channel_name);
 }
 
-function make_person_highlighter(query: string): (person: User) => string {
-    const highlight_query = typeahead_helper.make_query_highlighter(query);
-
-    return function (person: User): string {
-        return highlight_query(person.full_name);
-    };
-}
-
-function highlight_person(person: User, highlighter: (person: User) => string): UserPillItem {
-    const avatar_url = people.small_avatar_url_for_person(person);
-    const highlighted_name = highlighter(person);
-
+function user_pill_item(person: User): UserPillItem {
     return {
         id: person.user_id,
-        display_value: new Handlebars.SafeString(highlighted_name),
+        display_value: person.full_name,
         has_image: true,
-        img_src: avatar_url,
+        img_src: people.small_avatar_url_for_person(person),
         should_add_guest_user_indicator: people.should_add_guest_user_indicator(person.user_id),
     };
 }
@@ -164,14 +153,11 @@ function get_channel_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggest
 
     channels = typeahead_helper.sorter(query, channels, (x) => x);
 
-    const regex = typeahead_helper.build_highlight_regex(query);
-    const highlight_query = typeahead_helper.highlight_with_escaping_and_regex;
-
     return channels.map((channel_name) => {
         const prefix = "channel";
-        const highlighted_channel = highlight_query(regex, channel_name);
         const verb = last.negated ? "exclude " : "";
-        const description_html = verb + prefix + " " + highlighted_channel;
+        const description_html =
+            verb + prefix + " " + Handlebars.Utils.escapeExpression(channel_name);
         const channel = stream_data.get_sub_by_name(channel_name);
         assert(channel !== undefined);
         const term = {
@@ -278,8 +264,6 @@ function get_group_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
 
     const prefix = Filter.operator_to_prefix("dm", negated);
 
-    const person_highlighter = make_person_highlighter(last_part);
-
     return persons.map((person) => {
         const term = {
             operator: "dm",
@@ -292,10 +276,7 @@ function get_group_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
             terms = [{operator: "is", operand: "dm"}, term];
         }
 
-        const all_user_pill_contexts = [
-            ...user_pill_contexts,
-            highlight_person(person, person_highlighter),
-        ];
+        const all_user_pill_contexts = [...user_pill_contexts, user_pill_item(person)];
 
         return {
             description_html: prefix,
@@ -346,8 +327,6 @@ function get_person_suggestions(
         last = {operator: "dm", operand: "", negated: false};
     }
 
-    const query = last.operand;
-
     // Be especially strict about the less common "from" operator.
     if (autocomplete_operator === "from" && last.operator !== "from") {
         return [];
@@ -383,8 +362,6 @@ function get_person_suggestions(
 
     const prefix = Filter.operator_to_prefix(autocomplete_operator, last.negated);
 
-    const person_highlighter = make_person_highlighter(query);
-
     return persons.map((person) => {
         const terms: NarrowTerm[] = [
             {
@@ -410,7 +387,7 @@ function get_person_suggestions(
             is_people: true,
             users: [
                 {
-                    user_pill_context: highlight_person(person, person_highlighter),
+                    user_pill_context: user_pill_item(person),
                 },
             ],
         };
@@ -1103,9 +1080,7 @@ export function get_search_result(
         suggestion_line = [
             {
                 search_string: last.operand,
-                description_html: `search for <strong>${Handlebars.Utils.escapeExpression(
-                    last.operand,
-                )}</strong>`,
+                description_html: `search for ${Handlebars.Utils.escapeExpression(last.operand)}`,
                 is_people: false,
             },
         ];

--- a/web/src/settings_playgrounds.ts
+++ b/web/src/settings_playgrounds.ts
@@ -171,7 +171,7 @@ function build_page(): void {
             return [...language_labels.keys()];
         },
         helpOnEmptyStrings: true,
-        highlighter_html: (item: string): string =>
+        item_html: (item: string): string =>
             render_typeahead_item({primary: language_labels.get(item)}),
         matcher(item: string, query: string): boolean {
             const q = query.trim().toLowerCase();

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -560,7 +560,7 @@ export function setup_topic_search_typeahead(): void {
             }
             return [...filter_options.keys()];
         },
-        highlighter_html(item: string) {
+        item_html(item: string) {
             return typeahead_helper.render_topic_state(item);
         },
         matcher(item: string, query: string) {

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -1,4 +1,3 @@
-import Handlebars from "handlebars/runtime.js";
 import _ from "lodash";
 import assert from "minimalistic-assert";
 
@@ -47,48 +46,6 @@ export type CombinedPillContainer = InputPillContainer<CombinedPill>;
 
 export type GroupSettingPill = UserGroupPill | UserPill;
 export type GroupSettingPillContainer = InputPillContainer<GroupSettingPill>;
-
-export function build_highlight_regex(query: string): RegExp {
-    const regex = new RegExp("(" + _.escapeRegExp(query) + ")", "ig");
-    return regex;
-}
-
-export function highlight_with_escaping_and_regex(regex: RegExp, item: string): string {
-    // if regex is empty return entire item escaped
-    if (regex.source === "()") {
-        return Handlebars.Utils.escapeExpression(item);
-    }
-
-    // We need to assemble this manually (as opposed to doing 'join') because we need to
-    // (1) escape all the pieces and (2) the regex is case-insensitive, and we need
-    // to know the case of the content we're replacing (you can't just use a bolded
-    // version of 'query')
-
-    const pieces = item.split(regex).filter(Boolean);
-    let result = "";
-
-    for (const [i, piece] of pieces.entries()) {
-        if (regex.test(piece) && (i === 0 || pieces[i - 1]!.endsWith(" "))) {
-            // only highlight if the matching part is a word prefix, ie
-            // if it is the 1st piece or if there was a space before it
-            result += "<strong>" + Handlebars.Utils.escapeExpression(piece) + "</strong>";
-        } else {
-            result += Handlebars.Utils.escapeExpression(piece);
-        }
-    }
-
-    return result;
-}
-
-export function make_query_highlighter(query: string): (phrase: string) => string {
-    query = query.toLowerCase();
-
-    const regex = build_highlight_regex(query);
-
-    return function (phrase) {
-        return highlight_with_escaping_and_regex(regex, phrase);
-    };
-}
 
 type StreamData = {
     invite_only: boolean;

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1200,9 +1200,9 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 let expected_value = sweden_topics_to_show;
                 assert.deepEqual(actual_value, expected_value);
 
-                // options.highlighter_html()
+                // options.item_html()
                 options.query = "Kro";
-                actual_value = options.highlighter_html("kronor");
+                actual_value = options.item_html("kronor");
                 expected_value =
                     '<div class="typeahead-text-container">\n' +
                     '    <strong class="typeahead-strong-section">kronor</strong></div>\n';
@@ -1210,14 +1210,14 @@ test("initialize", ({override, override_rewire, mock_template}) => {
 
                 // Highlighted content should be escaped.
                 options.query = "<";
-                actual_value = options.highlighter_html("<&>");
+                actual_value = options.item_html("<&>");
                 expected_value =
                     '<div class="typeahead-text-container">\n' +
                     '    <strong class="typeahead-strong-section">&lt;&amp;&gt;</strong></div>\n';
                 assert.equal(actual_value, expected_value);
 
                 options.query = "even m";
-                actual_value = options.highlighter_html("even more ice");
+                actual_value = options.item_html("even more ice");
                 expected_value =
                     '<div class="typeahead-text-container">\n' +
                     '    <strong class="typeahead-strong-section">even more ice</strong></div>\n';
@@ -1437,13 +1437,13 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 assert.ok(caret_called);
 
                 othello.delivery_email = "othello@zulip.com";
-                // options.highlighter_html()
+                // options.item_html()
                 //
-                // Again, here we only verify that the highlighter has been set to
-                // content_highlighter_html.
+                // Again, here we only verify that the item_html has been set to
+                // content_item_html.
                 ct.get_or_set_completing_for_tests("mention");
                 ct.get_or_set_token_for_testing("othello");
-                actual_value = options.highlighter_html(othello_item);
+                actual_value = options.item_html(othello_item);
                 expected_value =
                     `    <span class="zulip-icon zulip-icon-user-circle-offline user-circle-offline user-circle"></span>\n` +
                     `    <img class="typeahead-image" src="/avatar/${othello.user_id}" />\n` +
@@ -1456,7 +1456,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
 
                 ct.get_or_set_completing_for_tests("mention");
                 ct.get_or_set_token_for_testing("hamletcharacters");
-                actual_value = options.highlighter_html(hamletcharacters);
+                actual_value = options.item_html(hamletcharacters);
                 expected_value =
                     '    <i class="typeahead-image zulip-icon zulip-icon-user-group no-presence-circle" aria-hidden="true"></i>\n' +
                     '<div class="typeahead-text-container">\n' +
@@ -2256,7 +2256,7 @@ test("tokenizing", () => {
     assert.equal(ct.tokenize_compose_str("foo #bar@foo"), "#bar@foo");
 });
 
-test("content_highlighter_html", ({override_rewire}) => {
+test("content_item_html", ({override_rewire}) => {
     ct.get_or_set_completing_for_tests("emoji");
     const emoji = {emoji_name: "person shrugging", emoji_url: "¯\\_(ツ)_/¯", type: "emoji"};
     let th_render_typeahead_item_called = false;
@@ -2264,7 +2264,7 @@ test("content_highlighter_html", ({override_rewire}) => {
         assert.deepEqual(item, emoji);
         th_render_typeahead_item_called = true;
     });
-    ct.content_highlighter_html(emoji);
+    ct.content_item_html(emoji);
 
     ct.get_or_set_completing_for_tests("mention");
     let th_render_person_called = false;
@@ -2272,14 +2272,14 @@ test("content_highlighter_html", ({override_rewire}) => {
         assert.deepEqual(person, othello_item);
         th_render_person_called = true;
     });
-    ct.content_highlighter_html(othello_item);
+    ct.content_item_html(othello_item);
 
     let th_render_user_group_called = false;
     override_rewire(typeahead_helper, "render_user_group", (user_group) => {
         assert.deepEqual(user_group, backend);
         th_render_user_group_called = true;
     });
-    ct.content_highlighter_html(backend);
+    ct.content_item_html(backend);
 
     // We don't have any fancy rendering for slash commands yet.
     ct.get_or_set_completing_for_tests("slash");
@@ -2296,7 +2296,7 @@ test("content_highlighter_html", ({override_rewire}) => {
         });
         th_render_slash_command_called = true;
     });
-    ct.content_highlighter_html(me_slash);
+    ct.content_item_html(me_slash);
 
     ct.get_or_set_completing_for_tests("stream");
     let th_render_stream_called = false;
@@ -2304,7 +2304,7 @@ test("content_highlighter_html", ({override_rewire}) => {
         assert.deepEqual(stream, denmark_stream);
         th_render_stream_called = true;
     });
-    ct.content_highlighter_html(denmark_stream);
+    ct.content_item_html(denmark_stream);
 
     ct.get_or_set_completing_for_tests("syntax");
     th_render_typeahead_item_called = false;
@@ -2315,7 +2315,7 @@ test("content_highlighter_html", ({override_rewire}) => {
         });
         th_render_typeahead_item_called = true;
     });
-    ct.content_highlighter_html({type: "syntax", language: "py"});
+    ct.content_item_html({type: "syntax", language: "py"});
 
     // Verify that all stub functions have been called.
     assert.ok(th_render_typeahead_item_called);

--- a/web/tests/pill_typeahead.test.cjs
+++ b/web/tests/pill_typeahead.test.cjs
@@ -186,7 +186,7 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
         assert.ok(config.stopAdvance);
 
         assert.equal(typeof config.source, "function");
-        assert.equal(typeof config.highlighter_html, "function");
+        assert.equal(typeof config.item_html, "function");
         assert.equal(typeof config.matcher, "function");
         assert.equal(typeof config.sorter, "function");
         assert.equal(typeof config.updater, "function");
@@ -194,8 +194,8 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
         // test queries
         const person_query = "me";
 
-        (function test_highlighter() {
-            assert.equal(config.highlighter_html(me_item, person_query), $fake_rendered_person);
+        (function test_item_html() {
+            assert.equal(config.item_html(me_item, person_query), $fake_rendered_person);
         })();
 
         (function test_matcher() {
@@ -278,7 +278,7 @@ run_test("set_up_stream", ({mock_template, override, override_rewire}) => {
         assert.ok(config.stopAdvance);
 
         assert.equal(typeof config.source, "function");
-        assert.equal(typeof config.highlighter_html, "function");
+        assert.equal(typeof config.item_html, "function");
         assert.equal(typeof config.matcher, "function");
         assert.equal(typeof config.sorter, "function");
         assert.equal(typeof config.updater, "function");
@@ -286,11 +286,8 @@ run_test("set_up_stream", ({mock_template, override, override_rewire}) => {
         // test queries
         const stream_query = "#denmark";
 
-        (function test_highlighter() {
-            assert.equal(
-                config.highlighter_html(denmark_item, stream_query),
-                $fake_rendered_stream,
-            );
+        (function test_item_html() {
+            assert.equal(config.item_html(denmark_item, stream_query), $fake_rendered_stream);
         })();
 
         (function test_matcher() {
@@ -374,15 +371,15 @@ run_test("set_up_user_group", ({mock_template, override, override_rewire}) => {
         assert.ok(config.stopAdvance);
 
         assert.equal(typeof config.source, "function");
-        assert.equal(typeof config.highlighter_html, "function");
+        assert.equal(typeof config.item_html, "function");
         assert.equal(typeof config.matcher, "function");
         assert.equal(typeof config.sorter, "function");
         assert.equal(typeof config.updater, "function");
 
         const group_query = "testers";
 
-        (function test_highlighter() {
-            assert.equal(config.highlighter_html(testers_item, group_query), $fake_rendered_group);
+        (function test_item_html() {
+            assert.equal(config.item_html(testers_item, group_query), $fake_rendered_group);
         })();
 
         (function test_matcher() {
@@ -474,7 +471,7 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
         assert.ok(config.stopAdvance);
 
         assert.equal(typeof config.source, "function");
-        assert.equal(typeof config.highlighter_html, "function");
+        assert.equal(typeof config.item_html, "function");
         assert.equal(typeof config.matcher, "function");
         assert.equal(typeof config.sorter, "function");
         assert.equal(typeof config.updater, "function");
@@ -484,31 +481,22 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
         const person_query = "me";
         const group_query = "test";
 
-        (function test_highlighter() {
+        (function test_item_html() {
             if (opts.stream) {
-                // Test stream highlighter_html for widgets that allow stream pills.
-                assert.equal(
-                    config.highlighter_html(denmark_item, stream_query),
-                    $fake_rendered_stream,
-                );
+                // Test stream item_html for widgets that allow stream pills.
+                assert.equal(config.item_html(denmark_item, stream_query), $fake_rendered_stream);
             }
             if (opts.user_group && opts.user) {
                 // If user is also allowed along with user_group
                 // then we should check that each of them rendered correctly.
-                assert.equal(
-                    config.highlighter_html(testers_item, group_query),
-                    $fake_rendered_group,
-                );
-                assert.equal(config.highlighter_html(me_item, person_query), $fake_rendered_person);
+                assert.equal(config.item_html(testers_item, group_query), $fake_rendered_group);
+                assert.equal(config.item_html(me_item, person_query), $fake_rendered_person);
             }
             if (opts.user && !opts.user_group) {
-                assert.equal(config.highlighter_html(me_item, person_query), $fake_rendered_person);
+                assert.equal(config.item_html(me_item, person_query), $fake_rendered_person);
             }
             if (!opts.user && opts.user_group) {
-                assert.equal(
-                    config.highlighter_html(testers_item, group_query),
-                    $fake_rendered_group,
-                );
+                assert.equal(config.item_html(testers_item, group_query), $fake_rendered_group);
             }
         })();
 
@@ -770,7 +758,7 @@ run_test("set_up_group_setting_typeahead", ({mock_template, override, override_r
         assert.ok(config.stopAdvance);
 
         assert.equal(typeof config.source, "function");
-        assert.equal(typeof config.highlighter_html, "function");
+        assert.equal(typeof config.item_html, "function");
         assert.equal(typeof config.matcher, "function");
         assert.equal(typeof config.sorter, "function");
         assert.equal(typeof config.updater, "function");
@@ -779,11 +767,11 @@ run_test("set_up_group_setting_typeahead", ({mock_template, override, override_r
         const person_query = "me";
         const group_query = "test";
 
-        (function test_highlighter() {
+        (function test_item_html() {
             // If user is also allowed along with user_group
             // then we should check that each of them rendered correctly.
-            assert.equal(config.highlighter_html(testers_item, group_query), $fake_rendered_group);
-            assert.equal(config.highlighter_html(me_item, person_query), $fake_rendered_person);
+            assert.equal(config.item_html(testers_item, group_query), $fake_rendered_group);
+            assert.equal(config.item_html(me_item, person_query), $fake_rendered_person);
         })();
 
         (function test_matcher() {

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -96,7 +96,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
                     [
                         "stream:Verona",
                         {
-                            description_html: "Stream <strong>Ver</strong>ona",
+                            description_html: "Stream Verona",
                             search_string: "stream:Verona",
                         },
                     ],
@@ -121,7 +121,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             let expected_value = `<div class="search_list_item">\n    <span>Search for ver</span>\n</div>\n`;
             assert.equal(opts.highlighter_html(source[0]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>Stream <strong>Ver</strong>ona</span>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n    <span>Stream Verona</span>\n</div>\n`;
             assert.equal(opts.highlighter_html(source[1]), expected_value);
 
             /* Test sorter */
@@ -140,7 +140,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
                             users: [
                                 {
                                     user_pill_context: {
-                                        display_value: "<strong>Zo</strong>e",
+                                        display_value: "Zoe",
                                         has_image: true,
                                         id: 7,
                                         img_src:
@@ -159,7 +159,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
                             users: [
                                 {
                                     user_pill_context: {
-                                        display_value: "<strong>Zo</strong>e",
+                                        display_value: "Zoe",
                                         has_image: true,
                                         id: 7,
                                         img_src:
@@ -178,7 +178,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
                             users: [
                                 {
                                     user_pill_context: {
-                                        display_value: "<strong>Zo</strong>e",
+                                        display_value: "Zoe",
                                         has_image: true,
                                         id: 7,
                                         img_src:
@@ -209,13 +209,13 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             let expected_value = `<div class="search_list_item">\n    <span>Search for zo</span>\n</div>\n`;
             assert.equal(opts.highlighter_html(source[0]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>sent by</span>\n        <span class="pill-container">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1" />\n    <div class="pill-image-border"></div>\n    <span class="pill-label">\n        <span class="pill-value">\n            &lt;strong&gt;Zo&lt;/strong&gt;e\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n        </span>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n    <span>sent by</span>\n        <span class="pill-container">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1" />\n    <div class="pill-image-border"></div>\n    <span class="pill-label">\n        <span class="pill-value">\n            Zoe\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n        </span>\n</div>\n`;
             assert.equal(opts.highlighter_html(source[1]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>direct messages with</span>\n        <span class="pill-container">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1" />\n    <div class="pill-image-border"></div>\n    <span class="pill-label">\n        <span class="pill-value">\n            &lt;strong&gt;Zo&lt;/strong&gt;e\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n        </span>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n    <span>direct messages with</span>\n        <span class="pill-container">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1" />\n    <div class="pill-image-border"></div>\n    <span class="pill-label">\n        <span class="pill-value">\n            Zoe\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n        </span>\n</div>\n`;
             assert.equal(opts.highlighter_html(source[2]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>group direct messages including</span>\n        <span class="pill-container">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1" />\n    <div class="pill-image-border"></div>\n    <span class="pill-label">\n        <span class="pill-value">\n            &lt;strong&gt;Zo&lt;/strong&gt;e\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n        </span>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n    <span>group direct messages including</span>\n        <span class="pill-container">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1" />\n    <div class="pill-image-border"></div>\n    <span class="pill-label">\n        <span class="pill-value">\n            Zoe\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n        </span>\n</div>\n`;
             assert.equal(opts.highlighter_html(source[3]), expected_value);
 
             /* Test sorter */

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -117,12 +117,12 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             const source = opts.source("ver");
             assert.deepStrictEqual(source, expected_source_value);
 
-            /* Test highlighter */
+            /* Test item_html */
             let expected_value = `<div class="search_list_item">\n    <span>Search for ver</span>\n</div>\n`;
-            assert.equal(opts.highlighter_html(source[0]), expected_value);
+            assert.equal(opts.item_html(source[0]), expected_value);
 
             expected_value = `<div class="search_list_item">\n    <span>Stream Verona</span>\n</div>\n`;
-            assert.equal(opts.highlighter_html(source[1]), expected_value);
+            assert.equal(opts.item_html(source[1]), expected_value);
 
             /* Test sorter */
             assert.equal(opts.sorter(search_suggestions.strings), search_suggestions.strings);
@@ -205,18 +205,18 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             const source = opts.source("zo");
             assert.deepStrictEqual(source, expected_source_value);
 
-            /* Test highlighter */
+            /* Test item_html */
             let expected_value = `<div class="search_list_item">\n    <span>Search for zo</span>\n</div>\n`;
-            assert.equal(opts.highlighter_html(source[0]), expected_value);
+            assert.equal(opts.item_html(source[0]), expected_value);
 
             expected_value = `<div class="search_list_item">\n    <span>sent by</span>\n        <span class="pill-container">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1" />\n    <div class="pill-image-border"></div>\n    <span class="pill-label">\n        <span class="pill-value">\n            Zoe\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n        </span>\n</div>\n`;
-            assert.equal(opts.highlighter_html(source[1]), expected_value);
+            assert.equal(opts.item_html(source[1]), expected_value);
 
             expected_value = `<div class="search_list_item">\n    <span>direct messages with</span>\n        <span class="pill-container">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1" />\n    <div class="pill-image-border"></div>\n    <span class="pill-label">\n        <span class="pill-value">\n            Zoe\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n        </span>\n</div>\n`;
-            assert.equal(opts.highlighter_html(source[2]), expected_value);
+            assert.equal(opts.item_html(source[2]), expected_value);
 
             expected_value = `<div class="search_list_item">\n    <span>group direct messages including</span>\n        <span class="pill-container">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1" />\n    <div class="pill-image-border"></div>\n    <span class="pill-label">\n        <span class="pill-value">\n            Zoe\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n        </span>\n</div>\n`;
-            assert.equal(opts.highlighter_html(source[3]), expected_value);
+            assert.equal(opts.item_html(source[3]), expected_value);
 
             /* Test sorter */
             assert.equal(opts.sorter(search_suggestions.strings), search_suggestions.strings);

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -705,7 +705,7 @@ test("topic_suggestions", ({override, mock_template}) => {
     function describe(q) {
         return suggestions.lookup_table.get(q).description_html;
     }
-    assert.equal(describe("te"), "Search for <strong>te</strong>");
+    assert.equal(describe("te"), "Search for te");
     assert.equal(describe(`channel:${office_id} topic:team`), "Channel office > team");
 
     suggestions = get_suggestions(`topic:staplers channel:${office_id}`);
@@ -816,6 +816,18 @@ test("whitespace_glitch", ({override, mock_template}) => {
     const expected = [`channel:${office_stream_id}`];
 
     assert.deepEqual(suggestions.strings, expected);
+});
+
+test("xss_channel_name", () => {
+    const stream_id = new_stream_id();
+    stream_data.add_sub({stream_id, name: "<em> Italics </em>", subscribed: true});
+
+    const query = "channel:ita";
+    const suggestions = get_suggestions(query);
+    assert.deepEqual(
+        suggestions.lookup_table.get(`channel:${stream_id}`).description_html,
+        "Channel &lt;em&gt; Italics &lt;/em&gt;",
+    );
 });
 
 test("channel_completion", ({override}) => {
@@ -944,7 +956,7 @@ test("people_suggestions", ({override, mock_template}) => {
     test_describe("sender:ted@zulip.com", "Sent by");
     test_describe("dm-including:ted@zulip.com", "Direct messages including");
 
-    let expectedString = "<strong>Te</strong>d Smith";
+    let expectedString = "Ted Smith";
 
     function test_full_name(q, full_name_html) {
         return suggestions.lookup_table.get(q).description_html.includes(full_name_html);

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -925,36 +925,6 @@ test("test compare directly for direct message", () => {
     assert.equal(th.compare_people_for_relevance(zman_item, all_obj_item), -1);
 });
 
-test("highlight_with_escaping", () => {
-    function highlight(query, item) {
-        return th.make_query_highlighter(query)(item);
-    }
-
-    let item = "Denmark";
-    let query = "Den";
-    let expected = "<strong>Den</strong>mark";
-    let result = highlight(query, item);
-    assert.equal(result, expected);
-
-    item = "w3IrD_naMe";
-    query = "w3IrD_naMe";
-    expected = "<strong>w3IrD_naMe</strong>";
-    result = highlight(query, item);
-    assert.equal(result, expected);
-
-    item = "development help";
-    query = "development h";
-    expected = "<strong>development h</strong>elp";
-    result = highlight(query, item);
-    assert.equal(result, expected);
-
-    item = "Prefix notprefix prefix";
-    query = "pre";
-    expected = "<strong>Pre</strong>fix notprefix <strong>pre</strong>fix";
-    result = highlight(query, item);
-    assert.equal(result, expected);
-});
-
 test("render_person when emails hidden", ({mock_template, override}) => {
     // Test render_person with regular person, under hidden email visibility case
     override(realm, "custom_profile_field_types", {


### PR DESCRIPTION
 Context: https://chat.zulip.org/#narrow/channel/101-design/topic/search.20typeahead.20highlighting/near/2188093

<blockquote>
I think overall I'd probably be fine with removing it. A few reasons:

* We don't do that with typeahead these days and that feels Fine.
* No highlighting seems better when you're matching on something that doesn't actually appear in the title or description.
* It's a little bit visually messy to have random characters being bold.
</blockquote>

I'm also generally in favor of simpler code/UX where complexity doesn't add that much.
