### PR TITLE
markdown: Tweak audio element styles for chromium based browsers.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -570,6 +570,7 @@
        or KaTeX. */
     &:has(> hr:first-child),
     &:has(> .message_inline_image:first-child),
+    &:has(> p:first-child > audio),
     &:has(> p:first-child > .katex-display) {
         align-self: center;
     }
@@ -584,6 +585,8 @@
             width: 100%;
         }
 
+        > audio:first-child,
+        p:first-child > audio,
         p:first-child > .katex-display,
         .message_inline_image {
             /* We'll display this bit of media as
@@ -606,6 +609,7 @@
             grid-template: "media" minmax(0, auto) / minmax(0, auto);
         }
 
+        p:first-child > audio,
         p:first-child > .katex-display > .katex,
         .message_inline_image .media-anchor-element,
         .message_inline_image .media-video-element {
@@ -614,6 +618,7 @@
             grid-area: media;
         }
 
+        p:first-child > audio::before,
         p:first-child > .katex-display::before,
         .message_inline_image::before {
             /* We generate a single . here to create
@@ -925,6 +930,79 @@
         font-size: 1.1363em;
         border: 1px solid var(--color-copy-button-square-bg-active);
         backdrop-filter: blur(20px);
+    }
+
+    p:first-child > audio:first-child {
+        /* TODO: This is probably not the best way create space here. */
+        padding-top: 0.5em;
+    }
+
+    audio {
+        width: 18em;
+        height: 2em;
+        max-width: 100%;
+
+        &::-webkit-media-controls-panel {
+            display: flex !important;
+            justify-content: space-between !important;
+            flex-wrap: nowrap !important;
+            box-sizing: border-box !important;
+            width: 100% !important;
+            min-width: 0 !important;
+            padding: 0 0.5em !important;
+            opacity: 1 !important;
+        }
+
+        &::-webkit-media-controls-play-button {
+            flex: 0 0 auto !important;
+            width: 1.75em !important;
+            min-width: 1.75em !important;
+        }
+
+        &::-webkit-media-controls-timeline-container,
+        &::-webkit-media-controls-timeline {
+            flex: 1 1 auto !important;
+            min-width: 4em !important;
+            max-width: 6em !important;
+            opacity: 1 !important;
+            margin: 0 0.5em !important;
+        }
+
+        &::-webkit-media-controls-current-time-display,
+        &::-webkit-media-controls-time-remaining-display {
+            flex: 0 0 auto !important;
+            min-width: 0 !important;
+            font-size: 1rem !important;
+        }
+
+        &::-webkit-media-controls-volume-control-container {
+            flex: 0 0 auto !important;
+            width: auto !important;
+            min-width: 0 !important;
+            max-width: 5em !important;
+            margin: 0 0.5em 0 0.25em !important;
+            display: flex !important;
+            flex-direction: row-reverse !important;
+            opacity: 1 !important;
+            visibility: visible !important;
+        }
+
+        &::-webkit-media-controls-volume-slider-container,
+        &::-webkit-media-controls-volume-slider {
+            display: block !important;
+            width: auto !important;
+            min-width: 1.5em !important;
+            max-width: 3em !important;
+            opacity: 1 !important;
+            visibility: visible !important;
+        }
+
+        &::-webkit-media-controls-mute-button {
+            flex: 0 0 auto !important;
+            width: 1.125em !important;
+            min-width: 1.125em !important;
+            margin-right: 0.25em !important;
+        }
     }
 }
 


### PR DESCRIPTION
This commit tweaks some styles for audio elements of chromium based browsers using `webkit` so as to render them in styles similar to firefox.

<!-- Describe your pull request here.-->

CZO - [#design > UI for audio controls @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/UI.20for.20audio.20controls/near/2220539)

<img width="1103" height="85" alt="image" src="https://github.com/user-attachments/assets/b7ebb22c-28db-4257-b83e-bc46b2ce1921" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
