### PR TITLE
user_profile: Fix the field for outgoing webhook bots `interface`.

### DIFF
--- a/web/templates/settings/add_new_bot_form.hbs
+++ b/web/templates/settings/add_new_bot_form.hbs
@@ -42,7 +42,7 @@
                 <div><label for="create_payload_url" generated="true" class="text-error"></label></div>
             </div>
             <div class="input-group">
-                <label for="interface_type" class="modal-field-label">{{t "Outgoing webhook message format" }}</label>
+                <label for="interface_type" class="modal-field-label">{{t "Webhook format" }}</label>
                 <select name="interface_type" id="create_interface_type" class="modal_select bootstrap-focus-style">
                     <option value="1">Zulip</option>
                     <option value="2">{{t "Slack compatible" }}</option>

--- a/web/templates/settings/edit_outgoing_webhook_service.hbs
+++ b/web/templates/settings/edit_outgoing_webhook_service.hbs
@@ -4,7 +4,7 @@
     <div><label for="edit_service_base_url" generated="true" class="text-error"></label></div>
 </div>
 <div class="input-group">
-    <label for="edit_service_interface">{{t "Interface" }}</label>
+    <label for="edit_service_interface">{{t "Webhook format" }}</label>
     <select id="edit_service_interface" class="modal_select bootstrap-focus-style" name="service_interface">
         <option value="1">{{t "Generic" }}</option>
         <option value="2">{{t "Slack's outgoing webhooks" }}</option>


### PR DESCRIPTION
This updates the `interface` field in the "Manage bot" modal for service bots to have a label consistent with the one in the "Add a new bot" modal.

Fixes: [#design > Service bot triggers UI @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/Service.20bot.20triggers.20UI/near/2196664)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
|![image](https://github.com/user-attachments/assets/8148bb49-399b-4529-ba7a-a7cf59606f85) | ![image](https://github.com/user-attachments/assets/229455c9-dca9-4607-924d-0a2a04be4a73)| 
|![image](https://github.com/user-attachments/assets/574ee8ce-443d-4b09-b916-df7588cbb0df) | ![image](https://github.com/user-attachments/assets/989e0a20-0286-43f7-95c5-770ebae14c05)|
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
