### PR TITLE
stream_list: Fix misleading tooltip.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -5,6 +5,7 @@ import * as tippy from "tippy.js";
 
 import render_filter_topics from "../templates/filter_topics.hbs";
 import render_go_to_channel_feed_tooltip from "../templates/go_to_channel_feed_tooltip.hbs";
+import render_go_to_channel_list_of_topics_tooltip from "../templates/go_to_channel_list_of_topics_tooltip.hbs";
 import render_stream_privacy from "../templates/stream_privacy.hbs";
 import render_stream_sidebar_row from "../templates/stream_sidebar_row.hbs";
 import render_stream_subheader from "../templates/streams_subheader.hbs";
@@ -878,7 +879,16 @@ export function initialize_tippy_tooltips(): void {
             const current_narrow_stream_id = narrow_state.stream_id();
             const current_topic = narrow_state.topic();
             if (current_narrow_stream_id === stream_id && current_topic !== undefined) {
-                instance.setContent(ui_util.parse_html(render_go_to_channel_feed_tooltip()));
+                if (
+                    user_settings.web_channel_default_view ===
+                    web_channel_default_view_values.list_of_topics.code
+                ) {
+                    instance.setContent(
+                        ui_util.parse_html(render_go_to_channel_list_of_topics_tooltip()),
+                    );
+                } else {
+                    instance.setContent(ui_util.parse_html(render_go_to_channel_feed_tooltip()));
+                }
                 return undefined;
             }
             // Then check for truncation

--- a/web/templates/go_to_channel_list_of_topics_tooltip.hbs
+++ b/web/templates/go_to_channel_list_of_topics_tooltip.hbs
@@ -1,0 +1,2 @@
+<div>{{t "Go to list of topics"}}</div>
+{{tooltip_hotkey_hints "Y"}}


### PR DESCRIPTION
When in topic narrow, hovering over the topic's channel, should correctly show where it would navigate to.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20wrong.20tooltip.20on.20channel

Tested that if the user setting it show list of topics, we show the list of topics tooltip, otherwise go to channel feed tooltip. Note this only works when in a topic narrow and hovering over the topic's channel.

![Screenshot from 2025-07-09 21-55-03](https://github.com/user-attachments/assets/17527bb9-e99b-4539-a39d-b363f304fb15)
