### PR TITLE
help: Add instructions for Okta-side configuration for SAML group sync.

### DIFF
--- a/help/saml-authentication.md
+++ b/help/saml-authentication.md
@@ -213,6 +213,57 @@ providers.
 
     Once SAML has been configured, consider also [configuring SCIM](/help/scim).
 
+## Synchronizing group membership with SAML
+
+You can configure each Zulip user's [groups](/help/user-groups) to be updated based
+on their groups in your Identity Provider's (IdP's) directory every time they
+log in.
+
+Your IdP directory's group names don't have to match the associated Zulip group
+names (e.g., membership in your IdP's group **finance** can be synced to
+membership in the Zulip group **finance-department**).
+
+How Zulip translates received SAML groups to Zulip group memberships
+is detailed in the [relevant section][saml-group-sync-readthedocs] the
+main SAML documentation. [Contact support](/help/contact-support) with any questions.
+
+!!! tip ""
+
+    It should be possible to set this up with any provider. If you're interested
+    in using this functionality with a provider other than Okta, reach out to
+    [support@zulip.com](mailto:support@zulip.com).
+
+{start_tabs}
+
+{tab|okta}
+
+1. Follow the instructions [above](#configure-saml) to configure SAML, and go to
+   the application you created for using SAML with Zulip in your
+   **Applications** menu.
+
+1. Select the **General** tab, and **Edit** the **SAML Settings** section.
+
+1. Proceed through the prompts until the main **Configure SAML** prompt.
+
+1. Scroll down below the **Attribute Statements** section (which you configured
+   when creating the app) to **Group Attribute Statements**.
+
+1. Add the following attribute:
+     * **Name**: `zulip_groups`
+     * **Name format**: `Unspecified`
+     * **Filter**: `Matches regex: .*`
+
+     When a user signs in to Zulip via SAML, Okta will now include a list of the
+     user's groups in its response to the Zulip server.
+
+1. To enable this feature, please email
+   [support@zulip.com](mailto:support@zulip.com) with the following information:
+     * Your Zulip organization URL.
+     * Which groups should be synced from your IdP's directory.
+     * Which groups should have a different name in Zulip (if any).
+
+{end_tabs}
+
 ## Related articles
 
 * [SAML configuration for self-hosting][saml-readthedocs]
@@ -220,3 +271,4 @@ providers.
 * [Moving to Zulip](/help/moving-to-zulip)
 
 [saml-readthedocs]: https://zulip.readthedocs.io/en/stable/production/authentication-methods.html#saml
+[saml-group-sync-readthedocs]: https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#synchronizing-group-membership-with-saml

--- a/templates/corporate/comparison_table_integrated.html
+++ b/templates/corporate/comparison_table_integrated.html
@@ -800,6 +800,17 @@
                 <td class="comparison-value-positive self-hosted-cell" data-title="{{ _('Supported') }}"><i class="icon icon-check"></i></td>
             </tr>
             <tr>
+                <td class="comparison-table-feature"><a href="/help/saml-authentication#synchronizing-group-membership-with-saml">SAML group sync</a></td>
+                <td class="comparison-value-negative cloud-cell"><i class="icon icon-x"></i></td>
+                <td class="comparison-value-negative cloud-cell"><i class="icon icon-x"></i></td>
+                <td class="comparison-value-positive cloud-cell"><i class="icon icon-check"></i></td>
+
+                <td class="comparison-value-warning self-hosted-cell" data-title="{{ _('Self-managed') }}"><i class="icon icon-wrench"></i></td>
+                <td class="comparison-value-warning self-hosted-cell" data-title="{{ _('Self-managed') }}"><i class="icon icon-wrench"></i></td>
+                <td class="comparison-value-warning self-hosted-cell" data-title="{{ _('Self-managed') }}"><i class="icon icon-wrench"></i></td>
+                <td class="comparison-value-positive self-hosted-cell" data-title="{{ _('Supported') }}"><i class="icon icon-check"></i></td>
+            </tr>
+            <tr>
                 <td class="comparison-table-feature"><a href="/help/scim">SCIM user sync</a></td>
                 <td class="comparison-value-negative cloud-cell"><i class="icon icon-x"></i></td>
                 <td class="comparison-value-negative cloud-cell"><i class="icon icon-x"></i></td>

--- a/templates/corporate/pricing_model.html
+++ b/templates/corporate/pricing_model.html
@@ -379,7 +379,7 @@
                                 <li><span>Unlimited <a href="https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html">mobile notifications</a></span></li>
                                 <li class="support-note"><span>Email, chat and phone support for:</span></li>
                                 <li><span><a href="https://zulip.readthedocs.io/en/stable/production/authentication-methods.html#openid-connect">SSO with OpenID Connect</a></span></li>
-                                <li><span><a href="https://zulip.readthedocs.io/en/stable/production/authentication-methods.html">AD/LDAP group sync</a></span></li>
+                                <li><span><a href="https://zulip.readthedocs.io/en/stable/production/authentication-methods.html">AD/LDAP</a> and <a href="https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#synchronizing-group-membership-with-saml">SAML</a> group sync</span></li>
                                 <li><span><a href="/help/scim">SCIM sync</a></span></li>
                                 <li><span>Implementation consulting</span></li>
                                 <li><span>Custom feature development</span></li>


### PR DESCRIPTION
Follow-up to #34671.

Notes:
- It's possible that this help page section could benefit from an extra link to production docs, as we're linking directly to it from /features in this PR. Production docs are linked from the top of the page.

Current SAML help page: https://zulip.com/help/saml-authentication
<details>
<summary>
screenshots
</summary>

<img width="736" height="859" alt="Screenshot 2025-07-14 at 14 33 21" src="https://github.com/user-attachments/assets/ebbaa59e-c623-4136-81d8-e30fca2ae1a3" />
<img width="381" height="318" alt="Screenshot 2025-07-14 at 14 35 40" src="https://github.com/user-attachments/assets/eeb17762-2738-4f7a-8491-8d1ddd59cd13" />
<img width="1155" height="168" alt="Screenshot 2025-07-14 at 14 36 35" src="https://github.com/user-attachments/assets/563a95f2-4078-4deb-aef2-7ec22cb83510" />

</details>
