### PR TITLE
tooltips: Don't destroy user popover instance on user status hover.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -512,6 +512,10 @@ export function initialize(): void {
                     observer.disconnect();
                 }
             },
+            onCreate(instance) {
+                const $popover = $(instance.popper);
+                $popover.addClass("buddy-list-tooltip-root");
+            },
             onShow(instance) {
                 if (!is_custom_observer_needed) {
                     return;
@@ -577,7 +581,13 @@ export function initialize(): void {
             $(".user_sidebar_entry .status-emoji-name").on("mouseenter", () => {
                 const element: tippy.ReferenceElement = util.the($elem);
                 const instance = element._tippy;
-                if (instance?.state.isVisible) {
+                // We make sure instance is of buddy list since we don't want to
+                // close any other tippy instances.
+                if (
+                    instance?.state.isVisible &&
+                    instance.reference.classList.contains("user_sidebar_entry") &&
+                    instance.popper.classList.contains("buddy-list-tooltip-root")
+                ) {
                     instance.destroy();
                 }
             });


### PR DESCRIPTION
This PR adds a check for instance and stops user status hover from destroying user popover instance.

Fixes: zulip#35175.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**After:**

[Screencast from 2025-07-09 02-27-50.webm](https://github.com/user-attachments/assets/3d474eb5-2867-49dd-b3d7-202eaddd3abc)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
