### PR TITLE
restart-server: Send client reload events in the background.

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-3
+++ b/scripts/lib/upgrade-zulip-stage-3
@@ -367,7 +367,7 @@ else:
     subprocess.check_call(["./scripts/lib/run_hooks.py", "post-deploy", *hooks_args])
 
     if not args.skip_client_reloads and not args.only_django:
-        subprocess.check_call(["./scripts/reload-clients"], preexec_fn=su_to_zulip)
+        subprocess.check_call(["./scripts/reload-clients", "--background"], preexec_fn=su_to_zulip)
 
 if args.audit_fts_indexes:
     logging.info("Correcting full-text search indexes for updated dictionary files")

--- a/scripts/reload-clients
+++ b/scripts/reload-clients
@@ -31,6 +31,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument(
     "--rate", type=int, help="Number of clients to reload per second", default=reload_rate
 )
+parser.add_argument("--background", action="store_true", help="Daemonize the process")
 
 args = parser.parse_args()
 reload_rate = args.rate
@@ -49,8 +50,24 @@ retry = Retry(total=3, backoff_factor=1, allowed_methods=Retry.DEFAULT_ALLOWED_M
 c = requests.Session()
 c.mount("http://", HTTPAdapter(max_retries=retry))
 
+log_filename = None
+if args.background:
+    # Double-fork to daemonize
+    pid = os.fork()
+    if pid > 0:
+        sys.exit(0)
+    os.setsid()
+    pid = os.fork()
+    if pid > 0:
+        sys.exit(0)
+    log_filename = "/var/log/zulip/reload-clients.log"
+
 logging.Formatter.converter = time.gmtime
-logging.basicConfig(format="%(asctime)s reload-clients: %(message)s", level=logging.INFO)
+logging.basicConfig(
+    format="%(asctime)s reload-clients: %(message)s",
+    level=logging.INFO,
+    filename=log_filename,
+)
 
 first = True
 server_total = 0

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -245,7 +245,8 @@ if (action == "start" or args.less_graceful) and not args.only_django:
 if has_application_server() and not args.skip_client_reloads and not args.only_django:
     # All of the servers have been (re)started; now enqueue events in
     # the Tornado servers to tell clients to reload.
-    subprocess.check_call(["./scripts/reload-clients"])
+    logging.info("Sending reload events to clients in the background")
+    subprocess.check_call(["./scripts/reload-clients", "--background"])
 
 logging.info("Done!")
 print(OKGREEN + f"Zulip {action}ed successfully!" + ENDC)


### PR DESCRIPTION
For deploys with --skip-puppet, this makes the output visible much more promptly.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
