### PR TITLE
user_status_ui: Show remove status icon when only emoji is present.

### DIFF
--- a/web/src/emoji_picker.ts
+++ b/web/src/emoji_picker.ts
@@ -759,7 +759,7 @@ function handle_status_emoji_clicked(emoji_name: string): void {
     }
     user_status_ui.set_selected_emoji_info(emoji_info);
     user_status_ui.update_button();
-    user_status_ui.toggle_clear_message_button();
+    user_status_ui.toggle_clear_status_button();
 }
 
 function handle_composition_emoji_clicked(emoji_name: string): void {

--- a/web/src/user_status_ui.ts
+++ b/web/src/user_status_ui.ts
@@ -18,6 +18,7 @@ let default_status_messages_and_emoji_info: {status_text: string; emoji: EmojiRe
 export function set_selected_emoji_info(emoji_info: Partial<UserStatusEmojiInfo>): void {
     selected_emoji_info = {...emoji_info};
     rebuild_status_emoji_selector_ui(selected_emoji_info);
+    toggle_clear_status_button();
 }
 export function input_field(): JQuery<HTMLInputElement> {
     return $<HTMLInputElement>("#set-user-status-modal input.user-status");
@@ -93,22 +94,22 @@ export function update_button(): void {
     }
 }
 
-export function toggle_clear_message_button(): void {
-    if (input_field().val() !== "" || selected_emoji_info.emoji_name) {
-        $("#clear_status_message_button").prop("disabled", false);
-    } else {
-        $("#clear_status_message_button").prop("disabled", true);
-    }
-}
-
 export function clear_message(): void {
     const $field = input_field();
     $field.val("");
-    $("#clear_status_message_button").prop("disabled", true);
+    toggle_clear_status_button();
 }
 
 export function user_status_picker_open(): boolean {
     return $("#set-user-status-modal").length > 0;
+}
+
+export function toggle_clear_status_button(): void {
+    if (input_field().val() === "" && !selected_emoji_info.emoji_name) {
+        $("#clear_status_message_button").hide();
+    } else {
+        $("#clear_status_message_button").show();
+    }
 }
 
 function emoji_status_fields_changed(
@@ -145,7 +146,7 @@ function user_status_post_render(): void {
     set_selected_emoji_info(old_emoji_info);
     const $field = input_field();
     $field.val(old_status_text);
-    toggle_clear_message_button();
+    toggle_clear_status_button();
 
     const $button = submit_button();
     $button.prop("disabled", true);
@@ -160,7 +161,7 @@ function user_status_post_render(): void {
                 (status) => status.status_text === user_status_value,
             )?.emoji ?? {};
         set_selected_emoji_info(emoji_info);
-        toggle_clear_message_button();
+        toggle_clear_status_button();
         update_button();
     });
 
@@ -174,7 +175,7 @@ function user_status_post_render(): void {
 
     input_field().on("keyup", () => {
         update_button();
-        toggle_clear_message_button();
+        toggle_clear_status_button();
     });
 
     $("#clear_status_message_button").on("click", () => {

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -36,10 +36,6 @@
             padding-left: 5px;
         }
 
-        #user-status-input:placeholder-shown + .clear_search_button {
-            visibility: hidden;
-        }
-
         .status-emoji-wrapper {
             padding: 4px 8px;
             border-right: 1px solid;

--- a/web/templates/set_status_overlay.hbs
+++ b/web/templates/set_status_overlay.hbs
@@ -5,7 +5,7 @@
         </div>
     </div>
     <input type="text" class="user-status modal_text_input" id="user-status-input" placeholder="{{t 'Your status' }}" maxlength="60"/>
-    <button type="button" class="clear_search_button" id="clear_status_message_button" disabled="disabled">
+    <button type="button" class="clear_search_button" id="clear_status_message_button">
         <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
     </button>
 </div>


### PR DESCRIPTION
Previously, due to a logic issue, the clear status icon did not appear when there is only selected emoji in the status—it appeared only when status text was present.

This PR fixes the bug and now the clear status icon disappears only when neither status text nor a selected emoji is present.

**Before** 


https://github.com/user-attachments/assets/d7bbdc5a-5529-41df-bec4-201db1df533c



**After**


https://github.com/user-attachments/assets/98ed35f9-b5e8-4ea2-aa7d-8936d01bbb22



Fixes: #35176

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
