### PR TITLE
message_report: Fix flaky tests.

### DIFF
--- a/zerver/tests/test_message_report.py
+++ b/zerver/tests/test_message_report.py
@@ -59,11 +59,15 @@ class ReportMessageTest(ZulipTestCase):
     def get_submitted_moderation_requests(self) -> list[dict[str, Any]]:
         notification_bot = get_system_bot(settings.NOTIFICATION_BOT, self.realm.id)
 
-        return Message.objects.filter(
-            realm_id=self.realm.id,
-            sender_id=notification_bot.id,
-            recipient=self.moderation_request_channel.recipient,
-        ).values(*["id", "content", DB_TOPIC_NAME])
+        return (
+            Message.objects.filter(
+                realm_id=self.realm.id,
+                sender_id=notification_bot.id,
+                recipient=self.moderation_request_channel.recipient,
+            )
+            .order_by("-id")
+            .values(*["id", "content", DB_TOPIC_NAME])
+        )
 
     def test_disabled_moderation_request_feature(self) -> None:
         # Disable moderation request feature
@@ -164,8 +168,8 @@ class ReportMessageTest(ZulipTestCase):
             "",
             message_id,
         )
-        reports = list(self.get_submitted_moderation_requests())
-        self.assertIn(expected_message_link_syntax, reports[-1]["content"])
+        reports = self.get_submitted_moderation_requests()
+        self.assertIn(expected_message_link_syntax, reports[0]["content"])
 
     def test_dm_report(self) -> None:
         # Send a DM to be reported

--- a/zerver/tests/test_message_report.py
+++ b/zerver/tests/test_message_report.py
@@ -119,6 +119,7 @@ class ReportMessageTest(ZulipTestCase):
         )
         self.assert_json_success(result)
         reports = self.get_submitted_moderation_requests()
+        assert len(reports) == 1
         self.assertEqual(reports[0]["content"], expected_message.strip())
         expected_report_topic = f"{self.reported_user.full_name}'s moderation requests"
         self.assertEqual(reports[0][DB_TOPIC_NAME], expected_report_topic)
@@ -131,6 +132,7 @@ class ReportMessageTest(ZulipTestCase):
         )
         self.assert_json_success(result)
         reports = self.get_submitted_moderation_requests()
+        assert len(reports) == 2
         self.assertEqual(reports[0]["content"], expected_message.strip())
         expected_report_topic = f"{self.reported_user.full_name}'s moderation requests"
         self.assertEqual(reports[0][DB_TOPIC_NAME], expected_report_topic)
@@ -222,6 +224,7 @@ class ReportMessageTest(ZulipTestCase):
         result = self.report_message(reporting_user, reported_dm_id, report_type, description)
         self.assert_json_success(result)
         reports = self.get_submitted_moderation_requests()
+        assert len(reports) == 1
         self.assertEqual(reports[0]["content"], expected_message.strip())
 
         # User can't report DM they're not a part of.
@@ -273,6 +276,7 @@ class ReportMessageTest(ZulipTestCase):
         result = self.report_message(reporting_user, reported_dm_id, report_type, description)
         self.assert_json_success(result)
         reports = self.get_submitted_moderation_requests()
+        assert len(reports) == 1
         self.assertEqual(reports[0]["content"], expected_message.strip())
 
         # User can't report DM they're not a part of.
@@ -323,6 +327,7 @@ class ReportMessageTest(ZulipTestCase):
         result = self.report_message(reporting_user, reported_gdm_id, report_type, description)
         self.assert_json_success(result)
         reports = self.get_submitted_moderation_requests()
+        assert len(reports) == 1
         self.assertEqual(reports[0]["content"], expected_message.strip())
 
         # User can't report group direct messages they're not a part of.
@@ -347,6 +352,7 @@ class ReportMessageTest(ZulipTestCase):
         self.assert_json_success(result)
 
         reports = self.get_submitted_moderation_requests()
+        assert len(reports) == 1
         self.assertNotIn(large_message, reports[0]["content"])
 
         expected_truncated_message = truncate_content(


### PR DESCRIPTION
Fixes: [#automated testing > test_channel_message_report backend test flake](https://chat.zulip.org/#narrow/channel/43-automated-testing/topic/test_channel_message_report.20backend.20test.20flake/with/2216731)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
