### PR TITLE
mime_types: Remove incorrect comment, and add audio/mp4 and audio/webm.

### DIFF
--- a/zerver/lib/mime_types.py
+++ b/zerver/lib/mime_types.py
@@ -25,19 +25,15 @@ for mime_type, extension in EXTRA_MIME_TYPES:
 AUDIO_INLINE_MIME_TYPES = [
     "audio/aac",
     "audio/flac",
+    "audio/mp4",
     "audio/mpeg",
     "audio/wav",
+    "audio/webm",
 ]
 
 INLINE_MIME_TYPES = [
     *AUDIO_INLINE_MIME_TYPES,
     "application/pdf",
-    # We don't want to include `audio/mp4` and `audio/webm` in the
-    # `AUDIO_INLINE_MIME` TYPES because despite their ability to be
-    # used for both audio and video, they happen to be parsed only
-    # in their video form.
-    "audio/mp4",
-    "audio/webm",
     "image/apng",
     "image/avif",
     "image/gif",


### PR DESCRIPTION
The comment came from when the only use of `AUDIO_INLINE_MIME_TYPES` was based on the result of `mimetypes.guess_type`, which would happen to always return `video/mp4` and not of `audio/mp4` for `.mp4` files. Before being merged, the code was updated to examine uploaded files' content-type, which can very well be `audio/mp4` -- and in such cases, should very much be shown inline.

Add the missing content-types to `AUDIO_INLINE_MIME_TYPES`, and remove the comment.
-----

cc @roanster007 
