### PR TITLE
pill_container: Fix background-color in dark theme.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -938,7 +938,6 @@ input[type="checkbox"] {
 .org-permissions-form .pill-container {
     /* Subtract 2 * (2px padding) + 2 * (1px border) */
     min-width: calc(var(--modal-input-width) - 6px);
-    background-color: hsl(0deg 0% 100%);
 
     .input {
         flex-grow: 1;
@@ -1812,7 +1811,6 @@ label.preferences-radio-choice-label {
     .pill-container {
         min-height: 24px;
         max-width: 206px;
-        background-color: hsl(0deg 0% 100%);
 
         &:focus-within {
             border-color: hsl(206deg 80% 62% / 80%);
@@ -2302,7 +2300,6 @@ label.preferences-radio-choice-label {
     .settings_text_input,
     .settings_textarea,
     .pill-container {
-        border-color: hsl(0deg 0% 100%);
         margin-bottom: 0;
 
         &:focus {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -902,7 +902,6 @@ h4.user_group_setting_subsection_title {
         }
 
         .pill-container {
-            background-color: hsl(0deg 0% 93%);
             opacity: 0.7;
 
             .pill {
@@ -1293,7 +1292,6 @@ div.settings-radio-input-parent {
 .advanced-configurations-container .pill-container {
     /* Subtract 2 * (2px padding) + 2 * (1px border) */
     min-width: calc(var(--modal-input-width) - 6px);
-    background-color: hsl(0deg 0% 100%);
 
     .input {
         flex-grow: 1;


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR fixes the background color of pill containers in dark theme by removing hard-coded values for `background-color` in `settings.css` and `subscriptions.css`. This bug was introduced in a4dd8e515d05cf5a3dacf4da5ea0936de614cdab.

<details><summary>Screenshots</summary>
<p>

| Before | After |
|--------|--------|
| <img width="602" height="328" alt="image" src="https://github.com/user-attachments/assets/efa62648-7296-40a7-9cba-186d2568375a" /> | <img width="537" height="302" alt="image" src="https://github.com/user-attachments/assets/8a7c7ebf-c9cb-4ebc-b25b-838ce7f8fa8e" /> |
| <img width="619" height="600" alt="image" src="https://github.com/user-attachments/assets/bb8a58a1-cfda-4426-9720-1d08fd06fe34" /> | <img width="602" height="578" alt="image" src="https://github.com/user-attachments/assets/0b376f8b-dd89-49b2-9b34-ac1fdb6e0701" /> |
| <img width="822" height="490" alt="image" src="https://github.com/user-attachments/assets/6aa994fa-a5d2-4c18-9e82-47f1c5f08452" /> | <img width="808" height="485" alt="image" src="https://github.com/user-attachments/assets/0fa7e1a1-fbf0-468b-859b-77f44da6b29f" /> | 

</p>
</details>

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
