### PR TITLE
stream_settings: Add new disable_topics option to topics_policy. 

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,17 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 11.0
 
+**Feature level 404**
+
+* [`GET /users/me/subscriptions`](/api/get-subscriptions),
+  [`GET /streams`](/api/get-streams), [`GET /events`](/api/get-events),
+  [`POST /register`](/api/register-queue): Added new `empty_topic_only`
+  option to `topics_policy` field in Stream and Subscription objects.
+* [`POST /users/me/subscriptions`](/api/subscribe),
+  [`PATCH /streams/{stream_id}`](/api/update-stream): Added new
+  `empty_topic_only` option to `topics_policy` to support channels
+  with topics disabled.
+
 **Feature level 403**
 
 * [`POST /register`](/api/register-queue): Added a `url_options` object

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -250,6 +250,7 @@ python_rules = RuleList(
             "exclude": FILES_WITH_LEGACY_SUBJECT,
             "exclude_line": {
                 ("zerver/lib/message.py", "message__subject__iexact=message.topic_name(),"),
+                ("zerver/lib/streams.py", '.exclude(subject="")'),
                 ("zerver/views/streams.py", "message__subject__iexact=topic_name,"),
                 ("zerver/lib/message_cache.py", 'and obj["subject"] == ""'),
                 (

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 403
+API_FEATURE_LEVEL = 404
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -93,7 +93,8 @@ export function by_stream_url(stream_id: number): string {
 export function channel_url_by_user_setting(channel_id: number): string {
     if (
         user_settings.web_channel_default_view ===
-        web_channel_default_view_values.list_of_topics.code
+            web_channel_default_view_values.list_of_topics.code &&
+        !stream_data.is_empty_topic_only_channel(channel_id)
     ) {
         return by_channel_topic_list_url(channel_id);
     }

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -112,6 +112,11 @@ export function is_topic_editable(message: Message, edit_limit_seconds_buffer = 
         return false;
     }
 
+    // Cannot edit topics only in the channel with topics disabled.
+    if (stream_data.is_empty_topic_only_channel(message.stream_id)) {
+        return false;
+    }
+
     const stream = stream_data.get_sub_by_id(message.stream_id);
     assert(stream !== undefined);
     if (!stream_data.user_can_move_messages_within_channel(stream)) {

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -267,8 +267,11 @@ export function get_topic_popover_content_context({
     const has_starred_messages = starred_messages.get_count_in_topic(sub.stream_id, topic_name) > 0;
     const has_unread_messages = num_unread_for_topic(sub.stream_id, topic_name) > 0;
     const can_move_topic = stream_data.user_can_move_messages_out_of_channel(sub);
-    const can_rename_topic = stream_data.user_can_move_messages_within_channel(sub);
+    const can_rename_topic =
+        stream_data.user_can_move_messages_within_channel(sub) &&
+        !stream_data.is_empty_topic_only_channel(sub.stream_id);
     const can_resolve_topic = !sub.is_archived && stream_data.can_resolve_topics(sub);
+
     const visibility_policy = user_topics.get_topic_visibility_policy(sub.stream_id, topic_name);
     const all_visibility_policies = user_topics.all_visibility_policies;
     const is_spectator = page_params.is_spectator;

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1510,7 +1510,7 @@ function enable_or_disable_save_button($subsection_elem: JQuery): void {
     ) {
         if (
             $subsection_elem.attr("id") === "org-message-retention" ||
-            $subsection_elem.hasClass("advanced-configurations-container")
+            $subsection_elem.closest(".advanced-configurations-container").length > 0
         ) {
             ui_util.disable_element_and_add_tooltip(
                 $save_button,

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -309,6 +309,7 @@ type RealmTopicsPolicyValues = {
 
 type StreamTopicsPolicyValues = {
     inherit: PolicyValue;
+    empty_topic_only: PolicyValue;
 } & RealmTopicsPolicyValues;
 
 export const get_realm_topics_policy_values = (): RealmTopicsPolicyValues => {
@@ -331,6 +332,7 @@ export const get_realm_topics_policy_values = (): RealmTopicsPolicyValues => {
 
 export const get_stream_topics_policy_values = (): StreamTopicsPolicyValues => {
     const realm_topics_policy_values = get_realm_topics_policy_values();
+    const empty_topic_name = util.get_final_topic_display_name("");
 
     return {
         inherit: {
@@ -338,6 +340,13 @@ export const get_stream_topics_policy_values = (): StreamTopicsPolicyValues => {
             description: $t({defaultMessage: "Automatic"}),
         },
         ...realm_topics_policy_values,
+        empty_topic_only: {
+            code: "empty_topic_only",
+            description: $t(
+                {defaultMessage: 'Only "{empty_topic_name}" topic allowed'},
+                {empty_topic_name},
+            ),
+        },
     };
 };
 

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -1111,7 +1111,25 @@ export function can_use_empty_topic(stream_id: number | undefined): boolean {
         topics_policy = realm.realm_topics_policy;
     }
     return (
-        topics_policy === settings_config.get_realm_topics_policy_values().allow_empty_topic.code
+        topics_policy ===
+            settings_config.get_stream_topics_policy_values().allow_empty_topic.code ||
+        topics_policy === settings_config.get_stream_topics_policy_values().empty_topic_only.code
+    );
+}
+
+export function is_empty_topic_only_channel(stream_id: number | undefined): boolean {
+    if (stream_id === undefined) {
+        return false;
+    }
+    const sub = sub_store.get(stream_id);
+    assert(sub !== undefined);
+
+    let topics_policy = sub.topics_policy;
+    if (sub.topics_policy === settings_config.get_stream_topics_policy_values().inherit.code) {
+        topics_policy = realm.realm_topics_policy;
+    }
+    return (
+        topics_policy === settings_config.get_stream_topics_policy_values().empty_topic_only.code
     );
 }
 

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -466,13 +466,7 @@ function build_stream_sidebar_li(sub: StreamSubscription): JQuery {
     const name = sub.name;
     const is_muted = stream_data.is_muted(sub.stream_id);
     const can_post_messages = stream_data.can_post_messages_in_stream(sub);
-    let url = hash_util.channel_url_by_user_setting(sub.stream_id);
-    if (
-        web_channel_default_view_values.list_of_topics.code ===
-        user_settings.web_channel_default_view
-    ) {
-        url = hash_util.by_channel_topic_list_url(sub.stream_id);
-    }
+    const url = hash_util.channel_url_by_user_setting(sub.stream_id);
     const args = {
         name,
         id: sub.stream_id,

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -919,6 +919,14 @@ export function set_event_handlers({
         const current_narrow_stream_id = narrow_state.stream_id();
         const current_topic = narrow_state.topic();
 
+        if (stream_data.is_empty_topic_only_channel(stream_id)) {
+            // If the channel doesn't support topics, take you
+            // directly to general chat regardless of settings.
+            const empty_topic_url = hash_util.by_channel_topic_permalink(stream_id, "");
+            browser_history.go_to_location(empty_topic_url);
+            return;
+        }
+
         if (
             user_settings.web_channel_default_view ===
             web_channel_default_view_values.list_of_topics.code

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -996,6 +996,32 @@ export async function build_move_topic_to_stream_popover(
         }
     }
 
+    function update_topic_input_placeholder_on_focus(): void {
+        const $topic_input = $<HTMLInputElement>("#move_topic_form input.move_messages_edit_topic");
+        const $topic_not_mandatory_placeholder = $(".move-topic-new-topic-placeholder");
+
+        $topic_input.attr("placeholder", "");
+        $topic_input.removeClass("empty-topic-display");
+
+        if ($topic_input.val() === "" && stream_data.can_use_empty_topic(stream_widget_value)) {
+            $topic_not_mandatory_placeholder.addClass("move-topic-new-topic-placeholder-visible");
+            update_clear_move_topic_button_state();
+        }
+    }
+
+    function update_topic_input_placeholder_on_blur(): void {
+        const $topic_input = $<HTMLInputElement>("#move_topic_form input.move_messages_edit_topic");
+        const $topic_not_mandatory_placeholder = $(".move-topic-new-topic-placeholder");
+
+        $topic_not_mandatory_placeholder.removeClass("move-topic-new-topic-placeholder-visible");
+
+        if ($topic_input.val() === "" && stream_data.can_use_empty_topic(stream_widget_value)) {
+            $topic_input.attr("placeholder", empty_string_topic_display_name);
+            $topic_input.addClass("empty-topic-display");
+            update_clear_move_topic_button_state();
+        }
+    }
+
     function move_topic_post_render(): void {
         $("#move_topic_modal .dialog_submit_button").prop("disabled", true);
         $("#move_topic_modal .move_topic_warning_container").hide();
@@ -1014,27 +1040,10 @@ export async function build_move_topic_to_stream_popover(
         }
 
         $topic_input.on("focus", () => {
-            $topic_input.attr("placeholder", "");
-            $topic_input.removeClass("empty-topic-display");
-            if ($topic_input.val() === "" && stream_data.can_use_empty_topic(stream_widget_value)) {
-                $topic_not_mandatory_placeholder.addClass(
-                    "move-topic-new-topic-placeholder-visible",
-                );
-                $("#clear_move_topic_new_topic_name").css("visibility", "hidden");
-            }
+            update_topic_input_placeholder_on_focus();
 
             $topic_input.one("blur", () => {
-                $topic_not_mandatory_placeholder.removeClass(
-                    "move-topic-new-topic-placeholder-visible",
-                );
-                if (
-                    $topic_input.val() === "" &&
-                    stream_data.can_use_empty_topic(stream_widget_value)
-                ) {
-                    $topic_input.attr("placeholder", empty_string_topic_display_name);
-                    $topic_input.addClass("empty-topic-display");
-                    $("#clear_move_topic_new_topic_name").css("visibility", "visible");
-                }
+                update_topic_input_placeholder_on_blur();
             });
         });
 

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -884,6 +884,7 @@ export async function build_move_topic_to_stream_popover(
         set_stream_topic_typeahead();
         render_selected_stream();
         maybe_show_topic_already_exists_warning();
+        update_clear_move_topic_button_state();
         update_topic_input_placeholder_visibility(topic_input_value);
         const selected_propagate_mode = String($("#message_move_select_options").val());
         void warn_unsubscribed_participants(selected_propagate_mode);
@@ -989,7 +990,7 @@ export async function build_move_topic_to_stream_popover(
     function update_clear_move_topic_button_state(): void {
         const $clear_topic_name_button = $("#clear_move_topic_new_topic_name");
         const topic_input_value = $("input#move-topic-new-topic-name").val();
-        if (topic_input_value === "") {
+        if (topic_input_value === "" || $("input#move-topic-new-topic-name").prop("disabled")) {
             $clear_topic_name_button.css("visibility", "hidden");
         } else {
             $clear_topic_name_button.css("visibility", "visible");

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -1070,6 +1070,20 @@ export async function build_move_topic_to_stream_popover(
                 if (stream.stream_id === current_stream_id) {
                     return true;
                 }
+                const current_stream = stream_data.get_sub_by_id(current_stream_id);
+                assert(current_stream !== undefined);
+                // If the user can't edit the topic, it is not possible for them to make
+                // following kind of moves:
+                //  1) messages from empty topics to channels where empty topics are disabled.
+                // So we filter them out here.
+                if (
+                    !stream_data.user_can_move_messages_within_channel(current_stream) &&
+                    !stream_data.user_can_move_messages_within_channel(stream) &&
+                    topic_name === "" &&
+                    !stream_data.can_use_empty_topic(stream.stream_id)
+                ) {
+                    return false;
+                }
                 return stream_data.can_post_messages_in_stream(stream);
             });
 

--- a/web/src/stream_topic_history.ts
+++ b/web/src/stream_topic_history.ts
@@ -33,6 +33,23 @@ export function stream_has_topics(stream_id: number): boolean {
     return history.has_topics();
 }
 
+export function stream_has_locally_available_named_topics(stream_id: number): boolean {
+    if (!stream_dict.has(stream_id)) {
+        return false;
+    }
+
+    const history = stream_dict.get(stream_id);
+    assert(history !== undefined);
+
+    const topic_names = history.topics.keys();
+    for (const topic_name of topic_names) {
+        if (topic_name !== "") {
+            return true;
+        }
+    }
+    return false;
+}
+
 export function stream_has_locally_available_resolved_topics(stream_id: number): boolean {
     if (!stream_dict.has(stream_id)) {
         return false;

--- a/web/src/stream_types.ts
+++ b/web/src/stream_types.ts
@@ -25,6 +25,7 @@ export type StreamPermissionGroupSetting = z.infer<typeof stream_permission_grou
 export const stream_topics_policy_schema = z.enum([
     "allow_empty_topic",
     "disable_empty_topic",
+    "empty_topic_only",
     "inherit",
 ]);
 export type StreamTopicsPolicy = z.infer<typeof stream_topics_policy_schema>;

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -7,6 +7,7 @@ import render_change_visibility_policy_button_tooltip from "../templates/change_
 import render_information_density_update_button_tooltip from "../templates/information_density_update_button_tooltip.hbs";
 import render_org_logo_tooltip from "../templates/org_logo_tooltip.hbs";
 import render_tooltip_templates from "../templates/tooltip_templates.hbs";
+import render_topics_not_allowed_error from "../templates/topics_not_allowed_error.hbs";
 
 import * as compose_validate from "./compose_validate.ts";
 import {$t} from "./i18n.ts";
@@ -873,6 +874,30 @@ export function initialize(): void {
             );
             instance.setContent(content);
         },
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    tippy.delegate("body", {
+        target: "#compose_recipient_box, #move-topic-new-topic-input-wrapper",
+        delay: LONG_HOVER_DELAY,
+        onShow(instance) {
+            const $elem = $(instance.reference);
+            if ($($elem).find(".empty-topic-only").prop("disabled")) {
+                const error_message = render_topics_not_allowed_error({
+                    empty_string_topic_display_name: util.get_final_topic_display_name(""),
+                });
+                instance.setContent(ui_util.parse_html(error_message));
+                // `display: flex` doesn't show the tooltip content inline when <i>general chat</i>
+                // is in the error message.
+                $(instance.popper).find(".tippy-content").css("display", "block");
+                return undefined;
+            }
+            instance.destroy();
+            return false;
+        },
+        appendTo: () => document.body,
         onHidden(instance) {
             instance.destroy();
         },

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1107,6 +1107,11 @@ textarea.new_message_textarea {
     #recipient_box_clear_topic_button {
         background: none;
         border: none;
+
+        &:disabled {
+            cursor: default;
+            opacity: 1;
+        }
     }
 
     /* Styles for input in the recipient_box */
@@ -1180,9 +1185,19 @@ textarea.new_message_textarea {
         ~ #recipient_box_clear_topic_button {
         visibility: hidden;
     }
+
+    #stream_message_recipient_topic:disabled
+        ~ #recipient_box_clear_topic_button {
+        visibility: hidden;
+    }
     /* This will reset the bootstrap margin-bottom: 10px value for the inputs */
     & input {
         margin-bottom: 0;
+    }
+
+    &.disabled {
+        background-color: transparent;
+        border-color: transparent;
     }
 }
 
@@ -1293,7 +1308,7 @@ textarea.new_message_textarea {
             outline: 1px solid var(--color-outline-low-attention-input-pill);
         }
 
-        &:hover {
+        &:hover:not(.disabled) {
             background-color: var(
                 --color-compose-recipient-box-background-color
             );

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -907,6 +907,10 @@ ul.popover-group-menu-member-list {
             &.empty-topic-display::placeholder {
                 color: inherit;
             }
+
+            &.empty-topic-only {
+                cursor: default;
+            }
         }
     }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -109,7 +109,8 @@
 }
 
 .user_group_creation_error,
-.stream_creation_error {
+.stream_creation_error,
+#settings-topics-already-exist-error {
     display: none;
     margin-left: 2px;
     color: hsl(0deg 100% 50%);

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -14,11 +14,9 @@
                 <span class="move-topic-new-topic-placeholder placeholder">
                     {{> topic_not_mandatory_placeholder_text empty_string_topic_display_name=empty_string_topic_display_name}}
                 </span>
-                {{#unless disable_topic_input}}
                 <button type="button" id="clear_move_topic_new_topic_name" class="clear_search_button">
                     <i class="zulip-icon zulip-icon-close"></i>
                 </button>
-                {{/unless}}
             </div>
         </div>
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -1,5 +1,5 @@
 {{#if is_stream}}
-<div class="message_header message_header_stream right_part" data-stream-id="{{stream_id}}" {{#if topic}}data-topic-name="{{topic}}"{{/if}}>
+<div class="message_header message_header_stream right_part" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}">
     <div class="message-header-contents" style="background: {{recipient_bar_color}};">
         {{! stream link }}
         <a class="message_label_clickable narrows_by_recipient stream_label tippy-narrow-tooltip"

--- a/web/templates/stream_settings/stream_permissions.hbs
+++ b/web/templates/stream_settings/stream_permissions.hbs
@@ -129,6 +129,7 @@
                 <select name="stream-topics-policy-setting" id="{{prefix}}topics_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="string">
                     {{> ../settings/dropdown_options_widget option_values=stream_topics_policy_values}}
                 </select>
+                {{> topics_already_exist_error .}}
             </div>
         </div>
 

--- a/web/templates/stream_settings/topics_already_exist_error.hbs
+++ b/web/templates/stream_settings/topics_already_exist_error.hbs
@@ -1,0 +1,7 @@
+<div id="settings-topics-already-exist-error">
+    {{#tr}}
+    To enable this configuration, all messages in this channel must be in the <z-empty-string-topic-display-name></z-empty-string-topic-display-name> topic. Consider <z-link-rename>renaming</z-link-rename> other topics to <z-empty-string-topic-display-name></z-empty-string-topic-display-name>.
+    {{#*inline "z-link-rename"}}<a target="_blank" rel="noopener noreferrer" href="/help/rename-a-topic">{{> @partial-block}}</a>{{/inline}}
+    {{#*inline "z-empty-string-topic-display-name"}}<span class="empty-topic-display">{{empty_string_topic_display_name}}</span>{{/inline}}
+    {{/tr}}
+</div>

--- a/web/templates/topics_not_allowed_error.hbs
+++ b/web/templates/topics_not_allowed_error.hbs
@@ -1,0 +1,4 @@
+{{#tr}}
+    Only the <z-empty-string-topic-display-name></z-empty-string-topic-display-name> topic is allowed in this channel.
+    {{#*inline "z-empty-string-topic-display-name"}}<span class="empty-topic-display">{{empty_string_topic_display_name}}</span>{{/inline}}
+{{/tr}}

--- a/web/tests/message_edit.test.cjs
+++ b/web/tests/message_edit.test.cjs
@@ -98,6 +98,7 @@ run_test("is_topic_editable", ({override}) => {
     override(stream_data, "is_stream_archived", () => false);
     override(stream_data, "user_can_move_messages_within_channel", () => true);
     override(stream_data, "get_sub_by_id", () => ({}));
+    override(stream_data, "is_empty_topic_only_channel", () => false);
     override(current_user, "is_moderator", true);
 
     assert.equal(message_edit.is_topic_editable(message), false);

--- a/web/tests/popover_menus_data.test.cjs
+++ b/web/tests/popover_menus_data.test.cjs
@@ -56,6 +56,7 @@ mock_esm("../src/stream_data", {
     is_stream_archived: () => false,
     get_sub_by_id: () => noop,
     user_can_move_messages_within_channel: () => true,
+    is_empty_topic_only_channel: () => false,
 });
 mock_esm("../src/group_permission_settings", {
     get_group_permission_setting_config() {

--- a/web/tests/settings_org.test.cjs
+++ b/web/tests/settings_org.test.cjs
@@ -181,6 +181,7 @@ function test_change_save_button_state() {
         props,
     } = createSaveButtons("msg-editing");
     $save_button_header.attr("id", "org-msg-editing");
+    $("#org-msg-editing").closest = () => ({});
 
     {
         settings_components.change_save_button_state($save_button_controls, "unsaved");

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -2209,3 +2209,30 @@ run_test("can_archive_stream", ({override}) => {
     social.can_administer_channel_group = me_group.id;
     assert.equal(stream_data.can_archive_stream(social), true);
 });
+
+run_test("is_empty_topic_only_channel", ({override}) => {
+    const social = {
+        subscribed: true,
+        color: "red",
+        name: "social",
+        stream_id: 2,
+        topics_policy: "empty_topic_only",
+    };
+    stream_data.add_sub(social);
+    const scotland = {
+        subscribed: true,
+        color: "red",
+        name: "scotland",
+        stream_id: 3,
+        topics_policy: "inherit",
+    };
+    override(realm, "realm_topics_policy", "allow_empty_topic");
+    assert.equal(stream_data.is_empty_topic_only_channel(undefined), false);
+
+    stream_data.add_sub(scotland);
+    override(current_user, "user_id", me.user_id);
+
+    override(current_user, "is_admin", true);
+    assert.equal(stream_data.is_empty_topic_only_channel(social.stream_id), true);
+    assert.equal(stream_data.is_empty_topic_only_channel(scotland.stream_id), false);
+});

--- a/web/tests/stream_topic_history.test.cjs
+++ b/web/tests/stream_topic_history.test.cjs
@@ -263,6 +263,7 @@ test("test_stream_has_topics", () => {
     const stream_id = 88;
 
     assert.equal(stream_topic_history.stream_has_topics(stream_id), false);
+    assert.equal(stream_topic_history.stream_has_locally_available_named_topics(stream_id), false);
 
     stream_topic_history.find_or_create(stream_id);
 
@@ -273,10 +274,20 @@ test("test_stream_has_topics", () => {
     stream_topic_history.add_message({
         stream_id,
         message_id: 888,
+        topic_name: "",
+    });
+
+    assert.equal(stream_topic_history.stream_has_topics(stream_id), true);
+    assert.equal(stream_topic_history.stream_has_locally_available_named_topics(stream_id), false);
+
+    stream_topic_history.add_message({
+        stream_id,
+        message_id: 888,
         topic_name: "whatever",
     });
 
     assert.equal(stream_topic_history.stream_has_topics(stream_id), true);
+    assert.equal(stream_topic_history.stream_has_locally_available_named_topics(stream_id), true);
 });
 
 test("test_stream_has_resolved_topics", () => {

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -35,6 +35,7 @@ from zerver.lib.exceptions import (
     StreamDoesNotExistError,
     StreamWildcardMentionNotAllowedError,
     StreamWithIDDoesNotExistError,
+    TopicsNotAllowedError,
     TopicWildcardMentionNotAllowedError,
     ZephyrMessageAlreadySentError,
 )
@@ -1785,14 +1786,13 @@ def check_message(
             # else can sneak past the access check.
             assert sender.bot_type == sender.OUTGOING_WEBHOOK_BOT
 
-        if (
-            get_stream_topics_policy(realm, stream)
-            == StreamTopicsPolicyEnum.disable_empty_topic.value
-            and topic_name == ""
-        ):
-            raise MessagesNotAllowedInEmptyTopicError(
-                get_topic_display_name("", sender.default_language)
-            )
+        topics_policy = get_stream_topics_policy(realm, stream)
+        empty_topic_display_name = get_topic_display_name("", sender.default_language)
+        if topics_policy == StreamTopicsPolicyEnum.disable_empty_topic.value and topic_name == "":
+            raise MessagesNotAllowedInEmptyTopicError(empty_topic_display_name)
+
+        if topics_policy == StreamTopicsPolicyEnum.empty_topic_only.value and topic_name != "":
+            raise TopicsNotAllowedError(empty_topic_display_name)
 
     elif addressee.is_private():
         user_profiles = addressee.user_profiles()

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -1757,6 +1757,9 @@ def do_set_stream_property(stream: Stream, name: str, value: Any, acting_user: U
         StreamTopicsPolicyEnum.disable_empty_topic.value: _(
             "No *{empty_topic_display_name}* topic"
         ).format(empty_topic_display_name=empty_topic_display_name),
+        StreamTopicsPolicyEnum.empty_topic_only.value: _(
+            "Only *{empty_topic_display_name}* topic allowed"
+        ).format(empty_topic_display_name=empty_topic_display_name),
     }
 
     NOTIFICATION_MESSAGES = {

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -38,6 +38,7 @@ from zerver.lib.stream_subscription import (
 from zerver.lib.stream_traffic import get_streams_traffic
 from zerver.lib.streams import (
     can_access_stream_metadata_user_ids,
+    channel_events_topic_name,
     check_basic_stream_access,
     get_anonymous_group_membership_dict_for_streams,
     get_stream_permission_policy_key,
@@ -190,7 +191,7 @@ def do_deactivate_stream(stream: Stream, *, acting_user: UserProfile | None) -> 
         internal_send_stream_message(
             sender,
             stream,
-            topic_name=str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
+            topic_name=channel_events_topic_name(stream),
             content=_("Channel #**{channel_name}** has been archived.").format(
                 channel_name=stream.name
             ),
@@ -314,7 +315,7 @@ def do_unarchive_stream(stream: Stream, new_name: str, *, acting_user: UserProfi
         internal_send_stream_message(
             sender,
             stream,
-            str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
+            channel_events_topic_name(stream),
             _("Channel #**{channel_name}** has been unarchived.").format(channel_name=new_name),
         )
 
@@ -1247,7 +1248,7 @@ def send_change_stream_permission_notification(
         internal_send_stream_message(
             sender,
             stream,
-            str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
+            channel_events_topic_name(stream),
             notification_string,
             archived_channel_notice=stream.deactivated,
         )
@@ -1481,7 +1482,7 @@ def send_stream_posting_permission_update_notification(
         internal_send_stream_message(
             sender,
             stream,
-            str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
+            channel_events_topic_name(stream),
             notification_string,
             archived_channel_notice=stream.deactivated,
         )
@@ -1536,7 +1537,7 @@ def do_rename_stream(stream: Stream, new_name: str, user_profile: UserProfile) -
         internal_send_stream_message(
             sender,
             stream,
-            str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
+            channel_events_topic_name(stream),
             _("{user_name} renamed channel {old_channel_name} to {new_channel_name}.").format(
                 user_name=silent_mention_syntax_for_user(user_profile),
                 old_channel_name=f"**{old_name}**",
@@ -1573,7 +1574,7 @@ def send_change_stream_description_notification(
         internal_send_stream_message(
             sender,
             stream,
-            str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
+            channel_events_topic_name(stream),
             notification_string,
             archived_channel_notice=stream.deactivated,
         )
@@ -1667,7 +1668,7 @@ def send_change_stream_message_retention_days_notification(
         internal_send_stream_message(
             sender,
             stream,
-            str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
+            channel_events_topic_name(stream),
             notification_string,
             archived_channel_notice=stream.deactivated,
         )
@@ -1772,7 +1773,7 @@ def do_set_stream_property(stream: Stream, name: str, value: Any, acting_user: U
             internal_send_stream_message(
                 sender,
                 stream,
-                str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
+                channel_events_topic_name(stream),
                 NOTIFICATION_MESSAGES[name],
             )
 

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -549,6 +549,32 @@ class MessagesNotAllowedInEmptyTopicError(JsonableError):
         )
 
 
+class TopicsNotAllowedError(JsonableError):
+    data_fields = ["empty_topic_display_name"]
+
+    def __init__(self, empty_topic_display_name: str) -> None:
+        self.empty_topic_display_name = empty_topic_display_name
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _("Only the {empty_topic_display_name} topic is allowed in this channel.")
+
+
+class CannotSetTopicsPolicyError(JsonableError):
+    data_fields = ["empty_topic_display_name"]
+
+    def __init__(self, empty_topic_display_name: str) -> None:
+        self.empty_topic_display_name = empty_topic_display_name
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _(
+            "To enable this configuration, all messages in this channel must be in the {empty_topic_display_name} topic. Consider renaming or deleting other topics."
+        )
+
+
 class DirectMessagePermissionError(JsonableError):
     def __init__(self, is_nobody_group: bool) -> None:
         if is_nobody_group:

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -263,6 +263,10 @@ def get_user_ids_with_metadata_access_via_permission_groups(stream: Stream) -> s
     return users_with_metadata_access_dict[stream.id]
 
 
+def channel_events_topic_name(stream: Stream) -> str:
+    return str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME)
+
+
 @transaction.atomic(savepoint=False)
 def create_stream_if_needed(
     realm: Realm,

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -264,7 +264,17 @@ def get_user_ids_with_metadata_access_via_permission_groups(stream: Stream) -> s
 
 
 def channel_events_topic_name(stream: Stream) -> str:
+    if stream.topics_policy == StreamTopicsPolicyEnum.empty_topic_only.value:
+        return ""
     return str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME)
+
+
+def channel_has_named_topics(stream: Stream) -> bool:
+    return (
+        Message.objects.filter(realm_id=stream.realm_id, recipient=stream.recipient)
+        .exclude(subject="")
+        .exists()
+    )
 
 
 @transaction.atomic(savepoint=False)

--- a/zerver/models/streams.py
+++ b/zerver/models/streams.py
@@ -27,6 +27,7 @@ class StreamTopicsPolicyEnum(Enum):
     inherit = 1
     allow_empty_topic = 2
     disable_empty_topic = 3
+    empty_topic_only = 4
 
 
 class Stream(models.Model):

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -27514,14 +27514,23 @@ components:
         - inherit
         - allow_empty_topic
         - disable_empty_topic
+        - empty_topic_only
       description: |
-        Configuration defining the default policy for sending messages in the empty topic.
+        Setting defining the policy for sending messages to the empty topic in
+        this channel.
 
         - inherit - Channel will inherit the organization-level setting, `realm_topics_policy`.
         - allow_empty_topic - Topics are not required to send messages in the channel.
         - disable_empty_topic - Topics are required to send messages in the channel.
+        - empty_topic_only - Only the empty topic is available in this channel.
 
-        **Changes**: New in Zulip 11.0 (feature level 392).
+        The `empty_topic_only` policy can only be enabled in a channel if all
+        messages in the channel are already in the empty topic.
+
+        **Changes**: In Zulip 11.0 (feature level 404), `empty_topic_only` option
+        was added.
+
+        New in Zulip 11.0 (feature level 392).
     ChannelCanAddSubscribersGroup:
       allOf:
         - $ref: "#/components/schemas/GroupSettingValue"

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -9,7 +9,11 @@ from zerver.actions.realm_settings import (
     do_change_realm_permission_group_setting,
     do_set_realm_property,
 )
-from zerver.actions.streams import do_change_stream_group_based_setting, do_change_stream_permission
+from zerver.actions.streams import (
+    do_change_stream_group_based_setting,
+    do_change_stream_permission,
+    do_set_stream_property,
+)
 from zerver.actions.user_groups import check_add_user_group
 from zerver.lib.message import has_message_access
 from zerver.lib.streams import (
@@ -25,7 +29,7 @@ from zerver.lib.user_groups import UserGroupMembershipDetails
 from zerver.models import Message, NamedUserGroup, Stream, UserMessage, UserProfile
 from zerver.models.groups import SystemGroups
 from zerver.models.realms import get_realm
-from zerver.models.streams import get_stream
+from zerver.models.streams import StreamTopicsPolicyEnum, get_stream
 from zerver.tornado.django_api import send_event_on_commit
 
 
@@ -1276,6 +1280,56 @@ class MessageMoveStreamTest(ZulipTestCase):
         # Channel administrators with content access can always move messages out of
         # the channel even if they are not in `can_move_messages_out_of_channel_group`.
         self.assert_move_message("shiva", stream_1, stream_id=stream_2.id)
+
+    def test_move_messages_to_channels_with_updated_topics_policy(self) -> None:
+        desdemona = self.example_user("desdemona")
+        realm = desdemona.realm
+
+        members_system_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MEMBERS, realm=realm, is_system_group=True
+        )
+
+        do_change_realm_permission_group_setting(
+            realm,
+            "can_move_messages_between_topics_group",
+            members_system_group,
+            acting_user=None,
+        )
+        do_change_realm_permission_group_setting(
+            realm,
+            "can_move_messages_between_channels_group",
+            members_system_group,
+            acting_user=None,
+        )
+
+        stream_1 = get_stream("Denmark", realm)
+        stream_2 = get_stream("Verona", realm)
+
+        self.assert_move_message("desdemona", stream_1, stream_id=stream_2.id, topic_name="")
+        self.assert_move_message(
+            "desdemona", stream_1, stream_id=stream_2.id, topic_name="new topic"
+        )
+
+        do_set_stream_property(
+            stream_2,
+            "topics_policy",
+            StreamTopicsPolicyEnum.disable_empty_topic.value,
+            acting_user=desdemona,
+        )
+        # Cannot move messages to empty topic as `topics_policy` is set to `disable_empty_topic`.
+        self.assert_move_message(
+            "desdemona",
+            stream_1,
+            stream_id=stream_2.id,
+            topic_name="",
+            expected_error="Sending messages to the general chat is not allowed in this channel.",
+        )
+        self.assert_move_message(
+            "desdemona", stream_1, stream_id=stream_2.id, topic_name="new topic"
+        )
+        # But can send messages to empty topic in "stream_1" as `topics_policy`
+        # is set to `allow_empty_topic`.
+        self.assert_move_message("desdemona", stream_2, stream_id=stream_1.id, topic_name="")
 
     def test_move_message_to_stream_with_topic_editing_not_allowed(self) -> None:
         (user_profile, old_stream, new_stream, msg_id, msg_id_later) = self.prepare_move_topics(

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -73,6 +73,7 @@ from zerver.lib.streams import (
     access_stream_by_name,
     access_stream_for_delete_or_update_requiring_metadata_access,
     access_web_public_stream,
+    channel_events_topic_name,
     check_stream_name_available,
     do_get_streams,
     filter_stream_authorization_for_adding_subscribers,
@@ -108,7 +109,7 @@ from zerver.lib.user_groups import (
 from zerver.lib.user_topics import get_users_with_user_topic_visibility_policy
 from zerver.lib.users import access_bot_by_id, bulk_access_users_by_email, bulk_access_users_by_id
 from zerver.lib.utils import assert_is_not_none
-from zerver.models import ChannelFolder, Realm, Stream, UserMessage, UserProfile, UserTopic
+from zerver.models import ChannelFolder, Stream, UserMessage, UserProfile, UserTopic
 from zerver.models.groups import SystemGroups
 from zerver.models.streams import StreamTopicsPolicyEnum
 from zerver.models.users import get_system_bot
@@ -1001,7 +1002,7 @@ def send_messages_for_new_subscribers(
                     internal_prep_stream_message(
                         sender=sender,
                         stream=stream,
-                        topic_name=str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
+                        topic_name=channel_events_topic_name(stream),
                         content=new_channel_message.format(
                             user_name=silent_mention_syntax_for_user(user_profile),
                         )


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Adds new configuration option `disable_topics` in `topics_policy` channel setting to support disabling topics in the channel.

Fixes #34553.
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/user-attachments/assets/bd0a2d74-c51f-44c7-9073-9d546530eb46)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
