### PR TITLE
webhooks/opsgenie: Support linking to EU instances.

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -540,7 +540,17 @@ WEBHOOK_INTEGRATIONS: list[WebhookIntegration] = [
     WebhookIntegration("opencollective", ["financial"], display_name="Open Collective"),
     WebhookIntegration("openproject", ["project-management"], display_name="OpenProject"),
     WebhookIntegration("opensearch", ["monitoring"], display_name="OpenSearch"),
-    WebhookIntegration("opsgenie", ["meta-integration", "monitoring"]),
+    WebhookIntegration(
+        "opsgenie",
+        ["meta-integration", "monitoring"],
+        config_options=[
+            WebhookConfigOption(
+                name="eu_region",
+                description="Use Opsgenie's European service region",
+                validator=check_bool,
+            )
+        ],
+    ),
     WebhookIntegration("pagerduty", ["monitoring"], display_name="PagerDuty"),
     WebhookIntegration("papertrail", ["monitoring"]),
     WebhookIntegration("patreon", ["financial"]),

--- a/zerver/webhooks/opsgenie/view.py
+++ b/zerver/webhooks/opsgenie/view.py
@@ -1,4 +1,5 @@
 from django.http import HttpRequest, HttpResponse
+from pydantic import Json
 
 from zerver.decorator import webhook_view
 from zerver.lib.response import json_success
@@ -32,10 +33,12 @@ def api_opsgenie_webhook(
     user_profile: UserProfile,
     *,
     payload: JsonBodyPayload[WildValue],
+    eu_region: Json[bool] = False,
 ) -> HttpResponse:
     # construct the body of the message
     info = {
         "additional_info": "",
+        "url_region": "eu." if eu_region else "",
         "alert_type": payload["action"].tame(check_string),
         "alert_id": payload["alert"]["alertId"].tame(check_string),
         "integration_name": payload["integrationName"].tame(check_string),
@@ -71,7 +74,7 @@ def api_opsgenie_webhook(
         info["additional_info"] += bullet_template.format(key=display_name, value=value)
 
     body_template = """
-[Opsgenie alert for {integration_name}](https://app.opsgenie.com/alert/V2#/show/{alert_id}):
+[Opsgenie alert for {integration_name}](https://app.{url_region}opsgenie.com/alert/V2#/show/{alert_id}):
 * **Type**: {alert_type}
 {additional_info}
 """.strip()


### PR DESCRIPTION
Adds a URL parameter to the webhook to track the region of the Opsgenie instance (US/EU), and uses that to construct the alert URL in the message. The user can add that parameter using the Generate-URL modal.

Fixes #34947.

- The payload does not carry any info regarding the region of the instances.
- The checkbox uses the label "Use Opsgenie's European service region". Improvements are welcome.
- Since the checkbox option seems fairly self-explanatory, I've not edited the doc to include any instructions regarding this addition.

<details>
<summary><h3>Screenshots</h3></summary>

Checked
![image](https://github.com/user-attachments/assets/e4cf0370-9c16-4577-ba7e-d02888a7dce0)

Unchecked
![image](https://github.com/user-attachments/assets/526f1b40-20ef-4840-979d-9a52a8dc6253)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
