### PR TITLE
help: Update instructions on "Logging in" article.

### DIFF
--- a/help/do-not-disturb.md
+++ b/help/do-not-disturb.md
@@ -3,7 +3,7 @@
 The Zulip desktop app offers a **Do Not Disturb (DND)** mode. Turning on **Do Not
 Disturb** mode disables [desktop notifications](/help/desktop-notifications)
 across all the organizations you have
-[added](/help/logging-in#log-in-for-the-first-time) to the Zulip desktop app.
+[added](/help/logging-in#log-in-to-a-new-organization) to the Zulip desktop app.
 This can be convenient for avoiding interruptions during a meeting, or when you need
 time to focus on your work.
 

--- a/help/include/switching-between-organizations.md
+++ b/help/include/switching-between-organizations.md
@@ -1,18 +1,5 @@
 {start_tabs}
 
-{tab|web}
-
-You can log in to multiple Zulip organizations by opening multiple tabs, and
-logging into one Zulip organization in each tab. To switch Zulip organizations,
-just switch tabs.
-
-{tab|desktop}
-
-1. Click on a logo in the **organizations sidebar** on the left, or choose
-an organization from the **Window** menu in the top menu bar.
-
-{!desktop-toggle-sidebar-tip.md!}
-
 {tab|mobile}
 
 1. Tap the **Menu** (<i class="zulip-icon zulip-icon-mobile-menu mobile-help"></i>)
@@ -22,5 +9,18 @@ an organization from the **Window** menu in the top menu bar.
    **Switch account**.
 
 1. Tap on the desired Zulip organization.
+
+{tab|desktop}
+
+1. Click on a logo in the **organizations sidebar** on the left, or choose
+an organization from the **Window** menu in the top menu bar.
+
+{!desktop-toggle-sidebar-tip.md!}
+
+{tab|web}
+
+You can log in to multiple Zulip organizations by opening multiple tabs, and
+logging into one Zulip organization in each tab. To switch Zulip organizations,
+just switch tabs.
 
 {end_tabs}

--- a/help/logging-in.md
+++ b/help/logging-in.md
@@ -62,7 +62,7 @@ Here are some ways to find the URL for your Zulip organization.
 
 {end_tabs}
 
-## Log in for the first time
+## Log in to a new organization
 
 {start_tabs}
 

--- a/help/logging-in.md
+++ b/help/logging-in.md
@@ -66,9 +66,17 @@ Here are some ways to find the URL for your Zulip organization.
 
 {start_tabs}
 
-{tab|web}
+{tab|mobile}
 
-1. Go to the Zulip URL of the organization.
+1. Tap the **Menu** (<i class="zulip-icon zulip-icon-mobile-menu mobile-help"></i>)
+   tab in the bottom right corner of the app.
+
+1. Tap <i class="zulip-icon zulip-icon-mobile-arrow-left-right mobile-help"></i>
+   **Switch account**.
+
+1. Tap **Add new account**.
+
+1. Enter the Zulip URL of the organization, and tap **Continue**.
 
 1. Follow the on-screen instructions.
 
@@ -89,17 +97,9 @@ from the **Zulip** menu in the top menu bar.
 
 {!desktop-toggle-sidebar-tip.md!}
 
-{tab|mobile}
+{tab|web}
 
-1. Tap the **Menu** (<i class="zulip-icon zulip-icon-mobile-menu mobile-help"></i>)
-   tab in the bottom right corner of the app.
-
-1. Tap <i class="zulip-icon zulip-icon-mobile-arrow-left-right mobile-help"></i>
-   **Switch account**.
-
-1. Tap **Add new account**.
-
-1. Enter the Zulip URL of the organization, and tap **Continue**.
+1. Go to the Zulip URL of the organization.
 
 1. Follow the on-screen instructions.
 


### PR DESCRIPTION
Based on https://github.com/zulip/zulip/pull/34869#discussion_r2146024254:
> So, I agree this is a bit confusing. I went with updating this section based on what we've got documented for the React Native app.
>
> When logging in for the first Zulip organization on the React Native app, the current instructions would be inaccurate as well.
> 
> I feel like, if the current changes are accurate for logging in for the first time to a new Zulip organization (when already logged in to another Zulip organization) in the Flutter app, then we merge these changes for now. And have a follow-up discussion in CZO documentation about revising them.

**Notes on changes**:
- Updates the section header "Log in for the first time" -> "Log in to a new organization".
- Reorders the app tabs in the instructions for logging in and switching accounts to have the mobile instructions shown first.

---

**Screenshots and screen captures:**

[CURRENT DOCUMENTATION](https://chat.zulip.org/help/logging-in)
![Screenshot from 2025-06-16 20-39-12](https://github.com/user-attachments/assets/700ac5e0-1554-462c-8c7a-52e02797abb0)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
