### PR TITLE
message_row: Fix misalignment of bot icon next to sender name.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -429,6 +429,9 @@
             .zulip-icon.zulip-icon-bot {
                 align-self: center;
                 margin-left: 5px;
+                /* Fixes slight vertical misalignment between bot icon and sender name.
+                 Verified across font sizes 12px–30px. */
+                margin-top: -2px;
             }
 
             .sender_name {


### PR DESCRIPTION
This PR fixes a minor UI misalignment where the bot icon next to the sender name appeared visually off-center.

- Since both the sender name and the bot icon are siblings inside the existing .sender_name flex container, we adjusted the alignment of the .zulip-icon-bot element using margin-top.
- No new containers were introduced; I ensured this change works responsively across font sizes and doesn’t affect other parts of the UI.
- Added a small top margin tweak (margin-top: -2px) to visually center the icon, accounting for its bottom-heavy appearance.

Fixes #32992.


**Screenshots and screen captures:**

**Before**-
![misalingment](https://github.com/user-attachments/assets/a8494bfb-55dc-4dd5-986c-87f47b368a3c)

**Before look with 12px font of sender's name-**-
![12px](https://github.com/user-attachments/assets/d5516be2-7e31-4756-ba95-9ada45eea333)

**Before look with 20px font of sender's name**-
![20px](https://github.com/user-attachments/assets/b077da1b-08de-491d-a8a3-824b9f9a8223)

**After**-
![corrected](https://github.com/user-attachments/assets/5f8461e2-565a-459c-b960-a02556781298)

**After look with 12px font of sender's name-**
![corrected_12px](https://github.com/user-attachments/assets/ad714599-66b2-47cb-8ff1-ef826f661917)

**After look with 20px font of sender's name**
![corrected_20px](https://github.com/user-attachments/assets/c90e7ba1-a355-479a-9779-fd77c87cac2a)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
