### PR TITLE
css: Align channel privacy icons in Personal settings > Notifications and modals.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -133,6 +133,15 @@
     &.simplebar-scrollable-y + .modal__footer {
         border-top: 1px solid var(--color-border-modal-footer);
     }
+
+    .channel-privacy-type-icon {
+        /* This pushes back on suspect styles
+           in app_components.css. A fuller fix
+           will require tracking down other
+           instances of this class. */
+        width: auto;
+        padding-right: 0;
+    }
 }
 
 .modal__button {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -531,6 +531,10 @@ input[type="checkbox"] {
         /* This gap matches a single space character. */
         gap: 0.4ch;
 
+        .stream-privacy {
+            display: flex;
+        }
+
         &:hover {
             .reset_stream_notifications {
                 opacity: 1;


### PR DESCRIPTION
This commit aligns the channel privacy icons displayed for channels with custom notifications in the notifications table in Personal settings.

<!-- Describe your pull request here.-->

Fixes: [#issues > misaligned channel privacy icon in modal, notification table](https://chat.zulip.org/#narrow/channel/9-issues/topic/misaligned.20channel.20privacy.20icon.20in.20modal.2C.20notification.20table/with/2192394).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
- For personal settings > Notifications:
   
   | Before | After |
   |--------------|-------------|
   | ![image](https://github.com/user-attachments/assets/fd6896ee-55fc-491d-a16b-4bbe1c8865a0) | ![image](https://github.com/user-attachments/assets/275ea417-f837-4b00-b474-e1b203775e14) |

- For the first stream created modal:

  |Font size | Before | After |
  |--------------|--------------|-------------|
  | 12px | ![image](https://github.com/user-attachments/assets/a94e5978-4cf6-4b47-bed2-018ae30a8f6b) | ![image](https://github.com/user-attachments/assets/7d11a2f3-d4af-4fb0-ad3c-ce7b33923486) |
  | 16px | ![image](https://github.com/user-attachments/assets/6b862bff-a91e-41b8-bddc-e792e92ac081) | ![image](https://github.com/user-attachments/assets/19dbce9d-147b-40c6-bc80-58ff4d77168e)
  | 20px | ![image](https://github.com/user-attachments/assets/503e1a5f-9134-480f-b147-87df393eac76) | ![image](https://github.com/user-attachments/assets/e6709df9-f64d-410d-a654-5b94a5af2ae0)

---



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
