### PR TITLE
inbox: Update reply-button label via show().

### DIFF
--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -207,6 +207,7 @@ export function update_buttons_for_stream_views(): void {
 export function update_buttons_for_non_specific_views(): void {
     $("#new_conversation_button").attr("data-conversation-type", "non-specific");
     update_buttons(should_disable_compose_reply_button_for_stream());
+    set_standard_text_for_reply_button();
 }
 
 function set_reply_button_label(label: string): void {


### PR DESCRIPTION
This attempts to correct a case where the `show()` logic on inbox_ui fails to update the label text of the closed compose-box reply button, especially on an empty inbox, making the action of clicking on the reply button confusing, as it presents an empty compose box with the channel picker open.

From my investigation, there was nothing in that code path to update the label when navigating into Inbox from a DM or topic view. But I'm not fully certain that this is the correct solution; it may just be papering over a lapse in logic elsewhere.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![dm-to-inbox-after](https://github.com/user-attachments/assets/6da157e1-8b56-4b5d-a269-22c80bfc2189) | ![dm-to-inbox-before](https://github.com/user-attachments/assets/9b808ed4-e5bc-4245-9a79-4d5b08006ccb) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>