### PR TITLE
register: Fix ToS error overlapping with subscribed checkbox text.

### DIFF
--- a/templates/zerver/accounts_accept_terms.html
+++ b/templates/zerver/accounts_accept_terms.html
@@ -55,7 +55,7 @@ the registration flow has its own (nearly identical) copy of the fields below in
                     </label>
                     {% if form.terms.errors %}
                         {% for error in form.terms.errors %}
-                        <p class="help-inline text-error">{{ error }}</p>
+                        <p class="error help-inline alert alert-error">{{ error }}</p>
                         {% endfor %}
                     {% endif %}
                 </div>

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -236,7 +236,7 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
                     </label>
                     {% if form.terms.errors %}
                         {% for error in form.terms.errors %}
-                        <p class="help-inline text-error">{{ error }}</p>
+                        <p class="error help-inline alert alert-error">{{ error }}</p>
                         {% endfor %}
                     {% endif %}
                 </div>

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -373,17 +373,6 @@ html {
         width: 330px;
         margin: 0 auto 10px;
     }
-
-    .terms-of-service .text-error {
-        position: relative;
-        display: block;
-        top: -5px;
-        padding: 0;
-        height: 0;
-
-        font-size: 0.7em;
-        font-weight: 600;
-    }
 }
 
 .account-creation {


### PR DESCRIPTION
Fixed by using the same set of classes we use to show error when verifying the form locally.

| before | after |
| --- | --- |
| ![Screenshot from 2025-06-24 13-04-31](https://github.com/user-attachments/assets/002a2ffe-4595-4a89-8099-90d1c0e64003) | ![Screenshot from 2025-06-24 13-04-21](https://github.com/user-attachments/assets/94a78ff9-c482-49d0-8f37-c27fb841c485) |
