### PR TITLE
help: Document channel-specific "general chat" permissions.

### DIFF
--- a/help/general-chat-channels.md
+++ b/help/general-chat-channels.md
@@ -1,0 +1,37 @@
+# “*General chat*” channels
+
+Zulip's [topics](/help/introduction-to-topics) help you keep conversations
+organized, but you may not need topics in some channels (e.g., a social channel,
+or one with a narrow purpose).
+
+If you have permission to administer a channel, you can configure it to only
+have the special “*general chat*” topic. The name of this topic is shown in
+italics, and is translated into [your language](/help/change-your-language).
+
+Users won't need to enter a topic when sending a message to a “*general chat*”
+channel.
+
+## Configure a channel to have only the “*general chat*” topic
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{relative|channel|all}
+
+1. Select a channel.
+
+{!select-channel-view-general-advanced.md!}
+
+1. Under **Messaging permissions**, set **Allow posting to the *general chat*
+   topic?** to **Only “general chat” topic allowed**.
+
+{!save-changes.md!}
+
+{end_tabs}
+
+## Related articles
+
+- [Introduction to topics](/help/introduction-to-topics)
+- [“*General chat*” topic](/help/general-chat-topic)
+- [Require topics in channel messages](/help/require-topics)

--- a/help/general-chat-topic.md
+++ b/help/general-chat-topic.md
@@ -8,7 +8,9 @@ example, this could be appropriate for social chatter, or for a one-off request
 {!general-chat-intro.md!}
 
 The “*general chat*” topic can be used only if [allowed](/help/require-topics)
-by your organization's administrators.
+by your organization's administrators, and channels can be
+[configured](/help/general-chat-channels) to only allow the “*general chat*”
+topic.
 
 ## Sending a message to the “*general chat*” topic
 
@@ -49,4 +51,5 @@ topic, or follow the instructions below.
 ## Related articles
 
 - [Introduction to topics](/help/introduction-to-topics)
+- [“*General chat*” channels](/help/general-chat-channels)
 - [Require topics in channel messages](/help/require-topics)

--- a/help/include/select-channel-view-general-advanced.md
+++ b/help/include/select-channel-view-general-advanced.md
@@ -1,0 +1,3 @@
+{!select-channel-view-general.md!}
+
+1. Click **Advanced configuration** to view advanced configuration options.

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -216,6 +216,7 @@
 * [Private channels](/help/channel-permissions#private-channels)
 * [Public channels](/help/channel-permissions#public-channels)
 * [Public access option](/help/public-access-option)
+* [“*General chat*” channels](/help/general-chat-channels)
 * [Channel permissions](/help/channel-permissions)
 * [Channel posting policy](/help/channel-posting-policy)
 * [Configure who can administer a channel](/help/configure-who-can-administer-a-channel)

--- a/help/require-topics.md
+++ b/help/require-topics.md
@@ -1,11 +1,16 @@
-# Require topics in channel messages
+# Configure whether topics are required in channel messages
 
 {!general-chat-intro.md!}
 
-Administrators can require topics in channel messages to disable the “*general
-chat*” topic.
+Administrators can configure the default for whether topics are required in
+channel messages (i.e., whether it's possible to send messages to the “*general
+chat*” topic).
 
-## Require topics in channel messages
+The default configuration can be overridden for any channel. You can also
+configure channels to [allow only the “*general chat*”
+topic](/help/general-chat-channels).
+
+## Set the default *general chat* topic configuration
 
 {!admin-only.md!}
 
@@ -13,7 +18,28 @@ chat*” topic.
 
 {settings_tab|organization-settings}
 
-1. Under **Compose settings**, toggle **Require topics in channel messages**.
+1. Under **Compose settings**, select the desired option from the **Default
+   *general chat* topic configuration for channels** dropdown.
+
+{!save-changes.md!}
+
+{end_tabs}
+
+## Configure permission to post to “*general chat*” in a channel
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{relative|channel|all}
+
+1. Select a channel.
+
+{!select-channel-view-general-advanced.md!}
+
+1. Under **Messaging permissions**, choose the desired option from the **Allow
+   posting to the *general chat* topic?** dropdown. The **Automatic** option
+   follows the default setting for the organization.
 
 {!save-changes.md!}
 
@@ -23,3 +49,4 @@ chat*” topic.
 
 * [Introduction to topics](/help/introduction-to-topics)
 * [“*General chat*” topic](/help/general-chat-topic)
+* [“*General chat*” channels](/help/general-chat-channels)


### PR DESCRIPTION
Current: https://zulip.com/help/require-topics, https://zulip.com/help/general-chat-topic
<details>
<summary>
Screenshots (updated + new page)
</summary>

![Screenshot 2025-07-09 at 15 13 41@2x](https://github.com/user-attachments/assets/4ead1f7a-3c6e-4371-9e3e-77758bd2208a)
---
![Screenshot 2025-07-09 at 15 14 04@2x](https://github.com/user-attachments/assets/c053c30f-ce86-4826-9ab3-139f075dde80)
---
![Screenshot 2025-07-09 at 15 13 16@2x](https://github.com/user-attachments/assets/d710cb0c-7991-445f-ac39-ea5e7838560e)

</details>

Notes:
- I think we don't need to rename the "Require topics in channel messages" label in the left sidebar.
- I think we don't need to change any compose instructions to account for general-chat-only channels.