### PR TITLE
 Don't show background behind transparent avatars in navbar

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -196,6 +196,10 @@ function initialize_navbar() {
     });
 
     $("#header-container").html(rendered_navbar);
+    // Track when the image is loaded to updated CSS properties.
+    $("#header-container img.header-button-avatar-image").on("load", (e) => {
+        e.currentTarget.classList.add("avatar-loaded");
+    });
 }
 
 function initialize_compose_box() {

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -152,7 +152,7 @@ export const update_person = function update(event: UserUpdate): void {
             current_user.avatar_url = url;
             current_user.avatar_url_medium = event.avatar_url_medium;
             $("#user-avatar-upload-widget .image-block").attr("src", event.avatar_url_medium);
-            $("#personal-menu .header-button-avatar-image").attr(
+            $("#personal-menu-dropdown .avatar-image, .header-button-avatar-image").attr(
                 "src",
                 `${event.avatar_url_medium}`,
             );

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2442,6 +2442,11 @@ body:not(.spectator-view) {
                avatar in the navbar from being lower by a pixel. */
             display: block;
         }
+
+        &:has(.avatar-loaded) {
+            background-color: transparent;
+            border-color: transparent;
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes a UI issue with the navbar avatars when the users have transparent portions of their background, causing the background of the avatars to be shown along with the actual users avatar. 

After discussions, this change also includes the removal of the square background border for the avatar image placeholder in the navbar aside from the gray background color of the avatar placeholder.

Fixes: https://github.com/zulip/zulip/issues/34466

#design thread Discussion: https://chat.zulip.org/#narrow/channel/101-design/topic/Don't.20show.20background.20behind.20transparent.20avatars.20in.20navbar/with/2206414

**Before (Fully opaque avatar):**
![oldborder](https://github.com/user-attachments/assets/2b7308f6-c306-480b-acba-7804aeadf77d)
**Before (Transparent avatar):**
![before highlight](https://github.com/user-attachments/assets/197a777b-6872-41ff-8c2e-36e4df8d7bdb)
**After (Fully opaque avatar):**
![newborders](https://github.com/user-attachments/assets/f28c4f37-e4b9-41ec-ad14-8c80fb7dcbf1)
**After (Transparent avatar):**
![highlight](https://github.com/user-attachments/assets/3d29d695-974a-4ccb-8856-75ce0ef48474)
