### PR TITLE
message_delete: Remove explicit is_spectator condition.

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -48,7 +48,6 @@ import * as message_store from "./message_store.ts";
 import type {Message} from "./message_store.ts";
 import * as message_viewport from "./message_viewport.ts";
 import * as onboarding_steps from "./onboarding_steps.ts";
-import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as resize from "./resize.ts";
 import * as rows from "./rows.ts";
@@ -236,10 +235,6 @@ export function is_message_sent_by_my_bot(message: Message): boolean {
 }
 
 export function get_deletability(message: Message): boolean {
-    if (page_params.is_spectator) {
-        return false;
-    }
-
     if (message.type === "stream" && stream_data.is_stream_archived(message.stream_id)) {
         return false;
     }

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -213,7 +213,7 @@ export function get_actions_popover_content_context(message_id: number): ActionP
 
     const conversation_time_url = hash_util.by_conversation_and_time_url(message);
 
-    const should_display_delete_option = message_edit.get_deletability(message) && not_spectator;
+    const should_display_delete_option = message_edit.get_deletability(message);
     const should_display_read_receipts_option = realm.realm_enable_read_receipts && not_spectator;
     const should_display_remind_me_option = not_spectator;
 

--- a/web/tests/message_edit.test.cjs
+++ b/web/tests/message_edit.test.cjs
@@ -216,9 +216,6 @@ run_test("get_deletability", ({override}) => {
         sender_id: 1,
     };
 
-    page_params.is_spectator = true;
-    assert.equal(message_edit.get_deletability(message), false);
-
     page_params.is_spectator = false;
 
     // User can delete any message


### PR DESCRIPTION
Removes explicit `is_spectator` condition when checking if message can deleted as it is checked by `user_has_permission_for_group_setting` function.

Follow-up for https://github.com/zulip/zulip/pull/35045#discussion_r2214385908.
<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
