### PR TITLE
copy_messages: Prevent blueslip error while copying overlay message header.

### DIFF
--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -328,7 +328,10 @@ export function analyze_selection(selection: Selection): {
 
         $startc = $(range.startContainer);
         start_data = find_boundary_tr(
-            $startc.parents(".selectable_row, .message_header").first(),
+            $startc
+                .parents(".selectable_row, .message_header")
+                .not(".overlay-message-header")
+                .first(),
             ($row) => $row.next(),
         );
         if (start_data === undefined) {

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -1,7 +1,7 @@
 <div class="draft-message-row overlay-message-row" data-draft-id="{{draft_id}}">
     <div class="draft-message-info-box overlay-message-info-box" tabindex="0">
         {{#if is_stream}}
-        <div class="message_header message_header_stream restore-overlay-message">
+        <div class="message_header message_header_stream restore-overlay-message overlay-message-header">
             <div class="message-header-contents" style="background: {{recipient_bar_color}};">
                 <div class="message_label_clickable stream_label">
                     <span class="stream-privacy-modified-color-{{stream_id}} stream-privacy filter-icon"  style="color: {{stream_privacy_icon_color}}">
@@ -24,7 +24,7 @@
             </div>
         </div>
         {{else}}
-        <div class="message_header message_header_private_message restore-overlay-message">
+        <div class="message_header message_header_private_message restore-overlay-message overlay-message-header">
             <div class="message-header-contents">
                 <div class="message_label_clickable stream_label">
                     <span class="private_message_header_icon"><i class="zulip-icon zulip-icon-user"></i></span>

--- a/web/templates/reminder_list.hbs
+++ b/web/templates/reminder_list.hbs
@@ -1,7 +1,7 @@
 {{#each reminders_data}}
     <div class="reminder-row overlay-message-row" data-reminder-id="{{reminder_id}}">
         <div class="reminder-info-box overlay-message-info-box" tabindex="0">
-            <div class="message_header message_header_private_message">
+            <div class="message_header message_header_private_message overlay-message-header">
                 <div class="message-header-contents">
                     <div class="message_label_clickable stream_label">
                         <span class="private_message_header_icon"><i class="zulip-icon zulip-icon-user"></i></span>

--- a/web/templates/scheduled_message.hbs
+++ b/web/templates/scheduled_message.hbs
@@ -2,7 +2,7 @@
     <div class="scheduled-message-row overlay-message-row" data-scheduled-message-id="{{scheduled_message_id}}">
         <div class="scheduled-message-info-box overlay-message-info-box" tabindex="0">
             {{#if is_stream}}
-            <div class="message_header message_header_stream restore-overlay-message">
+            <div class="message_header message_header_stream restore-overlay-message overlay-message-header">
                 <div class="message-header-contents" style="background: {{recipient_bar_color}};">
                     <div class="message_label_clickable stream_label">
                         <span class="stream-privacy-modified-color-{{stream_id}} stream-privacy filter-icon"  style="color: {{stream_privacy_icon_color}}">
@@ -21,7 +21,7 @@
                 </div>
             </div>
             {{else}}
-            <div class="message_header message_header_private_message restore-overlay-message">
+            <div class="message_header message_header_private_message restore-overlay-message overlay-message-header">
                 <div class="message-header-contents">
                     <div class="message_label_clickable stream_label">
                         <span class="private_message_header_icon"><i class="zulip-icon zulip-icon-user"></i></span>


### PR DESCRIPTION
Fixes: https://github.com/zulip/zulip/pull/35097#issuecomment-3058834909

Before:

https://github.com/user-attachments/assets/f78e6c70-b5d7-482a-ad88-9a834ffd7001



After:
https://github.com/user-attachments/assets/67d277e0-3c40-4f78-b592-5353ef30d071


https://github.com/user-attachments/assets/75f1e3e9-381f-4bd4-a4a8-1aa679a7cc94


https://github.com/user-attachments/assets/67c9fe42-c267-4605-8f0f-a8b900d46a6f


