### PR TITLE
help: Clarify where to tap in mobile instructions for logging out.

### DIFF
--- a/help/logging-out.md
+++ b/help/logging-out.md
@@ -12,7 +12,8 @@
 
 {!mobile-switch-account.md!}
 
-1. Tap on the Zulip organization you want to log out of.
+1. Tap the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical mobile-help"></i>)
+   to the right of the Zulip organization you want to log out of.
 
 1. Tap **Log out**.
 


### PR DESCRIPTION
Relevant CZO discussion: [#mobile > Log out button in Flutter app](https://chat.zulip.org/#narrow/channel/48-mobile/topic/Log.20out.20button.20in.20Flutter.20app/with/2213284)

From that conversation:
> Reading those instructions now, I think they could use one correction, or clarification: in the step that reads:
> - Tap on the Zulip organization you want to log out of.
>
> it should read:
>
> - Tap ⋮ Show menu on the Zulip organization you want to log out of.

**Notes**:
- Modified suggested text revision above for what we do for ellipsis/three-dot menu help center instructions for the web-app.

---

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="765" alt="Screenshot 2025-07-08 at 09 00 05" src="https://github.com/user-attachments/assets/6b8e0977-c2f5-4746-aa07-e4c2b60a8f4f" /> | <img width="759" alt="Screenshot 2025-07-08 at 09 00 16" src="https://github.com/user-attachments/assets/22355537-e642-4e02-b95b-f85e34b92b20" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
