### PR TITLE
billing: Fix loading spinner not aligned on upgrade page.

### DIFF
--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -226,8 +226,10 @@
 
     .zulip-loading-logo {
         margin: 0 auto;
-        width: 24px;
-        height: 24px;
+        width: 30px;
+        /* Adjusting height moves the loading spinner vertically.
+           Manually adjusted to align spinner and z-logo. */
+        height: 23px;
     }
 
     .zulip-loading-logo svg circle {


### PR DESCRIPTION
<img width="210" height="201" alt="image" src="https://github.com/user-attachments/assets/0c8398f5-4cc4-4ed7-bd14-15c533967c92" />
