### PR TITLE
home_view: Correctly justify unread marker.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -76,6 +76,7 @@
         .masked_unread_count {
             display: flex;
             grid-area: markers-and-unreads;
+            justify-self: end;
             visibility: visible;
         }
 


### PR DESCRIPTION
This introduces a minor bit of justification to ensure that unread markers remain properly aligned in the left-sidebar grid, no matter how many digits the (hidden) unread count climbs to (screenshots below are with three digits).

<!-- Describe your pull request here.-->

[#issues > hiding unread counts doesn't work for muted channels @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/hiding.20unread.20counts.20doesn't.20work.20for.20muted.20channels/near/2211519)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![masked-home-unread-before](https://github.com/user-attachments/assets/16e4725c-4887-4354-8c34-172d2ac4b9ed) | ![masked-home-unread-after](https://github.com/user-attachments/assets/899243e2-41f2-4776-9e2f-83087dda9762) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>