### PR TITLE
Replace the deprecated `keypress` with `keydown`.

### DIFF
--- a/web/src/list_util.ts
+++ b/web/src/list_util.ts
@@ -9,18 +9,18 @@ const list_selectors = [
     "#send_later_options",
 ];
 
-export function inside_list(e: JQuery.KeyDownEvent | JQuery.KeyPressEvent): boolean {
+export function inside_list(e: JQuery.KeyDownEvent): boolean {
     const $target = $(e.target);
     const in_list = $target.closest(list_selectors.join(", ")).length > 0;
     return in_list;
 }
 
-export function go_down(e: JQuery.KeyDownEvent | JQuery.KeyPressEvent): void {
+export function go_down(e: JQuery.KeyDownEvent): void {
     const $target = $(e.target);
     $target.closest("li").next().find("a").trigger("focus");
 }
 
-export function go_up(e: JQuery.KeyDownEvent | JQuery.KeyPressEvent): void {
+export function go_up(e: JQuery.KeyDownEvent): void {
     const $target = $(e.target);
     $target.closest("li").prev().find("a").trigger("focus");
 }

--- a/web/src/portico/integrations.ts
+++ b/web/src/portico/integrations.ts
@@ -274,7 +274,7 @@ function toggle_categories_dropdown(): void {
 }
 
 function integration_events(): void {
-    $<HTMLInputElement>('#integration-search input[type="text"]').on("keypress", function (e) {
+    $<HTMLInputElement>('#integration-search input[type="text"]').on("keydown", function (e) {
         if (e.key === "Enter" && this.value !== "") {
             $(".integration-lozenges .integration-lozenge:not([hidden])")[0]?.closest("a")?.click();
         }

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -319,8 +319,8 @@ $(() => {
         $("#new-user-email-address-visibility .current-selected-option").text(selected_option_text);
     });
 
-    $("#registration").on("click keypress", ".edit-realm-details", (e) => {
-        if (e.type === "keypress" && e.key !== "Enter") {
+    $("#registration").on("click keydown", ".edit-realm-details", (e) => {
+        if (e.type === "keydown" && e.key !== "Enter") {
             return;
         }
 

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -572,7 +572,7 @@ export function initialize(): void {
         },
     );
 
-    $("#channels_overlay_container").on("keypress", "#change_stream_description", (e) => {
+    $("#channels_overlay_container").on("keydown", "#change_stream_description", (e) => {
         // Stream descriptions cannot be multiline, so disable enter key
         // to prevent new line
         if (keydown_util.is_enter_event(e)) {

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -898,7 +898,7 @@ function setup_page(callback: () => void): void {
         // is only useful if the user has permission to create
         // streams, either explicitly via user_can_create_streams, or
         // implicitly because realm.realm_is_zephyr_mirror_realm.
-        $("#stream_filter input[type='text']").on("keypress", (e) => {
+        $("#stream_filter input[type='text']").on("keydown", (e) => {
             if (!keydown_util.is_enter_event(e)) {
                 return;
             }

--- a/web/src/user_status_ui.ts
+++ b/web/src/user_status_ui.ts
@@ -164,7 +164,7 @@ function user_status_post_render(): void {
         update_button();
     });
 
-    input_field().on("keypress", (event) => {
+    input_field().on("keydown", (event) => {
         if (keydown_util.is_enter_event(event)) {
             event.preventDefault();
 


### PR DESCRIPTION
More work related to [#frontend > Upgrading hotkey patterns @ 💬](https://chat.zulip.org/#narrow/channel/6-frontend/topic/Upgrading.20hotkey.20patterns/near/2184097)

Manually tested the UX related to these code changes.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
