### PR TITLE
Search typeahead pills small fixes.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -699,7 +699,7 @@ export class Filter {
 
         switch (operator) {
             case "channel":
-                return verb + "messages in #";
+                return verb + "messages in a channel";
             case "channels":
                 return verb + "channels";
             case "near":
@@ -842,10 +842,11 @@ export class Filter {
             if (prefix_for_operator !== "") {
                 if (canonicalized_operator === "channel") {
                     const stream = stream_data.get_sub_by_id_string(operand);
+                    const verb = term.negated ? "exclude " : "";
                     if (stream) {
                         return {
                             type: "channel",
-                            prefix_for_operator,
+                            prefix_for_operator: verb + "messages in #",
                             operand: stream.name,
                         };
                     }

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -191,10 +191,10 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
         helpOnEmptyStrings: true,
         stopAdvance: true,
         requireHighlight: false,
-        item_html(item: string): string {
+        item_html(item: string, query: string): string {
             const obj = search_map.get(item);
             assert(obj !== undefined);
-            return search_pill.generate_pills_html(obj);
+            return search_pill.generate_pills_html(obj, query);
         },
         // When the user starts typing new search operands,
         // we want to highlight the first typeahead row by default

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -121,7 +121,7 @@ function on_pill_exit(
 // pill. We can probably simplify things by separating out a function
 // that generates `description_html` from the information in a single
 // search pill, and remove `description_html` from the `Suggestion` type.
-export function generate_pills_html(suggestion: Suggestion): string {
+export function generate_pills_html(suggestion: Suggestion, query: string): string {
     const search_terms = Filter.parse(suggestion.search_string);
 
     const pill_render_data = search_terms.map((term, index) => {
@@ -136,11 +136,32 @@ export function generate_pills_html(suggestion: Suggestion): string {
         };
 
         if (search_pill.operator === "topic" && search_pill.operand === "") {
+            // There are two variants of this suggestion state: One is the user
+            // has selected a topic operator and operator, and and thus has
+            // exactly `topic:` or `-topic:` written out, and it's be
+            // appropriate to suggest the "general chat" value.
+            //
+            // The other variant is where we're suggesting `topic` as a
+            // potential operator to add, say if the user has typed `-to` so
+            // far. For that case, we want to suggest adding a topic operator,
+            // but the user hasn't done anything that would suggest we should
+            // further complete "general chat" as value for that topic operator.
+            //
+            // We can simply differentiate these cases by checking if `:` is
+            // present in the query. See `set_search_bar_contents` for more
+            // context.
+            if (query.includes(":")) {
+                return {
+                    ...search_pill,
+                    is_empty_string_topic: true,
+                    sign: search_pill.negated ? "-" : "",
+                    topic_display_name: util.get_final_topic_display_name(""),
+                };
+            }
             return {
                 ...search_pill,
                 is_empty_string_topic: true,
                 sign: search_pill.negated ? "-" : "",
-                topic_display_name: util.get_final_topic_display_name(""),
             };
         }
         if (search_pill.operator === "search") {

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -301,7 +301,11 @@
             /* Set the minimum width on the pill container;
                 this accommodates the avatar, a minimum
                 two-character username, and the closing X.
-                90px at 20px/1em */
+                90px at 20px/1em.
+
+               TODO: This would ideally be reworked, as we need to
+               override it for search suggestion pills (with no X) below.
+           */
             min-width: 4.5em;
             display: grid;
             grid-template-columns:
@@ -399,6 +403,15 @@
         .pill {
             align-items: baseline;
             margin: 0;
+
+            /* We remove the close button's column space from the grid template
+               for search suggestions, since there's no exit button.
+               The min-width here prevents extra space on very short names. */
+            min-width: 0;
+            grid-template-columns: var(--length-search-input-pill-image) minmax(
+                    0,
+                    1fr
+                );
 
             &:focus {
                 /* Keep the border the same color, there's no user interaction for users in the typeahead menu */

--- a/web/templates/input_pill.hbs
+++ b/web/templates/input_pill.hbs
@@ -18,7 +18,7 @@
                 {{~/if~}}
             {{/if}}
             {{#if is_empty_string_topic}}
-            {{sign}}topic: <span class="empty-topic-display">{{topic_display_name}}</span>
+            {{sign}}topic:{{#if topic_display_name}}<span class="empty-topic-display"> {{topic_display_name}}</span>{{/if}}
             {{else}}
             {{ display_value }}
             {{/if}}


### PR DESCRIPTION
Removes extra space in suggestion pills, changes description html for channel operator and removes operand in autocomplete topic suggestion pill

Fixes: [#issues > 🎯 pills in typeahead tweaks @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20pills.20in.20typeahead.20tweaks/near/2215874)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**After:**
<img width="352" height="294" alt="image" src="https://github.com/user-attachments/assets/8181741f-4b14-4e8f-92a6-e149ef9f41c5" />
<img width="352" height="148" alt="Screenshot from 2025-07-10 23-44-32" src="https://github.com/user-attachments/assets/f01a92ad-ab69-4bb3-9c39-020b6a12fcff" /> <img width="352" height="148" alt="Screenshot from 2025-07-10 23-44-38" src="https://github.com/user-attachments/assets/6308b948-ff22-4973-a4a1-5a151a39a78d" />
<img width="298" height="118" alt="Screenshot from 2025-07-11 01-54-06" src="https://github.com/user-attachments/assets/774ad178-d897-44f7-b3e0-ff813e764c31" />

[Screencast from 2025-07-11 01-54-15.webm](https://github.com/user-attachments/assets/b63b3327-2bb1-4d7f-9c40-bbdeeb5aab67)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
