### PR TITLE
buttons: Redesign some old-style buttons with rounded class.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1336,17 +1336,23 @@ div.settings-radio-input-parent {
 }
 
 .stream-settings-color-selector {
+    border: 1px solid var(--color-border-zulip-button);
     display: flex;
     align-items: center;
     gap: 10px;
     overflow: hidden;
+
+    &.action-button-quiet-neutral {
+        box-shadow: none;
+    }
 }
 
 .stream-settings-color-preview {
-    /* 33px at 12.8 font size (from .button.small) at 14px em */
-    width: 2.5781em;
-    height: 2.5781em;
-    margin: -6px 0 -6px -10px;
+    /* 28px at 16px font size */
+    width: 1.75em;
+    height: 1.75em;
+    /* -6px 0 -6px 10px at 16px font size. */
+    margin: -0.375em 0 -0.375em -0.625em;
 }
 
 #subscription_overlay .channel-folder-widget-container {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -331,10 +331,18 @@ p.n-margin {
     }
 
     .exit-me {
-        font-size: 20pt;
-        font-weight: 200;
-        margin: 0 0 0 10px;
-        cursor: pointer;
+        margin: 0 0 0 5px;
+    }
+
+    .float-header {
+        display: flex;
+        align-items: center;
+    }
+
+    .feedback-button-container {
+        display: flex;
+        align-items: center;
+        margin-left: auto;
     }
 }
 

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -21,9 +21,9 @@
                         <div class="delete-selected-drafts-button-container">
                             {{> ./components/icon_button intent="danger" custom_classes="delete-selected-drafts-button" icon="trash" disabled=true  }}
                         </div>
-                        <button class="button small rounded select-drafts-button" role="checkbox" aria-checked="false">
+                        <button class="action-button action-button-quiet-neutral select-drafts-button" role="checkbox" aria-checked="false">
                             <span>{{t "Select all drafts" }}</span>
-                            <i class="fa fa-square-o fa-lg select-state-indicator" aria-hidden="true"></i>
+                            <i class="fa fa-square-o select-state-indicator" aria-hidden="true"></i>
                         </button>
                     </div>
                 </div>

--- a/web/templates/feedback_container.hbs
+++ b/web/templates/feedback_container.hbs
@@ -1,9 +1,11 @@
 <div class="float-header">
     <h3 class="light no-margin small-line-height float-left feedback_title"></h3>
-    <div class="exit-me float-right">&#215;</div>
-    {{#if has_undo_button}}
-        <button class="button small rounded float-right feedback_undo" type="button" name="button"></button>
-    {{/if}}
+    <div class="feedback-button-container">
+        {{#if has_undo_button}}
+            {{> components/action_button intent="neutral" attention="quiet" custom_classes="feedback_undo"}}
+        {{/if}}
+        {{> ./components/icon_button intent="neutral" custom_classes="exit-me" icon="close"}}
+    </div>
     <div class="float-clear"></div>
 </div>
 <p class="n-margin feedback_content"></p>

--- a/web/templates/settings/add_new_custom_profile_field_form.hbs
+++ b/web/templates/settings/add_new_custom_profile_field_form.hbs
@@ -31,7 +31,12 @@
             <table class="profile_field_choices_table">
                 <tbody id="profile_field_choices" class="profile-field-choices"></tbody>
             </table>
-            <button type="button" class="button white rounded alphabetize-choices-button">{{t "Alphabetize choices" }}</button>
+            {{> ../components/action_button
+              label=(t "Alphabetize choices")
+              custom_classes="alphabetize-choices-button"
+              intent="neutral"
+              attention="quiet"
+              }}
         </div>
         <div class="input-group" id="custom_external_account_url_pattern">
             <label for="custom_field_url_pattern" class="modal-field-label">{{t "URL pattern" }}</label>

--- a/web/templates/settings/edit_custom_profile_field_form.hbs
+++ b/web/templates/settings/edit_custom_profile_field_form.hbs
@@ -18,7 +18,12 @@
                 {{/each}}
             </div>
         </div>
-        <button type="button" class="button white rounded alphabetize-choices-button">{{t "Alphabetize choices" }}</button>
+        {{> ../components/action_button
+          label=(t "Alphabetize choices")
+          custom_classes="alphabetize-choices-button"
+          intent="neutral"
+          attention="quiet"
+          }}
     </div>
     {{else if is_external_account_field}}
     <div class="prop-element" id="id-custom-profile-field-field-data" data-setting-widget-type="field-data-setting">

--- a/web/templates/settings/generate_integration_url_modal.hbs
+++ b/web/templates/settings/generate_integration_url_modal.hbs
@@ -40,8 +40,8 @@
 <div class="input-group hide" id="integrations-event-container">
     <label for="integrations-event-options">{{t "Events to include:"}}</label>
     <div class="integration-all-events-buttons">
-        <button class="button rounded" id="add-all-integration-events">{{t "Check all"}}</button>
-        <button class="button rounded" id="remove-all-integration-events">{{t "Uncheck all"}}</button>
+        {{> ../components/action_button attention="quiet" intent="neutral" id="add-all-integration-events" label=(t "Check all") }}
+        {{> ../components/action_button attention="quiet" intent="neutral" id="remove-all-integration-events" label=(t "Uncheck all") }}
     </div>
     <div id="integrations-event-options"></div>
 </div>

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -152,7 +152,7 @@
                 {{/each}}
                 <div class="input-group">
                     <label class="settings-field-label channel-color-label">{{t "Channel color" }}</label>
-                    <button class="button small rounded stream-settings-color-selector choose_stream_color" data-stream-id="{{ sub.stream_id }}">
+                    <button class="action-button action-button-quiet-neutral stream-settings-color-selector choose_stream_color" data-stream-id="{{ sub.stream_id }}">
                         <span class="stream-settings-color-preview" style="background: {{sub.color}};"></span>
                         <span class="stream-settings-color-selector-label">{{t "Change color"}}</span>
                     </button>


### PR DESCRIPTION
Fixes part of #35006.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| **Location**                  | **Before**                                                                                 | **After**                                                                                 |
| ----------------------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
| **Select all draft**          | ![Before](https://github.com/user-attachments/assets/da97e5cf-3511-4392-a3ce-2525b3dc4554) | ![After](https://github.com/user-attachments/assets/94246e74-5371-49aa-87a4-399a94e74a39) |
| **Alphatesze choice**         | ![Before](https://github.com/user-attachments/assets/322be5a1-04f7-4db4-a43d-c7ffa3d53f57) | ![After](https://github.com/user-attachments/assets/342c6c0c-31fc-4815-800a-94ba358effd7) |
| **Check/Uncheck all**         | ![Before](https://github.com/user-attachments/assets/e2dd4cea-a053-4551-b72d-7b9347475c9d) | ![After](https://github.com/user-attachments/assets/7ec04c13-3023-4a4a-878e-a73832407cc1) |
| **Change color**              | ![Before](https://github.com/user-attachments/assets/3f6fa67a-3894-4d86-98d6-79cfb3901908) | ![After](https://github.com/user-attachments/assets/93175159-235f-4cf5-ae54-cdec9fe8f314) |
| Feedback widget(Light) | <img width="441" alt="Screenshot 2025-07-09 at 2 28 30 AM" src="https://github.com/user-attachments/assets/2d06d437-2d7b-4432-815e-8615852758c0" /> | <img width="460" alt="Screenshot 2025-07-09 at 2 27 59 AM" src="https://github.com/user-attachments/assets/ed75daf6-02e5-47ee-b455-bc9aa98858a8" /> |
| Feedback widget(dark) | <img width="441" alt="Screenshot 2025-07-09 at 2 29 00 AM" src="https://github.com/user-attachments/assets/af2f25a9-cbef-45cc-85d4-e8296a5d0e4a" /> |  <img width="445" alt="Screenshot 2025-07-09 at 2 27 36 AM" src="https://github.com/user-attachments/assets/fe32283d-0cc6-4308-8e9f-7303b284741e" /> |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
