### PR TITLE
search: Single enter should narrow to current filters.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -582,6 +582,10 @@ export class Typeahead<ItemType extends string | object> {
         return this;
     }
 
+    has_active_item(): boolean {
+        return this.$menu.find(".active").length > 0;
+    }
+
     defaultMatcher(item: ItemType, query: string): boolean {
         assert(typeof item === "string");
         return item.toLowerCase().includes(query.toLowerCase());

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -21,6 +21,7 @@ export type InputPillConfig = {
 type InputPillCreateOptions<ItemType> = {
     $container: JQuery;
     pill_config?: InputPillConfig | undefined;
+    focus_input_on_backspace_remove?: boolean;
     split_text_on_comma?: boolean;
     convert_to_pill_on_enter?: boolean;
     create_item_from_text: (
@@ -61,6 +62,7 @@ type InputPillStore<ItemType> = {
     onPillRemove?: (pill: InputPill<ItemType>, trigger: RemovePillTrigger) => void;
     onPillExpand?: (pill: JQuery) => void;
     createPillonPaste?: () => void;
+    focus_input_on_backspace_remove: boolean;
     split_text_on_comma: boolean;
     convert_to_pill_on_enter: boolean;
     show_outline_on_invalid_input: boolean;
@@ -108,6 +110,7 @@ export function create<ItemType extends {type: string}>(
         create_item_from_text: opts.create_item_from_text,
         get_text_from_item: opts.get_text_from_item,
         get_display_value_from_item: opts.get_display_value_from_item,
+        focus_input_on_backspace_remove: opts.focus_input_on_backspace_remove ?? false,
         split_text_on_comma: opts.split_text_on_comma ?? true,
         convert_to_pill_on_enter: opts.convert_to_pill_on_enter ?? true,
         generate_pill_html: opts.generate_pill_html,
@@ -458,7 +461,9 @@ export function create<ItemType extends {type: string}>(
                     const $prev = $pill.prev();
                     const $next = $pill.next();
                     funcs.removePill(util.the($pill), "backspace");
-                    if ($prev.length > 0) {
+                    if (store.focus_input_on_backspace_remove) {
+                        store.$input.trigger("focus");
+                    } else if ($prev.length > 0) {
                         $prev.trigger("focus");
                     } else {
                         $next.trigger("focus");

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -110,7 +110,7 @@ export function create<ItemType extends {type: string}>(
         create_item_from_text: opts.create_item_from_text,
         get_text_from_item: opts.get_text_from_item,
         get_display_value_from_item: opts.get_display_value_from_item,
-        focus_input_on_backspace_remove: opts.focus_input_on_backspace_remove ?? false,
+        focus_input_on_backspace_remove: opts.focus_input_on_backspace_remove ?? true,
         split_text_on_comma: opts.split_text_on_comma ?? true,
         convert_to_pill_on_enter: opts.convert_to_pill_on_enter ?? true,
         generate_pill_html: opts.generate_pill_html,

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -58,6 +58,14 @@ function full_search_query_in_terms(): NarrowCanonicalTerm[] | undefined {
     return [...search_pill.get_current_search_pill_terms(search_pill_widget), ...search_terms];
 }
 
+function reopen_search_bar_if_collapsed(): void {
+    if ($(".navbar-search.expanded").length === 0) {
+        open_search_bar_and_close_narrow_description();
+        focus_search_input_at_end();
+        search_input_has_changed = true;
+    }
+}
+
 function narrow_or_search_for_term({on_narrow_search}: {on_narrow_search: OnNarrowSearch}): void {
     if (is_using_input_method) {
         // Neither narrow nor search when using input tools as
@@ -84,13 +92,7 @@ function narrow_or_search_for_term({on_narrow_search}: {on_narrow_search: OnNarr
     );
     on_narrow_search(terms, {trigger: "search"});
 
-    // It's sort of annoying that this is not in a position to
-    // blur the search box, because it means that Esc won't
-    // unnarrow, it'll leave the searchbox.
-
-    // Narrowing will have already put some terms in the search box,
-    // so leave the current text in.
-    $("#search_query").trigger("blur");
+    reopen_search_bar_if_collapsed();
     return;
 }
 
@@ -137,15 +139,7 @@ function narrow_to_search_contents_with_search_bar_open(): void {
 
     on_narrow_search(terms, {trigger: "search"});
 
-    // We want to keep the search bar open here, not show the
-    // message header. But here we'll let the message header
-    // get rendered first, so that it's up to date with the
-    // new narrow, and then reopen search if it got closed.
-    if ($(".navbar-search.expanded").length === 0) {
-        open_search_bar_and_close_narrow_description();
-        focus_search_input_at_end();
-        search_input_has_changed = true;
-    }
+    reopen_search_bar_if_collapsed();
 }
 
 export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -294,7 +294,7 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
         is_using_input_method = true;
     });
 
-    let typeahead_was_open_on_enter = false;
+    let typeahead_item_was_selected_on_enter = false;
     $searchbox_form
         .on("keydown", (e: JQuery.KeyDownEvent): void => {
             if (keydown_util.is_enter_event(e) && $search_query_box.is(":focus")) {
@@ -306,7 +306,10 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
 
             // Record this on keydown before the typeahead code closes the
             // typeahead, so we can use this information on keyup.
-            typeahead_was_open_on_enter = keydown_util.is_enter_event(e) && search_typeahead.shown;
+            typeahead_item_was_selected_on_enter =
+                keydown_util.is_enter_event(e) &&
+                search_typeahead.shown &&
+                search_typeahead.has_active_item();
         })
         .on("keyup", (e: JQuery.KeyUpEvent): void => {
             if (is_using_input_method) {
@@ -319,13 +322,14 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
             } else if (
                 keydown_util.is_enter_event(e) &&
                 $search_query_box.is(":focus") &&
-                !typeahead_was_open_on_enter
+                // When an item is highlighted, this Enter selected a typeahead
+                // item and the typeahead's own handler narrows, so we must not
+                // narrow again here.
+                !typeahead_item_was_selected_on_enter
             ) {
-                // If the typeahead was just open, the Enter event was selecting an item
-                // from the typeahead. When that's the case, we don't want to call
-                // narrow_or_search_for_term which exits the search bar, since the user
-                // might have more terms to add still.
                 if (convert_search_text_to_terms() === undefined) {
+                    // We just return and don't narrow if the search bar
+                    // contains any invalid term.
                     return;
                 }
                 narrow_or_search_for_term({on_narrow_search});

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -186,7 +186,10 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
     });
 
     $search_query_box.on("change", () => {
-        search_typeahead.lookup(false);
+        if (search_typeahead.shown) {
+            // Refresh the open typeahead with the current search content.
+            search_typeahead.lookup(false);
+        }
     });
 
     const bootstrap_typeahead_input: TypeaheadInputElement = {

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -359,6 +359,7 @@ export function create_pills($pill_container: JQuery): SearchPillWidget {
         $container: $pill_container,
         create_item_from_text: create_item_from_search_string,
         get_text_from_item: get_search_string_from_item,
+        focus_input_on_backspace_remove: true,
         split_text_on_comma: false,
         convert_to_pill_on_enter: false,
         generate_pill_html(item) {

--- a/web/tests/input_pill.test.cjs
+++ b/web/tests/input_pill.test.cjs
@@ -460,6 +460,44 @@ run_test("insert_remove", ({mock_template}) => {
     assert.ok($prev_pill_stub.is(":focus"));
 });
 
+run_test("backspace focuses input with focus_input_on_backspace_remove", ({mock_template}) => {
+    mock_template("input_pill.hbs", true, (_data, html) => html);
+
+    const info = set_up();
+    const $container = info.$container;
+    const $pill_input = info.$pill_input;
+    const items = info.items;
+
+    const widget = input_pill.create({
+        ...info.config,
+        focus_input_on_backspace_remove: true,
+    });
+    widget.appendValue("blue,red");
+
+    const pills = widget._get_pills_for_testing();
+    for (const pill of pills) {
+        pill.$element[0].remove = noop;
+    }
+
+    const red_pill = pills.find((pill) => pill.item.color_name === "RED");
+    const $prev_pill_stub = $("<prev-stub>");
+    red_pill.$element.set_prev($prev_pill_stub);
+    red_pill.$element.set_next($("<next-stub>"));
+    $container.set_find_results(".pill:focus", red_pill.$element);
+
+    const key_handler = $container.get_on_handler("keydown", ".pill");
+    key_handler({
+        key: "Backspace",
+        preventDefault: noop,
+    });
+
+    // With the option set, focus moves to the input rather than the
+    // previous pill, even though a previous pill exists.
+    assert.ok($pill_input.is(":focus"));
+    assert.ok(!$prev_pill_stub.is(":focus"));
+    assert.deepEqual(widget.items(), [items.blue]);
+});
+
 run_test("exit button on pill", ({mock_template}) => {
     mock_template("input_pill.hbs", true, (data, html) => {
         assert.equal(typeof data.display_value, "string");

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -101,6 +101,18 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
         on_narrow_search() {},
     });
 
+    // Removing a search pill triggers a "change" event on the search
+    // box. When the typeahead is closed, that shouldn't open it; an
+    // already-open typeahead is refreshed instead.
+    typeahead_forced_open = false;
+    search_typeahead.shown = false;
+    $search_query_box.trigger("change");
+    assert.ok(!typeahead_forced_open);
+    search_typeahead.shown = true;
+    $search_query_box.trigger("change");
+    assert.ok(typeahead_forced_open);
+    search_typeahead.shown = false;
+
     {
         {
             const search_suggestions = ["dm", "dm:"];

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -87,6 +87,10 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
 
         search_typeahead = {
             shown: false,
+            active_item: false,
+            has_active_item() {
+                return this.active_item;
+            },
             lookup() {
                 typeahead_forced_open = true;
             },
@@ -97,8 +101,11 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
         return search_typeahead;
     });
 
+    let narrowed_terms = null;
     search.initialize({
-        on_narrow_search() {},
+        on_narrow_search(search_terms) {
+            narrowed_terms = search_terms;
+        },
     });
 
     // Removing a search pill triggers a "change" event on the search
@@ -338,6 +345,45 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
     assert.ok($search_query_box.is(":focus"));
     $searchbox_form.trigger(ev);
     assert.ok($search_query_box.is(":focus"));
+
+    // With focus on the search box and the typeahead visible, Enter
+    // narrows to the current search terms, unless a typeahead item is
+    // highlighted - in that case Enter selects the item and the
+    // typeahead's own handler does the narrowing, so the keyup handler
+    // doesn't need to invoke narrow again.
+    terms = [
+        {
+            negated: false,
+            operator: "search",
+            operand: "ver",
+        },
+    ];
+    expected_pill_display_value = "ver";
+    _setup(terms);
+    $search_query_box.trigger("focus");
+    search_typeahead.shown = true;
+
+    function search_enter() {
+        ev.type = "keydown";
+        keydown(ev);
+
+        ev.type = "keyup";
+        $searchbox_form.trigger(ev);
+    }
+
+    ev = {type: "keydown", key: "Enter", preventDefault: noop};
+
+    // An item is highlighted, so the keyup handler does not narrow.
+    search_typeahead.active_item = true;
+    narrowed_terms = null;
+    search_enter();
+    assert.equal(narrowed_terms, null);
+
+    // Nothing highlighted: Enter narrows even though the typeahead is open.
+    search_typeahead.active_item = false;
+    narrowed_terms = null;
+    search_enter();
+    assert.deepEqual(narrowed_terms, terms);
 });
 
 run_test("initiate_search", ({override_rewire}) => {

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -337,7 +337,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
     // No change on first Enter keyup event
     assert.ok($search_query_box.is(":focus"));
     $searchbox_form.trigger(ev);
-    assert.ok(!$search_query_box.is(":focus"));
+    assert.ok($search_query_box.is(":focus"));
 });
 
 run_test("initiate_search", ({override_rewire}) => {


### PR DESCRIPTION
Currently, when we remove a search filter pill, we need to click
enter twice (once to update the pill from suggestion and again to
update narrow state) to navigate to the appropriate filter narrow.

This changes the behavior to:
If the search query has focus but no typeahead item is selected or highlighted, we navigate on Enter. We also keep the search bar open on navigation to match the behavior from when we add pills.

Pratik:
> So basically:
> 1) keyboard deletion moves focus to the input field instead of the pill and keeps the typeahead open
> 2) mouse deletion moves focus to the input field but doesn’t open the typeahead.
And we trigger the search on Enter in both cases?

Alya:
> Yeah, I think we can try that.

Intended behavior discussed in [#issues > 📂 Search filtering does not work seamlessly @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20Search.20filtering.20does.20not.20work.20seamlessly/near/2441516)

Fixes: zulip#33416.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/b5b2f8f4-b83f-4f87-83d5-453e95ba391b" />|<video src="https://github.com/user-attachments/assets/bb188283-2ce5-45a4-ad01-9e6cf18e0e51" />|
|Clicking on `x` opens typeahead|Clicking on `x` doesn't open typeahead|
|<video src="https://github.com/user-attachments/assets/3a9dc0dc-88be-4790-8fcd-aa078f88e221"  />|<video src="https://github.com/user-attachments/assets/e88f06fd-0888-486e-9d1c-dc93b8a636a8" />|
|Narrow on `Enter` triggers `blur`|Brings back focus to search on `Enter`|
|<video src="https://github.com/user-attachments/assets/3ace40eb-51a0-427b-8c02-3864710796ab" />|<video src="https://github.com/user-attachments/assets/fa1b91fe-76b3-4832-9dd2-da366d260da2" />|


<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
