### PR TITLE
push_notification: Use existing payload for 1:1 DM using DM group.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1000,7 +1000,9 @@ def get_message_payload(
         data["topic"] = get_topic_display_name(message.topic_name(), user_profile.default_language)
     elif message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
         data["recipient_type"] = "private"
-        data["pm_users"] = direct_message_group_users(message.recipient.id)
+        recipients = get_display_recipient(message.recipient)
+        if len(recipients) > 2:
+            data["pm_users"] = direct_message_group_users(message.recipient.id)
     else:  # Recipient.PERSONAL
         data["recipient_type"] = "private"
 
@@ -1014,7 +1016,8 @@ def get_apns_alert_title(message: Message, language: str) -> str:
     if message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
         recipients = get_display_recipient(message.recipient)
         assert isinstance(recipients, list)
-        return ", ".join(sorted(r["full_name"] for r in recipients))
+        if len(recipients) > 2:
+            return ", ".join(sorted(r["full_name"] for r in recipients))
     elif message.is_stream_message():
         stream_name = get_message_stream_name_from_database(message)
         topic_display_name = get_topic_display_name(message.topic_name(), language)
@@ -1057,6 +1060,10 @@ def get_apns_alert_subtitle(
         return _("{full_name} mentioned everyone:").format(full_name=sender_name)
     elif message.recipient.type == Recipient.PERSONAL:
         return ""
+    elif message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
+        recipients = get_display_recipient(message.recipient)
+        if len(recipients) <= 2:
+            return ""
     # For group direct messages, or regular messages to a stream,
     # just use a colon to indicate this is the sender.
     return sender_name + ":"


### PR DESCRIPTION
To maintain API compatibility during migration to `DirectMessageGroup` for 1:1 DMs, generate notification payloads for such messages in the same format as those sent to a `Personal` recipient.

Fixes: part of issue #25713.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
