### PR TITLE
typed_endpoint: Handle "dataclass_type" pydantic errors.

### DIFF
--- a/zerver/lib/typed_endpoint.py
+++ b/zerver/lib/typed_endpoint.py
@@ -316,6 +316,7 @@ def parse_view_func_signature(
 ERROR_TEMPLATES = {
     "bool_parsing": _("{var_name} is not a boolean"),
     "bool_type": _("{var_name} is not a boolean"),
+    "dataclass_type": _("{var_name} does not have the expected format"),
     "datetime_parsing": _("{var_name} is not a date"),
     "datetime_type": _("{var_name} is not a date"),
     "dict_type": _("{var_name} is not a dict"),

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -1319,6 +1319,11 @@ class UserGroupAPITestCase(UserGroupTestCase):
         leadership_group.deactivated = False
         leadership_group.save()
 
+        # Test updating with value not in the form of GroupSettingChangeRequest
+        params[setting_name] = orjson.dumps(support_group.id).decode()
+        result = self.client_patch(f"/json/user_groups/{leadership_group.id}", info=params)
+        self.assert_json_error(result, f"{setting_name} does not have the expected format")
+
     def test_update_user_group_permission_settings(self) -> None:
         hamlet = self.example_user("hamlet")
         check_add_user_group(hamlet.realm, "support", [hamlet], acting_user=hamlet)


### PR DESCRIPTION
This PR adds error message for handling "dataclass_type" pydantic errors. An example when
this occurs is when group setting value passed to update the setting is invalid like group ID is
passed directly and not in an object with "new" field and other invalid values as well.

<!-- Describe your pull request here.-->
 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
