### PR TITLE
compose_paste: Convert large pasted text into uploaded text file.

### DIFF
--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -80,6 +80,8 @@ IGNORED_PHRASES = [
     r"email",
     r"enabled",
     r"signups",
+    # Pasted text filename
+    r"PastedText",
     # Placeholders
     r"keyword",
     r"streamname",

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -39,6 +39,7 @@ export const CLASSNAMES = {
     non_interleaved_view_messages_fading: "non_interleaved_view_messages_fading",
     interleaved_view_messages_fading: "interleaved_view_messages_fading",
     topic_is_moved: "topic_is_moved",
+    convert_pasted_text_to_file: "convert_pasted_text_to_file",
     // unmute topic notifications are styled like warnings but have distinct behaviour
     unmute_topic_notification: "unmute_topic_notification warning-style",
     // warnings
@@ -289,4 +290,21 @@ export function show_unknown_zoom_user_error(email: string): void {
 
 export function has_error(): boolean {
     return $("#compose_banners .error").length > 0;
+}
+
+export function show_convert_pasted_text_to_file_banner(cb: () => void): JQuery {
+    $(`#compose_banners .${CSS.escape(CLASSNAMES.convert_pasted_text_to_file)}`).remove();
+    const $new_row = $(
+        render_compose_banner({
+            banner_type: INFO,
+            banner_text: $t({
+                defaultMessage: "Do you want to convert the pasted text into a file?",
+            }),
+            button_text: $t({defaultMessage: "Yes, convert"}),
+            classname: CLASSNAMES.convert_pasted_text_to_file,
+        }),
+    );
+    $new_row.on("click", ".main-view-banner-action-button", cb);
+    append_compose_banner_to_banner_list($new_row, $("#compose_banners"));
+    return $new_row;
 }

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -587,7 +587,9 @@ export async function initialize_everything(state_data) {
     add_stream_options_popover.initialize();
     click_handlers.initialize();
     scheduled_messages_overlay_ui.initialize();
-    compose_paste.initialize();
+    compose_paste.initialize({
+        upload_pasted_file: upload.upload_pasted_file,
+    });
     overlays.initialize();
     invite.initialize();
     message_view_header.initialize();

--- a/web/src/upload.ts
+++ b/web/src/upload.ts
@@ -279,6 +279,17 @@ export function rewire_upload_files(value: typeof upload_files): void {
     upload_files = value;
 }
 
+export function upload_pasted_file(textarea: HTMLTextAreaElement, pasted_file: File): void {
+    if (textarea.id === "compose-textarea") {
+        upload_files(compose_upload_object, compose_config, [pasted_file]);
+        return;
+    }
+    const row = rows.get_message_id(textarea);
+    const edit_uploader = upload_objects_by_message_edit_row.get(row);
+    assert(edit_uploader !== undefined);
+    upload_files(edit_uploader, edit_config(row), [pasted_file]);
+}
+
 // Borrowed from tus-js-client code at
 // https://github.com/tus/tus-js-client/blob/ca63ba254ea8766438b9d422f6f94284911f1fa5/lib/index.d.ts#L79
 // The library does not export this type, hence requiring a copy here.


### PR DESCRIPTION
When pasting a long piece of text into the compose box (or message edit textarea), we show a banner giving an option to put the text into a file and upload it.

The banner is only shown if the text is larger than `MINIMUM_PASTE_SIZE_FOR_FILE_TREATMENT`, and would cause the total message size to exceend
`realm.max_message_length`.

If the user chooses to "convert to file", the textarea content is
restored to its state before pasting and a file with the pasted
content is uploaded. The banner is hidden as
soon as any change is made to the textarea content to
avoid inconsistent state and confusion.

Fixes #33107.

Earlier work: #34642

This PR implements the suggestion in [#feedback > Dialog for posting text files ("Slack text snippets") @ 💬](https://chat.zulip.org/#narrow/channel/137-feedback/topic/Dialog.20for.20posting.20text.20files.20.28.22Slack.20text.20snippets.22.29/near/2197793).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

*I reduced the size limit here for the banner to appear*.
<img width="850" alt="image" src="https://github.com/user-attachments/assets/639ed4a3-7571-424e-b7cf-88efffd69046" />

<img width="850" alt="image" src="https://github.com/user-attachments/assets/80359fe1-3dca-4244-a964-53bddb87d628" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
