### PR TITLE
input_pill: Fix bug where focus indicator wasn't showing.

### DIFF
--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -32,9 +32,21 @@
         background-color: var(--color-background-input-pill);
         cursor: pointer;
 
+        /* Not focus-visible, because we want to support mouse+backpace to
+           delete pills */
         &:focus {
-            border-color: var(--color-focus-outline-input-pill);
+            /* Box shadow instead of border, because user pills have avatars
+               that extend all the way to the edge of the pill. */
+            box-shadow: 0 0 0 1px var(--color-focus-outline-input-pill) inset;
             outline: none;
+
+            /* For user pills with avatars, the avatar covers up the box
+               shadow, so we also have to make a border around the avatar. */
+            .pill-image-border {
+                border-right: none;
+                border-radius: 4px 0 0 4px;
+                border-color: var(--color-focus-outline-input-pill);
+            }
         }
 
         .pill-image {

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -268,6 +268,15 @@
             height: unset;
             border: 1px solid transparent;
 
+            /* Not focus-visible, because we want to support mouse+backpace
+               to delete pills */
+            &:focus {
+                /* Unlike regular `.pill` this multi-user pill has a border,
+                   so we use border instead of box-shadow on focus. */
+                box-shadow: none;
+                border-color: var(--color-focus-outline-input-pill);
+            }
+
             > .pill-label {
                 min-width: fit-content;
                 white-space: nowrap;


### PR DESCRIPTION
This bug was created in #34629 when we removed the transparent border (which became not transparent on focus).

Reported on CZO here: [#issues > missing focus indicators on user pills @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/missing.20focus.20indicators.20on.20user.20pills/near/2193813)

| screenshots |
| -- |
| <img width="364" alt="image" src="https://github.com/user-attachments/assets/a7748c98-2d1f-43a4-bb2e-81fc37f4df2e" /> |
| <img width="238" alt="image" src="https://github.com/user-attachments/assets/5a4ccde1-cb35-4ff9-9f56-df02995fd006" /> |
| <img width="258" alt="image" src="https://github.com/user-attachments/assets/9895c87c-3ae5-409c-8984-3916d8b0eb58" /> |
| <img width="521" alt="image" src="https://github.com/user-attachments/assets/48dfe13a-4aa1-401d-ba72-5fe9def323e6" /> |
| <img width="239" alt="image" src="https://github.com/user-attachments/assets/f44a9e7c-7ecc-4d41-ac43-963c37f18a1a" /> |
| <img width="448" alt="image" src="https://github.com/user-attachments/assets/47122878-806d-49f4-bc9d-c1b11ebb3fc6" /> |
