### PR TITLE
Fixed Issue

### DIFF
--- a/zerver/webhooks/opsgenie/view.py
+++ b/zerver/webhooks/opsgenie/view.py
@@ -33,7 +33,17 @@ def api_opsgenie_webhook(
     *,
     payload: JsonBodyPayload[WildValue],
 ) -> HttpResponse:
-    # construct the body of the message
+    # Determine the correct Opsgenie base URL
+    region = request.GET.get("region", "").lower()
+    opsgenie_base_url = "https://app.opsgenie.com"
+    if region == "eu":
+        opsgenie_base_url = "https://app.eu.opsgenie.com"
+    elif "source" in payload:
+        source = payload["source"].tame(check_string).lower()
+        if "eu" in source:
+            opsgenie_base_url = "https://app.eu.opsgenie.com"
+
+    # Construct the body of the message
     info = {
         "additional_info": "",
         "alert_type": payload["action"].tame(check_string),
@@ -70,10 +80,10 @@ def api_opsgenie_webhook(
             continue
         info["additional_info"] += bullet_template.format(key=display_name, value=value)
 
-    body_template = """
-[Opsgenie alert for {integration_name}](https://app.opsgenie.com/alert/V2#/show/{alert_id}):
-* **Type**: {alert_type}
-{additional_info}
+    body_template = f"""
+[Opsgenie alert for {{integration_name}}]({opsgenie_base_url}/alert/V2#/show/{{alert_id}}):
+* **Type**: {{alert_type}}
+{{additional_info}}
 """.strip()
 
     body = body_template.format(**info)


### PR DESCRIPTION
 Error / Issue
The original webhook handler in zulip/zerver/webhooks/opsgenie/view.py used a hardcoded Opsgenie URL:

`https://app.opsgenie.com/alert/V2#/show/{alert_id}`

This always pointed to the US Opsgenie environment, even when:

1. The user or organization used the EU Opsgenie instance (https://app.eu.opsgenie.com)
2. The payload was sent from an EU-based Opsgenie account
3. The user was logged in to the EU Opsgenie site

As a result:

1. Clicking on alert links in Zulip messages redirected users to the wrong environment.
2. Users faced authentication issues or missing alerts, since the EU environment uses a separate login/session.

Changes Made
Added dynamic URL support:

- Default URL: https://app.opsgenie.com
- If the webhook query includes ?region=eu, or if the payload's "source" field contains "eu", the URL is changed to:
`https://app.eu.opsgenie.com`

Code logic added to check:

- request.GET.get("region") from the webhook URL
- payload["source"], if present, to infer the correct region

The URL in the message body is now dynamically constructed using a variable opsgenie_base_url instead of a hardcoded string.

Consequences / Benefits
Correct region-specific URL is used in alert links:

1. EU users are now correctly directed to https://app.eu.opsgenie.com.
2. US users still go to the default https://app.opsgenie.com.

Improved user experience:

1. Users land directly on the alert detail page they expect.
2. No more login issues or access errors due to region mismatches.
3. Support for both environments without code duplication.