### PR TITLE
help: Remove unused message_handle_match.

### DIFF
--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -160,57 +160,10 @@ def group_handle_match(key: str) -> str:
     return group_all_instructions.format(item=item)
 
 
-draft_instructions = """
-1. Click on <i class="fa fa-pencil"></i> **Drafts** in the left sidebar.
-"""
-
-scheduled_instructions = """
-1. Click on <i class="fa fa-calendar"></i> **Scheduled messages** in the left
-   sidebar. If you do not see this link, you have no scheduled messages.
-"""
-
-recent_instructions = """
-1. Click on <i class="fa fa-clock-o"></i> **Recent conversations** in the left
-   sidebar, or use the <kbd>T</kbd> keyboard shortcut..
-"""
-
-all_instructions = """
-1. Click on <i class="fa fa-align-left"></i> **Combined feed** in the left
-   sidebar, or use the <kbd>A</kbd> keyboard shortcut.
-"""
-
-starred_instructions = """
-1. Click on <i class="fa fa-star"></i> **Starred messages** in the left
-   sidebar, or by [searching](/help/search-for-messages) for `is:starred`.
-"""
-
-inbox_instructions = """
-1. Click on <i class="zulip-icon zulip-icon-inbox"></i> **Inbox** in the left
-   sidebar, or use the <kbd>Shift</kbd> + <kbd>I</kbd> keyboard shortcut.
-"""
-
-message_info = {
-    "drafts": ["Drafts", "/#drafts", draft_instructions],
-    "scheduled": ["Scheduled messages", "/#scheduled", scheduled_instructions],
-    "recent": ["Recent conversations", "/#recent", recent_instructions],
-    "all": ["Combined feed", "/#feed", all_instructions],
-    "starred": ["Starred messages", "/#narrow/is/starred", starred_instructions],
-    "inbox": ["Inbox", "/#inbox", inbox_instructions],
-}
-
-
-def message_handle_match(key: str) -> str:
-    if relative_help_links:
-        return f"1. Go to [{message_info[key][0]}]({message_info[key][1]})."
-    else:
-        return message_info[key][2]
-
-
 LINK_TYPE_HANDLERS = {
     "gear": gear_handle_match,
     "gear-billing": billing_handle_match,
     "channel": channel_handle_match,
-    "message": message_handle_match,
     "help": help_handle_match,
     "group": group_handle_match,
 }


### PR DESCRIPTION
A search for `relative|message` returns zero matches. We should remove this unused part of `help_relative_links`.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
