### PR TITLE
Add topic filter focus check in `is_in_focus`.

### DIFF
--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -158,6 +158,7 @@ export function is_in_focus(): boolean {
         !modals.any_active_or_animating() &&
         !$(".home-page-input").is(":focus") &&
         !$("#search_query").is(":focus") &&
+        !$("#topic_filter_query").is(":focus") &&
         !$(".navbar-item").is(":focus")
     );
 }


### PR DESCRIPTION
Recent topic filter resolve state feature had to migrate from input field to div as part of the work. `.home-page-input` focus check in `is_in_focus` for handling hotkeys fails to work correctly for div elements like `#search_query` which has its own separate check.

This PR adds a topic filter focus check inside `is_in_focus` which prevents shifting focus from topic filter input to topic list when typing.


Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20hjkl.20keys.20shifting.20focus.20in.20list.20of.20topics.20view/near/2219301)[#issues > 🎯 hjkl keys shifting focus in list of topics view @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20hjkl.20keys.20shifting.20focus.20in.20list.20of.20topics.20view/near/2219301)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
