### PR TITLE
saml: Don't put group_memberships_sync_map in the session.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3656,8 +3656,11 @@ class SAMLAuthBackendTest(SocialAuthBase):
             self.logger_output("Returning role owner for user creation", type="info"),
         )
 
-        self.assertIn(
-            f"INFO:root:Syncing groups post-registration for new user {user_profile.id} in realm {realm.id}",
+        prereg_user = PreregistrationUser.objects.last()
+        assert prereg_user is not None
+        self.assertEqual(
+            f"INFO:root:Synced user groups for PreregistrationUser {prereg_user.id} in {realm.id}: "
+            '{"testgroup1": true, "testgroup2": false}. Final groups set: {\'testgroup1\'}',
             mock_root_logger.output[0],
         )
 
@@ -3735,8 +3738,11 @@ class SAMLAuthBackendTest(SocialAuthBase):
             )
         )
 
-        self.assertIn(
-            f"INFO:root:Syncing groups post-registration for new user {user_profile.id} in realm {realm.id}",
+        prereg_user = PreregistrationUser.objects.last()
+        assert prereg_user is not None
+        self.assertEqual(
+            f"INFO:root:Synced user groups for PreregistrationUser {prereg_user.id} in {realm.id}: "
+            '{"testgroup1": true, "testgroup2": false}. Final groups set: {\'testgroup1\'}',
             mock_root_logger.output[0],
         )
 


### PR DESCRIPTION
In 40956ae4c524416e07399ceffa742e2671bed77f we implemented group sync via SAML during sign in and sign up. The sign up implementation used a session variable group_memberships_sync_map to plumb through the sync information to the registration codepath, to execute group sync after user creation.

We can use a more robust approach instead, and just amend groups on the `PreregistrationUser` object that's going to be used for registration.

