### PR TITLE
help: Document new "Open message feeds at" mobile configuration.

### DIFF
--- a/help/configure-where-you-land.md
+++ b/help/configure-where-you-land.md
@@ -1,0 +1,43 @@
+# Configure where you land in message feeds
+
+When you go to a message feed in the Zulip web or desktop app, you'll generally
+land at your oldest unread message in that view.
+[Searches](/help/search-for-messages) and [starred
+messages](/help/star-a-message) put you at the newest message instead.
+
+
+In the mobile app, you can choose where message feeds will open:
+
+* **First unread message**: Recommended if you like to clear your inbox of
+  unread messages.
+* **First unread message in conversation views, newest message elsewhere**: In
+  Zulip, a **conversation** is a [direct message](/help/direct-messages) thread
+  (one-on-one or with a group), or a [topic in a
+  channel](/help/introduction-to-topics). This option works well if you have old
+  unread messages, and don't want to navigate there in your [Combined
+  feed](/help/combined-feed) and [channel feeds](/help/channel-feed).
+* **Newest message**: You may be used to this behavior from other chat
+  applications. To avoid accidentally marking messages as read,
+  consider setting [Mark messages as read on
+  scroll](/help/marking-messages-as-read#configure-whether-messages-are-automatically-marked-as-read)
+  to **Never** when using this setting.
+
+{start_tabs}
+
+{tab|mobile}
+
+1. Tap the **Menu** (<i class="zulip-icon zulip-icon-mobile-menu mobile-help"></i>)
+   tab in the bottom right corner of the app.
+
+1. Tap <i class="zulip-icon zulip-icon-gear mobile-help"></i> **Settings**.
+
+1. Tap **Open message feeds at**.
+
+1. Tap the desired configuration to select it.
+
+{end_tabs}
+
+## Related articles
+
+* [Marking messages as read](/help/marking-messages-as-read)
+* [Reading strategies](/help/reading-strategies)

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -108,6 +108,7 @@
 * [Marking messages as read](/help/marking-messages-as-read)
 * [Marking messages as unread](/help/marking-messages-as-unread)
 * [Configure unread message counters](/help/configure-unread-message-counters)
+* [Configure where you land](/help/configure-where-you-land)
 * [Emoji reactions](/help/emoji-reactions)
 * [View your mentions](/help/view-your-mentions)
 * [Star a message](/help/star-a-message)

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -133,5 +133,6 @@ channel or topic as read**.
 ## Related articles
 
 * [Marking messages as unread](/help/marking-messages-as-unread)
+* [Configure where you land in message feeds](/help/configure-where-you-land)
 * [Reading strategies](/help/reading-strategies)
 * [Read receipts](/help/read-receipts)

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -15,15 +15,15 @@ web/desktop app.
 
 - **Always**: Messages are marked as read whenever you scroll through them in
   the app. You may be used to this from other chat applications.
-- **Never**: Messages are marked as read only
-  [manually](#mark-all-messages-as-read). For example, if you often need to
-  follow up on messages at your computer after reading them in the mobile app,
-  you can choose this option for the mobile app.
 - **Only in conversation views**: In Zulip, a **conversation** is a [direct
   message](/help/direct-messages) thread (one-on-one or with a group), or a
   [topic in a channel](/help/introduction-to-topics). This option makes it
   convenient to preview new messages in a channel, or skim [Combined
   feed](/help/combined-feed), and later read each topic in detail.
+- **Never**: Messages are marked as read only
+  [manually](#mark-all-messages-as-read). For example, if you often need to
+  follow up on messages at your computer after reading them in the mobile app,
+  you can choose this option for the mobile app.
 
 {start_tabs}
 


### PR DESCRIPTION
Fixes: [#documentation > Flutter updates: open message feeds at feature](https://chat.zulip.org/#narrow/channel/19-documentation/topic/Flutter.20updates.3A.20open.20message.20feeds.20at.20feature/with/2195616)

![Screenshot 2025-06-16 at 13 20 26](https://github.com/user-attachments/assets/eabca1ed-c7d0-455b-9841-2224e7eaf7d0)


Notes:
- @laurynmm It would be great to get your review on this one, even if it's been merged already. In particular, I wasn't sure if we have standard for the "pick an option" instruction on mobile. I didn't want to re-list them here, as one of the option names is quite long, and also we don't normally list options in the body of the instructions.