### PR TITLE
channel_folders: Let a new channel in a folder be created through a hash.

### DIFF
--- a/web/src/channel_folders.ts
+++ b/web/src/channel_folders.ts
@@ -35,3 +35,7 @@ export function get_channel_folders(include_archived = false): ChannelFolder[] {
         return true;
     });
 }
+
+export function is_valid_folder_id(folder_id: number): boolean {
+    return channel_folder_by_id_dict.has(folder_id);
+}

--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -339,6 +339,17 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
     // the new overlay.
     if (coming_from_overlay && base === old_base) {
         if (base === "channels") {
+            if (hash_parser.get_current_nth_hash_section(1) === "folders") {
+                const folder_id = hash_parser.get_current_nth_hash_section(2);
+                stream_settings_ui.change_state(
+                    "new",
+                    undefined,
+                    "",
+                    Number.parseInt(folder_id, 10),
+                );
+                return;
+            }
+
             // e.g. #channels/29/social/subscribers
             const right_side_tab = hash_parser.get_current_nth_hash_section(3);
             stream_settings_ui.change_state(section, undefined, right_side_tab);
@@ -411,6 +422,12 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
     }
 
     if (base === "channels") {
+        if (hash_parser.get_current_nth_hash_section(1) === "folders") {
+            const folder_id = hash_parser.get_current_nth_hash_section(2);
+            stream_settings_ui.launch("new", undefined, "", Number.parseInt(folder_id, 10));
+            return;
+        }
+
         // e.g. #channels/29/social/subscribers
         const right_side_tab = hash_parser.get_current_nth_hash_section(3);
 

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -456,7 +456,7 @@ function create_stream(): void {
     });
 }
 
-export function new_stream_clicked(stream_name: string): void {
+export function new_stream_clicked(stream_name: string, folder_id: number | undefined): void {
     // this changes the tab switcher (settings/preview) which isn't necessary
     // to a add new stream title.
     stream_settings_components.show_subs_pane.create_stream();
@@ -466,6 +466,11 @@ export function new_stream_clicked(stream_name: string): void {
         $("#create_stream_name").val(stream_name);
     }
     show_new_stream_modal();
+    if (folder_id) {
+        folder_widget!.render(folder_id);
+    } else {
+        folder_widget!.render(-1);
+    }
     $("#create_stream_name").trigger("focus");
 }
 

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -971,11 +971,12 @@ export function change_state(
     section: string,
     left_side_tab: string | undefined,
     right_side_tab: string,
+    folder_id?: number,
 ): void {
     assert(toggler !== undefined);
     // if in #channels/new form.
     if (section === "new") {
-        do_open_create_stream();
+        do_open_create_stream(folder_id);
         show_right_section();
         resize.resize_settings_creation_overlay($("#channels_overlay_container"));
         return;
@@ -1036,6 +1037,7 @@ export function launch(
     section: string,
     left_side_tab: string | undefined,
     right_side_tab: string,
+    folder_id?: number,
 ): void {
     setup_page(() => {
         overlays.open_overlay({
@@ -1045,7 +1047,7 @@ export function launch(
                 browser_history.exit_overlay();
             },
         });
-        change_state(section, left_side_tab, right_side_tab);
+        change_state(section, left_side_tab, right_side_tab, folder_id);
         setTimeout(() => {
             if (!stream_settings_components.get_active_data().id) {
                 if (section === "new") {
@@ -1148,7 +1150,7 @@ export function view_stream(): void {
     }
 }
 
-export function do_open_create_stream(): void {
+export function do_open_create_stream(folder_id?: number): void {
     // Only call this directly for hash changes.
     // Prefer open_create_stream().
 
@@ -1161,7 +1163,7 @@ export function do_open_create_stream(): void {
         return;
     }
 
-    stream_create.new_stream_clicked(stream.trim());
+    stream_create.new_stream_clicked(stream.trim(), folder_id);
 }
 
 export function open_create_stream(): void {

--- a/web/tests/channel_folders.test.cjs
+++ b/web/tests/channel_folders.test.cjs
@@ -56,4 +56,7 @@ run_test("basics", () => {
         backend_folder,
         devops_folder,
     ]);
+
+    assert.ok(channel_folders.is_valid_folder_id(frontend_folder.id));
+    assert.ok(!channel_folders.is_valid_folder_id(999));
 });


### PR DESCRIPTION
Part of work on https://github.com/zulip/zulip/issues/31972.https://github.com/zulip/zulip/issues/31972, discussed on CZO here: [#frontend > create a channel within a folder @ 💬](https://chat.zulip.org/#narrow/channel/6-frontend/topic/create.20a.20channel.20within.20a.20folder/near/2203887)[#frontend > create a channel within a folder @ 💬](https://chat.zulip.org/#narrow/channel/6-frontend/topic/create.20a.20channel.20within.20a.20folder/near/2203887)

https://github.com/user-attachments/assets/e946064c-4088-4687-ae8c-d4d6cad688ef


