### PR TITLE
compose: Account for subpixel issues near formatting row.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -313,9 +313,17 @@
         display: grid;
         /* Vlad's design calls for 122px for the send column
            at its widest; 112px accounts for 6px of gap and
-           4px outside padding. */
+           4px outside padding.
+
+           We use minmax() on the formatting-row height to
+           try and avoid subpixel rendering problems that
+           may cause the bottom border to disappear.
+        */
         grid-template:
-            minmax(0, 1fr) var(--compose-formatting-buttons-row-height)
+            minmax(0, 1fr) minmax(
+                var(--compose-formatting-buttons-row-height),
+                auto
+            )
             / minmax(0, 1fr) var(--compose-send-controls-width);
         grid-template-areas:
             "message-content-container message-send-controls-container"
@@ -336,7 +344,11 @@
         );
     grid-template-areas: "message-content composebox-buttons";
     border-radius: 4px;
-    border: 1px solid var(--color-message-content-container-border);
+    /* The `thin` keyword should map to 1px on most browsers,
+       but this also gives browsers leeway to better calculate
+       the border's width at different pixel densities and
+       zoom levels. */
+    border: thin solid var(--color-message-content-container-border);
     transition: border-color 0.2s ease;
 
     &:has(.new_message_textarea:focus) {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -510,9 +510,10 @@
     grid-area: message-formatting-controls-container;
     border-radius: 0 0 3px 3px;
     background-color: var(--color-message-formatting-controls-container);
-    /* margin on either side to let the border of
+    /* Set width on either side to let the border of
        .message-content-container show through. */
-    margin: 0 1px;
+    width: calc(100% - 2px);
+    justify-self: center;
 }
 
 .compose-scrolling-buttons-container {


### PR DESCRIPTION
This is an experimental PR that attempts to change how borders are drawn around the compose area.

Note that it uses the `thin` keyword for the textarea border, so CI is going to fail on that point.

CZO issues:
* [#issues > missing bottom compose box border](https://chat.zulip.org/#narrow/channel/9-issues/topic/missing.20bottom.20compose.20box.20border)
* [#issues > ✔ 🎯 buttons spilling out of compose box when zoomed out](https://chat.zulip.org/#narrow/channel/9-issues/topic/.E2.9C.94.20.F0.9F.8E.AF.20buttons.20spilling.20out.20of.20compose.20box.20when.20zoomed.20out)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Zoomed out to 67% with Zulip's default font-size/line-height settings._

| Before | After (no apparent change here) |
| --- | --- |
| <img width="840" height="1200" alt="compose-border-before" src="https://github.com/user-attachments/assets/d9cd1503-8db6-4d51-a8f2-9f5930cc9dfe" /> | <img width="840" height="1200" alt="compose-border-after" src="https://github.com/user-attachments/assets/1ad873ad-533b-493e-82d9-f69217a5412b" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>