### PR TITLE
help: Add mobile view message exact timestamp documentation.

### DIFF
--- a/help/view-the-exact-time-a-message-was-sent.md
+++ b/help/view-the-exact-time-a-message-was-sent.md
@@ -1,8 +1,20 @@
 # View the exact time a message was sent
 
-To see the exact time a message was received by the Zulip server, hover over
-the timestamp to the right of the message.
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Hover over the timestamp to the right of the message.
+
+{tab|mobile}
+
+{!message-long-press-menu.md!}
+
+1. The timestamp will be at the top right of the menu.
+
+{end_tabs}
 
 ## Related articles
 
 * [Change the time format](/help/change-the-time-format)
+* [Message actions](/help/message-actions)


### PR DESCRIPTION
Updates the [View the exact time a message was sent](https://zulip.com/help/view-the-exact-time-a-message-was-sent) help center article.

**Screenshots and screen captures:**

<img width="775" height="324" alt="Screenshot 2025-07-10 at 21 34 06" src="https://github.com/user-attachments/assets/804affe0-a353-49d4-9756-daeba5de0b25" />
<img width="756" height="158" alt="Screenshot 2025-07-10 at 21 35 18" src="https://github.com/user-attachments/assets/72c0de23-8ddd-4566-ae5f-220ca6af1558" />


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
