### PR TITLE
stream_popover: Fix rename topic placeholder UI.

### DIFF
--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -890,13 +890,11 @@ export async function build_move_topic_to_stream_popover(
     }
 
     function update_topic_input_placeholder_visibility(topic_input_value: string): void {
-        if (stream_data.can_use_empty_topic(stream_widget_value)) {
-            const $topic_not_mandatory_placeholder = $(".move-topic-new-topic-placeholder");
-            $topic_not_mandatory_placeholder.toggleClass(
-                "move-topic-new-topic-placeholder-visible",
-                topic_input_value === "",
-            );
-        }
+        const $topic_not_mandatory_placeholder = $(".move-topic-new-topic-placeholder");
+        $topic_not_mandatory_placeholder.toggleClass(
+            "move-topic-new-topic-placeholder-visible",
+            topic_input_value === "" && stream_data.can_use_empty_topic(stream_widget_value),
+        );
     }
 
     function setup_resize_observer($topic_input: JQuery<HTMLInputElement>): void {
@@ -976,6 +974,7 @@ export async function build_move_topic_to_stream_popover(
             move_topic_to_stream_topic_typeahead?.hide();
         });
 
+        stream_widget_value = current_stream_id;
         if (only_topic_edit) {
             // Set select_stream_id to current_stream_id since user is not allowed
             // to edit stream in topic-edit only UI.
@@ -991,7 +990,6 @@ export async function build_move_topic_to_stream_popover(
             return;
         }
 
-        stream_widget_value = current_stream_id;
         const streams_list_options = (): dropdown_widget.Option[] =>
             stream_data.get_streams_for_move_messages_widget().filter(({stream}) => {
                 if (stream.stream_id === current_stream_id) {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Previously, the placeholder in the "Rename topic" input  overlapped with the text when renaming the "general chat" topic. Also, the placeholder was not updated to "general chat" when the input was empty and lost focus. This commit fixes the bug.

This bug was introduced in #34897.

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/149c1b6d-cffd-4723-83ae-f43d7f18b93c) | ![after - Made with Clipchamp (1)](https://github.com/user-attachments/assets/2287df8f-f30d-4368-aa2e-1a963ded4e27) | 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
