### PR TITLE
test_subs: Fix syntax errors in tests.

### DIFF
--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1419,7 +1419,6 @@ class StreamAdminTest(ZulipTestCase):
         desdemona = self.example_user("desdemona")
         iago = self.example_user("iago")
 
-        self.login_user(desdemona)
         stream = self.make_stream("test_stream", invite_only=False)
         self.subscribe(iago, stream.name)
 
@@ -1429,14 +1428,12 @@ class StreamAdminTest(ZulipTestCase):
 
         data = {}
         data["is_archived"] = "false"
-        result = self.api_patch(desdemona, f"/json/streams/{stream.id}", info=data)
+        result = self.api_patch(desdemona, f"/api/v1/streams/{stream.id}", info=data)
         self.assert_json_success(result)
         stream.refresh_from_db()
         self.assertFalse(stream.deactivated)
 
         cordelia = self.example_user("cordelia")
-        self.login_user(cordelia)
-
         stream1 = self.make_stream("test_stream_1", invite_only=False)
         self.subscribe(iago, stream1.name)
 
@@ -1444,7 +1441,7 @@ class StreamAdminTest(ZulipTestCase):
         stream1.refresh_from_db()
         self.assertTrue(stream1.deactivated)
 
-        result = self.api_patch(cordelia, f"/json/streams/{stream1.id}", info=data)
+        result = self.api_patch(cordelia, f"/api/v1/streams/{stream1.id}", info=data)
         self.assert_json_error(result, "You do not have permission to administer this channel.")
 
         do_change_stream_group_based_setting(
@@ -1454,7 +1451,7 @@ class StreamAdminTest(ZulipTestCase):
             acting_user=desdemona,
         )
 
-        result = self.api_patch(cordelia, f"/json/streams/{stream1.id}", info=data)
+        result = self.api_patch(cordelia, f"/api/v1/streams/{stream1.id}", info=data)
         self.assert_json_success(result)
 
         stream1.refresh_from_db()


### PR DESCRIPTION
This commit fixes the use of `/json/...` by replacing it with the correct `/api/v1/...`. Also removes
unnecessary `login_user` call when using `api_patch`.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
