### PR TITLE
topics: Follow topics that are merged into even after merge.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -486,14 +486,15 @@ def get_visibility_policy_after_merge(
     # Whichever of the two policies is most visible is what we keep.
     # The general motivation is to err on the side of showing messages
     # rather than hiding them.
-    if orig_topic_visibility_policy == target_topic_visibility_policy:
-        return orig_topic_visibility_policy
-    elif UserTopic.VisibilityPolicy.UNMUTED in (
-        orig_topic_visibility_policy,
-        target_topic_visibility_policy,
-    ):
+    visibility_policies = {orig_topic_visibility_policy, target_topic_visibility_policy}
+
+    if UserTopic.VisibilityPolicy.UNMUTED in visibility_policies:
         return UserTopic.VisibilityPolicy.UNMUTED
-    return UserTopic.VisibilityPolicy.INHERIT
+
+    if UserTopic.VisibilityPolicy.INHERIT in visibility_policies:
+        return UserTopic.VisibilityPolicy.INHERIT
+
+    return UserTopic.VisibilityPolicy.MUTED
 
 
 def update_message_content(

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -488,6 +488,9 @@ def get_visibility_policy_after_merge(
     # rather than hiding them.
     visibility_policies = {orig_topic_visibility_policy, target_topic_visibility_policy}
 
+    if UserTopic.VisibilityPolicy.FOLLOWED in visibility_policies:
+        return UserTopic.VisibilityPolicy.FOLLOWED
+
     if UserTopic.VisibilityPolicy.UNMUTED in visibility_policies:
         return UserTopic.VisibilityPolicy.UNMUTED
 

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -764,6 +764,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")
         aaron = self.example_user("aaron")
+        shiva = self.example_user("shiva")
 
         self.subscribe(hamlet, stream_name)
         self.login_user(hamlet)
@@ -778,6 +779,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         #   INHERIT       INHERIT       INHERIT
         #   INHERIT        MUTED        INHERIT
         #   INHERIT       UNMUTED       UNMUTED
+        #   INHERIT       FOLLOWED      FOLLOWED
         orig_topic = "Topic1"
         target_topic = "Topic1 edited"
         orig_message_id = self.send_stream_message(
@@ -799,6 +801,9 @@ class MessageMoveTopicTest(ZulipTestCase):
         do_set_user_topic_visibility_policy(
             aaron, stream, target_topic, visibility_policy=UserTopic.VisibilityPolicy.UNMUTED
         )
+        do_set_user_topic_visibility_policy(
+            shiva, stream, target_topic, visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED
+        )
 
         check_update_message(
             user_profile=hamlet,
@@ -821,6 +826,9 @@ class MessageMoveTopicTest(ZulipTestCase):
             aaron, orig_topic, stream, UserTopic.VisibilityPolicy.INHERIT
         )
         self.assert_has_visibility_policy(
+            shiva, orig_topic, stream, UserTopic.VisibilityPolicy.INHERIT
+        )
+        self.assert_has_visibility_policy(
             hamlet, target_topic, stream, UserTopic.VisibilityPolicy.INHERIT
         )
         self.assert_has_visibility_policy(
@@ -829,6 +837,9 @@ class MessageMoveTopicTest(ZulipTestCase):
         self.assert_has_visibility_policy(
             aaron, target_topic, stream, UserTopic.VisibilityPolicy.UNMUTED
         )
+        self.assert_has_visibility_policy(
+            shiva, target_topic, stream, UserTopic.VisibilityPolicy.FOLLOWED
+        )
 
         # Test the following cases:
         #
@@ -836,6 +847,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         #     MUTED       INHERIT        INHERIT
         #     MUTED        MUTED          MUTED
         #     MUTED       UNMUTED        UNMUTED
+        #     MUTED       FOLLOWED       FOLLOWED
         orig_topic = "Topic2"
         target_topic = "Topic2 edited"
         orig_message_id = self.send_stream_message(
@@ -855,10 +867,16 @@ class MessageMoveTopicTest(ZulipTestCase):
             aaron, stream, orig_topic, visibility_policy=UserTopic.VisibilityPolicy.MUTED
         )
         do_set_user_topic_visibility_policy(
+            shiva, stream, orig_topic, visibility_policy=UserTopic.VisibilityPolicy.MUTED
+        )
+        do_set_user_topic_visibility_policy(
             cordelia, stream, target_topic, visibility_policy=UserTopic.VisibilityPolicy.MUTED
         )
         do_set_user_topic_visibility_policy(
             aaron, stream, target_topic, visibility_policy=UserTopic.VisibilityPolicy.UNMUTED
+        )
+        do_set_user_topic_visibility_policy(
+            shiva, stream, target_topic, visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED
         )
 
         check_update_message(
@@ -882,6 +900,9 @@ class MessageMoveTopicTest(ZulipTestCase):
             aaron, orig_topic, stream, UserTopic.VisibilityPolicy.INHERIT
         )
         self.assert_has_visibility_policy(
+            shiva, orig_topic, stream, UserTopic.VisibilityPolicy.INHERIT
+        )
+        self.assert_has_visibility_policy(
             hamlet, target_topic, stream, UserTopic.VisibilityPolicy.INHERIT
         )
         self.assert_has_visibility_policy(
@@ -890,6 +911,9 @@ class MessageMoveTopicTest(ZulipTestCase):
         self.assert_has_visibility_policy(
             aaron, target_topic, stream, UserTopic.VisibilityPolicy.UNMUTED
         )
+        self.assert_has_visibility_policy(
+            shiva, target_topic, stream, UserTopic.VisibilityPolicy.FOLLOWED
+        )
 
         # Test the following cases:
         #
@@ -897,6 +921,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         #    UNMUTED       INHERIT        UNMUTED
         #    UNMUTED        MUTED         UNMUTED
         #    UNMUTED       UNMUTED        UNMUTED
+        #    UNMUTED       FOLLOWED       FOLLOWED
         orig_topic = "Topic3"
         target_topic = "Topic3 edited"
         orig_message_id = self.send_stream_message(
@@ -916,7 +941,83 @@ class MessageMoveTopicTest(ZulipTestCase):
             aaron, stream, orig_topic, visibility_policy=UserTopic.VisibilityPolicy.UNMUTED
         )
         do_set_user_topic_visibility_policy(
+            shiva, stream, orig_topic, visibility_policy=UserTopic.VisibilityPolicy.UNMUTED
+        )
+        do_set_user_topic_visibility_policy(
             cordelia, stream, target_topic, visibility_policy=UserTopic.VisibilityPolicy.MUTED
+        )
+        do_set_user_topic_visibility_policy(
+            aaron, stream, target_topic, visibility_policy=UserTopic.VisibilityPolicy.UNMUTED
+        )
+        do_set_user_topic_visibility_policy(
+            shiva, stream, target_topic, visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED
+        )
+
+        check_update_message(
+            user_profile=hamlet,
+            message_id=orig_message_id,
+            stream_id=None,
+            topic_name=target_topic,
+            propagate_mode="change_all",
+            send_notification_to_old_thread=False,
+            send_notification_to_new_thread=False,
+            content=None,
+        )
+
+        self.assert_has_visibility_policy(
+            hamlet, orig_topic, stream, UserTopic.VisibilityPolicy.INHERIT
+        )
+        self.assert_has_visibility_policy(
+            cordelia, orig_topic, stream, UserTopic.VisibilityPolicy.INHERIT
+        )
+        self.assert_has_visibility_policy(
+            aaron, orig_topic, stream, UserTopic.VisibilityPolicy.INHERIT
+        )
+        self.assert_has_visibility_policy(
+            shiva, orig_topic, stream, UserTopic.VisibilityPolicy.INHERIT
+        )
+        self.assert_has_visibility_policy(
+            hamlet, target_topic, stream, UserTopic.VisibilityPolicy.UNMUTED
+        )
+        self.assert_has_visibility_policy(
+            cordelia, target_topic, stream, UserTopic.VisibilityPolicy.UNMUTED
+        )
+        self.assert_has_visibility_policy(
+            aaron, target_topic, stream, UserTopic.VisibilityPolicy.UNMUTED
+        )
+        self.assert_has_visibility_policy(
+            shiva, target_topic, stream, UserTopic.VisibilityPolicy.FOLLOWED
+        )
+
+        # Test the following cases:
+        #
+        #  orig_topic | target_topic | final behaviour
+        #   FOLLOWED     INHERIT         FOLLOWED
+        #   FOLLOWED     MUTED           FOLLOWED
+        #   FOLLOWED     UNMUTED         FOLLOWED
+        orig_topic = "Topic4"
+        target_topic = "Topic4 edited"
+        orig_message_id = self.send_stream_message(
+            hamlet, stream_name, topic_name=orig_topic, content="Hello World"
+        )
+        self.send_stream_message(
+            hamlet, stream_name, topic_name=target_topic, content="Hello World 2"
+        )
+        do_set_user_topic_visibility_policy(
+            cordelia, stream, target_topic, visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED
+        )
+
+        do_set_user_topic_visibility_policy(
+            hamlet, stream, orig_topic, visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED
+        )
+        do_set_user_topic_visibility_policy(
+            cordelia, stream, orig_topic, visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED
+        )
+        do_set_user_topic_visibility_policy(
+            cordelia, stream, target_topic, visibility_policy=UserTopic.VisibilityPolicy.MUTED
+        )
+        do_set_user_topic_visibility_policy(
+            aaron, stream, orig_topic, visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED
         )
         do_set_user_topic_visibility_policy(
             aaron, stream, target_topic, visibility_policy=UserTopic.VisibilityPolicy.UNMUTED
@@ -943,13 +1044,13 @@ class MessageMoveTopicTest(ZulipTestCase):
             aaron, orig_topic, stream, UserTopic.VisibilityPolicy.INHERIT
         )
         self.assert_has_visibility_policy(
-            hamlet, target_topic, stream, UserTopic.VisibilityPolicy.UNMUTED
+            hamlet, target_topic, stream, UserTopic.VisibilityPolicy.FOLLOWED
         )
         self.assert_has_visibility_policy(
-            cordelia, target_topic, stream, UserTopic.VisibilityPolicy.UNMUTED
+            cordelia, target_topic, stream, UserTopic.VisibilityPolicy.FOLLOWED
         )
         self.assert_has_visibility_policy(
-            aaron, target_topic, stream, UserTopic.VisibilityPolicy.UNMUTED
+            aaron, target_topic, stream, UserTopic.VisibilityPolicy.FOLLOWED
         )
 
     def test_user_topic_states_on_moving_to_topic_with_no_messages(self) -> None:


### PR DESCRIPTION
Previously, when there were two topics -- A and B, and a user follows topic A, then when messages of topic B are merged into topic A then topic A loses its follow status.

This is fixed by updating the algorithm for getting the visibility policy after merge to be followed in the above case.

Fixes #35226

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
