### PR TITLE
realm_playground: Use lowercase language names in dropdown.

### DIFF
--- a/web/e2e-tests/realm-playground.test.ts
+++ b/web/e2e-tests/realm-playground.test.ts
@@ -45,7 +45,7 @@ async function _add_playground_and_return_status(page: Page, payload: Playground
 
 async function test_successful_playground_creation(page: Page): Promise<void> {
     const payload = {
-        pygments_language: "Python",
+        pygments_language: "python",
         playground_name: "Python3 playground",
         url_template: "https://python.example.com?code={code}",
     };
@@ -57,7 +57,7 @@ async function test_successful_playground_creation(page: Page): Promise<void> {
             page,
             ".playground_row span.playground_pygments_language",
         ),
-        "Python",
+        "python",
     );
     assert.strictEqual(
         await common.get_text_from_selector(page, ".playground_row span.playground_name"),
@@ -71,7 +71,7 @@ async function test_successful_playground_creation(page: Page): Promise<void> {
 
 async function test_invalid_playground_parameters(page: Page): Promise<void> {
     const payload = {
-        pygments_language: "Python",
+        pygments_language: "python",
         playground_name: "Python3 playground",
         url_template: "not_a_url_template{",
     };

--- a/web/src/realm_playground.ts
+++ b/web/src/realm_playground.ts
@@ -84,12 +84,15 @@ export function get_pygments_typeahead_list_for_settings(query: string): Map<str
 
     const playground_pygment_langs = [...map_language_to_playground_info.keys()];
     for (const lang of playground_pygment_langs) {
-        language_labels.set(lang, $t({defaultMessage: "Custom language: {query}"}, {query: lang}));
+        language_labels.set(
+            lang,
+            $t({defaultMessage: "Custom language: {query}"}, {query: lang.toLowerCase()}),
+        );
     }
 
     for (const [key, values] of map_pygments_pretty_name_to_aliases) {
         const formatted_string = util.format_array_as_list_with_conjunction(values, "narrow");
-        language_labels.set(key, key + " (" + formatted_string + ")");
+        language_labels.set(key.toLowerCase(), key.toLowerCase() + " (" + formatted_string + ")");
     }
 
     return language_labels;

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -44,7 +44,7 @@
                     <div class="alert" id="admin-playground-status"></div>
                     <div class="input-group">
                         <label for="playground_pygments_language"> {{t "Language" }}</label>
-                        <input type="text" id="playground_pygments_language" class="settings_text_input" name="pygments_language" autocomplete="off" placeholder="Rust" />
+                        <input type="text" id="playground_pygments_language" class="settings_text_input" name="pygments_language" autocomplete="off" placeholder="rust" />
                     </div>
                     <div class="input-group">
                         <label for="playground_name"> {{t "Name" }}</label>

--- a/web/tests/realm_playground.test.cjs
+++ b/web/tests/realm_playground.test.cjs
@@ -78,18 +78,18 @@ run_test("get_pygments_typeahead_list_for_settings", () => {
     let iterator = candidates.entries();
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: custom_lang"}));
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: invent_a_lang"}));
-    assert.equal(iterator.next().value[1], "Text only (text, text)");
+    assert.equal(iterator.next().value[1], "text only (text, text)");
     assert.equal(iterator.next().value[1], "quote (quote, quote)");
     assert.equal(iterator.next().value[1], "spoiler (spoiler, spoiler)");
     assert.equal(iterator.next().value[1], "math (math, math)");
-    assert.equal(iterator.next().value[1], "JavaScript (javascript, js, javascript, js)");
+    assert.equal(iterator.next().value[1], "javascript (javascript, js, javascript, js)");
     assert.equal(
         iterator.next().value[1],
-        "Python (python, bazel, py, py3, pyi, python3, sage, starlark, python, bazel, py, py3, pyi, python3, sage, starlark)",
+        "python (python, bazel, py, py3, pyi, python3, sage, starlark, python, bazel, py, py3, pyi, python3, sage, starlark)",
     );
-    assert.equal(iterator.next().value[1], "Java (java, java)");
-    assert.equal(iterator.next().value[1], "Go (go, golang, go, golang)");
-    assert.equal(iterator.next().value[1], "Rust (rust, rs, rust, rs)");
+    assert.equal(iterator.next().value[1], "java (java, java)");
+    assert.equal(iterator.next().value[1], "go (go, golang, go, golang)");
+    assert.equal(iterator.next().value[1], "rust (rust, rs, rust, rs)");
 
     // Test typing "cu". Previously added custom languages should show up too.
     candidates = realm_playground.get_pygments_typeahead_list_for_settings("cu");
@@ -100,14 +100,14 @@ run_test("get_pygments_typeahead_list_for_settings", () => {
     );
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: custom_lang"}));
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: invent_a_lang"}));
-    assert.equal(iterator.next().value[1], "Text only (text, text)");
+    assert.equal(iterator.next().value[1], "text only (text, text)");
     assert.equal(iterator.next().value[1], "quote (quote, quote)");
     assert.equal(iterator.next().value[1], "spoiler (spoiler, spoiler)");
     assert.equal(iterator.next().value[1], "math (math, math)");
-    assert.equal(iterator.next().value[1], "JavaScript (javascript, js, javascript, js)");
+    assert.equal(iterator.next().value[1], "javascript (javascript, js, javascript, js)");
     assert.equal(
         iterator.next().value[1],
-        "Python (python, bazel, py, py3, pyi, python3, sage, starlark, python, bazel, py, py3, pyi, python3, sage, starlark)",
+        "python (python, bazel, py, py3, pyi, python3, sage, starlark, python, bazel, py, py3, pyi, python3, sage, starlark)",
     );
 
     // Test typing "invent_a_lang". Make sure there is no duplicate entries.
@@ -115,7 +115,7 @@ run_test("get_pygments_typeahead_list_for_settings", () => {
     iterator = candidates.entries();
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: invent_a_lang"}));
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: custom_lang"}));
-    assert.equal(iterator.next().value[1], "Text only (text, text)");
+    assert.equal(iterator.next().value[1], "text only (text, text)");
     assert.equal(iterator.next().value[1], "quote (quote, quote)");
     assert.equal(iterator.next().value[1], "spoiler (spoiler, spoiler)");
 });


### PR DESCRIPTION
This PR updates the language names in the auto-complete dropdown in Settings > Code playgrounds to be lowercase, instead of the previously used uppercase format.

This change is made to maintain consistency with the typeahead behavior in code blocks.

## Before

<img width="818" height="546" alt="image" src="https://github.com/user-attachments/assets/1988365d-2a36-48ef-b770-5192dd4a7d87" />


## After

<img width="818" height="546" alt="image" src="https://github.com/user-attachments/assets/4cf19321-2aa8-409d-a782-b3d166fc8407" />


Fixes: #24021

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
