### PR TITLE
support: Follow general styling for showing fixed price plan info.

### DIFF
--- a/templates/corporate/support/current_plan_details.html
+++ b/templates/corporate/support/current_plan_details.html
@@ -28,7 +28,7 @@
         {% if plan_data.current_plan.price_per_license %}
             <b>Price per license</b>: ${{ dollar_amount(plan_data.current_plan.price_per_license) }}<br />
         {% elif plan_data.current_plan.fixed_price %}
-            <b>Plan has a fixed price.</b><br />
+            <b>Plan type</b>: Fixed price<br />
         {% endif %}
         <b>Annual recurring revenue</b>: ${{ dollar_amount(plan_data.annual_recurring_revenue) }}<br />
         <b>Start of next billing cycle</b>: {{ plan_data.next_billing_cycle_start.strftime('%d %B %Y') }}<br />


### PR DESCRIPTION
For fixed-price plans, we show **Plan has a fixed price.** in place of the line for the per license rate, which is:
> **Price per license**: $XX.XX

In order to format that more like the other lines in the plan details, we change that bold sentence to now be:
> **Plan type**: Fixed price.

**Notes**:
- Listening for and receiving billing webhook events in the dev environment is not working on my computer at the moment, so I can't create example screenshots. But, since this is just a string change that's been discussed, I thought it would be fine to put these changes up without screenshots.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
