### PR TITLE
widgets: Make poll options clickable.

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -156,7 +156,13 @@
         font-weight: 400;
     }
 
-    & span.poll-option {
+    .poll-option-label {
+        display: flex;
+        gap: 5px;
+        align-items: baseline;
+    }
+
+    .poll-option-text {
         font-weight: 600;
         /* Start with max-content, but allow options
            to shrink, so that voting names wrap comfortably. */

--- a/web/templates/widgets/poll_widget_results.hbs
+++ b/web/templates/widgets/poll_widget_results.hbs
@@ -1,9 +1,11 @@
 {{#each options}}
     <li>
-        <button class="poll-vote {{#if current_user_vote}}current-user-vote{{/if}}" data-key="{{ key }}">
-            {{ count }}
-        </button>
-        <span class="poll-option">{{ option }}</span>
+        <label class="poll-option-label">
+            <button class="poll-vote {{#if current_user_vote}}current-user-vote{{/if}}" data-key="{{ key }}">
+                {{ count }}
+            </button>
+            <span class="poll-option-text">{{ option }}</span>
+        </label>
         {{#if names}}
         <span class="poll-names">({{ names }})</span>
         {{/if}}


### PR DESCRIPTION
This PR makes the text of poll options clickable, sensibly, by using the `<label>` element. This has the added benefit of making polls more accessible to assistive technologies, too.

[#feedback > Clicking poll text should vote](https://chat.zulip.org/#narrow/channel/137-feedback/topic/Clicking.20poll.20text.20should.20vote/with/2190989)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Interactions (note, as always, that the arrow cursor is an artifact of macOS's screen recording; users will see a pointer icon):_

![clickable-poll-options](https://github.com/user-attachments/assets/45a669d6-84c5-478b-ba88-5ec3d9eb6c0d)

_This change does not interfere with text selection, [a concern that Tim expressed](https://chat.zulip.org/#narrow/channel/137-feedback/topic/Clicking.20poll.20text.20should.20vote/near/2193286):_

![selecting-text-clickable-poll-opts](https://github.com/user-attachments/assets/2c8c6f0c-36a6-4f7b-bb26-e0f7824e157c)

_The slight leftward shift in the name reflects a new flexbox regime in the area, where previously the option would flex open wider--effectively pushing the names further away._

| Before | After |
| --- | --- |
| ![clickable-poll-opts-before](https://github.com/user-attachments/assets/ffa1f3c7-dfaf-4817-99e8-aa6c1f4148b8) | ![clickable-poll-opts-after](https://github.com/user-attachments/assets/22a8cc48-594f-4d04-bc6d-7071517ed3bb) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>