### PR TITLE
Fix compose box prematurely switches to edit mode when sending from preview mode

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -142,6 +142,7 @@ export function clear_compose_box() {
 
 export function send_message_success(request, data) {
     if (!request.locally_echoed) {
+        do_post_send_tasks();
         clear_compose_box();
     }
 
@@ -240,6 +241,7 @@ export let send_message = (request = create_message_object()) => {
             // (Restoring this state is handled by clear_compose_box
             // for locally echoed messages.)
             compose_ui.hide_compose_spinner();
+            do_post_send_tasks();
             return;
         }
 
@@ -260,6 +262,7 @@ export let send_message = (request = create_message_object()) => {
     );
 
     if (locally_echoed) {
+        do_post_send_tasks();
         clear_compose_box();
         // Schedule a timer to display a spinner when the message is
         // taking a longtime to send.
@@ -323,7 +326,6 @@ export let finish = (scheduling_message = false) => {
     } else {
         send_message();
     }
-    do_post_send_tasks();
     return true;
 };
 
@@ -370,6 +372,7 @@ function schedule_message_to_custom_date() {
     const $banner_container = $("#compose_banners");
     const success = function (data) {
         drafts.draft_model.deleteDrafts([draft_id]);
+        do_post_send_tasks();
         clear_compose_box();
         const new_row_html = render_success_message_scheduled_banner({
             scheduled_message_id: data.scheduled_message_id,
@@ -385,6 +388,7 @@ function schedule_message_to_custom_date() {
 
     const error = function (xhr) {
         const response = channel.xhr_error_message("Error sending message", xhr);
+        do_post_send_tasks();
         compose_ui.hide_compose_spinner();
         compose_banner.show_error_message(
             response,

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -179,6 +179,7 @@ function assert_compose_send_button_attr_is_undefined() {
 
 test_ui("send_message_success", ({override, override_rewire}) => {
     mock_banners();
+    disable_document_triggers(override);
 
     const fake_compose_box = new FakeComposeBox();
 
@@ -263,6 +264,7 @@ test_ui("send_message_success", ({override, override_rewire}) => {
 
 test_ui("send_message", ({override, override_rewire, mock_template}) => {
     mock_banners();
+    disable_document_triggers(override);
     MockDate.set(new Date(fake_now * 1000));
     override_rewire(drafts, "sync_count", noop);
 
@@ -360,6 +362,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         assert.equal(fake_compose_box.textarea_val(), "");
         assert.ok(fake_compose_box.is_textarea_focused());
         assert.ok(!fake_compose_box.is_submit_button_spinner_visible());
+        fake_compose_box.assert_preview_mode_is_off();
     })();
 
     // This is the additional setup which is common to both the tests below.
@@ -450,6 +453,7 @@ test_ui("handle_enter_key_with_preview_open", ({override, override_rewire}) => {
     let send_message_called = false;
     override_rewire(compose, "send_message", () => {
         send_message_called = true;
+        compose.do_post_send_tasks();
     });
     override(realm, "realm_topics_policy", "allow_empty_topic");
 
@@ -532,6 +536,7 @@ test_ui("finish", ({override, override_rewire}) => {
         let send_message_called = false;
         override_rewire(compose, "send_message", () => {
             send_message_called = true;
+            compose.do_post_send_tasks();
         });
 
         assert.ok(compose.finish());


### PR DESCRIPTION
Earlier, when user were in preview mode and sent a message, if it wasn't locally rendered, there was a small window where preview mode would switch back to edit mode before server responded.

This PR changes this behaviour by switching the compose mode after server request was successful.

Fixes: zulip#33245

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

[Screencast from 2025-06-27 02-27-51.webm](https://github.com/user-attachments/assets/29bc7aed-feed-4f9d-ab31-bbff1e956eb0)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
