### PR TITLE
support: Revise view for deactivated, placeholder and scrubbed Zulip Cloud realms

### DIFF
--- a/corporate/lib/support.py
+++ b/corporate/lib/support.py
@@ -23,7 +23,7 @@ from corporate.models.plans import CustomerPlan, CustomerPlanOffer, get_current_
 from corporate.models.sponsorships import ZulipSponsorshipRequest
 from zerver.lib.timestamp import timestamp_to_datetime
 from zerver.models import Realm
-from zerver.models.realm_audit_logs import AuditLogEventType
+from zerver.models.realm_audit_logs import AuditLogEventType, RealmAuditLog
 from zerver.models.realms import get_org_type_display_name
 from zilencer.lib.remote_counts import MissingDataError
 from zilencer.models import (
@@ -127,6 +127,7 @@ class CloudSupportData:
     sponsorship_data: SponsorshipData
     user_data: UserData
     file_upload_usage: str
+    is_scrubbed: bool
 
 
 def get_stripe_customer_url(stripe_id: str) -> str:
@@ -498,4 +499,7 @@ def get_data_for_cloud_support_view(billing_session: BillingSession) -> CloudSup
         sponsorship_data=sponsorship_data,
         user_data=user_data,
         file_upload_usage=get_formatted_realm_upload_space_used(billing_session.realm),
+        is_scrubbed=RealmAuditLog.objects.filter(
+            realm=billing_session.realm, event_type=AuditLogEventType.REALM_SCRUBBED
+        ).exists(),
     )

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -839,11 +839,10 @@ class TestSupportEndpoint(ZulipTestCase):
                     '<option value="active" selected>Active</option>',
                     '<option value="deactivated" >Deactivated</option>',
                     f'<option value="{zulip_realm.org_type}" selected>',
-                    'scrub-realm-button">',
-                    'data-string-id="zulip"',
                 ],
                 result,
             )
+            self.assert_not_in_success_response(["scrub-realm-button"], result)
 
         def check_lear_realm_query_result(result: "TestHttpResponse") -> None:
             self.assert_in_success_response(
@@ -856,8 +855,6 @@ class TestSupportEndpoint(ZulipTestCase):
                     'input type="number" name="annual_discounted_price" value="None"',
                     '<option value="active" selected>Active</option>',
                     '<option value="deactivated" >Deactivated</option>',
-                    'scrub-realm-button">',
-                    'data-string-id="lear"',
                     "<b>Plan name</b>: Zulip Cloud Standard",
                     "<b>Status</b>: Active",
                     "<b>Billing schedule</b>: Annual",
@@ -870,6 +867,7 @@ class TestSupportEndpoint(ZulipTestCase):
                 ],
                 result,
             )
+            self.assert_not_in_success_response(["scrub-realm-button"], result)
 
         def check_preregistration_user_query_result(
             result: "TestHttpResponse", email: str, invite: bool = False
@@ -1826,6 +1824,10 @@ class TestSupportEndpoint(ZulipTestCase):
 
         iago = self.example_user("iago")
         self.login_user(iago)
+
+        # Confirm scrub realm button is shown for deactivated realms.
+        result = self.client_get("/activity/support", {"q": "limited"})
+        self.assert_in_success_response(["scrub-realm-button"], result)
 
         result = self.client_post(
             "/activity/support",

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -751,7 +751,7 @@ class TestSupportEndpoint(ZulipTestCase):
     def test_realm_support_view_queries(self) -> None:
         iago = self.example_user("iago")
         self.login_user(iago)
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(23):
             result = self.client_get("/activity/support", {"q": "zulip"}, subdomain="zulip")
             self.assertEqual(result.status_code, 200)
 

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -10,6 +10,13 @@
     {% if realm_support_data[realm.id].sponsorship_data.has_discount %}
         <p class="support-section-header">Has a discount 💸</p>
     {% endif %}
+    {% if realm.deactivated_redirect %}
+    <b>Placeholder realm</b><br />
+    <b>Redirects to</b>: {{ realm.deactivated_redirect }}
+    <a title="Copy URL" class="copy-button" data-clipboard-text="{{ realm.deactivated_redirect }}">
+        <i class="fa fa-copy"></i>
+    </a>
+    {% else %}
     <b>URL</b>: <a target="_blank" rel="noopener noreferrer" href="{{ realm.url }}">{{ realm.url }}</a> |
     <a target="_blank" rel="noopener noreferrer" href="/stats/realm/{{ realm.string_id }}/">stats</a> |
     <a target="_blank" rel="noopener noreferrer" href="/realm_activity/{{ realm.string_id }}/">activity</a><br />
@@ -60,7 +67,9 @@
     {% endwith %}
     <br />
     <b>File upload usage</b>: {{ realm_support_data[realm.id].file_upload_usage }}<br />
+    {% endif %}
 </div>
+{% if not realm.deactivated_redirect %}
 <div>
     <div class="realm-management-actions">
         <p class="support-section-header">🛠️ Realm management:</p>
@@ -180,3 +189,4 @@
         <button data-string-id="{{realm.string_id}}" class="scrub-realm-button">Scrub realm (danger)</button>
     </form>
 </div>
+{% endif %}

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -10,7 +10,10 @@
     {% if realm_support_data[realm.id].sponsorship_data.has_discount %}
         <p class="support-section-header">Has a discount 💸</p>
     {% endif %}
-    {% if realm.deactivated_redirect %}
+    {% set realm_is_scrubbed = realm_support_data[realm.id].is_scrubbed %}
+    {% if realm_is_scrubbed %}
+    <b>Realm has been scrubbed</b>
+    {% elif realm.deactivated_redirect %}
     <b>Placeholder realm</b><br />
     <b>Redirects to</b>: {{ realm.deactivated_redirect }}
     <a title="Copy URL" class="copy-button" data-clipboard-text="{{ realm.deactivated_redirect }}">
@@ -69,7 +72,8 @@
     <b>File upload usage</b>: {{ realm_support_data[realm.id].file_upload_usage }}<br />
     {% endif %}
 </div>
-{% if not realm.deactivated_redirect %}
+{% if realm_is_scrubbed %}
+{% elif not realm.deactivated_redirect %}
 <div>
     <div class="realm-management-actions">
         <p class="support-section-header">🛠️ Realm management:</p>

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -180,7 +180,7 @@
         {% endwith %}
     </div>
     {% endif %}
-
+    {% if realm.deactivated %}
     <form method="POST" class="scrub-realm-form support-form">
         <h3>❌ Scrub realm</h3>
         {{ csrf_input }}
@@ -188,5 +188,6 @@
         <input type="hidden" name="scrub_realm" value="true" />
         <button data-string-id="{{realm.string_id}}" class="scrub-realm-button">Scrub realm (danger)</button>
     </form>
+    {% endif %}
 </div>
 {% endif %}

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -1,5 +1,8 @@
 <div class="realm-support-information">
     <span class="cloud-label">Cloud realm</span>
+    {% if realm.deactivated %}
+    <span class="deactivated-label">DEACTIVATED</span>
+    {% endif %}
     <h3><img src="{{ realm_icon_url(realm) }}" class="support-realm-icon" /> {{ realm.name }}</h3>
     {% if realm.plan_type == SPONSORED_PLAN_TYPE %}
         <p class="support-section-header">On 100% sponsored Zulip Standard Free 🎉</p>

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -132,7 +132,15 @@
             <button type="submit" class="support-submit-button">Update</button>
         </form>
     </div>
-    {% if realm.plan_type != SPONSORED_PLAN_TYPE %}
+    {% if realm.deactivated %}
+    <div class="support-sponsorship-container">
+        {% with %}
+            {% set sponsorship_data = realm_support_data[realm.id].sponsorship_data %}
+            {% set dollar_amount = dollar_amount %}
+            {% include 'corporate/support/sponsorship_details.html' %}
+        {% endwith %}
+    </div>
+    {% elif realm.plan_type != SPONSORED_PLAN_TYPE %}
     <div class="support-sponsorship-container">
         {% with %}
             {% set sponsorship_data = realm_support_data[realm.id].sponsorship_data %}

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -83,6 +83,7 @@
             </select>
             <button type="submit" class="support-submit-button">Update</button>
         </form>
+        {% if not realm.deactivated %}
         <form method="POST" class="support-form">
             <b>New subdomain</b>:<br />
             {{ csrf_input }}
@@ -131,6 +132,7 @@
             <input type="number" name="max_invites" value="{{ realm.max_invites }}" min="0" required />
             <button type="submit" class="support-submit-button">Update</button>
         </form>
+        {% endif %}
     </div>
     {% if realm.deactivated %}
     <div class="support-sponsorship-container">

--- a/templates/corporate/support/support.html
+++ b/templates/corporate/support/support.html
@@ -91,7 +91,7 @@
                 {% set show_realm_details = False %}
                 {% elif confirmation.type == Confirmation.REALM_REACTIVATION %}
                 <h3>Realm reactivation</h3>
-                {% set realm = object %}
+                {% set realm = object.realm %}
                 {% set show_realm_details = False %}
                 {% endif %}
                 {% if email %}

--- a/templates/corporate/support/support.html
+++ b/templates/corporate/support/support.html
@@ -114,7 +114,8 @@
                     {% endwith %}
                 {% elif realm %}
                     <span class="cloud-label">Cloud realm</span>
-                    <h3>{{ realm.string_id }}</h3>
+                    <h3><img src="{{ realm_icon_url(realm) }}" class="support-realm-icon" /> {{ realm.name }}</h3>
+                    <b>Realm subdomain</b>: {{ realm.subdomain }}
                 {% else %}
                     <span class="cloud-label">Cloud realm</span>
                     <h3>N/A</h3>

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -159,6 +159,7 @@ tr.admin td:first-child {
     }
 
     .cloud-label,
+    .deactivated-label,
     .remote-label {
         padding: 2px 8px;
         font-size: 0.9em;
@@ -170,6 +171,10 @@ tr.admin td:first-child {
 
     .cloud-label {
         background-color: hsl(280deg 100% 40%);
+    }
+
+    .deactivated-label {
+        background-color: hsl(2deg 64% 53%);
     }
 
     .remote-label {


### PR DESCRIPTION
Updates the forms and information that is shown in the support panel for Zulip Cloud organizations:
- Active realms no longer have a "Scrub realm" button.
- Placeholder realms, that are deactivated and have a redirect URL for the newer subdomain only show that information.
- Deactivated realms have the "Scrub realm" button, no longer have sponsorship forms, and only have the management form to reactivate the realm.
- Scrubbed realms have no forms or buttons and show brief text about the state of the realm.

Also, fixes a bug with how realms associated with a realm reactivation confirmation object were shown, and makes how the realm name / subdomain are shown for confirmation objects consistent with the realm detailed information header.

---

**Screenshots and screen captures:**

### Realm reactivation confirmation objects:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-06-17 21-04-12](https://github.com/user-attachments/assets/ed4cb63e-6722-407b-b7db-6e1a6cdd16af) | ![Screenshot from 2025-06-17 21-03-52](https://github.com/user-attachments/assets/a84a0b0b-915c-4ace-ab20-d3361b15a863)

### Active realm - removed scrub realm button:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-06-17 21-03-09](https://github.com/user-attachments/assets/bb8d91c9-be12-412e-ad8a-bc7316eb99de) | ![Screenshot from 2025-06-17 21-02-54](https://github.com/user-attachments/assets/13704d8e-33cc-43cd-973d-104269f30260)

### Scrubbed realm - Found a realm audit log for this event:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-06-17 21-02-20](https://github.com/user-attachments/assets/93bba2f0-d25d-4077-b57e-41f4d662ab8e) | ![Screenshot from 2025-06-17 21-02-05](https://github.com/user-attachments/assets/aaf3a984-1458-4f73-90e2-067682b83c99)

### Deactivated realm - removed sponsorship forms and some management forms:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-06-17 21-01-39](https://github.com/user-attachments/assets/f2960746-98f9-498b-b05e-d04a2fb94206) | ![Screenshot from 2025-06-17 21-01-17](https://github.com/user-attachments/assets/6c15f1cc-e017-4859-a06a-3c62bfc0dfd6)

### Placeholder realm - only show redirect URL:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-06-17 21-00-43](https://github.com/user-attachments/assets/f7362fbf-70d9-4c44-b4c7-cd92b171175f) | ![Screenshot from 2025-06-17 21-00-24](https://github.com/user-attachments/assets/010e5aae-f08c-4097-8420-86a6fb17feab)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
