### PR TITLE
stream_list: Update unread counts after rendering.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -37,6 +37,7 @@ import * as topic_list_data from "./topic_list_data.ts";
 import * as ui_util from "./ui_util.ts";
 import * as unread from "./unread.ts";
 import type {FullUnreadCountsData, StreamCountInfo} from "./unread.ts";
+import * as unread_ui from "./unread_ui.ts";
 import {user_settings} from "./user_settings.ts";
 
 let pending_stream_list_rerender = false;
@@ -350,6 +351,8 @@ export function build_stream_list(force_rerender: boolean): void {
     }
 
     $parent.append(elems); // eslint-disable-line no-jquery/no-append-html
+    unread_ui.update_unread_counts();
+    sidebar_ui.update_unread_counts_visibility();
 }
 
 export function get_stream_li(stream_id: number): JQuery | undefined {

--- a/web/src/stream_muting.ts
+++ b/web/src/stream_muting.ts
@@ -4,7 +4,6 @@ import * as settings_notifications from "./settings_notifications.ts";
 import * as stream_edit from "./stream_edit.ts";
 import * as stream_list from "./stream_list.ts";
 import type {StreamSubscription} from "./sub_store.ts";
-import * as unread_ui from "./unread_ui.ts";
 
 export function update_is_muted(
     sub: StreamSubscription,
@@ -25,10 +24,6 @@ export function update_is_muted(
             }
         }
     }
-
-    // Since muted streams aren't counted in visible unread
-    // counts, we need to update the rendering of them.
-    unread_ui.update_unread_counts();
 
     settings_notifications.update_muted_stream_state(sub);
     stream_edit.update_muting_rendering(sub);


### PR DESCRIPTION
This ensures we're showing the correct counts after the render happens.
