### PR TITLE
topics: Fix live update of topic names upon topic capitalization.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -982,14 +982,21 @@ export class Filter {
         this.cached_sorted_terms_for_comparison = undefined;
     }
 
-    equals(filter: Filter, excluded_operators?: string[]): boolean {
+    equals(
+        filter: Filter,
+        excluded_operators?: string[],
+        require_identical_topic_case = false,
+    ): boolean {
         return _.isEqual(
-            filter.sorted_terms_for_comparison(excluded_operators),
-            this.sorted_terms_for_comparison(excluded_operators),
+            filter.sorted_terms_for_comparison(excluded_operators, require_identical_topic_case),
+            this.sorted_terms_for_comparison(excluded_operators, require_identical_topic_case),
         );
     }
 
-    sorted_terms_for_comparison(excluded_operators?: string[]): string[] {
+    sorted_terms_for_comparison(
+        excluded_operators?: string[],
+        require_identical_topic_case?: boolean,
+    ): string[] {
         if (!excluded_operators && this.cached_sorted_terms_for_comparison !== undefined) {
             return this.cached_sorted_terms_for_comparison;
         }
@@ -1004,7 +1011,10 @@ export class Filter {
         const sorted_simplified_terms = filter_terms
             .map((term) => {
                 let operand = term.operand;
-                if (term.operator === "channel" || term.operator === "topic") {
+                if (
+                    term.operator === "channel" ||
+                    (!require_identical_topic_case && term.operator === "topic")
+                ) {
                     operand = operand.toLowerCase();
                 }
 

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -336,8 +336,12 @@ export function try_rendering_locally_for_same_narrow(
     // is just a `near` operator, or just the value of a `near` operator,
     // we can render the new filter without a rerender of the message list
     // if the target message in the `near` operator is already rendered.
+    //
+    // NOTE that we need to compare the terms without ignoring the case
+    // of channel / topic operand, since we need a rerender to update
+    // message header if they differ just in cases.
     const excluded_operators = ["near"];
-    if (!filter.equals(current_filter, excluded_operators)) {
+    if (!filter.equals(current_filter, excluded_operators, true)) {
         return false;
     }
 


### PR DESCRIPTION
Previously, when the topic was renamed from left sidebar or from the message header with the new name involving just change in cases from older ones, the corresponding update was not reflected in the message header and left sidebar respectively.

This is fixed by making sure `stream_topic_history` entries were removed before being added, and making sure if topic names just differ in cases, then message list is rerendered.

<!-- Describe your pull request here.-->

Fixes: [#issues > 🤷 topic capitalization](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.A4.B7.20topic.20capitalization/with/2206625)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
