### PR TITLE
help-beta: Adjust kbd tags if the user is using a mac style keyboard.

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -272,6 +272,18 @@ export default tseslint.config(
         },
     },
     {
+        files: ["help-beta/src/scripts/client/**"],
+        rules: {
+            "unicorn/prefer-module": "off",
+        },
+        languageOptions: {
+            globals: {
+                ...globals.browser,
+            },
+            sourceType: "script",
+        },
+    },
+    {
         files: ["web/shared/**"],
         languageOptions: {
             globals: globals["shared-node-browser"],

--- a/help-beta/astro.config.mjs
+++ b/help-beta/astro.config.mjs
@@ -64,6 +64,7 @@ export default defineConfig({
             title: "Zulip help center",
             components: {
                 Footer: "./src/components/Footer.astro",
+                Head: "./src/components/Head.astro",
             },
             pagination: false,
             customCss: ["./src/styles/main.css", "./src/styles/steps.css"],

--- a/help-beta/src/components/Head.astro
+++ b/help-beta/src/components/Head.astro
@@ -1,0 +1,6 @@
+---
+import Default from "@astrojs/starlight/components/Head.astro";
+---
+
+<script src="../scripts/client/adjust_mac_kbd_tags.ts"></script>
+<Default><slot /></Default>

--- a/help-beta/src/scripts/client/adjust_mac_kbd_tags.ts
+++ b/help-beta/src/scripts/client/adjust_mac_kbd_tags.ts
@@ -1,0 +1,72 @@
+// Any changes to this file should be followed by a check for changes
+// needed to make to adjust_mac_kbd_tags of web/src/common.ts.
+
+const keys_map = new Map<string, string>([
+    ["Backspace", "Delete"],
+    ["Enter", "Return"],
+    ["Ctrl", "⌘"],
+    ["Alt", "⌥"],
+]);
+
+function has_mac_keyboard(): boolean {
+    "use strict";
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    return /mac/i.test(navigator.platform);
+}
+
+// We convert the <kbd> tags used for keyboard shortcuts to mac equivalent
+// key combinations, when we detect that the user is using a mac-style keyboard.
+function adjust_mac_kbd_tags(): void {
+    "use strict";
+
+    if (!has_mac_keyboard()) {
+        return;
+    }
+
+    const elements = document.querySelectorAll<HTMLElement>("kbd");
+
+    for (const element of elements) {
+        let key_text: string = element.textContent ?? "";
+
+        // We use data-mac-key attribute to override the default key in case
+        // of exceptions:
+        // - There are 2 shortcuts (for navigating back and forth in browser
+        //   history) which need "⌘" instead of the expected mapping ("Opt")
+        //   for the "Alt" key, so we use this attribute to override "Opt"
+        //   with "⌘".
+        // - The "Ctrl" + "[" shortcuts (which match the Vim keybinding behavior
+        //   of mapping to "Esc") need to display "Ctrl" for all users, so we
+        //   use this attribute to override "⌘" with "Ctrl".
+        const replace_key: string | undefined = element.dataset.macKey ?? keys_map.get(key_text);
+        if (replace_key !== undefined) {
+            key_text = replace_key;
+        }
+
+        element.textContent = key_text;
+
+        // In case of shortcuts, the Mac equivalent of which involves extra keys,
+        // we use data-mac-following-key attribute to append the extra key to the
+        // previous key. Currently, this is used to append Opt to Cmd for the Paste
+        // as plain text shortcut.
+        const following_key: string | undefined = element.dataset.macFollowingKey;
+        if (following_key !== undefined) {
+            const kbd_elem: HTMLElement = document.createElement("kbd");
+            kbd_elem.textContent = following_key;
+            element.after(kbd_elem);
+            element.after(" + ");
+        }
+
+        // In web/src/common.ts, we use zulip icon for ⌘ due to centering
+        // problems, we don't have that problem in the new help center and
+        // thus don't do that transformation here. We do need to make these
+        // symbols appear larger than they do by default since they are too
+        // small to see in the default font-size.
+        if (key_text === "⌘" || key_text === "⌥") {
+            element.style.fontSize = "1.5em";
+            element.style.verticalAlign = "middle";
+        }
+    }
+}
+
+adjust_mac_kbd_tags();

--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -11,6 +11,8 @@ export function phrase_match(query: string, phrase: string): boolean {
     return (" " + phrase.toLowerCase()).includes(" " + query.toLowerCase());
 }
 
+// Any changes to this function should be followed by a check for changes needed
+// to adjust_mac_kbd_tags of help-beta/src/scripts/adjust_mac_kbd_tags.ts.
 const keys_map = new Map([
     ["Backspace", "Delete"],
     ["Enter", "Return"],
@@ -18,6 +20,8 @@ const keys_map = new Map([
     ["Alt", "⌥"],
 ]);
 
+// Any changes to this function should be followed by a check for changes needed
+// to adjust_mac_kbd_tags of help-beta/src/scripts/adjust_mac_kbd_tags.ts.
 export function has_mac_keyboard(): boolean {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     return /mac/i.test(navigator.platform);
@@ -25,6 +29,8 @@ export function has_mac_keyboard(): boolean {
 
 // We convert the <kbd> tags used for keyboard shortcuts to mac equivalent
 // key combinations, when we detect that the user is using a mac-style keyboard.
+// Any changes to this function should be followed by a check for changes needed
+// to adjust_mac_kbd_tags of help-beta/src/scripts/adjust_mac_kbd_tags.ts.
 export function adjust_mac_kbd_tags(kbd_elem_class: string): void {
     if (!has_mac_keyboard()) {
         return;


### PR DESCRIPTION
Fixes #31287.
These tags are not limited to just KeyboardTip, so we want to run the transformation on all html.
We need to run the transformation client-side since the user's keyboard style is only known at that time.
We had to override the HEAD component since that's what starlight recommends to do if we want to include local assets on every page. If we were using a remote js file, we could have modified the head config option provided by starlight.
The script file to adjust the tags is mostly just copy-paste of the original function to adjust for the lack of JQuery. Most of the comments are also copy-pasted.
One change in the new script is to just use ⌘ symbol directly instead of using zulip-icon since we don't have any centering problems in the new help center.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="693" height="138" alt="Screenshot 2025-07-15 at 5 58 31 PM" src="https://github.com/user-attachments/assets/1b7103d1-da61-468c-b12d-25fbfca99c8f" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
