### PR TITLE
Improve inbox keyboard navigation experience.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -244,7 +244,7 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=1943053 -->
                         </button>
                     </div>
                 </div>
-                <div id="inbox-view">
+                <div id="inbox-view" class="no-visible-focus-outlines">
                     <div class="inbox-container">
                         <div id="inbox-pane"></div>
                     </div>

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1598,6 +1598,8 @@ function page_down_navigation(): void {
 }
 
 export function change_focused_element(input_key: string): boolean {
+    // Start showing visible focus outlines.
+    $("#inbox-view").removeClass("no-visible-focus-outlines");
     if (input_key === "tab" || input_key === "shift_tab") {
         // Tabbing should be handled by browser but to keep the focus element same
         // when we rerender or user uses other hotkeys, we need to track

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1599,8 +1599,16 @@ function page_down_navigation(): void {
 }
 
 export function change_focused_element(input_key: string): boolean {
-    // Start showing visible focus outlines.
-    $("#inbox-view").removeClass("no-visible-focus-outlines");
+    const is_first_user_keypress = $("#inbox-view").hasClass("no-visible-focus-outlines");
+    if (is_first_user_keypress) {
+        // Start showing visible focus outlines.
+        $("#inbox-view").removeClass("no-visible-focus-outlines");
+    }
+    const skip_keyboard_navigation = is_first_user_keypress && !is_search_focused();
+    if (skip_keyboard_navigation) {
+        return true;
+    }
+
     if (input_key === "tab" || input_key === "shift_tab") {
         // Tabbing should be handled by browser but to keep the focus element same
         // when we rerender or user uses other hotkeys, we need to track

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1344,6 +1344,7 @@ function get_row_index($elt: JQuery): number {
 function focus_clicked_list_element($elt: JQuery): void {
     row_focus = get_row_index($elt);
     update_triggered_by_user = true;
+    current_focus_id = $elt.closest(".inbox-row, .inbox-header").attr("id");
 }
 
 export function revive_current_focus(): void {

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -119,18 +119,7 @@
                     outline: 0;
                 }
 
-                &:focus-visible {
-                    .inbox-focus-border {
-                        border-color: var(--color-outline-focus);
-                    }
-
-                    .collapsible-button > .zulip-icon {
-                        opacity: 1;
-                    }
-                }
-
-                &:hover,
-                &:focus-visible {
+                &:hover {
                     .collapsible-button {
                         visibility: visible;
                     }
@@ -200,16 +189,6 @@
                     background: var(--color-background-inbox-row-hover);
                 }
 
-                &:focus-visible {
-                    .inbox-focus-border {
-                        border: 2px solid var(--color-outline-focus);
-                        border-radius: 3px;
-                    }
-
-                    outline: 0;
-                    padding: 0;
-                }
-
                 .inbox-left-part {
                     grid-template:
                         auto / min-content minmax(0, 1fr)
@@ -241,10 +220,6 @@
                     align-items: center;
                     border-radius: 3px;
                     margin-left: 3px;
-
-                    &:focus-visible {
-                        outline: 2px solid var(--color-outline-focus);
-                    }
                 }
             }
 
@@ -265,10 +240,6 @@
                    count from affecting overall row
                    size as test scales up. */
                 align-self: stretch;
-
-                &:focus-visible {
-                    outline: 2px solid var(--color-outline-focus);
-                }
             }
 
             .unread_mention_info {
@@ -364,10 +335,6 @@
 
         .inbox-row,
         .inbox-header {
-            /* Don't show the icons unless user is visibly focused
-               on the element or one of the elements within it. */
-            &:focus-within:not(:focus),
-            &:focus-visible,
             &:hover {
                 .inbox-row-visibility-policy-inherit,
                 .inbox-action-button {
@@ -392,10 +359,6 @@
 
             &.hide {
                 display: none;
-            }
-
-            &:focus-visible {
-                box-shadow: 0 0 0 2px var(--color-outline-focus);
             }
 
             & i {
@@ -448,7 +411,6 @@
             font-size: 1em;
         }
 
-        &:focus-visible,
         &:hover {
             .inbox-header-name-text,
             .collapsible-button .zulip-icon,
@@ -456,13 +418,6 @@
             .unread_count {
                 opacity: 1;
             }
-        }
-
-        &:focus-visible {
-            background: light-dark(
-                transparent,
-                var(--color-background-hover-popover-menu)
-            );
         }
     }
 
@@ -522,10 +477,6 @@
 
     &:focus {
         outline: none;
-    }
-
-    &:focus-visible {
-        outline: 2px solid var(--color-outline-focus);
     }
 }
 
@@ -674,4 +625,98 @@
     .inbox-header-name {
     /* 5px at 16px / 1em */
     padding: 1px 0.3125em 1px 0;
+}
+
+#inbox-view.no-visible-focus-outlines
+    .inbox-container
+    #inbox-pane
+    [tabindex="0"] {
+    /* Remove default focus outline from elements. */
+    &:focus-visible {
+        outline: 0;
+    }
+}
+
+#inbox-view:not(.no-visible-focus-outlines) .inbox-container #inbox-pane {
+    /* Only show focus outlines when user uses keyboard. */
+    #inbox-filter_widget {
+        &:focus-visible {
+            outline: 2px solid var(--color-outline-focus);
+        }
+    }
+
+    .inbox-header {
+        &:focus-visible {
+            .inbox-focus-border {
+                border-color: var(--color-outline-focus);
+            }
+
+            .collapsible-button > .zulip-icon {
+                opacity: 1;
+            }
+
+            .collapsible-button {
+                visibility: visible;
+            }
+        }
+    }
+
+    .inbox-row {
+        &:focus-visible {
+            .inbox-focus-border {
+                border: 2px solid var(--color-outline-focus);
+                border-radius: 3px;
+            }
+
+            outline: 0;
+            padding: 0;
+        }
+    }
+
+    .visibility-policy-indicator {
+        &:focus-visible {
+            outline: 2px solid var(--color-outline-focus);
+        }
+    }
+
+    .inbox-action-button {
+        &:focus-visible {
+            box-shadow: 0 0 0 2px var(--color-outline-focus);
+        }
+    }
+
+    .unread-count-focus-outline {
+        &:focus-visible {
+            outline: 2px solid var(--color-outline-focus);
+        }
+    }
+
+    .inbox-row,
+    .inbox-header {
+        /* Don't show the icons unless user is visibly focused
+            on the element or one of the elements within it. */
+        &:focus-within:not(:focus),
+        &:focus-visible {
+            .inbox-row-visibility-policy-inherit,
+            .inbox-action-button {
+                opacity: 1;
+            }
+        }
+    }
+
+    .inbox-folder {
+        &:focus-visible {
+            .inbox-header-name-text,
+            .collapsible-button .zulip-icon,
+            .unread_mention_info,
+            .unread_count {
+                opacity: 1;
+            }
+
+            background: light-dark(
+                transparent,
+                var(--color-background-hover-popover-menu)
+            );
+        }
+    }
 }


### PR DESCRIPTION
* Focus ring is not longer displayed without user input.
* If user starts using mouse after using keyboard once, we are not guarenteed to get a focus ring since `focus-visible` state is not controlled by us but is determined by the browser.
* Focus is set on the first row  by default - (It can be a folder row).


discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20inbox.20initial.20keyboard.20selection/with/2226815

TODO:
- [ ] Avoid setting focus on folder row.
- [ ] Look into debugging "I just noticed another change related to the key navigation: when I am in the Inbox view (accessible with shift+i) sometimes the shortcut j for "next message" doesn't immediately work. Using another shortcut (example using k) seems to "unblock". I can't quite pinpoint how to reproduce"