### PR TITLE
url_encoding: Standardize narrow url encoding methods.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -65,7 +65,7 @@ from zerver.lib.thumbnail import (
 from zerver.lib.timeout import unsafe_timeout
 from zerver.lib.timezone import common_timezones
 from zerver.lib.types import LinkifierDict
-from zerver.lib.url_encoding import encode_channel, hash_util_encode
+from zerver.lib.url_encoding import encode_channel, encode_hash_component
 from zerver.lib.url_preview.types import UrlEmbedData, UrlOEmbedData
 from zerver.models import Message, Realm, UserProfile
 from zerver.models.linkifiers import linkifiers_for_realm
@@ -2101,7 +2101,7 @@ class StreamTopicPattern(StreamTopicMessageProcessor):
         el.set("class", "stream-topic")
         el.set("data-stream-id", str(stream_id))
         stream_url = encode_channel(stream_id, stream_name)
-        topic_url = hash_util_encode(topic_name)
+        topic_url = encode_hash_component(topic_name)
         channel_topic_object = ChannelTopicInfo(stream_name, topic_name)
         with_operand = self.get_with_operand(channel_topic_object)
         if with_operand is not None:
@@ -2138,7 +2138,7 @@ class StreamTopicMessagePattern(StreamTopicMessageProcessor):
         el = Element("a")
         el.set("class", "message-link")
         stream_url = encode_channel(stream_id, stream_name)
-        topic_url = hash_util_encode(topic_name)
+        topic_url = encode_hash_component(topic_name)
         link = f"/#narrow/channel/{stream_url}/topic/{topic_url}/near/{message_id}"
         el.set("href", link)
 

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -65,7 +65,7 @@ from zerver.lib.thumbnail import (
 from zerver.lib.timeout import unsafe_timeout
 from zerver.lib.timezone import common_timezones
 from zerver.lib.types import LinkifierDict
-from zerver.lib.url_encoding import encode_stream, hash_util_encode
+from zerver.lib.url_encoding import encode_channel, hash_util_encode
 from zerver.lib.url_preview.types import UrlEmbedData, UrlOEmbedData
 from zerver.models import Message, Realm, UserProfile
 from zerver.models.linkifiers import linkifiers_for_realm
@@ -2072,7 +2072,7 @@ class StreamPattern(StreamTopicMessageProcessor):
         # href when it processes a message with one of these, to
         # provide more clarity to API clients.
         # Also do the same for StreamTopicPattern.
-        stream_url = encode_stream(stream_id, name)
+        stream_url = encode_channel(stream_id, name)
         el.set("href", f"/#narrow/channel/{stream_url}")
         text = f"#{name}"
         el.text = markdown.util.AtomicString(text)
@@ -2100,7 +2100,7 @@ class StreamTopicPattern(StreamTopicMessageProcessor):
         el = Element("a")
         el.set("class", "stream-topic")
         el.set("data-stream-id", str(stream_id))
-        stream_url = encode_stream(stream_id, stream_name)
+        stream_url = encode_channel(stream_id, stream_name)
         topic_url = hash_util_encode(topic_name)
         channel_topic_object = ChannelTopicInfo(stream_name, topic_name)
         with_operand = self.get_with_operand(channel_topic_object)
@@ -2137,7 +2137,7 @@ class StreamTopicMessagePattern(StreamTopicMessageProcessor):
             return None, None, None
         el = Element("a")
         el.set("class", "message-link")
-        stream_url = encode_stream(stream_id, stream_name)
+        stream_url = encode_channel(stream_id, stream_name)
         topic_url = hash_util_encode(topic_name)
         link = f"/#narrow/channel/{stream_url}/topic/{topic_url}/near/{message_id}"
         el.set("href", link)

--- a/zerver/lib/topic_link_util.py
+++ b/zerver/lib/topic_link_util.py
@@ -1,8 +1,8 @@
 # Keep this synchronized with web/src/topic_link_util.ts
 
 import re
-import urllib.parse
 
+from zerver.lib.url_encoding import encode_channel, encode_hash_component
 from zerver.models.messages import Message
 
 invalid_stream_topic_regex = re.compile(r"[`>*&\[\]]|(\$\$)")
@@ -31,19 +31,6 @@ def escape_invalid_stream_topic_characters(text: str) -> str:
     )
 
 
-hash_replacements = {
-    "%": ".",
-    "(": ".28",
-    ")": ".29",
-    ".": ".2E",
-}
-
-
-def encode_hash_component(s: str) -> str:
-    encoded = urllib.parse.quote(s, safe="*")
-    return "".join(hash_replacements.get(c, c) for c in encoded)
-
-
 def get_fallback_markdown_link(
     stream_id: int, stream_name: str, topic_name: str | None = None, message_id: int | None = None
 ) -> str:
@@ -55,7 +42,7 @@ def get_fallback_markdown_link(
     render properly due to special characters in the channel or topic name.
     """
     escape = escape_invalid_stream_topic_characters
-    link = f"#narrow/channel/{stream_id}-{encode_hash_component(stream_name.replace(' ', '-'))}"
+    link = f"#narrow/channel/{encode_channel(stream_id, stream_name)}"
     text = f"#{escape(stream_name)}"
     if topic_name is not None:
         link += f"/topic/{encode_hash_component(topic_name)}"

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -15,10 +15,10 @@ def hash_util_encode(string: str) -> str:
     return quote(string, safe=b"").replace(".", "%2E").replace("%", ".")
 
 
-def encode_stream(stream_id: int, stream_name: str) -> str:
-    # We encode streams for urls as something like 99-Verona.
-    stream_name = stream_name.replace(" ", "-")
-    return str(stream_id) + "-" + hash_util_encode(stream_name)
+def encode_channel(channel_id: int, channel_name: str) -> str:
+    # We encode channel for urls as something like 99-Verona.
+    channel_name = channel_name.replace(" ", "-")
+    return str(channel_id) + "-" + hash_util_encode(channel_name)
 
 
 def personal_narrow_url(*, realm: Realm, sender: UserProfile) -> str:
@@ -40,12 +40,14 @@ def direct_message_group_narrow_url(
 
 def stream_narrow_url(realm: Realm, stream: Stream) -> str:
     base_url = f"{realm.url}/#narrow/channel/"
-    return base_url + encode_stream(stream.id, stream.name)
+    return base_url + encode_channel(stream.id, stream.name)
 
 
 def topic_narrow_url(*, realm: Realm, stream: Stream, topic_name: str) -> str:
     base_url = f"{realm.url}/#narrow/channel/"
-    return f"{base_url}{encode_stream(stream.id, stream.name)}/topic/{hash_util_encode(topic_name)}"
+    return (
+        f"{base_url}{encode_channel(stream.id, stream.name)}/topic/{hash_util_encode(topic_name)}"
+    )
 
 
 def message_link_url(
@@ -79,7 +81,7 @@ def stream_message_url(
     stream_name = message["display_recipient"]
     topic_name = get_topic_from_message_info(message)
     encoded_topic_name = hash_util_encode(topic_name)
-    encoded_stream = encode_stream(stream_id=stream_id, stream_name=stream_name)
+    encoded_stream = encode_channel(stream_id, stream_name)
 
     parts = [
         realm.url,

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -74,11 +74,30 @@ def encode_user_ids(
     return direct_message_slug
 
 
+def encode_user_full_name_and_id(full_name: str, user_id: int, with_operator: bool = False) -> str:
+    """
+    This encodes the given `full_name` and `user_id` into a
+    recipient slug string that can be used to construct a
+    narrow URL.
+
+    e.g., 9, "King Hamlet" -> "9-King-Hamlet"
+
+    The `with_operator` parameter decides whether to append
+    the "dm" operator to the recipient slug or not.
+
+    e.g., "dm/9-King-Hamlet"
+    """
+    encoded_user_name = re2.sub(r'[ "%\/<>`\p{C}]+', "-", full_name.strip())
+    direct_message_slug = str(user_id) + "-" + encoded_user_name
+    if with_operator:
+        return f"dm/{direct_message_slug}"
+    return direct_message_slug
+
+
 def personal_narrow_url(*, realm: Realm, sender: UserProfile) -> str:
     base_url = f"{realm.url}/#narrow/dm/"
-    encoded_user_name = re2.sub(r'[ "%\/<>`\p{C}]+', "-", sender.full_name)
-    pm_slug = str(sender.id) + "-" + encoded_user_name
-    return base_url + pm_slug
+    direct_message_slug = encode_user_full_name_and_id(sender.full_name, sender.id)
+    return base_url + direct_message_slug
 
 
 def direct_message_group_narrow_url(

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -5652,11 +5652,11 @@ class PersonalMessagesTest(ZulipTestCase):
             realm=realm,
             message=message,
         )
-        self.assertEqual(url, "http://zulip.testserver/#narrow/dm/77,80-pm/near/555")
+        self.assertEqual(url, "http://zulip.testserver/#narrow/dm/77,80/near/555")
 
         url = message_link_url(
             realm=realm,
             message=message,
             conversation_link=True,
         )
-        self.assertEqual(url, "http://zulip.testserver/#narrow/dm/77,80-pm/with/555")
+        self.assertEqual(url, "http://zulip.testserver/#narrow/dm/77,80/with/555")

--- a/zerver/tests/test_reminders.py
+++ b/zerver/tests/test_reminders.py
@@ -56,7 +56,7 @@ class RemindersTest(ZulipTestCase):
     def get_dm_reminder_content(self, msg_content: str, msg_id: int) -> str:
         return (
             "You requested a reminder for the following direct message.\n\n"
-            f"@_**King Hamlet|10** [said](http://zulip.testserver/#narrow/dm/10,12-pm/near/{msg_id}):\n```quote\n{msg_content}\n```"
+            f"@_**King Hamlet|10** [said](http://zulip.testserver/#narrow/dm/10,12/near/{msg_id}):\n```quote\n{msg_content}\n```"
         )
 
     def get_channel_message_reminder_content(self, msg_content: str, msg_id: int) -> str:
@@ -376,7 +376,7 @@ class RemindersTest(ZulipTestCase):
                 delivered_message.content,
                 "You requested a reminder for the following direct message."
                 "\n\n"
-                f"@_**King Hamlet|10** [sent](http://zulip.testserver/#narrow/dm/10,12-pm/near/{reminder.reminder_target_message_id}) a poll.",
+                f"@_**King Hamlet|10** [sent](http://zulip.testserver/#narrow/dm/10,12/near/{reminder.reminder_target_message_id}) a poll.",
             )
             self.assertEqual(delivered_message.date_sent, more_than_scheduled_delivery_datetime)
 
@@ -411,6 +411,6 @@ class RemindersTest(ZulipTestCase):
                 delivered_message.content,
                 "You requested a reminder for the following direct message."
                 "\n\n"
-                f"@_**King Hamlet|10** [sent](http://zulip.testserver/#narrow/dm/10,12-pm/near/{reminder.reminder_target_message_id}) a todo list.",
+                f"@_**King Hamlet|10** [sent](http://zulip.testserver/#narrow/dm/10,12/near/{reminder.reminder_target_message_id}) a todo list.",
             )
             self.assertEqual(delivered_message.date_sent, more_than_scheduled_delivery_datetime)

--- a/zerver/tests/test_url_encoding.py
+++ b/zerver/tests/test_url_encoding.py
@@ -1,5 +1,5 @@
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.url_encoding import encode_channel, encode_user_ids
+from zerver.lib.url_encoding import encode_channel, encode_user_full_name_and_id, encode_user_ids
 
 
 class URLEncodeTest(ZulipTestCase):
@@ -24,3 +24,20 @@ class URLEncodeTest(ZulipTestCase):
         self.assertEqual(encode_user_ids([1, 2, 3], with_operator=True), "dm/1,2,3-group")
         with self.assertRaises(AssertionError):
             encode_user_ids([])
+
+    def test_encode_user_full_name_and_id(self) -> None:
+        self.assertEqual(encode_user_full_name_and_id("King Hamlet", 9), "9-King-Hamlet")
+        self.assertEqual(
+            encode_user_full_name_and_id("King Hamlet", 9, with_operator=True), "dm/9-King-Hamlet"
+        )
+        self.assertEqual(encode_user_full_name_and_id("ZOE", 1), "1-ZOE")
+        self.assertEqual(encode_user_full_name_and_id("  User Name  ", 100), "100-User-Name")
+        self.assertEqual(encode_user_full_name_and_id("User  Name", 101), "101-User-Name")
+        self.assertEqual(encode_user_full_name_and_id("User/Name", 200), "200-User-Name")
+        self.assertEqual(encode_user_full_name_and_id("User%Name", 201), "201-User-Name")
+        self.assertEqual(encode_user_full_name_and_id("User<Name>", 202), "202-User-Name-")
+        self.assertEqual(encode_user_full_name_and_id('User"Name`', 203), "203-User-Name-")
+        self.assertEqual(encode_user_full_name_and_id('User/ % < > ` " Name', 204), "204-User-Name")
+        self.assertEqual(encode_user_full_name_and_id("User--Name", 205), "205-User--Name")
+        self.assertEqual(encode_user_full_name_and_id("User%%Name", 206), "206-User-Name")
+        self.assertEqual(encode_user_full_name_and_id("User_Name", 5), "5-User_Name")

--- a/zerver/tests/test_url_encoding.py
+++ b/zerver/tests/test_url_encoding.py
@@ -1,5 +1,5 @@
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.url_encoding import encode_channel
+from zerver.lib.url_encoding import encode_channel, encode_user_ids
 
 
 class URLEncodeTest(ZulipTestCase):
@@ -9,3 +9,18 @@ class URLEncodeTest(ZulipTestCase):
         self.assertEqual(encode_channel(123, "General"), "123-General")
         self.assertEqual(encode_channel(7, "random_channel"), "7-random_channel")
         self.assertEqual(encode_channel(9, "Verona", with_operator=True), "channel/9-Verona")
+
+    def test_encode_user_ids(self) -> None:
+        # Group narrow URL has 3 or more user IDs
+        self.assertEqual(encode_user_ids([1, 2, 3]), "1,2,3-group")
+        self.assertEqual(encode_user_ids([3, 1, 2]), "1,2,3-group")
+
+        # One-on-one narrow URL has 2 user IDs
+        self.assertEqual(encode_user_ids([1, 2]), "1,2")
+
+        # Narrow URL to ones own direct message conversation
+        self.assertEqual(encode_user_ids([1]), "1")
+
+        self.assertEqual(encode_user_ids([1, 2, 3], with_operator=True), "dm/1,2,3-group")
+        with self.assertRaises(AssertionError):
+            encode_user_ids([])

--- a/zerver/tests/test_url_encoding.py
+++ b/zerver/tests/test_url_encoding.py
@@ -1,0 +1,11 @@
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.url_encoding import encode_channel
+
+
+class URLEncodeTest(ZulipTestCase):
+    def test_encode_channel(self) -> None:
+        # We have more tests for this function in `test_topic_link_utils.py`
+        self.assertEqual(encode_channel(9, "Verona"), "9-Verona")
+        self.assertEqual(encode_channel(123, "General"), "123-General")
+        self.assertEqual(encode_channel(7, "random_channel"), "7-random_channel")
+        self.assertEqual(encode_channel(9, "Verona", with_operator=True), "channel/9-Verona")


### PR DESCRIPTION
This is a prep PR to fix #31100, it;
- standardize the encoding function we use in `topic_link_utils.py` and `url_encoding.py`.
- refactors an `encode_user_ids`.
- refactors an `encode_user_full_name_and_id`.

discussion: [#backend > Fix narrow URLs in exported messages.](https://chat.zulip.org/#narrow/channel/3-backend/topic/Fix.20narrow.20URLs.20in.20exported.20messages.2E/with/2208096)


**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
