### PR TITLE
compose: Correct low-attention logic for combined feeds.

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -32,7 +32,7 @@ let compose_select_recipient_dropdown_widget: DropdownWidget;
 
 function composing_to_current_topic_narrow(): boolean {
     return (
-        util.lower_same(compose_state.stream_name(), narrow_state.stream_name() ?? "") &&
+        compose_state.stream_id() === narrow_state.stream_id() &&
         util.lower_same(compose_state.topic(), narrow_state.topic() ?? "")
     );
 }

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -31,6 +31,11 @@ type MessageType = "stream" | "private";
 let compose_select_recipient_dropdown_widget: DropdownWidget;
 
 function composing_to_current_topic_narrow(): boolean {
+    // If the narrow state's stream ID is undefined, then
+    // the user cannot be composing to a current topic narrow.
+    if (narrow_state.stream_id() === undefined) {
+        return false;
+    }
     return (
         compose_state.stream_id() === narrow_state.stream_id() &&
         util.lower_same(compose_state.topic(), narrow_state.topic() ?? "")
@@ -65,7 +70,7 @@ export let update_recipient_row_attention_level = (): void => {
     const is_compose_textarea_focused = document.activeElement?.id === "compose-textarea";
     if (
         is_compose_textarea_focused &&
-        composing_to_current_topic_narrow() &&
+        (composing_to_current_topic_narrow() || composing_to_current_private_message_narrow()) &&
         compose_state.has_full_recipient() &&
         !compose_state.is_recipient_edited_manually()
     ) {


### PR DESCRIPTION
This fixes an incorrect `true` value being returned by `composing_to_current_topic_narrow()` in places like the combined feed (the function was returning comparison values without considering whether `narrow_state.stream_name()` was undefined to begin with--a state that indicates we are *not* in a topic narrow, no matter how the other values evaluate).

Additionally, the `composing_to_current_private_message_narrow()` state had not been accounted for previously in the low-attention-span logic (meaning that DMs in true DM narrows were begin set to low-attention by virtue of the bug in `composing_to_current_topic_narrow()`), but is now here to ensure DM recipient-rows are set with the correct attention level in the compose box.

[#issues > 🎯 DM recipients deemphasized incorrectly](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20DM.20recipients.20deemphasized.20incorrectly/with/2214545)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| DMs from Combined View, Before | After |
| --- | --- |
| ![combined-dms-before](https://github.com/user-attachments/assets/68d83275-d24c-4f5c-9c7c-4344bceeb993) | ![combined-dms-after](https://github.com/user-attachments/assets/2716eab5-cbe6-453a-986a-ff08cd9eba31) |

| DMS in Search View, Before | After |
| --- | --- |
| ![search-dms-before](https://github.com/user-attachments/assets/67108b4c-a719-4ffb-b124-74d15a5831c5) | ![search-dms-after](https://github.com/user-attachments/assets/f993e3a4-3b29-45dd-ac05-aeb6009f3f88) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
