### PR TITLE
settings_overlay: Remove the settings-section show class on close.

### DIFF
--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -150,6 +150,10 @@ export function close_overlay(name: string): void {
     $(".app").attr("aria-hidden", "false");
     $("#navbar-fixed-container").attr("aria-hidden", "false");
 
+    // Prevent a bug where a blank settings section appears
+    // when the settings panel is reopened.
+    $(".settings-section").removeClass("show");
+
     active_overlay.close_handler();
     overlay_util.enable_scrolling();
 }


### PR DESCRIPTION
This PR attempts to fix a bug with the settings overlay displaying an apparently empty pane when the settings overlay is reopened.

[#issues > empty settings @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/empty.20settings/near/2219337)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>