### PR TITLE
Clean up placeholder text when no search results are found .

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -81,7 +81,7 @@ const MUTED_TOPICS_IN_CHANNEL_EMPTY_BANNER = {
 
 const NO_SEARCH_RESULTS_TITLE = $t({defaultMessage: "No search results."});
 
-function retrieve_search_query_data(current_filter: Filter): SearchData {
+function empty_search_query_banner(current_filter: Filter): NarrowBannerData {
     // when search bar contains multiple filters, only retrieve search queries
     const search_query = current_filter.operands("search")[0];
     const query_words = search_query!.split(" ");
@@ -121,7 +121,10 @@ function retrieve_search_query_data(current_filter: Filter): SearchData {
         }
     }
 
-    return search_string_result;
+    return {
+        title: NO_SEARCH_RESULTS_TITLE,
+        search_data: search_string_result,
+    };
 }
 
 export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerData {
@@ -204,12 +207,9 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
             };
         }
 
-        // For empty stream searches within other narrows, we display the stop words
+        // For empty search queries, we display excluded stop words
         if (current_filter.operands("search").length > 0) {
-            return {
-                title: NO_SEARCH_RESULTS_TITLE,
-                search_data: retrieve_search_query_data(current_filter),
-            };
+            return empty_search_query_banner(current_filter);
         }
 
         if (
@@ -345,10 +345,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
         }
         case "search": {
             // You are narrowed to empty search results.
-            return {
-                title: NO_SEARCH_RESULTS_TITLE,
-                search_data: retrieve_search_query_data(current_filter),
-            };
+            return empty_search_query_banner(current_filter);
         }
         case "dm": {
             if (!people.is_valid_bulk_emails_for_compose(first_operand.split(","))) {

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -79,6 +79,8 @@ const MUTED_TOPICS_IN_CHANNEL_EMPTY_BANNER = {
     ),
 };
 
+const NO_SEARCH_RESULTS_TITLE = $t({defaultMessage: "No search results."});
+
 function retrieve_search_query_data(current_filter: Filter): SearchData {
     // when search bar contains multiple filters, only retrieve search queries
     const search_query = current_filter.operands("search")[0];
@@ -140,7 +142,6 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                   },
               ),
     };
-    const default_banner_for_multiple_filters = $t({defaultMessage: "No search results."});
 
     if (current_filter.is_in_home()) {
         // We're in the combined feed view.
@@ -175,7 +176,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
         // No message can have multiple streams
         if (streams.length > 1) {
             return {
-                title: default_banner_for_multiple_filters,
+                title: NO_SEARCH_RESULTS_TITLE,
                 html: $t_html({
                     defaultMessage:
                         "<p>You are searching for messages that belong to more than one channel, which is not possible.</p>",
@@ -185,7 +186,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
         // No message can have multiple topics
         if (topics.length > 1) {
             return {
-                title: default_banner_for_multiple_filters,
+                title: NO_SEARCH_RESULTS_TITLE,
                 html: $t_html({
                     defaultMessage:
                         "<p>You are searching for messages that belong to more than one topic, which is not possible.</p>",
@@ -195,7 +196,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
         // No message can have multiple senders
         if (current_filter.operands("sender").length > 1) {
             return {
-                title: default_banner_for_multiple_filters,
+                title: NO_SEARCH_RESULTS_TITLE,
                 html: $t_html({
                     defaultMessage:
                         "<p>You are searching for messages that are sent by more than one person, which is not possible.</p>",
@@ -206,7 +207,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
         // For empty stream searches within other narrows, we display the stop words
         if (current_filter.operands("search").length > 0) {
             return {
-                title: default_banner_for_multiple_filters,
+                title: NO_SEARCH_RESULTS_TITLE,
                 search_data: retrieve_search_query_data(current_filter),
             };
         }
@@ -262,7 +263,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
 
         // For other multi-operator narrows, we just use the default banner
         return {
-            title: default_banner_for_multiple_filters,
+            title: NO_SEARCH_RESULTS_TITLE,
         };
     }
 
@@ -345,7 +346,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
         case "search": {
             // You are narrowed to empty search results.
             return {
-                title: $t({defaultMessage: "No search results."}),
+                title: NO_SEARCH_RESULTS_TITLE,
                 search_data: retrieve_search_query_data(current_filter),
             };
         }

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -82,7 +82,6 @@ const MUTED_TOPICS_IN_CHANNEL_EMPTY_BANNER = {
 const NO_SEARCH_RESULTS_TITLE = $t({defaultMessage: "No search results."});
 
 function empty_search_query_banner(current_filter: Filter): NarrowBannerData {
-    // when search bar contains multiple filters, only retrieve search queries
     const search_query = current_filter.operands("search")[0];
     const query_words = search_query!.split(" ");
 
@@ -90,20 +89,6 @@ function empty_search_query_banner(current_filter: Filter): NarrowBannerData {
         query_words: [],
         has_stop_word: false,
     };
-
-    // Add in stream:foo and topic:bar if present
-    if (current_filter.has_operator("channel") || current_filter.has_operator("topic")) {
-        const stream_id = current_filter.operands("channel")[0];
-        const topic = current_filter.operands("topic")[0];
-        if (stream_id) {
-            const stream_name = stream_data.get_valid_sub_by_id_string(stream_id).name;
-            search_string_result.stream_query = stream_name;
-        }
-        if (topic !== undefined) {
-            search_string_result.topic_query = util.get_final_topic_display_name(topic);
-            search_string_result.is_empty_string_topic = topic === "";
-        }
-    }
 
     // Gather information about each query word
     for (const query_word of query_words) {
@@ -121,10 +106,15 @@ function empty_search_query_banner(current_filter: Filter): NarrowBannerData {
         }
     }
 
-    return {
-        title: NO_SEARCH_RESULTS_TITLE,
-        search_data: search_string_result,
-    };
+    // We only show description of search query
+    // when there are excluded stop words.
+    if (search_string_result.has_stop_word) {
+        return {
+            title: NO_SEARCH_RESULTS_TITLE,
+            search_data: search_string_result,
+        };
+    }
+    return {title: NO_SEARCH_RESULTS_TITLE};
 }
 
 export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerData {

--- a/web/src/narrow_error.ts
+++ b/web/src/narrow_error.ts
@@ -8,9 +8,6 @@ type QueryWord = {
 export type SearchData = {
     query_words: QueryWord[];
     has_stop_word: boolean;
-    stream_query?: string;
-    topic_query?: string;
-    is_empty_string_topic?: boolean;
 };
 
 export type NarrowBannerData = {

--- a/web/templates/empty_feed_notice.hbs
+++ b/web/templates/empty_feed_notice.hbs
@@ -1,18 +1,9 @@
 <div class="empty_feed_notice">
     <h4 class="empty-feed-notice-title"> {{ title }} </h4>
-    <div class="empty-feed-notice-description">
-        {{#if search_data}}
-            {{#if search_data.has_stop_word}}{{t "Some common words were excluded from your search." }} <br/>{{/if}}{{t "You searched for:" }}
-            {{#if search_data.stream_query}}
-            <span>channel: {{search_data.stream_query}}</span>
-            {{/if}}
-            {{#if search_data.topic_query}}
-            {{#if search_data.is_empty_string_topic}}
-            <span>topic: <span class="empty-topic-display">{{search_data.topic_query}}</span></span>
-            {{else}}
-            <span>topic: {{search_data.topic_query}}</span>
-            {{/if}}
-            {{/if}}
+    {{#if search_data}}
+        {{#if search_data.has_stop_word}}
+        <div class="empty-feed-notice-description">
+            {{t "Common words were excluded from your search:" }} <br/>
             {{#each search_data.query_words}}
                 {{#if is_stop_word}}
                 <del>{{query_word}}</del>
@@ -20,8 +11,11 @@
                 <span class="search-query-word">{{query_word}}</span>
                 {{/if}}
             {{/each}}
-        {{else}}
-            {{{ html }}}
+        </div>
         {{/if}}
-    </div>
+    {{else if html}}
+        <div class="empty-feed-notice-description">
+            {{{ html }}}
+        </div>
+    {{/if}}
 </div>

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -116,89 +116,85 @@ user_groups.initialize({realm_user_groups: [nobody, everyone]});
 run_test("empty_narrow_html", ({mock_template}) => {
     mock_template("empty_feed_notice.hbs", true, (_data, html) => html);
 
-    let actual_html = empty_narrow_html("This is a title", "<h1> This is the html </h1>");
+    // Title only
+    let actual_html = empty_narrow_html("This is a title", undefined, undefined);
+    assert.equal(
+        actual_html,
+        `<div class="empty_feed_notice">
+    <h4 class="empty-feed-notice-title"> This is a title </h4>
+</div>
+`,
+    );
+
+    // Title and html
+    actual_html = empty_narrow_html("This is a title", "<h1> This is the html </h1>", undefined);
     assert.equal(
         actual_html,
         `<div class="empty_feed_notice">
     <h4 class="empty-feed-notice-title"> This is a title </h4>
     <div class="empty-feed-notice-description">
-            <h1> This is the html </h1>
+        <h1> This is the html </h1>
     </div>
-</div>
+    </div>
 `,
     );
 
-    const search_data_with_all_search_types = {
-        topic_query: "test",
-        stream_query: "new",
+    // Title and search data
+    const search_data_with_stop_word = {
         has_stop_word: true,
         query_words: [
-            {query_word: "search", is_stop_word: false},
             {query_word: "a", is_stop_word: true},
+            {query_word: "search", is_stop_word: false},
         ],
     };
-    actual_html = empty_narrow_html(
-        "This is a title",
-        undefined,
-        search_data_with_all_search_types,
-    );
+    actual_html = empty_narrow_html("This is a title", undefined, search_data_with_stop_word);
     assert.equal(
         actual_html,
         `<div class="empty_feed_notice">
     <h4 class="empty-feed-notice-title"> This is a title </h4>
     <div class="empty-feed-notice-description">
-            Some common words were excluded from your search. <br/>You searched for:
-            <span>channel: new</span>
-            <span>topic: test</span>
-                <span class="search-query-word">search</span>
-                <del>a</del>
+        Common words were excluded from your search: <br/>
+            <del>a</del>
+            <span class="search-query-word">search</span>
     </div>
 </div>
 `,
     );
 
-    const search_data_with_stream_without_stop_words = {
-        has_stop_word: false,
-        stream_query: "hello world",
-        query_words: [{query_word: "searchA", is_stop_word: false}],
+    const search_data_with_stop_words = {
+        has_stop_word: true,
+        query_words: [
+            {query_word: "a", is_stop_word: true},
+            {query_word: "search", is_stop_word: false},
+            {query_word: "and", is_stop_word: true},
+            {query_word: "return", is_stop_word: false},
+        ],
     };
-    actual_html = empty_narrow_html(
-        "This is a title",
-        undefined,
-        search_data_with_stream_without_stop_words,
-    );
+    actual_html = empty_narrow_html("This is a title", undefined, search_data_with_stop_words);
     assert.equal(
         actual_html,
         `<div class="empty_feed_notice">
     <h4 class="empty-feed-notice-title"> This is a title </h4>
     <div class="empty-feed-notice-description">
-            You searched for:
-            <span>channel: hello world</span>
-                <span class="search-query-word">searchA</span>
+        Common words were excluded from your search: <br/>
+            <del>a</del>
+            <span class="search-query-word">search</span>
+            <del>and</del>
+            <span class="search-query-word">return</span>
     </div>
 </div>
 `,
     );
 
-    const search_data_with_topic_without_stop_words = {
+    const search_data_without_stop_words = {
         has_stop_word: false,
-        topic_query: "hello",
-        query_words: [{query_word: "searchB", is_stop_word: false}],
+        query_words: [{query_word: "search", is_stop_word: false}],
     };
-    actual_html = empty_narrow_html(
-        "This is a title",
-        undefined,
-        search_data_with_topic_without_stop_words,
-    );
+    actual_html = empty_narrow_html("This is a title", undefined, search_data_without_stop_words);
     assert.equal(
         actual_html,
         `<div class="empty_feed_notice">
     <h4 class="empty-feed-notice-title"> This is a title </h4>
-    <div class="empty-feed-notice-description">
-            You searched for:
-            <span>topic: hello</span>
-                <span class="search-query-word">searchB</span>
-    </div>
 </div>
 `,
     );
@@ -648,9 +644,9 @@ run_test("show_empty_narrow_message_with_search", ({mock_template, override}) =>
 
     const current_filter = set_filter([["search", "grail"]]);
     narrow_banner.show_empty_narrow_message(current_filter);
-    assert.match(
+    assert.equal(
         $(".empty_feed_notice_main").html(),
-        /<span class="search-query-word">grail<\/span>/,
+        empty_narrow_html("translated: No search results."),
     );
 });
 
@@ -681,15 +677,6 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
 
     const streamA_id = 88;
     stream_data.add_sub({name: "streamA", stream_id: streamA_id});
-    const expected_stream_search_data = {
-        has_stop_word: true,
-        stream_query: "streamA",
-        query_words: [
-            {query_word: "what", is_stop_word: true},
-            {query_word: "about", is_stop_word: true},
-            {query_word: "grail", is_stop_word: false},
-        ],
-    };
     current_filter = set_filter([
         ["stream", streamA_id.toString()],
         ["search", "what about grail"],
@@ -697,19 +684,9 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No search results.", undefined, expected_stream_search_data),
+        empty_narrow_html("translated: No search results.", undefined, expected_search_data),
     );
 
-    const expected_stream_topic_search_data = {
-        has_stop_word: true,
-        stream_query: "streamA",
-        topic_query: "topicA",
-        query_words: [
-            {query_word: "what", is_stop_word: true},
-            {query_word: "about", is_stop_word: true},
-            {query_word: "grail", is_stop_word: false},
-        ],
-    };
     current_filter = set_filter([
         ["stream", streamA_id.toString()],
         ["topic", "topicA"],
@@ -718,11 +695,7 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html(
-            "translated: No search results.",
-            undefined,
-            expected_stream_topic_search_data,
-        ),
+        empty_narrow_html("translated: No search results.", undefined, expected_search_data),
     );
 });
 


### PR DESCRIPTION
Previously, we included channel, topic, sender name and search qeries (if present) in the empty feed banner.
With this PR, we will now not include channelm topic and sender name and only display the search queries.

### Changes

- Changed "Some common words were excluded from your search." to "Common words were excluded from your search::
- if stop words are present, the banner will look as follows:

>No search results.
>Common words were excluded from your search:
>the bananas

![image](https://github.com/user-attachments/assets/5f43ea01-0d35-4311-a63e-c7edbe7909b5)

- If stop words are not present, the banner will look as follows:

> No search results.

![image](https://github.com/user-attachments/assets/12b081b1-0c89-4096-9c27-730ee9e017f1)


Fixes: #34872


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
