### PR TITLE
settings: Fix data export spinner size.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -349,6 +349,7 @@ select.settings_select {
     word-break: normal;
 }
 
+.export_url_spinner,
 .last_active {
     .loading_indicator_spinner {
         width: 1.25em;


### PR DESCRIPTION
This commit adds the same styles to the data export loader as we have for the users table loader, ensuring that the spinner is sized correctly and maintains consistency across the tables we have in settings panel.

<!-- Describe your pull request here.-->

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/data.20export.20spinner.20size/with/2191897)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After (12px) | After (16px) | After (20px) |
|---|--|--|--|
| <img width="204" alt="Screenshot 2025-06-17 at 2 27 34 PM" src="https://github.com/user-attachments/assets/34b9f756-f5bd-4d2a-bff7-3703161d92e1" /> | <img width="175" alt="Screenshot 2025-06-17 at 2 23 06 PM" src="https://github.com/user-attachments/assets/0180616f-e23b-4961-8950-482b66f8f28a" /> | <img width="250" alt="Screenshot 2025-06-17 at 2 22 50 PM" src="https://github.com/user-attachments/assets/f0a9ee9c-3417-463c-aca6-b589e93b7b5d" /> | <img width="295" alt="Screenshot 2025-06-17 at 2 23 32 PM" src="https://github.com/user-attachments/assets/a82fe1df-4bd8-4bc4-b707-0d0bcfa305c0" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
