### PR TITLE
Fix navigation_view event class mapping and complete built-in views.

### DIFF
--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -39,9 +39,9 @@ from zerver.lib.event_types import (
     EventMessage,
     EventMutedTopics,
     EventMutedUsers,
-    EventNavigationViewsAdd,
-    EventNavigationViewsRemove,
-    EventNavigationViewsUpdate,
+    EventNavigationViewAdd,
+    EventNavigationViewRemove,
+    EventNavigationViewUpdate,
     EventOnboardingSteps,
     EventPresence,
     EventReactionAdd,
@@ -180,9 +180,9 @@ check_heartbeat = make_checker(EventHeartbeat)
 check_invites_changed = make_checker(EventInvitesChanged)
 check_message = make_checker(EventMessage)
 check_muted_users = make_checker(EventMutedUsers)
-check_navigation_view_add = make_checker(EventNavigationViewsAdd)
-check_navigation_view_remove = make_checker(EventNavigationViewsRemove)
-check_navigation_view_update = make_checker(EventNavigationViewsUpdate)
+check_navigation_view_add = make_checker(EventNavigationViewAdd)
+check_navigation_view_remove = make_checker(EventNavigationViewRemove)
+check_navigation_view_update = make_checker(EventNavigationViewUpdate)
 check_onboarding_steps = make_checker(EventOnboardingSteps)
 check_reaction_add = make_checker(EventReactionAdd)
 check_reaction_remove = make_checker(EventReactionRemove)

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -289,13 +289,13 @@ class NavigationViewFields(BaseModel):
     name: str | None
 
 
-class EventNavigationViewsAdd(BaseEvent):
+class EventNavigationViewAdd(BaseEvent):
     type: Literal["navigation_view"]
     op: Literal["add"]
     navigation_view: NavigationViewFields
 
 
-class EventNavigationViewsRemove(BaseEvent):
+class EventNavigationViewRemove(BaseEvent):
     type: Literal["navigation_view"]
     op: Literal["remove"]
     fragment: str
@@ -306,7 +306,7 @@ class NavigationViewFieldsForUpdate(BaseModel):
     name: str | None = None
 
 
-class EventNavigationViewsUpdate(BaseEvent):
+class EventNavigationViewUpdate(BaseEvent):
     type: Literal["navigation_view"]
     op: Literal["update"]
     fragment: str

--- a/zerver/views/navigation_views.py
+++ b/zerver/views/navigation_views.py
@@ -26,6 +26,7 @@ BUILT_IN_VIEW_FRAGMENTS = [
     "narrow/is/mentioned",
     # Starred messages view
     "narrow/is/starred",
+    "scheduled",
 ]
 
 


### PR DESCRIPTION
This PR aligns the `navigation_view` event type with the Python event schema classes.
The schema validation script constructs class names from event types, so this change ensures that the `navigation_view` event type matches the expected `EventNavigationView*` class names.

It also adds the `"scheduled"` built-in view fragment, which was missed in PR [#32528](https://github.com/zulip/zulip/pull/32528).


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
(variable names, code reuse, readability, etc.).
<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->


Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
