### PR TITLE
lightbox: Fix media title update on change in title.

### DIFF
--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -212,6 +212,10 @@ export function clear_for_testing(): void {
     asset_map.clear();
 }
 
+export function maybe_invalidate_asset_map_of_message(message_id: number): void {
+    asset_map.delete(message_id);
+}
+
 function set_selected_media_element($media: JQuery<HTMLMediaElement | HTMLImageElement>): void {
     // Clear out any previously selected element
     $(".media-to-select-in-lightbox-list").removeClass("media-to-select-in-lightbox-list");

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -34,9 +34,10 @@ type Media = {
 let is_open = false;
 
 // The asset map is a map of all retrieved images and YouTube videos that are memoized instead of
-// being looked up multiple times.  It is keyed by the asset's "canonical URL," which is likely the
-// `src` used in the message feed, but for thumbnailed images is the full-resolution original URL.
-const asset_map = new Map<string, Media>();
+// being looked up multiple times.  It is keyed by the message id and asset's "canonical URL,"
+// which is likely the `src` used in the message feed, but for thumbnailed images is the
+// full-resolution original URL.
+const asset_map = new Map<number, Map<string, Media>>();
 
 export class PanZoomControl {
     // Class for both initializing and controlling the
@@ -479,10 +480,11 @@ function supports_heic(): boolean {
 
 // retrieve the metadata from the DOM and store into the asset_map.
 export function parse_media_data(media: HTMLMediaElement | HTMLImageElement): Media {
+    const message_id = rows.get_message_id(media);
     const canonical_url = canonical_url_of_media(media);
-    if (asset_map.has(canonical_url)) {
+    if (asset_map.has(message_id) && asset_map.get(message_id)?.has(canonical_url)) {
         // Use the cached value
-        const payload = asset_map.get(canonical_url);
+        const payload = asset_map.get(message_id)!.get(canonical_url);
         assert(payload !== undefined);
         return payload;
     }
@@ -561,7 +563,6 @@ export function parse_media_data(media: HTMLMediaElement | HTMLImageElement): Me
     if (is_compose_preview_media) {
         sender_full_name = people.my_full_name();
     } else {
-        const message_id = rows.get_message_id(media);
         const message = message_store.get(message_id);
         if (message === undefined) {
             blueslip.error("Lightbox for unknown message", {message_id});
@@ -582,7 +583,10 @@ export function parse_media_data(media: HTMLMediaElement | HTMLImageElement): Me
     };
 
     if (!is_loading_placeholder && canonical_url !== "") {
-        asset_map.set(canonical_url, payload);
+        if (!asset_map.has(message_id)) {
+            asset_map.set(message_id, new Map<string, Media>());
+        }
+        asset_map.get(message_id)!.set(canonical_url, payload);
     }
     return payload;
 }

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -17,6 +17,7 @@ import * as direct_message_group_data from "./direct_message_group_data.ts";
 import * as drafts from "./drafts.ts";
 import * as echo from "./echo.ts";
 import type {Filter} from "./filter.ts";
+import {maybe_invalidate_asset_map_of_message} from "./lightbox.ts";
 import * as message_edit from "./message_edit.ts";
 import * as message_edit_history from "./message_edit_history.ts";
 import * as message_events_util from "./message_events_util.ts";
@@ -812,6 +813,12 @@ export function update_messages(events: UpdateMessageEvent[]): void {
                 post_edit_topic,
                 post_edit_stream_id,
             );
+        } else {
+            // Since the message content is edited, it could be possible
+            // that the cached asset props of media elements may also be
+            // updated. Hence, we invalidate the older ones to compute
+            // new properties when assets are opened in lightbox again.
+            maybe_invalidate_asset_map_of_message(event.message_id);
         }
 
         // Rerender "Message edit history" if it was open to the edited message.


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Previously, when title of media element is updated the change is not reflected in lightbox view.

This is because the title of the element is cached from the last time when the media element was opened in lightbox.

This is fixed by invalidating a message's asset_map cache whenever the content of message is edited.

Fixes #21311


**Testing - Steps to reproduce the bug**:
- Open a media element -- image or video in lightbox view
- go back to message list view and update the media element's title
- re-open the media element in lightbox view to see the title update.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
