### PR TITLE
deferred_email_senders: Correct worker class name

### DIFF
--- a/zerver/worker/deferred_email_senders.py
+++ b/zerver/worker/deferred_email_senders.py
@@ -4,5 +4,5 @@ from zerver.worker.email_senders_base import EmailSendingWorker
 
 
 @assign_queue("deferred_email_senders")
-class ImmediateEmailSenderWorker(EmailSendingWorker):
+class DeferredEmailSenderWorker(EmailSendingWorker):
     pass


### PR DESCRIPTION
This name seems to have been copied from
zerver.worker.email_senders.ImmediateEmailSenderWorker, but deferred is the opposite of immediate.

Cc @alexmv (#24564).