### PR TITLE
buttons: Redesign buttons in personal settings.

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -718,7 +718,7 @@ export let get_input_element_value = (
         case "field-data-setting":
             return get_field_data_input_value($input_elem);
         case "language-setting":
-            return $input_elem.find(".language_selection_button span").attr("data-language-code");
+            return $input_elem.attr("data-language-code");
         case "auth-methods":
             return JSON.stringify(get_auth_method_list_data());
         case "group-setting-type": {
@@ -882,9 +882,9 @@ export function check_realm_settings_property_changed(elem: HTMLElement): boolea
             proposed_val = get_jitsi_server_url_setting_value($(elem), false);
             break;
         case "realm_default_language":
-            proposed_val = $(
-                "#org-notifications .language_selection_widget .language_selection_button span",
-            ).attr("data-language-code");
+            proposed_val = $("#org-notifications .language_selection_widget").attr(
+                "data-language-code",
+            );
             break;
         default:
             if (current_val !== undefined) {

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -536,11 +536,11 @@ export function discard_realm_property_element_changes(elem: HTMLElement): void 
         }
         case "realm_default_language":
             assert(typeof property_value === "string");
-            $("#org-notifications .language_selection_widget .language_selection_button span").attr(
+            $("#org-notifications .language_selection_widget").attr(
                 "data-language-code",
                 property_value,
             );
-            $("#org-notifications .language_selection_widget .language_selection_button span").text(
+            $("#org-notifications .language_selection_widget .language_selection_button").text(
                 // We know this is defined, since we got the `property_value` from a dropdown
                 // of valid language options.
                 get_language_name(property_value)!,

--- a/web/src/settings_preferences.ts
+++ b/web/src/settings_preferences.ts
@@ -118,10 +118,8 @@ function org_notification_default_language_modal_post_render(): void {
             assert(setting_value !== undefined);
             const new_language = $link.attr("data-name");
             assert(new_language !== undefined);
-            const $language_element = $(
-                "#org-notifications .language_selection_widget .language_selection_button span",
-            );
-            $language_element.text(new_language);
+            const $language_element = $("#org-notifications .language_selection_widget");
+            $language_element.find(".language_selection_button").text(new_language);
             $language_element.attr("data-language-code", setting_value);
             settings_components.save_discard_realm_settings_widget_status_handler(
                 $("#org-notifications"),
@@ -144,10 +142,10 @@ function user_default_language_modal_post_render(): void {
 
             const new_language = $link.attr("data-name");
             assert(new_language !== undefined);
-            $("#user-preferences .language_selection_widget .language_selection_button span").text(
+            $("#user-preferences .language_selection_widget .language_selection_button").text(
                 new_language,
             );
-            $("#user-preferences .language_selection_widget .language_selection_button span").attr(
+            $("#user-preferences .language_selection_widget").attr(
                 "data-language-code",
                 setting_value,
             );
@@ -442,7 +440,7 @@ export function update_page(property: UserSettingsProperty): void {
     // The default_language button text updates to the language
     // name and not the value of the user_settings property.
     if (property === "default_language") {
-        $container.find(".default_language_name").text(user_default_language_name ?? "");
+        $container.find(".language_selection_button").text(user_default_language_name ?? "");
         return;
     }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -468,6 +468,10 @@ input[type="checkbox"] {
     }
 }
 
+.send_test_notification {
+    margin-bottom: 15px;
+}
+
 .preferences-settings-form {
     .tab-picker {
         width: 325px;

--- a/web/templates/settings/language_selection_widget.hbs
+++ b/web/templates/settings/language_selection_widget.hbs
@@ -1,11 +1,16 @@
-<div class="language_selection_widget input-group prop-element" id="id_{{section_name}}" data-setting-widget-type="language-setting">
+<div class="language_selection_widget input-group prop-element" id="id_{{section_name}}" data-language-code="{{language_code}}" data-setting-widget-type="language-setting">
     <label class="settings-field-label" for="id_language_selection_button">
         {{section_title}}
         {{#if help_link_widget_link}}
         {{> ../help_link_widget link=help_link_widget_link }}
         {{/if}}
     </label>
-    <button type="button" id="id_language_selection_button" class="language_selection_button button rounded tippy-zulip-delayed-tooltip" data-section="{{section_name}}" data-tippy-content="{{t 'Change language' }}">
-        <span class="{{section_name}}" data-language-code="{{language_code}}">{{setting_value}}</span>
-    </button>
+    {{> ../components/action_button
+      label=setting_value
+      custom_classes="language_selection_button tippy-zulip-delayed-tooltip"
+      data-tippy-content=(t "Change language")
+      id="id_language_selection_button"
+      intent="neutral"
+      attention="quiet"
+      }}
 </div>

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -134,7 +134,12 @@
         <div class="desktop-notification-settings-banners banner-wrapper"></div>
 
         {{#unless for_realm_settings}}
-        <p><a class="send_test_notification">{{t "Send a test notification" }}</a></p>
+        {{> ../components/action_button
+          label=(t "Send a test notification")
+          attention="quiet"
+          intent="neutral"
+          custom_classes="send_test_notification"
+          }}
         {{/unless}}
 
         {{#each notification_settings.desktop_notification_settings}}


### PR DESCRIPTION
This PR modifies the Preferences button to an action button in neutral, and 'Send a test notification' into a medium-emphasis neutral action button.

Fixes: #34535

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|-------|
| ![before-subscribe](https://github.com/user-attachments/assets/ec36f9c4-f9b9-424f-bd85-7de4e782b930) | ![after-subscribe](https://github.com/user-attachments/assets/0c4414ad-2cb3-4d46-9550-34b25e51a126) |
| ![before-unsubscribe](https://github.com/user-attachments/assets/4751db48-b167-4fa7-bded-f1305f3da3dd)) | ![after-unsubscribe](https://github.com/user-attachments/assets/1d4c7cbd-f1b4-4d89-b686-d81825918bd3) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
