### PR TITLE
filter: Do not set anchor as `first_unread` for starred messages view.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1536,7 +1536,10 @@ export class Filter {
     }
 
     allow_use_first_unread_when_narrowing(): boolean {
-        return this.can_mark_messages_read() || this.has_operator("is");
+        return (
+            this.can_mark_messages_read() ||
+            (this.has_operator("is") && !this.has_operand("is", "starred"))
+        );
     }
 
     contains_only_private_messages(): boolean {

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -834,6 +834,10 @@ test("show_first_unread", () => {
     assert.ok(filter.can_mark_messages_read());
     assert.ok(filter.allow_use_first_unread_when_narrowing());
 
+    terms = [{operator: "is", operand: "starred"}];
+    filter = new Filter(terms);
+    assert.ok(!filter.allow_use_first_unread_when_narrowing());
+
     // Side case
     terms = [{operator: "is", operand: "any"}];
     filter = new Filter(terms);


### PR DESCRIPTION
Fixes
https://chat.zulip.org/#narrow/channel/9-issues/topic/Starred.20messages.20view.20performance/near/2184251. Anchor for starred messages was `first_unread` and the query to find first_unread in a user's starred messages can turn out to be expensive. This commit ensures that we default to newest instead since first_unread is not of important for the starred messages view. By excluding starred messages from using `first_unread`, it will default to newest based on the logic in message_view.ts.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
