### PR TITLE
copy_messages: Expand selection for multi-message selection.

### DIFF
--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -268,6 +268,19 @@ export function copy_handler(ev: ClipboardEvent): boolean {
         return false;
     }
 
+    // Expand selection to select content from all the messages
+    // belonging to the multi-message selection.
+    const first = $(`[data-message-id='${start_id}']`).find(".messagebox-content")[0];
+    const last = $(`[data-message-id='${end_id}']`).find(".messagebox-content")[0];
+
+    if (first && last) {
+        selection.removeAllRanges();
+        const range = document.createRange();
+        range.setStartBefore(first);
+        range.setEndAfter(last);
+        selection.addRange(range);
+    }
+
     // We've now decided to handle the copy event ourselves.
     //
     // We construct a temporary div for what we want the copy to pick up.


### PR DESCRIPTION
Fixes: #6316.

![make-selection-consistent-for-multi-message-selection](https://github.com/user-attachments/assets/3bfeec31-15f5-43db-9d92-b0ac6e60d455)



