### PR TITLE
banners: Add utility class for uniform bold.

### DIFF
--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -456,7 +456,12 @@ export function format_array_as_list_with_highlighted_elements(
 ): string {
     // If Intl.ListFormat is not supported
     if (Intl.ListFormat === undefined) {
-        return array.map((item) => `<b>${Handlebars.Utils.escapeExpression(item)}</b>`).join(", ");
+        return array
+            .map(
+                (item) =>
+                    `<b class="highlighted-element">${Handlebars.Utils.escapeExpression(item)}</b>`,
+            )
+            .join(", ");
     }
 
     // Use Intl.ListFormat to format the array as a Internationalized list.
@@ -469,7 +474,7 @@ export function format_array_as_list_with_highlighted_elements(
             // items), and literals (commas, etc.). We need to
             // HTML-escape the elements, but not the literals.
             if (part.type === "element") {
-                return `<b>${Handlebars.Utils.escapeExpression(part.value)}</b>`;
+                return `<b class="highlighted-element">${Handlebars.Utils.escapeExpression(part.value)}</b>`;
             }
             return part.value;
         })

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -59,6 +59,10 @@ kbd {
     font-weight: 300;
 }
 
+.highlighted-element {
+    font-weight: 600;
+}
+
 .inline-block {
     display: inline-block;
 }

--- a/web/templates/modal_banner/unsubscribed_participants_warning_banner.hbs
+++ b/web/templates/modal_banner/unsubscribed_participants_warning_banner.hbs
@@ -4,20 +4,20 @@
             {{#tr}}
                 Message sender <z-user-names></z-user-names> is not subscribed to &nbsp;<z-stream></z-stream>.
                 {{#*inline "z-user-names"}}({{{unsubscribed_participant_formatted_names_list}}}){{/inline}}
-                {{#*inline "z-stream"}}<strong>{{> ../inline_decorated_channel_name stream=stream show_colored_icon=true}}</strong>{{/inline}}
+                {{#*inline "z-stream"}}<strong class="highlighted-element">{{> ../inline_decorated_channel_name stream=stream show_colored_icon=true}}</strong>{{/inline}}
             {{/tr}}
 
         {{else if few_unsubscribed_participants}}
             {{#tr}}
                 Some topic participants <z-user-names></z-user-names> are not subscribed to &nbsp;<z-stream></z-stream>.
                 {{#*inline "z-user-names"}}({{{unsubscribed_participant_formatted_names_list}}}){{/inline}}
-                {{#*inline "z-stream"}}<strong>{{> ../inline_decorated_channel_name stream=stream show_colored_icon=true}}</strong>{{/inline}}
+                {{#*inline "z-stream"}}<strong class="highlighted-element">{{> ../inline_decorated_channel_name stream=stream show_colored_icon=true}}</strong>{{/inline}}
             {{/tr}}
 
         {{else}}
             {{#tr}}
                 {unsubscribed_participants_count} topic participants are not subscribed to &nbsp;<z-stream></z-stream>.
-                {{#*inline "z-stream"}}<strong>{{> ../inline_decorated_channel_name stream=stream show_colored_icon=true}}</strong>{{/inline}}
+                {{#*inline "z-stream"}}<strong class="highlighted-element">{{> ../inline_decorated_channel_name stream=stream show_colored_icon=true}}</strong>{{/inline}}
             {{/tr}}
         {{/if}}
     </p>

--- a/web/tests/util.test.cjs
+++ b/web/tests/util.test.cjs
@@ -369,7 +369,7 @@ run_test("format_array_as_list", () => {
     );
     assert.equal(
         util.format_array_as_list_with_highlighted_elements(array, "long", "conjunction"),
-        "<b>apple</b>, <b>banana</b>, and <b>orange</b>",
+        '<b class="highlighted-element">apple</b>, <b class="highlighted-element">banana</b>, and <b class="highlighted-element">orange</b>',
     );
 
     // Conjunction format
@@ -391,7 +391,7 @@ run_test("format_array_as_list", () => {
         );
         assert.equal(
             util.format_array_as_list_with_highlighted_elements(array, "long", "conjunction"),
-            "<b>apple</b>, <b>banana</b>, <b>orange</b>",
+            '<b class="highlighted-element">apple</b>, <b class="highlighted-element">banana</b>, <b class="highlighted-element">orange</b>',
         );
 
         assert.equal(


### PR DESCRIPTION
This introduces a more performant, shared utility class (`.highlighted-element`) to ensure uniform bold weights (600), in particular on the move-message modal.

The `util.format_array_as_list_with_highlighted_elements()` function is called from within user_group_edit, but I was not able to quickly determine where in the UI that is output. Regardless, the new class should not have any negative impact beyond reducing to our normal 600-weight bold.

[#issues > 🎯 different bolds in banner?](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20different.20bolds.20in.20banner.3F/with/2182161)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![modal-bolds-before](https://github.com/user-attachments/assets/1c268305-96b3-4da3-8a77-5851b0dbbeb4) | ![modal-bolds-after](https://github.com/user-attachments/assets/33210e68-b468-4404-af35-78e33eee0636) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>