### PR TITLE
message-edit-tooltips: Fix the breaking tooltips on rerender.

### DIFF
--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -52,7 +52,7 @@ export function clean_up_compose_singleton_tooltip(context: SingletonContext): v
 
 export function initialize_compose_tooltips(context: SingletonContext, selector: string): void {
     // Listen on body for the very first mouseenter on any element matching `selector`
-    $(document.body).one("mouseenter", selector, () => {
+    $(document.body).one("mousemove", selector, (e) => {
         // Clean up existing instances first
         clean_up_compose_singleton_tooltip(context);
 
@@ -80,6 +80,11 @@ export function initialize_compose_tooltips(context: SingletonContext, selector:
                 }
             },
         });
+
+        // Show the tooltip since user has hovered over the element.
+        if (e.currentTarget instanceof HTMLElement) {
+            e.currentTarget.dispatchEvent(new MouseEvent("mouseenter"));
+        }
 
         compose_button_singleton_context_map.set(context, {
             tooltip_instances,


### PR DESCRIPTION
The reason for the bug mentioned in issue description is because when we come back to editing state of a message, the tooltip won't show up because by the time when the `initialize_compose_tooltips` is called, the `selector` were not present in the DOM.

So, in order to address this, we can add MutationObserver and wait for the selector to appear in order to move ahead by calling the function for initializing the tooltips.


Fixes: #35217.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
