### PR TITLE
help: Document new options for which messages are marked as read.

### DIFF
--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -20,10 +20,10 @@ web/desktop app.
   [topic in a channel](/help/introduction-to-topics). This option makes it
   convenient to preview new messages in a channel, or skim [Combined
   feed](/help/combined-feed), and later read each topic in detail.
-- **Never**: Messages are marked as read only
-  [manually](#mark-all-messages-as-read). For example, if you often need to
-  follow up on messages at your computer after reading them in the mobile app,
-  you can choose this option for the mobile app.
+- **Never**: Messages are marked as read only manually. For example,
+  if you often need to follow up on messages at your computer after
+  reading them in the mobile app, you can choose this option for the
+  mobile app.
 
 {start_tabs}
 
@@ -76,17 +76,13 @@ topics you don't follow.
 
 {end_tabs}
 
-## Mark all messages as read
-
-You can manually **mark all messages as read**, or **mark all messages in a
-channel or topic as read**.
+## Mark all messages in a channel or topic as read
 
 {start_tabs}
 
 {tab|via-left-sidebar}
 
-1. Hover over a channel, topic, or your [home view](/help/configure-home-view)
-   in the left sidebar.
+1. Hover over a channel or topic in the left sidebar.
 
 1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>).
 
@@ -114,16 +110,45 @@ channel or topic as read**.
 
 {tab|mobile}
 
-1. Tap a channel, topic, or the **Combined feed**
+1. Press and hold a channel or topic until the long-press menu appears.
+
+1. Tap **Mark channel as read** or **Mark topic as read**.
+
+!!! tip ""
+
+    You can also scroll down to the bottom of a message view, and tap **Mark
+    all messages as read**.
+
+{end_tabs}
+
+## Mark messages in multiple topics and channels as read
+
+In the web and desktop apps, you can mark all messages as read, or just messages
+in muted topics or topics you don't follow.
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Hover over your [home view](/help/configure-home-view) in the left sidebar.
+
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>).
+
+1. Select the desired option from the dropdown, and click **Confirm**.
+
+!!! tip ""
+
+    You can also mark all messages in your current view as read by
+    jumping to the bottom with the **Scroll to bottom**
+    (<i class="fa fa-chevron-down"></i>) button or the <kbd>End</kbd> shortcut.
+
+{tab|mobile}
+
+1. Tap the **Combined feed**
    (<i class="zulip-icon zulip-icon-all-messages mobile-help"></i>) tab.
 
 1. Scroll down to the bottom of the message view, and tap **Mark all messages
    as read**.
-
-!!! tip ""
-
-    You can also press and hold a channel or topic until the long-press menu
-    appears, and select the option to mark as read.
 
 {end_tabs}
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3197,7 +3197,7 @@ paths:
                                 [message-flags]: /api/update-message-flags#available-flags
                                 [message-event]: /api/get-events#message
                                 [message-delete]: /api/get-events#delete_message
-                                [all-read]: /help/marking-messages-as-read#mark-all-messages-as-read
+                                [all-read]: /help/marking-messages-as-read#mark-messages-in-multiple-topics-and-channels-as-read
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"


### PR DESCRIPTION
Documents  #30025 / #32102.

The tip about scrolling is actually contingent on what type of view you're in and your settings, but I think it's OK. If it doesn't work automatically, you'll see a banner. So I left it in.


Current: https://zulip.com/help/marking-messages-as-read#mark-all-messages-as-read

Updated:

<img width="747" height="660" alt="Screenshot 2025-07-11 at 13 27 40" src="https://github.com/user-attachments/assets/92532ddb-71d6-4109-9d8c-b02d2b2a9019" />
<img width="751" height="507" alt="Screenshot 2025-07-11 at 13 27 54" src="https://github.com/user-attachments/assets/ba1cbf86-dc3d-4960-a7ad-a98a88f8302c" />
