### PR TITLE
remove_single_newlines: Fix double-space issue.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -1733,7 +1733,7 @@ def set_visibility_policy_possible(user_profile: UserProfile, message: Message) 
 
 def remove_single_newlines(content: str) -> str:
     content = content.strip("\n")
-    return re.sub(r"(?<!\n)\n(?!\n|[-*] |[0-9]+\. )", " ", content)
+    return re.sub(r"(?<!\n)\n(?!\n|[-*] |[0-9]+\. ) *", " ", content)
 
 
 def is_1_to_1_message(message: Message) -> bool:


### PR DESCRIPTION
The Flutter mobile apps don't collapse repeated spaces into single spaces the same way HTML text does, so leading/trailing whitespace in these automated messages end up rendering weirdly.

The regex previously didn't handle a corner case that appears in the latest message.
