### PR TITLE
settings-banner: Fix bugs in the rendering of the desktop notification banner.

### DIFF
--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -42,7 +42,7 @@ const DESKTOP_NOTIFICATIONS_BANNER: banners.Banner = {
     buttons: [
         {
             label: $t({defaultMessage: "Enable notifications"}),
-            custom_classes: "request-desktop-notifications",
+            custom_classes: "desktop-notifications-request",
             attention: "primary",
         },
     ],
@@ -273,6 +273,26 @@ export function set_up(settings_panel: SettingsPanel): void {
         settings_object.automatically_unmute_topics_in_muted_streams_policy,
     );
 
+    update_desktop_notification_banner();
+
+    $container.on("click", ".desktop-notifications-request", (e) => {
+        e.preventDefault();
+        // This is only accessed via the notifications banner, so we
+        // do not need to do a mobile check here--as that banner is
+        // not shown in a mobile context anyway.
+        void Notification.requestPermission().then((permission) => {
+            if (permission === "granted") {
+                update_desktop_notification_banner();
+            } else if (permission === "denied") {
+                window.open(
+                    "/help/desktop-notifications#check-platform-settings",
+                    "_blank",
+                    "noopener noreferrer",
+                );
+            }
+        });
+    });
+
     set_enable_digest_emails_visibility($container, for_realm_settings);
 
     if (for_realm_settings) {
@@ -380,24 +400,6 @@ export function set_up(settings_panel: SettingsPanel): void {
         message_notifications.send_test_notification(
             $t({defaultMessage: "This is a test notification from Zulip."}),
         );
-    });
-
-    $("#settings_content").on("click", ".request-desktop-notifications", (e) => {
-        e.preventDefault();
-        // This is only accessed via the notifications banner, so we
-        // do not need to do a mobile check here--as that banner is
-        // not shown in a mobile context anyway.
-        void Notification.requestPermission().then((permission) => {
-            if (permission === "granted") {
-                update_desktop_notification_banner();
-            } else if (permission === "denied") {
-                window.open(
-                    "/help/desktop-notifications#check-platform-settings",
-                    "_blank",
-                    "noopener noreferrer",
-                );
-            }
-        });
     });
 
     $("#settings_content").on("click", ".banner-close-button", (e) => {

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -542,6 +542,10 @@ input.settings_text_input {
     }
 }
 
+.desktop-setting-notifications {
+    margin-bottom: 10px;
+}
+
 .invite-stream-notice {
     margin-bottom: 20px;
 }

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -114,7 +114,7 @@
             {{> settings_save_discard_widget section_name="desktop-message-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
 
-        <div class="desktop-notification-settings-banners"></div>
+        <div class="desktop-notification-settings-banners banner-wrapper"></div>
 
         {{#unless for_realm_settings}}
         <p><a class="send_test_notification">{{t "Send a test notification" }}</a></p>


### PR DESCRIPTION
- This commit adds the `banner-wrapper` class to the parent container of the banner.

- Added `margin-bottom: 10px` to the banner to improve its appearance.

- Placed the event listener at the correct location with the $container element so that it binds only once. Previously, it was being bound every time the settings page was loaded, causing multiple event listeners to be attached to the same element.

- Additionally, the banner was not rendering when opening Org settings > DEFAULT USER SETTINGS directly,
and this has been fixed by ensuring the banner is rendered correctly.

- Also, if the banner gets rendered in the DEFAULT USER SETTINGS after opening personal settings first, the button click is not working, which is now fixed.


<!-- Describe your pull request here.-->

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/Bugs.20in.20Desktop.20Notification.20Banner.20Rendering.2E/with/2191415)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--|--|
| <img width="666" alt="Screenshot 2025-06-11 at 12 23 25 PM" src="https://github.com/user-attachments/assets/1c100a15-23bd-424c-9d96-fe887e461452" /> | <img width="653" alt="Screenshot 2025-06-11 at 12 24 28 PM" src="https://github.com/user-attachments/assets/a10f38a7-a899-41ef-ae9b-23b5fa9ed9c3" /> |
| <img width="289" alt="Screenshot 2025-06-11 at 12 24 42 PM" src="https://github.com/user-attachments/assets/be2e0824-9c06-47ad-9eb4-a810f320065b" /> | <img width="307" alt="Screenshot 2025-06-11 at 11 57 01 AM" src="https://github.com/user-attachments/assets/a6c0f39d-d293-405e-848d-03f9cc54ee10" /> |
| <img width="393" alt="Screenshot 2025-06-11 at 12 23 59 PM" src="https://github.com/user-attachments/assets/59091848-f1bb-4fe3-971e-0a818a1da4fa" />  | <img width="639" alt="Screenshot 2025-06-11 at 11 56 47 AM" src="https://github.com/user-attachments/assets/569edc77-2a0f-4097-afcb-4dc0c0bcf675" /> |






<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
