### PR TITLE
inputs: Correct text colors, custom select chevrons.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1126,7 +1126,7 @@ input.settings_text_input {
 
 .filter_text_input {
     padding: 4px 6px;
-    color: hsl(0deg 0% 33%);
+    color: var(--color-text-default);
     border: 1px solid hsl(0deg 0% 80%);
     transition:
         border-color linear 0.2s,

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1998,7 +1998,7 @@
         hsl(0deg 0% 46.7%),
         hsl(236deg 33% 90%)
     );
-    --icon-chevron-down: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M3.52977 5.52973C3.78947 5.27004 4.21053 5.27004 4.47023 5.52973L8 9.05951L11.5298 5.52973C11.7895 5.27004 12.2105 5.27004 12.4702 5.52973C12.7299 5.78943 12.7299 6.21049 12.4702 6.47019L8.47023 10.4702C8.21053 10.7299 7.78947 10.7299 7.52977 10.4702L3.52977 6.47019C3.27008 6.21049 3.27008 5.78943 3.52977 5.52973Z' fill='%23333333'/%3E%3C/svg%3E%0A");
+    --icon-chevron-down: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='%23333333' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath clip-rule='evenodd' d='M3.52977 5.52973C3.78947 5.27004 4.21053 5.27004 4.47023 5.52973L8 9.05951L11.5298 5.52973C11.7895 5.27004 12.2105 5.27004 12.4702 5.52973C12.7299 5.78943 12.7299 6.21049 12.4702 6.47019L8.47023 10.4702C8.21053 10.7299 7.78947 10.7299 7.52977 10.4702L3.52977 6.47019C3.27008 6.21049 3.27008 5.78943 3.52977 5.52973Z'/%3E%3C/svg%3E");
 
     /* Button colors on modals and message editing. */
     /* Don't define light theme colors for modal here
@@ -2823,7 +2823,7 @@
         0 12.177px 21.4737px 0 hsl(0deg 0% 0% / 11%),
         0 18.7257px 35.4802px 0 hsl(0deg 0% 0% / 15%),
         0 41px 80px 0 hsl(0deg 0% 0% / 20%);
-    --icon-chevron-down: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M3.52977 5.52973C3.78947 5.27004 4.21053 5.27004 4.47023 5.52973L8 9.05951L11.5298 5.52973C11.7895 5.27004 12.2105 5.27004 12.4702 5.52973C12.7299 5.78943 12.7299 6.21049 12.4702 6.47019L8.47023 10.4702C8.21053 10.7299 7.78947 10.7299 7.52977 10.4702L3.52977 6.47019C3.27008 6.21049 3.27008 5.78943 3.52977 5.52973Z' fill='%23FFFFFFBF'/%3E%3C/svg%3E%0A");
+    --icon-chevron-down: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='%23DEDEDE' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath clip-rule='evenodd' d='M3.52977 5.52973C3.78947 5.27004 4.21053 5.27004 4.47023 5.52973L8 9.05951L11.5298 5.52973C11.7895 5.27004 12.2105 5.27004 12.4702 5.52973C12.7299 5.78943 12.7299 6.21049 12.4702 6.47019L8.47023 10.4702C8.21053 10.7299 7.78947 10.7299 7.52977 10.4702L3.52977 6.47019C3.27008 6.21049 3.27008 5.78943 3.52977 5.52973Z'/%3E%3C/svg%3E");
 
     /* Button colors on modals and message editing. */
     --color-exit-button-text: hsl(0deg 0% 100%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -121,7 +121,6 @@
     #organization-settings .dropdown-widget-button {
         background-color: hsl(0deg 0% 0% / 20%);
         border-color: hsl(0deg 0% 0% / 60%);
-        color: inherit;
     }
 
     .popover-filter-input-wrapper .popover-filter-input:focus {

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -400,7 +400,7 @@
 .modal_select {
     width: var(--modal-input-width);
     padding: 4px 25px 4px 6px;
-    color: hsl(0deg 0% 33%);
+    color: var(--color-text-default);
     border-radius: 4px;
     border: 1px solid hsl(0deg 0% 80%);
     cursor: pointer;
@@ -436,7 +436,7 @@
 .modal_url_input,
 .modal_text_input {
     padding: 4px 6px;
-    color: hsl(0deg 0% 33%);
+    color: var(--color-text-default);
     border-radius: 4px;
     border: 1px solid hsl(0deg 0% 80%);
     box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -309,7 +309,7 @@ h3,
 .settings_select,
 .list_select {
     padding: 0 25px 0 6px;
-    color: hsl(0deg 0% 33%);
+    color: var(--color-text-default);
     border-radius: 4px;
     border: 1px solid hsl(0deg 0% 80%);
     cursor: pointer;
@@ -911,13 +911,13 @@ input[type="checkbox"] {
 
 #organization-permissions {
     .dropdown-widget-button {
-        color: hsl(0deg 0% 33%);
+        color: var(--color-text-default);
     }
 }
 
 #organization-settings {
     .dropdown-widget-button {
-        color: hsl(0deg 0% 33%);
+        color: var(--color-text-default);
     }
 }
 
@@ -1611,7 +1611,7 @@ label.preferences-radio-choice-label {
 .time-limit-custom-input,
 .realm_jitsi_server_url_custom_input {
     padding: 4px 6px;
-    color: hsl(0deg 0% 33%);
+    color: var(--color-text-default);
     border: 1px solid hsl(0deg 0% 80%);
     transition:
         border-color linear 0.2s,
@@ -1836,7 +1836,7 @@ label.preferences-radio-choice-label {
 }
 
 .settings_textarea {
-    color: hsl(0deg 0% 33%);
+    color: var(--color-text-default);
     background-color: hsl(0deg 0% 100%);
     border-radius: 4px;
     vertical-align: middle;
@@ -2259,7 +2259,7 @@ label.preferences-radio-choice-label {
 .settings_url_input,
 .settings_text_input {
     padding: 4px 6px;
-    color: hsl(0deg 0% 33%);
+    color: var(--color-text-default);
     border-radius: 4px;
     border: 1px solid hsl(0deg 0% 80%);
     box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -332,7 +332,7 @@ select.settings_select {
     background-image: var(--icon-chevron-down);
     background-repeat: no-repeat;
     background-position: 98%;
-    background-size: 14px;
+    background-size: 1em;
 }
 
 #admin-active-users-list,

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -130,7 +130,7 @@
         border: 1px solid hsl(0deg 0% 80%);
         box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
         border-radius: 4px;
-        color: hsl(0deg 0% 33%);
+        color: var(--color-text-default);
 
         &:focus {
             border-color: hsl(206deg 80% 62% / 80%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -986,7 +986,7 @@ div.focused-message-list.is-conversation-view .recipient_row {
     flex: 1;
     line-height: 1.2142em;
     padding: 0 5px;
-    color: hsl(0deg 0% 33%);
+    color: var(--color-text-default);
     border-radius: 4px;
     border: 1px solid hsl(0deg 0% 80%);
 
@@ -1344,7 +1344,7 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     margin-right: 15px;
 
     padding: 4px 6px;
-    color: hsl(0deg 0% 33%);
+    color: var(--color-text-default);
     border-radius: 4px;
     border: 1px solid hsl(0deg 0% 80%);
     box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);


### PR DESCRIPTION
This PR brings light mode explicitly in league with dark mode, which owing to a `color: inherit` value in `dark_theme.css` was using the default text color.

Rather than crossing our fingers with more `color: inherit`, or deleting the `color:` property on affected selectors, I've opted to explicitly set the default-text color value.

Additionally, another commit corrects a pixel-based size for chevrons on our customized `<select>` elements, allowing them to scale and better match their button-based select/widget-launcher counterparts. While neither the chevron shapes nor their righthand alignment are pixel-perfect, their differences now are much less apparent--especially at larger font sizes.

CZO issues:
* [#issues > status text box greyed out](https://chat.zulip.org/#narrow/channel/9-issues/topic/status.20text.20box.20greyed.20out/with/2184106)
* [#issues > mismatched dropdown angles](https://chat.zulip.org/#narrow/channel/9-issues/topic/mismatched.20dropdown.20angles/with/2184105)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Setting status, before | Setting status, after (no change in dark) |
| --- | --- |
| ![set-status-light-before](https://github.com/user-attachments/assets/5a8b7c9c-aa7f-4f08-b21b-813cef7316b2) | ![set-status-light-after](https://github.com/user-attachments/assets/77c9bc9a-99a2-4b2d-84b3-e758f6107362) |
| ![set-status-dark-after](https://github.com/user-attachments/assets/634f48b6-c04d-4ed0-bf2b-4ae51bc09308) | ![set-status-dark-before](https://github.com/user-attachments/assets/a74f18c4-3c6f-4537-9bde-b24bbfb37621) |

| Move-messages modal, before | Move-messages modal, after |
| --- | --- |
| ![move-messages-modal-light-before](https://github.com/user-attachments/assets/84cf049e-ccab-4925-a97b-586992736171) | ![move-messages-modal-light-after](https://github.com/user-attachments/assets/dbb5ce31-06c3-4bc8-8492-ab10394c4f85) |
| ![move-messages-modal-dark-before](https://github.com/user-attachments/assets/3ce35114-40d6-44ef-8d9e-393024ab3541) | ![move-messages-modal-dark-after](https://github.com/user-attachments/assets/ed4e1111-e452-46e8-9d27-df3620bd0bb1) |

| Notification settings, before | Notifications settings, after |
| --- | --- |
| ![notifications-light-before](https://github.com/user-attachments/assets/268e9abb-6b38-4cca-a990-8ece5ddbcd45) | ![notifications-light-after](https://github.com/user-attachments/assets/fbcc19d0-7a25-4097-951a-81d2171af8d6) |
| ![notifications-dark-before](https://github.com/user-attachments/assets/ec39c59b-7e9f-4de6-b2e7-3ac9df4ab3d8) | ![notifications-dark-after](https://github.com/user-attachments/assets/a5fe97bf-c347-4231-a03e-6268a6d8dd34) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>