### PR TITLE
Prevent races resulting in incorrect search index results for newly sent messages.

### DIFF
--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -17,6 +17,7 @@ from sqlalchemy.sql import (
     Select,
     and_,
     column,
+    exists,
     false,
     func,
     literal,
@@ -809,7 +810,24 @@ class NarrowBuilder:
                 func.escape_html(topic_column_sa(), type_=Text), keywords
             ).label("topic_matches"),
         )
-        condition = column("search_pgroonga", Text).op("&@~")(operand_escaped)
+        fts_table = table("fts_update_log", column("message_id", Integer))
+
+        fts_unindexed = exists(
+            select(literal_column("1"))
+            .select_from(fts_table)
+            .where(fts_table.c.message_id == column("id"))
+        )
+        condition = or_(
+            and_(~fts_unindexed, column("search_pgroonga", Text).op("&@~")(operand_escaped)),
+            and_(
+                fts_unindexed,
+                (
+                    func.escape_html(topic_column_sa(), type_=Text)
+                    + literal(" ")
+                    + column("rendered_content")
+                ).op("&@~")(operand_escaped),
+            ),
+        )
         return query.where(maybe_negate(condition))
 
     def _by_search_tsearch(
@@ -845,7 +863,22 @@ class NarrowBuilder:
                 )
                 query = query.where(maybe_negate(cond))
 
-        cond = column("search_tsvector", postgresql.TSVECTOR).op("@@")(tsquery)
+        fts_table = table("fts_update_log", column("message_id", Integer))
+
+        fts_unindexed = exists(
+            select(literal_column("1"))
+            .select_from(fts_table)
+            .where(fts_table.c.message_id == column("id"))
+        )
+        cond = or_(
+            and_(~fts_unindexed, column("search_tsvector", postgresql.TSVECTOR).op("@@")(tsquery)),
+            and_(
+                fts_unindexed,
+                func.to_tsvector(
+                    "zulip.english_us_search", topic_column_sa() + column("rendered_content", Text)
+                ),
+            ).op("@@")(tsquery),
+        )
         return query.where(maybe_negate(cond))
 
 

--- a/zerver/migrations/0745_index_fts_message_id.py
+++ b/zerver/migrations/0745_index_fts_message_id.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("zerver", "0744_alter_channelfolder_name"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS fts_update_log_message_id
+                ON fts_update_log(message_id)
+            """,
+            reverse_sql="""
+                DROP INDEX CONCURRENTLY IF EXISTS fts_update_log_message_id
+            """,
+        ),
+    ]

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -562,7 +562,7 @@ class NarrowBuilderTest(ZulipTestCase):
         term = NarrowParameter(operator="search", operand='"french fries"')
         self._do_add_term_test(
             term,
-            "WHERE (content ILIKE %(content_1)s OR subject ILIKE %(subject_1)s AND is_channel_message) AND (search_tsvector @@ plainto_tsquery(%(param_4)s, %(param_5)s))",
+            "WHERE (content ILIKE %(content_1)s OR subject ILIKE %(subject_1)s AND is_channel_message) AND (NOT (EXISTS (SELECT 1 \nFROM fts_update_log \nWHERE fts_update_log.message_id = id)) AND (search_tsvector @@ plainto_tsquery(%(param_4)s, %(param_5)s)) OR ((EXISTS (SELECT 1 \nFROM fts_update_log \nWHERE fts_update_log.message_id = id)) AND to_tsvector(%(to_tsvector_1)s, subject || rendered_content) @@ plainto_tsquery(%(param_4)s, %(param_5)s)))",
         )
 
     @override_settings(USING_PGROONGA=False)
@@ -570,19 +570,23 @@ class NarrowBuilderTest(ZulipTestCase):
         term = NarrowParameter(operator="search", operand='"french fries"', negated=True)
         self._do_add_term_test(
             term,
-            "WHERE NOT (content ILIKE %(content_1)s OR subject ILIKE %(subject_1)s AND is_channel_message) AND NOT (search_tsvector @@ plainto_tsquery(%(param_4)s, %(param_5)s))",
+            "WHERE NOT (content ILIKE %(content_1)s OR subject ILIKE %(subject_1)s AND is_channel_message) AND NOT (NOT (EXISTS (SELECT 1 \nFROM fts_update_log \nWHERE fts_update_log.message_id = id)) AND (search_tsvector @@ plainto_tsquery(%(param_4)s, %(param_5)s)) OR ((EXISTS (SELECT 1 \nFROM fts_update_log \nWHERE fts_update_log.message_id = id)) AND to_tsvector(%(to_tsvector_1)s, subject || rendered_content) @@ plainto_tsquery(%(param_4)s, %(param_5)s)))",
         )
 
     @override_settings(USING_PGROONGA=True)
     def test_add_term_using_search_operator_pgroonga(self) -> None:
         term = NarrowParameter(operator="search", operand='"french fries"')
-        self._do_add_term_test(term, "WHERE search_pgroonga &@~ escape_html(%(escape_html_1)s)")
+        self._do_add_term_test(
+            term,
+            "WHERE NOT (EXISTS (SELECT 1 \nFROM fts_update_log \nWHERE fts_update_log.message_id = id)) AND (search_pgroonga &@~ escape_html(%(escape_html_1)s)) OR (EXISTS (SELECT 1 \nFROM fts_update_log \nWHERE fts_update_log.message_id = id)) AND (escape_html(subject) || %(param_1)s || rendered_content &@~ escape_html(%(escape_html_1)s))",
+        )
 
     @override_settings(USING_PGROONGA=True)
     def test_add_term_using_search_operator_and_negated_pgroonga(self) -> None:  # NEGATED
         term = NarrowParameter(operator="search", operand='"french fries"', negated=True)
         self._do_add_term_test(
-            term, "WHERE NOT (search_pgroonga &@~ escape_html(%(escape_html_1)s))"
+            term,
+            "WHERE NOT (NOT (EXISTS (SELECT 1 \nFROM fts_update_log \nWHERE fts_update_log.message_id = id)) AND (search_pgroonga &@~ escape_html(%(escape_html_1)s)) OR (EXISTS (SELECT 1 \nFROM fts_update_log \nWHERE fts_update_log.message_id = id)) AND (escape_html(subject) || %(param_1)s || rendered_content &@~ escape_html(%(escape_html_1)s)))",
         )
 
     def test_add_term_using_has_operator_and_attachment_operand(self) -> None:
@@ -5127,7 +5131,11 @@ WHERE user_profile_id = {hamlet_id} AND (zerver_recipient.type != 2 OR (EXISTS (
 FROM zerver_stream \n\
 WHERE zerver_stream.recipient_id = zerver_recipient.id AND (NOT zerver_stream.invite_only AND NOT zerver_stream.is_in_zephyr_realm OR zerver_stream.can_subscribe_group_id IN {hamlet_groups} OR zerver_stream.can_add_subscribers_group_id IN {hamlet_groups}))) OR (EXISTS (SELECT  \n\
 FROM zerver_subscription \n\
-WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND (search_tsvector @@ plainto_tsquery('zulip.english_us_search', 'jumping')) ORDER BY message_id ASC \n\
+WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND (NOT (EXISTS (SELECT 1 \n\
+FROM fts_update_log \n\
+WHERE fts_update_log.message_id = id)) AND (search_tsvector @@ plainto_tsquery('zulip.english_us_search', 'jumping')) OR ((EXISTS (SELECT 1 \n\
+FROM fts_update_log \n\
+WHERE fts_update_log.message_id = id)) AND to_tsvector('zulip.english_us_search', subject || rendered_content) @@ plainto_tsquery('zulip.english_us_search', 'jumping'))) ORDER BY message_id ASC \n\
  LIMIT 10) AS anon_1 ORDER BY message_id ASC\
 """
         sql = sql_template.format(**query_ids)
@@ -5143,7 +5151,11 @@ FROM unnest(string_to_array(ts_headline('zulip.english_us_search', rendered_cont
 FROM unnest(string_to_array(ts_headline('zulip.english_us_search', escape_html(subject), plainto_tsquery('zulip.english_us_search', 'jumping'), 'HighlightAll = TRUE, StartSel = <ts-match>, StopSel = </ts-match>'), '<ts-match>')) AS anon_5\n\
  LIMIT ALL OFFSET 1)) AS topic_matches \n\
 FROM zerver_message \n\
-WHERE realm_id = 2 AND recipient_id = {scotland_recipient} AND (search_tsvector @@ plainto_tsquery('zulip.english_us_search', 'jumping')) ORDER BY zerver_message.id ASC \n\
+WHERE realm_id = 2 AND recipient_id = {scotland_recipient} AND (NOT (EXISTS (SELECT 1 \n\
+FROM fts_update_log \n\
+WHERE fts_update_log.message_id = id)) AND (search_tsvector @@ plainto_tsquery('zulip.english_us_search', 'jumping')) OR ((EXISTS (SELECT 1 \n\
+FROM fts_update_log \n\
+WHERE fts_update_log.message_id = id)) AND to_tsvector('zulip.english_us_search', subject || rendered_content) @@ plainto_tsquery('zulip.english_us_search', 'jumping'))) ORDER BY zerver_message.id ASC \n\
  LIMIT 10) AS anon_1 ORDER BY message_id ASC\
 """
         sql = sql_template.format(**query_ids)
@@ -5169,7 +5181,11 @@ WHERE user_profile_id = {hamlet_id} AND (zerver_recipient.type != 2 OR (EXISTS (
 FROM zerver_stream \n\
 WHERE zerver_stream.recipient_id = zerver_recipient.id AND (NOT zerver_stream.invite_only AND NOT zerver_stream.is_in_zephyr_realm OR zerver_stream.can_subscribe_group_id IN {hamlet_groups} OR zerver_stream.can_add_subscribers_group_id IN {hamlet_groups}))) OR (EXISTS (SELECT  \n\
 FROM zerver_subscription \n\
-WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND (content ILIKE '%jumping%' OR subject ILIKE '%jumping%' AND is_channel_message) AND (search_tsvector @@ plainto_tsquery('zulip.english_us_search', '"jumping" quickly')) ORDER BY message_id ASC \n\
+WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND (content ILIKE '%jumping%' OR subject ILIKE '%jumping%' AND is_channel_message) AND (NOT (EXISTS (SELECT 1 \n\
+FROM fts_update_log \n\
+WHERE fts_update_log.message_id = id)) AND (search_tsvector @@ plainto_tsquery('zulip.english_us_search', '"jumping" quickly')) OR ((EXISTS (SELECT 1 \n\
+FROM fts_update_log \n\
+WHERE fts_update_log.message_id = id)) AND to_tsvector('zulip.english_us_search', subject || rendered_content) @@ plainto_tsquery('zulip.english_us_search', '"jumping" quickly'))) ORDER BY message_id ASC \n\
  LIMIT 10) AS anon_1 ORDER BY message_id ASC\
 """
         sql = sql_template.format(**query_ids)


### PR DESCRIPTION
This PR checks message id against pending message ids in `fts_update_log` and calculates narrow match directly if it is yet to be indexed in the db. This prevents false negative narrow match on newly sent message which sometimes results in not adding to the current narrow even if it should.

Fixes: zulip#33267

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
\* **Fts indexing is disabled here**
| Before | After |
|-----------|---------|
| <video src="https://github.com/user-attachments/assets/9245eb68-ceb1-4fa3-9457-bc7af3003d7a"> | <video src="https://github.com/user-attachments/assets/e9699b5b-3a67-46b1-b376-4e1082e8f1a2">

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
