### PR TITLE
status_modal: Correct light-mode background color.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1399,6 +1399,15 @@
         hsl(0deg 0% 80%),
         hsl(0deg 0% 0% / 60%)
     );
+    /* TODO: Light mode uses browser-default white
+       backgrounds; we should extend the use of this
+       color variable to 1) explicitly set the
+       background color of inputs, and 2) clean up a
+       lingering stack of selectors in dark_theme.css. */
+    --color-background-input: light-dark(
+        hsl(0deg 0% 100%),
+        hsl(0deg 0% 0% / 20%)
+    );
     /* Link colors */
     --color-text-link: light-dark(hsl(210deg 94% 42%), hsl(200deg 100% 50%));
     --color-text-link-decoration: light-dark(

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -11,6 +11,7 @@
         border: 1px solid;
         border-color: hsl(0deg 0% 0% / 60%);
         border-radius: 5px;
+        background-color: var(--color-background-input);
 
         & input.user-status {
             grid-area: search-input;
@@ -18,6 +19,9 @@
             border: none;
             outline: none;
             box-shadow: none;
+            /* Transparent here is to allow the input
+               background set on the wrapper to show
+               through. */
             background-color: transparent;
             margin: 0;
 


### PR DESCRIPTION
This PR sets an explicit background-color on the wrapper for setting a status.

I've also left a TODO for explicitly setting background colors on light-mode inputs, which can ultimately be done in service of further cleaning up `dark_theme.css`.

[#issues > status text box greyed out @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/status.20text.20box.20greyed.20out/near/2193917)

**Screenshots and screen captures:**

_No change in dark mode:_

| Before | After |
| --- | --- |
| ![status-input-background-light-before](https://github.com/user-attachments/assets/b8c109a8-4e3a-41ed-b10c-d2814a6d8541) | ![status-input-background-light-after](https://github.com/user-attachments/assets/80e5b1c8-75e5-47db-b510-ad8dd38cecea) |
| ![status-input-background-dark-before](https://github.com/user-attachments/assets/e5480e61-383d-42fb-881f-a79cfc610b5a) | ![status-input-background-dark-after--no-change](https://github.com/user-attachments/assets/49b355b1-9193-446f-b440-7f47f29b84af) |
