### PR TITLE
compose: Defer triggering focus.

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -64,12 +64,12 @@ export let update_recipient_row_attention_level = (): void => {
 
     // We're piggy-backing here, in a roundabout way, on
     // compose_ui.set_focus(). Any time the topic or DM recipient
-    // row is focused, that puts us outside the low-attention
+    // row is focused, that puts users outside the low-attention
     // recipient-row state--including the `c` hotkey or the
-    // Start new conversation button being clicked.
-    const is_compose_textarea_focused = document.activeElement?.id === "compose-textarea";
+    // Start new conversation button being clicked. But that
+    // logic is handled via the event handlers in compose_setup.js
+    // that call set_high_attention_recipient_row().
     if (
-        is_compose_textarea_focused &&
         (composing_to_current_topic_narrow() || composing_to_current_private_message_narrow()) &&
         compose_state.has_full_recipient() &&
         !compose_state.is_recipient_edited_manually()

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -35,6 +35,7 @@ export const DEFAULT_COMPOSE_PLACEHOLDER = $t({defaultMessage: "Compose your mes
 
 export type ComposeTriggeredOptions = {
     trigger: string;
+    defer_focus?: boolean | undefined;
 } & (
     | {
           message_type: "stream";


### PR DESCRIPTION
This commit fixes a bug on iPad/Safari that caused the entire viewport to scroll wildly when navigating to lengthy DM conversations.

As Aman & I discussed on a call this morning, there should be no ill side-effects to deferring focus, as that should be the last thing to happen after all other calculations and rendering have taken place.

<!-- Describe your pull request here.-->

[#issues > 🎯 whole-screen scroll when clicking into DMs on iPad](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20whole-screen.20scroll.20when.20clicking.20into.20DMs.20on.20iPad)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_There appears to be a slight flutter in the After capture, in going from Desdemona et al. back to Hamlet, but that seems to be exaggerated based on the point at which the mov-to-gif converter sampled the video._

| Before | After |
| --- | --- |
| ![ipad-dms-before](https://github.com/user-attachments/assets/e196f374-284a-45f7-912e-13252446d98c) | ![ipad-dms-after](https://github.com/user-attachments/assets/b5f14d79-0a27-4959-8a18-87d6df23dea3) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>