### PR TITLE
help-beta: Fix incorrectly linked entries in sidebar.

### DIFF
--- a/help-beta/astro.config.mjs
+++ b/help-beta/astro.config.mjs
@@ -82,8 +82,14 @@ export default defineConfig({
                     label: "Guides",
                     items: [
                         "getting-started-with-zulip",
-                        "choosing-a-team-chat-app",
-                        "why-zulip",
+                        {
+                            label: "Choosing a team chat app",
+                            link: "https://blog.zulip.com/2024/11/04/choosing-a-team-chat-app/",
+                        },
+                        {
+                            label: "Why Zulip",
+                            link: "https://zulip.com/why-zulip/",
+                        },
                         "trying-out-zulip",
                         "zulip-cloud-or-self-hosting",
                         "moving-to-zulip",


### PR DESCRIPTION
Slug was mentioned for the two entries in question as if they were normal help pages, but they were external links and should have been mentioned accordingly.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
