### PR TITLE
banners: Improve responsiveness in normal banners.

### DIFF
--- a/web/src/portico/showroom.ts
+++ b/web/src/portico/showroom.ts
@@ -125,7 +125,7 @@ const alert_banners: Record<string, AlertBanner> = {
         custom_classes: "navbar-alert-banner",
     },
     notifications: {
-        process: "notifications",
+        process: "desktop-notifications",
         intent: "brand",
         label: new Handlebars.SafeString(
             $t_html({

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -659,23 +659,12 @@
     /* Banner grid layout variables */
     --banner-horizontal-padding: 0.8125em; /* 13px at 16px/1em */
     --banner-vertical-padding: 0.3125em; /* 5px at 16px/1em */
-    --banner-grid-template-areas-lg: ". . . . . . banner-close-button banner-close-button"
-        ". . banner-label . banner-action-buttons . banner-close-button banner-close-button"
-        ". . . . . . banner-close-button banner-close-button";
-    --banner-grid-template-columns-lg: var(--banner-horizontal-padding) 0 auto
-        minmax(0, 1fr) auto 0 minmax(0, auto) var(--banner-horizontal-padding);
-    --banner-grid-template-rows-lg: 0.3125em auto 0.3125em; /* 5px at 16px/1em */
-    --banner-grid-template-areas-md: ". . . . banner-close-button banner-close-button"
-        ". . banner-label banner-label banner-close-button banner-close-button"
-        ". banner-action-buttons banner-action-buttons banner-action-buttons banner-close-button banner-close-button"
-        ". . . . banner-close-button banner-close-button";
-    --banner-grid-template-columns-md: var(--banner-horizontal-padding) 0
-        minmax(auto, 1fr) 0 minmax(0, auto) var(--banner-horizontal-padding);
-    --banner-grid-template-rows-md: 0.3125em auto auto 0.3125em; /* 5px at 16px/1em */
-    --banner-grid-template-areas-sm: ". . . . banner-close-button banner-close-button"
-        ". . banner-label banner-label banner-close-button banner-close-button"
-        ". banner-action-buttons banner-action-buttons banner-action-buttons banner-close-button banner-close-button"
-        ". . . . banner-close-button banner-close-button";
+    --banner-grid-template-areas: " . . banner-close-button banner-close-button"
+        ". banner-content banner-close-button banner-close-button"
+        ". . banner-close-button banner-close-button";
+    --banner-grid-template-columns: var(--banner-horizontal-padding)
+        minmax(0, 1fr) minmax(0, auto) var(--banner-horizontal-padding);
+    --banner-grid-template-rows: 0.3125em auto 0.3125em; /* 5px at 16px/1em */
 
     /* Popup banner related variables */
     --popup-banner-translate-y-distance: 100px;

--- a/web/styles/banners.css
+++ b/web/styles/banners.css
@@ -5,10 +5,10 @@
 .banner {
     box-sizing: border-box;
     display: grid;
-    grid-template: var(--banner-grid-template-rows-lg) / var(
-            --banner-grid-template-columns-lg
+    grid-template: var(--banner-grid-template-rows) / var(
+            --banner-grid-template-columns
         );
-    grid-template-areas: var(--banner-grid-template-areas-lg);
+    grid-template-areas: var(--banner-grid-template-areas);
     place-items: start;
     border: 1px solid;
     border-radius: 6px;
@@ -30,8 +30,22 @@
     }
 }
 
+.banner-content {
+    grid-area: banner-content;
+    display: flex;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    width: 100%;
+    gap: 0 0.625em; /* 10px at 16px/1em */
+}
+
 .banner-label {
-    grid-area: banner-label;
+    /* We allow the banner label to grow and shrink, and set
+       the flex basis to 60% of the query container's width.
+       When the width of the banner label goes below this
+       flex basis value, the banner action buttons are wrapped
+       on to the next line.  */
+    flex: 1 1 60cqw;
     /* The padding and line-height values for the banner label
        are identical to those of the action buttons', to match
        the height of both of these elements. This is required to
@@ -44,10 +58,9 @@
 }
 
 .banner-action-buttons {
-    grid-area: banner-action-buttons;
     display: flex;
+    flex-wrap: wrap;
     gap: 0.5em; /* 8px at 16px/1em */
-    margin-left: 0.625em; /* 10px at 16px/1em */
 }
 
 .banner-close-button {
@@ -62,52 +75,69 @@
 }
 
 .navbar-alert-banner {
-    grid-template-columns:
-        var(--banner-horizontal-padding) minmax(0, 1fr)
-        auto 0 auto minmax(0, 1fr) minmax(0, auto) var(
-            --banner-horizontal-padding
-        );
     border: unset;
     border-bottom: 1px solid;
     border-radius: 0;
     place-items: start center;
-}
 
-.navbar-alert-banner .banner-action-buttons {
-    justify-content: center;
-}
+    .banner-content {
+        justify-content: center;
+        flex-wrap: nowrap;
+    }
 
-@container banner (width >= 44em) and (width < 63em) {
-    .navbar-alert-banner[data-process="desktop-notifications"] {
-        grid-template: var(--banner-grid-template-rows-md) / var(
-                --banner-grid-template-columns-md
-            );
-        grid-template-areas: var(--banner-grid-template-areas-md);
-        text-align: center;
+    .banner-label {
+        /* Reset to initial value */
+        flex: 0 1 auto;
+    }
+
+    .banner-action-buttons {
+        flex-wrap: nowrap;
     }
 }
 
-@container banner (width < 44em) {
-    .banner {
-        grid-template: var(--banner-grid-template-rows-md) / var(
-                --banner-grid-template-columns-md
-            );
-        grid-template-areas: var(--banner-grid-template-areas-md);
+/* This utility class defines the structure of the medium-type
+   navbar banners where the banner action buttons are placed
+   below the banner label. This utility class is required since
+   unlike the normal banners, the navbar counterparts have
+   horizontally centered elements, wherein the flex-basis logic
+   won't apply and we need to manually apply these properties
+   based on the container size queries below. */
+.navbar-alert-medium-banner {
+    .banner-content {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .banner-label {
+        text-align: center;
     }
 
     .banner-action-buttons {
         flex-wrap: wrap;
-        margin-left: 0;
+        justify-content: center;
     }
+}
 
+@container banner (width >= 44em) and (width < 63em) {
+    .navbar-alert-banner[data-process="desktop-notifications"] {
+        @extend .navbar-alert-medium-banner;
+    }
+}
+
+@container banner (width < 44em) {
     .navbar-alert-banner {
-        text-align: center;
+        @extend .navbar-alert-medium-banner;
     }
 }
 
 @container banner (width < 25em) {
-    .banner {
-        grid-template-areas: var(--banner-grid-template-areas-sm);
+    .banner-content {
+        flex-direction: column;
+    }
+
+    .banner-label {
+        /* Reset to initial value */
+        flex: 0 1 auto;
     }
 
     .banner-action-buttons {

--- a/web/templates/components/banner.hbs
+++ b/web/templates/components/banner.hbs
@@ -1,15 +1,17 @@
 <div {{#if process}}data-process="{{process}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}banner banner-{{intent}}">
-    <span class="banner-label">
-        {{label}}
-    </span>
-    <span class="banner-action-buttons">
-        {{#each buttons}}
-            {{#if this.intent}}
-                {{> action_button .}}
-            {{else}}
-                {{> action_button . intent=../intent}}
-            {{/if}}
-        {{/each}}
+    <span class="banner-content">
+        <span class="banner-label">
+            {{label}}
+        </span>
+        <span class="banner-action-buttons">
+            {{#each buttons}}
+                {{#if this.intent}}
+                    {{> action_button .}}
+                {{else}}
+                    {{> action_button . intent=../intent}}
+                {{/if}}
+            {{/each}}
+        </span>
     </span>
     {{#if close_button}}
         {{> icon_button custom_classes="banner-close-action banner-close-button" icon="close" intent=intent}}


### PR DESCRIPTION
This PR improves the responsiveness of normal banners by adopting a flexbox layout for the label and action buttons. This change better accommodates varying text lengths and button counts in the banners, due to the natural flowy nature of flexboxes.

The key logic shift involves using `flex-basis` to manage layout transitions: the label and the group of action buttons now wrap to separate lines when the label's width is less than 60% of the banner query container's width (60cqw).

This PR also updates the CSS for navbar banners to align with the new flexbox layout between the label and the group of action buttons, while also ensuring that the layout behavior of these banners remains consistent with the previous implementation.

<!-- Describe your pull request here.-->

Test the PR locally by using http://localhost:9991/devtools/banners/.

Fixes: [#frontend > Improve banner responsiveness](https://chat.zulip.org/#narrow/channel/6-frontend/topic/Improve.20banner.20responsiveness) and [#frontend > Correct banner behaviour at narrower widths.](https://chat.zulip.org/#narrow/channel/6-frontend/topic/Correct.20banner.20behaviour.20at.20narrower.20widths.2E)

Unblocks: #34491

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Settings banner from #34491 |
|--------|
| ![user_group_settings_banner](https://github.com/user-attachments/assets/9aeea29d-a7fc-41b0-8b43-ce1c6dea2775) |
| ![zulip_cloud_standard_banner](https://github.com/user-attachments/assets/fd1b8cf9-5756-4cc6-8a3a-6ecd4aba1c6b) |

| Navbar banners responsiveness remains consistent |
|--------|
| ![navbar_behavior_same](https://github.com/user-attachments/assets/47cf1cb3-4795-433e-bc19-d37aa98efc8c) |
| ![desktop_notifications_banner_opt](https://github.com/user-attachments/assets/b19c11f3-2ef0-45f1-8aff-2f2105d9a002) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
