### PR TITLE
left_sidebar: Show channel folders in left sidebar

### DIFF
--- a/web/src/add_stream_options_popover.ts
+++ b/web/src/add_stream_options_popover.ts
@@ -31,8 +31,6 @@ export function initialize(): void {
             instance.setContent(parse_html(render_left_sidebar_stream_setting_popover()));
             popover_menus.on_show_prep(instance);
 
-            $("#streams_header").addClass("showing-streams-popover");
-
             //  When showing the popover menu, we want the
             // "Add channels" and the "Filter channels" tooltip
             //  to appear below the "Add channels" icon.
@@ -48,8 +46,6 @@ export function initialize(): void {
         onHidden(instance) {
             instance.destroy();
             popover_menus.popover_instances.stream_settings = null;
-
-            $("#streams_header").removeClass("showing-streams-popover");
 
             //  After the popover menu is closed, we want the
             //  "Add channels" and the "Filter channels" tooltip

--- a/web/src/add_stream_options_popover.ts
+++ b/web/src/add_stream_options_popover.ts
@@ -43,15 +43,6 @@ export function initialize(): void {
                 placement: "bottom",
             });
 
-            const filter_streams_tooltip: (tippy.ReferenceElement & HTMLElement) | undefined =
-                $("#filter_streams_tooltip").get(0);
-            // If `filter_streams_tooltip` is not triggered yet, this will set its initial placement.
-            assert(filter_streams_tooltip !== undefined);
-            filter_streams_tooltip.dataset.tippyPlacement = "bottom";
-            filter_streams_tooltip._tippy?.setProps({
-                placement: "bottom",
-            });
-
             return undefined;
         },
         onHidden(instance) {
@@ -68,14 +59,6 @@ export function initialize(): void {
                 $("#add_streams_tooltip").get(0);
             assert(add_streams_tooltip !== undefined);
             add_streams_tooltip._tippy?.setProps({
-                placement: "top",
-            });
-
-            const filter_streams_tooltip: (tippy.ReferenceElement & HTMLElement) | undefined =
-                $("#filter_streams_tooltip").get(0);
-            assert(filter_streams_tooltip !== undefined);
-            filter_streams_tooltip.dataset.tippyPlacement = "top";
-            filter_streams_tooltip._tippy?.setProps({
                 placement: "top",
             });
         },

--- a/web/src/channel_folders.ts
+++ b/web/src/channel_folders.ts
@@ -1,3 +1,4 @@
+import assert from "minimalistic-assert";
 import type {z} from "zod";
 
 import {FoldDict} from "./fold_dict.ts";
@@ -38,4 +39,10 @@ export function get_channel_folders(include_archived = false): ChannelFolder[] {
 
 export function is_valid_folder_id(folder_id: number): boolean {
     return channel_folder_by_id_dict.has(folder_id);
+}
+
+export function get_channel_folder_by_id(folder_id: number): ChannelFolder {
+    const folder = channel_folder_by_id_dict.get(folder_id);
+    assert(folder !== undefined);
+    return folder;
 }

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -838,11 +838,6 @@ export function initialize(): void {
 
     $("body").on("click", "#clear_search_topic_button", topic_list.clear_topic_search);
 
-    $(".streams_filter_icon").on("click", (e) => {
-        e.stopPropagation();
-        stream_list.toggle_filter_displayed(e);
-    });
-
     $("body").on("click", "#direct-messages-section-header.zoom-out", (e) => {
         if ($(e.target).closest("#show-all-direct-messages").length === 1) {
             // Let the browser handle the "direct message feed" widget.

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -430,7 +430,7 @@ export function process_escape_key(e) {
         }
 
         if (stream_list.searching()) {
-            stream_list.clear_and_hide_search();
+            stream_list.clear_search();
             return true;
         }
 
@@ -586,14 +586,6 @@ export function process_enter_key(e) {
     }
 
     if (processing_text()) {
-        if (stream_list.searching()) {
-            // This is sort of funny behavior, but I think
-            // the intention is that we want it super easy
-            // to close stream search.
-            stream_list.clear_and_hide_search();
-            return true;
-        }
-
         // Don't send the message if topic box is focused.
         if (compose.is_topic_input_focused()) {
             return true;

--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -2,6 +2,7 @@ import $ from "jquery";
 import _ from "lodash";
 import assert from "minimalistic-assert";
 
+import * as channel_folders from "./channel_folders.ts";
 import type {Filter} from "./filter.ts";
 import {localstorage} from "./localstorage.ts";
 import {page_params} from "./page_params.ts";
@@ -88,7 +89,7 @@ export function update_dom_with_unread_counts(
         assert(sub);
         if (sub.pin_to_top) {
             pinned_unread_count += stream_unread_count;
-        } else if (sub.folder_id) {
+        } else if (sub.folder_id !== null) {
             const prev_count = folder_unread_counts.get(sub.folder_id) ?? 0;
             folder_unread_counts.set(sub.folder_id, prev_count + stream_unread_count);
         } else if (stream_list_sort.has_recent_activity(sub)) {
@@ -110,7 +111,9 @@ export function update_dom_with_unread_counts(
         $("#stream-list-dormant-streams-container .heading-markers-and-unreads"),
         inactive_unread_count,
     );
-    for (const [folder_id, count] of folder_unread_counts.entries()) {
+    const channel_folder_ids = channel_folders.get_channel_folders().map((folder) => folder.id);
+    for (const folder_id of channel_folder_ids) {
+        const count = folder_unread_counts.get(folder_id) ?? 0;
         ui_util.update_unread_count_in_dom(
             $(`#stream-list-${folder_id}-container .heading-markers-and-unreads`),
             count,

--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -68,12 +68,11 @@ export function update_dom_with_unread_counts(
     // mentioned/home views have simple integer counts
     const $mentioned_li = $(".top_left_mentions");
     const $home_view_li = $(".selected-home-view");
-    const $streams_header = $("#streams_header");
     const $back_to_streams = $("#topics_header");
 
     ui_util.update_unread_count_in_dom($mentioned_li, counts.mentioned_message_count);
     ui_util.update_unread_count_in_dom($home_view_li, counts.home_unread_messages);
-    ui_util.update_unread_count_in_dom($streams_header, counts.stream_unread_messages);
+    // TODO(evy) display counts for each header
     ui_util.update_unread_count_in_dom($back_to_streams, counts.stream_unread_messages);
 
     if (!skip_animations) {

--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import _ from "lodash";
+import assert from "minimalistic-assert";
 
 import type {Filter} from "./filter.ts";
 import {localstorage} from "./localstorage.ts";
@@ -8,6 +9,8 @@ import * as people from "./people.ts";
 import * as resize from "./resize.ts";
 import * as scheduled_messages from "./scheduled_messages.ts";
 import * as settings_config from "./settings_config.ts";
+import * as stream_list_sort from "./stream_list_sort.ts";
+import * as sub_store from "./sub_store.ts";
 import * as ui_util from "./ui_util.ts";
 import * as unread from "./unread.ts";
 
@@ -72,8 +75,47 @@ export function update_dom_with_unread_counts(
 
     ui_util.update_unread_count_in_dom($mentioned_li, counts.mentioned_message_count);
     ui_util.update_unread_count_in_dom($home_view_li, counts.home_unread_messages);
-    // TODO(evy) display counts for each header
     ui_util.update_unread_count_in_dom($back_to_streams, counts.stream_unread_messages);
+
+    let pinned_unread_count = 0;
+    const folder_unread_counts = new Map<number, number>();
+    let normal_unread_count = 0;
+    let inactive_unread_count = 0;
+
+    for (const [stream_id, stream_count_info] of counts.stream_count.entries()) {
+        const stream_unread_count = stream_count_info.unmuted_count + stream_count_info.muted_count;
+        const sub = sub_store.get(stream_id);
+        assert(sub);
+        if (sub.pin_to_top) {
+            pinned_unread_count += stream_unread_count;
+        } else if (sub.folder_id) {
+            const prev_count = folder_unread_counts.get(sub.folder_id) ?? 0;
+            folder_unread_counts.set(sub.folder_id, prev_count + stream_unread_count);
+        } else if (stream_list_sort.has_recent_activity(sub)) {
+            normal_unread_count += stream_unread_count;
+        } else {
+            inactive_unread_count += stream_unread_count;
+        }
+    }
+
+    ui_util.update_unread_count_in_dom(
+        $("#stream-list-pinned-streams-container .heading-markers-and-unreads"),
+        pinned_unread_count,
+    );
+    ui_util.update_unread_count_in_dom(
+        $("#stream-list-normal-streams-container .heading-markers-and-unreads"),
+        normal_unread_count,
+    );
+    ui_util.update_unread_count_in_dom(
+        $("#stream-list-dormant-streams-container .heading-markers-and-unreads"),
+        inactive_unread_count,
+    );
+    for (const [folder_id, count] of folder_unread_counts.entries()) {
+        ui_util.update_unread_count_in_dom(
+            $(`#stream-list-${folder_id}-container .heading-markers-and-unreads`),
+            count,
+        );
+    }
 
     if (!skip_animations) {
         animate_mention_changes($mentioned_li, counts.mentioned_message_count);

--- a/web/src/left_sidebar_tooltips.ts
+++ b/web/src/left_sidebar_tooltips.ts
@@ -136,7 +136,9 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: ["#add_streams_tooltip"].join(","),
+        target: ["#add_streams_tooltip", ".stream-list-section-container .add_stream_tooltip"].join(
+            ",",
+        ),
         appendTo: () => document.body,
     });
 

--- a/web/src/left_sidebar_tooltips.ts
+++ b/web/src/left_sidebar_tooltips.ts
@@ -136,7 +136,7 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: ["#streams_header .streams-tooltip-target", "#add_streams_tooltip"].join(","),
+        target: ["#add_streams_tooltip"].join(","),
         appendTo: () => document.body,
     });
 

--- a/web/src/left_sidebar_tooltips.ts
+++ b/web/src/left_sidebar_tooltips.ts
@@ -136,11 +136,7 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: [
-            "#streams_header .streams-tooltip-target",
-            "#add_streams_tooltip",
-            "#filter_streams_tooltip",
-        ].join(","),
+        target: ["#streams_header .streams-tooltip-target", "#add_streams_tooltip"].join(","),
         appendTo: () => document.body,
     });
 

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -135,10 +135,10 @@ export function update_invite_user_option(): void {
 export function update_unread_counts_visibility(): void {
     const hidden = !user_settings.web_left_sidebar_unreads_count_summary;
 
-    const $streams_header: JQuery = $("#streams_header");
+    const $channel_sections: JQuery = $(".stream-list-subsection-header");
     const $home_view_li: JQuery = $(".top_left_row");
 
-    for (const $el of [$home_view_li, $streams_header]) {
+    for (const $el of [$home_view_li, $channel_sections]) {
         $el.toggleClass("hide-unread-messages-count", hidden);
     }
 }

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -5,16 +5,15 @@ import * as tippy from "tippy.js";
 
 import render_filter_topics from "../templates/filter_topics.hbs";
 import render_go_to_channel_feed_tooltip from "../templates/go_to_channel_feed_tooltip.hbs";
+import render_stream_list_section_container from "../templates/stream_list_section_container.hbs";
 import render_stream_privacy from "../templates/stream_privacy.hbs";
 import render_stream_sidebar_row from "../templates/stream_sidebar_row.hbs";
-import render_stream_subheader from "../templates/streams_subheader.hbs";
 import render_subscribe_to_more_streams from "../templates/subscribe_to_more_streams.hbs";
 
 import * as blueslip from "./blueslip.ts";
 import * as browser_history from "./browser_history.ts";
 import type {Filter} from "./filter.ts";
 import * as hash_util from "./hash_util.ts";
-import {$t} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
 import {ListCursor} from "./list_cursor.ts";
 import * as narrow_state from "./narrow_state.ts";
@@ -268,88 +267,50 @@ export function build_stream_list(force_rerender: boolean): void {
         return;
     }
 
-    const $parent = $("#stream_filters");
-    const elems = [];
-
-    function add_sidebar_li(stream_id: number): void {
+    function add_sidebar_li(stream_id: number, $list: JQuery): void {
         const sidebar_row = stream_sidebar.get_row(stream_id);
         assert(sidebar_row !== undefined);
         sidebar_row.update_whether_active();
-        elems.push(sidebar_row.get_li());
+        const $li = sidebar_row.get_li();
+        $list.append($li);
     }
 
     clear_topics();
-    $parent.empty();
-
-    const any_pinned_streams =
-        stream_groups.pinned_streams.length > 0 || stream_groups.muted_pinned_streams.length > 0;
-    const any_normal_streams =
-        stream_groups.normal_streams.length > 0 || stream_groups.muted_active_streams.length > 0;
-    const any_dormant_streams = stream_groups.dormant_streams.length > 0;
-
-    const need_section_subheaders =
-        (any_pinned_streams ? 1 : 0) +
-            (any_normal_streams ? 1 : 0) +
-            (any_dormant_streams ? 1 : 0) >=
-        2;
-
-    if (any_pinned_streams && need_section_subheaders) {
-        elems.push(
+    $("#stream_filters").empty();
+    for (const section of stream_groups.sections) {
+        $("#stream_filters").append(
             $(
-                render_stream_subheader({
-                    subheader_name: $t({
-                        defaultMessage: "Pinned",
-                    }),
+                render_stream_list_section_container({
+                    id: section.id,
+                    section_title: section.section_title,
                 }),
             ),
         );
-    }
+        const is_empty = section.streams.length === 0 && section.muted_streams.length === 0;
+        $(`#stream-list-${section.id}-container`).toggleClass("no-display", is_empty);
 
-    for (const stream_id of stream_groups.pinned_streams) {
-        add_sidebar_li(stream_id);
+        for (const stream_id of section.streams) {
+            add_sidebar_li(stream_id, $(`#stream-list-${section.id}`));
+        }
+        for (const stream_id of section.muted_streams) {
+            add_sidebar_li(stream_id, $(`#stream-list-${section.id}`));
+        }
     }
+    sidebar_ui.update_unread_counts_visibility();
+}
 
-    for (const stream_id of stream_groups.muted_pinned_streams) {
-        add_sidebar_li(stream_id);
-    }
-
-    if (any_normal_streams && need_section_subheaders) {
-        elems.push(
-            $(
-                render_stream_subheader({
-                    subheader_name: $t({
-                        defaultMessage: "Active",
-                    }),
-                }),
-            ),
-        );
-    }
-
-    for (const stream_id of stream_groups.normal_streams) {
-        add_sidebar_li(stream_id);
-    }
-
-    for (const stream_id of stream_groups.muted_active_streams) {
-        add_sidebar_li(stream_id);
-    }
-
-    if (any_dormant_streams && need_section_subheaders) {
-        elems.push(
-            $(
-                render_stream_subheader({
-                    subheader_name: $t({
-                        defaultMessage: "Inactive",
-                    }),
-                }),
-            ),
-        );
-    }
-
-    for (const stream_id of stream_groups.dormant_streams) {
-        add_sidebar_li(stream_id);
-    }
-
-    $parent.append(elems); // eslint-disable-line no-jquery/no-append-html
+function toggle_section_collapse($container: JQuery): void {
+    $container.toggleClass("collapsed");
+    const is_collapsed = $container.hasClass("collapsed");
+    const container_selector = $container.attr("id")!;
+    $(`#${container_selector} .stream-list-section-toggle`).toggleClass(
+        "rotate-icon-down",
+        !is_collapsed,
+    );
+    $(`#${container_selector} .stream-list-section-toggle`).toggleClass(
+        "rotate-icon-right",
+        is_collapsed,
+    );
 }
 
 export function get_stream_li(stream_id: number): JQuery | undefined {
@@ -411,9 +372,6 @@ export function zoom_in_topics(options: {stream_id: number | undefined}): void {
     $(".stream-filters-label").each(function () {
         $(this).hide();
     });
-    $(".streams_subheader").each(function () {
-        $(this).hide();
-    });
 
     $("#stream_filters li.narrow-filter").each(function () {
         const $elt = $(this);
@@ -433,9 +391,6 @@ export function zoom_in_topics(options: {stream_id: number | undefined}): void {
 export function zoom_out_topics(): void {
     // Show stream list titles and pinned stream splitter
     $(".stream-filters-label").each(function () {
-        $(this).show();
-    });
-    $(".streams_subheader").each(function () {
         $(this).show();
     });
 
@@ -1040,6 +995,15 @@ export function set_event_handlers({
         stream_cursor.clear();
     });
     $search_input.on("input", update_streams_for_search);
+
+    $(".stream-list-section-container").on(
+        "click",
+        ".stream-list-subsection-header",
+        function (this: HTMLElement, e: JQuery.ClickEvent) {
+            e.stopPropagation();
+            toggle_section_collapse($(this).closest(".stream-list-section-container"));
+        },
+    );
 }
 
 export function searching(): boolean {
@@ -1074,8 +1038,16 @@ function scroll_stream_into_view($stream_li: JQuery): void {
         blueslip.error("Invalid stream_li was passed in");
         return;
     }
-    const stream_header_height = $("#streams_header").outerHeight();
-    scroll_util.scroll_element_into_container($stream_li, $container, stream_header_height);
+    const stream_filter_height = $(".stream_search_section").outerHeight()!;
+    const header_height = $stream_li
+        .closest(".stream-list-section-container")
+        .children(".stream-list-subsection-header")
+        .outerHeight()!;
+    scroll_util.scroll_element_into_container(
+        $stream_li,
+        $container,
+        stream_filter_height + header_height,
+    );
 }
 
 export function maybe_scroll_narrow_into_view(first_messages_fetch_done: boolean): void {

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -277,12 +277,19 @@ export function build_stream_list(force_rerender: boolean): void {
 
     clear_topics();
     $("#stream_filters").empty();
+    const can_create_streams =
+        settings_data.user_can_create_private_streams() ||
+        settings_data.user_can_create_public_streams() ||
+        settings_data.user_can_create_web_public_streams();
     for (const section of stream_groups.sections) {
         $("#stream_filters").append(
             $(
                 render_stream_list_section_container({
                     id: section.id,
                     section_title: section.section_title,
+                    show_plus_icon:
+                        can_create_streams &&
+                        !["pinned-streams", "dormant-streams"].includes(section.id),
                 }),
             ),
         );
@@ -1004,6 +1011,11 @@ export function set_event_handlers({
             toggle_section_collapse($(this).closest(".stream-list-section-container"));
         },
     );
+
+    $(".stream-list-section-container").on("click", ".add_stream_icon_container", (e) => {
+        // To prevent toggling the header
+        e.stopPropagation();
+    });
 }
 
 export function searching(): boolean {

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -905,7 +905,7 @@ export function set_event_handlers({
             return;
         }
 
-        clear_and_hide_search();
+        clear_search();
         e.preventDefault();
         e.stopPropagation();
 
@@ -972,7 +972,10 @@ export function set_event_handlers({
         }
     });
 
-    $("#clear_search_stream_button").on("click", clear_search);
+    $("#clear_search_stream_button").on("click", (e: JQuery.ClickEvent) => {
+        e.stopPropagation();
+        clear_search();
+    });
 
     function toggle_pm_header_icon(): void {
         if (pm_list.is_private_messages_collapsed()) {
@@ -1010,7 +1013,7 @@ export function set_event_handlers({
             return;
         }
 
-        clear_and_hide_search();
+        clear_search();
         on_stream_click(stream_id, "sidebar enter key");
     }
 
@@ -1043,43 +1046,7 @@ export function searching(): boolean {
     return $(".stream-list-filter").expectOne().is(":focus");
 }
 
-export function clear_search(e: JQuery.ClickEvent): void {
-    e.stopPropagation();
-    const $filter = $(".stream-list-filter").expectOne();
-    if ($filter.val() === "") {
-        clear_and_hide_search();
-        return;
-    }
-    $filter.val("");
-    $filter.trigger("blur");
-    update_streams_for_search();
-}
-
-export function show_search_section(): void {
-    $("#streams_header").addClass("showing-stream-search-section");
-    $(".stream_search_section").expectOne().removeClass("notdisplayed");
-    resize.resize_stream_filters_container();
-}
-
-export function hide_search_section(): void {
-    $("#streams_header").removeClass("showing-stream-search-section");
-    $(".stream_search_section").expectOne().addClass("notdisplayed");
-    resize.resize_stream_filters_container();
-}
-
-export function initiate_search(): void {
-    popovers.hide_all();
-    show_search_section();
-
-    const $filter = $(".stream-list-filter").expectOne();
-
-    sidebar_ui.show_left_sidebar();
-    $filter.trigger("focus");
-
-    stream_cursor.reset();
-}
-
-export function clear_and_hide_search(): void {
+export function clear_search(): void {
     const $filter = $(".stream-list-filter").expectOne();
     if ($filter.val() !== "") {
         $filter.val("");
@@ -1087,17 +1054,17 @@ export function clear_and_hide_search(): void {
     }
     stream_cursor.clear();
     $filter.trigger("blur");
-
-    hide_search_section();
 }
 
-export function toggle_filter_displayed(e: JQuery.ClickEvent): void {
-    if ($(".stream_search_section.notdisplayed").length === 0) {
-        clear_and_hide_search();
-    } else {
-        initiate_search();
-    }
-    e.preventDefault();
+export function initiate_search(): void {
+    popovers.hide_all();
+
+    const $filter = $(".stream-list-filter").expectOne();
+
+    sidebar_ui.show_left_sidebar();
+    $filter.trigger("focus");
+
+    stream_cursor.reset();
 }
 
 function scroll_stream_into_view($stream_li: JQuery): void {

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -282,14 +282,21 @@ export function build_stream_list(force_rerender: boolean): void {
         settings_data.user_can_create_public_streams() ||
         settings_data.user_can_create_web_public_streams();
     for (const section of stream_groups.sections) {
+        let plus_icon_url;
+        if (can_create_streams && section.id === "normal-streams") {
+            plus_icon_url = "#channels/new";
+        } else if (
+            can_create_streams &&
+            !["pinned-streams", "dormant-streams"].includes(section.id)
+        ) {
+            plus_icon_url = `#channels/folders/${section.id}/new`;
+        }
         $("#stream_filters").append(
             $(
                 render_stream_list_section_container({
                     id: section.id,
                     section_title: section.section_title,
-                    show_plus_icon:
-                        can_create_streams &&
-                        !["pinned-streams", "dormant-streams"].includes(section.id),
+                    plus_icon_url,
                 }),
             ),
         );
@@ -1043,7 +1050,7 @@ export function initiate_search(): void {
     stream_cursor.reset();
 }
 
-function scroll_stream_into_view($stream_li: JQuery): void {
+export function scroll_stream_into_view($stream_li: JQuery): void {
     const $container = $("#left_sidebar_scroll_container");
 
     if ($stream_li.length !== 1) {

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -974,16 +974,6 @@ export function set_event_handlers({
 
     $("#clear_search_stream_button").on("click", clear_search);
 
-    $("#streams_header")
-        .expectOne()
-        .on("click", (e) => {
-            e.preventDefault();
-            if (e.target.id === "streams_inline_icon") {
-                return;
-            }
-            toggle_filter_displayed(e);
-        });
-
     function toggle_pm_header_icon(): void {
         if (pm_list.is_private_messages_collapsed()) {
             return;

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1038,7 +1038,7 @@ function scroll_stream_into_view($stream_li: JQuery): void {
         blueslip.error("Invalid stream_li was passed in");
         return;
     }
-    const stream_filter_height = $(".stream_search_section").outerHeight()!;
+    const stream_filter_height = $("#stream_search_and_add").outerHeight()!;
     const header_height = $stream_li
         .closest(".stream-list-section-container")
         .children(".stream-list-subsection-header")

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -1,5 +1,6 @@
 import assert from "minimalistic-assert";
 
+import {$t} from "./i18n.ts";
 import * as settings_config from "./settings_config.ts";
 import * as stream_data from "./stream_data.ts";
 import * as sub_store from "./sub_store.ts";
@@ -8,11 +9,7 @@ import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
 
 let first_render_completed = false;
-let previous_pinned: number[] = [];
-let previous_normal: number[] = [];
-let previous_dormant: number[] = [];
-let previous_muted_active: number[] = [];
-let previous_muted_pinned: number[] = [];
+let previous_sections: StreamListSection[] = [];
 let all_streams: number[] = [];
 
 // Because we need to check whether we are filtering inactive streams
@@ -71,13 +68,16 @@ export function has_recent_activity(sub: StreamSubscription): boolean {
     return sub.is_recently_active || sub.newly_subscribed;
 }
 
+type StreamListSection = {
+    id: string;
+    section_title: string;
+    streams: number[];
+    muted_streams: number[];
+};
+
 type StreamListSortResult = {
     same_as_before: boolean;
-    pinned_streams: number[];
-    normal_streams: number[];
-    dormant_streams: number[];
-    muted_pinned_streams: number[];
-    muted_active_streams: number[];
+    sections: StreamListSection[];
 };
 
 export function sort_groups(stream_ids: number[], search_term: string): StreamListSortResult {
@@ -95,74 +95,80 @@ export function sort_groups(stream_ids: number[], search_term: string): StreamLi
         return has_recent_activity(sub);
     }
 
-    const pinned_streams = [];
-    const normal_streams = [];
-    const muted_pinned_streams = [];
-    const muted_active_streams = [];
-    const dormant_streams = [];
+    const pinned_section: StreamListSection = {
+        id: "pinned-streams",
+        section_title: $t({defaultMessage: "PINNED CHANNELS"}),
+        streams: [],
+        muted_streams: [],
+    };
+    const normal_section: StreamListSection = {
+        id: "normal-streams",
+        section_title: $t({defaultMessage: "ACTIVE CHANNELS"}),
+        streams: [],
+        muted_streams: [],
+    };
+    const dormant_section: StreamListSection = {
+        id: "dormant-streams",
+        section_title: $t({defaultMessage: "INACTIVE CHANNELS"}),
+        streams: [],
+        muted_streams: [], // Not used for the dormant section
+    };
 
     for (const stream_id of stream_ids) {
         const sub = sub_store.get(stream_id);
         assert(sub);
-        const pinned = sub.pin_to_top;
         if (sub.is_archived) {
             continue;
         }
-        if (pinned) {
-            if (!sub.is_muted) {
-                pinned_streams.push(stream_id);
+        if (sub.pin_to_top) {
+            if (sub.is_muted) {
+                pinned_section.muted_streams.push(stream_id);
             } else {
-                muted_pinned_streams.push(stream_id);
+                pinned_section.streams.push(stream_id);
             }
         } else if (is_normal(sub)) {
-            if (!sub.is_muted) {
-                normal_streams.push(stream_id);
+            if (sub.is_muted) {
+                normal_section.muted_streams.push(stream_id);
             } else {
-                muted_active_streams.push(stream_id);
+                normal_section.streams.push(stream_id);
             }
         } else {
-            dormant_streams.push(stream_id);
+            dormant_section.streams.push(stream_id);
         }
     }
 
-    pinned_streams.sort(compare_function);
-    normal_streams.sort(compare_function);
-    muted_pinned_streams.sort(compare_function);
-    muted_active_streams.sort(compare_function);
-    dormant_streams.sort(compare_function);
+    // This needs to have the same ordering as the order they're displayed in the sidebar.
+    const sections = [pinned_section, normal_section, dormant_section];
+
+    for (const section of sections) {
+        section.streams.sort(compare_function);
+        section.muted_streams.sort(compare_function);
+    }
 
     const same_as_before =
         first_render_completed &&
-        util.array_compare(previous_pinned, pinned_streams) &&
-        util.array_compare(previous_normal, normal_streams) &&
-        util.array_compare(previous_muted_pinned, muted_pinned_streams) &&
-        util.array_compare(previous_muted_active, muted_active_streams) &&
-        util.array_compare(previous_dormant, dormant_streams);
+        sections.entries().every((entry) => {
+            const i = entry[0];
+            const section = entry[1];
+            const previous_section = previous_sections.at(i);
+            return (
+                previous_section !== undefined &&
+                section.id === previous_section.id &&
+                section.section_title === previous_section.section_title &&
+                util.array_compare(section.streams, previous_section.streams) &&
+                util.array_compare(section.muted_streams, previous_section.muted_streams)
+            );
+        });
 
     if (!same_as_before) {
         first_render_completed = true;
-        previous_pinned = pinned_streams;
-        previous_normal = normal_streams;
-        previous_muted_pinned = muted_pinned_streams;
-        previous_muted_active = muted_active_streams;
-        previous_dormant = dormant_streams;
-
-        all_streams = [
-            ...pinned_streams,
-            ...muted_pinned_streams,
-            ...normal_streams,
-            ...muted_active_streams,
-            ...dormant_streams,
-        ];
+        previous_sections = sections;
+        all_streams = sections.flatMap((section) => [...section.streams, ...section.muted_streams]);
     }
 
     return {
         same_as_before,
-        pinned_streams,
-        normal_streams,
-        dormant_streams,
-        muted_pinned_streams,
-        muted_active_streams,
+        sections,
     };
 }
 

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -1,5 +1,6 @@
 import assert from "minimalistic-assert";
 
+import * as channel_folders from "./channel_folders.ts";
 import {$t} from "./i18n.ts";
 import * as settings_config from "./settings_config.ts";
 import * as stream_data from "./stream_data.ts";
@@ -55,7 +56,7 @@ export function is_filtering_inactives(): boolean {
 }
 
 export function has_recent_activity(sub: StreamSubscription): boolean {
-    if (!filter_out_inactives || sub.pin_to_top) {
+    if (!filter_out_inactives || sub.pin_to_top || sub.folder_id) {
         // If users don't want to filter inactive streams
         // to the bottom, we respect that setting and don't
         // treat any streams as dormant.
@@ -103,7 +104,7 @@ export function sort_groups(stream_ids: number[], search_term: string): StreamLi
     };
     const normal_section: StreamListSection = {
         id: "normal-streams",
-        section_title: $t({defaultMessage: "ACTIVE CHANNELS"}),
+        section_title: $t({defaultMessage: "OTHER CHANNELS"}),
         streams: [],
         muted_streams: [],
     };
@@ -113,6 +114,8 @@ export function sort_groups(stream_ids: number[], search_term: string): StreamLi
         streams: [],
         muted_streams: [], // Not used for the dormant section
     };
+
+    const folder_sections = new Map<number, StreamListSection>();
 
     for (const stream_id of stream_ids) {
         const sub = sub_store.get(stream_id);
@@ -126,6 +129,23 @@ export function sort_groups(stream_ids: number[], search_term: string): StreamLi
             } else {
                 pinned_section.streams.push(stream_id);
             }
+        } else if (sub.folder_id) {
+            const folder = channel_folders.get_channel_folder_by_id(sub.folder_id);
+            let section = folder_sections.get(sub.folder_id);
+            if (!section) {
+                section = {
+                    id: sub.folder_id.toString(),
+                    section_title: folder.name.toUpperCase(),
+                    streams: [],
+                    muted_streams: [],
+                };
+                folder_sections.set(sub.folder_id, section);
+            }
+            if (sub.is_muted) {
+                section.muted_streams.push(stream_id);
+            } else {
+                section.streams.push(stream_id);
+            }
         } else if (is_normal(sub)) {
             if (sub.is_muted) {
                 normal_section.muted_streams.push(stream_id);
@@ -137,8 +157,21 @@ export function sort_groups(stream_ids: number[], search_term: string): StreamLi
         }
     }
 
+    const folder_sections_sorted = [...folder_sections.values()].sort((section_a, section_b) =>
+        util.strcmp(section_a.section_title, section_b.section_title),
+    );
+
     // This needs to have the same ordering as the order they're displayed in the sidebar.
-    const sections = [pinned_section, normal_section, dormant_section];
+    const sections = [pinned_section, ...folder_sections_sorted, normal_section, dormant_section];
+
+    // Don't call it "other channels" if there's nothing above it.
+    if (
+        folder_sections_sorted.length === 0 &&
+        pinned_section.streams.length === 0 &&
+        pinned_section.muted_streams.length === 0
+    ) {
+        normal_section.section_title = $t({defaultMessage: "CHANNELS"});
+    }
 
     for (const section of sections) {
         section.streams.sort(compare_function);

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -243,6 +243,11 @@ export function update_is_default_stream(): void {
 export function update_channel_folder(sub: StreamSubscription, folder_id: number | null): void {
     stream_data.update_channel_folder(sub, folder_id);
     stream_ui_updates.update_channel_folder_dropdown(sub);
+    stream_list.build_stream_list(false);
+    const $stream_li = stream_list.get_stream_li(sub.stream_id);
+    if ($stream_li) {
+        stream_list.scroll_stream_into_view($stream_li);
+    }
 }
 
 export function update_subscribers_ui(sub: StreamSubscription): void {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -32,8 +32,7 @@
     margin-right: var(--left-sidebar-right-margin);
 }
 
-#streams_inline_icon,
-.streams_filter_icon {
+#streams_inline_icon {
     color: var(--color-left-sidebar-heads-up-icon);
     border-radius: 3px;
 
@@ -44,10 +43,6 @@
         );
         cursor: pointer;
     }
-}
-
-.streams_filter_icon.web_public {
-    margin-right: 10px;
 }
 
 .masked_unread_count {
@@ -1765,18 +1760,6 @@ li.topic-list-item {
         }
     }
 
-    #filter_streams_tooltip {
-        display: none;
-        align-items: center;
-        justify-content: center;
-        grid-row: 1 / 1;
-        margin: 2px 0;
-
-        @media (hover: none) {
-            display: flex;
-        }
-    }
-
     #add_streams_tooltip {
         grid-row: 1 / 1;
         margin: 2px 0;
@@ -1809,7 +1792,6 @@ li.topic-list-item {
             opacity: var(--opacity-sidebar-heading-hover);
         }
 
-        #filter_streams_tooltip,
         #streams_inline_icon {
             display: flex;
         }
@@ -1826,14 +1808,15 @@ li.topic-list-item {
     }
 }
 
-.stream_search_section,
+.stream_search_section {
+    .stream-list-filter:placeholder-shown + #clear_search_stream_button {
+        visibility: hidden;
+    }
+}
+
 .direct-messages-search-section {
     .direct-messages-list-filter:placeholder-shown
         + #clear-direct-messages-search-button {
-        visibility: hidden;
-    }
-
-    .stream-list-filter:placeholder-shown + #clear_search_stream_button {
         visibility: hidden;
     }
 }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -32,9 +32,16 @@
     margin-right: var(--left-sidebar-right-margin);
 }
 
-#streams_inline_icon {
-    color: var(--color-left-sidebar-heads-up-icon);
+.add_stream_icon_container {
+    grid-area: add-channel;
+    display: grid;
+    place-items: center center;
+    margin: 2px 0;
     border-radius: 3px;
+
+    .add_stream_icon {
+        color: var(--color-left-sidebar-heads-up-icon);
+    }
 
     &:hover {
         color: var(--color-left-sidebar-heads-up-icon-hover);
@@ -289,15 +296,26 @@
     }
 }
 
-.stream_search_section {
+.spectator-view #stream_search_and_add {
+    grid-template-columns: minmax(0, 1fr);
+}
+
+#stream_search_and_add {
+    display: grid;
+    grid-template-areas: "filter add-channel";
+    grid-template-columns: minmax(0, 1fr) var(--left-sidebar-header-icon-width);
     position: sticky;
     top: 0;
     /* Must be more than .stream-list-subsection-header */
     z-index: 3;
-    white-space: nowrap;
+    background: var(--color-background);
     /* Must be padding not margin so that the sticky headers don't show behind it */
     padding: var(--left-sidebar-sections-vertical-gutter)
         var(--left-sidebar-right-margin) 3px 5px;
+
+    .stream_search_section {
+        white-space: nowrap;
+    }
 
     .stream-list-filter {
         grid-area: filter-box;
@@ -323,7 +341,7 @@
     /* input is 1.4em tall with 4px top/bottom padding and 1px border
        input container has 8px and 3px top/bottom padding = 21px total padding */
     top: calc(1.4em + 21px);
-    /* Must be more than .sidebar-topic-check and less than .stream_search_section */
+    /* Must be more than .sidebar-topic-check and less than #stream_search_and_add */
     z-index: 2;
     color: var(--color-text-default);
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -333,14 +333,14 @@
     /* There's no three-dot menu here, but we still want the markers to line-up with
        markers in other rows that do have three-dot menus. */
     grid-template:
-        "arrow row-content add-channel three-dot-placeholder" var(
+        "arrow row-content add-channel markers-and-unreads three-dot-placeholder" var(
             --line-height-sidebar-row-prominent
         )
         / var(--right-sidebar-header-icon-toggle-width) minmax(0, 1fr) minmax(
             0,
             max-content
         )
-        var(--left-sidebar-vdots-width);
+        minmax(0, max-content) var(--left-sidebar-vdots-width);
     cursor: pointer;
     background-color: var(--color-background);
     position: sticky;
@@ -384,6 +384,20 @@
     .stream-list-section-toggle {
         color: var(--color-text-sidebar-heading);
         opacity: var(--opacity-sidebar-heading-icon);
+    }
+
+    .heading-markers-and-unreads {
+        grid-area: markers-and-unreads;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        grid-gap: 5px;
+        /* Extra margin for unreads. */
+        margin-right: var(--left-sidebar-unread-offset);
+
+        &:has(.unread_count:empty) {
+            margin-right: 0;
+        }
     }
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -330,11 +330,17 @@
 .stream-list-subsection-header {
     display: grid;
     align-items: center;
+    /* There's no three-dot menu here, but we still want the markers to line-up with
+       markers in other rows that do have three-dot menus. */
     grid-template:
-        "arrow row-content scroll-buffer" var(
+        "arrow row-content add-channel three-dot-placeholder" var(
             --line-height-sidebar-row-prominent
         )
-        / var(--right-sidebar-header-icon-toggle-width) minmax(0, 1fr);
+        / var(--right-sidebar-header-icon-toggle-width) minmax(0, 1fr) minmax(
+            0,
+            max-content
+        )
+        var(--left-sidebar-vdots-width);
     cursor: pointer;
     background-color: var(--color-background);
     position: sticky;
@@ -344,6 +350,18 @@
     /* Must be more than .sidebar-topic-check and less than #stream_search_and_add */
     z-index: 2;
     color: var(--color-text-default);
+
+    .add_stream_icon_container {
+        text-decoration: none;
+        grid-auto-columns: var(--left-sidebar-header-icon-width);
+        grid-template-rows: calc(
+            var(--line-height-sidebar-row-prominent) - 4px
+        );
+    }
+
+    .add_stream_icon {
+        display: none;
+    }
 
     &:hover {
         background-color: var(--color-background-opaque-hover-narrow-filter);
@@ -356,6 +374,10 @@
         .left-sidebar-title,
         .stream-list-section-toggle {
             opacity: var(--opacity-sidebar-heading-hover);
+        }
+
+        .add_stream_icon {
+            display: grid;
         }
     }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -300,8 +300,8 @@
         var(--left-sidebar-right-margin) 3px 5px;
 
     .stream-list-filter {
-       grid-area: filter-box;
-       padding-right: var(--line-height-sidebar-row-prominent);
+        grid-area: filter-box;
+        padding-right: var(--line-height-sidebar-row-prominent);
     }
 
     .stream-list-filter:placeholder-shown + #clear_search_stream_button {
@@ -1088,7 +1088,6 @@ li.top_left_scheduled_messages {
 }
 
 #direct-messages-section-header,
-#streams_header,
 #topics_header {
     display: grid;
     align-items: center;
@@ -1782,122 +1781,10 @@ li.topic-list-item {
     }
 }
 
-#streams_header {
-    grid-template-columns:
-        var(--left-sidebar-toggle-width-offset) 0 0 minmax(0, 1fr) minmax(
-            0,
-            max-content
-        )
-        minmax(0, max-content) var(--left-sidebar-vdots-width)
-        0;
-    /* Keep the stream-search area rows collapsed. */
-    grid-template-rows: var(--line-height-sidebar-row-prominent) 0 0;
-    cursor: pointer;
-    margin: var(--left-sidebar-sections-vertical-gutter)
-        var(--left-sidebar-right-margin) 3px 0;
-    position: sticky;
-    /* Keep sticky within SimpleBar context. The -0.25px
-    offset ensures that no gap is present between the
-    direct-messages-section-header and the streams-header */
-    top: -0.25px;
-    z-index: 2;
-    background-color: var(--color-background);
-
-    &.showing-stream-search-section {
-        /* Open up the stream-search rows. The 3px gap + 7px
-           row maintains space with the streams list
-           below. */
-        grid-template-rows: var(--line-height-sidebar-row-prominent) auto 7px;
-        row-gap: 3px;
-
-        /* When the search section is showing, switch
-           off the hover effects on the row. */
-        &:hover {
-            background-color: var(--color-background);
-            box-shadow: unset;
-        }
-    }
-
-    .left-sidebar-title {
-        grid-area: row-content;
-    }
-
-    .heading-markers-and-unreads {
-        grid-area: markers-and-unreads;
-        height: 100%;
-        display: flex;
-        align-items: center;
-        grid-gap: 5px;
-        /* Extra margin for unreads. */
-        margin-right: var(--left-sidebar-unread-offset);
-
-        &:has(.unread_count:empty) {
-            margin-right: 0;
-        }
-    }
-
-    #add_streams_tooltip {
-        grid-row: 1 / 1;
-        margin: 2px 0;
-    }
-
-    #streams_inline_icon {
-        display: none;
-        align-items: center;
-        justify-content: center;
-        /* Ensure the clickable area grows to
-           the height of the controls grid. */
-        height: 100%;
-
-        @media (hover: none) {
-            display: flex;
-        }
-    }
-
-    &:hover,
-    &.showing-streams-popover {
-        /* We only set the border radius on the hover/popover states,
-           so as to prevent the background on highlighted channels
-           from bleeding through. */
-        border-radius: 4px;
-        background-color: var(--color-background-opaque-hover-narrow-filter);
-        box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
-
-        .left-sidebar-title,
-        .sidebar-heading-icon {
-            opacity: var(--opacity-sidebar-heading-hover);
-        }
-
-        #streams_inline_icon {
-            display: flex;
-        }
-    }
-}
-
 .direct-messages-search-section {
     .direct-messages-list-filter:placeholder-shown
         + #clear-direct-messages-search-button {
         visibility: hidden;
-    }
-}
-
-/* Prepare an adjusted grid for the logged-out state,
-   one that reassigns the vdots space to markers and
-   controls. */
-.spectator-view #streams_header {
-    grid-template-columns:
-        var(--left-sidebar-toggle-width-offset) 0 0 minmax(0, 1fr) 0
-        minmax(var(--left-sidebar-vdots-width), max-content) 0 0;
-    margin-right: var(--left-sidebar-right-margin);
-
-    /* With markers and controls now sized the same
-       as the ordinary vdots area (but allowed to grow,
-       care of `minmax(30px, max-content)`, should
-       additional logged-out icons be added in the
-       future), let's center the icon in that area,
-       just like vdots would be. */
-    .heading-markers-and-unreads {
-        justify-content: center;
     }
 }
 
@@ -1921,8 +1808,7 @@ li.topic-list-item {
         position: sticky;
         /* We subtract a quarter pixel of space to correct
            for possible bleedthrough under certain viewing
-           conditions (e.g., external monitors.) This same
-           technique is used on #streams_header. */
+           conditions (e.g., external monitors.) */
         top: -0.25px;
         z-index: 2;
         padding-bottom: 1px;
@@ -1935,7 +1821,6 @@ li.topic-list-item {
         }
     }
 
-    #streams_header,
     #subscribe-to-more-streams,
     #login-to-more-streams,
     .show-more-topics {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -65,8 +65,8 @@
     }
 }
 
-.selected-home-view,
-#streams_header {
+#left-sidebar-navigation-list .selected-home-view,
+.stream-list-subsection-header {
     &.hide-unread-messages-count {
         .masked_unread_count {
             display: flex;
@@ -84,8 +84,8 @@
     }
 }
 
-.selected-home-view:hover,
-#streams_header:hover,
+#left-sidebar-navigation-list .selected-home-view:hover,
+.stream-list-subsection-header:hover,
 .selected-home-view.top-left-active-filter {
     &.hide-unread-messages-count {
         .masked_unread_count {
@@ -286,6 +286,82 @@
         #show-all-direct-messages {
             display: flex;
         }
+    }
+}
+
+.stream_search_section {
+    position: sticky;
+    top: 0;
+    /* Must be more than .stream-list-subsection-header */
+    z-index: 3;
+    white-space: nowrap;
+    /* Must be padding not margin so that the sticky headers don't show behind it */
+    padding: var(--left-sidebar-sections-vertical-gutter)
+        var(--left-sidebar-right-margin) 3px 5px;
+
+    .stream-list-filter {
+       grid-area: filter-box;
+       padding-right: var(--line-height-sidebar-row-prominent);
+    }
+
+    .stream-list-filter:placeholder-shown + #clear_search_stream_button {
+        visibility: hidden;
+    }
+}
+
+.stream-list-subsection-header {
+    display: grid;
+    align-items: center;
+    grid-template:
+        "arrow row-content scroll-buffer" var(
+            --line-height-sidebar-row-prominent
+        )
+        / var(--right-sidebar-header-icon-toggle-width) minmax(0, 1fr);
+    cursor: pointer;
+    background-color: var(--color-background);
+    position: sticky;
+    /* input is 1.4em tall with 4px top/bottom padding and 1px border
+       input container has 8px and 3px top/bottom padding = 21px total padding */
+    top: calc(1.4em + 21px);
+    /* Must be more than .sidebar-topic-check and less than .stream_search_section */
+    z-index: 2;
+    color: var(--color-text-default);
+
+    &:hover {
+        background-color: var(--color-background-opaque-hover-narrow-filter);
+        box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
+        /* We only set the border radius on the hover/popover states,
+           so as to prevent the background on highlighted channels
+           from bleeding through. */
+        border-radius: 4px;
+
+        .left-sidebar-title,
+        .stream-list-section-toggle {
+            opacity: var(--opacity-sidebar-heading-hover);
+        }
+    }
+
+    .stream-list-section-toggle {
+        color: var(--color-text-sidebar-heading);
+        opacity: var(--opacity-sidebar-heading-icon);
+    }
+}
+
+.stream-list-section {
+    margin: 0;
+}
+
+.stream-list-section-container {
+    margin-top: 10px;
+
+    &.no-display {
+        display: none;
+    }
+}
+
+.stream-list-section-container.collapsed {
+    .stream-list-section {
+        display: none;
     }
 }
 
@@ -1353,7 +1429,7 @@ li.top_left_scheduled_messages {
     /* As a grid item, adjust the checkmark's z-index here so
        that the background color appears above the grouping
        bracket's bottom line. Its value must less than
-       the z-index set on the #streams_header selector. */
+       the z-index set on .stream-list-subsection-header */
     z-index: 1;
 }
 
@@ -1796,22 +1872,6 @@ li.topic-list-item {
             display: flex;
         }
     }
-
-    .stream_search_section {
-        grid-area: filter-box;
-        white-space: nowrap;
-    }
-
-    .stream-list-filter {
-        grid-area: filter-box;
-        padding-right: var(--line-height-sidebar-row-prominent);
-    }
-}
-
-.stream_search_section {
-    .stream-list-filter:placeholder-shown + #clear_search_stream_button {
-        visibility: hidden;
-    }
 }
 
 .direct-messages-search-section {
@@ -1841,49 +1901,6 @@ li.topic-list-item {
     }
 }
 
-.streams_subheader {
-    /* 14px at 16px/1em */
-    font-size: 0.875em;
-    font-weight: normal;
-    /* 16px line-height at 0.8em (11.2px at 14px legacy em) */
-    line-height: 1.4286em;
-    letter-spacing: 0.04em;
-    padding-left: var(--left-sidebar-toggle-width-offset);
-    cursor: pointer;
-    text-align: center;
-    margin-right: var(--left-sidebar-right-margin);
-
-    & .streams-subheader-wrapper {
-        display: flex;
-        flex-direction: row;
-        width: 100%;
-        left: 0.5em;
-        right: 0.5em;
-        color: var(--color-text-sidebar-base);
-    }
-
-    & .streams-subheader-wrapper::before,
-    .streams-subheader-wrapper::after {
-        content: " ";
-        flex: 1 1;
-        vertical-align: middle;
-        margin: auto;
-        border-top: 1px solid var(--color-border-sidebar-subheader);
-    }
-
-    & .streams-subheader-wrapper::before {
-        margin-right: 0.2em;
-    }
-
-    & .streams-subheader-wrapper::after {
-        margin-left: 0.2em;
-    }
-
-    .streams-subheader-name {
-        opacity: 0.4;
-    }
-}
-
 .direct-messages-list-filter,
 .stream-list-filter {
     white-space: nowrap;
@@ -1906,10 +1923,7 @@ li.topic-list-item {
            for possible bleedthrough under certain viewing
            conditions (e.g., external monitors.) This same
            technique is used on #streams_header. */
-        top: calc(
-            var(--left-sidebar-sections-vertical-gutter) +
-                var(--line-height-sidebar-row-prominent) - 0.25px
-        );
+        top: -0.25px;
         z-index: 2;
         padding-bottom: 1px;
         background-color: var(--color-background);

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -186,11 +186,16 @@
         </div>
 
         <div id="streams_list" class="zoom-out">
-            <div class="stream_search_section left-sidebar-filter-row">
-                <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter channels' }}" />
-                <button type="button" class="clear_search_button" id="clear_search_stream_button">
-                    <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
-                </button>
+            <div id="stream_search_and_add" class="zoom-in-hide">
+                <div class="stream_search_section left-sidebar-filter-row">
+                    <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter channels' }}" />
+                    <button type="button" class="clear_search_button" id="clear_search_stream_button">
+                        <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
+                    </button>
+                </div>
+                <span id="add_streams_tooltip" class="add_stream_icon_container hidden-for-spectators" data-tippy-content="{{t 'Add channels' }}">
+                    <i id="streams_inline_icon" class="add_stream_icon zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
+                </span>
             </div>
             <div id="topics_header">
                 <a class="show-all-streams" tabindex="0">{{t 'Back to channels' }}</a> <span class="unread_count quiet-count"></span>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -186,22 +186,6 @@
         </div>
 
         <div id="streams_list" class="zoom-out">
-            {{!-- TODO(evy) remove #streams_header completely, but for smaller reviewable commits I'm just
-            hiding the header for now --}}
-            <div id="streams_header" style="display: none;" class="showing-stream-search-section zoom-in-hide">
-                <h4 class="left-sidebar-title"><span class="streams-tooltip-target">{{t 'CHANNELS' }}</span></h4>
-                <div class="left-sidebar-controls">
-                    <span id="add_streams_tooltip" class="hidden-for-spectators" data-tippy-content="{{t 'Add channels' }}">
-                        <i id="streams_inline_icon" class="zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
-                    </span>
-                </div>
-                <div class="heading-markers-and-unreads">
-                    <span class="unread_count quiet-count"></span>
-                    <span class="masked_unread_count">
-                        <i class="zulip-icon zulip-icon-masked-unread"></i>
-                    </span>
-                </div>
-            </div>
             <div class="stream_search_section left-sidebar-filter-row">
                 <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter channels' }}" />
                 <button type="button" class="clear_search_button" id="clear_search_stream_button">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -186,7 +186,9 @@
         </div>
 
         <div id="streams_list" class="zoom-out">
-            <div id="streams_header" class="showing-stream-search-section zoom-in-hide">
+            {{!-- TODO(evy) remove #streams_header completely, but for smaller reviewable commits I'm just
+            hiding the header for now --}}
+            <div id="streams_header" style="display: none;" class="showing-stream-search-section zoom-in-hide">
                 <h4 class="left-sidebar-title"><span class="streams-tooltip-target">{{t 'CHANNELS' }}</span></h4>
                 <div class="left-sidebar-controls">
                     <span id="add_streams_tooltip" class="hidden-for-spectators" data-tippy-content="{{t 'Add channels' }}">
@@ -199,12 +201,12 @@
                         <i class="zulip-icon zulip-icon-masked-unread"></i>
                     </span>
                 </div>
-                <div class="stream_search_section left-sidebar-filter-row">
-                    <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter channels' }}" />
-                    <button type="button" class="clear_search_button" id="clear_search_stream_button">
-                        <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
-                    </button>
-                </div>
+            </div>
+            <div class="stream_search_section left-sidebar-filter-row">
+                <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter channels' }}" />
+                <button type="button" class="clear_search_button" id="clear_search_stream_button">
+                    <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
+                </button>
             </div>
             <div id="topics_header">
                 <a class="show-all-streams" tabindex="0">{{t 'Back to channels' }}</a> <span class="unread_count quiet-count"></span>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -186,10 +186,9 @@
         </div>
 
         <div id="streams_list" class="zoom-out">
-            <div id="streams_header" class="zoom-in-hide">
-                <h4 class="left-sidebar-title"><span class="streams-tooltip-target" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'CHANNELS' }}</span></h4>
+            <div id="streams_header" class="showing-stream-search-section zoom-in-hide">
+                <h4 class="left-sidebar-title"><span class="streams-tooltip-target">{{t 'CHANNELS' }}</span></h4>
                 <div class="left-sidebar-controls">
-                    <i id="filter_streams_tooltip" class="streams_filter_icon zulip-icon zulip-icon-search" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
                     <span id="add_streams_tooltip" class="hidden-for-spectators" data-tippy-content="{{t 'Add channels' }}">
                         <i id="streams_inline_icon" class="zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
                     </span>
@@ -200,8 +199,7 @@
                         <i class="zulip-icon zulip-icon-masked-unread"></i>
                     </span>
                 </div>
-
-                <div class="notdisplayed stream_search_section left-sidebar-filter-row">
+                <div class="stream_search_section left-sidebar-filter-row">
                     <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter channels' }}" />
                     <button type="button" class="clear_search_button" id="clear_search_stream_button">
                         <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>

--- a/web/templates/stream_list_section_container.hbs
+++ b/web/templates/stream_list_section_container.hbs
@@ -1,0 +1,9 @@
+<div id="stream-list-{{id}}-container" class="stream-list-section-container">
+    <div class="stream-list-subsection-header zoom-in-hide">
+        <i class="stream-list-section-toggle zulip-icon zulip-icon-heading-triangle-right rotate-icon-down" aria-hidden="true"></i>
+        <h4 class="left-sidebar-title">
+            {{section_title}}
+        </h4>
+    </div>
+    <ul id="stream-list-{{id}}" class="stream-list-section"></ul>
+</div>

--- a/web/templates/stream_list_section_container.hbs
+++ b/web/templates/stream_list_section_container.hbs
@@ -4,6 +4,11 @@
         <h4 class="left-sidebar-title">
             {{section_title}}
         </h4>
+        {{#if show_plus_icon}}
+        <a href="#channels/new" class="add_stream_tooltip add_stream_icon_container hidden-for-spectators" data-tippy-content="{{t 'Create a channel' }}">
+            <i class="add_stream_icon zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
+        </a>
+        {{/if}}
     </div>
     <ul id="stream-list-{{id}}" class="stream-list-section"></ul>
 </div>

--- a/web/templates/stream_list_section_container.hbs
+++ b/web/templates/stream_list_section_container.hbs
@@ -4,8 +4,8 @@
         <h4 class="left-sidebar-title">
             {{section_title}}
         </h4>
-        {{#if show_plus_icon}}
-        <a href="#channels/new" class="add_stream_tooltip add_stream_icon_container hidden-for-spectators" data-tippy-content="{{t 'Create a channel' }}">
+        {{#if plus_icon_url}}
+        <a href="{{plus_icon_url}}" class="add_stream_tooltip add_stream_icon_container hidden-for-spectators" data-tippy-content="{{t 'Create a channel' }}">
             <i class="add_stream_icon zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
         </a>
         {{/if}}

--- a/web/templates/stream_list_section_container.hbs
+++ b/web/templates/stream_list_section_container.hbs
@@ -9,6 +9,12 @@
             <i class="add_stream_icon zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
         </a>
         {{/if}}
+        <div class="heading-markers-and-unreads">
+            <span class="unread_count quiet-count"></span>
+            <span class="masked_unread_count">
+                <i class="zulip-icon zulip-icon-masked-unread"></i>
+            </span>
+        </div>
     </div>
     <ul id="stream-list-{{id}}" class="stream-list-section"></ul>
 </div>

--- a/web/templates/streams_subheader.hbs
+++ b/web/templates/streams_subheader.hbs
@@ -1,7 +1,0 @@
-<div class="streams_subheader">
-    <span class="streams-subheader-wrapper">
-        <span class="streams-subheader-name">
-            {{ subheader_name }}
-        </span>
-    </span>
-</div>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -171,10 +171,6 @@
         <div class="tootlip-inner-content views-message-count italic"></div>
     </div>
 </template>
-<template id="filter-streams-tooltip-template">
-    {{t 'Filter channels' }}
-    {{tooltip_hotkey_hints "Q"}}
-</template>
 <template id="message-expander-tooltip-template">
     {{t 'Show more' }}
     {{tooltip_hotkey_hints "-"}}

--- a/web/tests/stream_list.test.cjs
+++ b/web/tests/stream_list.test.cjs
@@ -147,22 +147,6 @@ function create_social_sidebar_row({mock_template}) {
     assert.equal($social_unread_mention_info.text(), "@");
 }
 
-function create_stream_subheader({mock_template}) {
-    mock_template("streams_subheader.hbs", false, (data) => {
-        if (data.subheader_name === "translated: Pinned") {
-            pinned_subheader_flag = true;
-            return "<pinned-subheader-stub>";
-        } else if (data.subheader_name === "translated: Active") {
-            active_subheader_flag = true;
-            return "<active-subheader-stub>";
-        }
-
-        assert.ok(data.subheader_name === "translated: Inactive");
-        inactive_subheader_flag = true;
-        return "<inactive-subheader-stub>";
-    });
-}
-
 function test_ui(label, f) {
     run_test(label, (helpers) => {
         stream_data.clear_subscriptions();
@@ -181,8 +165,6 @@ test_ui("create_sidebar_row", ({override, mock_template}) => {
 
     create_devel_sidebar_row({mock_template});
     create_social_sidebar_row({mock_template});
-    create_stream_subheader({mock_template});
-
     topic_list.get_stream_li = noop;
 
     const $pinned_subheader = $("<pinned-subheader-stub>");
@@ -262,8 +244,6 @@ test_ui("pinned_streams_never_inactive", ({mock_template}) => {
 
     create_devel_sidebar_row({mock_template});
     create_social_sidebar_row({mock_template});
-    create_stream_subheader({mock_template});
-
     // non-pinned streams can be made inactive
     const $social_sidebar = $("<social-sidebar-row-stub>");
     let stream_id = social.stream_id;
@@ -407,10 +387,6 @@ test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     $splitter.show();
     assert.ok($splitter.visible());
 
-    $.create(".streams_subheader", {
-        children: [elem($splitter)],
-    });
-
     const $stream_li1 = $.create("stream1 stub");
     const $stream_li2 = $.create("stream2 stub");
 
@@ -472,8 +448,7 @@ test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     assert.ok(!filter_topics_appended);
 });
 
-test_ui("narrowing", ({mock_template}) => {
-    create_stream_subheader({mock_template});
+test_ui("narrowing", () => {
     initialize_stream_data();
 
     topic_list.close = noop;
@@ -538,8 +513,7 @@ test_ui("focus_user_filter", () => {
     click_handler(e);
 });
 
-test_ui("sort_streams", ({mock_template}) => {
-    create_stream_subheader({mock_template});
+test_ui("sort_streams", () => {
     // Set subheader flag to false
     pinned_subheader_flag = false;
     active_subheader_flag = false;
@@ -598,10 +572,8 @@ test_ui("sort_streams", ({mock_template}) => {
     assert.ok(!stream_list.stream_sidebar.has_row_for(stream_id));
 });
 
-test_ui("separators_only_pinned_and_dormant", ({mock_template}) => {
+test_ui("separators_only_pinned_and_dormant", () => {
     // Test only pinned and dormant streams
-
-    create_stream_subheader({mock_template});
     pinned_subheader_flag = false;
     inactive_subheader_flag = false;
 
@@ -704,8 +676,6 @@ test_ui("separators_only_pinned", () => {
 test_ui("rename_stream", ({mock_template, override}) => {
     override(user_settings, "web_stream_unreads_count_display_policy", 3);
     override(current_user, "user_id", me.user_id);
-
-    create_stream_subheader({mock_template});
     initialize_stream_data();
 
     const sub = stream_data.get_sub_by_name("devel");

--- a/web/tests/stream_search.test.cjs
+++ b/web/tests/stream_search.test.cjs
@@ -156,7 +156,7 @@ run_test("basics", ({override, override_rewire}) => {
 
     // Escape a non-empty search.
     $input.val("foo");
-    stream_list.clear_and_hide_search();
+    stream_list.clear_search();
     verify_collapsed();
 
     // Expand the widget.
@@ -165,7 +165,7 @@ run_test("basics", ({override, override_rewire}) => {
 
     // Escape an empty search.
     $input.val("");
-    stream_list.clear_and_hide_search();
+    stream_list.clear_search();
     verify_collapsed();
 });
 


### PR DESCRIPTION
This PR is broken into several commits out of a hope that it makes it easier to review, but let me know if you'd prefer I squash anything (or separate it differently). We should probably squash most of these before merging?

The one thing I still have left to do is add the "N more inactive channels" button for inactive channels. This felt not urgent enough to prevent me from opening this draft PR, but I plan on working on it soon unless we want to punt it a post-release followup (which I think is quite reasonable, considering there will likely be very few inactive channels in folders at first).

I also have barely touched any of the tests and will need to update many of them, but am opening this PR for us to test-deploy on CZO in the meantime.

Here are some test cases I've tested manually. It would be great for a reviewer to also run through most of these. Feel free to also add further test cases to this list!

- pinned channels section
    - muted channels are still faded
    - pinned inactive channels show up (notably without the view N more logic) and aren’t faded
    - pinned channels that are also in channel folders are displayed in the pinned section
    - pinning and unpinning a channel updates the list immediately (including adding/removing the whole pinned channels section if it transitions to or from being empty)
- channel folder sections section
    - muted channels still faded
    - inactive channels in the folder show up (after clicking view N more) and aren’t faded
        - **TODO**: add the "view N more" functionality
    - adding and removing a channel to a folder updates the stream list immediately (including adding/removing a channel folder section if it transitions to or from being empty)
- "other channels” section
    - should be named just “channels” if there are no folders or pinned channels
- inactive section
    - all channels are faded (no visual distinction for muted channels)
- plus button for channel folders
    - only visible for channel folders and the “other channels” section (not pinned or inactive)
    - doesn’t show up for users who can’t create channels (e.g. guests, spectators)
    - tooltip says “Create a channel” not “Add channels”
    - clicking the button opens the creation modal with the folder selected (or no folder selected, for the “other channels” section)
- search filter
    - X button only visible when text is in the search box
    - filtering works as expected (only matches are visible)
    - clearing search with X or ESC works
- plus button beside search filter
    - not visible when logged out (and therefore filter becomes full width)
    - tooltip says “Create a channel” not “Add channels”
    - clicking it opens the popover if two options are available, and just opens the browse channels overlay if channel creation isn’t permitted
- sticky on scroll
    - search bar is always visible on scroll, and nothing pokes out behind it as it scrolls past
    - other headers stick until the section has scrolled past and another header replaces it
- unread counts
    - section counts are correct totals of their channels’ counts
    - counts are hidden when “Show unread count summaries in the left sidebar” isn’t checked, and show again on hover
    - when the unread count is 0, it's not shown (and dots aren't shown when counts are hidden)
- misc
    - sections can be toggled collapsed/uncollapsed by clicking on them
    - when pinning a channel, if the pinned section isn’t in view, the stream list scrolls so that the pinned channel comes into view
    - when putting a channel in a folder, if the folder isn’t in view, the stream list scrolls so that the moved channel comes into view

