### PR TITLE
sidebar_ui: Remove unused hide_unread_counts passed to left sidebar.

### DIFF
--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -302,7 +302,6 @@ export function initialize_left_sidebar(): void {
             user_settings.web_home_view === settings_config.web_home_view_values.all_messages.code,
         is_recent_view_home_view:
             user_settings.web_home_view === settings_config.web_home_view_values.recent_topics.code,
-        hide_unread_counts: settings_data.should_mask_unread_count(false),
         is_spectator: page_params.is_spectator,
     });
 


### PR DESCRIPTION
Missed in #32795.
