### PR TITLE
More tweaks to slack import process.

### DIFF
--- a/templates/zerver/slack_import.html
+++ b/templates/zerver/slack_import.html
@@ -70,7 +70,7 @@
                         {% endtrans %}
                     </div>
                     <div id="slack-import-drag-and-drop" data-max-file-size="{{max_file_size}}"></div>
-                    <p id="slack-import-file-upload-error" class="help-inline text-error"></p>
+                    <p id="slack-import-file-upload-error" class="help-inline text-error">{{ invalid_file_error_message }}</p>
                 </div>
                 <form id="slack-import-start-upload-wrapper" method="post" class="form-inline {% if uploaded_import_file_name %}{% else %}hidden{% endif %}" action="{{ url('import_realm_from_slack') }}">
                     {{ csrf_input }}

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -434,7 +434,11 @@ $(() => {
                 },
             },
         });
-        uppy.use(Tus, {endpoint: "/api/v1/tus/"});
+        uppy.use(Tus, {
+            endpoint: "/api/v1/tus/",
+            // Allow user to upload the same file multiple times.
+            removeFingerprintOnSuccess: true,
+        });
         uppy.on("restriction-failed", (_file, error) => {
             $("#slack-import-file-upload-error").text(error.message);
         });

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -776,3 +776,14 @@ class DeliveryTimeNotInFutureError(JsonableError):
     @override
     def msg_format() -> str:
         return _("Scheduled delivery time must be in the future.")
+
+
+class SlackImportInvalidFileError(Exception):
+    """
+    An error that is raised during the Slack import process
+    and is intended to be shown to the user.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -1223,7 +1223,7 @@ def realm_import_post_process(
 
     claimable_users = UserProfile.objects.filter(
         realm=realm, is_active=True, is_bot=False, is_mirror_dummy=False
-    )
+    ).order_by("full_name")
     context = {
         "users": claimable_users,
         "verified_email": preregistration_realm.email,

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -1055,7 +1055,7 @@ def realm_import_status(
         # TODO: Either store the path to the temporary conversion directory on
         # preregistration_realm.data_import_metadata, or have the conversion
         # process support writing updates to this for a better progress indicator.
-        return json_success(request, {"status": _("Converting Slack data…")})
+        return json_success(request, {"status": _("Converting Slack data… This may take a while.")})
 
     if realm.deactivated:
         # These "if" cases are in the inverse order than they're done


### PR DESCRIPTION
Addresses more points from #34649

discussion: https://chat.zulip.org/#narrow/channel/191-kandra-support/topic/Slack.20import/with/2192069

## Import process

- [ ] "Converting Slack data…" seems to take a while sometimes, so maybe we should set that expectation?

> Converting Slack data… This may take a while.

**Done**


- [ ] When I upload a random zip file (not a Slack export), it seems to just get stuck at "Converting Slack data…". Can we handle that better? In case it's relevant, in my terminal, I see:

> 2025-05-15 20:10:39.219 INFO [zr] 127.0.0.1       GET     200   3ms (db: 0ms/3q) /json/realm/import/status/6eq5nbqf6d3j3klblz3ur32a (unauth@root via Mozilla)


**Fixed to navigate user back to file upload page and show an error**

![Screenshot from 2025-06-11 10-21-39](https://github.com/user-attachments/assets/05cadfba-dfc3-4188-9789-d01a1fb938c1)

## When there's no matching email
  - [ ] Is it correct that bot account are listed in the dropdown? I would think not?


![Image](https://github.com/user-attachments/assets/5f80f9ed-71cf-4073-ab12-e4323029e3d4)
**Removed slack bot**

- [ ] A couple of of the times I ran an export, I got an error page. I don't know how to reproduce, so maybe something was just off with my dev environment?

![Image](https://github.com/user-attachments/assets/db031276-7b00-49f7-96b1-d9a7fcbf9a26)

**Fixed**