### PR TITLE
copy_paste: Offset to the left, not the right.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -862,7 +862,7 @@ strong {
 .copy-paste-text {
     /* Hide the text that we want copy paste to capture */
     position: absolute;
-    right: -99999px;
+    left: -99999px;
 }
 
 @keyframes rotate {


### PR DESCRIPTION
Ugh. This simple fix to a bone-headed error I made on #34758 corrects the seemingly unrelated odd behavior originally reported at [#issues > ✔ Sliding of message_feed_container over the left-sidebar](https://chat.zulip.org/#narrow/channel/9-issues/topic/.E2.9C.94.20Sliding.20of.20message_feed_container.20over.20the.20left-sidebar/with/2184913)

The mistake in #34758 was pulling the `.copy-paste-text` off to the far right, when it should've gone off to the far left.

In addition to the slide-over behavior that caused on iPad/Safari, I discovered a 1:1 correlated bug that presented in Firefox, which defaults to "Fit to page width" when printing. Those before and after screenshots are presented below.

Fixes part of [#issues > whole-screen scroll when clicking into DMs on iPad](https://chat.zulip.org/#narrow/channel/9-issues/topic/whole-screen.20scroll.20when.20clicking.20into.20DMs.20on.20iPad/with/2192716) 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![firefox-printable-area-before](https://github.com/user-attachments/assets/ccf86046-786a-4956-b8fb-6ec4bee7c026) | ![firefox-printable-area-after](https://github.com/user-attachments/assets/16a18714-8ad8-4105-abd6-5bb9c810e5a7) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>