### PR TITLE
help: Document channel-specific permissions to move messages.

### DIFF
--- a/help/moderating-open-organizations.md
+++ b/help/moderating-open-organizations.md
@@ -32,7 +32,7 @@ problematic behavior.
   announcements](/help/configure-automated-notices#new-channel-announcements).
 * Restrict who can [add custom emoji](/help/custom-emoji#change-who-can-add-custom-emoji).
 * Restrict who can [move messages to another
-  channel](/help/restrict-moving-messages#configure-who-can-move-messages-to-another-channel),
+  channel](/help/restrict-moving-messages#configure-who-can-move-messages-to-another-channel-from-anywhere),
   and set a [time
   limit](/help/restrict-moving-messages#set-a-time-limit-for-editing-topics) for
   editing topics.

--- a/help/move-content-to-another-channel.md
+++ b/help/move-content-to-another-channel.md
@@ -1,14 +1,12 @@
 # Move content to another channel
 
-Zulip makes it possible to move messages, or an entire topic, to another channel.
-Organizations can [configure][configure-moving-permissions] which
-[roles](/help/user-roles) have permission to move messages between
+Zulip makes it possible to move messages, or an entire topic, to another
+channel. Organization administrators can
+[configure](/help/restrict-moving-messages) who can move messages between
 channels.
 
-[configure-moving-permissions]: /help/restrict-moving-messages#configure-who-can-move-messages-to-another-channel
-
-To help others find moved content, you can have the [notification
-bot][notification-bot] send automated notices to the source topic, the
+To help others find moved content, you can have [Notification
+Bot][notification-bot] send automated notices to the source topic, the
 destination topic, or both. These notices include:
 
 * A link to the source or destination topic.
@@ -16,9 +14,6 @@ destination topic, or both. These notices include:
 * Who moved the content.
 
 ## Move a topic to another channel
-
-To move a topic, you must have access to both the source and
-destination channels.
 
 {start_tabs}
 
@@ -35,12 +30,10 @@ destination channels.
 
 1. Click **Confirm** to move the topic to another channel.
 
-
 !!! warn ""
 
     **Note**: When a topic is moved to a private channel with protected history,
               messages in the topic will be visible to all the subscribers.
-
 
 {end_tabs}
 
@@ -64,7 +57,6 @@ destination channels.
 1. Toggle whether automated notices should be sent.
 
 1. Click **Confirm** to move the selected content to another channel.
-
 
 !!! warn ""
 

--- a/help/restrict-moving-messages.md
+++ b/help/restrict-moving-messages.md
@@ -1,11 +1,13 @@
 # Restrict moving messages
 
-{!admin-only.md!}
-
 Zulip lets you configure who can edit message topics and move topics between
 channels. These permissions can be granted to any combination of
 [roles](/help/user-roles), [groups](/help/user-groups), and individual
 [users](/help/introduction-to-users).
+
+In addition to granting organization-wide permissions, you can configure
+permissions for each channel. For example, you could allow the "engineering"
+group to move messages just in the #engineering channel.
 
 In general, allowing all organization members to edit message topics is highly
 recommended because:
@@ -20,7 +22,9 @@ administrators and moderators.
 
 Permissions for moving messages between channels can be configured separately.
 
-## Configure who can edit topics
+## Configure who can edit topics everywhere
+
+{!admin-only.md!}
 
 {start_tabs}
 
@@ -28,6 +32,25 @@ Permissions for moving messages between channels can be configured separately.
 
 1. Under **Moving messages**, configure **Who can move messages to another
    topic**.
+
+{!save-changes.md!}
+
+{end_tabs}
+
+## Configure who can edit topics in a channel
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{relative|channel|all}
+
+1. Select a channel.
+
+{!select-channel-view-general.md!}
+
+1. Under **Channel permissions**, configure **Who can move messages inside this
+   channel**.
 
 {!save-changes.md!}
 
@@ -48,7 +71,7 @@ Permissions for moving messages between channels can be configured separately.
 
 {end_tabs}
 
-## Configure who can move messages to another channel
+## Configure who can move messages to another channel from anywhere
 
 {start_tabs}
 
@@ -60,6 +83,26 @@ Permissions for moving messages between channels can be configured separately.
 {!save-changes.md!}
 
 {end_tabs}
+
+## Configure who can move messages to another channel from a specific channel
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{relative|channel|all}
+
+1. Select a channel.
+
+{!select-channel-view-general.md!}
+
+1. Under **Channel permissions**, configure **Who can move messages out of this
+   channel**.
+
+{!save-changes.md!}
+
+{end_tabs}
+
 
 ## Set a time limit for moving messages between channels
 

--- a/help/setting-up-zulip-for-a-class.md
+++ b/help/setting-up-zulip-for-a-class.md
@@ -173,7 +173,7 @@ how to assign roles and permissions for a class.
   (Recommended: Admins and moderators)
 
 [user-group-permissions]: /help/manage-user-groups#configure-who-can-create-user-groups
-[move-between-channels]: /help/restrict-moving-messages#configure-who-can-move-messages-to-another-channel
+[move-between-channels]: /help/restrict-moving-messages#configure-who-can-move-messages-to-another-channel-from-anywhere
 
 #### Recommended roles and permissions for a department
 


### PR DESCRIPTION
Documents #34867.

Current: https://zulip.com/help/restrict-moving-messages
<details>
<summary>
Updated
</summary>

![Screenshot 2025-06-24 at 15 55 51](https://github.com/user-attachments/assets/5c0cec19-b8ed-4720-9656-47bde6239492)
![Screenshot 2025-06-24 at 15 56 01](https://github.com/user-attachments/assets/68406d46-e6d0-4f03-8599-0c7747ed2eaf)

</details>

---

Current: https://zulip.com/help/move-content-to-another-channel
<details>
<summary>
Updated
</summary>


![Screenshot 2025-06-24 at 15 58 39](https://github.com/user-attachments/assets/3d207f87-1641-41f4-a14c-660fc5aa388c)

</details>
