### PR TITLE
users: Add SENSITIVE_USER_FIELDS to UserBaseSettings.

### DIFF
--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -410,6 +410,29 @@ class UserBaseSettings(models.Model):
         **modern_settings,
     }
 
+    # Settings where security policy may restrict the ability of
+    # organization administrators to change this setting for other
+    # accounts.
+    #
+    # Core account fields like name and email address are not part of
+    # the property_types framework and thus do not appear here.
+    SECURITY_SENSITIVE_USER_SETTINGS = frozenset(
+        {
+            # Data privacy controls
+            "allow_private_data_export",
+            "email_address_visibility",
+            # Email notification controls
+            "enable_digest_emails",
+            "enable_login_emails",
+            "enable_marketing_emails",
+            # Availability/presence privacy controls
+            "presence_enabled",
+            "send_private_typing_notifications",
+            "send_read_receipts",
+            "send_stream_typing_notifications",
+        }
+    )
+
     class Meta:
         abstract = True
 


### PR DESCRIPTION
This commit is a preparatory step for enabling organization owners to reset user preferences. It defines a set of sensitive user settings that will be excluded from resets, ensuring certain privacy-related preferences remain protected.

This groundwork will allow follow-up changes to safely reset non-sensitive preferences while respecting user autonomy.


This is a prep PR for #33701 .

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
