### PR TITLE
unread_ops: Fix filter term check for current narrow when bulk update.

### DIFF
--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -277,9 +277,14 @@ function bulk_update_read_flags_for_narrow(
                             term.negated === false
                         ),
                 );
-                // Current narrow may have "with" operator around a message target which
-                // we would want to ignore for bulk reading a message list.
-                if (message_lists.current?.data.filter.equals(new Filter(filter_terms), ["with"])) {
+                // Current narrow may have "with" or "near" operator around a message
+                // target which we would want to ignore for bulk reading a message list.
+                if (
+                    message_lists.current?.data.filter.equals(new Filter(filter_terms), [
+                        "with",
+                        "near",
+                    ])
+                ) {
                     message_lists.current?.resume_reading();
                     unread_ui.hide_unread_banner();
                 }


### PR DESCRIPTION
This commit ignores the near operator when comparing with current message list filter terms which may have near operator.

Extension to this https://github.com/zulip/zulip/pull/34713#issuecomment-3014266546
Fixes: zulip#33866.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
