### PR TITLE
settings_ui: Remove search box from dropdown in exports panel

### DIFF
--- a/web/src/settings_exports.ts
+++ b/web/src/settings_exports.ts
@@ -256,6 +256,7 @@ export function populate_export_consents_table(): void {
         },
         $events_container: $("#data-exports"),
         default_id: filter_by_consent_options[0]!.unique_id,
+        hide_search_box: true,
     });
     filter_by_consent_dropdown_widget.setup();
 }


### PR DESCRIPTION
Removed the search box from filter_by_consent dropdown in the exports panel as it has only two options.

<!-- Describe your pull request here.-->

Fixes: #35028

**Screenshots:**
| Before | After |
|--------|-------|
|![image](https://github.com/user-attachments/assets/8e90941c-ba23-430a-ae7e-c0d6755927b7)| ![image](https://github.com/user-attachments/assets/167156d5-ab9c-4b02-aae9-54a8cbbd5c03) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

**Communicate decisions, questions, and potential concerns**
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

**Individual commits are ready for review** ([commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html))
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

**Completed manual review and testing of the following:**
- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
