### PR TITLE
channel_email: Fix copy email button not copying displayed text.

### DIFF
--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -502,6 +502,11 @@ function show_stream_email_address_modal(address: string, sub: StreamSubscriptio
 
     const email_address_clipboard = new ClipboardJS(
         "#copy_email_address_modal .copy-email-address",
+        {
+            text() {
+                return $(".email-address").text();
+            },
+        },
     );
     email_address_clipboard.on("success", (e) => {
         assert(e.trigger instanceof HTMLElement);


### PR DESCRIPTION
PR to fix the bug where clicking the copy icon in the `#copy_email_address_modal` did not copy the email address displayed to the clipboard.

Fixes: #35062.




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
