### PR TITLE
popover_menus: Fix channel popover displayed out of visible area.

### DIFF
--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -317,7 +317,7 @@ export const left_sidebar_tippy_options: Partial<tippy.Props> = {
             {
                 name: "flip",
                 options: {
-                    fallbackPlacements: "bottom",
+                    fallbackPlacements: ["bottom", "top", "left"],
                 },
             },
         ],


### PR DESCRIPTION
Fixes #35150

Fixed by adding more fallback options.

Reproduced by clicking on left sidebar or inbox channel popover triggers at the bottom right corner.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20Channel.20settings.20sometimes.20unreachable.20on.20mobile.20.2335150

| before | after |
| --- | --- |
|<img width="841" height="699" alt="Screenshot from 2025-07-21 10-08-44" src="https://github.com/user-attachments/assets/6d7bd00c-abbe-4bd8-a095-1c6590715e6e" /> | <img width="841" height="699" alt="Screenshot from 2025-07-21 10-08-07" src="https://github.com/user-attachments/assets/4f03901a-6048-4d76-a3bb-9d3e3806300f" /> |
|<img width="841" height="699" alt="Screenshot from 2025-07-21 10-08-36" src="https://github.com/user-attachments/assets/4015be98-418b-4ff3-971f-4b31bbac477d" /> | <img width="841" height="699" alt="Screenshot from 2025-07-21 10-08-24" src="https://github.com/user-attachments/assets/3047dc7f-43a1-4fe2-9f82-eb426f454b27" /> |
