### PR TITLE
left_sidebar: Fix unread counts showing for muted channels.

### DIFF
--- a/web/src/settings_data.ts
+++ b/web/src/settings_data.ts
@@ -278,7 +278,10 @@ export function user_can_delete_own_message(): boolean {
     );
 }
 
-export function should_mask_unread_count(sub_muted: boolean): boolean {
+export function should_mask_unread_count(
+    sub_muted: boolean,
+    unmuted_unread_count: number,
+): boolean {
     if (
         user_settings.web_stream_unreads_count_display_policy ===
         settings_config.web_stream_unreads_count_display_policy_values.no_streams.code
@@ -286,11 +289,17 @@ export function should_mask_unread_count(sub_muted: boolean): boolean {
         return true;
     }
 
+    /* istanbul ignore next */
     if (
         user_settings.web_stream_unreads_count_display_policy ===
         settings_config.web_stream_unreads_count_display_policy_values.unmuted_streams.code
     ) {
-        return sub_muted;
+        if (!sub_muted) {
+            // This policy always shows unread counts in non-muted channels.
+            return false;
+        }
+        // For muted channels, it depends whether any unmuted unreads exist.
+        return unmuted_unread_count === 0;
     }
 
     return false;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -172,16 +172,6 @@
         }
     }
 
-    .has-unmuted-unreads.hide_unread_counts {
-        .masked_unread_count {
-            display: none;
-        }
-
-        .unread_count {
-            display: inline;
-        }
-    }
-
     .toggle_stream_mute {
         margin-right: 3px;
         opacity: 0.5;

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -2,7 +2,7 @@
 
 <li class="narrow-filter{{#if is_muted}} out_of_home_view{{/if}}" data-stream-id="{{id}}">
     <div class="bottom_left_row">
-        <a href="{{url}}" class="subscription_block selectable_sidebar_block {{#if hide_unread_count}}hide_unread_counts{{/if}}">
+        <a href="{{url}}" class="subscription_block selectable_sidebar_block">
 
             <span class="stream-privacy-original-color-{{id}} stream-privacy filter-icon" style="color: {{color}}">
                 {{> stream_privacy . }}

--- a/web/tests/stream_list.test.cjs
+++ b/web/tests/stream_list.test.cjs
@@ -343,6 +343,7 @@ const testSub = {
     subscribed: true,
     is_recently_active: true,
     can_send_message_group: everyone_group.id,
+    is_muted: true,
 };
 
 const announceSub = {
@@ -733,7 +734,6 @@ test_ui("rename_stream", ({mock_template, override}) => {
             is_web_public: undefined,
             color: payload.color,
             pin_to_top: true,
-            hide_unread_count: true,
             can_post_messages: true,
             is_empty_topic_only_channel: false,
         });


### PR DESCRIPTION
Previously, the unmuted unread counts were still being shown in the left sidebar, despite setting the "Show unread counts for" to "No channels".

<!-- Describe your pull request here.-->

Fixes: [#issues > 🎯 hiding unread counts doesn't work for muted channels @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20hiding.20unread.20counts.20doesn't.20work.20for.20muted.20channels/near/2207895)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Verona-> Unmuted stream
Venice-> Muted stream
Zulip -> Muted stream with unmuted unreads.

| Setting | Before | After |
|--------|--------|--------|
| No channels | ![image](https://github.com/user-attachments/assets/3cf27e8d-9904-456b-b964-53e2858a4c1c) | ![image](https://github.com/user-attachments/assets/a0b6f1b8-1e41-468d-9535-da15891e6280) |
| Unmuted channels and topics | ![image](https://github.com/user-attachments/assets/8bfd13fc-86b2-4a75-b1f0-7d029515ce8e) | ![image](https://github.com/user-attachments/assets/97a64efc-4ea8-4641-a84f-2234e8817ce7) |
| All channels | ![image](https://github.com/user-attachments/assets/943c0f7d-9e72-4d74-9026-81fae5ae3693) | ![image](https://github.com/user-attachments/assets/52c82a2c-f9e2-4e6d-9faf-d2e34d046a38) | 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
