### PR TITLE
message_report: Use `get_message_link_syntax` function.

### DIFF
--- a/zerver/lib/message_report.py
+++ b/zerver/lib/message_report.py
@@ -6,6 +6,7 @@ from zerver.lib.display_recipient import get_display_recipient
 from zerver.lib.markdown.fenced_code import get_unused_fence
 from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.message import is_1_to_1_message, truncate_content
+from zerver.lib.topic_link_util import get_message_link_syntax
 from zerver.models import Message, Realm, UserProfile
 from zerver.models.recipients import Recipient
 from zerver.models.users import get_system_bot
@@ -59,8 +60,13 @@ def send_message_report(
     else:
         assert reported_message.is_stream_message() is True
         topic_name = reported_message.topic_name()
-        channel = reported_message.recipient.label()
-        channel_message_link = f"#**{channel}>{topic_name}@{reported_message.id}**"
+        channel = reported_message.recipient
+        channel_message_link = get_message_link_syntax(
+            channel.id,
+            channel.label(),
+            topic_name,
+            reported_message.id,
+        )
         report_header = _(
             "{reporting_user_mention} reported {channel_message_link} sent by {reported_user_mention}."
         ).format(


### PR DESCRIPTION
This updates the message report module to use the
`get_message_link_syntax` function.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
