### PR TITLE
left_sidebar: Standardize topic list filter input.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -838,7 +838,7 @@ export function initialize(): void {
 
     // LEFT SIDEBAR
 
-    $("body").on("click", "#clear_search_topic_button", topic_list.clear_topic_search);
+    $("body").on("click", ".filter-topics .input-button", topic_list.clear_topic_search);
 
     $(".streams_filter_icon").on("click", (e) => {
         e.stopPropagation();

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -453,7 +453,7 @@ export function process_escape_key(e) {
 
         // When the input is focused, we blur and clear the input. A second "Esc"
         // will zoom out, handled below.
-        if (stream_list.is_zoomed_in() && $("#left-sidebar-filter-topic-input").is(":focus")) {
+        if (stream_list.is_zoomed_in() && $("#topic_filter_query").is(":focus")) {
             topic_list.clear_topic_search(e);
             return true;
         }

--- a/web/src/inputs.ts
+++ b/web/src/inputs.ts
@@ -1,12 +1,33 @@
 import $ from "jquery";
 
-$("body").on("input", ".input-element", function (this: HTMLInputElement, _e: JQuery.Event) {
+// We use the `input` tag in the selector to avoid conflicts with the pill containing
+// counterpart, which uses a `contenteditable` div instead of an input element.
+$("body").on("input", "input.input-element", function (this: HTMLInputElement, _e: JQuery.Event) {
     if (this.value.length === 0) {
         $(this).removeClass("input-element-nonempty");
     } else {
         $(this).addClass("input-element-nonempty");
     }
 });
+
+$("body").on(
+    "input change",
+    ".has-input-pills .pill-container",
+    function (this: HTMLInputElement, _e: JQuery.Event) {
+        // We define another event handler for inputs with pill, similar to the one above.
+        // However, due to the way inputs with pill use a contenteditable div instead of an
+        // input element, we need to check the textContent of the pill container instead of
+        // the value of an input element.
+        // Here we need to listen to the `change` event in conjunction with the `input` event
+        // to handle the addition or removal of input pills.
+        const value = this.textContent?.trim() ?? "";
+        if (value.length === 0) {
+            $(this).removeClass("input-element-nonempty");
+        } else {
+            $(this).addClass("input-element-nonempty");
+        }
+    },
+);
 
 $("body").on(
     "click",

--- a/web/src/inputs.ts
+++ b/web/src/inputs.ts
@@ -1,34 +1,5 @@
 import $ from "jquery";
 
-// We use the `input` tag in the selector to avoid conflicts with the pill containing
-// counterpart, which uses a `contenteditable` div instead of an input element.
-$("body").on("input", "input.input-element", function (this: HTMLInputElement, _e: JQuery.Event) {
-    if (this.value.length === 0) {
-        $(this).removeClass("input-element-nonempty");
-    } else {
-        $(this).addClass("input-element-nonempty");
-    }
-});
-
-$("body").on(
-    "input change",
-    ".has-input-pills .pill-container",
-    function (this: HTMLInputElement, _e: JQuery.Event) {
-        // We define another event handler for inputs with pill, similar to the one above.
-        // However, due to the way inputs with pill use a contenteditable div instead of an
-        // input element, we need to check the textContent of the pill container instead of
-        // the value of an input element.
-        // Here we need to listen to the `change` event in conjunction with the `input` event
-        // to handle the addition or removal of input pills.
-        const value = this.textContent?.trim() ?? "";
-        if (value.length === 0) {
-            $(this).removeClass("input-element-nonempty");
-        } else {
-            $(this).addClass("input-element-nonempty");
-        }
-    },
-);
-
 $("body").on(
     "click",
     ".filter-input .input-button",

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -425,7 +425,7 @@ export function zoom_in_topics(options: {stream_id: number | undefined}): void {
             $elt.show();
             // Add search box for topics list.
             $elt.children("div.bottom_left_row").append($(render_filter_topics()));
-            $("#left-sidebar-filter-topic-input").trigger("focus");
+            $("#topic_filter_query").trigger("focus");
             topic_list.setup_topic_search_typeahead();
         } else {
             $elt.hide();

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -374,26 +374,17 @@ export class LeftSidebarTopicListWidget extends TopicListWidget {
 
 export function clear_topic_search(e: JQuery.Event): void {
     e.stopPropagation();
+
+    search_pill_widget?.clear(true);
+
     const $input = $("#topic_filter_query");
-    if ($input.length > 0) {
-        $input.text("");
-        $input.trigger("blur");
-
-        search_pill_widget?.clear(true);
-        update_clear_button();
-
-        // Since this changes the contents of the search input, we
-        // need to rerender the topic list.
-        const stream_ids = [...active_widgets.keys()];
-
-        const stream_id = stream_ids[0];
-        assert(stream_id !== undefined);
-        const widget = active_widgets.get(stream_id);
-        assert(widget !== undefined);
-        const parent_widget = widget.get_parent();
-
-        rebuild_left_sidebar(parent_widget, stream_id);
-    }
+    // Since the `clear` function of the search_pill_widget
+    // takes care of clearing both the text content and the
+    // pills, we just need to trigger an input event on the
+    // contenteditable element to reset the topic list via
+    // the `input` event handler without having to manually
+    // manage the reset of the topic list.
+    $input.trigger("input");
 }
 
 export function active_stream_id(): number | undefined {
@@ -517,7 +508,7 @@ const filter_options = new Map<string, string>([
 
 export function update_clear_button(): void {
     const $filter_query = $("#topic_filter_query");
-    const $clear_button = $("#clear_search_topic_button");
+    const $clear_button = $(".filter-topics .input-button");
     if (get_left_sidebar_topic_search_term() === "" && get_typeahead_search_term() === "") {
         $clear_button.css("visibility", "hidden");
         // When we use backspace to clear the content of the search box,

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -506,21 +506,6 @@ const filter_options = new Map<string, string>([
     [$t({defaultMessage: "All topics"}), ""],
 ]);
 
-export function update_clear_button(): void {
-    const $filter_query = $("#topic_filter_query");
-    const $clear_button = $(".filter-topics .input-button");
-    if (get_left_sidebar_topic_search_term() === "" && get_typeahead_search_term() === "") {
-        $clear_button.css("visibility", "hidden");
-        // When we use backspace to clear the content of the search box,
-        // a <br> tag is left inside it, preventing the data-placeholder
-        // value from reappearing as the element never becomes truly empty.
-        // Therefore, we manually set the text to empty.
-        $filter_query.empty();
-    } else {
-        $clear_button.css("visibility", "visible");
-    }
-}
-
 export function setup_topic_search_typeahead(): void {
     const $input = $("#topic_filter_query");
     const $pill_container = $("#left-sidebar-filter-topic-input");
@@ -592,7 +577,6 @@ export function setup_topic_search_typeahead(): void {
     });
 
     search_pill_widget.onPillRemove(() => {
-        update_clear_button();
         const stream_id = active_stream_id();
         if (stream_id !== undefined) {
             const widget = active_widgets.get(stream_id);
@@ -639,8 +623,5 @@ export function initialize({
         const stream_id = active_stream_id();
         assert(stream_id !== undefined);
         active_widgets.get(stream_id)?.build();
-        update_clear_button();
     });
-
-    update_clear_button();
 }

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -494,7 +494,7 @@ export function zoom_in(): void {
 }
 
 export function get_left_sidebar_topic_search_term(): string {
-    return $("#left-sidebar-filter-topic-input .input").text().trim();
+    return $("#topic_filter_query").text().trim();
 }
 
 export function get_typeahead_search_term(): string {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -242,7 +242,7 @@
     );
     /* This represents the space in the sidebar reserved for symbols like
        the #; labels like the stream name go to the right of this. */
-    --left-sidebar-icon-column-width: 16px;
+    --left-sidebar-icon-column-width: 1em;
     /* Offset on unreads to make New topic button appear centered. */
     --left-sidebar-unread-offset: 6.5px;
     /* space direct message / stream / topic names from unread counters

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1860,13 +1860,17 @@
         hsl(0deg 0% 100% / 85%),
         hsl(0deg 0% 0% / 40%)
     );
-    --color-background-compose-direct-recipient-pill-container: light-dark(
+    --color-background-pill-container: light-dark(
         hsl(0deg 0% 100%),
         hsl(0deg 0% 0% / 20%)
     );
     --color-background-pill-container-input-disabled: light-dark(
         hsl(0deg 0% 93%),
         hsl(0deg 0% 0% / 20%)
+    );
+    --color-border-pill-container: light-dark(
+        hsl(0deg 0% 0% / 15%),
+        hsl(0deg 0% 0% / 60%)
     );
 
     /* Inbox view constants - Values from Figma design */

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2629,28 +2629,24 @@
     );
 
     /* Inputs */
-    --color-text-input: light-dark(
-        color-mix(in oklch, hsl(0deg 0% 15%) 50%, transparent),
-        color-mix(in oklch, hsl(0deg 0% 83%) 50%, transparent)
-    );
-    --color-text-input-focus: light-dark(hsl(0deg 0% 15%), hsl(0deg 0% 83%));
+    --color-text-input: light-dark(hsl(0deg 0% 14%), hsl(0deg 0% 95%));
     /* TODO: Light mode uses browser-default white
        backgrounds; we should extend the use of this
        color variable to 1) explicitly set the
        background color of inputs, and 2) clean up a
        lingering stack of selectors in dark_theme.css. */
-    --color-background-input: light-dark(hsl(0deg 0% 100%), hsl(220deg 6% 10%));
+    --color-background-input: light-dark(hsl(0deg 0% 100%), hsl(225deg 6% 10%));
     --color-background-input-focus: light-dark(
         hsl(0deg 0% 100%),
-        hsl(240deg 6% 7%)
+        hsl(225deg 6% 7%)
     );
     --color-border-input: light-dark(
         color-mix(in oklch, hsl(229deg 22% 10%) 30%, transparent),
         color-mix(in oklch, hsl(0deg 0% 100%) 20%, transparent)
     );
     --color-border-input-hover: light-dark(
-        color-mix(in oklch, hsl(229deg 22% 10%) 30%, transparent),
-        color-mix(in oklch, hsl(0deg 0% 100%) 20%, transparent)
+        color-mix(in oklch, hsl(229deg 22% 10%) 60%, transparent),
+        color-mix(in oklch, hsl(0deg 0% 100%) 40%, transparent)
     );
     --color-border-input-focus: light-dark(
         color-mix(in oklch, hsl(229deg 22% 10%) 80%, transparent),

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -107,7 +107,6 @@
 
     textarea,
     select,
-    .pill-container,
     .user-status-content-wrapper,
     .custom-time-input-value,
     #organization-permissions .dropdown-widget-button,

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -4,8 +4,10 @@
     flex-wrap: wrap;
     min-width: 0;
 
+    background-color: var(--color-background-pill-container);
+
     padding: var(--outer-spacing-input-pill-container);
-    border: 1px solid hsl(0deg 0% 0% / 15%);
+    border: 1px solid var(--color-border-pill-container);
     border-radius: 4px;
     align-items: center;
 
@@ -236,9 +238,6 @@
 
 #compose-direct-recipient .pill-container {
     border: 1px solid var(--color-compose-recipient-box-border-color);
-    background-color: var(
-        --color-background-compose-direct-recipient-pill-container
-    );
 
     .input:first-child:empty::before {
         content: attr(data-no-recipients-text);

--- a/web/styles/inputs.css
+++ b/web/styles/inputs.css
@@ -114,23 +114,42 @@
     padding: 0.25em; /* 4px at 16px/1em */
 }
 
-/* We use the `input` tag in the selector to avoid conflicts
-   with the pill containing counterpart, which uses a `contenteditable`
-   div instead of an input element, and thus doesn't support the
-   placeholder pseudo-classes. */
-.filter-input input.input-element {
-    &:placeholder-shown {
-        /* In case of filter inputs, when the input field
-           is empty, we hide the input button and adjust
-           the right padding to compensate for the same. */
-        padding-right: 0.5em;
+.filter-input {
+    /* We use the `input` tag in the selector to avoid conflicts
+       with the pill containing counterpart, which uses a `contenteditable`
+       div instead of an input element, and thus doesn't support the
+       placeholder pseudo-classes. */
+    input.input-element {
+        &:placeholder-shown {
+            /* In case of filter inputs, when the input field
+            is empty, we hide the input button and adjust
+            the right padding to compensate for the same. */
+            padding-right: 0.5em;
 
-        ~ .input-button {
-            visibility: hidden;
+            ~ .input-button {
+                visibility: hidden;
+            }
+        }
+
+        &:not(:placeholder-shown) {
+            @extend .input-active-styles;
         }
     }
 
-    &:not(:placeholder-shown) {
-        @extend .input-active-styles;
+    /* Specific styles for filter input with pills */
+    &.has-input-pills {
+        &:not(:has(.pill)):has(.input:empty) {
+            .input-element {
+                padding-right: 0.5em;
+            }
+
+            .input-button {
+                visibility: hidden;
+            }
+        }
+
+        &:has(.pill):not(:has(.input:empty)) .input-element {
+            @extend .input-active-styles;
+        }
     }
 }

--- a/web/styles/inputs.css
+++ b/web/styles/inputs.css
@@ -48,16 +48,18 @@
     }
 
     &.has-input-icon .input-element {
+        /* Subtract 1px to compensate for the left border */
         padding-left: calc(
             var(--input-icon-starting-offset) + var(--input-icon-width) +
-                var(--input-icon-content-gap)
+                var(--input-icon-content-gap) - 1px
         );
     }
 
     &.has-input-button .input-element {
+        /* Subtract 1px to compensate for the right border */
         padding-right: calc(
             var(--input-button-content-gap) + var(--input-button-width) +
-                var(--input-button-ending-offset)
+                var(--input-button-ending-offset) - 1px
         );
     }
 

--- a/web/styles/inputs.css
+++ b/web/styles/inputs.css
@@ -38,12 +38,9 @@
         }
 
         &:focus {
-            box-shadow: 0 0 5px var(--color-box-shadow-input-focus);
-        }
-
-        &:focus,
-        &.input-element-nonempty {
             @extend .input-active-styles;
+
+            box-shadow: 0 0 5px var(--color-box-shadow-input-focus);
         }
     }
 
@@ -86,12 +83,9 @@
         }
 
         &:has(.input:focus) {
-            box-shadow: 0 0 5px var(--color-box-shadow-input-focus);
-        }
-
-        &:has(.input:focus),
-        &.input-element-nonempty:has(.input) {
             @extend .input-active-styles;
+
+            box-shadow: 0 0 5px var(--color-box-shadow-input-focus);
         }
     }
 }

--- a/web/styles/inputs.css
+++ b/web/styles/inputs.css
@@ -60,6 +60,38 @@
                 var(--input-button-ending-offset)
         );
     }
+
+    /* Special styles for input with pills */
+    &.has-input-pills .pill-container {
+        .input {
+            flex-grow: 1;
+            /* Override default values in web/styles/input_pill.css  */
+            padding: 0;
+            line-height: inherit;
+
+            &:empty::before {
+                color: var(--color-text-placeholder);
+                content: attr(data-placeholder);
+            }
+        }
+
+        .pill {
+            height: 1.25em; /* 20px at 16px/1em */
+        }
+
+        &:has(.input:hover) {
+            border-color: var(--color-border-input-hover);
+        }
+
+        &:has(.input:focus) {
+            box-shadow: 0 0 5px var(--color-box-shadow-input-focus);
+        }
+
+        &:has(.input:focus),
+        &.input-element-nonempty:has(.input) {
+            @extend .input-active-styles;
+        }
+    }
 }
 
 .input-icon {
@@ -77,11 +109,15 @@
     padding: 0.25em; /* 4px at 16px/1em */
 }
 
-.filter-input .input-element {
+/* We use the `input` tag in the selector to avoid conflicts
+   with the pill containing counterpart, which uses a `contenteditable`
+   div instead of an input element, and thus doesn't support the
+   placeholder pseudo-classes. */
+.filter-input input.input-element {
     &:placeholder-shown {
         /* In case of filter inputs, when the input field
-        is empty, we hide the input button and adjust
-        the right padding to compensate for the same. */
+           is empty, we hide the input button and adjust
+           the right padding to compensate for the same. */
         padding-right: 0.5em;
 
         ~ .input-button {

--- a/web/styles/inputs.css
+++ b/web/styles/inputs.css
@@ -1,5 +1,5 @@
 .input-active-styles {
-    color: var(--color-text-input-focus);
+    color: var(--color-text-input);
     background-color: var(--color-background-input-focus);
     border-color: var(--color-border-input-focus);
 }
@@ -96,7 +96,10 @@
 
 .input-icon {
     grid-area: input-icon;
-    color: var(--color-text-input);
+    /* Matching the color of input icon on the left to
+       that of a neutral icon button gives us a consistent
+       look when paired with the input button on the right. */
+    color: var(--color-text-neutral-icon-button);
     /* We need to set the z-index, since the input icon
        comes before the input element in the DOM, but we
        want to display it over the input element in the UI. */

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1363,31 +1363,8 @@ li.top_left_scheduled_messages {
     }
 }
 
-.topic-list-filter {
-    grid-area: filter-box;
-    padding-right: var(--line-height-sidebar-row-prominent);
-    box-shadow: none;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    gap: 0.125em; /* 2px at 16px em */
-    background-color: var(--color-background-active-narrow-filter);
-    font-weight: 400;
-
-    .input:empty::before {
-        color: var(--color-text-placeholder);
-        content: attr(data-placeholder);
-    }
-
-    .input {
-        flex-grow: 1;
-        min-width: 0;
-    }
-}
-
-#clear_search_topic_button {
-    visibility: hidden;
-    height: 2em; /* 32px at 16px/1em */
+.filter-topics {
+    font-weight: initial;
 }
 
 .searching-for-more-topics img {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1069,7 +1069,7 @@ li.top_left_scheduled_messages {
             var(--left-sidebar-toggle-width-offset) -
                 var(--input-icon-starting-offset)
         )
-        minmax(0, 1fr) var(--left-sidebar-vdots-width);
+        minmax(0, 1fr) 0;
 
     .filter-input,
     .filter-topics {

--- a/web/templates/filter_topics.hbs
+++ b/web/templates/filter_topics.hbs
@@ -1,13 +1,7 @@
 <div class="left-sidebar-filter-input-container">
-    <div class="topic_search_section filter-topics left-sidebar-filter-row">
-        <div class="topic-list-filter home-page-input filter_text_input pill-container" id="left-sidebar-filter-topic-input">
-            <div class="input" contenteditable="true" id="topic_filter_query"
-              data-placeholder="{{t 'Filter topics' }}">
-                {{~! Squash whitespace so that placeholder is displayed when empty. ~}}
-            </div>
+    {{#> input_wrapper input_type="filter-input" custom_classes="topic_search_section filter-topics has-input-pills" icon="search" input_button_icon="close"}}
+        <div class="input-element home-page-input pill-container" id="left-sidebar-filter-topic-input">
+            <div class="input" contenteditable="true" id="topic_filter_query" data-placeholder="{{t 'Filter topics' }}"></div>
         </div>
-        <button type="button" class="clear_search_button" id="clear_search_topic_button">
-            <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
-        </button>
-    </div>
+    {{/input_wrapper}}
 </div>


### PR DESCRIPTION
This follow-up PR replaces the current left sidebar topic list filter input implementation with the redesigned input_wrapper
component.

This PR also serves as the base for supporting inputs using the search_pill_widget, and thus adjusts the previously defined logic at certain places to ensure that the input pills are handled and displayed accurately.

Other changes in the PR:
- Fixes input color values deviating from the design.
- Stretch filter inputs in the left sidebar to fill available space on right. ([#issues > show all topics spacing @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/show.20all.20topics.20spacing/near/2215476))
- A prep commit moving the color variables of input pill to `app_variables.css`; away from `dark_theme.css`.
- Noticed some out of place selectors as an after effect of #34135, fixed all of them under one commit. (some of the changes here are for clarity purposes.)

Fixes part of #34476.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![Screenshot 2025-07-10 at 6 26 18 AM](https://github.com/user-attachments/assets/3bfaef63-b726-45db-a3e0-26942fe1f3bf) | ![Screenshot 2025-07-10 at 6 25 44 AM](https://github.com/user-attachments/assets/af45e1a8-4bcd-490a-80c4-339eb03d219f) |
| ![Screenshot 2025-07-10 at 6 26 30 AM](https://github.com/user-attachments/assets/713b8b6e-d2a0-4cb8-ab88-ac205050f899) | ![Screenshot 2025-07-10 at 6 25 33 AM](https://github.com/user-attachments/assets/0afef01b-bb07-4914-9ec8-b2b05b464da1) | 

### In action
#### Light Mode

https://github.com/user-attachments/assets/8f583d5b-90fc-44c2-937b-5bc19aad52d7

#### Dark Mode

https://github.com/user-attachments/assets/322bc9d2-8a62-4763-beb5-50c72c1819c4

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
