### PR TITLE
Redesign buttons and disable autocomplete in Add-emoji modal.

### DIFF
--- a/web/templates/settings/add_emoji.hbs
+++ b/web/templates/settings/add_emoji.hbs
@@ -2,8 +2,19 @@
     <div>
         <input type="file" name="emoji_file_input" class="notvisible"
           id="emoji_file_input" value="{{t 'Upload image or GIF' }}"/>
-        <button type="button" class="button white rounded" style="display: none;" id="emoji_image_clear_button">{{t "Clear image" }}</button>
-        <button type="button" class="button rounded" id="emoji_upload_button">{{t "Upload image or GIF" }}</button>
+        {{> ../components/action_button
+          label=(t "Clear image")
+          attention="quiet"
+          intent="danger"
+          id="emoji_image_clear_button"
+          hidden=true
+          }}
+        {{> ../components/action_button
+          label=(t "Upload image or GIF")
+          attention="quiet"
+          intent="brand"
+          id="emoji_upload_button"
+          }}
         <div style="display: none;" id="emoji_preview_text">
             {{t "Preview:" }} <i id="emoji_placeholder_icon" class="fa fa-file-image-o" aria-hidden="true"></i><img class="emoji" id="emoji_preview_image" src=""/>
         </div>

--- a/web/templates/settings/add_emoji.hbs
+++ b/web/templates/settings/add_emoji.hbs
@@ -23,6 +23,6 @@
     <div id="emoji_file_input_error" class="text-error"></div>
     <div class="emoji_name_input">
         <label for="emoji_name" class="modal-field-label">{{t "Emoji name" }}</label>
-        <input type="text" name="name" id="emoji_name" class="modal_text_input" placeholder="{{t 'leafy green vegetable' }}" />
+        <input type="text" name="name" id="emoji_name" class="modal_text_input" autocomplete="off" placeholder="{{t 'leafy green vegetable' }}" />
     </div>
 </form>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: 
Autocomplete discussion: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/Selecting.20from.20suggestions.20gives.20error.2E/with/2197953)

Button redesing discussion: [CZO](https://chat.zulip.org/#narrow/channel/6-frontend/topic/Upload.20avatar.20buttons.20in.20.22Add.20emoji.22.20modal.2E/with/2197944)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After(light) | After (Dark) | 
|---|--|--|
| <img width="246" alt="Screenshot 2025-06-19 at 10 17 49 AM" src="https://github.com/user-attachments/assets/c87a82b7-7938-4f34-a9a6-32d2e2a644ec" /> | <img width="242" alt="Screenshot 2025-06-19 at 9 40 33 AM" src="https://github.com/user-attachments/assets/e54fb22f-9d74-454d-a265-4005d09a598b" /> | <img width="228" alt="Screenshot 2025-06-19 at 9 41 05 AM" src="https://github.com/user-attachments/assets/676dfd11-b52f-4cdf-8043-f4388b4f0e99" /> |
| <img width="194" alt="Screenshot 2025-06-19 at 10 17 59 AM" src="https://github.com/user-attachments/assets/d3b39999-8f60-4214-8ead-3b5fd1dd6b69" /> | <img width="211" alt="Screenshot 2025-06-19 at 9 40 41 AM" src="https://github.com/user-attachments/assets/c846b1e3-16ab-4e6c-a291-f934b82425d8" /> | <img width="172" alt="Screenshot 2025-06-19 at 9 41 15 AM" src="https://github.com/user-attachments/assets/a925361c-2e1b-4cf7-8913-bc772e98bc83" /> |
 



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
