### PR TITLE
search: Remove background suggestion highlight for text search.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -391,6 +391,10 @@
             align-items: center;
         }
 
+        .search_list_item .description {
+            margin: 2px 0;
+        }
+
         .search_list_item .pill-container {
             margin: 2px 0;
             /* This contains only one pill, which handles its own border */

--- a/web/templates/search_list_item.hbs
+++ b/web/templates/search_list_item.hbs
@@ -1,14 +1,12 @@
 <div class="search_list_item">
     {{#each pills}}
-        <span class="pill-container">
-            {{#if (eq this.type "search_user")}}
-                {{> search_user_pill this}}
-            {{else if (eq this.operator "search")}}
-                {{{this.description_html}}}
-            {{else}}
-                {{> input_pill this}}
-            {{/if}}
-        </span>
+        {{#if (eq this.operator "search")}}
+            <div class="description">{{{this.description_html}}}</div>
+        {{else if (eq this.type "search_user")}}
+            <span class="pill-container">{{> search_user_pill this}}</span>
+        {{else}}
+            <span class="pill-container">{{> input_pill this}}</span>
+        {{/if}}
     {{/each}}
     {{#if description_html}}<div class="description">{{{description_html}}}</div>{{/if}}
 </div>

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -115,12 +115,12 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
 
             /* Test highlighter */
             let description_html = "Search for ver";
-            let expected_value = `<div class="search_list_item">\n        <span class="pill-container">\n                ${description_html}\n        </span>\n    \n</div>\n`;
+            let expected_value = `<div class="search_list_item">\n            <div class="description">Search for ver</div>\n    \n</div>\n`;
             assert.equal(opts.item_html(source[0]), expected_value);
 
             const search_string = "channel: Verona";
             description_html = "Stream Verona";
-            expected_value = `<div class="search_list_item">\n        <span class="pill-container">\n                <div class='pill ' tabindex=0>\n    <span class="pill-label">\n        <span class="pill-value">\n            ${search_string}\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n                    </span>\n    <div class="description">${description_html}</div>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class='pill ' tabindex=0>\n    <span class="pill-label">\n        <span class="pill-value">\n            ${search_string}\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n</span>\n            <div class="description">${description_html}</div>\n</div>\n`;
             assert.equal(opts.item_html(source[1]), expected_value);
 
             /* Test sorter */
@@ -170,7 +170,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
 
             /* Test highlighter */
             const description_html = "Search for zo";
-            let expected_value = `<div class="search_list_item">\n        <span class="pill-container">\n                ${description_html}\n        </span>\n    \n</div>\n`;
+            let expected_value = `<div class="search_list_item">\n            <div class="description">${description_html}</div>\n    \n</div>\n`;
             assert.equal(opts.item_html(source[0]), expected_value);
 
             people.add_active_user({
@@ -179,13 +179,13 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
                 full_name: "Zoe",
             });
             override(realm, "realm_enable_guest_user_indicator", true);
-            expected_value = `<div class="search_list_item">\n        <span class="pill-container">\n                <div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">sender:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n        </span>\n    \n</div>\n`;
+            expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">sender:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n</span>\n    \n</div>\n`;
             assert.equal(opts.item_html(source[1]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n        <span class="pill-container">\n                <div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">dm:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n        </span>\n    \n</div>\n`;
+            expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">dm:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n</span>\n    \n</div>\n`;
             assert.equal(opts.item_html(source[2]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n        <span class="pill-container">\n                <div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">dm-including:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n        </span>\n    \n</div>\n`;
+            expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">dm-including:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n</span>\n    \n</div>\n`;
             assert.equal(opts.item_html(source[3]), expected_value);
 
             /* Test sorter */


### PR DESCRIPTION
This commit removes the background suggestion highlight in the search suggestion for text search suggestion.

<!-- Describe your pull request here.-->

Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20text.20not.20highlighted.20in.20search.20typeahead/near/2223702)[#issues > 🎯 text not highlighted in search typeahead @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20text.20not.20highlighted.20in.20search.20typeahead/near/2223702)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**After:**
<img width="414" height="178" alt="Screenshot from 2025-07-18 01-46-26" src="https://github.com/user-attachments/assets/c067dd20-b049-459d-aa43-979032a82266" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
