### PR TITLE
search: Fix user pill min-width overridden by parent rule.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -259,73 +259,73 @@
         &.focused .user-pill-container {
             flex-flow: row wrap;
         }
-    }
 
-    .user-pill-container {
-        gap: 2px 5px;
-        /* Don't enforce a height, as user-pill containers
-            can contain multiple user pills that wrap onto
-            new lines. */
-        height: unset;
-        border: 1px solid transparent;
+        .user-pill-container {
+            gap: 2px 5px;
+            /* Don't enforce a height, as user-pill containers
+                can contain multiple user pills that wrap onto
+                new lines. */
+            height: unset;
+            border: 1px solid transparent;
 
-        /* Not focus-visible, because we want to support mouse+backpace
-            to delete pills */
-        &:focus {
-            /* Unlike regular `.pill` this multi-user pill has a border,
-                so we use border instead of box-shadow on focus. */
-            box-shadow: none;
-            border-color: var(--color-focus-outline-input-pill);
-        }
-
-        > .pill-label {
-            min-width: fit-content;
-            white-space: nowrap;
-            width: fit-content;
-            /* Replaced by the 5px gap. */
-            margin-right: 0;
-            /* Don't inherit large line-height for user pill labels. */
-            line-height: 1.1;
-        }
-
-        .pill {
-            /* Reduce user pill height by 2px to
-                preserve an apparent border around
-                them even under `box-sizing: border-box`
-                in the area. */
-            height: calc(var(--height-input-pill) - 2px);
-            border: none;
-            /* Match border radius to image */
-            border-radius: 4px;
-            max-width: none;
-            /* Set the minimum width on the pill container;
-                this accommodates the avatar, a minimum
-                two-character username, and the closing X.
-                90px at 20px/1em.
-
-               TODO: This would ideally be reworked, as we need to
-               override it for search suggestion pills (with no X) below.
-           */
-            min-width: 4.5em;
-            display: grid;
-            grid-template-columns:
-                var(--length-search-input-pill-image) minmax(0, 1fr)
-                var(--length-input-pill-exit);
-            align-content: center;
-            /* Don't inherit large line-height for user pills themselves, either. */
-            line-height: 1.1;
-
-            .pill-image {
-                height: var(--length-search-input-pill-image);
-                width: var(--length-search-input-pill-image);
+            /* Not focus-visible, because we want to support mouse+backpace
+                to delete pills */
+            &:focus {
+                /* Unlike regular `.pill` this multi-user pill has a border,
+                    so we use border instead of box-shadow on focus. */
+                box-shadow: none;
+                border-color: var(--color-focus-outline-input-pill);
             }
 
-            .pill-image-border {
+            > .pill-label {
+                min-width: fit-content;
+                white-space: nowrap;
+                width: fit-content;
+                /* Replaced by the 5px gap. */
+                margin-right: 0;
+                /* Don't inherit large line-height for user pill labels. */
+                line-height: 1.1;
+            }
+
+            .pill {
+                /* Reduce user pill height by 2px to
+                    preserve an apparent border around
+                    them even under `box-sizing: border-box`
+                    in the area. */
+                height: calc(var(--height-input-pill) - 2px);
                 border: none;
-            }
+                /* Match border radius to image */
+                border-radius: 4px;
+                max-width: none;
+                /* Set the minimum width on the pill container;
+                    this accommodates the avatar, a minimum
+                    two-character username, and the closing X.
+                    90px at 20px/1em.
 
-            &:not(.deactivated-pill) {
-                background-color: var(--color-background-user-pill);
+                TODO: This would ideally be reworked, as we need to
+                override it for search suggestion pills (with no X) below.
+               */
+                min-width: 4.5em;
+                display: grid;
+                grid-template-columns:
+                    var(--length-search-input-pill-image) minmax(0, 1fr)
+                    var(--length-input-pill-exit);
+                align-content: center;
+                /* Don't inherit large line-height for user pills themselves, either. */
+                line-height: 1.1;
+
+                .pill-image {
+                    height: var(--length-search-input-pill-image);
+                    width: var(--length-search-input-pill-image);
+                }
+
+                .pill-image-border {
+                    border: none;
+                }
+
+                &:not(.deactivated-pill) {
+                    background-color: var(--color-background-user-pill);
+                }
             }
         }
     }


### PR DESCRIPTION
`min-width: unset` is overriding the user pill min-width value.

This PR fixes this by prioritizing this min-width rule for user pill.

<!-- Describe your pull request here.-->

Fixes: [#issues > Search bar compression @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/Search.20bar.20compression/near/2223993)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**Before:**

<img width="1226" height="92" alt="image" src="https://github.com/user-attachments/assets/c2bc266c-2516-45dd-928b-63e08affdb43" />

**After:**

<img width="928" height="48" alt="Screenshot from 2025-07-20 23-43-34" src="https://github.com/user-attachments/assets/da65f6ca-8503-425f-999b-0159501cd63d" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
