### PR TITLE
x-buttons: Replace remove/unsubscribe buttons with x icons in tables.

### DIFF
--- a/web/templates/settings/admin_default_streams_list.hbs
+++ b/web/templates/settings/admin_default_streams_list.hbs
@@ -6,11 +6,12 @@
     </td>
     {{#if ../can_modify}}
     <td class="actions">
-        {{> ../components/action_button
-          attention="quiet"
+        {{> ../components/icon_button
+          icon="x-circle"
           intent="danger"
-          label=(t "Remove from default")
-          custom_classes="remove-default-stream"
+          custom_classes="remove-default-stream tippy-zulip-delayed-tooltip"
+          aria-label=(t "Remove from default")
+          data-tippy-content=(t "Remove from default")
           }}
     </td>
     {{/if}}

--- a/web/templates/stream_settings/stream_member_list_entry.hbs
+++ b/web/templates/stream_settings/stream_member_list_entry.hbs
@@ -10,9 +10,9 @@
     {{#if can_remove_subscribers}}
     <td class="unsubscribe">
         {{#if for_user_group_members}}
-            {{> ../components/action_button label=(t "Remove") custom_classes="remove-subscriber-button" attention="quiet" intent="danger" aria-label=(t "Remove") }}
+            {{> ../components/icon_button icon="x-circle" custom_classes="remove-subscriber-button tippy-zulip-delayed-tooltip" intent="danger" aria-label=(t "Remove") data-tippy-content=(t "Remove") }}
         {{else}}
-            {{> ../components/action_button label=(t "Unsubscribe") custom_classes="remove-subscriber-button" attention="quiet" intent="danger" aria-label=(t "Unsubscribe") }}
+            {{> ../components/icon_button icon="x-circle" custom_classes="remove-subscriber-button tippy-zulip-delayed-tooltip" intent="danger" aria-label=(t "Unsubscribe") data-tippy-content=(t "Unsubscribe") }}
         {{/if}}
     </td>
     {{/if}}

--- a/web/templates/user_group_list_item.hbs
+++ b/web/templates/user_group_list_item.hbs
@@ -9,10 +9,10 @@
     {{#if can_remove_members }}
     <td class="remove_member">
         {{#if is_direct_member}}
-            {{> components/action_button label=(t "Remove") custom_classes="remove-member-button" attention="quiet" intent="danger" aria-label=(t "Remove") }}
+            {{> components/icon_button icon="x-circle" custom_classes="remove-member-button tippy-zulip-delayed-tooltip" intent="danger" aria-label=(t "Remove") data-tippy-content=(t "Remove") }}
         {{else}}
             <span class="tippy-zulip-tooltip" data-tippy-content="{{#if is_me}}{{t 'You are a member of {name} because you are a member of a subgroup ({subgroups_name}).'}} {{else}}{{t 'This user is a member of {name} because they are a member of a subgroup ({subgroups_name}).'}}{{/if}}">
-                {{> components/action_button label=(t "Remove") custom_classes="remove-member-button" attention="quiet" intent="danger" aria-label=(t "Remove") disabled="disabled" }}
+                {{> components/icon_button icon="x-circle" custom_classes="remove-member-button tippy-zulip-delayed-tooltip" intent="danger" aria-label=(t "Remove") data-tippy-content=(t "Remove") disabled="disabled" }}
             </span>
         {{/if}}
     </td>

--- a/web/templates/user_group_settings/user_group_subgroup_entry.hbs
+++ b/web/templates/user_group_settings/user_group_subgroup_entry.hbs
@@ -5,7 +5,7 @@
     <td class="empty-email-col-for-user-group"></td>
     {{#if can_remove_members}}
     <td class="remove">
-        {{> ../components/action_button custom_classes="remove-subgroup-button" label=(t "Remove") attention="quiet" intent="danger" aria-label=(t "Remove") }}
+        {{> ../components/icon_button icon="x-circle" custom_classes="remove-subgroup-button tippy-zulip-delayed-tooltip" intent="danger" aria-label=(t "Remove") data-tippy-content=(t "Remove") }}
     </td>
     {{/if}}
 </tr>

--- a/web/templates/user_stream_list_item.hbs
+++ b/web/templates/user_stream_list_item.hbs
@@ -10,11 +10,11 @@
     {{#if show_unsubscribe_button}}
     <td class="remove_subscription">
         {{#if show_private_stream_unsub_tooltip}}
-            {{> components/action_button label=(t "Unsubscribe") custom_classes="remove-subscription-button tippy-zulip-tooltip" attention="quiet" intent="danger" aria-label=(t "Unsubscribe") data-tippy-content=(t "Use channel settings to unsubscribe from private channels.") }}
+            {{> components/icon_button  icon="x-circle" custom_classes="remove-subscription-button tippy-zulip-tooltip" intent="danger" aria-label=(t "Unsubscribe") data-tippy-content=(t "Use channel settings to unsubscribe from private channels.") }}
         {{else if show_last_user_in_private_stream_unsub_tooltip}}
-            {{> components/action_button label=(t "Unsubscribe") custom_classes="remove-subscription-button tippy-zulip-tooltip" attention="quiet" intent="danger" aria-label=(t "Unsubscribe") data-tippy-content=(t "Use channel settings to unsubscribe the last user from a private channel.") }}
+            {{> components/icon_button  icon="x-circle" custom_classes="remove-subscription-button tippy-zulip-tooltip" intent="danger" aria-label=(t "Unsubscribe") data-tippy-content=(t "Use channel settings to unsubscribe the last user from a private channel.") }}
         {{else}}
-            {{> components/action_button label=(t "Unsubscribe") custom_classes="remove-subscription-button" attention="quiet" intent="danger" aria-label=(t "Unsubscribe") }}
+            {{> components/icon_button  icon="x-circle" custom_classes="remove-subscription-button tippy-zulip-delayed-tooltip"  intent="danger" aria-label=(t "Unsubscribe") data-tippy-content=(t "Unsubscribe") }}
         {{/if}}
     </td>
     {{/if}}


### PR DESCRIPTION
Fixes #34874.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After | After (with tooltips) |
|---|----|----|
| <img width="711" alt="Screenshot 2025-06-14 at 12 44 48 PM" src="https://github.com/user-attachments/assets/0835dda2-8887-43c7-a405-5aff12ddfbf7" /> | <img width="711" alt="Screenshot 2025-06-14 at 12 37 53 PM" src="https://github.com/user-attachments/assets/c50af5cd-a977-45d3-a985-4ca52ddfe159" /> | <img width="715" alt="Screenshot 2025-06-14 at 12 37 59 PM" src="https://github.com/user-attachments/assets/0e870868-44b5-4419-ba44-e64772679ea4" /> |
| <img width="708" alt="Screenshot 2025-06-14 at 12 45 01 PM" src="https://github.com/user-attachments/assets/9726b00d-798d-42c7-bd34-18358dbb784f" /> | <img width="707" alt="Screenshot 2025-06-14 at 12 38 22 PM" src="https://github.com/user-attachments/assets/cd2acb35-9674-450e-b80d-905f9c375ba0" /> | <img width="703" alt="Screenshot 2025-06-14 at 12 38 28 PM" src="https://github.com/user-attachments/assets/541d0b7c-3f1a-4d63-bf1e-fd9a931ac4e4" /> |
| <img width="873" alt="Screenshot 2025-06-14 at 12 45 10 PM" src="https://github.com/user-attachments/assets/99916f05-bfb8-4cbc-a694-5b9d696d6108" /> | <img width="873" alt="Screenshot 2025-06-14 at 12 38 41 PM" src="https://github.com/user-attachments/assets/b7518b6c-29e2-468b-b383-a2ec4183ad15" /> | <img width="887" alt="Screenshot 2025-06-14 at 12 38 47 PM" src="https://github.com/user-attachments/assets/82411670-0d10-4703-af73-7e6b7d4d6dd5" /> |
| <img width="586" alt="Screenshot 2025-06-14 at 12 45 23 PM" src="https://github.com/user-attachments/assets/5e431af8-bf11-43a3-be13-d24b4dd583aa" /> | <img width="593" alt="Screenshot 2025-06-14 at 12 39 02 PM" src="https://github.com/user-attachments/assets/62a92e4c-cb11-4f90-92a7-6e608201b5cb" /> | <img width="622" alt="Screenshot 2025-06-14 at 12 39 09 PM" src="https://github.com/user-attachments/assets/2e456875-4950-4c9b-bb8d-0dcecdef0cf2" /> |
| <img width="592" alt="Screenshot 2025-06-14 at 12 45 31 PM" src="https://github.com/user-attachments/assets/b3a7ab8f-847e-4893-a865-7d0cc4ed58c1" /> | <img width="619" alt="Screenshot 2025-06-14 at 12 39 15 PM" src="https://github.com/user-attachments/assets/9cdd9089-86b9-471a-8f1c-970a6e1e1492" /> | <img width="631" alt="Screenshot 2025-06-14 at 12 39 20 PM" src="https://github.com/user-attachments/assets/51ef58a5-fe87-4d7a-b751-82f5d52b47c7" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
-  [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
