### PR TITLE
request: Use Django 5.2 HttpRequest.get_preferred_type

### DIFF
--- a/corporate/lib/decorator.py
+++ b/corporate/lib/decorator.py
@@ -16,7 +16,6 @@ from corporate.lib.remote_billing_util import (
     get_remote_server_and_user_from_session,
 )
 from zerver.lib.exceptions import RemoteBillingAuthenticationError
-from zerver.lib.request import get_preferred_type
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.url_encoding import append_url_query_string
 from zilencer.models import RemoteRealm
@@ -125,7 +124,7 @@ def authenticated_remote_realm_management_endpoint(
 
             # Return error for AJAX requests with url.
             if (
-                get_preferred_type(request, ["application/json", "text/html"]) != "text/html"
+                request.get_preferred_type(["application/json", "text/html"]) != "text/html"
             ):  # nocoverage
                 return session_expired_ajax_response(url)
 
@@ -211,7 +210,7 @@ def authenticated_remote_server_management_endpoint(
 
             # Return error for AJAX requests with url.
             if (
-                get_preferred_type(request, ["application/json", "text/html"]) != "text/html"
+                request.get_preferred_type(["application/json", "text/html"]) != "text/html"
             ):  # nocoverage
                 return session_expired_ajax_response(url)
 

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -98,22 +98,3 @@ class RequestVariableConversionError(JsonableError):
 
 
 arguments_map: dict[str, list[str]] = defaultdict(list)
-
-
-# Equivalent to request.get_preferred_type() in Django 5.2.
-def get_preferred_type(request: HttpRequest, media_types: list[str]) -> str | None:
-    best_type = None
-    best_score = 0.0, True, True
-    for accepted_type in request.accepted_types:
-        score = (
-            float(accepted_type.params.get("q", "1")),
-            accepted_type.main_type != "*",
-            accepted_type.sub_type != "*",
-        )
-        if best_score < score:
-            for media_type in media_types:
-                if accepted_type.match(media_type):
-                    best_type = media_type
-                    best_score = score
-                    break
-    return best_type

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -33,7 +33,7 @@ from zerver.lib.exceptions import ErrorCode, JsonableError, MissingAuthenticatio
 from zerver.lib.markdown import get_markdown_requests, get_markdown_time
 from zerver.lib.per_request_cache import flush_per_request_caches
 from zerver.lib.rate_limiter import RateLimitResult
-from zerver.lib.request import RequestNotes, get_preferred_type
+from zerver.lib.request import RequestNotes
 from zerver.lib.response import (
     AsynchronousResponse,
     json_response,
@@ -377,7 +377,7 @@ class LogRequests(MiddlewareMixin):
 class JsonErrorHandler(MiddlewareMixin):
     def process_exception(self, request: HttpRequest, exception: Exception) -> HttpResponse | None:
         if isinstance(exception, MissingAuthenticationError):
-            if get_preferred_type(request, ["application/json", "text/html"]) == "text/html":
+            if request.get_preferred_type(["application/json", "text/html"]) == "text/html":
                 # If this looks like a request from a top-level page in a
                 # browser, send the user to the login page.
                 #

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import orjson
 import pyvips
 from django.conf import settings
-from django.http.request import MediaType
+from django.http import HttpRequest
 from django.test import override_settings
 
 from zerver.lib.test_classes import ZulipTestCase
@@ -920,13 +920,14 @@ class TestThumbnailRetrieval(ZulipTestCase):
         rendered_formats = [
             StoredThumbnailFormat(**data) for data in image_attachment.thumbnail_metadata
         ]
-        accepts = [MediaType("image/webp"), MediaType("image/*"), MediaType("*/*;q=0.8")]
+        request = HttpRequest()
+        request.META["HTTP_ACCEPT"] = "image/webp, image/*, */*;q=0.8"
 
         # Prefer to match -animated, even though we have a .gif
         self.assertEqual(
             str(
                 closest_thumbnail_format(
-                    ThumbnailFormat("gif", 100, 75, animated=True), accepts, rendered_formats
+                    ThumbnailFormat("gif", 100, 75, animated=True), request, rendered_formats
                 )
             ),
             "100x75-anim.webp",
@@ -936,7 +937,7 @@ class TestThumbnailRetrieval(ZulipTestCase):
         self.assertEqual(
             str(
                 closest_thumbnail_format(
-                    ThumbnailFormat("gif", 10, 10, animated=False), accepts, rendered_formats
+                    ThumbnailFormat("gif", 10, 10, animated=False), request, rendered_formats
                 )
             ),
             "100x75.gif",
@@ -946,37 +947,39 @@ class TestThumbnailRetrieval(ZulipTestCase):
         self.assertEqual(
             str(
                 closest_thumbnail_format(
-                    ThumbnailFormat("tif", 10, 10, animated=False), accepts, rendered_formats
+                    ThumbnailFormat("tif", 10, 10, animated=False), request, rendered_formats
                 )
             ),
             "10x10.webp",
         )
+        request = HttpRequest()
+        request.META["HTTP_ACCEPT"] = "image/webp;q=0.9, image/gif"
         self.assertEqual(
             str(
                 closest_thumbnail_format(
-                    ThumbnailFormat("tif", 10, 10, animated=False),
-                    [MediaType("image/webp;q=0.9"), MediaType("image/gif")],
-                    rendered_formats,
+                    ThumbnailFormat("tif", 10, 10, animated=False), request, rendered_formats
                 )
             ),
             "100x75.gif",
         )
+        request = HttpRequest()
+        request.META["HTTP_ACCEPT"] = "image/gif"
         self.assertEqual(
             str(
                 closest_thumbnail_format(
-                    ThumbnailFormat("tif", 10, 10, animated=False),
-                    [MediaType("image/gif")],
-                    rendered_formats,
+                    ThumbnailFormat("tif", 10, 10, animated=False), request, rendered_formats
                 )
             ),
             "100x75.gif",
         )
 
         # Closest width
+        request = HttpRequest()
+        request.META["HTTP_ACCEPT"] = "image/webp, image/*, */*;q=0.8"
         self.assertEqual(
             str(
                 closest_thumbnail_format(
-                    ThumbnailFormat("webp", 20, 100, animated=False), accepts, rendered_formats
+                    ThumbnailFormat("webp", 20, 100, animated=False), request, rendered_formats
                 )
             ),
             "10x10.webp",
@@ -984,19 +987,19 @@ class TestThumbnailRetrieval(ZulipTestCase):
         self.assertEqual(
             str(
                 closest_thumbnail_format(
-                    ThumbnailFormat("webp", 80, 10, animated=False), accepts, rendered_formats
+                    ThumbnailFormat("webp", 80, 10, animated=False), request, rendered_formats
                 )
             ),
             "100x75.webp",
         )
 
         # Smallest filesize if they have no media preference
+        request = HttpRequest()
+        request.META["HTTP_ACCEPT"] = "image/gif, image/webp"
         self.assertEqual(
             str(
                 closest_thumbnail_format(
-                    ThumbnailFormat("tif", 100, 75, animated=False),
-                    [MediaType("image/gif"), MediaType("image/webp")],
-                    rendered_formats,
+                    ThumbnailFormat("tif", 100, 75, animated=False), request, rendered_formats
                 )
             ),
             "100x75.webp",

--- a/zerver/views/upload.py
+++ b/zerver/views/upload.py
@@ -193,40 +193,11 @@ def serve_file_url_backend(
     return serve_file(request, user_profile, realm_id_str, filename, url_only=True)
 
 
-def preferred_accept(request: HttpRequest, served_types: list[str]) -> str | None:
-    # Returns the first of the served_types which the browser will
-    # accept, based on the browser's stated quality preferences.
-    # Returns None if none of the served_types are accepted by the
-    # browser.
-    accepted_types = sorted(
-        request.accepted_types,
-        key=lambda e: float(e.params.get("q", "1.0")),
-        reverse=True,
-    )
-    for potential_type in accepted_types:
-        for served_type in served_types:
-            if potential_type.match(served_type):
-                return served_type
-    return None
-
-
 def closest_thumbnail_format(
     requested_format: BaseThumbnailFormat,
     request: HttpRequest,
     rendered_formats: list[StoredThumbnailFormat],
 ) -> StoredThumbnailFormat:
-    accepted_types = sorted(
-        request.accepted_types,
-        key=lambda e: float(e.params.get("q", "1.0")),
-        reverse=True,
-    )
-
-    def q_for(content_type: str) -> float:
-        for potential_type in accepted_types:
-            if potential_type.match(content_type):
-                return float(potential_type.params.get("q", "1.0"))
-        return 0.0
-
     # Serve a "close" format -- preferring animated which
     # matches, followed by the format they requested, or one
     # their browser supports, in the size closest to what they
@@ -237,12 +208,14 @@ def closest_thumbnail_format(
         return (
             possible_format.animated != requested_format.animated,
             possible_format.extension != requested_format.extension,
-            1.0 - q_for(possible_format.content_type),
+            0.0
+            if (accepted_type := request.accepted_type(possible_format.content_type)) is None
+            else -accepted_type.quality,
             abs(requested_format.max_width - possible_format.max_width),
             possible_format.byte_size,
         )
 
-    return sorted(rendered_formats, key=grade_format)[0]
+    return min(rendered_formats, key=grade_format)
 
 
 def serve_file(
@@ -265,7 +238,7 @@ def serve_file(
         return FileResponse(open(static_path(image_path), "rb"), status=status)
 
     if attachment is None:
-        if preferred_accept(request, ["text/html", "image/png"]) == "image/png":
+        if request.get_preferred_type(["text/html", "image/png"]) == "image/png":
             response = serve_image_error(404, "images/errors/image-not-exist.png")
         else:
             response = HttpResponseNotFound(
@@ -274,7 +247,7 @@ def serve_file(
         patch_vary_headers(response, ("Accept",))
         return response
     if not is_authorized:
-        if preferred_accept(request, ["text/html", "image/png"]) == "image/png":
+        if request.get_preferred_type(["text/html", "image/png"]) == "image/png":
             response = serve_image_error(403, "images/errors/image-no-auth.png")
         elif isinstance(maybe_user_profile, AnonymousUser):
             response = zulip_redirect_to_login(request)

--- a/zerver/views/upload.py
+++ b/zerver/views/upload.py
@@ -17,7 +17,6 @@ from django.http import (
     HttpResponseForbidden,
     HttpResponseNotFound,
 )
-from django.http.request import MediaType
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.cache import patch_cache_control, patch_vary_headers
@@ -213,11 +212,11 @@ def preferred_accept(request: HttpRequest, served_types: list[str]) -> str | Non
 
 def closest_thumbnail_format(
     requested_format: BaseThumbnailFormat,
-    accepts: list[MediaType],
+    request: HttpRequest,
     rendered_formats: list[StoredThumbnailFormat],
 ) -> StoredThumbnailFormat:
     accepted_types = sorted(
-        accepts,
+        request.accepted_types,
         key=lambda e: float(e.params.get("q", "1.0")),
         reverse=True,
     )
@@ -331,7 +330,7 @@ def serve_file(
                 # set, or the client is just guessing a format and
                 # hoping.
                 requested_format = closest_thumbnail_format(
-                    requested_format, request.accepted_types, rendered_formats
+                    requested_format, request, rendered_formats
                 )
         elif requested_format not in rendered_formats:
             # They requested a valid format, but one we've not


### PR DESCRIPTION
~~This should probably wait until Django 5.2.4 (expected July 2) due to [Django #36447 “HttpRequest.get_preferred_type misorders types when more specific accepted types have lower q”](https://code.djangoproject.com/ticket/36447).~~ We upgraded to 5.2.4 in #35260.

- Followup to #34336.