### PR TITLE
personal_recipient: Handle cases with none values.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -1397,7 +1397,9 @@ def get_recent_conversations_recipient_id(
     return recipient_id
 
 
-def get_recent_private_conversations(user_profile: UserProfile) -> dict[int, dict[str, Any]]:
+def _get_recent_conversations_via_legacy_personal_recipient(
+    user_profile_id: int, recipient_id: int
+) -> list[tuple[int, int]]:
     """This function uses some carefully optimized SQL queries, designed
     to use the UserMessage index on private_messages.  It is
     somewhat complicated by the fact that for 1:1 direct
@@ -1410,16 +1412,8 @@ def get_recent_private_conversations(user_profile: UserProfile) -> dict[int, dic
     It may be possible to write this query directly in Django, however
     it is made much easier by using CTEs, which Django does not
     natively support.
-
-    We return a dictionary structure for convenient modification
-    below; this structure is converted into its final form by
-    post_process.
-
     """
     RECENT_CONVERSATIONS_LIMIT = 1000
-
-    recipient_map = {}
-    my_recipient_id = user_profile.recipient_id
 
     query = SQL(
         """
@@ -1433,12 +1427,12 @@ def get_recent_private_conversations(user_profile: UserProfile) -> dict[int, dic
         message AS (
             SELECT message_id,
                    CASE
-                          WHEN m.recipient_id = %(my_recipient_id)s
+                          WHEN m.recipient_id = %(recipient_id)s
                           THEN m.sender_id
                           ELSE NULL
                    END AS sender_id,
                    CASE
-                          WHEN m.recipient_id <> %(my_recipient_id)s
+                          WHEN m.recipient_id <> %(recipient_id)s
                           THEN m.recipient_id
                           ELSE NULL
                    END AS outgoing_recipient_id
@@ -1464,32 +1458,65 @@ def get_recent_private_conversations(user_profile: UserProfile) -> dict[int, dic
         cursor.execute(
             query,
             {
-                "user_profile_id": user_profile.id,
+                "user_profile_id": user_profile_id,
                 "conversation_limit": RECENT_CONVERSATIONS_LIMIT,
-                "my_recipient_id": my_recipient_id,
+                "recipient_id": recipient_id,
             },
         )
-        rows = cursor.fetchall()
+        return cursor.fetchall()
 
-    # The resulting rows will be (recipient_id, max_message_id)
-    # objects for all parties we've had recent (group?) private
-    # message conversations with, including direct messages with
-    # yourself (those will generate an empty list of user_ids).
-    for recipient_id, max_message_id in rows:
-        recipient_map[recipient_id] = dict(
-            max_message_id=max_message_id,
-            user_ids=[],
+
+def _get_recent_conversations_via_direct_message_group(
+    user_profile_id: int,
+) -> list[tuple[int, int]]:
+    """
+    This functions fetches the most recent conversations given that all
+    private messages of this user are through direct message groups.
+    """
+    RECENT_CONVERSATIONS_LIMIT = 1000
+
+    recent_pm_message_ids = (
+        UserMessage.objects.filter(user_profile_id=user_profile_id)
+        .extra(where=[UserMessage.where_flag_is_present(UserMessage.flags.is_private)])  # noqa: S610
+        .order_by("-message_id")
+        .values_list("message_id", flat=True)[:RECENT_CONVERSATIONS_LIMIT]
+    )
+
+    return list(
+        Message.objects.filter(id__in=recent_pm_message_ids)
+        .values("recipient_id")
+        .annotate(max_message_id=Max("id"))
+        .values_list("recipient_id", "max_message_id")
+    )
+
+
+def get_recent_private_conversations(user_profile: UserProfile) -> dict[int, dict[str, Any]]:
+    """
+    We return a dictionary structure for convenient modification
+    below; this structure is converted into its final form by
+    post_process.
+    """
+    # Step 1: Collect recent message info
+    if user_profile.recipient_id is not None:
+        recent_conversations = _get_recent_conversations_via_legacy_personal_recipient(
+            user_profile.id, user_profile.recipient_id
         )
+    else:
+        recent_conversations = _get_recent_conversations_via_direct_message_group(user_profile.id)
 
-    # Now we need to map all the recipient_id objects to lists of user IDs
-    for recipient_id, user_profile_id in (
+    recipient_map: dict[int, dict[str, Any]] = {
+        recipient_id: {"max_message_id": max_message_id, "user_ids": []}
+        for recipient_id, max_message_id in recent_conversations
+    }
+
+    subscriptions = (
         Subscription.objects.filter(recipient_id__in=recipient_map.keys())
         .exclude(user_profile_id=user_profile.id)
         .values_list("recipient_id", "user_profile_id")
-    ):
+    )
+    for recipient_id, user_profile_id in subscriptions:
         recipient_map[recipient_id]["user_ids"].append(user_profile_id)
 
-    # Sort to prevent test flakes and client bugs.
     for rec in recipient_map.values():
         rec["user_ids"].sort()
 

--- a/zerver/lib/recipient_users.py
+++ b/zerver/lib/recipient_users.py
@@ -39,35 +39,40 @@ def get_recipient_from_user_profiles(
     recipient_profiles_map[sender.id] = sender
     user_ids = list(recipient_profiles_map)
 
-    # Important note: We are transitioning 1:1 DMs and self DMs to use
-    # DirectMessageGroup as the Recipient type. If a
-    # DirectMessageGroup exists for the collection of user IDs, it is
-    # guaranteed to contain that entire DM conversation. If none
-    # exists, we use the legacy personal recipient (which may or may
-    # not exist). Once the migration completes, this code path should
-    # just call get_or_create_direct_message_group.
+    # Note: We are migrating 1:1 and self DMs to use DirectMessageGroup
+    # as the Recipient type. If any user lacks a personal recipient, we
+    # create or use a DirectMessageGroup. Otherwise, we prefer an existing
+    # DirectMessageGroup if available; if not, we fall back to the legacy
+    # personal recipient. After the migration, this code should always use
+    # get_or_create_direct_message_group.
     if len(recipient_profiles_map) <= 2:
-        direct_message_group = get_direct_message_group(user_ids)
-        if direct_message_group:
-            # Use the existing direct message group as the preferred recipient.
-            return Recipient(
-                id=direct_message_group.recipient_id,
-                type=Recipient.DIRECT_MESSAGE_GROUP,
-                type_id=direct_message_group.id,
-            )
-
-        # if no direct message group recipient exists, we need to
-        # force the direct message to be a personal internally.
-        del recipient_profiles_map[sender.id]
-        if len(recipient_profiles_map) == 1:
-            [recipient_user_profile] = recipient_profiles_map.values()
-        else:
-            recipient_user_profile = sender
-        return Recipient(
-            id=recipient_user_profile.recipient_id,
-            type=Recipient.PERSONAL,
-            type_id=recipient_user_profile.id,
+        has_personal_recipient = all(
+            user_profile.recipient_id is not None
+            for user_profile in recipient_profiles_map.values()
         )
+
+        if has_personal_recipient:
+            direct_message_group = get_direct_message_group(user_ids)
+            if direct_message_group:
+                # Use the existing direct message group as the preferred recipient.
+                return Recipient(
+                    id=direct_message_group.recipient_id,
+                    type=Recipient.DIRECT_MESSAGE_GROUP,
+                    type_id=direct_message_group.id,
+                )
+
+            # if no direct message group recipient exists, we need to
+            # force the direct message to be a personal internally.
+            del recipient_profiles_map[sender.id]
+            if len(recipient_profiles_map) == 1:
+                [recipient_user_profile] = recipient_profiles_map.values()
+            else:
+                recipient_user_profile = sender
+            return Recipient(
+                id=recipient_user_profile.recipient_id,
+                type=Recipient.PERSONAL,
+                type_id=recipient_user_profile.id,
+            )
 
     if create:
         direct_message_group = get_or_create_direct_message_group(user_ids)

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -743,8 +743,10 @@ def check_can_access_user(
     ).exists():
         return True
 
-    assert user_profile.recipient_id is not None
-    assert target_user.recipient_id is not None
+    if user_profile.recipient_id is None or target_user.recipient_id is None:
+        # If either user does not have a recipient_id, they rely on
+        # direct message groups for 1:1 or self DMs.
+        return False
 
     # Querying the "Message" table is expensive so we do this last.
     direct_message_query = Message.objects.filter(
@@ -795,6 +797,11 @@ def get_inaccessible_user_ids(
     possible_inaccessible_user_ids = set(target_human_user_ids) - set(common_subscription_user_ids)
     if not possible_inaccessible_user_ids:
         return set()
+
+    if not acting_user.recipient_id:
+        # If the acting user does not have a recipient_id, they only rely on
+        # direct message groups for 1:1 or self DMs.
+        return possible_inaccessible_user_ids
 
     target_user_recipient_ids = UserProfile.objects.filter(
         id__in=possible_inaccessible_user_ids
@@ -934,7 +941,9 @@ def get_users_involved_in_dms_with_target_users(
 
         direct_message_participants_dict[sender_id] = recipient_user_ids
 
-    personal_recipient_ids_for_target_users = [user.recipient_id for user in target_users]
+    personal_recipient_ids_for_target_users = [
+        user.recipient_id for user in target_users if user.recipient_id is not None
+    ]
     direct_message_senders_query = Message.objects.filter(
         realm=realm,
         recipient_id__in=personal_recipient_ids_for_target_users,

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2634,6 +2634,26 @@ class PersonalMessageSendTest(ZulipTestCase):
             receiver=receiver,
         )
 
+    def test_personal_create_direct_message_group(self) -> None:
+        """
+        If you send a personal using direct_message_group, only you and the recipient see it.
+        """
+        sender = self.example_user("hamlet")
+        receiver = self.example_user("othello")
+
+        # Removing the personal recipient to ensure a new direct message group is created.
+        receiver.recipient = None
+        receiver.save()
+
+        self.login("hamlet")
+        self.assert_personal(
+            sender=sender,
+            receiver=receiver,
+        )
+
+        message = most_recent_message(sender)
+        self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+
     def test_direct_message_initiator_group_setting(self) -> None:
         """
         Tests that direct_message_initiator_group_setting works correctly.


### PR DESCRIPTION
When migrating personal messages to use direct message groups, we need to handle cases where the personal recipient is `None` properly. This ensures a smooth transition as we move towards using direct message groups for all 1:1 conversations.

The changes handle:
- Cases where `user_profile.recipient` is `None` during message sending
- Migration path from personal recipients to direct message groups
- Tests to verify proper handling of `None` recipients


Fixes: part of https://github.com/zulip/zulip/issues/25713.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
