### PR TITLE
internal_url: Exclude stream name from encoded slug if it is too long.

### DIFF
--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -55,7 +55,7 @@ export function encode_stream_id(stream_id: number): string {
     // URI encoding piece
     const slug = stream_data.id_to_slug(stream_id);
 
-    return internal_url.encodeHashComponent(slug);
+    return internal_url.encode_slug(stream_id, slug);
 }
 
 export function decode_operand(operator: string, operand: string): string {

--- a/web/src/internal_url.ts
+++ b/web/src/internal_url.ts
@@ -39,6 +39,26 @@ export function stream_id_to_slug(
     return `${stream_id}-${name}`;
 }
 
+export function encode_slug(stream_id: number, slug: string): string {
+    // When generating slugs for channels in URLs, we like to provide
+    // an encoding of the channel name in the URL along with the
+    // channel ID to have the link hint what channel it is. But we
+    // want to only do this when the hinting is useful and does not
+    // greatly lengthen the string as a whole.
+    const MAX_SLUG_LENGTH_DIFF_FROM_ENCODING = 10;
+    const MAX_SLUG_LENGTH_RATIO_FROM_ENCODING = 1.5;
+
+    const encoded_slug = encodeHashComponent(slug);
+    const length_diff = encoded_slug.length - slug.length;
+    if (
+        length_diff > Math.max(slug.length, MAX_SLUG_LENGTH_DIFF_FROM_ENCODING) ||
+        encoded_slug.length > slug.length * MAX_SLUG_LENGTH_RATIO_FROM_ENCODING
+    ) {
+        return String(stream_id);
+    }
+    return encoded_slug;
+}
+
 export function encode_stream_id(
     stream_id: number,
     maybe_get_stream_name: MaybeGetStreamName,
@@ -47,7 +67,7 @@ export function encode_stream_id(
     // URI encoding piece.
     const slug = stream_id_to_slug(stream_id, maybe_get_stream_name);
 
-    return encodeHashComponent(slug);
+    return encode_slug(stream_id, slug);
 }
 
 export function by_stream_url(

--- a/web/tests/internal_url.test.cjs
+++ b/web/tests/internal_url.test.cjs
@@ -63,3 +63,34 @@ run_test("test by_stream_topic_url", () => {
     result = internal_url.by_stream_topic_url(123, "test topic", maybe_get_stream_name, 12);
     assert.equal(result, "#narrow/channel/123-a-test-stream/topic/test.20topic/with/12");
 });
+
+run_test("test encode_slug", () => {
+    // The test cases include stream id to mirror how
+    // internal_url.encode_stream_id works.
+    const test_cases = [
+        [false, "1-精选 - 译文"], // 1-.E7.B2.BE.E9.80.89.20-.20.E8.AF.91.E6.96.87
+        [false, "1-精选 - 原创"], // 1-.E7.B2.BE.E9.80.89.20-.20.E5.8E.9F.E5.88.9B
+        [false, "1-ビデオゲーム"], // 1-.E3.83.93.E3.83.87.E3.82.AA.E3.82.B2.E3.83.BC.E3.83.A0
+        [false, "1-goûta à l'œuf brûlé"], // 1-go.C3.BBta.20.C3.A0.20l'.C5.93uf.20br.C3.BBl.C3.A9
+        [false, "1-(2+3)%5"], // 1-.282.2B3.29.255
+        [false, "1-$um @nd m%d"], // 1-.24um.20.40nd.20m.25d
+        [true, "1-books.2C-film.2C-tv.2C-and-games"], // 1-books.2E2C-film.2E2C-tv.2E2C-and-games
+        [true, "1-test-stream-autocomplete"], // 1-test-stream-autocomplete
+        [false, "1-ñoño"], // 1-.C3.B1o.C3.B1o
+        [false, "1-యశ"], // 1-.E0.B0.AF.E0.B0.B6
+        [false, "1-l'été"], // 1-l'.C3.A9t.C3.A9
+        [false, "1-书籍"], // 1-.E4.B9.A6.E7.B1.8D
+        [true, "1-seeking-arête"], // 1-seeking-ar.C3.AAte
+    ];
+
+    for (const [include_slug, channel_slug] of test_cases) {
+        if (include_slug) {
+            assert.equal(
+                internal_url.encode_slug(1, channel_slug),
+                internal_url.encodeHashComponent(channel_slug),
+            );
+        } else {
+            assert.ok(Number(internal_url.encode_slug(1, channel_slug)) === 1);
+        }
+    }
+});


### PR DESCRIPTION
The URL becomes very long and ugly if the channel/topic name contains non-ascii characters. We can't yet change the encoded topic names as topics are content-addressed by the string. So we shorten the stream part of the url using a heuristic.


This is relatively insignificant on its own - once we have topic ids or something similar, we can also drop topics from the URL, and that would be a more significant improvement on the url size.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
