### PR TITLE
help: Add note about pasting plain URLs.

### DIFF
--- a/help/link-to-a-message-or-conversation.md
+++ b/help/link-to-a-message-or-conversation.md
@@ -98,7 +98,9 @@ In addition, links to messages, topics, and channels are **permanent**:
 
 When you copy a Zulip link and paste it anywhere that accepts HTML
 formatting (e.g., your email, GitHub, docs, etc.), the link will be
-formatted as it would be in Zulip (e.g., [#channel > topic](/)).
+formatted as it would be in Zulip (e.g., [#channel > topic](/)). To paste the
+plain URL, you can paste without formatting (likely <kbd>Ctrl</kbd> +
+<kbd>Shift</kbd> + <kbd>V</kbd> in your browser).
 
 ### Get a link to a specific message
 


### PR DESCRIPTION
Follow-up to #35142.

Current: https://zulip.com/help/link-to-a-message-or-conversation#link-to-zulip-from-anywhere

Updated:
![Screenshot 2025-07-07 at 13 49 58@2x](https://github.com/user-attachments/assets/274542e5-08a7-43ce-821f-e4af94aba527)
