### PR TITLE
[Issue-34815] style: Update background color and hover effects for pill containers in channel and group settings

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -492,14 +492,36 @@
 
     .panel_user_list > .pill-container,
     .creator_details > .display_only_pill {
+        background-color: hsl(240deg 70% 70% / 20%);
+        gap: 2px;
+        flex-wrap: nowrap;
+
+        &.inline_with_text_pill > .pill-deactivated {
+            font-size: 0.9em;
+            padding-right: 2px;
+        }
+
         &:hover {
             color: inherit;
+            background-color: hsla(240, 40%, 48%, 0.25);
         }
 
         > .pill {
-            &:focus,
-            &:hover {
+            background-color: transparent;
+            border: none;
+            text-decoration: none;
+
+            &:focus {
                 color: inherit;
+            }
+
+            > .pill-label {
+                margin: 0;
+
+                > .pill-value {
+                    padding: 5px;
+                    max-width: 165px;
+                }
             }
         }
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -503,7 +503,7 @@
 
         &:hover {
             color: inherit;
-            background-color: hsla(240, 40%, 48%, 0.25);
+            background-color: hsl(240deg 40% 48% / 25%);
         }
 
         > .pill {

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -291,7 +291,7 @@
    profile cards when clicked. */
 .panel_user_list > .pill-container,
 .creator_details > .display_only_pill {
-    background-color: hsl(0deg 0% 0% / 7%);
+    background-color: hsl(240deg 70% 70% / 20%);
     gap: 2px;
     flex-wrap: nowrap;
 
@@ -302,6 +302,7 @@
 
     &:hover {
         color: inherit;
+        background-color: hsl(240deg 52% 60% / 25%);
     }
 
     > .pill {


### PR DESCRIPTION
Fixes: [Make user pills consistently purple #34815](https://github.com/zulip/zulip/issues/34815)

Changed user pills colors in all settings menus (including group and channel settings) in both light and dark mode. Took the color schema from [here](https://github.com/zulip/zulip/blob/9fe3a036615414d273ed61996d8e26f8e11fd105/web/styles/app_variables.css#L1798C5-L1801C7)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Screenshots and screen captures:</summary>


Before: 

![image](https://github.com/user-attachments/assets/0d40a6bd-4a78-42ff-9058-70cd4ce155bc)

After:

![Recording 2025-06-26 190556](https://github.com/user-attachments/assets/c67f66cd-a109-4424-870f-d99106f6177f)
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>


CZO thread: [#design > grey pills in settings](https://chat.zulip.org/#narrow/channel/101-design/topic/grey.20pills.20in.20settings/with/2186172)