### PR TITLE
rendered_markdown: Implement large emoji feature #15390.

### DIFF
--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -91,6 +91,42 @@ function wrap_mention_content_in_dom_element(element: HTMLElement, is_bot = fals
     return element;
 }
 
+// Function that verifies if the content of a message is
+// composed only by emojis.
+export function is_emojis_only_message($content: JQuery): boolean {
+    const $paragraphs = $content.find("p");
+
+    if ($paragraphs.length === 0) {
+        return false;
+    }
+
+    let i = 0;
+    while (i < $paragraphs.length) {
+        // Get each paragraph
+        const $p = $paragraphs.eq(i);
+
+        const $emojis = $p.find(".emoji");
+
+        // Checks if there are any emojis in the message
+        if ($emojis.length === 0) {
+            return false;
+        }
+
+        // If there are emojis, we remove them from the content
+        // And check if there is any text in the message
+        const $pClone = $p.clone();
+        $pClone.find(".emoji").remove();
+
+        const text = $pClone.text().trim();
+
+        if (text.length > 0) {
+            return false;
+        }
+        i += 1;
+    }
+    return true;
+}
+
 // Helper function to update a mentioned user's name.
 export function set_name_in_mention_element(
     element: HTMLElement,
@@ -380,5 +416,14 @@ export const update_elements = ($content: JQuery): void => {
             })
             .contents()
             .unwrap();
+    }
+
+    // Display emojis in a message as a larger version (32x32)
+    // if the message is composed only by emojis.
+    if (is_emojis_only_message($content)) {
+        const $emojis = $content.find(".emoji");
+        if (typeof $emojis.addClass === "function") {
+            $emojis.addClass("large-emoji");
+        }
     }
 };

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -381,6 +381,10 @@
             2
     );
 
+    /* Large emoji elements' sizing is a 32px square
+       at a 14px font size, for 2.2857em at 14px/1em. */
+    --length-line-oversize-block-largeemoji: 2.2857em;
+
     /* Legacy values */
     --legacy-body-line-height-unitless: calc(20 / 14);
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -247,6 +247,13 @@
         vertical-align: var(--line-fitted-vertical-align-offset-em);
     }
 
+    .large-emoji {
+        height: var(--length-line-oversize-block-largeemoji);
+        width: var(--length-line-oversize-block-largeemoji);
+        margin: var(--length-line-oversize-block-margin-adjust) auto;
+        vertical-align: var(--line-fitted-vertical-align-offset-em);
+    }
+
     /* Mentions and alert words */
     .user-group-mention,
     .user-mention,


### PR DESCRIPTION
In this commit, we implemented the new feature that renders emojis in a message as a larger version if the message is composed only by emojis. We also included tests.

We changed the web/src/rendered_markdown.ts file's update elements function. Now it checks the generated html, if the elements are all emojis, the emoji will be changed to large-emoji, a new class with size 32x32 instead of the regular 20x20. This way the content of the message does not have to be passed as arguments to any extra functions as it would have otherwise, making the code more efficient and more succinct.

We manually tested the following cases:

- Message with only one emoji.
- Message with multiple emoji.
- Message with one emoji and text.
- Message with multiple emoji and text.
- Message with emoji in different paragraphs.
- Message with emojis and text in different paragraphs.
- Message with one paragraph containing only emoji ans one paragraph with only text.

the feature worked as intended in all cases.

Fixes: #15390 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="795" alt="Captura de Tela 2025-06-30 às 16 27 46" src="https://github.com/user-attachments/assets/21f6f486-fdb6-4340-bd4d-52e95da6faff" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
