### PR TITLE
web: Refactor variables to indicate markup.

### DIFF
--- a/web/src/favicon.ts
+++ b/web/src/favicon.ts
@@ -4,7 +4,7 @@ import static_favicon_image from "../../static/images/favicon.svg";
 import render_favicon_svg from "../templates/favicon.svg.hbs";
 
 import * as blueslip from "./blueslip.ts";
-import favicon_font_url from "./favicon_font_url!=!url-loader!font-subset-loader2?glyphs=0123456789KMGT∞!source-sans/TTF/SourceSans3-Bold.ttf"; // eslint-disable-line import/extensions
+import favicon_font_url_html from "./favicon_font_url!=!url-loader!font-subset-loader2?glyphs=0123456789KMGT∞!source-sans/TTF/SourceSans3-Bold.ttf"; // eslint-disable-line import/extensions
 
 let favicon_state: {image: HTMLImageElement; url: string} | undefined;
 
@@ -58,7 +58,7 @@ export function update_favicon(new_message_count: number, pm_count: number): voi
             count,
             count_long,
             have_pm: pm_count !== 0,
-            favicon_font_url,
+            favicon_font_url_html,
         });
 
         load_and_set_favicon(rendered_favicon);

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -53,7 +53,7 @@ import * as views_util from "./views_util.ts";
 type DirectMessageContext = {
     conversation_key: string;
     is_direct: boolean;
-    rendered_dm_with: string;
+    rendered_dm_with_html: string;
     is_group: boolean;
     user_circle_class: string | false | undefined;
     is_bot: boolean;
@@ -70,7 +70,7 @@ type DirectMessageContext = {
 const direct_message_context_properties: (keyof DirectMessageContext)[] = [
     "conversation_key",
     "is_direct",
-    "rendered_dm_with",
+    "rendered_dm_with_html",
     "is_group",
     "user_circle_class",
     "is_bot",
@@ -469,7 +469,7 @@ function format_dm(
 
     const reply_to = people.user_ids_string_to_emails_string(user_ids_string);
     assert(reply_to !== undefined);
-    const rendered_dm_with = recipient_ids
+    const rendered_dm_with_html = recipient_ids
         .map((recipient_id) => ({
             name: people.get_display_full_name(recipient_id),
             status_emoji_info: user_status.get_status_emoji(recipient_id),
@@ -492,7 +492,10 @@ function format_dm(
     const context = {
         conversation_key: user_ids_string,
         is_direct: true,
-        rendered_dm_with: util.format_array_as_list_with_conjunction(rendered_dm_with, "long"),
+        rendered_dm_with_html: util.format_array_as_list_with_conjunction(
+            rendered_dm_with_html,
+            "long",
+        ),
         is_group: recipient_ids.length > 1,
         user_circle_class,
         is_bot,

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -82,7 +82,7 @@ export type MessageContainer = {
 
 export type MessageGroup = {
     bookend_top?: boolean;
-    date: string;
+    date_html: string;
     date_unchanged: boolean;
     message_containers: MessageContainer[];
     message_group_id: string;
@@ -96,7 +96,7 @@ export type MessageGroup = {
           is_topic_editable: boolean;
           is_web_public: boolean;
           just_unsubscribed?: boolean;
-          match_topic: string | undefined;
+          match_topic_html: string | undefined;
           recipient_bar_color: string;
           stream_id: number;
           stream_name?: string;
@@ -364,7 +364,7 @@ function populate_group_from_message(
     const is_private = message.is_private;
     const display_recipient = message.display_recipient;
     const message_group_id = _.uniqueId("message_group_");
-    const date = get_group_display_date(message, year_changed);
+    const date_html = get_group_display_date(message, year_changed);
 
     // Each searched message is a self-contained result,
     // so we always display date in the recipient bar for those messages.
@@ -381,7 +381,7 @@ function populate_group_from_message(
         const topic = message.topic;
         const topic_display_name = util.get_final_topic_display_name(topic);
         const is_empty_string_topic = topic === "";
-        const match_topic = util.get_match_topic(message);
+        const match_topic_html = util.get_match_topic(message);
         const stream_url = hash_util.channel_url_by_user_setting(message.stream_id);
         const is_archived = stream_data.is_stream_archived(message.stream_id);
         const topic_url = internal_url.by_stream_topic_url(
@@ -420,7 +420,7 @@ function populate_group_from_message(
             ...get_topic_edit_properties(message),
             user_can_resolve_topic,
             ...subscription_markers,
-            date,
+            date_html,
             display_recipient,
             date_unchanged,
             topic_links,
@@ -431,7 +431,7 @@ function populate_group_from_message(
             stream_privacy_icon_color,
             invite_only,
             is_web_public,
-            match_topic,
+            match_topic_html,
             stream_url,
             is_archived,
             topic_url,
@@ -454,7 +454,7 @@ function populate_group_from_message(
         is_stream,
         is_private,
         ...get_topic_edit_properties(message),
-        date,
+        date_html,
         date_unchanged,
         display_recipient,
         pm_with_url: message.pm_with_url,
@@ -2000,7 +2000,7 @@ export class MessageListView {
                 .attr("id")!;
             const group = this._find_message_group(message_group_id);
             if (group !== undefined) {
-                const rendered_date = group.date;
+                const rendered_date = group.date_html;
                 dom_updates.html_updates.push({
                     $element: $current_sticky_header.find(".recipient_row_date"),
                     rendered_date,

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -614,7 +614,7 @@ type ConversationContext = {
     | {
           is_private: true;
           user_ids_string: string;
-          rendered_pm_with: string;
+          rendered_pm_with_html: string;
           recipient_id: number;
           pm_url: string;
           is_group: boolean;
@@ -713,7 +713,7 @@ function format_conversation(conversation_data: ConversationData): ConversationC
         // Direct message info
         const user_ids_string = last_msg.to_user_ids;
         assert(typeof last_msg.display_recipient !== "string");
-        const rendered_pm_with = last_msg.display_recipient
+        const rendered_pm_with_html = last_msg.display_recipient
             .filter(
                 (recipient: DisplayRecipientUser) =>
                     !people.is_my_user_id(recipient.id) || last_msg.display_recipient.length === 1,
@@ -759,7 +759,11 @@ function format_conversation(conversation_data: ConversationData): ConversationC
 
         dm_context = {
             user_ids_string,
-            rendered_pm_with: util.format_array_as_list(rendered_pm_with, "long", "conjunction"),
+            rendered_pm_with_html: util.format_array_as_list(
+                rendered_pm_with_html,
+                "long",
+                "conjunction",
+            ),
             recipient_id,
             pm_url,
             is_group,

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -603,7 +603,7 @@ export async function build_move_topic_to_stream_popover(
         const participant_names = unsubscribed_participant_ids.map(
             (user_id) => people.get_user_by_id_assert_valid(user_id).full_name,
         );
-        const unsubscribed_participant_formatted_names_list =
+        const unsubscribed_participant_formatted_names_list_html =
             util.format_array_as_list_with_highlighted_elements(
                 participant_names,
                 "long",
@@ -625,7 +625,7 @@ export async function build_move_topic_to_stream_popover(
             hide_close_button: true,
             stream: destination_stream,
             selected_propagate_mode,
-            unsubscribed_participant_formatted_names_list,
+            unsubscribed_participant_formatted_names_list_html,
             unsubscribed_participants_count,
             few_unsubscribed_participants,
         };

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -135,7 +135,7 @@ function handle_skipped_unsubscribed_streams(
                 "conjunction",
             );
             const rendered_html = render_skipped_marking_unread({
-                streams: formatted_stream_list_text,
+                streams_html: formatted_stream_list_text,
             });
             $container.html(rendered_html);
         };

--- a/web/templates/favicon.svg.hbs
+++ b/web/templates/favicon.svg.hbs
@@ -4,7 +4,7 @@
         font-family: 'Source Sans 3';
         font-style: normal;
         font-weight: 700;
-        src: url({{{favicon_font_url}}}) format('truetype');
+        src: url({{{favicon_font_url_html}}}) format('truetype');
         }
     </style>
     <linearGradient id="a" x1="0" y1="0" x2="0" y2="1">

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -15,7 +15,7 @@
                                 {{else}}
                                 <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle" data-presence-indicator-user-id="{{user_ids_string}}"></span>
                                 {{/if}}
-                                <span class="recipients_name">{{{rendered_dm_with}}}</span>
+                                <span class="recipients_name">{{{rendered_dm_with_html}}}</span>
                             </span>
                         </a>
                         <span class="unread_mention_info tippy-zulip-tooltip

--- a/web/templates/modal_banner/unsubscribed_participants_warning_banner.hbs
+++ b/web/templates/modal_banner/unsubscribed_participants_warning_banner.hbs
@@ -3,14 +3,14 @@
         {{#if (eq selected_propagate_mode "change_one")}}
             {{#tr}}
                 Message sender <z-user-names></z-user-names> is not subscribed to &nbsp;<z-stream></z-stream>.
-                {{#*inline "z-user-names"}}({{{unsubscribed_participant_formatted_names_list}}}){{/inline}}
+                {{#*inline "z-user-names"}}({{{unsubscribed_participant_formatted_names_list_html}}}){{/inline}}
                 {{#*inline "z-stream"}}<strong class="highlighted-element">{{> ../inline_decorated_channel_name stream=stream show_colored_icon=true}}</strong>{{/inline}}
             {{/tr}}
 
         {{else if few_unsubscribed_participants}}
             {{#tr}}
                 Some topic participants <z-user-names></z-user-names> are not subscribed to &nbsp;<z-stream></z-stream>.
-                {{#*inline "z-user-names"}}({{{unsubscribed_participant_formatted_names_list}}}){{/inline}}
+                {{#*inline "z-user-names"}}({{{unsubscribed_participant_formatted_names_list_html}}}){{/inline}}
                 {{#*inline "z-stream"}}<strong class="highlighted-element">{{> ../inline_decorated_channel_name stream=stream show_colored_icon=true}}</strong>{{/inline}}
             {{/tr}}
 

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -32,7 +32,7 @@
         <div class="flex_container">
             <div class="left_part recent_view_focusable line_clamp" data-col-index="{{ column_indexes.topic }}">
                 {{#if is_private}}
-                <a href="{{pm_url}}" class="recent-view-table-link {{#if is_group}}recent-view-dm-group{{else}}recent-view-dm{{/if}}">{{{rendered_pm_with}}}</a>
+                <a href="{{pm_url}}" class="recent-view-table-link {{#if is_group}}recent-view-dm-group{{else}}recent-view-dm{{/if}}">{{{rendered_pm_with_html}}}</a>
                 {{else}}
                 <a class="white-space-preserve-wrap recent-view-table-link {{#if is_empty_string_topic}}empty-topic-display{{/if}}" href="{{topic_url}}">{{topic_display_name}}</a>
                 {{/if}}

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -29,7 +29,7 @@
               href="{{topic_url}}"
               data-tippy-content="{{t 'Go to #{display_recipient} > {topic_display_name}' }}">
                 {{#if (and use_match_properties (not is_empty_string_topic))}}
-                    <span class="stream-topic-inner">{{{match_topic}}}</span>
+                    <span class="stream-topic-inner">{{{match_topic_html}}}</span>
                 {{else}}
                     <span class="stream-topic-inner {{#if is_empty_string_topic}}empty-topic-display{{/if}}">{{topic_display_name}}</span>
                 {{/if}}
@@ -86,7 +86,7 @@
                 {{> components/icon_button icon="more-vertical" intent="neutral" custom_classes="recipient-bar-control-icon" data-tippy-content=(t "Topic actions") aria-label=(t "Topic actions") }}
             </span>
         </span>
-        <span class="recipient_row_date {{#if (and (not always_display_date) date_unchanged )}}recipient_row_date_unchanged{{/if}}">{{{date}}}</span>
+        <span class="recipient_row_date {{#if (and (not always_display_date) date_unchanged )}}recipient_row_date_unchanged{{/if}}">{{{date_html}}}</span>
     </div>
 </div>
 {{else}}
@@ -111,7 +111,7 @@
             {{/if}}
         </span>
         </a>
-        <span class="recipient_row_date {{#if (and (not always_display_date) date_unchanged )}}recipient_row_date_unchanged{{/if}}">{{{date}}}</span>
+        <span class="recipient_row_date {{#if (and (not always_display_date) date_unchanged )}}recipient_row_date_unchanged{{/if}}">{{{date_html}}}</span>
     </div>
 </div>
 {{/if}}

--- a/web/templates/skipped_marking_unread.hbs
+++ b/web/templates/skipped_marking_unread.hbs
@@ -1,4 +1,4 @@
 {{#tr}}
     Because you are not subscribed to <z-streams></z-streams>, messages in this channel were not marked as unread.
-    {{#*inline "z-streams"}}<strong>{{{streams}}}</strong>{{/inline}}
+    {{#*inline "z-streams"}}<strong>{{{streams_html}}}</strong>{{/inline}}
 {{/tr}}

--- a/web/templates/stream_settings/copy_email_address_modal.hbs
+++ b/web/templates/stream_settings/copy_email_address_modal.hbs
@@ -14,7 +14,7 @@
                 <input class="tag-checkbox" id="{{ this.name }}" type="checkbox"/>
                 <span class="rendered-checkbox"></span>
             </label>
-            <label class="inline" for="{{this.name}}">{{{this.description}}}</label>
+            <label class="inline" for="{{this.name}}">{{this.description}}</label>
         </div>
     {{/each}}
     <hr />


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This updates variable names to clearly denote that they are HTML strings which should not be escaped like other variables in the templates.
These variables are renamed from `variable` to `variable_html`.
Some might sound more natural by prefixing with `html_`, suggestions are welcome.
The last commit replaces the use of  `{{{` with `{{` because I did not find any instance of  `description`  in HTML format.

Fixes:  https://github.com/zulip/zulip/pull/34912#issuecomment-3091355122