### PR TITLE
left_sidebar: Fade inactive streams in the same way as muted streams.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -181,10 +181,6 @@
         }
     }
 
-    .inactive_stream:not(.active-filter) {
-        opacity: 0.5;
-    }
-
     .toggle_stream_mute {
         margin-right: 3px;
         opacity: 0.5;
@@ -625,7 +621,8 @@ ul.filters {
         }
     }
 
-    & li.out_of_home_view {
+    & li.out_of_home_view,
+    .inactive_stream:not(.active-filter) {
         .stream-privacy,
         .stream-name,
         .channel-new-topic-button,


### PR DESCRIPTION
This fixes a double fade bug reported here:
https://chat.zulip.org/#narrow/channel/9-issues/topic/muted.20inactive.20channels/near/2209364
