### PR TITLE
help: Update "who can subscribe" page for new channel settings UI.

### DIFF
--- a/help/archive-a-channel.md
+++ b/help/archive-a-channel.md
@@ -71,7 +71,9 @@ content](#hide-content-in-an-archived-channel).
 1. Under **Channel permissions**, [make the channel
    private](/help/change-the-privacy-of-a-channel).
 
-1. Under **Advanced configurations**, remove everyone from **Who can subscribe
+1. Click **Advanced configuration** to view advanced configuration options.
+
+1. Under **Subscription permissions**, remove everyone from **Who can subscribe
    to this channel**, and **Who can subscribe anyone to this channel**. These
    permissions give users content access to the channel.
 

--- a/help/change-the-channel-description.md
+++ b/help/change-the-channel-description.md
@@ -22,7 +22,7 @@ disabled. Use Markdown formatting to include a link to a website, Zulip
 
 {!select-channel-view-general.md!}
 
-1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon
+1. Click the **edit** (<i class="zulip-icon zulip-icon-edit"></i>) icon
    to the right of the channel name, and enter a new description.
 
 {!save-changes.md!}

--- a/help/channel-posting-policy.md
+++ b/help/channel-posting-policy.md
@@ -10,9 +10,9 @@ you can set up an announcement channel where only a specific
 
 1. Select a channel.
 
-{!select-channel-view-general.md!}
+{!select-channel-view-general-advanced.md!}
 
-1. Under **Channel permissions**, configure **Who can post to the channel**.
+1. Under **Messaging permissions**, configure **Who can post to this channel**.
 
 {!save-changes.md!}
 

--- a/help/configure-who-can-administer-a-channel.md
+++ b/help/configure-who-can-administer-a-channel.md
@@ -14,9 +14,9 @@
 
 1. Select a channel.
 
-{!select-channel-view-general.md!}
+{!select-channel-view-general-advanced.md!}
 
-1. Under **Channel permissions**, configure **Who can administer
+1. Under **Administrative permissions**, configure **Who can administer
    this channel**.
 
 {!save-changes.md!}

--- a/help/configure-who-can-invite-to-channels.md
+++ b/help/configure-who-can-invite-to-channels.md
@@ -44,9 +44,9 @@ have content access in order to change this configuration.
 
 1. Select a channel.
 
-{!select-channel-view-general.md!}
+{!select-channel-view-general-advanced.md!}
 
-1. Under **Advanced configurations**, configure **Who can subscribe anyone to
+1. Under **Subscription permissions**, configure **Who can subscribe anyone to
    this channel**.
 
 {!save-changes.md!}

--- a/help/configure-who-can-subscribe.md
+++ b/help/configure-who-can-subscribe.md
@@ -34,9 +34,9 @@ have content access in order to change this configuration.
 
 1. Select a channel.
 
-{!select-channel-view-general.md!}
+{!select-channel-view-general-advanced.md!}
 
-1. Under **Channel permissions**, configure **Who can subscribe to this
+1. Under **Subscription permissions**, configure **Who can subscribe to this
    channel**.
 
 {!save-changes.md!}

--- a/help/configure-who-can-unsubscribe-others.md
+++ b/help/configure-who-can-unsubscribe-others.md
@@ -10,9 +10,9 @@ unsubscribe anyone from a channel.
 
 1. Select a channel.
 
-{!select-channel-view-general.md!}
+{!select-channel-view-general-advanced.md!}
 
-1. Under **Advanced configurations**, configure **Who can unsubscribe anyone
+1. Under **Subscription permissions**, configure **Who can unsubscribe anyone
    from this channel**.
 
 {!save-changes.md!}

--- a/help/include/create-a-channel-instructions.md
+++ b/help/include/create-a-channel-instructions.md
@@ -9,7 +9,7 @@
 
 1. Fill out the requested information.
 
-1. _(optional)_ Click on **Advanced configurations** to review and update
+1. _(optional)_ Click on **Advanced configuration** to review and update
    additional channel settings.
 
 1. Click **Continue to add subscribers**.

--- a/help/message-a-channel-by-email.md
+++ b/help/message-a-channel-by-email.md
@@ -30,7 +30,7 @@ API](/api/send-message).
 
 {!select-channel-view-general.md!}
 
-1. Click **Generate email address** under **Email address**.
+1. Under **Channel details**, click **Generate email address**.
 
 1. Select **Who should be the sender of the Zulip messages for this email
    address**.

--- a/help/message-retention-policy.md
+++ b/help/message-retention-policy.md
@@ -45,9 +45,9 @@ Standard hosting.
 
 1. Select a channel.
 
-{!select-channel-view-general.md!}
+{!select-channel-view-general-advanced.md!}
 
-1. Under **Channel permissions**, configure the
+1. Under **Administrative permissions**, configure the
    **Message retention period**.
 
 {!save-changes.md!}

--- a/help/pin-information.md
+++ b/help/pin-information.md
@@ -26,7 +26,7 @@ You can also pin messages for yourself by [starring](/help/star-a-message) them.
 
 {!select-channel-view-general.md!}
 
-1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon
+1. Click the **edit** (<i class="zulip-icon zulip-icon-edit"></i>) icon
    to the right of the channel name to edit the description.
 
 1. Add any number of links, which you can separate with `|` or another symbol.

--- a/help/rename-a-channel.md
+++ b/help/rename-a-channel.md
@@ -13,7 +13,7 @@ and Unicode emoji.
 
 {!select-channel-view-general.md!}
 
-1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon
+1. Click the **edit** (<i class="zulip-icon zulip-icon-edit"></i>) icon
    to the right of the channel name, and enter a new channel name.
 
 {!save-changes.md!}

--- a/help/restrict-moving-messages.md
+++ b/help/restrict-moving-messages.md
@@ -46,9 +46,9 @@ Permissions for moving messages between channels can be configured separately.
 
 1. Select a channel.
 
-{!select-channel-view-general.md!}
+{!select-channel-view-general-advanced.md!}
 
-1. Under **Channel permissions**, configure **Who can move messages inside this
+1. Under **Moderation permissions**, configure **Who can move messages inside this
    channel**.
 
 {!save-changes.md!}
@@ -72,6 +72,8 @@ Permissions for moving messages between channels can be configured separately.
 
 ## Configure who can move messages out of any channel
 
+{!admin-only.md!}
+
 {start_tabs}
 
 {settings_tab|organization-permissions}
@@ -92,9 +94,9 @@ Permissions for moving messages between channels can be configured separately.
 
 1. Select a channel.
 
-{!select-channel-view-general.md!}
+{!select-channel-view-general-advanced.md!}
 
-1. Under **Channel permissions**, configure **Who can move messages out of this
+1. Under **Moderation permissions**, configure **Who can move messages out of this
    channel**.
 
 {!save-changes.md!}

--- a/help/restrict-resolving-topics.md
+++ b/help/restrict-resolving-topics.md
@@ -1,11 +1,13 @@
 # Restrict resolving topics
 
-{!admin-only.md!}
-
 Zulip lets you configure who can [mark topics as resolved](/help/resolve-a-topic). This
 permission can be granted to any combination of [roles](/help/user-roles),
 [groups](/help/user-groups), and individual
 [users](/help/introduction-to-users).
+
+## Configure who can resolve topics in any channel
+
+{!admin-only.md!}
 
 {start_tabs}
 
@@ -14,6 +16,25 @@ permission can be granted to any combination of [roles](/help/user-roles),
 {settings_tab|organization-permissions}
 
 1. Under **Moving messages**, configure **Who can resolve topics**.
+
+{!save-changes.md!}
+
+{end_tabs}
+
+## Configure who can resolve topics in a specific channel
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{relative|channel|all}
+
+1. Select a channel.
+
+{!select-channel-view-general-advanced.md!}
+
+1. Under **Moderation permissions**, configure **Who can resolve topics in this
+   channel**.
 
 {!save-changes.md!}
 

--- a/web/templates/stream_settings/stream_permissions.hbs
+++ b/web/templates/stream_settings/stream_permissions.hbs
@@ -122,7 +122,7 @@
               setting_name="can_send_message_group"
               label=group_setting_labels.can_send_message_group
               prefix=prefix
-              help_link="/help/stream-sending-policy" }}
+              help_link="/help/channel-posting-policy" }}
 
             <div class="input-group">
                 <label for="{{prefix}}topics_policy" class="settings-field-label">{{> stream_topics_policy_label .}}</label>


### PR DESCRIPTION
This sets up the pattern for updating the help center for the changes in #35148.

@laurynmm Could you please take this over to apply it to all the channel settings under advanced configuration?

We might decide to fiddle with the wording for the "Click **Advanced configuration**..." instruction, but that'll be trivial to do.

Before: https://zulip.com/help/configure-who-can-subscribe
After:
![Screenshot 2025-07-07 at 11 42 23@2x](https://github.com/user-attachments/assets/89aef1af-4259-4243-8cfe-67de41743289)
