### PR TITLE
help-beta: Remove top margin from unplugin icons.

### DIFF
--- a/help-beta/astro.config.mjs
+++ b/help-beta/astro.config.mjs
@@ -82,8 +82,14 @@ export default defineConfig({
                     label: "Guides",
                     items: [
                         "getting-started-with-zulip",
-                        "choosing-a-team-chat-app",
-                        "why-zulip",
+                        {
+                            label: "Choosing a team chat app",
+                            link: "https://blog.zulip.com/2024/11/04/choosing-a-team-chat-app/",
+                        },
+                        {
+                            label: "Why Zulip",
+                            link: "https://zulip.com/why-zulip/",
+                        },
                         "trying-out-zulip",
                         "zulip-cloud-or-self-hosting",
                         "moving-to-zulip",

--- a/help-beta/astro.config.mjs
+++ b/help-beta/astro.config.mjs
@@ -16,7 +16,7 @@ export default defineConfig({
                 // It was setting the height to 1024 and 960 for some
                 // icons. It is better to set the height explicitly.
                 defaultStyle:
-                    "display: inline; vertical-align: text-bottom; height: 1em; width: 1em; margin-bottom: 0;",
+                    "display: inline; vertical-align: text-bottom; height: 1em; width: 1em; margin-bottom: 0; margin-top: 0;",
                 customCollections: {
                     // unplugin-icons has a FileSystemIconLoader which is more
                     // versatile. But it only supports one directory path for


### PR DESCRIPTION
NOTE: First commit is from https://github.com/zulip/zulip/pull/35321, please help rebase if that is already merged at the time of review.

In some cases, some of the starlight css was inserting a margin top of 1rem to the svg tag inserted by unplgin-icons. We make the top margin 0 explicitly to make sure that extra margin is not added.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before:
<img width="783" height="409" alt="no_relative_links_passed" src="https://github.com/user-attachments/assets/161c6b1c-a2c3-4536-87b6-bad4bf212bda" />

After:
<img width="783" height="409" alt="Screenshot 2025-07-17 at 5 03 17 PM" src="https://github.com/user-attachments/assets/d816d0d3-7d5c-4639-8f25-870dc67bfd86" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
