### PR TITLE
Fix: Ensure channel name input has 100% width in modal

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -454,7 +454,8 @@
         box-shadow linear 0.2s;
     margin-bottom: 10px;
     /* subtract padding (6px each side) and border (1px each side) */
-    width: calc(var(--modal-input-width) - 14px);
+    width: 100%; /* Add this line */
+    box-sizing: border-box; 
 
     &:focus {
         border-color: hsl(206deg 80% 62% / 80%);


### PR DESCRIPTION
This pull request fixes a CSS bug where the channel name input field in the "Edit channel" modal does not resize correctly on mobile or narrow screens, causing it to overflow its container.

I've changed the width of the `.modal_text_input` class from a fixed, calculated value to `100%` and added `box-sizing: border-box`. This makes the input field responsive, ensuring it always fits within the modal's content area while respecting its padding, just like the description field below it.

Fixes: #35301

**Screenshots and screen captures:**

| Before | After |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate. (N/A for this CSS change)

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>