### PR TITLE
settings: Remove unreachable click handler for settings.

### DIFF
--- a/web/src/settings.ts
+++ b/web/src/settings.ts
@@ -10,7 +10,6 @@ import * as common from "./common.ts";
 import * as flatpickr from "./flatpickr.ts";
 import {$t} from "./i18n.ts";
 import * as information_density from "./information_density.ts";
-import * as modals from "./modals.ts";
 import * as overlays from "./overlays.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
@@ -195,21 +194,4 @@ export function initialize(): void {
             settings_data.user_can_invite_users_by_email(),
     });
     $("#settings_overlay_container").append($(rendered_settings_overlay));
-
-    $("#settings_overlay_container").on("click", (e) => {
-        if (!modals.any_active()) {
-            return;
-        }
-        if ($(e.target).closest(".micromodal").length > 0) {
-            return;
-        }
-        e.preventDefault();
-        e.stopPropagation();
-        // Whenever opening a modal(over settings overlay) in an event handler
-        // attached to a click event, make sure to stop the propagation of the
-        // event to the parent container otherwise the modal will not open. This
-        // is so because this event handler will get fired on any click in settings
-        // overlay and subsequently close any open modal.
-        modals.close_active();
-    });
 }


### PR DESCRIPTION
This commit removes click handler for settings overlay container for closing modals over settings which was added for earlier modal version. Current modal doesn't use this handler to close modal.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
