### PR TITLE
Fix Dropbox image previews

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,14 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 11.0
 
+**Feature level 395**
+
+* [Markdown message
+  formatting](/api/message-formatting#removed-features): Previously,
+  Zulip's Markdown syntax had special support for previewing Dropbox
+  albums. Dropbox albums no longer exist, and links to Dropbox folders
+  now consistently use Zulip's standard open graph preview markup.
+
 **Feature level 394**
 
 * [`POST /register`](/api/register-queue), [`GET

--- a/api_docs/message-formatting.md
+++ b/api_docs/message-formatting.md
@@ -365,7 +365,33 @@ features.
 
 ## Removed features
 
-**Changes**: In Zulip 4.0 (feature level 24), the rarely used `!avatar()`
+### Removed legacy Dropbox link preview markup
+
+In Zulip 11.0 (feature level 395), the Zulip server stopped generating
+legacy Dropbox link previews. Dropbox links are now previewed just
+like standard Zulip image/link previews. However, some legacy Dropbox
+previews may exist in existing messages.
+
+Clients are recommended to prune these previews from message HTML;
+since they always appear after the actual link, there is no loss of
+information/functionality. They can be recognized via the classes
+`message_inline_ref`, `message_inline_image_desc`, and
+`message_inline_image_title`:
+
+``` html
+<div class="message_inline_ref">
+    <a href="https://www.dropbox.com/sh/cm39k9e04z7fhim/AAAII5NK-9daee3FcF41anEua?dl=" title="Saves">
+        <img src="/path/to/folder_dropbox.png">
+    </a>
+    <div><div class="message_inline_image_title">Saves</div>
+        <desc class="message_inline_image_desc"></desc>
+    </div>
+</div>
+```
+
+### Removed legacy avatar markup
+
+In Zulip 4.0 (feature level 24), the rarely used `!avatar()`
 and `!gravatar()` markup syntax, which was never documented and had an
 inconsistent syntax, were removed.
 

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 394
+API_FEATURE_LEVEL = 395
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -185,6 +185,10 @@
            12.4px at 16px/1em */
         padding: 0;
         padding-inline-start: 0.775em;
+    }
+
+    & blockquote,
+    .message_embed {
         /* We want to keep the border roughly centered
            with bullets and single-digit list markers.
            3.5px at 16px/1em */
@@ -744,7 +748,6 @@
             )
             [fader-start] 10% [data-container-end thumbnail-end border-end fader-end];
         column-gap: 5px;
-        margin: 0 0 var(--markdown-interelement-space-px);
         /* We want to control the height without worrying about
            padding... */
         box-sizing: border-box;
@@ -753,7 +756,6 @@
            text works as expected. */
         height: calc(var(--length-message-preview-embeds) + 10px);
         padding: 5px;
-        border-inline-start: 3px solid hsl(0deg 0% 93%);
 
         .message_embed_title {
             font-size: 1.2em;

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -486,6 +486,9 @@
         margin-bottom: var(--markdown-interelement-space-px);
     }
 
+    /* We used to use this for certain dropbox previews, we are keeping
+       this around as to not break any previous instances of these
+       previews. */
     .message_inline_image_title {
         font-weight: bold;
     }
@@ -640,6 +643,9 @@
         margin-right: 0.75em;
     }
 
+    /* We used to use this for certain dropbox previews, we are keeping
+       this around as to not break any previous instances of these
+       previews. */
     .message_inline_ref {
         margin-bottom: var(--markdown-interelement-space-px);
         margin-inline-start: 5px;

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -678,14 +678,6 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
         else:
             img.set("src", image_url)
 
-        if class_attr == "message_inline_ref":
-            summary_div = SubElement(div, "div")
-            title_div = SubElement(summary_div, "div")
-            title_div.set("class", "message_inline_image_title")
-            title_div.text = title
-            desc_div = SubElement(summary_div, "desc")
-            desc_div.set("class", "message_inline_image_desc")
-
     def add_oembed_data(self, root: Element, link: str, extracted_data: UrlOEmbedData) -> None:
         if extracted_data.image is None:
             # Don't add an embed if an image is not found
@@ -1236,7 +1228,6 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
             uncle = grandparent[insertion_index]
             inline_image_classes = {
                 "message_inline_image",
-                "message_inline_ref",
                 "inline-preview-twitter",
             }
             if (

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1062,32 +1062,28 @@ class MarkdownEmbedsTest(ZulipTestCase):
             self.assertFalse(url_embed_preview_enabled(message, no_previews=True))
 
     def test_inline_dropbox(self) -> None:
-        msg = "Look at how hilarious our old office was: https://www.dropbox.com/s/ymdijjcg67hv2ta/IMG_0923.JPG"
+        msg = "Look at how hilarious our old office was: https://www.dropbox.com/scl/fi/cbabl5ryv1veky9ehs603/IMG_0923.JPG?rlkey=24sfgf0k0dneebzf5tfccldg0"
         image_info = {
-            "image": "https://photos-4.dropbox.com/t/2/AABIre1oReJgPYuc_53iv0IHq1vUzRaDg2rrCfTpiWMccQ/12/129/jpeg/1024x1024/2/_/0/4/IMG_0923.JPG/CIEBIAEgAiAHKAIoBw/ymdijjcg67hv2ta/AABz2uuED1ox3vpWWvMpBxu6a/IMG_0923.JPG",
-            "desc": "Shared with Dropbox",
-            "title": "IMG_0923.JPG",
+            "image": "https://www.dropbox.com/scl/fi/cbabl5ryv1veky9ehs603/IMG_0923.JPG?rlkey=24sfgf0k0dneebzf5tfccldg0&raw=1",
         }
         with mock.patch("zerver.lib.markdown.fetch_open_graph_image", return_value=image_info):
             converted = markdown_convert_wrapper(msg)
 
         self.assertEqual(
             converted,
-            f"""<p>Look at how hilarious our old office was: <a href="https://www.dropbox.com/s/ymdijjcg67hv2ta/IMG_0923.JPG">https://www.dropbox.com/s/ymdijjcg67hv2ta/IMG_0923.JPG</a></p>\n<div class="message_inline_image"><a href="https://www.dropbox.com/s/ymdijjcg67hv2ta/IMG_0923.JPG" title="IMG_0923.JPG"><img src="{get_camo_url("https://www.dropbox.com/s/ymdijjcg67hv2ta/IMG_0923.JPG?raw=1")}"></a></div>""",
+            f"""<p>Look at how hilarious our old office was: <a href="https://www.dropbox.com/scl/fi/cbabl5ryv1veky9ehs603/IMG_0923.JPG?rlkey=24sfgf0k0dneebzf5tfccldg0">https://www.dropbox.com/scl/fi/cbabl5ryv1veky9ehs603/IMG_0923.JPG?rlkey=24sfgf0k0dneebzf5tfccldg0</a></p>\n<div class="message_inline_image"><a href="https://www.dropbox.com/scl/fi/cbabl5ryv1veky9ehs603/IMG_0923.JPG?rlkey=24sfgf0k0dneebzf5tfccldg0&amp;raw=1"><img src="{get_camo_url("https://www.dropbox.com/scl/fi/cbabl5ryv1veky9ehs603/IMG_0923.JPG?rlkey=24sfgf0k0dneebzf5tfccldg0&raw=1")}"></a></div>""",
         )
 
-        msg = "Look at my hilarious drawing folder: https://www.dropbox.com/sh/cm39k9e04z7fhim/AAAII5NK-9daee3FcF41anEua?dl="
+        msg = "Look at my hilarious drawing folder: https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&st=dz5p1ytw"  # codespell:ignore fo
         image_info = {
-            "image": "https://cf.dropboxstatic.com/static/images/icons128/folder_dropbox.png",
-            "desc": "Shared with Dropbox",
-            "title": "Saves",
+            "image": "https://www.dropbox.com/static/metaserver/static/images/opengraph/opengraph-content-icon-folder-dropbox-landscape.png",
         }
         with mock.patch("zerver.lib.markdown.fetch_open_graph_image", return_value=image_info):
             converted = markdown_convert_wrapper(msg)
 
         self.assertEqual(
             converted,
-            f"""<p>Look at my hilarious drawing folder: <a href="https://www.dropbox.com/sh/cm39k9e04z7fhim/AAAII5NK-9daee3FcF41anEua?dl=">https://www.dropbox.com/sh/cm39k9e04z7fhim/AAAII5NK-9daee3FcF41anEua?dl=</a></p>\n<div class="message_inline_ref"><a href="https://www.dropbox.com/sh/cm39k9e04z7fhim/AAAII5NK-9daee3FcF41anEua?dl=" title="Saves"><img src="{get_camo_url("https://cf.dropboxstatic.com/static/images/icons128/folder_dropbox.png")}"></a><div><div class="message_inline_image_title">Saves</div><desc class="message_inline_image_desc"></desc></div></div>""",
+            """<p>Look at my hilarious drawing folder: <a href="https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&amp;st=dz5p1ytw">https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&amp;st=dz5p1ytw</a></p>\n<div class="message_embed"><a class="message_embed_image" href="https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&amp;st=dz5p1ytw" style="background-image: url(&quot;https://external-content.zulipcdn.net/external_content/a301902b9942efb85cfe2a6f4bb07d76ba7b86de/68747470733a2f2f7777772e64726f70626f782e636f6d2f7374617469632f6d6574617365727665722f7374617469632f696d616765732f6f70656e67726170682f6f70656e67726170682d636f6e74656e742d69636f6e2d666f6c6465722d64726f70626f782d6c616e6473636170652e706e67&quot;)"></a><div class="data-container"><div class="message_embed_title"><a href="https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&amp;st=dz5p1ytw" title="Dropbox folder">Dropbox folder</a></div><div class="message_embed_description">Click to open folder.</div></div></div>""",  # codespell:ignore fo
         )
 
     def test_inline_dropbox_preview(self) -> None:
@@ -1095,15 +1091,14 @@ class MarkdownEmbedsTest(ZulipTestCase):
         msg = "https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5"
         image_info = {
             "image": "https://photos-6.dropbox.com/t/2/AAAlawaeD61TyNewO5vVi-DGf2ZeuayfyHFdNTNzpGq-QA/12/271544745/jpeg/1024x1024/2/_/0/5/baby-piglet.jpg/CKnjvYEBIAIgBygCKAc/tditp9nitko60n5/AADX03VAIrQlTl28CtujDcMla/0",
-            "desc": "Shared with Dropbox",
-            "title": "1 photo",
         }
         with mock.patch("zerver.lib.markdown.fetch_open_graph_image", return_value=image_info):
             converted = markdown_convert_wrapper(msg)
 
         self.assertEqual(
             converted,
-            f"""<p><a href="https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5">https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5</a></p>\n<div class="message_inline_image"><a href="https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5" title="1 photo"><img src="{get_camo_url("https://photos-6.dropbox.com/t/2/AAAlawaeD61TyNewO5vVi-DGf2ZeuayfyHFdNTNzpGq-QA/12/271544745/jpeg/1024x1024/2/_/0/5/baby-piglet.jpg/CKnjvYEBIAIgBygCKAc/tditp9nitko60n5/AADX03VAIrQlTl28CtujDcMla/0")}"></a></div>""",
+            """<p><a href="https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5">https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5</a></p>
+<div class="message_embed"><a class="message_embed_image" href="https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5" style="background-image: url(&quot;https://external-content.zulipcdn.net/external_content/e7584a56d9ba7f2a2aee96ee1427a6b746eab5ff/68747470733a2f2f70686f746f732d362e64726f70626f782e636f6d2f742f322f4141416c6177616544363154794e65774f357656692d444766325a6575617966794846644e544e7a7047712d51412f31322f3237313534343734352f6a7065672f3130323478313032342f322f5f2f302f352f626162792d7069676c65742e6a70672f434b6e6a7659454249414967427967434b41632f7464697470396e69746b6f36306e352f41414458303356414972516c546c32384374756a44634d6c612f30&quot;)"></a><div class="data-container"><div class="message_embed_title"><a href="https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5" title="Dropbox folder">Dropbox folder</a></div><div class="message_embed_description">Click to open folder.</div></div></div>""",
         )
 
     def test_inline_dropbox_negative(self) -> None:


### PR DESCRIPTION
Fixes #32640.

The URL structure for a shared link has changed since this function was returned and this commit makes sure our code is in compliance with that structure.

The concept of an album doesn't exist anymore and folders exist in-lieu of that.

For dropbox links that are folders on non-image files, we show previews same as any other link previews. It is not possible to get information about the shared link except whether it is a file or folder. So for title and description for that linked preview, we use `Dropbox file` or `Dropbox folder` respectively.

Earlier, we were just having raw=1 as the query param to get the image file if required, but now for every dropbox sharing link, preserving query params is important (otherwise we get a 404), this commit makes changes to address that.

For /sc/ links, it is not possible to generate them anymore (afaik), but it is possible to view those existing links, so we support that link but treat it as a folder instead.

You can check https://www.dropboxforum.com/discussions/101001012/shared-link--scl-to-s/689070/replies/695266 for URL structure info.

https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20message_inline_ref.20dropbox.20links

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="704" alt="Screenshot 2025-06-11 at 6 21 04 PM" src="https://github.com/user-attachments/assets/13152337-ecb9-4e7b-b490-ea8f1a6b9346" />
<img width="712" alt="Screenshot 2025-06-13 at 2 01 13 PM" src="https://github.com/user-attachments/assets/2705f5a2-47bf-4e55-8574-4e19353b8ad8" />
<img width="712" alt="Screenshot 2025-06-13 at 2 01 06 PM" src="https://github.com/user-attachments/assets/15d4a958-045e-436e-8a0f-0e741c25eea3" />




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
