### PR TITLE
pill_container: Remove hardcoded HSL value from input_pill.css.

### DIFF
--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -219,7 +219,6 @@
 
     &.not-editable-by-user {
         cursor: not-allowed;
-        background-color: hsl(0deg 0% 93%);
 
         .pill {
             cursor: not-allowed;


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR fixes background color pill container of "Users" type custom profile fields when they can't be edited by non-admin users.

| Before | After |
|--------|--------|
| <img width="551" height="166" alt="image" src="https://github.com/user-attachments/assets/1a8de191-a774-4f2c-9531-ee4fc01809bd" />| <img width="505" height="247" alt="image" src="https://github.com/user-attachments/assets/e0acf078-615d-4f32-8e9d-b1f263f9fc2b" /> |
| <img width="522" height="181" alt="image" src="https://github.com/user-attachments/assets/20981904-5f69-4d21-9d19-7412e1cb034f" /> | <img width="534" height="165" alt="image" src="https://github.com/user-attachments/assets/853345bc-a765-4cdb-8354-de23edd54f23" /> | 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
