### PR TITLE
search: Improve search by topic.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -141,7 +141,11 @@ function message_in_home(message: Message): boolean {
     return user_topics.is_topic_visible_in_home(message.stream_id, message.topic);
 }
 
-function message_matches_search_term(message: Message, operator: string, operand: string): boolean {
+export function message_matches_search_term(
+    message: Message,
+    operator: string,
+    operand: string,
+): boolean {
     switch (operator) {
         case "has":
             switch (operand) {
@@ -221,8 +225,15 @@ function message_matches_search_term(message: Message, operator: string, operand
             if (realm.realm_is_zephyr_mirror_realm) {
                 return zephyr_topic_name_match(message, operand);
             }
-            return message.topic.toLowerCase() === operand;
-
+            return (
+                message.topic.toLowerCase().split(/\s+/).includes(operand.toLowerCase()) ||
+                message.topic.toLowerCase() === operand.toLowerCase()
+            );
+        case "exact-topic":
+            if (message.type !== "stream") {
+                return false;
+            }
+            return message.topic === operand;
         case "sender":
             return people.id_matches_email_operand(message.sender_id, operand);
 
@@ -315,7 +326,7 @@ export class Filter {
         }
 
         if (util.is_topic_synonym(operator)) {
-            return "topic";
+            return "exact-topic";
         }
 
         if (util.is_channel_synonym(operator)) {
@@ -348,6 +359,8 @@ export class Filter {
             case "channel":
                 break;
             case "topic":
+                break;
+            case "exact-topic":
                 break;
             case "sender":
             case "dm":
@@ -404,6 +417,9 @@ export class Filter {
                 case "topic":
                     contains_topic_term = true;
                     break;
+                case "exact-topic":
+                    contains_topic_term = true;
+                    break;
                 case "dm":
                     contains_dm_term = true;
             }
@@ -416,7 +432,7 @@ export class Filter {
             return undefined;
         }
 
-        const conversation_terms = new Set(["channel", "topic", "dm"]);
+        const conversation_terms = new Set(["channel", "exact-topic", "dm"]);
 
         const non_conversation_terms = orig_terms.filter((term) => {
             const operator = Filter.canonicalize_operator(term.operator);
@@ -424,9 +440,8 @@ export class Filter {
         });
 
         assert(message.type === "stream");
-
         const channel_term = {operator: "channel", operand: message.stream_id.toString()};
-        const topic_term = {operator: "topic", operand: message.topic};
+        const topic_term = {operator: "exact-topic", operand: message.topic};
 
         const updated_terms = [channel_term, topic_term, ...non_conversation_terms];
         return updated_terms;
@@ -578,6 +593,8 @@ export class Filter {
                 return term.operand === "public";
             case "topic":
                 return true;
+            case "exact-topic":
+                return true;
             case "sender":
             case "from":
             case "dm":
@@ -649,6 +666,7 @@ export class Filter {
             "channels-public",
             "channel",
             "topic",
+            "exact-topic",
             "dm",
             "dm-including",
             "with",
@@ -714,6 +732,8 @@ export class Filter {
 
             case "topic":
                 return verb + "topic";
+            case "exact-topic":
+                return verb + "exact topic";
 
             case "sender":
                 return verb + "sent by";
@@ -737,7 +757,6 @@ export class Filter {
     // Convert a list of terms to a human-readable description.
     static parts_for_describe(terms: NarrowTerm[], is_operator_suggestion: boolean): Part[] {
         const parts: Part[] = [];
-
         if (terms.length === 0) {
             parts.push({type: "plain_text", content: "combined feed"});
             return parts;
@@ -1068,6 +1087,15 @@ export class Filter {
                 term.operand.toLowerCase() === operand.toLowerCase(),
         );
     }
+    partial_operand_case_insensitive(operator: string, operand: string): boolean {
+        return this._terms.some(
+            (term) =>
+                !term.negated &&
+                term.operator === operator &&
+                (term.operand.toLowerCase().split(/\s+/).includes(operand.toLowerCase()) ||
+                    term.operand.toLowerCase() === operand.toLowerCase()),
+        );
+    }
 
     has_operand(operator: string, operand: string): boolean {
         return this._terms.some(
@@ -1126,6 +1154,8 @@ export class Filter {
         const valid_term_types = new Set([
             "channel",
             "not-channel",
+            "exact-topic",
+            "not-exact-topic",
             "topic",
             "not-topic",
             "dm",
@@ -1774,7 +1804,9 @@ export class Filter {
         const term_types = this.sorted_term_types();
         if (
             _.isEqual(term_types, ["channel", "topic", "with"]) ||
+            _.isEqual(term_types, ["channel", "exact-topic", "with"]) ||
             _.isEqual(term_types, ["channel", "topic"]) ||
+            _.isEqual(term_types, ["channel", "exact-topic"]) ||
             _.isEqual(term_types, ["dm", "with"]) ||
             _.isEqual(term_types, ["dm"])
         ) {
@@ -1787,6 +1819,7 @@ export class Filter {
         const term_types = this.sorted_term_types();
         if (
             _.isEqual(term_types, ["channel", "topic", "near"]) ||
+            _.isEqual(term_types, ["channel", "exact-topic", "near"]) ||
             _.isEqual(term_types, ["dm", "near"])
         ) {
             return true;
@@ -1805,6 +1838,7 @@ export class Filter {
     may_contain_multiple_conversations(): boolean {
         return !(
             (this.has_operator("channel") && this.has_operator("topic")) ||
+            (this.has_operator("channel") && this.has_operator("exact-topic")) ||
             this.has_operator("dm")
         );
     }
@@ -1813,6 +1847,8 @@ export class Filter {
         return (
             // not narrowed to a topic
             !(this.has_operator("channel") && this.has_operator("topic")) &&
+            // not narrowed to a exact-topic
+            !(this.has_operator("channel") && this.has_operator("exact-topic")) &&
             // not narrowed to search
             !this.is_keyword_search() &&
             // not narrowed to dms
@@ -1861,7 +1897,10 @@ export class Filter {
             return true;
         }
 
-        if (this.has_operand_case_insensitive("topic", new_topic)) {
+        if (this.partial_operand_case_insensitive("topic", new_topic)) {
+            return true;
+        }
+        if (this.has_operand_case_insensitive("exact-topic", new_topic)) {
             return true;
         }
 
@@ -1876,6 +1915,7 @@ export class Filter {
             // are very unlikely to be used in practice.
             "not-channel",
             "not-topic",
+            "not-exact-topic",
             "is-followed",
             "not-is-followed",
             "is-resolved",

--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -130,6 +130,7 @@ export const allowed_web_public_narrow_operators = [
     "streams",
     "stream",
     "topic",
+    "exact-topic",
     "sender",
     "has",
     "search",

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -678,7 +678,7 @@ export function update_messages(events: UpdateMessageEvent[]): void {
 
                 if (new_filter && topic_edited) {
                     new_filter = new_filter.filter_with_new_params({
-                        operator: "topic",
+                        operator: "exact-topic",
                         operand: new_topic,
                     });
                     changed_narrow = true;

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1319,7 +1319,7 @@ export function narrow_to_next_topic(opts: {trigger: string; only_followed_topic
 
     const filter_expr = [
         {operator: "channel", operand: next_narrow.stream_id.toString()},
-        {operator: "topic", operand: next_narrow.topic},
+        {operator: "exact-topic", operand: next_narrow.topic},
     ];
 
     show(filter_expr, opts);
@@ -1384,7 +1384,7 @@ export function narrow_by_topic(
 
     const search_terms = [
         {operator: "channel", operand: original.stream_id.toString()},
-        {operator: "topic", operand: original.topic},
+        {operator: "exact-topic", operand: original.topic},
     ];
     show(search_terms, {then_select_id: target_id, ...opts});
 }
@@ -1462,7 +1462,7 @@ export function to_compose_target(): void {
         const terms = [{operator: "channel", operand: stream_id.toString()}];
         const topic = compose_state.topic();
         if (topic !== "" || stream_data.can_use_empty_topic(stream_id)) {
-            terms.push({operator: "topic", operand: topic});
+            terms.push({operator: "exact-topic", operand: topic});
         }
         show(terms, opts);
         return;

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -422,8 +422,16 @@ function get_topic_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
         {operator: "is", operand: "dm"},
         {operator: "dm-including"},
         {operator: "topic"},
+        {operator: "exact-topic"},
     ];
-    if (!check_validity(last, terms, ["channel", "topic", "search"], incompatible_patterns)) {
+    if (
+        !check_validity(
+            last,
+            terms,
+            ["channel", "topic", "exact-topic", "search"],
+            incompatible_patterns,
+        )
+    ) {
         return [];
     }
 
@@ -457,6 +465,7 @@ function get_topic_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
             suggest_terms.push(last);
             break;
         case "topic":
+        case "exact-topic":
         case "search":
             guess = operand;
             if (filter.has_operator("channel")) {
@@ -507,7 +516,7 @@ function get_topic_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
     topics.sort();
 
     return topics.map((topic) => {
-        const topic_term = {operator: "topic", operand: topic, negated};
+        const topic_term = {operator, operand: topic, negated};
         const terms = [...suggest_terms, topic_term];
         return format_as_suggestion(terms);
     });
@@ -649,6 +658,7 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
                     {operator: "dm"},
                     {operator: "in"},
                     {operator: "topic"},
+                    {operator: "exact-topic"},
                 ],
             },
             {
@@ -805,6 +815,7 @@ function get_operator_suggestions(last: NarrowTerm): Suggestion[] {
     let choices = [
         "channel",
         "topic",
+        "exact-topic",
         "dm",
         "dm-including",
         "sender",

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -715,7 +715,8 @@ export function get_sidebar_stream_topic_info(filter: Filter): {
     result.stream_id = stream_id;
 
     const op_topic = filter.operands("topic");
-    result.topic_selected = op_topic.length === 1;
+    const op_exact_topic = filter.operands("exact-topic");
+    result.topic_selected = op_topic.length === 1 || op_exact_topic.length === 1;
 
     return result;
 }

--- a/web/src/stream_topic_history_util.ts
+++ b/web/src/stream_topic_history_util.ts
@@ -76,7 +76,7 @@ export function update_topic_last_message_id(
         data: {
             narrow: JSON.stringify([
                 {operator: "stream", operand: stream_id},
-                {operator: "topic", operand: topic_name},
+                {operator: "exact-topic", operand: topic_name},
             ]),
             anchor: "newest",
             num_before: 1,

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -98,7 +98,7 @@ export function zoom_out(): void {
 
 type ListInfoNodeOptions =
     | {
-          type: "topic";
+          type: "exact-topic";
           conversation: TopicInfo;
       }
     | {
@@ -115,14 +115,14 @@ export function keyed_topic_li(conversation: TopicInfo): ListInfoNode {
     const render = (): string => render_topic_list_item(conversation);
 
     const eq = (other: ListInfoNode): boolean =>
-        other.type === "topic" && _.isEqual(conversation, other.conversation);
+        other.type === "exact-topic" && _.isEqual(conversation, other.conversation);
 
     const key = "t:" + conversation.topic_name;
 
     return {
         key,
         render,
-        type: "topic",
+        type: "exact-topic",
         conversation,
         eq,
     };

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -17,6 +17,7 @@ const resolved_topic = zrequire("../shared/src/resolved_topic");
 const stream_data = zrequire("stream_data");
 const people = zrequire("people");
 const {Filter} = zrequire("../src/filter");
+const {message_matches_search_term} = zrequire("../src/filter");
 const {set_current_user, set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 const muted_users = zrequire("muted_users");
@@ -614,6 +615,60 @@ test("basics", () => {
     terms = [{operator: "channel", operand: "foo", negated: false}];
     filter = new Filter(terms);
     assert.ok(filter.is_channel_view());
+
+    terms = [
+        {operator: "channel", operand: foo_stream_id.toString()},
+        {operator: "exact-topic", operand: "Announcements"},
+    ];
+    filter = new Filter(terms);
+
+    assert.ok(filter.has_operator("exact-topic"));
+    assert.ok(!filter.has_operator("topic"));
+
+    // Operand presence
+    assert.ok(filter.has_operand("exact-topic", "Announcements"));
+    assert.ok(!filter.has_operand("exact-topic", "announcements")); // exact case-sensitive in has_operand
+
+    // Case-insensitive operand check
+    assert.ok(filter.has_operand_case_insensitive("exact-topic", "announcements"));
+
+    // Matching terms
+    assert.deepEqual(filter.operands("channel"), [foo_stream_id.toString()]);
+    assert.deepEqual(filter.operands("exact-topic"), ["Announcements"]);
+
+    // Filter capabilities
+    assert.ok(!filter.is_keyword_search());
+    assert.ok(filter.includes_full_stream_history());
+    assert.ok(filter.can_apply_locally());
+    assert.ok(filter.can_bucket_by("channel"));
+    assert.ok(filter.can_bucket_by("channel", "exact-topic"));
+    assert.ok(!filter.has_exactly_channel_topic_operators());
+
+    terms = [
+        {operator: "channel", operand: foo_stream_id.toString()},
+        {operator: "exact-topic", operand: "Meta"},
+        {operator: "exact-topic", operand: "Random", negated: true}, // exclusion
+    ];
+    filter = new Filter(terms);
+
+    assert.ok(filter.has_operator("exact-topic"));
+    assert.ok(filter.has_operand("exact-topic", "Meta"));
+    assert.ok(!filter.has_operand("exact-topic", "Random")); // negated operand should not appear
+
+    // Internal behavior
+    assert.ok(!filter.is_keyword_search());
+    assert.ok(filter.can_apply_locally());
+
+    terms = [
+        {operator: "channel", operand: foo_stream_id.toString()},
+        {operator: "exact-topic", operand: "General"},
+        {operator: "search", operand: "bugs"},
+    ];
+    filter = new Filter(terms);
+
+    assert.ok(filter.has_operator("search"));
+    assert.ok(filter.is_keyword_search());
+    assert.ok(!filter.can_apply_locally());
 });
 
 function assert_not_mark_read_with_has_operands(additional_terms_to_test) {
@@ -950,7 +1005,7 @@ test("redundancies", () => {
 test("canonicalization", () => {
     assert.equal(Filter.canonicalize_operator("Is"), "is");
     assert.equal(Filter.canonicalize_operator("Stream"), "channel");
-    assert.equal(Filter.canonicalize_operator("Subject"), "topic");
+    assert.equal(Filter.canonicalize_operator("Subject"), "exact-topic");
     assert.equal(Filter.canonicalize_operator("FROM"), "sender");
 
     let term;
@@ -1011,6 +1066,7 @@ test("canonicalization", () => {
 
 test("ensure_channel_topic_terms", () => {
     const channel_term = {operator: "channel", operand: `${general_sub.stream_id}`};
+    const exact_topic_term = {operator: "exact-topic", operand: "discussion"};
     const topic_term = {operator: "topic", operand: "discussion"};
 
     const message = {
@@ -1026,7 +1082,7 @@ test("ensure_channel_topic_terms", () => {
         message,
     );
     const term_2 = Filter.ensure_channel_topic_terms(
-        [topic_term, {operator: "with", operand: message.id}],
+        [exact_topic_term, {operator: "with", operand: message.id}],
         message,
     );
     const term_3 = Filter.ensure_channel_topic_terms(
@@ -1044,11 +1100,20 @@ test("ensure_channel_topic_terms", () => {
         [{operator: "with", operand: message.id}],
         message,
     );
-
+    const term_6 = Filter.ensure_channel_topic_terms(
+        [topic_term, {operator: "with", operand: message.id}],
+        message,
+    );
+    assert.deepEqual(term_6, [
+        channel_term,
+        exact_topic_term,
+        topic_term,
+        {operator: "with", operand: 12},
+    ]);
     const terms = [term_1, term_2, term_3, term_4, term_5];
 
     for (const term of terms) {
-        assert.deepEqual(term, [channel_term, topic_term, {operator: "with", operand: 12}]);
+        assert.deepEqual(term, [channel_term, exact_topic_term, {operator: "with", operand: 12}]);
     }
 });
 
@@ -1644,7 +1709,7 @@ test("unparse", () => {
         {operator: "stream", operand: foo_stream_id.toString()},
         {operator: "subject", operand: "Bar"},
     ];
-    string = `channel:${foo_stream_id} topic:Bar`;
+    string = `channel:${foo_stream_id} exact-topic:Bar`;
     assert.deepEqual(Filter.unparse(terms), string);
 
     terms = [
@@ -1801,7 +1866,7 @@ test("describe", ({mock_template, override}) => {
         {operator: "stream", operand: devel_id.toString()},
         {operator: "subject", operand: "JS", negated: true},
     ];
-    string = "messages in #devel, exclude topic JS";
+    string = "messages in #devel, exclude exact topic JS";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     // Empty string topic involved.
@@ -1936,6 +2001,7 @@ test("term_type", () => {
         };
     }
 
+    // Term type classification
     assert_term_type(term("channels", "public"), "channels-public");
     assert_term_type(term("channel", "whatever"), "channel");
     assert_term_type(term("dm", "whomever"), "dm");
@@ -1944,38 +2010,41 @@ test("term_type", () => {
     assert_term_type(term("is", "private"), "is-private");
     assert_term_type(term("has", "link"), "has-link");
     assert_term_type(term("has", "attachment", true), "not-has-attachment");
+    assert_term_type(term("topic", "Ghost Town"), "topic");
+    assert_term_type(term("topic", "Ghost Town", true), "not-topic");
+    assert_term_type(term("exact-topic", "Ghost Town"), "exact-topic");
+    assert_term_type(term("exact-topic", "Ghost Town", true), "not-exact-topic");
 
+    // Sorting utility
     function assert_term_sort(in_terms, expected) {
         const sorted_terms = Filter.sorted_term_types(in_terms);
         assert.deepEqual(sorted_terms, expected);
     }
 
+    // Sorting tests with both topic and exact-topic
     assert_term_sort(["topic", "channel", "sender"], ["channel", "topic", "sender"]);
-
     assert_term_sort(
         ["has-link", "near", "is-unread", "dm"],
         ["dm", "near", "is-unread", "has-link"],
     );
-
     assert_term_sort(["topic", "channel", "with"], ["channel", "topic", "with"]);
-
     assert_term_sort(["bogus", "channel", "topic"], ["channel", "topic", "bogus"]);
     assert_term_sort(["channel", "topic", "channel"], ["channel", "channel", "topic"]);
-
     assert_term_sort(["search", "channels-public"], ["channels-public", "search"]);
+    assert_term_sort(["exact-topic", "topic", "channel"], ["channel", "topic", "exact-topic"]);
 
+    // Filter instance test with both topic types
     const terms = [
-        {operator: "topic", operand: "lunch"},
+        {operator: "topic", operand: "Lunch"},
+        {operator: "exact-topic", operand: "Ghost Town"},
         {operator: "sender", operand: "steve@foo.com"},
         {operator: "channel", operand: new_stream_id().toString()},
     ];
     let filter = new Filter(terms);
     const term_types = filter.sorted_term_types();
+    assert.deepEqual(term_types, ["channel", "topic", "exact-topic", "sender"]);
 
-    assert.deepEqual(term_types, ["channel", "topic", "sender"]);
-
-    // test caching of term types
-    // init and stub
+    // Caching test
     filter = new Filter(terms);
     filter.stub = filter._build_sorted_term_types;
     filter._build_sorted_term_types = function () {
@@ -1986,13 +2055,13 @@ test("term_type", () => {
     // uncached trial
     filter._build_sorted_term_types_called = false;
     const built_terms = filter.sorted_term_types();
-    assert.deepEqual(built_terms, ["channel", "topic", "sender"]);
+    assert.deepEqual(built_terms, ["channel", "topic", "exact-topic", "sender"]);
     assert.ok(filter._build_sorted_term_types_called);
 
     // cached trial
     filter._build_sorted_term_types_called = false;
     const cached_terms = filter.sorted_term_types();
-    assert.deepEqual(cached_terms, ["channel", "topic", "sender"]);
+    assert.deepEqual(cached_terms, ["channel", "topic", "exact-topic", "sender"]);
     assert.ok(!filter._build_sorted_term_types_called);
 });
 
@@ -2039,6 +2108,11 @@ test("is_valid_search_term", () => {
         ["channels:public", true],
         ["channels:private", false],
         ["topic:GhostTown", true],
+        ["topic:GhostTown,foo", true],
+        ["topic:GhostTown,foo,bar", true],
+        ["exact-topic:GhostTown", true],
+        ["exact-topic:GhostTown,foo", true],
+        ["exact-topic:GhostTown,foo,bar", true],
         ["dm-including:alice@example.com", true],
         ["sender:ghost@zulip.com", false],
         ["sender:me", true],
@@ -2060,6 +2134,40 @@ test("is_valid_search_term", () => {
         }),
         false,
     );
+});
+test("message_matches_search_term", () => {
+    const stream_message = {
+        id: 1,
+        type: "stream",
+        stream_id: 10,
+        topic: "Ghost Town",
+    };
+
+    const pm_message = {
+        id: 2,
+        type: "private",
+        topic: undefined,
+    };
+
+    const test_data = [
+        ["topic", "Ghost", true], // partial match
+        ["topic", "ghost", true], // partial match
+        ["topic", "town", true], // partial match
+        ["topic", "Town", true], // exact match
+        ["topic", "ghost town", true],
+        ["topic", "notfound", false],
+        ["exact-topic", "Ghost Town", true],
+        ["exact-topic", "ghost town", false],
+        ["exact-topic", "Ghost", false], // partial match doesn't work
+        ["exact-topic", "Town", false], // partial match doesn't work
+        ["topic", "Ghost", false, pm_message],
+        ["exact-topic", "Ghost Town", false, pm_message],
+    ];
+
+    for (const [operator, operand, expected, custom_msg] of test_data) {
+        const message = custom_msg || stream_message;
+        assert.equal(message_matches_search_term(message, operator, operand), expected);
+    }
 });
 
 test("update_email", () => {
@@ -2167,7 +2275,7 @@ test("try_adjusting_for_moved_with_target", ({override}) => {
     assert.deepEqual(filter.requires_adjustment_for_moved_with_target, false);
     assert.deepEqual(filter.terms(), [
         {operator: "channel", operand: scotland_id.toString(), negated: false},
-        {operator: "topic", operand: "Test 1", negated: false},
+        {operator: "exact-topic", operand: "Test 1", negated: false},
         {operator: "with", operand: "12", negated: false},
     ]);
 
@@ -3006,11 +3114,21 @@ run_test("can_newly_match_moved_messages", () => {
     assert.deepEqual(filter.can_newly_match_moved_messages("General", "test"), true);
     assert.deepEqual(filter.can_newly_match_moved_messages("random-stream", "test"), false);
 
-    // Matches topic
+    // Matches topic (case-insensitive, partial match allowed)
     filter = new Filter([{operator: "topic", operand: "Test topic"}]);
     assert.deepEqual(filter.can_newly_match_moved_messages("general", "Test topic"), true);
     assert.deepEqual(filter.can_newly_match_moved_messages("general", "test topic"), true);
+    assert.deepEqual(filter.can_newly_match_moved_messages("general", "Test"), true);
+    assert.deepEqual(filter.can_newly_match_moved_messages("general", "test"), true);
     assert.deepEqual(filter.can_newly_match_moved_messages("general", "random topic"), false);
+
+    // Matches exact-topic (case-sensitive, exact match only)
+    filter = new Filter([{operator: "exact-topic", operand: "Test Topic"}]);
+    assert.deepEqual(filter.can_newly_match_moved_messages("general", "Test Topic"), true);
+    assert.deepEqual(filter.can_newly_match_moved_messages("general", "test topic"), true); // different case
+    assert.deepEqual(filter.can_newly_match_moved_messages("general", "Test"), false); // partial
+    assert.deepEqual(filter.can_newly_match_moved_messages("general", "test"), false); // partial
+    assert.deepEqual(filter.can_newly_match_moved_messages("general", "Test Topic random"), false);
 
     // Matches common narrows
     filter = new Filter([{operator: "is", operand: "followed"}]);
@@ -3037,5 +3155,22 @@ run_test("get_stringified_narrow_for_server_query", () => {
     assert.equal(
         narrow,
         '[{"negated":false,"operator":"channel","operand":1},{"negated":false,"operator":"topic","operand":"bar"}]',
+    );
+});
+run_test("get_stringified_narrow_for_server_query with exact-topic", () => {
+    const filter = new Filter([{operator: "exact-topic", operand: "λ-topic"}]);
+    const narrow = filter.get_stringified_narrow_for_server_query();
+    assert.equal(narrow, '[{"negated":false,"operator":"exact-topic","operand":"λ-topic"}]');
+});
+
+run_test("get_stringified_narrow_for_server_query with channel and exact-topic", () => {
+    const filter = new Filter([
+        {operator: "channel", operand: "1"},
+        {operator: "exact-topic", operand: "λ-topic"},
+    ]);
+    const narrow = filter.get_stringified_narrow_for_server_query();
+    assert.equal(
+        narrow,
+        '[{"negated":false,"operator":"channel","operand":1},{"negated":false,"operator":"exact-topic","operand":"λ-topic"}]',
     );
 });

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -784,7 +784,7 @@ run_test("narrow_to_compose_target streams", ({override, override_rewire}) => {
     assert.equal(args.opts.trigger, "narrow_to_compose_target");
     assert.deepEqual(args.terms, [
         {operator: "channel", operand: rome_id.toString()},
-        {operator: "topic", operand: "one"},
+        {operator: "exact-topic", operand: "one"},
     ]);
 
     // Test with new topic
@@ -794,7 +794,7 @@ run_test("narrow_to_compose_target streams", ({override, override_rewire}) => {
     assert.equal(args.called, true);
     assert.deepEqual(args.terms, [
         {operator: "channel", operand: rome_id.toString()},
-        {operator: "topic", operand: "four"},
+        {operator: "exact-topic", operand: "four"},
     ]);
 
     // Test with blank topic, with realm_topics_policy
@@ -813,7 +813,7 @@ run_test("narrow_to_compose_target streams", ({override, override_rewire}) => {
     assert.equal(args.called, true);
     assert.deepEqual(args.terms, [
         {operator: "channel", operand: rome_id.toString()},
-        {operator: "topic", operand: ""},
+        {operator: "exact-topic", operand: ""},
     ]);
 
     // Test with no topic, with realm mandatory topics
@@ -832,7 +832,7 @@ run_test("narrow_to_compose_target streams", ({override, override_rewire}) => {
     assert.equal(args.called, true);
     assert.deepEqual(args.terms, [
         {operator: "channel", operand: rome_id.toString()},
-        {operator: "topic", operand: ""},
+        {operator: "exact-topic", operand: ""},
     ]);
 });
 

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -156,6 +156,18 @@ test("subset_suggestions", ({mock_template}) => {
     ];
 
     assert.deepEqual(suggestions.strings, expected);
+
+    // Exact-topic query
+    const exact_topic_query = `channel:${denmark_id} exact-topic:"To be or not to be" shakespeare`;
+    const exact_topic_suggestions = get_suggestions(exact_topic_query);
+
+    const expected_exact_topic = [
+        `channel:${denmark_id} exact-topic:To+be+or+not+to+be shakespeare`,
+        `channel:${denmark_id} exact-topic:To+be+or+not+to+be`,
+        `channel:${denmark_id}`,
+    ];
+
+    assert.deepEqual(exact_topic_suggestions.strings, expected_exact_topic);
 });
 
 test("dm_suggestions", ({override, mock_template}) => {
@@ -693,8 +705,8 @@ test("topic_suggestions", ({override, mock_template}) => {
         "dm:ted@zulip.com",
         "sender:ted@zulip.com",
         "dm-including:ted@zulip.com",
-        `channel:${office_id} topic:team`,
-        `channel:${office_id} topic:test`,
+        `channel:${office_id} team`,
+        `channel:${office_id} test`,
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -702,7 +714,7 @@ test("topic_suggestions", ({override, mock_template}) => {
         return suggestions.lookup_table.get(q).description_html;
     }
     assert.equal(describe("te"), "Search for te");
-    assert.equal(describe(`channel:${office_id} topic:team`), "Messages in #office > team");
+    assert.equal(describe(`channel:${office_id} team`), "Messages in #office, search for team");
 
     suggestions = get_suggestions(`topic:staplers channel:${office_id}`);
     expected = [`topic:staplers channel:${office_id}`, "topic:staplers"];
@@ -751,6 +763,14 @@ test("topic_suggestions", ({override, mock_template}) => {
         `topic:REXX channel:${devel_id} topic:`,
         `topic:REXX channel:${devel_id}`,
         "topic:REXX",
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    suggestions = get_suggestions(`exact-topic:REXX channel:${devel_id} exact-topic:`);
+    expected = [
+        `exact-topic:REXX channel:${devel_id} exact-topic:`,
+        `exact-topic:REXX channel:${devel_id}`,
+        "exact-topic:REXX",
     ];
     assert.deepEqual(suggestions.strings, expected);
 });

--- a/web/tests/stream_topic_history.test.cjs
+++ b/web/tests/stream_topic_history.test.cjs
@@ -407,7 +407,7 @@ test("ask_server_for_latest_topic_data", () => {
         assert.equal(opts.url, "/json/messages");
         assert.deepEqual(opts.data, {
             anchor: "newest",
-            narrow: '[{"operator":"stream","operand":1080},{"operator":"topic","operand":"Topic1"}]',
+            narrow: '[{"operator":"stream","operand":1080},{"operator":"exact-topic","operand":"Topic1"}]',
             num_after: 0,
             num_before: 1,
             allow_empty_topic_name: true,

--- a/zerver/lib/narrow_predicate.py
+++ b/zerver/lib/narrow_predicate.py
@@ -14,7 +14,7 @@ channels_operators: list[str] = ["channels", "streams"]
 
 
 def check_narrow_for_events(narrow: Collection[NeverNegatedNarrowTerm]) -> None:
-    supported_operators = [*channel_operators, "topic", "sender", "is"]
+    supported_operators = [*channel_operators, "topic", "exact-topic", "sender", "is"]
     unsupported_is_operands = ["followed"]
     for narrow_term in narrow:
         operator = narrow_term.operator
@@ -47,8 +47,16 @@ def build_narrow_predicate(
             elif operator == "topic":
                 if message["type"] != "stream":
                     return False
+                topic_name = get_topic_from_message_info(message).lower()
+                operand_lower = operand.lower()
+                if operand_lower == topic_name or operand_lower in topic_name.split():
+                    return True
+                return False
+            elif operator == "exact-topic":
+                if message["type"] != "stream":
+                    return False
                 topic_name = get_topic_from_message_info(message)
-                if operand.lower() != topic_name.lower():
+                if operand != topic_name:
                     return False
             elif operator == "sender":
                 if operand.lower() != message["sender_email"].lower():

--- a/zerver/lib/user_topics.py
+++ b/zerver/lib/user_topics.py
@@ -257,8 +257,8 @@ def exclude_stream_and_topic_mutes(
         recipient_id = row["recipient_id"]
         topic_name = row["topic_name"]
         stream_cond = column("recipient_id", Integer) == recipient_id
-        topic_cond = topic_match_sa(topic_name)
-        return and_(stream_cond, topic_cond)
+        exact_topic_cond = topic_match_sa(topic_name, exact=True)
+        return and_(stream_cond, exact_topic_cond)
 
     # Add this query later to reduce the number of messages it has to run on.
     if excluded_topic_rows:

--- a/zerver/tests/test_message_topics.py
+++ b/zerver/tests/test_message_topics.py
@@ -674,7 +674,7 @@ class EmptyTopicNameTest(ZulipTestCase):
             "narrow": orjson.dumps(
                 [
                     {"operator": "channel", "operand": "Denmark"},
-                    {"operator": "topic", "operand": Message.EMPTY_TOPIC_FALLBACK_NAME},
+                    {"operator": "exact-topic", "operand": Message.EMPTY_TOPIC_FALLBACK_NAME},
                 ]
             ).decode(),
         }


### PR DESCRIPTION
This pull request updates the `topic:` search operator to support partial, case-insensitive word matching, making it easier for users to find topics even if they don’t remember the full title. It also introduces a new `exact-topic:` operator for case-sensitive, exact string matches, preserving the old behavior for users who need precise control.

The implementation includes backend changes to query handling, UI support for the new operator in the search bar and suggestions, and a full set of frontend and backend tests to cover both operators behavior. The final behavior matches what was discussed in Zulip chat and we believe is the best approach for this feature, which slightly differs from the original GitHub issue.

<!-- Describe your pull request here.-->

Fixes: zulip#12328.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/6b6c957a-a659-4d24-be25-2ed4560d39cc

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
