### PR TITLE
help: Document managing channel notifications via personal settings.

### DIFF
--- a/help/channel-notifications.md
+++ b/help/channel-notifications.md
@@ -11,7 +11,7 @@ channels](/help/mute-a-channel), channel notification settings apply only to
 
 {start_tabs}
 
-{tab|desktop-web}
+{tab|via-left-sidebar}
 
 {!channel-actions.md!}
 
@@ -21,6 +21,25 @@ channels](/help/mute-a-channel), channel notification settings apply only to
 
 1. Under **Notification settings**, toggle your preferred
    notifications settings for the channel.
+
+{tab|via-personal-settings}
+
+{settings_tab|notifications}
+
+1. In the **Notification triggers** table, find the name of the channel
+   you want to configure. If the channel is currently set to the default
+   channel notification settings, you can select it from the **Customize
+   another channel** dropdown at the bottom of the table.
+
+1. Toggle your preferred notifications settings for the selected
+   channel.
+
+!!! tip ""
+
+    To reset a channel's notifications to the default settings, hover
+    over its name in the notification triggers table, and click the
+    **reset to default notifications**
+    (<i class="zulip-icon zulip-icon-reset"></i>) icon.
 
 {tab|mobile}
 


### PR DESCRIPTION
Changes the tab for the current web app instructions to be "Via left sidebar" and adds a tab for web app instructions "Via personal settings".

Also, includes a tip for resetting a channel's notifications to the default via hovering over the channel name in the notifications table and clicking the icon to reset to default notifications.

**Notes**
- The tab names for the instructions are different from what was specified in the issue.
  - The current instructions actually start in the left sidebar, so I used that instead of "Via channel settings" as that's usually navigated to through the gear menu.
  - The new instructions start in the personal settings overlay. We don't have a tabbed section for "Via notification settings" currently.

Fixes #34862.

---

**Screenshots and screen captures:**

[CURRENT DOCUMENTATION](https://zulip.com/help/channel-notifications)
<img width="764" alt="Screenshot 2025-07-02 at 20 23 10" src="https://github.com/user-attachments/assets/16b347a9-db8a-4882-8c19-64f71d5188f1" />
<img width="764" alt="Screenshot 2025-07-02 at 20 23 21" src="https://github.com/user-attachments/assets/dce856d5-8176-4d5c-ab49-0295b2794941" />


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
