### PR TITLE
help-beta: Introduce NavigationSteps component for settings/relative links. 

### DIFF
--- a/help-beta/astro.config.mjs
+++ b/help-beta/astro.config.mjs
@@ -45,6 +45,12 @@ export default defineConfig({
                 optional: true,
                 default: true,
             }),
+            SHOW_BILLING_HELP_LINKS: envField.boolean({
+                context: "client",
+                access: "public",
+                optional: true,
+                default: true,
+            }),
         },
     },
     integrations: [

--- a/help-beta/astro.config.mjs
+++ b/help-beta/astro.config.mjs
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 
 import starlight from "@astrojs/starlight";
-import {defineConfig} from "astro/config";
+import {defineConfig, envField} from "astro/config";
 import Icons from "unplugin-icons/vite";
 
 // https://astro.build/config
@@ -16,7 +16,7 @@ export default defineConfig({
                 // It was setting the height to 1024 and 960 for some
                 // icons. It is better to set the height explicitly.
                 defaultStyle:
-                    "display: inline; vertical-align: text-bottom; height: 1em; width: 1em;",
+                    "display: inline; vertical-align: text-bottom; height: 1em; width: 1em; margin-bottom: 0;",
                 customCollections: {
                     // unplugin-icons has a FileSystemIconLoader which is more
                     // versatile. But it only supports one directory path for
@@ -36,6 +36,16 @@ export default defineConfig({
                 },
             }),
         ],
+    },
+    env: {
+        schema: {
+            SHOW_RELATIVE_LINKS: envField.boolean({
+                context: "client",
+                access: "public",
+                optional: true,
+                default: true,
+            }),
+        },
     },
     integrations: [
         starlight({

--- a/help-beta/src/components/NavigationSteps.astro
+++ b/help-beta/src/components/NavigationSteps.astro
@@ -1,0 +1,191 @@
+---
+import { SHOW_RELATIVE_LINKS } from "astro:env/client";
+import RawZulipIconGear from "~icons/zulip-icon/gear?raw";
+
+// This list has been transformed one-off from `help_settings_links.py`, we
+// have added a comment in that file to update this list in case of any
+// changes.
+const setting_link_mapping: {
+    [key: string]: {
+        setting_type: string,
+        setting_name: string,
+        setting_link: string,
+    }
+} = {
+    // a mapping from the setting identifier that is the same as the final URL
+    // breadcrumb to that setting to the name of its setting type, the setting
+    // name as it appears in the user interface, and a relative link that can
+    // be used to get to that setting
+    "profile": {
+        setting_type: "Personal settings",
+        setting_name: "Profile",
+        setting_link: "/#settings/profile"
+    },
+    "account-and-privacy": {
+        setting_type: "Personal settings",
+        setting_name: "Account & privacy",
+        setting_link: "/#settings/account-and-privacy"
+    },
+    "preferences": {
+        setting_type: "Personal settings",
+        setting_name: "Preferences",
+        setting_link: "/#settings/preferences"
+    },
+    "notifications": {
+        setting_type: "Personal settings",
+        setting_name: "Notifications",
+        setting_link: "/#settings/notifications"
+    },
+    "your-bots": {
+        setting_type: "Personal settings",
+        setting_name: "Bots",
+        setting_link: "/#settings/your-bots"
+    },
+    "alert-words": {
+        setting_type: "Personal settings",
+        setting_name: "Alert words",
+        setting_link: "/#settings/alert-words"
+    },
+    "uploaded-files": {
+        setting_type: "Personal settings",
+        setting_name: "Uploaded files",
+        setting_link: "/#settings/uploaded-files"
+    },
+    "topics": {
+        setting_type: "Personal settings",
+        setting_name: "Topics",
+        setting_link: "/#settings/topics"
+    },
+    "muted-users": {
+        setting_type: "Personal settings",
+        setting_name: "Muted users",
+        setting_link: "/#settings/muted-users"
+    },
+    "organization-profile": {
+        setting_type: "Organization settings",
+        setting_name: "Organization profile",
+        setting_link: "/#organization/organization-profile"
+    },
+    "organization-settings": {
+        setting_type: "Organization settings",
+        setting_name: "Organization settings",
+        setting_link: "/#organization/organization-settings"
+    },
+    "organization-permissions": {
+        setting_type: "Organization settings",
+        setting_name: "Organization permissions",
+        setting_link: "/#organization/organization-permissions"
+    },
+    "default-user-settings": {
+        setting_type: "Organization settings",
+        setting_name: "Default user settings",
+        setting_link: "/#organization/organization-level-user-defaults"
+    },
+    "emoji-settings": {
+        setting_type: "Organization settings",
+        setting_name: "Custom emoji",
+        setting_link: "/#organization/emoji-settings"
+    },
+    "auth-methods": {
+        setting_type: "Organization settings",
+        setting_name: "Authentication methods",
+        setting_link: "/#organization/auth-methods"
+    },
+    "users": {
+        setting_type: "Organization settings",
+        setting_name: "Users",
+        setting_link: "/#organization/users/active"
+    },
+    "deactivated": {
+        setting_type: "Organization settings",
+        setting_name: "Users",
+        setting_link: "/#organization/users/deactivated"
+    },
+    "invitations": {
+        setting_type: "Organization settings",
+        setting_name: "Users",
+        setting_link: "/#organization/users/invitations"
+    },
+    "bot-list-admin": {
+        setting_type: "Organization settings",
+        setting_name: "Bots",
+        setting_link: "/#organization/bot-list-admin"
+    },
+    "default-channels-list": {
+        setting_type: "Organization settings",
+        setting_name: "Default channels",
+        setting_link: "/#organization/default-channels-list"
+    },
+    "linkifier-settings": {
+        setting_type: "Organization settings",
+        setting_name: "Linkifiers",
+        setting_link: "/#organization/linkifier-settings"
+    },
+    "playground-settings": {
+        setting_type: "Organization settings",
+        setting_name: "Code playgrounds",
+        setting_link: "/#organization/playground-settings"
+    },
+    "profile-field-settings": {
+        setting_type: "Organization settings",
+        setting_name: "Custom profile fields",
+        setting_link: "/#organization/profile-field-settings"
+    },
+    "data-exports-admin": {
+        setting_type: "Organization settings",
+        setting_name: "Data exports",
+        setting_link: "/#organization/data-exports-admin"
+    }
+};
+
+const getSettingsMarkdown = (setting_type_name: string, setting_name: string) => `
+<ol>
+    <li>
+        Click on the <b>gear</b> (${RawZulipIconGear}) icon in the upper
+        right corner of the web or desktop app.
+    </li>
+    <li>
+        Select <b>${setting_type_name}</b>.
+    </li>
+    <li>
+        On the left, click <b>${setting_name}</b>.
+    </li>
+</ol>
+`
+
+const getSettingsHTML = (
+  setting_key: string,
+  SHOW_RELATIVE_LINKS: boolean
+): string => {
+    const {
+        setting_type,
+        setting_name,
+        setting_link,
+    } = setting_link_mapping[setting_key]!;
+
+    if (!SHOW_RELATIVE_LINKS) {
+        return getSettingsMarkdown(setting_type, setting_name);
+    }
+    
+    const relativeLink = `<a href="${setting_link}">${setting_name}</a>`;
+
+    // The "Bots" label appears in both Personal and Organization settings
+    // in the user interface so we need special text for this setting.
+    const label = (setting_name === "Bots" || setting_name === "Users")
+        ? `Navigate to the ${relativeLink} tab of the <b>${setting_type}</b> menu.`
+        : `Go to ${relativeLink}.`;
+
+    return `<ol>
+                <li>${label}</li>
+            </ol>`;
+}
+
+const { identifier } = Astro.props;
+const navigation_link_type = identifier.split("/")[0];
+if (navigation_link_type !== "settings") {
+    throw new Error("Invalid navigation link type. Only `settings` is allowed.");
+}
+const resultHTML = getSettingsHTML(identifier.split("/")[1], SHOW_RELATIVE_LINKS);
+
+---
+<Fragment set:html={resultHTML} />

--- a/help-beta/src/components/NavigationSteps.astro
+++ b/help-beta/src/components/NavigationSteps.astro
@@ -1,6 +1,19 @@
 ---
-import { SHOW_RELATIVE_LINKS } from "astro:env/client";
+import { SHOW_RELATIVE_LINKS, SHOW_BILLING_HELP_LINKS } from "astro:env/client";
+import assert from "node:assert";
 import RawZulipIconGear from "~icons/zulip-icon/gear?raw";
+import RawZulipIconHash from "~icons/zulip-icon/hash?raw";
+import RawZulipIconTool from "~icons/zulip-icon/tool?raw";
+import RawZulipIconBuilding from "~icons/zulip-icon/building?raw";
+import RawZulipIconUserGroupCog from "~icons/zulip-icon/user-group-cog?raw";
+import RawZulipIconBarChart from "~icons/zulip-icon/bar-chart?raw";
+import RawZulipIconGitPullRequest from "~icons/zulip-icon/git-pull-request?raw";
+import RawZulipIconRocket from "~icons/zulip-icon/rocket?raw";
+import RawZulipIconCreditCard from "~icons/zulip-icon/credit-card?raw";
+import RawZulipIconKeyboard from "~icons/zulip-icon/keyboard?raw";
+import RawZulipIconEdit from "~icons/zulip-icon/edit?raw";
+import RawZulipIconManageSearch from "~icons/zulip-icon/manage-search?raw";
+import RawZulipIconInfo from "~icons/zulip-icon/info?raw";
 
 // This list has been transformed one-off from `help_settings_links.py`, we
 // have added a comment in that file to update this list in case of any
@@ -138,6 +151,135 @@ const setting_link_mapping: {
     }
 };
 
+type RelativeLinkInfo = {
+  label: string;
+  relative_link: string;
+};
+
+const default_template_for_relative_links = `
+<ol>
+  <li>Click on the <strong>gear</strong> (${RawZulipIconGear}) icon in the upper right corner of the web or desktop app.</li>
+  <li>Select {item}.</li>
+</ol>
+`
+
+const relative_link_mapping: Record<
+  string,
+  {
+    data: Record<string, RelativeLinkInfo>;
+    template: string;
+    is_link_relative: () => boolean;
+  }
+> = {
+  gear: {
+    data: {
+      "channel-settings": {
+        label: `${RawZulipIconHash} Channel settings`,
+        relative_link: "/#channels/subscribed",
+      },
+      settings: {
+        label: `${RawZulipIconTool} Personal Settings`,
+        relative_link: "/#settings/profile",
+      },
+      "organization-settings": {
+        label: `${RawZulipIconBuilding} Organization settings`,
+        relative_link: "/#organization/organization-profile",
+      },
+      "group-settings": {
+        label: `${RawZulipIconUserGroupCog} Group settings`,
+        relative_link: "/#groups/your",
+      },
+      stats: {
+        label: `${RawZulipIconBarChart} Usage statistics`,
+        relative_link: "/stats",
+      },
+      integrations: {
+        label: `${RawZulipIconGitPullRequest} Integrations`,
+        relative_link: "/integrations/",
+      },
+      "about-zulip": {
+        label: "About Zulip",
+        relative_link: "/#about-zulip",
+      },
+    },
+    template: default_template_for_relative_links,
+    is_link_relative: () => SHOW_RELATIVE_LINKS,
+  },
+  "gear-billing": {
+    data: {
+      plans: {
+        label: `${RawZulipIconRocket} Plans and pricing`,
+        relative_link: "/plans/",
+      },
+      billing: {
+        label: `${RawZulipIconCreditCard} Billing`,
+        relative_link: "/billing/",
+      },
+    },
+    template: default_template_for_relative_links,
+    is_link_relative: () => SHOW_RELATIVE_LINKS && SHOW_BILLING_HELP_LINKS,
+  },
+  help: {
+    data: {
+      "keyboard-shortcuts": {
+        label: `${RawZulipIconKeyboard} Keyboard shortcuts`,
+        relative_link: "/#keyboard-shortcuts",
+      },
+      "message-formatting": {
+        label: `${RawZulipIconEdit} Message formatting`,
+        relative_link: "/#message-formatting",
+      },
+      "search-filters": {
+        label: `${RawZulipIconManageSearch} Search filters`,
+        relative_link: "/#search-operators",
+      },
+      "about-zulip": {
+        label: `${RawZulipIconInfo} About Zulip`,
+        relative_link: "/#about-zulip",
+      },
+    },
+    template: default_template_for_relative_links,
+    is_link_relative: () => SHOW_RELATIVE_LINKS,
+  },
+  channel: {
+    data: {
+      all: {
+        label: "All",
+        relative_link: "/#channels/all",
+      },
+      "not-subscribed": {
+        label: "Not subscribed",
+        relative_link: "/#channels/notsubscribed",
+      },
+    },
+    template: `
+<ol>
+  <li>Click on the <strong>gear</strong> (${RawZulipIconGear}) icon in the upper right corner of the web or desktop app.</li>
+  <li>Select ${RawZulipIconHash} <strong>Channel settings</strong>.</li>
+  <li>Click {item} in the upper left.</li>
+</ol>
+`,
+    is_link_relative: () => SHOW_RELATIVE_LINKS,
+  },
+  group: {
+    data: {
+      all: {
+        label: "All groups",
+        relative_link: "/#groups/all",
+      },
+    },
+    template: `
+<ol>
+  <li>Click on the <strong>gear</strong> (${RawZulipIconGear}) icon in the upper right corner of the web or desktop app.</li>
+  <li>Select ${RawZulipIconUserGroupCog} <strong>Group settings</strong>.</li>
+  <li>Click {item} in the upper left.</li>
+</ol>
+`,
+    is_link_relative: () => SHOW_RELATIVE_LINKS,
+  },
+};
+
+
 const getSettingsMarkdown = (setting_type_name: string, setting_name: string) => `
 <ol>
     <li>
@@ -180,12 +322,34 @@ const getSettingsHTML = (
             </ol>`;
 }
 
+const LINK_TYPE_HANDLERS: Record<string, (key: string) => string> = {};
+
+for (const type in relative_link_mapping) {
+  const { data, template, is_link_relative } = relative_link_mapping[type]!;
+
+  LINK_TYPE_HANDLERS[type] = (key: string) => {
+    const { label, relative_link } = data[key]!;
+    const formattedItem = is_link_relative() ? `<a href="${relative_link}">${label}</a>` : `<strong>${label}</strong>`;
+    return template.replace("{item}", formattedItem);
+  };
+}
+
 const { identifier } = Astro.props;
 const navigation_link_type = identifier.split("/")[0];
-if (navigation_link_type !== "settings") {
-    throw new Error("Invalid navigation link type. Only `settings` is allowed.");
+
+if (navigation_link_type !== "settings" && navigation_link_type !== "relative" ) {
+    throw new Error("Invalid navigation link type. Only `settings` or `relative` is allowed.");
 }
-const resultHTML = getSettingsHTML(identifier.split("/")[1], SHOW_RELATIVE_LINKS);
+
+let resultHTML: string | undefined;
+if (navigation_link_type === "settings") {
+    resultHTML = getSettingsHTML(identifier.split("/")[1], SHOW_RELATIVE_LINKS);
+} else {
+    const link_type = identifier.split("/")[1];
+    const key = identifier.split("/")[2];
+    resultHTML = LINK_TYPE_HANDLERS[link_type]!(key);
+}
+assert(resultHTML !== undefined);
 
 ---
 <Fragment set:html={resultHTML} />

--- a/tools/build-help-center
+++ b/tools/build-help-center
@@ -1,4 +1,28 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
 
-./tools/convert-help-center-docs-to-mdx
-(cd ./help-beta/ && /usr/local/bin/corepack pnpm build)
+import os
+import subprocess
+import sys
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.lib.setup_path import setup_path
+
+setup_path()
+
+os.environ["DJANGO_SETTINGS_MODULE"] = "zproject.settings"
+
+import django
+
+django.setup()
+
+
+def run() -> None:
+    subprocess.check_call(["./tools/convert-help-center-docs-to-mdx"], stderr=subprocess.STDOUT)
+    subprocess.check_call(
+        ["/usr/local/bin/corepack", "pnpm", "build"], stderr=subprocess.STDOUT, cwd="help-beta"
+    )
+
+
+run()

--- a/tools/build-help-center
+++ b/tools/build-help-center
@@ -16,12 +16,18 @@ os.environ["DJANGO_SETTINGS_MODULE"] = "zproject.settings"
 import django
 
 django.setup()
+from django.conf import settings
 
 
 def run() -> None:
     subprocess.check_call(["./tools/convert-help-center-docs-to-mdx"], stderr=subprocess.STDOUT)
+    env = os.environ.copy()
+    env["SHOW_BILLING_HELP_LINKS"] = str(settings.CORPORATE_ENABLED).lower()
     subprocess.check_call(
-        ["/usr/local/bin/corepack", "pnpm", "build"], stderr=subprocess.STDOUT, cwd="help-beta"
+        ["/usr/local/bin/corepack", "pnpm", "build"],
+        stderr=subprocess.STDOUT,
+        cwd="help-beta",
+        env=env,
     )
 
 

--- a/tools/convert-help-center-docs-to-mdx
+++ b/tools/convert-help-center-docs-to-mdx
@@ -25,6 +25,7 @@ django.setup()
 from zerver.lib.markdown.tabbed_sections import generate_content_blocks, parse_tabs
 
 INDENT_SPACES = "    "
+SETTINGS_LINK_PATTERN = re.compile(r"{settings_tab\|(?P<setting_identifier>.*?)}")
 
 # TODO list before cutover.
 #
@@ -67,6 +68,21 @@ def replace_emoticon_translation_table(markdown_string: str, import_statement_se
         )
 
     return result
+
+
+def replace_setting_links(
+    markdown_string: str, import_statement_set: set[str], import_relative_base_path: str
+) -> str:
+    setting_links_pattern = re.compile(r"{settings_tab\|(?P<setting_identifier>.*?)}")
+
+    def replace_setting_links_match(match: re.Match[str]) -> str:
+        import_statement_set.add(
+            f'import NavigationSteps from "{import_relative_base_path}/NavigationSteps.astro"'
+        )
+        setting_identifier = match.group("setting_identifier")
+        return f'<NavigationSteps identifier="settings/{setting_identifier}" />'
+
+    return setting_links_pattern.sub(replace_setting_links_match, markdown_string)
 
 
 def replace_image_path(markdown_string: str, replacement_path: str) -> str:
@@ -321,6 +337,10 @@ def insert_flattened_steps_component(
                 if include_files_info[filename]["is_only_ordered_list"]:
                     index += step
                     continue
+            settings_link_match = SETTINGS_LINK_PATTERN.match(line)
+            if settings_link_match:
+                index += step
+                continue
             break
         return index
 
@@ -330,11 +350,8 @@ def insert_flattened_steps_component(
     # resulting in two opening <FlattenList> one after the other.
     # Using a set avoids this problem.
     insertions = set()
-    for match in file_include_pattern.finditer(markdown_string):
-        filename = match.group(1)
-        if not include_files_info[filename]["is_only_ordered_list"]:
-            continue
 
+    def insert_flatten_list(match: re.Match[str]) -> None:
         match_line_index = markdown_string[: match.start()].count("\n")
 
         upper_bound = traverse_to_boundary(match_line_index - 1, step=-1)
@@ -342,6 +359,15 @@ def insert_flattened_steps_component(
 
         lower_bound = traverse_to_boundary(match_line_index + 1, step=1)
         insertions.add((lower_bound, "</FlattenList>"))
+
+    for match in SETTINGS_LINK_PATTERN.finditer(markdown_string):
+        insert_flatten_list(match)
+
+    for match in file_include_pattern.finditer(markdown_string):
+        filename = match.group(1)
+        if not include_files_info[filename]["is_only_ordered_list"]:
+            continue
+        insert_flatten_list(match)
 
     if insertions:
         import_statement_set.add("import FlattenList from '../../components/FlattenList.astro';")
@@ -491,6 +517,7 @@ def convert_help_center_file_to_mdx(
     result = fix_file_imports(result, import_statement_set, "./include")
     result = convert_admonitions_to_asides(result, import_statement_set, "../../components")
     result = convert_tab_syntax(result, import_statement_set)
+    result = replace_setting_links(result, import_statement_set, "../../components")
     result = escape_curly_braces(result)
     result = fix_relative_path(result)
     result = replace_emoticon_translation_table(result, import_statement_set)
@@ -527,6 +554,7 @@ def convert_include_file_to_mdx(
     result = fix_file_imports(result, import_statement_set, ".")
     result = convert_admonitions_to_asides(result, import_statement_set, "../../../components")
     result = convert_tab_syntax(result, import_statement_set)
+    result = replace_setting_links(result, import_statement_set, "../../../components")
     result = escape_curly_braces(result)
     result = fix_relative_path(result)
     result = replace_image_path(result, "../../../../../static/images/help")

--- a/tools/convert-help-center-docs-to-mdx
+++ b/tools/convert-help-center-docs-to-mdx
@@ -505,6 +505,7 @@ def convert_help_center_file_to_mdx(
     # All imports inserted during conversion should be tracked here.
     import_statement_set: set[str] = set()
 
+    result = fix_relative_path(result)
     # We are not inserting FlattenList components for files
     # with !!! tip components, since we need to do it inside the
     # include file. We can do it during the cutover manually or
@@ -519,7 +520,6 @@ def convert_help_center_file_to_mdx(
     result = convert_tab_syntax(result, import_statement_set)
     result = replace_setting_links(result, import_statement_set, "../../components")
     result = escape_curly_braces(result)
-    result = fix_relative_path(result)
     result = replace_emoticon_translation_table(result, import_statement_set)
     result = replace_image_path(result, "../../../../static/images/help")
     result = replace_icons(result, import_statement_set)
@@ -551,12 +551,12 @@ def convert_include_file_to_mdx(
     # All imports inserted during conversion should be tracked here.
     import_statement_set: set[str] = set()
 
+    result = fix_relative_path(result)
     result = fix_file_imports(result, import_statement_set, ".")
     result = convert_admonitions_to_asides(result, import_statement_set, "../../../components")
     result = convert_tab_syntax(result, import_statement_set)
     result = replace_setting_links(result, import_statement_set, "../../../components")
     result = escape_curly_braces(result)
-    result = fix_relative_path(result)
     result = replace_image_path(result, "../../../../../static/images/help")
     result = replace_icons(result, import_statement_set)
     result = convert_comments(result)

--- a/tools/convert-help-center-docs-to-mdx
+++ b/tools/convert-help-center-docs-to-mdx
@@ -26,6 +26,7 @@ from zerver.lib.markdown.tabbed_sections import generate_content_blocks, parse_t
 
 INDENT_SPACES = "    "
 SETTINGS_LINK_PATTERN = re.compile(r"{settings_tab\|(?P<setting_identifier>.*?)}")
+RELATIVE_LINKS_PATTERN = re.compile(r"\{relative\|(?P<link_type>.*?)\|(?P<key>.*?)\}")
 
 # TODO list before cutover.
 #
@@ -83,6 +84,20 @@ def replace_setting_links(
         return f'<NavigationSteps identifier="settings/{setting_identifier}" />'
 
     return setting_links_pattern.sub(replace_setting_links_match, markdown_string)
+
+
+def replace_relative_links(
+    markdown_string: str, import_statement_set: set[str], import_relative_base_path: str
+) -> str:
+    def replace_relative_links_match(match: re.Match[str]) -> str:
+        import_statement_set.add(
+            f'import NavigationSteps from "{import_relative_base_path}/NavigationSteps.astro"'
+        )
+        link_type = match.group("link_type")
+        key = match.group("key")
+        return f'<NavigationSteps identifier="relative/{link_type}/{key}" />'
+
+    return RELATIVE_LINKS_PATTERN.sub(replace_relative_links_match, markdown_string)
 
 
 def replace_image_path(markdown_string: str, replacement_path: str) -> str:
@@ -338,7 +353,8 @@ def insert_flattened_steps_component(
                     index += step
                     continue
             settings_link_match = SETTINGS_LINK_PATTERN.match(line)
-            if settings_link_match:
+            relative_links_match = RELATIVE_LINKS_PATTERN.match(line)
+            if settings_link_match or relative_links_match:
                 index += step
                 continue
             break
@@ -361,6 +377,9 @@ def insert_flattened_steps_component(
         insertions.add((lower_bound, "</FlattenList>"))
 
     for match in SETTINGS_LINK_PATTERN.finditer(markdown_string):
+        insert_flatten_list(match)
+
+    for match in RELATIVE_LINKS_PATTERN.finditer(markdown_string):
         insert_flatten_list(match)
 
     for match in file_include_pattern.finditer(markdown_string):
@@ -519,6 +538,7 @@ def convert_help_center_file_to_mdx(
     result = convert_admonitions_to_asides(result, import_statement_set, "../../components")
     result = convert_tab_syntax(result, import_statement_set)
     result = replace_setting_links(result, import_statement_set, "../../components")
+    result = replace_relative_links(result, import_statement_set, "../../components")
     result = escape_curly_braces(result)
     result = replace_emoticon_translation_table(result, import_statement_set)
     result = replace_image_path(result, "../../../../static/images/help")
@@ -556,6 +576,7 @@ def convert_include_file_to_mdx(
     result = convert_admonitions_to_asides(result, import_statement_set, "../../../components")
     result = convert_tab_syntax(result, import_statement_set)
     result = replace_setting_links(result, import_statement_set, "../../../components")
+    result = replace_relative_links(result, import_statement_set, "../../../components")
     result = escape_curly_braces(result)
     result = replace_image_path(result, "../../../../../static/images/help")
     result = replace_icons(result, import_statement_set)

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -15,6 +15,11 @@ from zerver.lib.markdown.priorities import PREPROCESSOR_PRIORITIES
 
 REGEXP = re.compile(r"\{settings_tab\|(?P<setting_identifier>.*?)\}")
 
+
+# If any changes to this link mapping are made,
+# `help-beta/src/components/NavigationSteps.astro` should be updated accordingly.
+# This manual update mechanism will cease to exist once we have switched to the
+# help-beta system.
 link_mapping = {
     # a mapping from the setting identifier that is the same as the final URL
     # breadcrumb to that setting to the name of its setting type, the setting


### PR DESCRIPTION
Fixes #31253 and #31254.

We are using `SHOW_SETTINGS_LINK` as the env variable to set if we want to show relative settings link or non-linked markdown instructions. We are not trying to determine `SHOW_SETTINGS_LINK` by ourselves. See https://chat.zulip.org/#narrow/channel/49-development-help/topic/Passing.20sitename.20for.20astro.20project.20in.20production.2E for more details.

Until the cutover happens, we would need to manually update the mapping in both the astro component and the python file, but since that mapping is not frequently changed, that is a tradeoff we can make.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
```
## Add a bot or integration

{start_tabs}

{tab|via-personal-settings}

{settings_tab|your-bots}

1. Click **Add a new bot**.

1. Fill out the fields, and click **Add**.
```
from help/add-a-bot-or-integration.md becomes:
<img width="758" alt="Screenshot 2025-06-23 at 9 23 51 PM" src="https://github.com/user-attachments/assets/b72127b7-4a92-4a52-9aab-a5dbdad792af" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
