### PR TITLE
left_sidebar: Don't show 'add channels' in tooltip if that's not allowed

### DIFF
--- a/web/src/left_sidebar_tooltips.ts
+++ b/web/src/left_sidebar_tooltips.ts
@@ -4,6 +4,7 @@ import * as tippy from "tippy.js";
 import * as drafts from "./drafts.ts";
 import {$t} from "./i18n.ts";
 import * as scheduled_messages from "./scheduled_messages.ts";
+import * as settings_data from "./settings_data.ts";
 import * as starred_messages from "./starred_messages.ts";
 import {
     EXTRA_LONG_HOVER_DELAY,
@@ -136,11 +137,22 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: [
-            "#streams_header .streams-tooltip-target",
-            "#add_streams_tooltip",
-            "#filter_streams_tooltip",
-        ].join(","),
+        target: ["#streams_header .streams-tooltip-target", "#filter_streams_tooltip"].join(","),
+        appendTo: () => document.body,
+    });
+
+    tippy.delegate("body", {
+        target: "#add_streams_tooltip",
+        onShow(instance) {
+            const can_create_streams =
+                settings_data.user_can_create_private_streams() ||
+                settings_data.user_can_create_public_streams() ||
+                settings_data.user_can_create_web_public_streams();
+            const tooltip_text = can_create_streams
+                ? $t({defaultMessage: "Add channels"})
+                : $t({defaultMessage: "Browse channels"});
+            instance.setContent(tooltip_text);
+        },
         appendTo: () => document.body,
     });
 

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -190,7 +190,7 @@
                 <h4 class="left-sidebar-title"><span class="streams-tooltip-target" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'CHANNELS' }}</span></h4>
                 <div class="left-sidebar-controls">
                     <i id="filter_streams_tooltip" class="streams_filter_icon zulip-icon zulip-icon-search" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
-                    <span id="add_streams_tooltip" class="hidden-for-spectators" data-tippy-content="{{t 'Add channels' }}">
+                    <span id="add_streams_tooltip" class="hidden-for-spectators">
                         <i id="streams_inline_icon" class="zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
                     </span>
                 </div>


### PR DESCRIPTION
Discussed here:
https://chat.zulip.org/#narrow/channel/101-design/topic/channel.20folders.20in.20left.20sidebar.20.2331972/near/2202343