### PR TITLE
Add `channels:all` and `channels:subscribed` filter.

### DIFF
--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -58,6 +58,9 @@ as an empty string.
 
 ## Changes
 
+* In Zulip 11.0 (feature level ZF-e876f8), support was added for a new
+  `channels:subscribed` filter, matching messages in all the subscribed channels.
+
 * In Zulip 11.0 (feature level ZF-cf1fc8), support was added for a new
   `channels:all` filter, matching messages in all the accessible channels.
 

--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -58,6 +58,9 @@ as an empty string.
 
 ## Changes
 
+* In Zulip 11.0 (feature level ZF-cf1fc8), support was added for a new
+  `channels:all` filter, matching messages in all the accessible channels.
+
 * In Zulip 10.0 (feature level 366), support was added for a new
   `is:muted` operator combination, matching messages in topics and
   channels that the user has [muted](/help/mute-a-topic).

--- a/api_docs/unmerged.d/ZF-cf1fc8.md
+++ b/api_docs/unmerged.d/ZF-cf1fc8.md
@@ -1,0 +1,7 @@
+* [`GET /messages`](/api/get-messages),
+  [`GET /messages/matches_narrow`](/api/check-messages-match-narrow),
+  [`POST /messages/flags/narrow`](/api/update-message-flags-for-narrow),
+  [`POST /register`](/api/register-queue):
+  Added a new [search/narrow filter](/api/construct-narrow),
+  `channels:all`, which allows users to search messages
+  across all accessible channels.

--- a/api_docs/unmerged.d/ZF-e876f8.md
+++ b/api_docs/unmerged.d/ZF-e876f8.md
@@ -1,0 +1,7 @@
+* [`GET /messages`](/api/get-messages),
+  [`GET /messages/matches_narrow`](/api/check-messages-match-narrow),
+  [`POST /messages/flags/narrow`](/api/update-message-flags-for-narrow),
+  [`POST /register`](/api/register-queue):
+  Added a new [search/narrow filter](/api/construct-narrow),
+  `channels:subscribed`, which allows users to search messages
+  across all the subscribed channels.

--- a/starlight_help/src/content/docs/search-for-messages.mdx
+++ b/starlight_help/src/content/docs/search-for-messages.mdx
@@ -108,6 +108,8 @@ additional messages.
 * `channels:public`: Search messages in all
   [public](/help/channel-permissions#public-channels) and
   [web-public](/help/channel-permissions#web-public-channels) channels.
+* `channels:subscribed`: Search messages in all the channels you're subscribed
+  to, including messages sent before you were a subscriber.
 * `channels:web-public`: Search messages in all
   [web-public](/help/change-the-privacy-of-a-channel) channels in the organization,
   including channels you are not subscribed to.

--- a/starlight_help/src/content/docs/search-for-messages.mdx
+++ b/starlight_help/src/content/docs/search-for-messages.mdx
@@ -103,6 +103,8 @@ To avoid cluttering your search results, by default, Zulip searches just the
 messages you received. You can use `channels:` or `channel:` filters to search
 additional messages.
 
+* `channels:all`: Search messages across all channels you are allowed to access,
+  including channels you aren't subscribed to.
 * `channels:public`: Search messages in all
   [public](/help/channel-permissions#public-channels) and
   [web-public](/help/channel-permissions#web-public-channels) channels.

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -77,7 +77,7 @@ type ValidOrInvalidUser =
     | {valid_user: true; user_pill_context: UserPillItem}
     | {valid_user: false; operand: string};
 
-const channels_operands = new Set(["public", "web-public", "all"]);
+const channels_operands = new Set(["public", "web-public", "all", "subscribed"]);
 
 function zephyr_stream_name_match(
     message: Message & {type: "stream"},
@@ -227,6 +227,7 @@ function message_matches_search_term(message: Message, operator: string, operand
                 case "web-public":
                     return stream_privacy_policy === "web-public";
                 case "all":
+                case "subscribed":
                     return [
                         "public",
                         "web-public",
@@ -668,6 +669,7 @@ export class Filter {
             "in",
             "channels-all",
             "channels-public",
+            "channels-subscribed",
             "channels-web-public",
             "channel",
             "topic",
@@ -908,6 +910,8 @@ export class Filter {
                 return possible_prefix + "all web-public channels";
             case "all":
                 return possible_prefix + "all channels that you can view";
+            case "subscribed":
+                return possible_prefix + "all subscribed channels";
             default:
                 return possible_prefix + "all public channels";
         }
@@ -1176,6 +1180,8 @@ export class Filter {
             "not-channels-all",
             "channels-public",
             "not-channels-public",
+            "channels-subscribed",
+            "not-channels-subscribed",
             "channels-web-public",
             "not-channels-web-public",
             "near",
@@ -1287,6 +1293,9 @@ export class Filter {
         if (_.isEqual(term_types, ["channels-public"])) {
             return true;
         }
+        if (_.isEqual(term_types, ["channels-subscribed"])) {
+            return true;
+        }
         if (_.isEqual(term_types, ["channels-web-public"])) {
             return true;
         }
@@ -1364,6 +1373,8 @@ export class Filter {
                     return "/#narrow/channels/all";
                 case "channels-public":
                     return "/#narrow/channels/public";
+                case "channels-subscribed":
+                    return "/#narrow/channels/subscribed";
                 case "channels-web-public":
                     return "/#narrow/channels/web-public";
                 case "dm":
@@ -1543,6 +1554,8 @@ export class Filter {
                     return $t({defaultMessage: "Messages in all public channels"});
                 case "channels-web-public":
                     return $t({defaultMessage: "Messages in all web-public channels"});
+                case "channels-subscribed":
+                    return $t({defaultMessage: "Messages in all subscribed channels"});
                 case "is-starred":
                     return $t({defaultMessage: "Starred messages"});
                 case "is-mentioned":
@@ -1939,6 +1952,8 @@ export class Filter {
             "not-channels-public",
             "channels-web-public",
             "not-channels-web-public",
+            "channels-subscribed",
+            "not-channels-subscribed",
             "is-muted",
             "not-is-muted",
             "in-home",

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -77,7 +77,7 @@ type ValidOrInvalidUser =
     | {valid_user: true; user_pill_context: UserPillItem}
     | {valid_user: false; operand: string};
 
-const channels_operands = new Set(["public", "web-public"]);
+const channels_operands = new Set(["public", "web-public", "all"]);
 
 function zephyr_stream_name_match(
     message: Message & {type: "stream"},
@@ -226,6 +226,13 @@ function message_matches_search_term(message: Message, operator: string, operand
                     return ["public", "web-public"].includes(stream_privacy_policy);
                 case "web-public":
                     return stream_privacy_policy === "web-public";
+                case "all":
+                    return [
+                        "public",
+                        "web-public",
+                        "invite-only-public-history",
+                        "invite-only",
+                    ].includes(stream_privacy_policy);
                 default:
                     return false;
             }
@@ -659,6 +666,7 @@ export class Filter {
     static sorted_term_types(term_types: string[]): string[] {
         const levels = [
             "in",
+            "channels-all",
             "channels-public",
             "channels-web-public",
             "channel",
@@ -898,6 +906,8 @@ export class Filter {
         switch (operand) {
             case "web-public":
                 return possible_prefix + "all web-public channels";
+            case "all":
+                return possible_prefix + "all channels that you can view";
             default:
                 return possible_prefix + "all public channels";
         }
@@ -1162,6 +1172,8 @@ export class Filter {
             "not-is-muted",
             "in-home",
             "in-all",
+            "channels-all",
+            "not-channels-all",
             "channels-public",
             "not-channels-public",
             "channels-web-public",
@@ -1269,6 +1281,9 @@ export class Filter {
         if (_.isEqual(term_types, ["is-starred"])) {
             return true;
         }
+        if (_.isEqual(term_types, ["channels-all"])) {
+            return true;
+        }
         if (_.isEqual(term_types, ["channels-public"])) {
             return true;
         }
@@ -1345,6 +1360,8 @@ export class Filter {
                     return "/#narrow/is/starred";
                 case "is-mentioned":
                     return "/#narrow/is/mentioned";
+                case "channels-all":
+                    return "/#narrow/channels/all";
                 case "channels-public":
                     return "/#narrow/channels/public";
                 case "channels-web-public":
@@ -1515,6 +1532,8 @@ export class Filter {
                     return $t({defaultMessage: "Combined feed"});
                 case "in-all":
                     return $t({defaultMessage: "All messages including muted channels"});
+                case "channels-all":
+                    return $t({defaultMessage: "Messages in all channels"});
                 case "channels-public":
                     if (page_params.is_spectator || current_user.is_guest) {
                         return $t({
@@ -1914,6 +1933,8 @@ export class Filter {
             "not-is-followed",
             "is-resolved",
             "not-is-resolved",
+            "channels-all",
+            "not-channels-all",
             "channels-public",
             "not-channels-public",
             "channels-web-public",

--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -121,6 +121,9 @@ export function is_an_allowed_web_public_narrow(operator: string, operand: strin
     if (operator === "is" && operand === "resolved") {
         return true;
     }
+    if ((operator === "channels" || operator === "streams") && operand === "subscribed") {
+        return false;
+    }
     return allowed_web_public_narrow_operators.includes(operator);
 }
 

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -620,6 +620,7 @@ function get_channels_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]):
     const public_channels_search_string = "channels:public";
     const web_public_channels_search_string = "channels:web-public";
     const all_accessible_channels_search_string = "channels:all";
+    const subscribed_channels_search_string = "channels:subscribed";
     const suggestions: SuggestionAndIncompatiblePatterns[] = [];
 
     if (!page_params.is_spectator || stream_data.realm_has_web_public_streams()) {
@@ -631,11 +632,18 @@ function get_channels_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]):
     }
 
     if (!page_params.is_spectator) {
-        suggestions.push({
-            search_string: public_channels_search_string,
-            description_html: "all public channels",
-            incompatible_patterns: incompatible_patterns.channels!,
-        });
+        suggestions.push(
+            {
+                search_string: public_channels_search_string,
+                description_html: "all public channels",
+                incompatible_patterns: incompatible_patterns.channels!,
+            },
+            {
+                search_string: subscribed_channels_search_string,
+                description_html: "all subscribed channels",
+                incompatible_patterns: incompatible_patterns.channels!,
+            },
+        );
     }
 
     if (stream_data.realm_has_web_public_streams()) {

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -619,7 +619,16 @@ function get_channels_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]):
     }
     const public_channels_search_string = "channels:public";
     const web_public_channels_search_string = "channels:web-public";
+    const all_accessible_channels_search_string = "channels:all";
     const suggestions: SuggestionAndIncompatiblePatterns[] = [];
+
+    if (!page_params.is_spectator || stream_data.realm_has_web_public_streams()) {
+        suggestions.push({
+            search_string: all_accessible_channels_search_string,
+            description_html: "all channels that you can view",
+            incompatible_patterns: incompatible_patterns.channels!,
+        });
+    }
 
     if (!page_params.is_spectator) {
         suggestions.push({

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -61,6 +61,12 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">channels:all</td>
+                        <td class="definition">
+                            {{t 'Search all channels that you can view.'}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">channels:public</td>
                         <td class="definition">
                             {{#if can_access_all_public_channels }}

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -77,6 +77,12 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">channels:subscribed</td>
+                        <td class="definition">
+                            {{t 'Search all subscribed channels.'}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">channels:web-public</td>
                         <td class="definition">
                             {{t 'Search all web-public channels.'}}

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -1758,3 +1758,16 @@ def is_message_to_self(message: Message) -> bool:
         return message.recipient == message.sender.recipient
 
     return False
+
+
+def get_messages_with_protected_history_queryset(
+    user_profile: UserProfile, streams_with_protected_history: QuerySet[Stream]
+) -> QuerySet[UserMessage]:
+    recipient_ids = Recipient.objects.filter(
+        type=Recipient.STREAM,
+        type_id__in=streams_with_protected_history.values_list("id", flat=True),
+    ).values_list("id", flat=True)
+
+    return UserMessage.objects.filter(
+        user_profile=user_profile, message__recipient_id__in=recipient_ids
+    )

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ValidationError
 from django.db import connection
+from django.db.models import QuerySet
 from django.utils.translation import gettext as _
 from pydantic import BaseModel, model_validator
 from sqlalchemy.dialects import postgresql
@@ -38,16 +39,21 @@ from zerver.lib.message import (
     access_message,
     access_web_public_message,
     get_first_visible_message_id,
+    get_messages_with_protected_history_queryset,
 )
 from zerver.lib.narrow_predicate import channel_operators, channels_operators
 from zerver.lib.recipient_users import recipient_for_user_profiles
 from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
+from zerver.lib.stream_subscription import get_subscribed_stream_ids_for_user
 from zerver.lib.streams import (
     can_access_stream_history_by_id,
     can_access_stream_history_by_name,
+    get_content_accessible_streams_without_protected_history_queryset,
     get_public_streams_queryset,
     get_stream_by_narrow_operand_access_unchecked,
+    get_subscribed_streams_with_protected_history_queryset,
     get_web_public_streams_queryset,
+    is_user_subscribed_to_protected_history_stream,
 )
 from zerver.lib.topic import maybe_rename_general_chat_to_empty_topic
 from zerver.lib.topic_sqlalchemy import (
@@ -323,6 +329,20 @@ class NarrowBuilder:
                 "No message can be both a channel message and direct message"
             )
 
+    def get_recipient_condition(self, queryset: QuerySet[Stream]) -> ClauseElement:
+        recipient_ids = queryset.values_list("recipient_id", flat=True).order_by("id")
+        return column("recipient_id", Integer).in_(recipient_ids)
+
+    def get_protected_history_condition(
+        self, streams_with_protected_history: QuerySet[Stream]
+    ) -> ClauseElement:
+        assert self.user_profile is not None
+
+        message_ids = get_messages_with_protected_history_queryset(
+            self.user_profile, streams_with_protected_history
+        ).values_list("message_id", flat=True)
+        return self.msg_id_column.in_(message_ids)
+
     def add_term(self, query: Select, term: NarrowParameter) -> Select:
         """
         Extend the given query to one narrowed by the given term, and return the result.
@@ -523,13 +543,43 @@ class NarrowBuilder:
             # Get all both subscribed and non-subscribed public channels
             # but exclude any private subscribed channels.
             recipient_queryset = get_public_streams_queryset(self.realm)
+            cond = self.get_recipient_condition(recipient_queryset)
         elif operand == "web-public":
             recipient_queryset = get_web_public_streams_queryset(self.realm)
+            cond = self.get_recipient_condition(recipient_queryset)
+        elif operand == "all":
+            if self.user_profile is None:
+                recipient_queryset = get_web_public_streams_queryset(self.realm)
+                cond = self.get_recipient_condition(recipient_queryset)
+            else:
+                subscribed_stream_ids = get_subscribed_stream_ids_for_user(self.user_profile)
+
+                full_history_recipient_queryset = (
+                    get_content_accessible_streams_without_protected_history_queryset(
+                        self.user_profile, subscribed_stream_ids
+                    )
+                )
+                full_history_recipient_cond = self.get_recipient_condition(
+                    full_history_recipient_queryset
+                )
+
+                protected_history_recipient_cond: ClauseElement = false()
+                if is_user_subscribed_to_protected_history_stream(
+                    self.user_profile, subscribed_stream_ids
+                ):
+                    streams_with_protected_history = (
+                        get_subscribed_streams_with_protected_history_queryset(
+                            self.user_profile, subscribed_stream_ids
+                        )
+                    )
+                    protected_history_recipient_cond = self.get_protected_history_condition(
+                        streams_with_protected_history
+                    )
+
+                cond = or_(full_history_recipient_cond, protected_history_recipient_cond)
         else:
             raise BadNarrowOperatorError("unknown channels operand " + operand)
 
-        recipient_ids = recipient_queryset.values_list("recipient_id", flat=True).order_by("id")
-        cond = column("recipient_id", Integer).in_(recipient_ids)
         return query.where(maybe_negate(cond))
 
     def by_topic(self, query: Select, operand: str, maybe_negate: ConditionTransform) -> Select:
@@ -886,7 +936,7 @@ def ok_to_include_history(
                     include_history = can_access_stream_history_by_id(user_profile, operand)
             elif (
                 term.operator in channels_operators
-                and term.operand == "public"
+                and term.operand in ["public", "all"]
                 and not term.negated
                 and user_profile.can_access_public_streams()
             ):

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -972,6 +972,54 @@ def access_stream_by_id_for_message(
     return (stream, sub)
 
 
+def get_content_accessible_streams_without_protected_history_queryset(
+    user_profile: UserProfile, subscribed_stream_ids: QuerySet[Subscription, int]
+) -> QuerySet[Stream]:
+    realm = user_profile.realm
+    user_recursive_group_ids = set(
+        get_recursive_membership_groups(user_profile).values_list("id", flat=True)
+    )
+
+    private_stream_query_Set = get_subscribed_streams_without_protected_history_queryset(
+        user_profile, subscribed_stream_ids
+    )
+    public_streams_query_set = get_public_streams_queryset(realm)
+    permission_accessible_private_streams = Stream.objects.filter(
+        Q(realm=realm, invite_only=True, history_public_to_subscribers=True)
+        & (
+            Q(can_add_subscribers_group_id__in=user_recursive_group_ids)
+            | Q(can_subscribe_group_id__in=user_recursive_group_ids)
+        )
+    )
+    return public_streams_query_set.union(
+        permission_accessible_private_streams, private_stream_query_Set
+    )
+
+
+def get_subscribed_streams_without_protected_history_queryset(
+    user_profile: UserProfile, subscribed_stream_ids: QuerySet[Subscription, int]
+) -> QuerySet[Stream]:
+    return Stream.objects.filter(
+        realm=user_profile.realm, id__in=subscribed_stream_ids, history_public_to_subscribers=True
+    )
+
+
+def get_subscribed_streams_with_protected_history_queryset(
+    user_profile: UserProfile, subscribed_stream_ids: QuerySet[Subscription, int]
+) -> QuerySet[Stream]:
+    return Stream.objects.filter(
+        realm=user_profile.realm, id__in=subscribed_stream_ids, history_public_to_subscribers=False
+    )
+
+
+def is_user_subscribed_to_protected_history_stream(
+    user_profile: UserProfile, subscribed_stream_ids: QuerySet[Subscription, int]
+) -> bool:
+    return Stream.objects.filter(
+        realm=user_profile.realm, id__in=subscribed_stream_ids, history_public_to_subscribers=False
+    ).exists()
+
+
 def get_public_streams_queryset(realm: Realm) -> QuerySet[Stream]:
     return Stream.objects.filter(realm=realm, invite_only=False, history_public_to_subscribers=True)
 

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -17,7 +17,9 @@ from analytics.models import RealmCount
 from zerver.actions.message_edit import build_message_edit_request, do_update_message
 from zerver.actions.reactions import check_add_reaction
 from zerver.actions.realm_settings import do_set_realm_property
+from zerver.actions.streams import do_change_stream_group_based_setting
 from zerver.actions.uploads import do_claim_attachments
+from zerver.actions.user_groups import check_add_user_group
 from zerver.actions.user_settings import do_change_user_setting
 from zerver.actions.users import do_deactivate_user
 from zerver.lib.avatar import avatar_url
@@ -220,6 +222,90 @@ class NarrowBuilderTest(ZulipTestCase):
             "WHERE (recipient_id NOT IN (__[POSTCOMPILE_recipient_id_1]))",
         )
 
+    def test_add_term_using_channels_operator_and_all_operand(self) -> None:
+        hamlet = self.user_profile
+        term = NarrowParameter(operator="channels", operand="all")
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id IN (__[POSTCOMPILE_recipient_id_1]) OR id IN (__[POSTCOMPILE_id_1])",
+        )
+        realm = get_realm("zulip")
+        hamlet_group = check_add_user_group(
+            realm,
+            "hamlet_group",
+            [hamlet],
+            acting_user=hamlet,
+        )
+        # Add new channels
+        channel_dicts: list[StreamDict] = [
+            {
+                "name": "private-channel",
+                "description": "Private channel with non-public history",
+                "invite_only": True,
+            },
+            {
+                "name": "private-channel-with-history",
+                "description": "Private channel with public history",
+                "invite_only": True,
+                "history_public_to_subscribers": True,
+                "can_add_subscribers_group": hamlet_group,
+            },
+        ]
+        created, existing = create_streams_if_needed(realm, channel_dicts)
+
+        self.assert_length(created, 2)
+        self.assert_length(existing, 0)
+
+        # Number of recipient ids will increase by 1 and not 2
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id IN (__[POSTCOMPILE_recipient_id_1]) OR id IN (__[POSTCOMPILE_id_1])",
+        )
+
+        self.subscribe(self.user_profile, "private_channel")
+        self.send_stream_message(self.user_profile, "private_channel")
+
+    def test_add_term_using_channels_operator_and_all_operand_negated(self) -> None:
+        hamlet = self.user_profile
+        term = NarrowParameter(operator="channels", operand="all", negated=True)
+        self.builder = NarrowBuilder(self.user_profile, column("message_id", Integer), self.realm)
+        self._do_add_term_test(
+            term,
+            "WHERE NOT (recipient_id IN (__[POSTCOMPILE_recipient_id_1]) OR message_id IN (__[POSTCOMPILE_message_id_1]))",
+        )
+        realm = get_realm("zulip")
+        hamlet_group = check_add_user_group(
+            realm,
+            "hamlet_group",
+            [hamlet],
+            acting_user=hamlet,
+        )
+        # Add new channels
+        channel_dicts: list[StreamDict] = [
+            {
+                "name": "private-channel",
+                "description": "Private channel with non-public history",
+                "invite_only": True,
+            },
+            {
+                "name": "private-channel-with-history",
+                "description": "Private channel with public history",
+                "invite_only": True,
+                "history_public_to_subscribers": True,
+                "can_add_subscribers_group": hamlet_group,
+            },
+        ]
+        created, existing = create_streams_if_needed(realm, channel_dicts)
+
+        self.assert_length(created, 2)
+        self.assert_length(existing, 0)
+
+        # Number of recipient ids will increase by 1 and not 2
+        self._do_add_term_test(
+            term,
+            "WHERE NOT (recipient_id IN (__[POSTCOMPILE_recipient_id_1]) OR message_id IN (__[POSTCOMPILE_message_id_1]))",
+        )
+
     def test_add_term_using_is_operator_and_dm_operand(self) -> None:
         term = NarrowParameter(operator="is", operand="dm")
         self._do_add_term_test(term, "WHERE (flags & %(flags_1)s) != %(param_1)s")
@@ -386,6 +472,11 @@ class NarrowBuilderTest(ZulipTestCase):
             self._build_query(channels_term)
         self.assertEqual(expected_error_message, str(error.exception))
 
+        channels_term = NarrowParameter(operator="channels", operand="all")
+        with self.assertRaises(BadNarrowOperatorError) as error:
+            self._build_query(channels_term)
+        self.assertEqual(expected_error_message, str(error.exception))
+
     def test_combined_channel_with_negated_is_dm(self) -> None:
         dm_term = NarrowParameter(operator="is", operand="dm", negated=True)
         self._build_query(dm_term)
@@ -393,11 +484,17 @@ class NarrowBuilderTest(ZulipTestCase):
         channel_term = NarrowParameter(operator="channels", operand="public")
         self._build_query(channel_term)
 
+        channel_term = NarrowParameter(operator="channels", operand="all")
+        self._build_query(channel_term)
+
     def test_combined_negated_channel_with_is_dm(self) -> None:
         dm_term = NarrowParameter(operator="is", operand="dm")
         self._build_query(dm_term)
 
         channel_term = NarrowParameter(operator="channels", operand="public", negated=True)
+        self._build_query(channel_term)
+
+        channel_term = NarrowParameter(operator="channels", operand="all", negated=True)
         self._build_query(channel_term)
 
     def test_add_term_using_dm_operator_not_the_same_user_as_operand_and_negated(
@@ -763,6 +860,21 @@ class NarrowBuilderTest(ZulipTestCase):
             "WHERE (recipient_id NOT IN (__[POSTCOMPILE_recipient_id_1]))",
         )
 
+    def test_add_term_using_streams_operator_and_all_operand(self) -> None:
+        term = NarrowParameter(operator="streams", operand="all")
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id IN (__[POSTCOMPILE_recipient_id_1]) OR id IN (__[POSTCOMPILE_id_1])",
+        )
+
+    def test_add_term_using_streams_operator_and_all_operand_negated(self) -> None:
+        term = NarrowParameter(operator="streams", operand="all", negated=True)
+        self.builder = NarrowBuilder(self.user_profile, column("message_id", Integer), self.realm)
+        self._do_add_term_test(
+            term,
+            "WHERE NOT (recipient_id IN (__[POSTCOMPILE_recipient_id_1]) OR message_id IN (__[POSTCOMPILE_message_id_1]))",
+        )
+
     def _do_add_term_test(
         self, term: NarrowParameter, where_clause: str, params: dict[str, Any] | None = None
     ) -> None:
@@ -1106,6 +1218,9 @@ class NarrowLibraryTest(ZulipTestCase):
         self.assertTrue(
             is_spectator_compatible([NarrowParameter(operator="channels", operand="public")])
         )
+        self.assertTrue(
+            is_spectator_compatible([NarrowParameter(operator="channels", operand="all")])
+        )
 
         # "is:private" is a legacy alias for "is:dm".
         self.assertFalse(
@@ -1139,6 +1254,9 @@ class NarrowLibraryTest(ZulipTestCase):
         self.assertTrue(
             is_spectator_compatible([NarrowParameter(operator="streams", operand="public")])
         )
+        self.assertTrue(
+            is_spectator_compatible([NarrowParameter(operator="streams", operand="all")])
+        )
 
 
 class IncludeHistoryTest(ZulipTestCase):
@@ -1161,6 +1279,18 @@ class IncludeHistoryTest(ZulipTestCase):
         # Negated -channels:public searches should not include history.
         narrow = [
             NarrowParameter(operator="channels", operand="public", negated=True),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+
+        # channels:all searches should include history for non-guest members.
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+        ]
+        self.assertTrue(ok_to_include_history(narrow, user_profile, False))
+
+        # Negated -channels:all searches should not include history.
+        narrow = [
+            NarrowParameter(operator="channels", operand="all", negated=True),
         ]
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
 
@@ -1237,6 +1367,29 @@ class IncludeHistoryTest(ZulipTestCase):
         ]
         self.assertTrue(ok_to_include_history(narrow, user_profile, False))
 
+        # No point in searching history for is operator even if included with
+        # channels:all
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+            NarrowParameter(operator="is", operand="mentioned"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+            NarrowParameter(operator="is", operand="unread"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+            NarrowParameter(operator="is", operand="alerted"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+            NarrowParameter(operator="is", operand="resolved"),
+        ]
+        self.assertTrue(ok_to_include_history(narrow, user_profile, False))
+
         # simple True case
         narrow = [
             NarrowParameter(operator="channel", operand="public_channel"),
@@ -1258,6 +1411,12 @@ class IncludeHistoryTest(ZulipTestCase):
         # channels:public searches should not include history for guest members.
         narrow = [
             NarrowParameter(operator="channels", operand="public"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
+
+        # channels:all searches should not include history for guest members.
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
         ]
         self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
 
@@ -3733,6 +3892,103 @@ class GetOldMessagesTest(ZulipTestCase):
         )
         self.assert_length(result["messages"], 1)
         self.assertEqual(result["messages"][0]["id"], anchor)
+
+    def test_get_messages_using_narrow_channels_all(self) -> None:
+        realm = get_realm("zulip")
+
+        result = self.get_and_check_messages(
+            dict(
+                narrow=orjson.dumps(
+                    [
+                        dict(operator="channels", operand="all"),
+                        dict(operator="channels", operand="web-public"),
+                    ]
+                ).decode()
+            )
+        )
+
+        self.assert_length(result["messages"], 1)
+        self.assertEqual(result["messages"][0]["display_recipient"], "Rome")
+
+        # Add new channels
+        channel_dicts: list[StreamDict] = [
+            {
+                "name": "public-channel",
+                "description": "Public channel with public history",
+                "is_web_public": False,
+            },
+            {
+                "name": "private-channel",
+                "description": "Private channel with non-public history",
+                "invite_only": True,
+            },
+            {
+                "name": "private-channel-with-history",
+                "description": "Private channel with public history",
+                "invite_only": True,
+                "history_public_to_subscribers": True,
+            },
+        ]
+        create_streams_if_needed(realm, channel_dicts)
+
+        iago = self.example_user("iago")
+        self.login("iago")
+        message_ids = []
+        for stream_name in ["public-channel", "private-channel", "private-channel-with-history"]:
+            self.subscribe(iago, stream_name)
+            message_ids.append(self.send_stream_message(iago, stream_name))
+        self.logout()
+
+        hamlet = self.example_user("hamlet")
+        self.login("hamlet")
+
+        hamlet_group = check_add_user_group(
+            realm,
+            "hamlet_group",
+            [hamlet],
+            acting_user=hamlet,
+        )
+        for stream_name in ["private-channel", "private-channel-with-history"]:
+            do_change_stream_group_based_setting(
+                get_stream(stream_name, realm),
+                "can_add_subscribers_group",
+                hamlet_group,
+                acting_user=iago,
+            )
+
+        narrow = [dict(operator="channels", operand="all")]
+
+        # Private messages that the user has access to but not subscribed should be included
+        # along with the messages from public channels.
+        result = self.get_and_check_messages(
+            dict(
+                narrow=orjson.dumps(narrow).decode(),
+                anchor=message_ids[0],
+                num_before=0,
+                num_after=3,
+            )
+        )
+
+        self.assert_length(result["messages"], 2)
+        self.assertEqual(result["messages"][0]["display_recipient"], "public-channel")
+        self.assertEqual(result["messages"][1]["display_recipient"], "private-channel-with-history")
+
+        self.subscribe(hamlet, "private-channel")
+        # Users in private channels with protected history can only see messages sent while subscribed.
+        self.send_stream_message(hamlet, "private-channel")
+        result = self.get_and_check_messages(
+            dict(
+                narrow=orjson.dumps(narrow).decode(),
+                anchor=message_ids[0],
+                num_before=0,
+                num_after=3,
+            )
+        )
+
+        self.assert_length(result["messages"], 3)
+        self.assertEqual(result["messages"][0]["display_recipient"], "public-channel")
+        self.assertEqual(result["messages"][1]["display_recipient"], "private-channel-with-history")
+        self.assertEqual(result["messages"][2]["display_recipient"], "private-channel")
 
     def test_get_visible_messages_with_anchor(self) -> None:
         def messages_matches_ids(messages: list[dict[str, Any]], message_ids: list[int]) -> None:

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -306,6 +306,91 @@ class NarrowBuilderTest(ZulipTestCase):
             "WHERE NOT (recipient_id IN (__[POSTCOMPILE_recipient_id_1]) OR message_id IN (__[POSTCOMPILE_message_id_1]))",
         )
 
+    def test_add_term_using_channels_operator_and_subscribed_operand(self) -> None:
+        hamlet = self.user_profile
+        term = NarrowParameter(operator="channels", operand="subscribed")
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id IN (__[POSTCOMPILE_recipient_id_1]) OR id IN (__[POSTCOMPILE_id_1])",
+        )
+        realm = get_realm("zulip")
+        hamlet_group = check_add_user_group(
+            realm,
+            "hamlet_group",
+            [hamlet],
+            acting_user=hamlet,
+        )
+        # Add new channels
+        channel_dicts: list[StreamDict] = [
+            {
+                "name": "private-channel",
+                "description": "Private channel with non-public history",
+                "invite_only": True,
+            },
+            {
+                "name": "private-channel-with-history",
+                "description": "Private channel with public history",
+                "invite_only": True,
+                "history_public_to_subscribers": True,
+                "can_add_subscribers_group": hamlet_group,
+            },
+        ]
+        created, existing = create_streams_if_needed(realm, channel_dicts)
+
+        self.assert_length(created, 2)
+        self.assert_length(existing, 0)
+        self.subscribe(hamlet, "private-channel")
+        # Number of recipient ids will increase by 1 and not 2
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id IN (__[POSTCOMPILE_recipient_id_1]) OR id IN (__[POSTCOMPILE_id_1])",
+        )
+
+        self.subscribe(self.user_profile, "private_channel")
+        self.send_stream_message(self.user_profile, "private_channel")
+
+    def test_add_term_using_channels_operator_and_subscribed_operand_negated(self) -> None:
+        hamlet = self.user_profile
+        term = NarrowParameter(operator="channels", operand="subscribed", negated=True)
+        self.builder = NarrowBuilder(self.user_profile, column("message_id", Integer), self.realm)
+        self._do_add_term_test(
+            term,
+            "WHERE NOT (recipient_id IN (__[POSTCOMPILE_recipient_id_1]) OR message_id IN (__[POSTCOMPILE_message_id_1]))",
+        )
+        realm = get_realm("zulip")
+        hamlet_group = check_add_user_group(
+            realm,
+            "hamlet_group",
+            [hamlet],
+            acting_user=hamlet,
+        )
+        # Add new channels
+        channel_dicts: list[StreamDict] = [
+            {
+                "name": "private-channel",
+                "description": "Private channel with non-public history",
+                "invite_only": True,
+            },
+            {
+                "name": "private-channel-with-history",
+                "description": "Private channel with public history",
+                "invite_only": True,
+                "history_public_to_subscribers": True,
+                "can_add_subscribers_group": hamlet_group,
+            },
+        ]
+        created, existing = create_streams_if_needed(realm, channel_dicts)
+
+        self.assert_length(created, 2)
+        self.assert_length(existing, 0)
+
+        self.subscribe(hamlet, "private-channel")
+        # Number of recipient ids will increase by 1 and not 2
+        self._do_add_term_test(
+            term,
+            "WHERE NOT (recipient_id IN (__[POSTCOMPILE_recipient_id_1]) OR message_id IN (__[POSTCOMPILE_message_id_1]))",
+        )
+
     def test_add_term_using_is_operator_and_dm_operand(self) -> None:
         term = NarrowParameter(operator="is", operand="dm")
         self._do_add_term_test(term, "WHERE (flags & %(flags_1)s) != %(param_1)s")
@@ -477,6 +562,11 @@ class NarrowBuilderTest(ZulipTestCase):
             self._build_query(channels_term)
         self.assertEqual(expected_error_message, str(error.exception))
 
+        channels_term = NarrowParameter(operator="channels", operand="subscribed")
+        with self.assertRaises(BadNarrowOperatorError) as error:
+            self._build_query(channels_term)
+        self.assertEqual(expected_error_message, str(error.exception))
+
     def test_combined_channel_with_negated_is_dm(self) -> None:
         dm_term = NarrowParameter(operator="is", operand="dm", negated=True)
         self._build_query(dm_term)
@@ -487,6 +577,9 @@ class NarrowBuilderTest(ZulipTestCase):
         channel_term = NarrowParameter(operator="channels", operand="all")
         self._build_query(channel_term)
 
+        channel_term = NarrowParameter(operator="channels", operand="subscribed")
+        self._build_query(channel_term)
+
     def test_combined_negated_channel_with_is_dm(self) -> None:
         dm_term = NarrowParameter(operator="is", operand="dm")
         self._build_query(dm_term)
@@ -495,6 +588,9 @@ class NarrowBuilderTest(ZulipTestCase):
         self._build_query(channel_term)
 
         channel_term = NarrowParameter(operator="channels", operand="all", negated=True)
+        self._build_query(channel_term)
+
+        channel_term = NarrowParameter(operator="channels", operand="subscribed", negated=True)
         self._build_query(channel_term)
 
     def test_add_term_using_dm_operator_not_the_same_user_as_operand_and_negated(
@@ -875,6 +971,21 @@ class NarrowBuilderTest(ZulipTestCase):
             "WHERE NOT (recipient_id IN (__[POSTCOMPILE_recipient_id_1]) OR message_id IN (__[POSTCOMPILE_message_id_1]))",
         )
 
+    def test_add_term_using_streams_operator_and_subscribed_operand(self) -> None:
+        term = NarrowParameter(operator="streams", operand="subscribed")
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id IN (__[POSTCOMPILE_recipient_id_1]) OR id IN (__[POSTCOMPILE_id_1])",
+        )
+
+    def test_add_term_using_streams_operator_and_subscribed_operand_negated(self) -> None:
+        term = NarrowParameter(operator="streams", operand="subscribed", negated=True)
+        self.builder = NarrowBuilder(self.user_profile, column("message_id", Integer), self.realm)
+        self._do_add_term_test(
+            term,
+            "WHERE NOT (recipient_id IN (__[POSTCOMPILE_recipient_id_1]) OR message_id IN (__[POSTCOMPILE_message_id_1]))",
+        )
+
     def _do_add_term_test(
         self, term: NarrowParameter, where_clause: str, params: dict[str, Any] | None = None
     ) -> None:
@@ -1221,6 +1332,9 @@ class NarrowLibraryTest(ZulipTestCase):
         self.assertTrue(
             is_spectator_compatible([NarrowParameter(operator="channels", operand="all")])
         )
+        self.assertFalse(
+            is_spectator_compatible([NarrowParameter(operator="channels", operand="subscribed")])
+        )
 
         # "is:private" is a legacy alias for "is:dm".
         self.assertFalse(
@@ -1257,6 +1371,9 @@ class NarrowLibraryTest(ZulipTestCase):
         self.assertTrue(
             is_spectator_compatible([NarrowParameter(operator="streams", operand="all")])
         )
+        self.assertFalse(
+            is_spectator_compatible([NarrowParameter(operator="streams", operand="subscribed")])
+        )
 
 
 class IncludeHistoryTest(ZulipTestCase):
@@ -1291,6 +1408,18 @@ class IncludeHistoryTest(ZulipTestCase):
         # Negated -channels:all searches should not include history.
         narrow = [
             NarrowParameter(operator="channels", operand="all", negated=True),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+
+        # channels:subscribed searches should include history for non-guest members.
+        narrow = [
+            NarrowParameter(operator="channels", operand="subscribed"),
+        ]
+        self.assertTrue(ok_to_include_history(narrow, user_profile, False))
+
+        # Negated -channels:subscribed searches should not include history.
+        narrow = [
+            NarrowParameter(operator="channels", operand="subscribed", negated=True),
         ]
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
 
@@ -1417,6 +1546,12 @@ class IncludeHistoryTest(ZulipTestCase):
         # channels:all searches should not include history for guest members.
         narrow = [
             NarrowParameter(operator="channels", operand="all"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
+
+        # channels:subscribed searches should not include history for guest members.
+        narrow = [
+            NarrowParameter(operator="channels", operand="subscribed"),
         ]
         self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
 
@@ -3989,6 +4124,86 @@ class GetOldMessagesTest(ZulipTestCase):
         self.assertEqual(result["messages"][0]["display_recipient"], "public-channel")
         self.assertEqual(result["messages"][1]["display_recipient"], "private-channel-with-history")
         self.assertEqual(result["messages"][2]["display_recipient"], "private-channel")
+
+    def test_get_messages_using_narrow_channels_subscribed(self) -> None:
+        realm = get_realm("zulip")
+
+        # Add new channels
+        channel_dicts: list[StreamDict] = [
+            {
+                "name": "public-channel",
+                "description": "Public channel with public history",
+                "is_web_public": False,
+            },
+            {
+                "name": "private-channel",
+                "description": "Private channel with non-public history",
+                "invite_only": True,
+            },
+            {
+                "name": "private-channel-with-history",
+                "description": "Private channel with public history",
+                "invite_only": True,
+                "history_public_to_subscribers": True,
+            },
+        ]
+        create_streams_if_needed(realm, channel_dicts)
+
+        iago = self.example_user("iago")
+        self.login("iago")
+        message_ids = []
+        for stream_name in ["public-channel", "private-channel", "private-channel-with-history"]:
+            self.subscribe(iago, stream_name)
+            message_ids.append(self.send_stream_message(iago, stream_name))
+        self.logout()
+
+        polonius = self.example_user("polonius")
+        # Polonius is subscribed to "Verona" by default, so we unsubscribe
+        # it so that it becomes easier to test the `channels:subscribed` filter.
+        self.unsubscribe(polonius, "Verona")
+
+        self.login("polonius")
+        polonius_group = check_add_user_group(
+            realm,
+            "polonius_group",
+            [polonius],
+            acting_user=polonius,
+        )
+        for stream_name in ["private-channel", "private-channel-with-history"]:
+            do_change_stream_group_based_setting(
+                get_stream(stream_name, realm),
+                "can_add_subscribers_group",
+                polonius_group,
+                acting_user=iago,
+            )
+
+        narrow = [dict(operator="channels", operand="subscribed")]
+
+        # Only the messages from the subscribed channels should be included.
+        result = self.get_and_check_messages(
+            dict(
+                narrow=orjson.dumps(narrow).decode(),
+                anchor=message_ids[0],
+                num_before=0,
+                num_after=3,
+            )
+        )
+        self.assert_length(result["messages"], 0)
+
+        self.subscribe(polonius, "private-channel")
+
+        self.send_stream_message(polonius, "private-channel")
+        result = self.get_and_check_messages(
+            dict(
+                narrow=orjson.dumps(narrow).decode(),
+                anchor=message_ids[0],
+                num_before=0,
+                num_after=3,
+            )
+        )
+
+        self.assert_length(result["messages"], 1)
+        self.assertEqual(result["messages"][0]["display_recipient"], "private-channel")
 
     def test_get_visible_messages_with_anchor(self) -> None:
         def messages_matches_ids(messages: list[dict[str, Any]], message_ids: list[int]) -> None:


### PR DESCRIPTION
<!-- Describe your pull request here.-->

1st commit adds `channels:all` filter.
2nd commit adds `channels:subscribed` filter.

Fixes: #33534  and #13052

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://github.com/user-attachments/assets/3f5b4bdd-475b-4d71-a401-27b9483edb39)

![image](https://github.com/user-attachments/assets/26728e77-3863-4a5a-af52-c3ab82b5e9a2)

**Help menu**

<img width="709" height="634" alt="image" src="https://github.com/user-attachments/assets/53aaca59-c649-423a-9556-9121fa97dbd7" />

**Search suggestion**

<img width="710" height="192" alt="image" src="https://github.com/user-attachments/assets/694a04df-ac82-4685-94aa-dc74996faf38" />

**Documentation**

<img width="738" height="370" alt="image" src="https://github.com/user-attachments/assets/74aa0068-983f-46a4-9d0d-251eb04e0d36" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
