### PR TITLE
stream_list: Remove unused references to stream-filters-label.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -416,10 +416,7 @@ export function zoom_in_topics(options: {stream_id: number | undefined}): void {
 
     $("#streams_list").expectOne().removeClass("zoom-out").addClass("zoom-in");
 
-    // Hide stream list titles and pinned stream splitter
-    $(".stream-filters-label").each(function () {
-        $(this).hide();
-    });
+    // Hide pinned stream splitter
     $(".streams_subheader").each(function () {
         $(this).hide();
     });
@@ -441,10 +438,7 @@ export function zoom_in_topics(options: {stream_id: number | undefined}): void {
 }
 
 export function zoom_out_topics(): void {
-    // Show stream list titles and pinned stream splitter
-    $(".stream-filters-label").each(function () {
-        $(this).show();
-    });
+    // Show pinned stream splitter
     $(".streams_subheader").each(function () {
         $(this).show();
     });

--- a/web/tests/stream_list.test.cjs
+++ b/web/tests/stream_list.test.cjs
@@ -397,19 +397,6 @@ function elem($obj) {
 test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     topic_list.setup_topic_search_typeahead = noop;
 
-    const $label1 = $.create("label1 stub");
-    const $label2 = $.create("label2 stub");
-
-    $label1.show();
-    $label2.show();
-
-    assert.ok($label1.visible());
-    assert.ok($label2.visible());
-
-    $.create(".stream-filters-label", {
-        children: [elem($label1), elem($label2)],
-    });
-
     const $splitter = $.create("<active-subheader-stub>");
 
     $splitter.show();
@@ -452,8 +439,6 @@ test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     });
     stream_list.zoom_in_topics({stream_id: 42});
 
-    assert.ok(!$label1.visible());
-    assert.ok(!$label2.visible());
     assert.ok(!$splitter.visible());
     assert.ok($stream_li1.visible());
     assert.ok(!$stream_li2.visible());
@@ -471,8 +456,6 @@ test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     };
     stream_list.zoom_out_topics({$stream_li: $stream_li1});
 
-    assert.ok($label1.visible());
-    assert.ok($label2.visible());
     assert.ok($splitter.visible());
     assert.ok($stream_li1.visible());
     assert.ok($stream_li2.visible());


### PR DESCRIPTION
Asked on CZO to confirm we can delete this: [#frontend > stream-filters-label @ 💬](https://chat.zulip.org/#narrow/channel/6-frontend/topic/stream-filters-label/near/2226642)

I see some JQuery for stream-filters-label added in f8bb7503e6dea but don't see it used in templates anywhere in that commit or on main or in the DOM for main. Is that code safe to remove?