### PR TITLE
markdown: Render inline audio files using the `![title](url)` syntax.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 11.0
 
+**Feature level 405**
+
+* [Message formatting](/api/message-formatting): Added new HTML
+  formatting for uploaded audio files generating a player experience.
+
 **Feature level 404**
 
 * [`GET /users/me/subscriptions`](/api/get-subscriptions),

--- a/api_docs/message-formatting.md
+++ b/api_docs/message-formatting.md
@@ -243,10 +243,11 @@ assume that messages sent prior to the introduction of thumbnailing
 have been re-rendered to use the new format or have thumbnails
 available.
 
-## Video previews
+## Video embeddings and previews
 
-When a Zulip message is sent linking to an uploaded video, Zulip will
+When a Zulip message is sent linking to an uploaded video, Zulip may
 generate a video preview element with the following format.
+
 
 ``` html
 <div class="message_inline_image message_inline_video">
@@ -256,6 +257,40 @@ generate a video preview element with the following format.
   </a>
 </div>
 ```
+
+## Audio Players
+
+When the Markdown media syntax is used with an uploaded file with an
+audio `Content-Type`, Zulip will generate an HTML5 `<audio>` player
+element. Supported MIME types are currently `audio/aac`, `audio/flac`,
+`audio/mpeg`, and `audio/wav`.
+
+For example, `[file.mp3](/user_uploads/path/to/file.mp3)` renders as:
+
+``` html
+<audio controls preload="metadata"
+  src="/user_uploads/path/to/file.mp3" title="file.mp3">
+</audio>
+```
+
+If the Zulip server has rewritten the URL of the audio file, it will
+provide the URL in a `data-original-url` parameter. The Zulip server
+does this for all non-uploaded file audio URLs.
+
+``` html
+<audio controls preload="metadata"
+  data-original-url="https://example.com/path/to/original/file.mp3"
+  src="https://zulipcdn.example.com/path/to/playable/file.mp3" title="file.mp3">
+</audio>
+```
+
+Clients that cannot render an audio player are recommended to convert
+audio elements into a link to the original URL.
+
+The Zulip server does not validate whether uploaded files with an
+audio `Content-Type` are actually playable.
+
+**Changes**: New in Zulip 11.0 (feature level ZF-79b5ee.md).
 
 ## Mentions and silent mentions
 

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 404
+API_FEATURE_LEVEL = 405
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -23,10 +23,10 @@ import * as util from "./util.ts";
 // If we see preview-related syntax in our content, we will need the
 // backend to render it.
 const preview_regexes = [
-    // Inline image and video previews, check for contiguous chars ending in image and video suffix
+    // Inline media previews, check for contiguous chars ending in media suffix
     // To keep the below regexes simple, split them out for the end-of-message case
 
-    /\S*(?:\.bmp|\.gif|\.jpg|\.jpeg|\.png|\.webp|\.mp4|\.webm)\)?(\s+|$)/m,
+    /\S*(?:\.bmp|\.gif|\.jpg|\.jpeg|\.png|\.webp|\.mp4|\.webm|\.aac|\.flac|\.mp3|\.mpeg|\.wav)\)?(\s+|$)/m,
 
     // Twitter and youtube links are given previews
 

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1734,7 +1734,7 @@ def re_thumbnail(
         message.rendered_content,
         enqueue=enqueue,
         lock=True,
-    )
+    ).image_metadata
 
     new_content, _ = rewrite_thumbnailed_images(
         message.rendered_content,

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -904,7 +904,7 @@ def do_send_messages(
                     lock=True,
                     enqueue=False,
                     path_ids=list(send_request.rendering_result.thumbnail_spinners),
-                )
+                ).image_metadata
                 new_rendered_content = rewrite_thumbnailed_images(
                     send_request.message.rendered_content, previews
                 )[0]

--- a/zerver/lib/mime_types.py
+++ b/zerver/lib/mime_types.py
@@ -22,13 +22,21 @@ for mime_type, extension in EXTRA_MIME_TYPES:
     add_type(mime_type, extension)
 
 
-INLINE_MIME_TYPES = [
-    "application/pdf",
+AUDIO_INLINE_MIME_TYPES = [
     "audio/aac",
     "audio/flac",
-    "audio/mp4",
     "audio/mpeg",
     "audio/wav",
+]
+
+INLINE_MIME_TYPES = [
+    *AUDIO_INLINE_MIME_TYPES,
+    "application/pdf",
+    # We don't want to include `audio/mp4` and `audio/webm` in the
+    # `AUDIO_INLINE_MIME` TYPES because despite their ability to be
+    # used for both audio and video, they happen to be parsed only
+    # in their video form.
+    "audio/mp4",
     "audio/webm",
     "image/apng",
     "image/avif",

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -472,6 +472,12 @@
       "text_content": "Google link\n"
     },
     {
+      "name": "only_inline_audio_camo",
+      "input": "![Audio link](http://example.com/audio.mp3)",
+      "expected_output": "<p><audio controls data-original-url=\"http://example.com/audio.mp3\" preload=\"metadata\" src=\"https://external-content.zulipcdn.net/external_content/57cf2db553c3f6cc2af6781c11232e70983f4762/687474703a2f2f6578616d706c652e636f6d2f617564696f2e6d7033\" title=\"Audio link\"></audio></p>",
+      "backend_only_rendering": true
+    },
+    {
       "name": "link_with_text",
       "input": "[hello](https://github.com)",
       "expected_output": "<p><a href=\"https://github.com\">hello</a></p>"


### PR DESCRIPTION
Previouly, there was no option to play the inline audio files within the web app without downloading or leaving the browser.

This commit adds option to render inline audio files that use the syntax `![title](url)`.

Fixes #27007

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
