### PR TITLE
report_message: Use existing template for reporting 1:1 DM via DM group.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -58,6 +58,7 @@ from zerver.models import (
 from zerver.models.constants import MAX_TOPIC_NAME_LENGTH
 from zerver.models.messages import get_usermessage_by_message_id
 from zerver.models.realms import MessageEditHistoryVisibilityPolicyEnum
+from zerver.models.recipients import DirectMessageGroup
 
 
 class MessageDetailsDict(TypedDict, total=False):
@@ -1733,3 +1734,14 @@ def set_visibility_policy_possible(user_profile: UserProfile, message: Message) 
 def remove_single_newlines(content: str) -> str:
     content = content.strip("\n")
     return re.sub(r"(?<!\n)\n(?!\n|[-*] |[0-9]+\. )", " ", content)
+
+
+def is_1_to_1_message(message: Message) -> bool:
+    if message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
+        direct_message_group = DirectMessageGroup.objects.get(id=message.recipient.type_id)
+        return direct_message_group.group_size <= 2
+
+    if message.recipient.type == Recipient.PERSONAL:
+        return True
+
+    return False

--- a/zerver/lib/message_report.py
+++ b/zerver/lib/message_report.py
@@ -5,7 +5,7 @@ from zerver.actions.message_send import internal_send_stream_message
 from zerver.lib.display_recipient import get_display_recipient
 from zerver.lib.markdown.fenced_code import get_unused_fence
 from zerver.lib.mention import silent_mention_syntax_for_user
-from zerver.lib.message import truncate_content
+from zerver.lib.message import is_1_to_1_message, truncate_content
 from zerver.models import Message, Realm, UserProfile
 from zerver.models.recipients import Recipient
 from zerver.models.users import get_system_bot
@@ -34,7 +34,7 @@ def send_message_report(
     reporting_user_mention = silent_mention_syntax_for_user(reporting_user)
 
     # Build reported message header
-    if reported_message.recipient.type == Recipient.PERSONAL:
+    if is_1_to_1_message(reported_message):
         report_header = _(
             "{reporting_user_mention} reported a DM sent by {reported_user_mention}."
         ).format(

--- a/zerver/tests/test_message_report.py
+++ b/zerver/tests/test_message_report.py
@@ -10,6 +10,7 @@ from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.topic import DB_TOPIC_NAME
 from zerver.models import UserProfile
 from zerver.models.messages import Message
+from zerver.models.recipients import get_or_create_direct_message_group
 from zerver.models.users import get_system_bot
 
 
@@ -150,6 +151,57 @@ class ReportMessageTest(ZulipTestCase):
         assert reported_dm.id == reported_dm_id
 
         reporting_user = self.example_user("hamlet")
+        report_type = "harassment"
+        description = "this is crime against food"
+        reporting_user_mention = silent_mention_syntax_for_user(reporting_user)
+        reported_user_mention = silent_mention_syntax_for_user(self.reported_user)
+
+        message_sent_to = f"{reporting_user_mention} reported a DM sent by {reported_user_mention}."
+        expected_message = """
+{message_sent_to}
+- Reason: **{report_type}**
+- Notes:
+```quote
+{description}
+```
+{fence} spoiler **Message sent by {reported_user}**
+{reported_message}
+{fence}
+""".format(
+            report_type=report_type,
+            description=description,
+            reported_user=reported_user_mention,
+            message_sent_to=message_sent_to,
+            reported_message=reported_dm.content,
+            fence=get_unused_fence(reported_dm.content),
+        )
+
+        result = self.report_message(reporting_user, reported_dm_id, report_type, description)
+        self.assert_json_success(result)
+        reports = self.get_submitted_moderation_requests()
+        self.assertEqual(reports[0]["content"], expected_message.strip())
+
+        # User can't report DM they're not a part of.
+        ZOE = self.example_user("ZOE")
+        result = self.report_message(ZOE, reported_dm_id, report_type, description)
+        self.assert_json_error(result, msg="Invalid message(s)")
+
+    def test_personal_message_report_using_direct_message_group(self) -> None:
+        direct_message_group = get_or_create_direct_message_group(
+            id_list=[self.hamlet.id, self.reported_user.id],
+        )
+
+        # Send a DM to be reported
+        reported_dm_id = self.send_personal_message(
+            self.reported_user,
+            self.hamlet,
+            content="I dip fries in ice cream",
+        )
+        reported_dm = self.get_last_message()
+        assert reported_dm.id == reported_dm_id
+        assert reported_dm.recipient == direct_message_group.recipient
+
+        reporting_user = self.hamlet
         report_type = "harassment"
         description = "this is crime against food"
         reporting_user_mention = silent_mention_syntax_for_user(reporting_user)


### PR DESCRIPTION
To maintain API compatibility during and after the migration to use `DirectMessageGroup` for 1:1 messages, we need to build the existing report message format when reporting 1:1 DMs using `DirectMessageGroup`.

Fixes: part of issue https://github.com/zulip/zulip/issues/25713.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
