### PR TITLE
demo-orgs: Make password not required for demo organization creation.

### DIFF
--- a/zerver/views/development/registration.py
+++ b/zerver/views/development/registration.py
@@ -118,7 +118,6 @@ def register_demo_development_realm(request: HttpRequest) -> HttpResponse:
         realm_default_language=realm_default_language,
         email_address_visibility=email_address_visibility,
         full_name=name,
-        password="test",
         realm_subdomain=realm_subdomain,
         terms="true",
         is_demo_organization="true",

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -614,7 +614,12 @@ def registration_helper(
                 pass
         form = RegistrationForm(postdata, realm_creation=realm_creation, realm=realm)
 
-    if not (password_auth_enabled(realm) and password_required):
+    if realm_creation and demo_organization_creation:
+        # TODO: Remove settings.DEVELOPMENT when demo organization feature ready
+        # to be fully implemented.
+        assert settings.DEVELOPMENT
+        form["password"].field.required = False
+    elif not (password_auth_enabled(realm) and password_required):
         form["password"].field.required = False
 
     if form.is_valid():
@@ -623,7 +628,8 @@ def registration_helper(
         else:
             # If the user wasn't prompted for a password when
             # completing the authentication form (because they're
-            # signing up with SSO and no password is required), set
+            # signing up with SSO and no password is required, or
+            # because they're creating a new demo organization), set
             # the password field to `None` (Which causes Django to
             # create an unusable password).
             password = None


### PR DESCRIPTION
Creating a demo organization will not require the user to set either an email or password, so explicitly set the password field to not be required for that case.

Updates the form submitted in the development environment login page to create a new demo organization to not send a password value.

**Notes**:
- I included the assertion for the development environment here, but that might not be needed. We have the same assertion earlier in the registration helper when the email value in the form is an empty string. So since we'll need to update that before launching the feature as complete, it seemed fined to include it here as well.
- Tested creating demo organizations in the development environment and went through the process of adding the owner email, inviting users and converting the demo organization with these changes in place.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
