### PR TITLE
compose: Set grid-area for iconless channel label.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1689,10 +1689,11 @@ textarea.new_message_textarea {
            surrounding negative space. */
         /* 7px at 20px/1em; 4px at 20px/1em. */
         grid-template:
-            "lefthand-offset privacy-icon privacy-icon-gap channel-name righthand-offset" auto / 0.35em auto 0.2em minmax(
+            "lefthand-offset privacy-icon privacy-icon-gap channel-name righthand-offset" auto / 0.35em [select-label-start] auto 0.2em minmax(
                 0,
                 1fr
             )
+            [select-label-end]
             0.35em;
 
         .channel-privacy-type-icon {
@@ -1722,6 +1723,10 @@ textarea.new_message_textarea {
             text-overflow: ellipsis;
             white-space: nowrap;
             color: var(--color-text-default);
+        }
+
+        .select-channel-label {
+            grid-area: select-label;
         }
     }
 


### PR DESCRIPTION
This corrects the presentation of the "Select a channel" label in the channel picker, reducing space that would otherwise be used to offset the label from an icon (which this label, of course, does not have).

[#design > always-open compose box @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/always-open.20compose.20box/near/2202340)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![select-a-channel-before](https://github.com/user-attachments/assets/ab742ff2-7abd-45b6-934e-9c116adf7c11) | ![select-a-channel-after](https://github.com/user-attachments/assets/c4871ebe-e967-40bf-a2d0-550067c9531d) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>