### PR TITLE
Configure default email based on org type.

### DIFF
--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -791,6 +791,22 @@ def do_change_realm_org_type(
     realm.org_type = org_type
     realm.save(update_fields=["org_type"])
 
+    realm_user_default = RealmUserDefault.objects.get(realm=realm)
+    if org_type == Realm.ORG_TYPES["business"]["id"]:
+        new_email_address_visibility = UserProfile.EMAIL_ADDRESS_VISIBILITY_EVERYONE
+    elif org_type in (
+        Realm.ORG_TYPES["education"]["id"],
+        Realm.ORG_TYPES["education_nonprofit"]["id"],
+    ):
+        new_email_address_visibility = UserProfile.EMAIL_ADDRESS_VISIBILITY_MODERATORS
+    else:
+        new_email_address_visibility = UserProfile.EMAIL_ADDRESS_VISIBILITY_ADMINS
+
+    if realm_user_default.email_address_visibility != new_email_address_visibility:
+        old_value = realm_user_default.email_address_visibility
+        realm_user_default.email_address_visibility = new_email_address_visibility
+        realm_user_default.save(update_fields=["email_address_visibility"])
+
     RealmAuditLog.objects.create(
         event_type=AuditLogEventType.REALM_ORG_TYPE_CHANGED,
         realm=realm,


### PR DESCRIPTION
This PR allows default configurations for `email_visibility` to be more private depending on the organization type. If it is a `Business` organization, `email_visibility` is set to `everyone`. `Education` is set to `moderators` and above and all other organization is `admin` only.

Fixes: #34859 

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
