### PR TITLE
widget: Hide widgets from muted users like normal messages.

### DIFF
--- a/web/src/poll_widget.ts
+++ b/web/src/poll_widget.ts
@@ -7,12 +7,14 @@ import type {
     QuestionOutboundData,
     VoteOutboundData,
 } from "../shared/src/poll_data.ts";
+import render_message_hidden_dialog from "../templates/message_hidden_dialog.hbs";
 import render_widgets_poll_widget from "../templates/widgets/poll_widget.hbs";
 import render_widgets_poll_widget_results from "../templates/widgets/poll_widget_results.hbs";
 
 import * as blueslip from "./blueslip.ts";
 import {$t} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
+import * as message_lists from "./message_lists.ts";
 import type {Message} from "./message_store.ts";
 import * as people from "./people.ts";
 
@@ -49,6 +51,7 @@ export function activate({
         comma_separated_names: people.get_full_names_for_poll_option,
         report_error_function: blueslip.warn,
     });
+    const message_container = message_lists.current?.view.message_containers.get(message.id);
 
     function update_edit_controls(): void {
         const has_question =
@@ -234,13 +237,22 @@ export function activate({
             poll_data.handle_event(event.sender_id, event.data);
         }
 
+        if (message_container?.is_hidden) {
+            return;
+        }
+
         render_question();
         render_results();
     };
 
-    build_widget();
-    render_question();
-    render_results();
+    if (message_container?.is_hidden) {
+        const html = render_message_hidden_dialog();
+        $elem.html(html);
+    } else {
+        build_widget();
+        render_question();
+        render_results();
+    }
 
     return handle_events;
 }

--- a/web/src/todo_widget.ts
+++ b/web/src/todo_widget.ts
@@ -3,11 +3,13 @@ import _ from "lodash";
 import assert from "minimalistic-assert";
 import {z} from "zod";
 
+import render_message_hidden_dialog from "../templates/message_hidden_dialog.hbs";
 import render_widgets_todo_widget from "../templates/widgets/todo_widget.hbs";
 import render_widgets_todo_widget_tasks from "../templates/widgets/todo_widget_tasks.hbs";
 
 import * as blueslip from "./blueslip.ts";
 import {$t} from "./i18n.ts";
+import * as message_lists from "./message_lists.ts";
 import type {Message} from "./message_store.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
@@ -342,6 +344,7 @@ export function activate({
         tasks,
         report_error_function: blueslip.warn,
     });
+    const message_container = message_lists.current?.view.message_containers.get(message.id);
 
     function update_edit_controls(): void {
         const has_title =
@@ -525,13 +528,22 @@ export function activate({
             task_data.handle_event(event.sender_id, event.data);
         }
 
+        if (message_container?.is_hidden) {
+            return;
+        }
+
         render_task_list_title();
         render_results();
     };
 
-    build_widget();
-    render_task_list_title();
-    render_results();
+    if (message_container?.is_hidden) {
+        const html = render_message_hidden_dialog();
+        $elem.html(html);
+    } else {
+        build_widget();
+        render_task_list_title();
+        render_results();
+    }
 
     return handle_events;
 }


### PR DESCRIPTION
Earlier, messages from muted users were hidden with a hidden dialog but widgets were still visible.

This PR corrects this behaviour by hiding it if the message container is supposed to be hidden.

Fixes part of zulip#34886.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**After:**

[Screencast from 2025-07-04 15-14-05.webm](https://github.com/user-attachments/assets/061f848a-7312-4e34-af6f-ea8865dbcf2d)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
