### PR TITLE
realm_reactivation: Use redirect-to-POST trick.

### DIFF
--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -273,7 +273,7 @@ _properties = {
         "join", validity_in_days=settings.INVITATION_LINK_VALIDITY_DAYS
     ),
     Confirmation.REALM_CREATION: ConfirmationType("get_prereg_key_and_redirect"),
-    Confirmation.REALM_REACTIVATION: ConfirmationType("realm_reactivation"),
+    Confirmation.REALM_REACTIVATION: ConfirmationType("realm_reactivation_get"),
 }
 if settings.ZILENCER_ENABLED:
     _properties[Confirmation.REMOTE_SERVER_BILLING_LEGACY_LOGIN] = ConfirmationType(

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -124,6 +124,7 @@ from zerver.views.realm import (
     check_subdomain_available,
     deactivate_realm,
     realm_reactivation,
+    realm_reactivation_get,
     update_realm,
     update_realm_user_settings_defaults,
 )
@@ -698,7 +699,8 @@ i18n_urls = [
     path("new/", create_realm),
     path("new/<creation_key>", create_realm, name="create_realm"),
     # Realm reactivation
-    path("reactivate/<confirmation_key>", realm_reactivation, name="realm_reactivation"),
+    path("reactivate/", realm_reactivation, name="realm_reactivation"),
+    path("reactivate/<confirmation_key>", realm_reactivation_get, name="realm_reactivation_get"),
     # Login/registration
     path("register/", accounts_home, name="register"),
     path("login/", login_page, {"template_name": "zerver/login.html"}, name="login_page"),


### PR DESCRIPTION
Uses the approach done for email change confirmations in #34980 to avoid triggering a reactivation via just a GET request. Instead, the GET should return a page which will trigger the browser to then POST the key to the endpoint.

