### PR TITLE
users: Fix `check_valid_bot_config` bug.

### DIFF
--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -134,7 +134,7 @@ def check_valid_bot_config(
                     option.name: option.validator for option in integration.config_options
                 }
                 break
-        if not config_options:
+        if config_options is None:
             raise JsonableError(
                 _("Invalid integration '{integration_name}'.").format(integration_name=service_name)
             )

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -39,7 +39,7 @@ def _check_string(var_name: str, val: str) -> str | None:
     return None
 
 
-stripe_sample_config_options = [
+test_sample_config_options = [
     WebhookIntegration(
         "stripe",
         ["financial"],
@@ -50,6 +50,7 @@ stripe_sample_config_options = [
             )
         ],
     ),
+    WebhookIntegration("helloworld", ["misc"], display_name="Hello World"),
 ]
 
 
@@ -2043,7 +2044,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         self.assertEqual(bot_owner_user_ids(new_bot), set())
 
-    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
+    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", test_sample_config_options)
     def test_create_incoming_webhook_bot_with_service_name_and_with_keys(self) -> None:
         self.login("hamlet")
         bot_metadata = {
@@ -2060,7 +2061,21 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             config_data, {"integration_id": "stripe", "stripe_api_key": "sample-api-key"}
         )
 
-    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
+    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", test_sample_config_options)
+    def test_create_incoming_webhook_bot_with_service_name_and_no_config_options(self) -> None:
+        self.login("hamlet")
+        bot_metadata = {
+            "full_name": "My Hello World Bot",
+            "short_name": "my-helloworld",
+            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
+            "service_name": "helloworld",
+        }
+        self.create_bot(**bot_metadata)
+        new_bot = UserProfile.objects.get(full_name="My Hello World Bot")
+        config_data = get_bot_config(new_bot)
+        self.assertEqual(config_data, {"integration_id": "helloworld"})
+
+    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", test_sample_config_options)
     def test_create_incoming_webhook_bot_with_service_name_incorrect_keys(self) -> None:
         self.login("hamlet")
         bot_metadata = {
@@ -2077,7 +2092,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         with self.assertRaises(UserProfile.DoesNotExist):
             UserProfile.objects.get(full_name="My Stripe Bot")
 
-    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
+    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", test_sample_config_options)
     def test_create_incoming_webhook_bot_with_service_name_without_keys(self) -> None:
         self.login("hamlet")
         bot_metadata = {
@@ -2093,7 +2108,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         with self.assertRaises(UserProfile.DoesNotExist):
             UserProfile.objects.get(full_name="My Stripe Bot")
 
-    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
+    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", test_sample_config_options)
     def test_create_incoming_webhook_bot_without_service_name(self) -> None:
         self.login("hamlet")
         bot_metadata = {
@@ -2106,7 +2121,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         with self.assertRaises(ConfigError):
             get_bot_config(new_bot)
 
-    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
+    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", test_sample_config_options)
     def test_create_incoming_webhook_bot_with_incorrect_service_name(self) -> None:
         self.login("hamlet")
         bot_metadata = {


### PR DESCRIPTION
Currently `check_valid_bot_config` checks if `config_options` has a falsy value to determine whether an integration is invalid or not. But, what it actually does is check whether an exists in WEBHOOK_INTEGRATIONS, and it has at least one WebhookConfigOption.

It should instead, check if `config_options` is `None` to determine whether an integration is invalid or not.

<!-- Describe your pull request here.-->

Related discussion: [#integrations > Auto populate integration bot avatar feature](https://chat.zulip.org/#narrow/channel/127-integrations/topic/Auto.20populate.20integration.20bot.20avatar.20feature/with/1797079)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
