### PR TITLE
Prevent vanishing of code formating list.

### DIFF
--- a/help/code-blocks.md
+++ b/help/code-blocks.md
@@ -22,10 +22,10 @@ formatting:
 
 1. _(optional)_ Select the text you want to format.
 
-1. Click the **Code** (<i class="zulip-icon zulip-icon-code"></i>) icon at the
+2. Click the **Code** (<i class="zulip-icon zulip-icon-code"></i>) icon at the
    bottom of the compose box to insert code formatting.
 
-1. _(optional)_ To enable syntax highlighting in a code bock, start typing the
+3. _(optional)_ To enable syntax highlighting in a code bock, start typing the
    name of the desired programming language directly after the initial ` ``` `.
    Select the language from the auto-complete suggestions.
 
@@ -33,6 +33,11 @@ formatting:
 
     You can also use the **Code** (<i class="zulip-icon zulip-icon-code"></i>)
     icon to remove existing code formatting from the selected text.
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
+    to insert code formatting.
 
 {tab|via-markdown}
 
@@ -63,6 +68,11 @@ formatting:
 
     You can also use `~~~` to start code blocks, or just indent the code 4 or more
     spaces.
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
+    to insert code formatting.
 
 {end_tabs}
 

--- a/help/format-your-message-using-markdown.md
+++ b/help/format-your-message-using-markdown.md
@@ -92,8 +92,8 @@ below.
 !!! tip ""
 
     You can also use the **Code** (<i class="zulip-icon zulip-icon-code"></i>)
-    button in the compose box to insert code formatting.
-    [Learn more](/help/code-blocks).
+    button or a keyboard shortcut (<kbd>Ctrl</kbd> + <kbd>Shift</kbd> +
+    <kbd>C</kbd>) to insert code formatting. [Learn more](/help/code-blocks).
 
 ## LaTeX
 

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -163,6 +163,10 @@ in the Zulip app to add more to your repertoire as needed.
 * **Insert or create a [saved snippet](/help/saved-snippets)**:
   <kbd>Ctrl</kbd> + <kbd>'</kbd>
 
+* **Insert code formatting**: `` `code` `` or ```` ```code``` ```` or <kbd>Ctrl</kbd> +
+  <kbd>Shift</kbd> + <kbd>C</kbd>.
+  See [contextually appropriate code formatting](/help/code-blocks#insert-code-formatting).
+
 * **Toggle preview mode**: <kbd>Alt</kbd> + <kbd>P</kbd>
 
 * **Cancel compose and save draft**: <kbd>Esc</kbd> or

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -735,6 +735,9 @@ export class Typeahead<ItemType extends string | object> {
         switch (e.key) {
             case "ArrowDown":
             case "ArrowUp":
+            case "Shift":
+            case "Control":
+            case "Meta":
                 break;
 
             case "Tab":

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -600,6 +600,8 @@ export function handle_keydown(
         type = "italic";
     } else if (key === "l" && event.shiftKey) {
         type = "link";
+    } else if (key === "c" && event.shiftKey) {
+        type = "code";
     }
 
     // detect Cmd and Ctrl key
@@ -1208,6 +1210,7 @@ export let format_text = (
             break;
         }
         case "code": {
+            // Ctrl + Shift + C: Toggle code syntax on selection.
             const inline_code_syntax = "`";
             let block_code_syntax_start = "```\n";
             let block_code_syntax_end = "\n```";

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -864,7 +864,6 @@ export function get_candidates(
         if (default_language) {
             language_list.unshift(default_language);
         }
-        compose_ui.set_code_formatting_button_triggered(false);
         const matcher = get_language_matcher(token);
         const matches = language_list.filter((item) => matcher(item));
         const matches_list: LanguageSuggestion[] = matches.map((language) => ({

--- a/web/src/info_overlay.ts
+++ b/web/src/info_overlay.ts
@@ -132,6 +132,7 @@ This text won't be visible until the user clicks.
 def zulip():
     print "Zulip"
 \`\`\``,
+        usage_html: format_usage_html("Ctrl", "Shift", "C"),
     },
     {
         markdown: `\

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -50,7 +50,7 @@
         <div class="divider"></div>
         <a role="button" data-format-type="quote" class="compose_control_button zulip-icon zulip-icon-quote formatting_button" aria-label="{{t 'Quote' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Quote' }}"></a>
         <a role="button" data-format-type="spoiler" class="compose_control_button zulip-icon zulip-icon-spoiler formatting_button" aria-label="{{t 'Spoiler' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Spoiler' }}"></a>
-        <a role="button" data-format-type="code" class="compose_control_button zulip-icon zulip-icon-code formatting_button" aria-label="{{t 'Code' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Code' }}"></a>
+        <a role="button" data-format-type="code" class="compose_control_button zulip-icon zulip-icon-code formatting_button" aria-label="{{t 'Code' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="code-tooltip"></a>
         <a role="button" data-format-type="latex" class="compose_control_button zulip-icon zulip-icon-math formatting_button" aria-label="{{t 'Math (LaTeX)' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Math (LaTeX)' }}"></a>
     </div>
     <div class="divider"></div>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -90,6 +90,10 @@
     {{t 'Italic' }}
     {{tooltip_hotkey_hints "Ctrl" "I"}}
 </template>
+<template id="code-tooltip">
+    {{t 'Code' }}
+    {{tooltip_hotkey_hints "Ctrl" "Shift" "C"}}
+</template>
 <template id="delete-draft-tooltip-template">
     {{t 'Delete draft' }}
     {{tooltip_hotkey_hints "Backspace"}}

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -1210,6 +1210,15 @@ run_test("markdown_shortcuts", ({override_rewire}) => {
         compose_ui.handle_keydown(event, $("textarea#compose-textarea"));
         assert.equal(format_text_type, "link");
         format_text_type = undefined;
+
+        // Test code block insertion:
+        // Mac = Cmd+Shift+C
+        // Windows/Linux = Ctrl+Shift+C
+        event.key = "c";
+        event.shiftKey = true;
+        compose_ui.handle_keydown(event, $("textarea#compose-textarea"));
+        assert.equal(format_text_type, "code");
+        format_text_type = undefined;
     }
 
     // This function cross tests the Cmd/Ctrl + Markdown shortcuts in


### PR DESCRIPTION
FIxes the bug mentioned here: https://github.com/zulip/zulip/pull/30533#discussion_r1720723462


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
