### PR TITLE
stream_list: Hide channels on zoom-in using .hide instead of hide().

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -429,13 +429,13 @@ export function zoom_in_topics(options: {stream_id: number | undefined}): void {
         const stream_id = options.stream_id;
 
         if (stream_id_for_elt($elt) === stream_id) {
-            $elt.show();
+            $elt.toggleClass("hide", false);
             // Add search box for topics list.
             $elt.children("div.bottom_left_row").append($(render_filter_topics()));
             $("#topic_filter_query").trigger("focus");
             topic_list.setup_topic_search_typeahead();
         } else {
-            $elt.hide();
+            $elt.toggleClass("hide", true);
         }
     });
 }
@@ -450,7 +450,7 @@ export function zoom_out_topics(): void {
     });
 
     $("#streams_list").expectOne().removeClass("zoom-in").addClass("zoom-out");
-    $("#stream_filters li.narrow-filter").show();
+    $("#stream_filters li.narrow-filter").toggleClass("hide", false);
     // Remove search box for topics list from DOM.
     $(".filter-topics").remove();
 }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1904,6 +1904,10 @@ li.topic-list-item {
 }
 
 .zoom-in {
+    .narrow-filter.hide {
+        display: none;
+    }
+
     .narrow-filter > .bottom_left_row {
         position: sticky;
         /* We subtract a quarter pixel of space to correct

--- a/web/tests/stream_list.test.cjs
+++ b/web/tests/stream_list.test.cjs
@@ -455,14 +455,14 @@ test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     assert.ok(!$label1.visible());
     assert.ok(!$label2.visible());
     assert.ok(!$splitter.visible());
-    assert.ok($stream_li1.visible());
-    assert.ok(!$stream_li2.visible());
+    assert.ok(!$stream_li1.hasClass("hide"));
+    assert.ok($stream_li2.hasClass("hide"));
     assert.ok($("#streams_list").hasClass("zoom-in"));
     assert.ok(filter_topics_appended);
 
-    $("#stream_filters li.narrow-filter").show = () => {
-        $stream_li1.show();
-        $stream_li2.show();
+    $("#stream_filters li.narrow-filter").toggleClass = (classname, value) => {
+        $stream_li1.toggleClass(classname, value);
+        $stream_li2.toggleClass(classname, value);
     };
 
     $stream_li1.length = 1;
@@ -474,8 +474,8 @@ test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     assert.ok($label1.visible());
     assert.ok($label2.visible());
     assert.ok($splitter.visible());
-    assert.ok($stream_li1.visible());
-    assert.ok($stream_li2.visible());
+    assert.ok(!$stream_li1.hasClass("hide"));
+    assert.ok(!$stream_li2.hasClass("hide"));
     assert.ok($("#streams_list").hasClass("zoom-out"));
     assert.ok(!filter_topics_appended);
 });


### PR DESCRIPTION
This gives us more control, for example `show()` was adding `display: inline-block;` to channels after unhiding them which was overriding other code (added for channel folders in upcoming code) that was trying to hide the channels.

CZO: [#issues > 🎯 channel folder toggle not responding after zoom in @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20channel.20folder.20toggle.20not.20responding.20after.20zoom.20in/near/2221871)