### PR TITLE
Apply hide unread summary count setting only to the home view.

### DIFF
--- a/help/configure-unread-message-counters.md
+++ b/help/configure-unread-message-counters.md
@@ -27,7 +27,7 @@ opening it.
 ## Configure unread summary counters
 
 You can configure whether Zulip displays unread count summaries on your home
-view and channels section in the left sidebar. You will still be able to see the
+view in the left sidebar. You will still be able to see the
 summary counts by moving your mouse over them in the left sidebar. The counter
 on your home view will also be shown when you're in that view.
 
@@ -46,8 +46,7 @@ on your home view will also be shown when you're in that view.
 
 {settings_tab|preferences}
 
-1. Under **Information**, toggle **Show unread count summaries in the
-   left sidebar**.
+1. Under **Information**, toggle **Show unread count total on home view**.
 
 {end_tabs}
 

--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -16,7 +16,6 @@ import * as stream_list_sort from "./stream_list_sort.ts";
 import * as sub_store from "./sub_store.ts";
 import * as ui_util from "./ui_util.ts";
 import * as unread from "./unread.ts";
-import {user_settings} from "./user_settings.ts";
 
 let last_mention_count = 0;
 const ls_key = "left_sidebar_views_state";
@@ -75,16 +74,6 @@ export function update_reminders_row(): void {
         $reminders_li.removeClass("show-with-reminders");
     }
     ui_util.update_unread_count_in_dom($reminders_li, count);
-}
-
-function should_mask_header_unread_count(
-    show_muted: boolean,
-    unmuted_unread_count: number,
-): boolean {
-    if (!user_settings.web_left_sidebar_unreads_count_summary) {
-        return true;
-    }
-    return settings_data.should_mask_unread_count(show_muted, unmuted_unread_count);
 }
 
 type SectionUnreadCount = {
@@ -172,8 +161,8 @@ export function update_dom_with_unread_counts(
         }
         $header.toggleClass("has-only-muted-unreads", show_muted_count);
         $header.toggleClass(
-            "hide-unread-messages-count",
-            should_mask_header_unread_count(show_muted_count, unmuted_count),
+            "hide_unread_counts",
+            settings_data.should_mask_unread_count(show_muted_count, unmuted_count),
         );
     }
 

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -636,7 +636,7 @@ export const preferences_settings_labels = {
     receives_typing_notifications: $t({defaultMessage: "Show when other users are typing"}),
     starred_message_counts: $t({defaultMessage: "Show counts for starred messages"}),
     web_left_sidebar_unreads_count_summary: $t({
-        defaultMessage: "Show unread count summaries in the left sidebar",
+        defaultMessage: "Show unread count total on home view",
     }),
     twenty_four_hour_time: $t({defaultMessage: "Time format"}),
     translate_emoticons: new Handlebars.SafeString(

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -134,12 +134,8 @@ export function update_invite_user_option(): void {
 export function update_unread_counts_visibility(): void {
     const hidden = !user_settings.web_left_sidebar_unreads_count_summary;
 
-    const $channel_sections: JQuery = $(".stream-list-subsection-header");
-    const $home_view_li: JQuery = $(".top_left_row");
-
-    for (const $el of [$home_view_li, $channel_sections]) {
-        $el.toggleClass("hide-unread-messages-count", hidden);
-    }
+    const $home_view_li = $(".top_left_row");
+    $home_view_li.toggleClass("hide-unread-messages-count", hidden);
 }
 
 export function hide_all(): void {

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -688,6 +688,7 @@ function toggle_hide_unread_counts(
 export function update_dom_unread_counts_visibility(): void {
     // TODO: It's not obviously why this function exists; can't we
     // just do a full left sidebar rebuild?
+    left_sidebar_navigation_area.update_dom_with_unread_counts(unread.get_counts(), false);
     for (const stream of stream_sidebar.rows.values()) {
         const $subscription_block = stream.get_li().find(".subscription_block");
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -79,27 +79,20 @@
     width: var(--left-sidebar-single-digit-unread-width);
 }
 
-.selected-home-view {
-    &.hide-unread-messages-count {
-        .masked_unread_count {
-            /* Adding margin-right aligns the .masked_unread_count with the rest of the masked unread counts. */
-            margin-right: var(--left-sidebar-unread-offset);
-        }
-    }
-}
-
-#left-sidebar-navigation-list .selected-home-view,
-.show-inactive-channels {
+#left-sidebar-navigation-list .selected-home-view {
     &.hide-unread-messages-count {
         .masked_unread_count {
             display: flex;
             grid-area: markers-and-unreads;
+            /* Adding margin-right aligns the .masked_unread_count  */
+            /* with the rest of the masked unread counts. */
+            margin-right: var(--left-sidebar-unread-offset);
             justify-self: end;
             visibility: visible;
         }
 
         .unread_count {
-            visibility: hidden;
+            visibility: hidden !important;
         }
         /* When message summary count is 0, we dont want to show unread_count or masked_unread_count. */
         .unread_count.hide + .masked_unread_count {
@@ -109,7 +102,6 @@
 }
 
 #left-sidebar-navigation-list .selected-home-view:hover,
-.stream-list-toggle-inactive-channels:hover .show-inactive-channels,
 .selected-home-view.top-left-active-filter {
     &.hide-unread-messages-count {
         .masked_unread_count {
@@ -118,7 +110,7 @@
         }
 
         .unread_count {
-            visibility: visible;
+            visibility: visible !important;
         }
     }
 }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -355,7 +355,8 @@
        below. This extra margin prevents that overlap. */
     margin-bottom: 1px;
 
-    .unread_count {
+    .unread_count,
+    .masked_unread_count {
         margin-right: var(--left-sidebar-unread-offset);
     }
 
@@ -394,6 +395,35 @@
         color: var(--color-text-sidebar-heading);
         opacity: var(--opacity-sidebar-heading-icon);
         justify-self: center;
+    }
+
+    &.hide_unread_counts {
+        .unread_count,
+        .unread_count.hide,
+        .masked_unread_count {
+            display: none;
+        }
+
+        /* When an empty unread count is hidden,
+           hide the masked unread count, too. */
+        .unread_count.hide + .masked_unread_count {
+            display: none;
+        }
+
+        .masked_unread_count {
+            display: flex;
+        }
+
+        &:hover {
+            .unread_count {
+                display: block;
+            }
+
+            .hide,
+            .masked_unread_count {
+                display: none;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
1st commit: Apply the hide unread summary count setting only to the home view.
2nd commit: Hides the unread count of the "CHANNELS" heading when the unread counts are hidden for all the channels.
Fixes: #35326.

CZO discussion: [#design > channel folders masked unreads](https://chat.zulip.org/#narrow/channel/101-design/topic/channel.20folders.20masked.20unreads/with/2231900)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Initial config:**
<img width="320" height="290" alt="image" src="https://github.com/user-attachments/assets/d13593db-4180-4354-a05e-cc8ee1710c2e" />

|  | After |
|--------|--------|
| Setting string | <img width="455" height="127" alt="image" src="https://github.com/user-attachments/assets/6c0a3788-9a45-4755-a0f4-684ced7bfc1a" /> |
| Hide unread counts of home view | <img width="352" height="378" alt="image" src="https://github.com/user-attachments/assets/10f24d68-2c1d-4668-a326-6f54598e7d7f" /> | 
| Show unread counts of channels subheader when the unreads of all the channels are visible | <img width="310" height="69" alt="image" src="https://github.com/user-attachments/assets/e7410428-4df4-487d-98f5-dfc776086f51" />| 
| When unread count of only unmuted channels are visible |<img width="321" height="81" alt="image" src="https://github.com/user-attachments/assets/54411fc6-e414-423a-9ac6-7fe7cdf68658" /> |
| when unread counts of all the channels are hidden |<img width="323" height="72" alt="image" src="https://github.com/user-attachments/assets/48f0272b-e8d1-4ed3-9f74-73b788852f24" /> |
| Help center | <img width="773" height="323" alt="image" src="https://github.com/user-attachments/assets/1f8a4b7d-a8c1-4435-8f2d-c746df369222" /> |
| Help center | <img width="743" height="292" alt="image" src="https://github.com/user-attachments/assets/9fd11cc4-10fb-456e-aa69-eb1a225b87d6" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
