### PR TITLE
inbox: Attempt to fix inbox scrolling to top unexpectedly.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -2123,8 +2123,14 @@ export function initialize({hide_other_views}: {hide_other_views: () => void}): 
     $(document).on(
         "scroll",
         _.throttle(() => {
-            move_focus_to_visible_area();
-        }, 50),
+            if (!inbox_util.is_visible()) {
+                // This check is duplicated with move_focus_to_visible_area. It
+                // is worth doing to avoid the performance hit of wrapping
+                // requestAnimationFramearound a likely noop.
+                return;
+            }
+            requestAnimationFrame(move_focus_to_visible_area);
+        }, 100),
     );
 
     $("body").on(


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/channel/101-design/topic/channel.20folders.20UI.3A.20Inbox/with/2225780

Inbox can suddenly scroll to top due to a rerender when user is trying to scroll down. A possible caues for this is `move_focus_to_visible_area` being triggered on scroll but the element located using:

```
document.elementFromPoint(inbox_center_x, inbox_row_below_filters);
```

being out of view. To fix it, we try to locate the element in the same animation frame. This will remove the possibility of element being out of view when we try to set focus to it.
