### PR TITLE
message_edit: Show message edit button while saving changes.

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -68,7 +68,7 @@ import * as util from "./util.ts";
 export const currently_editing_messages = new Map<number, JQuery<HTMLTextAreaElement>>();
 let currently_deleting_messages: number[] = [];
 let currently_topic_editing_message_ids: number[] = [];
-const currently_echoing_messages = new Map<number, EchoedMessageData>();
+export const currently_echoing_messages = new Map<number, EchoedMessageData>();
 
 type EchoedMessageData = {
     raw_content: string;
@@ -165,9 +165,10 @@ export function is_message_editable_ignoring_permissions(message: Message): bool
     }
 
     // Messages where we're currently locally echoing an edit not yet acknowledged
-    // by the server.
+    // by the server are shown in the message edit box, but with "Save"
+    // disabled.
     if (currently_echoing_messages.has(message.id)) {
-        return false;
+        return true;
     }
     return true;
 }
@@ -409,9 +410,14 @@ function handle_message_edit_enter(
     if (composebox_typeahead.should_enter_send(e)) {
         const $row = $message_edit_content.closest(".message_row");
         const $message_edit_save_button = $row.find(".message_edit_save");
-        if ($message_edit_save_button.prop("disabled")) {
-            // In cases when the save button is disabled
-            // we need to disable save on pressing Enter
+        const $message_edit_save_container = $row.find(".message_edit_save_container");
+        if (
+            $message_edit_save_button.prop("disabled") ||
+            !$message_edit_save_container.hasClass("hide")
+        ) {
+            // In cases when the save button is disabled,
+            // or the save button is hidden to show the saving
+            // button, we need to disable save on pressing Enter
             // Prevent default to avoid new-line on pressing
             // Enter inside the textarea in this case
             e.preventDefault();
@@ -596,12 +602,14 @@ function edit_message($row: JQuery, raw_content: string): void {
     }
 
     const is_editable = is_content_editable(message, seconds_left_buffer);
+    const currently_echoing = currently_echoing_messages.has(message.id);
 
     const $form = $(
         render_message_edit_form({
             message_id: message.id,
             is_editable,
             content: raw_content,
+            is_echoing: currently_echoing,
             file_upload_enabled,
             giphy_enabled: giphy_state.is_giphy_enabled(),
             minutes_to_edit: Math.floor((realm.realm_message_content_edit_limit_seconds ?? 0) / 60),
@@ -1314,7 +1322,6 @@ export async function save_message_row_edit($row: JQuery): Promise<void> {
         success(res) {
             if (edit_locally_echoed) {
                 delete message.local_edit_timestamp;
-                currently_echoing_messages.delete(message_id);
             }
 
             // Ordinarily, in a code path like this, we'd make
@@ -1413,8 +1420,11 @@ export function maybe_show_edit($row: JQuery, id: number): void {
     }
 
     if (currently_editing_messages.has(id)) {
-        const $message_edit_content = currently_editing_messages.get(id);
-        edit_message($row, $message_edit_content?.val() ?? "");
+        const message_edit_content = currently_editing_messages.get(id)?.val();
+        start_edit_with_content($row, message_edit_content ?? "");
+        if ($row.hasClass("show_preview")) {
+            show_preview_area($row);
+        }
     }
 }
 

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -425,8 +425,18 @@ export function update_messages(events: UpdateMessageEvent[]): void {
                 anchor_message.is_me_message = event.is_me_message;
             }
 
-            // mark the current message edit attempt as complete.
-            message_edit.end_message_edit(event.message_id);
+            // mark the current message edit attempt as complete if the
+            // message edit box is hidden.
+            const $row = message_lists.current?.get_row(event.message_id);
+            if ($row) {
+                const $message_edit = $row.find(".message_edit");
+                if ($message_edit.length > 0 && $message_edit.hasClass("hide")) {
+                    message_edit.end_message_edit(event.message_id);
+                }
+            } else {
+                message_edit.end_message_edit(event.message_id);
+            }
+            message_edit.currently_echoing_messages.delete(event.message_id);
 
             // Save the content edit to the front end anchor_message.edit_history
             // before topic edits to ensure that combined topic / content

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1683,8 +1683,13 @@ export class MessageListView {
         if (message_content_edited) {
             $rendered_msg.addClass("fade-in-message");
         }
-        this._post_process($rendered_msg);
+        if ($row.hasClass("preview_mode")) {
+            // We'll render the preview area after we've
+            // rendered the message edit content in this new row.
+            $rendered_msg.addClass("show_preview");
+        }
         $row.replaceWith($rendered_msg);
+        this._post_process($rendered_msg);
 
         // If this list not currently displayed, we don't need to select the message.
         if (was_selected && this.list === message_lists.current) {
@@ -1757,6 +1762,7 @@ export class MessageListView {
             this.update_sticky_recipient_headers();
             maybe_restore_focus_to_message_edit_form();
         }
+        autosize.update(this.$list.find(".message_edit_content"));
     }
 
     append(

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -30,20 +30,28 @@
                     {{/if}}
                     <div class="message-edit-buttons-and-timer">
                         {{#if is_editable}}
-                            <div class="message_edit_save_container">
-                                <button type="button" class="message-actions-button message_edit_save">
-                                    <img class="loader" alt="" src="" />
-                                    <span>{{t "Save" }}</span>
-                                </button>
-                            </div>
-                            <button type="button" class="message-actions-button message_edit_cancel"><span>{{t "Cancel" }}</span></button>
-                            <span class="tippy-zulip-tooltip message-limit-indicator" data-tippy-content="{{t 'Maximum message length: {max_message_length} characters' }}"></span>
-                            <div class="message-edit-timer">
-                                <span class="message_edit_countdown_timer
-                                  tippy-zulip-tooltip" data-tippy-content="{{t 'This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.' }}"></span>
-                            </div>
+                        <div class="message-edit-saving-container tippy-zulip-tooltip {{#unless is_echoing}}hide{{/unless}}"
+                          data-tippy-content="{{t 'Saving previous changes.' }}">
+                            <button type="button" class="message-actions-button message-edit-saving saving" disabled>
+                                <span class="fa fa-spinner fa-spin save-discard-widget-button-loading"></span>
+                                <span>{{t "Saving" }}</span>
+                            </button>
+                        </div>
+
+                        <div class="message_edit_save_container {{#if is_echoing}}hide{{/if}}">
+                            <button type="button" class="message-actions-button message_edit_save">
+                                <img class="loader" alt="" src="" />
+                                <span>{{t "Save" }}</span>
+                            </button>
+                        </div>
+                        <button type="button" class="message-actions-button message_edit_cancel"><span>{{t "Cancel" }}</span></button>
+                        <span class="tippy-zulip-tooltip message-limit-indicator" data-tippy-content="{{t 'Maximum message length: {max_message_length} characters' }}"></span>
+                        <div class="message-edit-timer">
+                            <span class="message_edit_countdown_timer
+                              tippy-zulip-tooltip" data-tippy-content="{{t 'This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.' }}"></span>
+                        </div>
                         {{else}}
-                            <button type="button" class="message-actions-button message_edit_close"><span>{{t "Close" }}</span></button>
+                        <button type="button" class="message-actions-button message_edit_close"><span>{{t "Close" }}</span></button>
                         {{/if}}
                     </div>
                 </div>

--- a/web/tests/message_events.test.cjs
+++ b/web/tests/message_events.test.cjs
@@ -130,7 +130,15 @@ run_test("update_messages", ({override, override_rewire}) => {
     const $modal = $.create("micromodal").addClass("modal--open");
     $message_edit_history_modal.set_parents_result(".micromodal", $modal);
 
+    const $row = $.create("<stub message row>");
+    const $message_edit = $.create("<stub message edit>");
+    $message_edit.addClass("hide");
+    $message_edit.length = 1;
+    $row.set_find_results(".message_edit", $message_edit);
+    override(message_lists.current, "get_row", () => $row);
+
     // TEST THIS:
+    override(message_edit, "currently_echoing_messages", new Map());
     message_events.update_messages(events);
 
     assert.ok(!unread.unread_mentions_counter.has(original_message.id));


### PR DESCRIPTION
Previously, when a message is edited and saved, when the window is closed during local echo, we would show an option to view the source, despite the edit not being saved and us waiting for the server response.

This commit rather continues to show the edit button in such a state, with the edit window showing "Saving" with a spinner instead of the "save" button.

If the success response for the previous edit comes while the current edit is in progress, we retain the latest edit state (even after rerendering) so that the user doesn't lose their changes. The "save" button too, is now enabled again.
Same is the case for a failure response.

### This PR builds upon #29357.
I couldn't reproduce [this bug](https://github.com/zulip/zulip/pull/29357#issuecomment-2161502537) anymore, probably because recent work on that code path has solved it. So I inspected the code path to ensure this bug actually isn't possible now. Here's the walkthrough:

### Situation: After editing a message, while we're waiting for the server response, the user again opens the message edit box.
This causes the map `currently_editing_messages` to contain an entry for that message.

When the server response for the previous edit finally arrives:
- The function `message_events.update_messages` is eventually called. Here we end the message edit. This PR introduces a check to only end the message edit if the edit box isn't open. So in our situation, the message edit isn't ended (which would cause the user to lose new changes).
- Further down the line, `message_list_view._rerender_messages`, and subsequently, `_rerender_message` is called.
- Here, the current row is replaced with a fresh rerender of the row. This removes the edit textarea from the dom, but we still have reference to it in `currently_editing_messages`. We also determine whether to show preview area, based on whether it was already being shown, and attach a class to the newly rendered row.
- This is followed by `_post_process`, then `_post_process_single_row`, then `maybe_show_edit`.
- Now we use `currently_editing_messages` to retrieve the edit textarea content and pass it to `start_edit_with_content`, where the message_edit_form is rendered with the newer unsaved content, and file upload handlers etc are taken care of.

This guarantees that we don't lose the new unsaved changes while waiting for the previous edit response.

As for the above mentioned bug, the reason for it is that we remove the `message_id` from the map `currently_echoing_messages` when the message edit api call in `message_edit.save_message_row_edit` succeeds. However, the rerendering of the message occurs when the corresponding event arrives (through `message_events.update_messages`). We should remove the message id from the map only after the edit event has arrived (no matter whether api response has arrived or not, since now we know it is safe to request another edit), and before the rerendering of the message. Since there is a race between the api response removing the message id and the message event causing a rerender of the message row, we observed non-deterministic behaviour.

### Testing
We can add a `time.sleep` call in `message_edit.py` inside `update_message_backend` to simulate server delay.

Fixes #29028

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
