### PR TITLE
test_subs: Fix the incorrect syntax in 'test_unarchive_stream'.

### DIFF
--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1354,7 +1354,6 @@ class StreamAdminTest(ZulipTestCase):
     def test_unarchive_stream(self) -> None:
         iago = self.example_user("iago")
         cordelia = self.example_user("cordelia")
-        self.login_user(iago)
 
         stream = self.make_stream("new_stream", is_web_public=True)
         was_invite_only = stream.invite_only
@@ -1368,7 +1367,7 @@ class StreamAdminTest(ZulipTestCase):
         data = {}
         data["is_archived"] = "false"
         with self.capture_send_event_calls(expected_num_events=3) as events:
-            result = self.api_patch(iago, f"/json/streams/{stream.id}", info=data)
+            result = self.api_patch(iago, f"/api/v1/streams/{stream.id}", info=data)
             self.assert_json_success(result)
 
         # Clients will get this event only if they support


### PR DESCRIPTION
A syntax mistake was spotted at https://github.com/zulip/zulip/pull/34016/files#diff-700e48fae89da13e8a8efa5bcc79f0cea59ee83f0581de6e11fb5e3b0666bbbeR2196-R2213 .

This PR fixes the use of `/json/streams/...` by replacing it with the correct `/api/v1/streams/...`. Also removes unnecessary `login_user` call when using `api_patch`.

[#issues > Wrong syntax in 'test_unarchive_stream'](https://chat.zulip.org/#narrow/channel/9-issues/topic/Wrong.20syntax.20in.20'test_unarchive_stream'/with/2195476)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
