### PR TITLE
filter_inputs: Improvements for filter input elements.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -824,7 +824,11 @@ export function initialize(): void {
 
     // LEFT SIDEBAR
 
-    $("body").on("click", ".filter-topics .input-button", topic_list.clear_topic_search);
+    $("body").on(
+        "click",
+        ".filter-topics .input-close-filter-button",
+        topic_list.clear_topic_search,
+    );
 
     $(".streams_filter_icon").on("click", (e) => {
         e.stopPropagation();

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -454,6 +454,7 @@ export function process_escape_key(e) {
         // will zoom out, handled below.
         if (stream_list.is_zoomed_in() && $("#topic_filter_query").is(":focus")) {
             topic_list.clear_topic_search(e);
+            $("#topic_filter_query").trigger("blur");
             return true;
         }
 

--- a/web/src/inputs.ts
+++ b/web/src/inputs.ts
@@ -2,7 +2,7 @@ import $ from "jquery";
 
 $("body").on(
     "click",
-    ".filter-input .input-button",
+    ".filter-input .input-close-filter-button",
     function (this: HTMLElement, _e: JQuery.Event) {
         const $input = $(this).prev(".input-element");
         $input.val("").trigger("input");

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1063,7 +1063,7 @@ export function set_event_handlers({
             e.preventDefault();
             if (
                 e.target.id === "streams_inline_icon" ||
-                $(e.target).parent().hasClass("input-button")
+                $(e.target).parent().hasClass("input-close-filter-button")
             ) {
                 return;
             }

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -389,7 +389,6 @@ export function clear_topic_search(e: JQuery.Event): void {
     search_pill_widget?.clear(true);
 
     const $input = $("#topic_filter_query");
-    $input.trigger("blur");
     // Since the `clear` function of the search_pill_widget
     // takes care of clearing both the text content and the
     // pills, we just need to trigger an input event on the

--- a/web/src/user_search.ts
+++ b/web/src/user_search.ts
@@ -21,7 +21,7 @@ export class UserSearch {
         this._update_list = opts.update_list;
         this._on_focus = opts.on_focus;
 
-        $("#userlist-header-search .input-button").on("click", () => {
+        $("#userlist-header-search .input-close-filter-button").on("click", () => {
             this.clear_search();
         });
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2641,15 +2641,15 @@
         hsl(0deg 0% 100%),
         hsl(225deg 6% 7%)
     );
-    --color-border-input: light-dark(
+    --color-outline-input: light-dark(
         color-mix(in oklch, hsl(229deg 22% 10%) 30%, transparent),
         color-mix(in oklch, hsl(0deg 0% 100%) 20%, transparent)
     );
-    --color-border-input-hover: light-dark(
+    --color-outline-input-hover: light-dark(
         color-mix(in oklch, hsl(229deg 22% 10%) 60%, transparent),
         color-mix(in oklch, hsl(0deg 0% 100%) 40%, transparent)
     );
-    --color-border-input-focus: light-dark(
+    --color-outline-input-focus: light-dark(
         color-mix(in oklch, hsl(229deg 22% 10%) 80%, transparent),
         color-mix(in oklch, hsl(0deg 0% 100%) 50%, transparent)
     );

--- a/web/styles/inputs.css
+++ b/web/styles/inputs.css
@@ -120,7 +120,7 @@
             the right padding to compensate for the same. */
             padding-right: 0.5em;
 
-            ~ .input-button {
+            ~ .input-close-filter-button {
                 visibility: hidden;
             }
         }
@@ -137,7 +137,7 @@
                 padding-right: 0.5em;
             }
 
-            .input-button {
+            .input-close-filter-button {
                 visibility: hidden;
             }
         }

--- a/web/styles/inputs.css
+++ b/web/styles/inputs.css
@@ -15,7 +15,6 @@
             --input-button-ending-offset
         )
         [input-element-end];
-    align-items: center;
 
     .input-element {
         grid-area: input-element;
@@ -100,11 +99,19 @@
        want to display it over the input element in the UI. */
     z-index: 1;
     pointer-events: none;
+    /* This margin is required to align the icon with the
+       first line of a multi-line input, where we cannot
+       use `align-items: center`. */
+    margin: 0.375em 0; /* 6px at 16px/1em */
 }
 
 .input-button {
     grid-area: input-button;
     padding: 0.25em; /* 4px at 16px/1em */
+    /* This margin is required to align the icon with the
+       first line of a multi-line input, where we cannot
+       use `align-items: center`. */
+    margin: 0.125em 0; /* 2px at 16px/1em */
 }
 
 .filter-input {

--- a/web/styles/inputs.css
+++ b/web/styles/inputs.css
@@ -1,7 +1,7 @@
 .input-active-styles {
     color: var(--color-text-input);
     background-color: var(--color-background-input-focus);
-    border-color: var(--color-border-input-focus);
+    outline-color: var(--color-outline-input-focus);
 }
 
 .input-element-wrapper {
@@ -20,21 +20,22 @@
     .input-element {
         grid-area: input-element;
         box-sizing: border-box;
-        padding: 0.1875em 0.5em; /* 3px at 16px/1em and 8px at 16px/1em */
+        padding: 0.25em 0.5em; /* 4px at 16px/1em and 8px at 16px/1em */
         font-size: var(--base-font-size-px);
         font-family: "Source Sans 3 VF", sans-serif;
         line-height: 1.25;
         text-overflow: ellipsis;
         color: var(--color-text-input);
         background: var(--color-background-input);
-        border: 1px solid var(--color-border-input);
+        outline: 1px solid var(--color-outline-input);
+        outline-offset: -1px;
+        border: none;
         border-radius: 4px;
-        outline: none;
         transition: 0.1s linear;
-        transition-property: border-color, box-shadow;
+        transition-property: outline-color, box-shadow;
 
         &:hover {
-            border-color: var(--color-border-input-hover);
+            outline-color: var(--color-outline-input-hover);
         }
 
         &:focus {
@@ -45,18 +46,16 @@
     }
 
     &.has-input-icon .input-element {
-        /* Subtract 1px to compensate for the left border */
         padding-left: calc(
             var(--input-icon-starting-offset) + var(--input-icon-width) +
-                var(--input-icon-content-gap) - 1px
+                var(--input-icon-content-gap)
         );
     }
 
     &.has-input-button .input-element {
-        /* Subtract 1px to compensate for the right border */
         padding-right: calc(
             var(--input-button-content-gap) + var(--input-button-width) +
-                var(--input-button-ending-offset) - 1px
+                var(--input-button-ending-offset)
         );
     }
 
@@ -79,7 +78,7 @@
         }
 
         &:has(.input:hover) {
-            border-color: var(--color-border-input-hover);
+            outline-color: var(--color-outline-input-hover);
         }
 
         &:has(.input:focus) {

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -161,7 +161,7 @@
 
     #recent-view-search-wrapper {
         flex-grow: 1;
-        margin-bottom: 10px;
+        margin-bottom: 0.7142em; /* Legacy 10px at 14px/1em. */
     }
 
     .button-recent-filters {

--- a/web/templates/components/input_wrapper.hbs
+++ b/web/templates/components/input_wrapper.hbs
@@ -4,6 +4,10 @@
     {{/if}}
     {{> @partial-block .}}
     {{#if input_button_icon}}
-        {{> icon_button custom_classes="input-button" squared=true icon=input_button_icon intent="neutral" }}
+        {{#if (eq input_type "filter-input") }}
+            {{> icon_button custom_classes="input-button input-close-filter-button" squared=true icon=input_button_icon intent="neutral" }}
+        {{else}}
+            {{> icon_button custom_classes="input-button" squared=true icon=input_button_icon intent="neutral" }}
+        {{/if}}
     {{/if}}
 </div>

--- a/web/tests/user_search.test.cjs
+++ b/web/tests/user_search.test.cjs
@@ -114,9 +114,9 @@ test("clear_search with button", ({override}) => {
     override(fake_buddy_list, "populate", (user_ids) => {
         assert.deepEqual(user_ids, {all_user_ids: ordered_user_ids});
     });
-    $("#userlist-header-search .input-button").trigger("click");
+    $("#userlist-header-search .input-close-filter-button").trigger("click");
     assert.equal($("input.user-list-filter").val(), "");
-    $("#userlist-header-search .input-button").trigger("click");
+    $("#userlist-header-search .input-close-filter-button").trigger("click");
 });
 
 test("clear_search", ({override}) => {


### PR DESCRIPTION
This PR consists of the following commits:
- Commit 1: Adds the `input-close-filter-button` class to the clear filter button as suggested in https://github.com/zulip/zulip/pull/35194#discussion_r2205777827
- Commit 2: Fixes the vertical alignment of the recent view filter input.
- Commit 3: Replaces borders in the inputs with outlines for focus indicators, aiding with calculations (https://github.com/zulip/zulip/pull/35194#discussion_r2205791661)
- Commit 4: Fix icon alignment for multi-line inputs.
- Commit 5: Moves input blur on escape logic to hotkey.js module. ([#issues > 🎯 Escape keyboard handling in "Filter topics" input @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Escape.20keyboard.20handling.20in.20.22Filter.20topics.22.20input/near/2225832))


Fixes: Follow-up tasks in #35194.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Reference | Before | After |
|--------|--------|--------|
| Commit 2 | <img width="519" height="113" alt="Screenshot 2025-07-22 at 4 04 58 AM" src="https://github.com/user-attachments/assets/6c6251b1-3859-4052-96b6-ac58d0652ef8" /> | <img width="519" height="113" alt="Screenshot 2025-07-22 at 4 05 14 AM" src="https://github.com/user-attachments/assets/c20a43dd-297e-4fba-aa10-bba5b3df01e4" /> |
| Commit 4 | <img width="359" height="194" alt="Screenshot 2025-07-22 at 4 06 19 AM" src="https://github.com/user-attachments/assets/db495538-ee2e-4a7d-bf0e-68a1d46a20a9" /> | <img width="359" height="194" alt="Screenshot 2025-07-22 at 4 07 02 AM" src="https://github.com/user-attachments/assets/99a717ae-0fd4-497d-ada2-4ba059f2eb73" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
