### PR TITLE
[DRAFT] compose: Keep compose box always open.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -13,6 +13,7 @@ import * as buddy_data from "./buddy_data.ts";
 import * as compose_actions from "./compose_actions.ts";
 import * as compose_reply from "./compose_reply.ts";
 import * as compose_state from "./compose_state.ts";
+import * as compose_ui from "./compose_ui.ts";
 import * as emoji_picker from "./emoji_picker.ts";
 import * as hash_util from "./hash_util.ts";
 import * as hashchange from "./hashchange.ts";
@@ -978,7 +979,7 @@ export function initialize(): void {
                 // of overlays or selecting text (for copy+paste) trigger cancelling.
                 // Check if the click is within the body to prevent extensions from
                 // interfering with the compose box.
-                compose_actions.cancel();
+                compose_ui.blur_compose_inputs();
             }
         }
     });

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -14,6 +14,7 @@ import * as buddy_data from "./buddy_data.ts";
 import * as compose_actions from "./compose_actions.ts";
 import * as compose_reply from "./compose_reply.ts";
 import * as compose_state from "./compose_state.ts";
+import * as compose_ui from "./compose_ui.ts";
 import * as emoji_picker from "./emoji_picker.ts";
 import * as flatpickr from "./flatpickr.ts";
 import * as hash_util from "./hash_util.ts";
@@ -1133,7 +1134,7 @@ export function initialize(): void {
                 // of overlays or selecting text (for copy+paste) trigger cancelling.
                 // Check if the click is within the body to prevent extensions from
                 // interfering with the compose box.
-                compose_actions.cancel();
+                compose_ui.blur_compose_inputs();
             }
         }
     });

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -87,12 +87,11 @@ function hide_box(): void {
     blur_compose_inputs();
     $(".new_message_textarea").css("min-height", "");
     compose_fade.clear_compose();
-    $(".message_comp").hide();
-    $("#compose_controls").show();
     // Assume a muted recipient row for the next time
     // the compose box is reopened
     $("#compose-recipient").addClass("low-attention-recipient-row");
-    $("#compose").removeClass("compose-box-open");
+    $("#compose-content").removeClass("compose-box-open");
+    $("#compose-content").addClass("compose-box-closed");
 }
 
 function show_compose_box(opts: ComposeActionsOpts): void {
@@ -119,7 +118,8 @@ function show_compose_box(opts: ComposeActionsOpts): void {
     // to this class we add a slight delay to avoid transitions firing
     // immediately.
     requestAnimationFrame(() => {
-        $("#compose").addClass("compose-box-open");
+        $("#compose-content").removeClass("compose-box-closed");
+        $("#compose-content").addClass("compose-box-open");
     });
 }
 
@@ -186,8 +186,8 @@ export function rewire_autosize_message_content(value: typeof autosize_message_c
 
 export let expand_compose_box = (): void => {
     $("#compose_close").attr("data-tooltip-template-id", "compose_close_tooltip_template");
-    $("#compose_controls").hide();
-    $(".message_comp").show();
+    $("#compose-content").addClass("compose-box-open");
+    $("#compose-content").removeClass("compose-box-closed");
 };
 
 export function rewire_expand_compose_box(value: typeof expand_compose_box): void {

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -73,18 +73,10 @@ function call_hooks(hooks: ComposeHook[]): void {
     }
 }
 
-export let blur_compose_inputs = (): void => {
-    $(".message_comp").find("input, textarea, button, #private_message_recipient").trigger("blur");
-};
-
-export function rewire_blur_compose_inputs(value: typeof blur_compose_inputs): void {
-    blur_compose_inputs = value;
-}
-
 function hide_box(): void {
     // This is the main hook for saving drafts when closing the compose box.
     drafts.update_draft();
-    blur_compose_inputs();
+    compose_ui.blur_compose_inputs();
     $(".new_message_textarea").css("min-height", "");
     compose_fade.clear_compose();
     // Assume a muted recipient row for the next time

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -85,8 +85,6 @@ function hide_box(): void {
     // This is the main hook for saving drafts when closing the compose box.
     drafts.update_draft();
     blur_compose_inputs();
-    $("#compose_recipient_box").hide();
-    $("#compose-direct-recipient").hide();
     $(".new_message_textarea").css("min-height", "");
     compose_fade.clear_compose();
     $(".message_comp").hide();

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -96,7 +96,8 @@ function hide_box(): void {
     // Assume a muted recipient row for the next time
     // the compose box is reopened
     $("#compose-recipient").addClass("low-attention-recipient-row");
-    $("#compose").removeClass("compose-box-open");
+    $("#compose-content").removeClass("compose-box-open");
+    $("#compose-content").addClass("compose-box-closed");
 }
 
 function show_compose_box(opts: ComposeActionsOpts): void {
@@ -132,7 +133,8 @@ function show_compose_box(opts: ComposeActionsOpts): void {
     // to this class; we add a slight delay to avoid transitions firing
     // immediately.
     requestAnimationFrame(() => {
-        $("#compose").addClass("compose-box-open");
+        $("#compose-content").removeClass("compose-box-closed");
+        $("#compose-content").addClass("compose-box-open");
     });
 }
 
@@ -199,7 +201,9 @@ export function rewire_autosize_message_content(value: typeof autosize_message_c
 
 export let expand_compose_box = (): void => {
     $("#compose_close").attr("data-tooltip-template-id", "compose_close_tooltip_template");
-    $("#compose").addClass("compose-box-open");
+    // TODO: Check this; HEAD had it on `#compose`
+    $("#compose-content").addClass("compose-box-open");
+    $("#compose-content").removeClass("compose-box-closed");
 };
 
 export function rewire_expand_compose_box(value: typeof expand_compose_box): void {

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -79,18 +79,10 @@ function call_hooks(hooks: ComposeHook[]): void {
     }
 }
 
-export let blur_compose_inputs = (): void => {
-    $(".message_comp").find("input, textarea, button, #private_message_recipient").trigger("blur");
-};
-
-export function rewire_blur_compose_inputs(value: typeof blur_compose_inputs): void {
-    blur_compose_inputs = value;
-}
-
 function hide_box(): void {
     // This is the main hook for saving drafts when closing the compose box.
     drafts.update_draft();
-    blur_compose_inputs();
+    compose_ui.blur_compose_inputs();
     $(".new_message_textarea").css("min-height", "");
     compose_fade.clear_compose();
     // Assume a muted recipient row for the next time

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -50,6 +50,7 @@ type ComposeActionsStartOpts = {
     is_reply?: boolean;
     keep_composebox_empty?: boolean | undefined;
     defer_focus?: boolean | undefined;
+    blur_compose?: boolean | undefined;
 };
 
 // An iteration on `ComposeActionsStartOpts` that enforces that
@@ -99,6 +100,7 @@ function show_compose_box(opts: ComposeActionsOpts): void {
             trigger: opts.trigger,
             message_type: "private",
             private_message_recipient_ids: opts.private_message_recipient_ids,
+            blur_compose: opts.blur_compose,
         };
     } else {
         opts_by_message_type = {
@@ -106,6 +108,7 @@ function show_compose_box(opts: ComposeActionsOpts): void {
             message_type: "stream",
             stream_id: opts.stream_id,
             topic: opts.topic,
+            blur_compose: opts.blur_compose,
         };
     }
     compose_recipient.update_compose_for_message_type(opts_by_message_type);
@@ -556,27 +559,13 @@ export function on_show_navigation_view(): void {
 }
 
 export let on_topic_narrow = (): void => {
-    if (!compose_state.composing()) {
-        // If our compose box is closed, then just
-        // leave it closed, assuming that the user is
-        // catching up on their feed and not actively
-        // composing.
-        return;
-    }
-
-    if (compose_state.stream_name() !== narrow_state.stream_name()) {
+    if (
         // If we changed streams, then we only leave the
         // compose box open if there is content or if the recipient was edited.
-        if (
-            compose_state.has_novel_message_content() ||
-            compose_state.is_recipient_edited_manually()
-        ) {
-            compose_fade.update_message_list();
-            return;
-        }
-
-        // Otherwise, avoid a mix.
-        cancel();
+        compose_state.stream_name() !== narrow_state.stream_name() &&
+        (compose_state.has_novel_message_content() || compose_state.is_recipient_edited_manually())
+    ) {
+        compose_fade.update_message_list();
         return;
     }
 
@@ -601,12 +590,10 @@ export let on_topic_narrow = (): void => {
     // we should update the compose topic to match the new narrow.
     // See #3300 for context--a couple users specifically asked for
     // this convenience.
-    compose_recipient.update_topic_displayed_text(narrow_state.topic());
-    compose_validate.warn_if_topic_resolved(true);
-    compose_fade.set_focused_recipient("stream");
-    compose_fade.update_message_list();
-    drafts.update_compose_draft_count();
-    $("textarea#compose-textarea").trigger("focus");
+    start({
+        message_type: "stream",
+        blur_compose: true,
+    });
 };
 
 export function rewire_on_topic_narrow(value: typeof on_topic_narrow): void {
@@ -689,12 +676,8 @@ export function on_narrow(opts: NarrowActivateOpts): void {
             // Defer setting focus on the compose box to avoid a
             // whole-screen scrolling bug on iPad/Safari.
             defer_focus: true,
+            blur_compose: true,
         });
         return;
     }
-
-    // If we got this far, then we assume the user is now in "reading"
-    // mode, so we close the compose box to make it easier to use navigation
-    // hotkeys and to provide more screen real estate for messages.
-    cancel();
 }

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -433,7 +433,7 @@ export function update_topic_displayed_text(topic_name = "", has_topic_focus = f
 export let update_compose_area_placeholder_text = (): void => {
     const $textarea: JQuery<HTMLTextAreaElement> = $("textarea#compose-textarea");
     // Change compose placeholder text only if compose box is open.
-    if ($(".message_comp").css("display") === "none") {
+    if ($("#compose-content").hasClass("compose-box-open")) {
         return;
     }
     const message_type = compose_state.get_message_type();

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -210,15 +210,11 @@ export function update_compose_for_message_type(opts: ComposeTriggeredOptions): 
     if (opts.message_type === "stream") {
         $("#compose-direct-recipient").hide();
         $("#compose_recipient_box").show();
-        $("#stream_toggle").addClass("active");
-        $("#private_message_toggle").removeClass("active");
         $("#compose-recipient").removeClass("compose-recipient-direct-selected");
         update_recipient_label(opts.stream_id);
     } else {
         $("#compose-direct-recipient").show();
         $("#compose_recipient_box").hide();
-        $("#stream_toggle").removeClass("active");
-        $("#private_message_toggle").addClass("active");
         $("#compose-recipient").addClass("compose-recipient-direct-selected");
         // TODO: When "Direct message" is selected, we show "DM" on the dropdown
         // button. It would be nice if the dropdown supported a way to attach

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -67,9 +67,7 @@ export let update_recipient_row_attention_level = (): void => {
     // row is focused, that puts us outside the low-attention
     // recipient-row state--including the `c` hotkey or the
     // Start new conversation button being clicked.
-    const is_compose_textarea_focused = document.activeElement?.id === "compose-textarea";
     if (
-        is_compose_textarea_focused &&
         (composing_to_current_topic_narrow() || composing_to_current_private_message_narrow()) &&
         compose_state.has_full_recipient() &&
         !compose_state.is_recipient_edited_manually()

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -561,7 +561,7 @@ export function update_placeholder_visibility(): void {
 export let update_compose_area_placeholder_text = (): void => {
     const $textarea: JQuery<HTMLTextAreaElement> = $("textarea#compose-textarea");
     // Change compose placeholder text only if compose box is open.
-    if ($(".message_comp").css("display") === "none") {
+    if ($("#compose-content").hasClass("compose-box-open")) {
         return;
     }
     const message_type = compose_state.get_message_type();

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -249,16 +249,12 @@ export function update_compose_for_message_type(opts: ComposeTriggeredOptions): 
         compose_select_recipient_dropdown_widget.current_value = opts.stream_id;
         $("#compose-direct-recipient").hide();
         $("#compose-channel-recipient").show();
-        $("#stream_toggle").addClass("active");
-        $("#private_message_toggle").removeClass("active");
         $("#compose-recipient").removeClass("compose-recipient-direct-selected");
         update_recipient_label(opts.stream_id);
     } else {
         compose_select_recipient_dropdown_widget.current_value = compose_state.DIRECT_MESSAGE_ID;
         $("#compose-direct-recipient").show();
         $("#compose-channel-recipient").hide();
-        $("#stream_toggle").removeClass("active");
-        $("#private_message_toggle").addClass("active");
         $("#compose-recipient").addClass("compose-recipient-direct-selected");
         // TODO: When "Direct message" is selected, we show "DM" on the dropdown
         // button. It would be nice if the dropdown supported a way to attach

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -35,6 +35,7 @@ export const DEFAULT_COMPOSE_PLACEHOLDER = $t({defaultMessage: "Compose your mes
 
 export type ComposeTriggeredOptions = {
     trigger: string;
+    blur_compose?: boolean | undefined;
 } & (
     | {
           message_type: "stream";
@@ -242,6 +243,13 @@ export function rewire_blur_compose_inputs(value: typeof blur_compose_inputs): v
 }
 
 export function set_focus(opts: ComposeTriggeredOptions): void {
+    // For the always-open compose box, we can use opts.blur_compose
+    // to prevent focusing, especially when moving from narrow to
+    // narrow or view to view with an empty compose box.
+    if (opts.blur_compose === true) {
+        blur_compose_inputs();
+        return;
+    }
     // Called mainly when opening the compose box or switching the
     // message type to set the focus in the first empty input in the
     // compose box.

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -233,6 +233,14 @@ function get_focus_area(opts: ComposeTriggeredOptions): string {
 // Export for testing
 export const _get_focus_area = get_focus_area;
 
+export let blur_compose_inputs = (): void => {
+    $(".message_comp").find("input, textarea, button, #private_message_recipient").trigger("blur");
+};
+
+export function rewire_blur_compose_inputs(value: typeof blur_compose_inputs): void {
+    blur_compose_inputs = value;
+}
+
 export function set_focus(opts: ComposeTriggeredOptions): void {
     // Called mainly when opening the compose box or switching the
     // message type to set the focus in the first empty input in the

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -237,6 +237,14 @@ function get_focus_area(opts: ComposeTriggeredOptions): string {
 // Export for testing
 export const _get_focus_area = get_focus_area;
 
+export let blur_compose_inputs = (): void => {
+    $(".message_comp").find("input, textarea, button, #private_message_recipient").trigger("blur");
+};
+
+export function rewire_blur_compose_inputs(value: typeof blur_compose_inputs): void {
+    blur_compose_inputs = value;
+}
+
 export function set_focus(opts: ComposeTriggeredOptions): void {
     // Called mainly when opening the compose box or switching the
     // message type to set the focus in the first empty input in the

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -39,6 +39,7 @@ export const DEFAULT_COMPOSE_PLACEHOLDER = $t({defaultMessage: "Compose your mes
 export type ComposeTriggeredOptions = {
     trigger: string;
     defer_focus?: boolean | undefined;
+    blur_compose?: boolean | undefined;
 } & (
     | {
           message_type: "stream";
@@ -246,6 +247,13 @@ export function rewire_blur_compose_inputs(value: typeof blur_compose_inputs): v
 }
 
 export function set_focus(opts: ComposeTriggeredOptions): void {
+    // For the always-open compose box, we can use opts.blur_compose
+    // to prevent focusing, especially when moving from narrow to
+    // narrow or view to view with an empty compose box.
+    if (opts.blur_compose === true) {
+        blur_compose_inputs();
+        return;
+    }
     // Called mainly when opening the compose box or switching the
     // message type to set the focus in the first empty input in the
     // compose box.

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1346,13 +1346,7 @@ export function narrow_to_next_pm_string(opts = {}): void {
 
     const filter_expr = [{operator: "dm", operand: direct_message}];
 
-    // force_close parameter is true to not auto open compose_box
-    const updated_opts = {
-        ...opts,
-        force_close: true,
-    };
-
-    show(filter_expr, updated_opts);
+    show(filter_expr, opts);
 }
 
 export function narrow_by_topic(

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1580,13 +1580,7 @@ export function narrow_to_next_pm_string(opts = {}): void {
 
     const filter_expr: NarrowTerm[] = [{operator: "dm", operand: direct_message}];
 
-    // force_close parameter is true to not auto open compose_box
-    const updated_opts = {
-        ...opts,
-        force_close: true,
-    };
-
-    show(filter_expr, updated_opts);
+    show(filter_expr, opts);
 }
 
 export function narrow_by_topic(

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -188,8 +188,24 @@
     }
 }
 
+/* We do not want these to occupy space,
+   so `display: none` is the correct property
+   here. However, we do not specify the inverse,
+   allowing these swappable compose elements to
+   display as specified elsewhere in the CSS. */
+.compose-box-open {
+    #compose_controls {
+        display: none;
+    }
+}
+
+.compose-box-closed {
+    .message_comp {
+        display: none;
+    }
+}
+
 .message_comp {
-    display: none;
     padding: 0 7px 0 0;
 
     #compose_banners {
@@ -1226,7 +1242,7 @@ textarea.new_message_textarea {
    interactions (e.g., Shift-Tabbing from the compose textarea
    to the topic box) show instant changes, so we don't need to
    accommodate them here. */
-#compose.compose-box-open:hover {
+#compose:hover .compose-box-open {
     .low-attention-recipient-row {
         #compose_select_recipient_widget,
         #compose_recipient_box,

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -195,8 +195,24 @@
     }
 }
 
+/* We do not want these to occupy space,
+   so `display: none` is the correct property
+   here. However, we do not specify the inverse,
+   allowing these swappable compose elements to
+   display as specified elsewhere in the CSS. */
+.compose-box-open {
+    #compose_controls {
+        display: none;
+    }
+}
+
+.compose-box-closed {
+    .message_comp {
+        display: none;
+    }
+}
+
 .message_comp {
-    display: none;
     padding: 0 7px 0 0;
 
     #compose_banners {
@@ -1286,7 +1302,7 @@ textarea.new_message_textarea {
    accommodate them here, which we prevent by applying the
    transitions only when focus isn't within the recipient row,
    or hasn't recently been within the topic box. */
-#compose.compose-box-open {
+#compose:hover .compose-box-open {
     .low-attention-recipient-row:not(.recently-focused, :focus-within) {
         #compose_select_recipient_widget,
         #compose-channel-recipient,

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -1,4 +1,4 @@
-<div id="compose-content">
+<div id="compose-content" class="compose-box-closed">
     {{!-- scroll to bottom button is not part of compose but
     helps us align it at various screens sizes with
     minimal css and no JS. We keep it `position: absolute` to prevent

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -49,6 +49,7 @@ const compose_ui = mock_esm("../src/compose_ui", {
     is_expanded: () => false,
     set_focus: noop,
     compute_placeholder_text: noop,
+    blur_compose_inputs: noop,
 });
 const hash_util = mock_esm("../src/hash_util");
 const narrow_state = mock_esm("../src/narrow_state", {
@@ -156,7 +157,6 @@ test("start", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_actions, "autosize_message_content", noop);
     override_rewire(compose_actions, "expand_compose_box", noop);
     override_rewire(compose_actions, "complete_starting_tasks", noop);
-    override_rewire(compose_actions, "blur_compose_inputs", noop);
     override_rewire(compose_actions, "clear_textarea", noop);
     const $composeContent = $("#compose-content");
     const $elem = $("#send_message_form");

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -158,6 +158,7 @@ test("start", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_actions, "complete_starting_tasks", noop);
     override_rewire(compose_actions, "blur_compose_inputs", noop);
     override_rewire(compose_actions, "clear_textarea", noop);
+    const $composeContent = $("#compose-content");
     const $elem = $("#send_message_form");
     const $textarea = $("textarea#compose-textarea");
     const $indicator = $("#compose-limit-indicator");
@@ -300,11 +301,11 @@ test("start", ({override, override_rewire, mock_template}) => {
     });
     $("textarea#compose-textarea").set_height(50);
 
-    assert_hidden("#compose_controls");
+    assert.ok($composeContent.hasClass("compose-box-open"));
     cancel();
     assert.ok(abort_xhr_called);
     assert.ok(pill_cleared);
-    assert_visible("#compose_controls");
+    assert.ok($composeContent.hasClass("compose-box-closed"));
     assert.ok(!compose_state.composing());
 });
 

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -305,7 +305,6 @@ test("start", ({override, override_rewire, mock_template}) => {
     assert.ok(abort_xhr_called);
     assert.ok(pill_cleared);
     assert_visible("#compose_controls");
-    assert_hidden("#compose-direct-recipient");
     assert.ok(!compose_state.composing());
 });
 

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -68,6 +68,7 @@ const compose_ui = mock_esm("../src/compose_ui", {
     is_expanded: () => false,
     set_focus: noop,
     compute_placeholder_text: noop,
+    blur_compose_inputs: noop,
 });
 const narrow_state = mock_esm("../src/narrow_state", {
     set_compose_defaults: noop,
@@ -177,7 +178,6 @@ test("start", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_actions, "autosize_message_content", noop);
     override_rewire(compose_actions, "expand_compose_box", noop);
     override_rewire(compose_actions, "complete_starting_tasks", noop);
-    override_rewire(compose_actions, "blur_compose_inputs", noop);
     override_rewire(compose_actions, "clear_textarea", noop);
     const $compose_content = $("#compose-content");
     const $elem = $("#send_message_form");

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -179,6 +179,7 @@ test("start", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_actions, "complete_starting_tasks", noop);
     override_rewire(compose_actions, "blur_compose_inputs", noop);
     override_rewire(compose_actions, "clear_textarea", noop);
+    const $compose_content = $("#compose-content");
     const $elem = $("#send_message_form");
     const $textarea = $("textarea#compose-textarea");
     const $indicator = $("#compose-limit-indicator");
@@ -321,10 +322,11 @@ test("start", ({override, override_rewire, mock_template}) => {
     });
     $("textarea#compose-textarea").set_height(50);
 
+    assert.ok($compose_content.hasClass("compose-box-open"));
     cancel();
     assert.ok(abort_xhr_called);
     assert.ok(pill_cleared);
-    assert.ok(!$("#compose").hasClass("compose-box-open"));
+    assert.ok($compose_content.hasClass("compose-box-closed"));
     assert.ok(!compose_state.composing());
 });
 

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -157,10 +157,6 @@ function stub_message_row($textarea) {
 function initialize_pm_pill(mock_template) {
     $.clear_all_elements();
 
-    $(".message_comp").css = (property) => {
-        assert.equal(property, "display");
-        return "block";
-    };
     $("#compose-send-button").trigger("focus");
     $("#compose-send-button .loader").hide();
 


### PR DESCRIPTION
This PR is a draft for keeping the compose box always open.

As of 2025-07-08, this is working with single topic and DM narrows. The compose box is effectively updated with calls to `compose_actions.start()` navigating from narrow to narrow. While I considered writing logic to update the channel picker and topic box, similar to what's happening in `compose_closed_ui.ts` for the closed compose state, that looked less appealing when it came to managing a compose box that already includes content.

There are some critical UX questions that will need to be settled with topic and DM narrows, which even in this initial iteration we can probably begin thinking about:

- [ ] Should we introduce other means/events by which a draft is saved? The existing logic is that drafts are saved when the compose box is closed manually, either via the keyboard or the compose box's `x`, or via the vdots menu. This PR by necessity removes other previous means of closing the compose box, such as clicking elsewhere in the UI.
- [ ] Do we want to reduce the height of the always-open compose box to further reduce its footprint? And if so, do we want to increase the height to, say, its existing height once the compose box receives focus?

Issue: #32986
