### PR TITLE
docs: Clean up index page.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,28 +1,32 @@
-# Welcome to the Zulip documentation!
+# Zulip documentation overview
 
-Welcome! Zulip's documentation is split into four parts:
+Welcome! This is the documentation site for running [Zulip organized team
+chat](https://zulip.com) in production, contributing to the [Zulip open-source
+project](https://github.com/zulip), and generally learning how Zulip works under
+the hood.
 
-- [Help center documentation](https://zulip.com/help/), for users and
+The following pages may help you get started:
+
+- [Installation instructions](production/install.md) for setting up your Zulip
+  server.
+- [Contributing guide](contributing/contributing.md), with step-by-step
+  instructions on how to get started contributing code to Zulip.
+
+You may also want to check out:
+
+- [An overview](https://zulip.com/features/) of the features available in Zulip.
+- [Help center documentation](https://zulip.com/help/) for users and
   administrators of Zulip organizations.
-- [Installation documentation](production/install.md), for
-  installing and maintaining a production self-hosted Zulip installation.
-- [API documentation](https://zulip.com/api/), for writing
-  integrations or bots using the Zulip API.
-- [Contributor documentation](contributing/contributing.md), for
-  developing the Zulip software, translating, submitting bug reports,
-  or making other contributions to the project.
+- [API documentation](https://zulip.com/api/) for writing integrations or bots
+  using the Zulip API.
 
-Zulip has well over 150,000 words of documentation. If you can't find
-what you're looking for, please [let us
-know](https://zulip.com/development-community/)! Further information on
-the Zulip project and its features can be found at
-<https://zulip.com>.
+If there's any information you can't find, please drop by the
+[#documentation](https://chat.zulip.org/#narrow/channel/19-documentation)
+channel in the [Zulip development
+community](https://zulip.com/development-community/) and let us know! We work
+hard to make Zulip's documentation comprehensive and easy to follow.
 
-This site contains our installation and contributor documentation. If
-this is your first time here, you may want to start with [Production
-installation](production/install.md) or [Contributing guide](contributing/contributing.md).
-
-Contents:
+The documentation here is organized into the following sections:
 
 - {ref}`Overview <overview>`
 - {ref}`Zulip in production <zulip-in-production>`
@@ -35,6 +39,8 @@ Contents:
 - {ref}`Writing documentation <writing-documentation>`
 - {ref}`Translating Zulip <translating>`
 - {ref}`Outreach programs <outreach>`
+
+## Documentation index
 
 (overview)=
 

--- a/docs/outreach/overview.md
+++ b/docs/outreach/overview.md
@@ -32,7 +32,7 @@ your internship experience with the Zulip project will be highly interactive.
 
 As part of our commitment to mentorship, Zulip has over 160,000 words of
 [documentation for
-developers](../index.md#welcome-to-the-zulip-documentation), much of it
+developers](../index.md#zulip-documentation-overview), much of it
 designed to explain not just how Zulip works, but why Zulip works the way that
 it does. To learn more about our mission and values, check out [this blog
 post](https://blog.zulip.com/2021/04/28/why-zulip-is-on-github-sponsors/)!


### PR DESCRIPTION
Current page: https://zulip.readthedocs.io/en/latest/

Updated:
<img width="733" height="932" alt="Screenshot 2025-07-10 at 16 28 25" src="https://github.com/user-attachments/assets/92c593a0-ba08-42ae-9649-b157e5f689c4" />

(+ full index)