### PR TITLE
help: Document resolved topics filter in the left sidebar.

### DIFF
--- a/help/include/filter-resolved-left-sidebar.md
+++ b/help/include/filter-resolved-left-sidebar.md
@@ -1,0 +1,15 @@
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click on a channel in the left sidebar.
+
+1. Click **show all topics** at the bottom of the list of recent topics in the
+   selected channel.
+
+1. In the search box at the top of the list of topics, type `is:`.
+
+1. Choose **Unresolved topics** or **Resolved topics** from the typeahead
+   suggestions.
+
+{end_tabs}

--- a/help/left-sidebar.md
+++ b/help/left-sidebar.md
@@ -75,6 +75,10 @@ information you need in the moment.
 
 {end_tabs}
 
+### Filter by whether topics are resolved
+
+{!filter-resolved-left-sidebar.md!}
+
 ### Show the left sidebar
 
 {start_tabs}

--- a/help/resolve-a-topic.md
+++ b/help/resolve-a-topic.md
@@ -148,6 +148,10 @@ accident.
 
 {end_tabs}
 
+## Filter by whether topics are resolved
+
+{!filter-resolved-left-sidebar.md!}
+
 ## Details
 
 * Resolving a topic works by moving the messages to a new topic.


### PR DESCRIPTION
Current: https://zulip.com/help/left-sidebar, https://zulip.com/help/resolve-a-topic

New section:

<img width="730" height="261" alt="Screenshot 2025-07-15 at 17 24 20" src="https://github.com/user-attachments/assets/9264f65e-bd94-4896-a9c9-7d255ef9a4eb" />
