### PR TITLE
message_delete: Fix flaky 'do_delete_messages' function.

### DIFF
--- a/zerver/actions/message_delete.py
+++ b/zerver/actions/message_delete.py
@@ -120,15 +120,15 @@ def do_delete_messages(
             recipient_id = message.recipient.id
             private_messages_by_recipient[recipient_id].append(message)
 
-    for recipient_id, grouped_messages in private_messages_by_recipient.items():
+    for recipient_id, grouped_messages in sorted(private_messages_by_recipient.items()):
         _process_grouped_messages_deletion(
             realm, grouped_messages, stream=None, topic=None, acting_user=acting_user
         )
 
     for (
-        recipient_id,
-        topic_name,
-    ), grouped_messages in stream_messages_by_recipient_and_topic.items():
+        (recipient_id, topic_name),
+        grouped_messages,
+    ) in sorted(stream_messages_by_recipient_and_topic.items()):
         if recipient_id not in stream_by_recipient_id:
             stream_by_recipient_id[recipient_id] = Stream.objects.get(recipient_id=recipient_id)
         stream = stream_by_recipient_id[recipient_id]


### PR DESCRIPTION
Fixes: [#backend > do_delete_messages assumes messages from same stream &amp; topic @ 💬](https://chat.zulip.org/#narrow/channel/3-backend/topic/do_delete_messages.20assumes.20messages.20from.20same.20stream.20.26.20topic/near/2199272)

I have wrote  a bit long commit description to explain the issue in the commit only .

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
