### PR TITLE
scheduled_messages: Set read_by_sender for self-DMs using DM group.

### DIFF
--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -64,8 +64,8 @@ def check_schedule_message(
         # Legacy default: a scheduled message you sent from a non-API client is
         # automatically marked as read for yourself, unless it was sent to
         # yourself only.
-        read_by_sender = (
-            client.default_read_by_sender() and send_request.message.recipient != sender.recipient
+        read_by_sender = client.default_read_by_sender() and not addressee.is_message_to_self(
+            sender
         )
 
     return do_schedule_messages(

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -97,6 +97,13 @@ class Addressee:
         assert self._topic_name is not None
         return self._topic_name
 
+    def is_message_to_self(self, sender: UserProfile) -> bool:
+        return (
+            self.is_private()
+            and len(self.user_profiles()) == 1
+            and self.user_profiles()[0].id == sender.id
+        )
+
     @staticmethod
     def legacy_build(
         sender: UserProfile,

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -15,7 +15,7 @@ from psycopg2.sql import SQL
 from analytics.lib.counts import COUNT_STATS
 from analytics.models import RealmCount
 from zerver.lib.cache import generic_bulk_cached_fetch, to_dict_cache_key_id
-from zerver.lib.display_recipient import get_display_recipient_by_id
+from zerver.lib.display_recipient import get_display_recipient, get_display_recipient_by_id
 from zerver.lib.exceptions import JsonableError, MissingAuthenticationError
 from zerver.lib.markdown import MessageRenderingResult
 from zerver.lib.mention import MentionData, sender_can_mention_group
@@ -1743,5 +1743,16 @@ def is_1_to_1_message(message: Message) -> bool:
 
     if message.recipient.type == Recipient.PERSONAL:
         return True
+
+    return False
+
+
+def is_message_to_self(message: Message) -> bool:
+    if message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
+        group_members = get_display_recipient(message.recipient)
+        return len(group_members) == 1 and group_members[0]["id"] == message.sender.id
+
+    if message.recipient.type == Recipient.PERSONAL:
+        return message.recipient == message.sender.recipient
 
     return False


### PR DESCRIPTION
When using a direct message group as the recipient for 1:1 or self DMs, we need to ensure the `read_by_sender` [parameter](https://github.com/zulip/zulip/blob/10.x/zerver/actions/scheduled_messages.py#L61-L63) is set correctly when scheduling a message.


Fixes: part of issue https://github.com/zulip/zulip/issues/25713.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
