### PR TITLE
topic_list: Fix bug related to br element in empty contenteditable div.

### DIFF
--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -632,5 +632,20 @@ export function initialize({
         const stream_id = active_stream_id();
         assert(stream_id !== undefined);
         active_widgets.get(stream_id)?.build();
+
+        if (get_left_sidebar_topic_search_term() === "") {
+            // When the contenteditable div is empty, the browser
+            // adds a <br> element to it, which interferes with
+            // the ":empty" selector in the CSS. Hence, we detect
+            // this case and clear the content of the div to ensure
+            // that the CSS styles are applied correctly.
+            // TODO: Remove this when we have a better way to handle
+            // empty contenteditable elements. Since while testing this
+            // effect in a sandbox, a `display: inline` applied to the
+            // contenteditable element seems to fix the issue, but that
+            // doesn't work in this particular case.
+            // See: https://stackoverflow.com/questions/14638887/br-is-inserted-into-contenteditable-html-element-if-left-empty
+            $("#topic_filter_query").empty();
+        }
     });
 }


### PR DESCRIPTION
When the contenteditable div in the topic list filter is empty, the browser adds a `<br>` element to it, which interferes with the ":empty" selector in the CSS — responsible for showing the placeholder and hiding the clear button in the input field. Hence, we detect this case of an empty contenteditable div and clear the content of the div to ensure that the CSS styles are applied correctly.

<!-- Describe your pull request here.-->

Fixes: https://github.com/zulip/zulip/pull/35194#issuecomment-3070965779

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![filter-input-empty-bug-fix](https://github.com/user-attachments/assets/5e9aec23-3558-4580-87f9-091fe21b1336)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
