### PR TITLE
compose: Present smaller formatting icons.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1558,18 +1558,20 @@ textarea.new_message_textarea {
 .compose-control-buttons-container {
     display: flex;
     align-items: center;
+    /* 30px at 15px/1em */
+    height: var(--compose-formatting-buttons-row-height);
 
     .compose_control_button {
-        /* 22px at 14px/1em */
-        font-size: 1.5714em;
+        /* 22px at 15px/1em */
+        font-size: 1.4667em;
         /* Constrain icon fonts to a perfect
-           box (22px at 14px/1em) */
+           box (22px at 15px/1em) to sit centered
+           in the 30px by 30px button area. */
         line-height: 1;
         /* Coordinate with the value of
            --compose-formatting-buttons-row-height */
-        /* 28px at 22px/1em */
-        height: 1.2727em;
         /* 30px at 22px/1em */
+        height: 1.3636em;
         width: 1.3636em;
         display: flex;
         align-items: center;


### PR DESCRIPTION
This PR implements the 15px em called for in Vlad's original spec, https://terpimost.github.io/compose-decomposed/, creating visually smaller icons while maintaining a generous clickable area.

Previously, as in Vlad's spec, that clickable area was 30px wide by 28px tall. However, this PR establishes a perfectly square box and formatting row (now also 30px tall at 15px/1em) that matches the height of the Send button.

[#design > compose box buttons size](https://chat.zulip.org/#narrow/channel/101-design/topic/compose.20box.20buttons.20size/with/2190706)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_The second set shows the flexbox around a single icon, to give a better sense of how much more comfortably icons sit within their allotted clickable area._

| Before | After |
| --- | --- |
| <img width="1400" height="1200" alt="compose-formatting-buttons-before" src="https://github.com/user-attachments/assets/a4145afc-2638-41af-a46d-f7bd1727c0bb" /> | <img width="1400" height="1200" alt="compose-formatting-buttons-after" src="https://github.com/user-attachments/assets/2d7f611c-b0de-474a-8686-81c52388b56d" /> |
| <img width="1400" height="1200" alt="formatting-flex-showing-before" src="https://github.com/user-attachments/assets/f6aa3b6b-6e3c-422e-8cf0-ec7cda39d5c8" /> | <img width="1400" height="1200" alt="formatting-flex-showing-after" src="https://github.com/user-attachments/assets/d8cbdfc5-6230-4096-b177-3980d3c32865" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>