### PR TITLE
help: Indent tables that are in unordered lists.

### DIFF
--- a/help/import-from-mattermost.md
+++ b/help/import-from-mattermost.md
@@ -264,10 +264,10 @@ keep in mind about the import process:
 - Mattermost's user roles are mapped to Zulip's [user
   roles](/help/user-roles) in the following way:
 
-| Mattermost role         | Zulip role    |
-|-------------------------|---------------|
-| Team administrator      | Owner         |
-| Member                  | Member        |
+    | Mattermost role         | Zulip role    |
+    |-------------------------|---------------|
+    | Team administrator      | Owner         |
+    | Member                  | Member        |
 
 - Mattermost's export tool does not support exporting user avatars or message
   edit history.

--- a/help/import-from-rocketchat.md
+++ b/help/import-from-rocketchat.md
@@ -112,11 +112,11 @@ keep in mind about the import process:
 - Rocket.Chat user roles are mapped to Zulip's [user
   roles](/help/user-roles) in the following way:
 
-| Rocket.Chat role | Zulip role |
-|------------------|------------|
-| Admin            | Owner      |
-| User             | Member     |
-| Guest            | Guest      |
+    | Rocket.Chat role | Zulip role |
+    |------------------|------------|
+    | Admin            | Owner      |
+    | User             | Member     |
+    | Guest            | Guest      |
 
 - User avatars are not imported.
 - Default channels for new users are not imported.

--- a/help/import-from-slack.md
+++ b/help/import-from-slack.md
@@ -153,15 +153,15 @@ in mind about the import process:
 - Slack's user roles are mapped to Zulip's [user
   roles](/help/user-roles) in the following way:
 
-| Slack role              | Zulip role    |
-|-------------------------|---------------|
-| Workspace Primary Owner | Owner         |
-| Workspace Owner         | Owner         |
-| Workspace Admin         | Administrator |
-| Member                  | Member        |
-| Single Channel Guest    | Guest         |
-| Multi Channel Guest     | Guest         |
-| Channel creator         | none          |
+    | Slack role              | Zulip role    |
+    |-------------------------|---------------|
+    | Workspace Primary Owner | Owner         |
+    | Workspace Owner         | Owner         |
+    | Workspace Admin         | Administrator |
+    | Member                  | Member        |
+    | Single Channel Guest    | Guest         |
+    | Multi Channel Guest     | Guest         |
+    | Channel creator         | none          |
 
 - Slack threads are imported as topics with names that include snippets of the
   original message, such as "2023-05-30 Hi, can anyone reply if you're o…".


### PR DESCRIPTION
[#documentation > import from RocketChat/Slack - table in unordered list](https://chat.zulip.org/#narrow/channel/19-documentation/topic/import.20from.20RocketChat.2FSlack.20-.20table.20in.20unordered.20list)

Indents the tables for user mapping in the three "Import from ..." help center articles.

**Notes**:
- The lack of padding isn't great in the current help center, but since we're in the process of migrating to Astro, that won't be an issue for too long.

---

**Screenshots and screen captures:**

[current doc](https://zulip.com/help/import-from-mattermost#import-your-data-into-zulip)
<img width="760" height="478" alt="Screenshot 2025-07-22 at 18 08 14" src="https://github.com/user-attachments/assets/060ec79d-cc16-43c1-8246-166b0bf52abd" />

[current doc](https://zulip.com/help/import-from-slack#import-your-data-into-zulip)
<img width="771" height="665" alt="Screenshot 2025-07-22 at 18 08 27" src="https://github.com/user-attachments/assets/5ba4c63d-a3d8-45a6-b965-9fda4d9f7c0a" />

[current doc](https://zulip.com/help/import-from-rocketchat#import-your-data-into-zulip)
<img width="756" height="792" alt="Screenshot 2025-07-22 at 18 08 41" src="https://github.com/user-attachments/assets/0a97c92f-4364-4cf5-9171-b95d61cabce3" />


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
