### PR TITLE
Fix users not getting added to groups when joining via multi-use invite link with social auth

### DIFF
--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -289,17 +289,20 @@ def maybe_send_to_registration(
         )
 
         streams_to_subscribe = None
+        user_groups = None
         include_realm_default_subscriptions = None
         if multiuse_obj is not None:
             # If the user came here explicitly via a multiuse invite link, then
             # we use the defaults implied by the invite.
             streams_to_subscribe = list(multiuse_obj.streams.all())
+            user_groups = list(multiuse_obj.groups.all())
             include_realm_default_subscriptions = multiuse_obj.include_realm_default_subscriptions
         elif existing_prereg_user:
             # Otherwise, the user is doing this signup not via any invite link,
             # but we can use the pre-existing PreregistrationUser for these values
             # since it tells how they were intended to be, when the user was invited.
             streams_to_subscribe = list(existing_prereg_user.streams.all())
+            user_groups = list(existing_prereg_user.groups.all())
             include_realm_default_subscriptions = (
                 existing_prereg_user.include_realm_default_subscriptions
             )
@@ -307,6 +310,8 @@ def maybe_send_to_registration(
 
         if streams_to_subscribe:
             prereg_user.streams.set(streams_to_subscribe)
+        if user_groups:
+            prereg_user.groups.set(user_groups)
         if include_realm_default_subscriptions is not None:
             prereg_user.include_realm_default_subscriptions = include_realm_default_subscriptions
 


### PR DESCRIPTION


When a user was joining via a multi-use invitation link, using one of the social auth methods (e.g. Login with Google), the intended group memberships configured on the multi-use invite would be ignored.
