### PR TITLE
register_push_device: Add an error code to push-not-configured error.

### DIFF
--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -61,6 +61,7 @@ class ErrorCode(Enum):
     HOSTNAME_ALREADY_IN_USE_BOUNCER_ERROR = auto()
     INVALID_BOUNCER_PUBLIC_KEY = auto()
     REQUEST_EXPIRED = auto()
+    PUSH_SERVICE_NOT_CONFIGURED = auto()
 
 
 class JsonableError(Exception):
@@ -863,3 +864,15 @@ class InvalidEncryptedPushRegistrationError(JsonableError):
     @override
     def msg_format() -> str:
         return _("Invalid encrypted_push_registration")
+
+
+class PushServiceNotConfiguredError(JsonableError):
+    code = ErrorCode.PUSH_SERVICE_NOT_CONFIGURED
+
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _("Server is not configured to use push notification service.")

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12619,7 +12619,7 @@ paths:
                       {
                         "result": "error",
                         "msg": "Server is not configured to use push notification service.",
-                        "code": "BAD_REQUEST",
+                        "code": "PUSH_SERVICE_NOT_CONFIGURED",
                       }
                     description: |
                       Error when the server is not configured to use push notification service:

--- a/zerver/views/push_notifications.py
+++ b/zerver/views/push_notifications.py
@@ -15,6 +15,7 @@ from zerver.lib.exceptions import (
     JsonableError,
     MissingRemoteRealmError,
     OrganizationOwnerRequiredError,
+    PushServiceNotConfiguredError,
     RemoteRealmServerMismatchError,
     ResourceNotFoundError,
 )
@@ -280,7 +281,7 @@ def register_push_device(
     encrypted_push_registration: str,
 ) -> HttpResponse:
     if not (settings.ZILENCER_ENABLED or uses_notification_bouncer()):
-        raise JsonableError(_("Server is not configured to use push notification service."))
+        raise PushServiceNotConfiguredError
 
     # Idempotency
     already_registered = PushDevice.objects.filter(


### PR DESCRIPTION
CZO Discussion: [#api design > E2EE - error raised by server @ 💬](https://chat.zulip.org/#narrow/channel/378-api-design/topic/E2EE.20-.20error.20raised.20by.20server/near/2220692)

> error will be raised by server when client tries to register and server can't connect with bouncer

> That seems reasonable; though maybe we want that to have a code; the client may want special understanding for that situation.

> if the server isn't configured for notifications, then that's definitely a situation we'll be interested in handling explicitly in the client.


Fixes part of #35368.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
