### PR TITLE
inbox: Fix first row icon visible without user action.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -452,8 +452,10 @@
 
         .inbox-row,
         .inbox-header {
-            &:focus,
-            &:focus-within,
+            /* Don't show the icons unless user is visibly focused
+               on the element or one of the elements within it. */
+            &:focus-within:not(:focus),
+            &:focus-visible,
             &:hover {
                 .inbox-row-visibility-policy-inherit,
                 .inbox-action-button {


### PR DESCRIPTION
Now the icons will only be visible if user made a relevant keyboard input or hovers over the row.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/menu.20buttons.20shown.20without.20hover.20in.20list.20of.20topics/with/2202988