### PR TITLE
Fix uncontrolled data used in path expression

### DIFF
--- a/zerver/views/upload.py
+++ b/zerver/views/upload.py
@@ -427,7 +427,9 @@ def serve_local_avatar_unauthed(request: HttpRequest, path: str) -> HttpResponse
         url = get_public_upload_root_url() + path
         return redirect(url, permanent=True)
 
-    local_path = os.path.join(settings.LOCAL_AVATARS_DIR, path)
+    local_path = os.path.normpath(os.path.join(settings.LOCAL_AVATARS_DIR, path))
+    if not local_path.startswith(os.path.normpath(settings.LOCAL_AVATARS_DIR)):
+        raise JsonableError(_("Invalid path"))
     assert_is_local_storage_path("avatars", local_path)
     if not os.path.isfile(local_path):
         return HttpResponseNotFound("<p>File not found</p>")


### PR DESCRIPTION
https://github.com/zulip/zulip/blob/3dc54a10d7cbfb6f6f66a868a31d17ee9e215f53/zerver/views/upload.py#L430-L436


Accessing files using paths constructed from user-controlled data can allow an attacker to access unexpected resources. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.


Fix the issue need to validate the `local_path` constructed from the user-provided `path` parameter. This involves normalizing the path using `os.path.normpath` and ensuring that the resulting path is contained within the `settings.LOCAL_AVATARS_DIR` directory. This approach prevents path traversal attacks by removing any `..` segments and verifying the directory containment.

Steps to implement the fix:
1. Normalize the `local_path` using `os.path.normpath`.
2. Check that the normalized path starts with `settings.LOCAL_AVATARS_DIR`.
3. Raise an exception or return an error response if the validation fails.


#### References
[Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
[werkzeug.utils.secure_filename](http://werkzeug.pocoo.org/docs/utils/#werkzeug.utils.secure_filename)




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
