### PR TITLE
api-docs: Revise feature level 404 and 392 changes entries.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -67,12 +67,13 @@ format used by the Zulip server that they are interacting with.
 
 * [`GET /users/me/subscriptions`](/api/get-subscriptions),
   [`GET /streams`](/api/get-streams), [`GET /events`](/api/get-events),
-  [`POST /register`](/api/register-queue): Added new `empty_topic_only`
-  option to `topics_policy` field in Stream and Subscription objects.
+  [`POST /register`](/api/register-queue): Added new `"empty_topic_only"`
+  option to the `topics_policy` field on Stream and Subscription
+  objects.
 * [`POST /users/me/subscriptions`](/api/subscribe),
   [`PATCH /streams/{stream_id}`](/api/update-stream): Added new
-  `empty_topic_only` option to `topics_policy` to support channels
-  with topics disabled.
+  `"empty_topic_only"` option to `topics_policy` parameter for
+  ["general chat" channels](/help/general-chat-channels).
 
 **Feature level 403**
 
@@ -198,26 +199,31 @@ format used by the Zulip server that they are interacting with.
 
 * [`GET /users/me/subscriptions`](/api/get-subscriptions),
   [`GET /streams`](/api/get-streams), [`GET /events`](/api/get-events),
-  [`POST /register`](/api/register-queue): Added `topics_policy`
-  field to Stream and Subscription objects.
+  [`POST /register`](/api/register-queue): Added the `topics_policy`
+  field to Stream and Subscription objects to support channel-level
+  configurations for sending messages to the empty ["general chat"
+  topic](/help/general-chat-topic).
 * [`POST /users/me/subscriptions`](/api/subscribe),
   [`PATCH /streams/{stream_id}`](/api/update-stream): Added
-  `topics_policy` parameter to support setting and changing the
-  the configuration for sending messages in the empty topic of the
-  channel.
-* `PATCH /realm`, [`POST /register`](/api/register-queue),
-  [`GET /events`](/api/get-events): Added `can_set_topics_policy_group`
-  realm setting, which is a [group-setting value](/api/group-setting-values)
-  describing the set of users with permission to change per-channel `topics_policy`
+  `topics_policy` parameter to support setting and updating the
+  channel-level configuration for sending messages to the
+  empty ["general chat" topic](/help/general-chat-topic).
+* `PATCH /realm`, [`GET /events`](/api/get-events),
+  [`POST /register`](/api/register-queue): Added
+  `can_set_topics_policy_group` realm setting, which is a
+  [group-setting value](/api/group-setting-values) describing the set
+  of users with permission to change the per-channel `topics_policy`
   setting.
 * `PATCH /realm`, [`GET /events`](/api/get-events),
   [`POST /register`](/api/register-queue):
-  Added a new realm setting, `topics_policy` defining the
-  default configuration for sending messages in empty topics.
+  Added a new realm `topics_policy` setting for the organization's
+  default policy for sending channel messages to the empty ["general
+  chat" topic](/help/general-chat-topic).
 * [`GET /events`](/api/get-events), [`POST /register`](/api/register-queue):
-  Deprecated `mandatory_topics` field in favor of `topics_policy` realm setting.
-* `PATCH /realm`: Removed `mandatory_topics` field as it is now replaced by
-  `topics_policy` field.
+  Deprecated the realm `mandatory_topics` setting in favor of the new
+  realm `topics_policy` setting.
+* `PATCH /realm`: Removed the `mandatory_topics` parameter as it is now
+  replaced by the realm `topics_policy` setting.
 
 **Feature level 391**
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -178,7 +178,7 @@ format used by the Zulip server that they are interacting with.
 
 * [`POST /register`](/api/register-queue), [`GET
   /events`](/api/get-events), [`GET /streams`](/api/get-streams),
-  [`GET /streams/{stream_id}`](/api/get-stream-by-id):: Added a new
+  [`GET /streams/{stream_id}`](/api/get-stream-by-id): Added a new
   field `subscriber_count` to Stream and Subscription objects with the
   total number of non-deactivated users who are subscribed to the
   channel.
@@ -1196,7 +1196,7 @@ deactivated groups.
 * [`DELETE /saved_snippets/{saved_snippet_id}`](/api/delete-saved-snippet): Added
   a new endpoint for deleting saved snippets.
 
-**Feature level 296**:
+**Feature level 296**
 
 * [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),
   [`POST /realm/profile_fields`](/api/create-custom-profile-field),

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5173,27 +5173,30 @@ paths:
                                       description: |
                                         The URL of the organization's wide logo configured in the
                                         [organization profile](/help/create-your-organization-profile).
-                                    mandatory_topics:
-                                      type: boolean
-                                      deprecated: true
-                                      description: |
-                                        Whether [topics are required](/help/require-topics) for messages in this organization.
-
-                                        **Changes**: Deprecated in Zulip 11.0 (feature level 392). This configuration is
-                                        now controlled by `topics_policy` realm setting.
                                     topics_policy:
                                       type: string
                                       enum:
                                         - allow_empty_topic
                                         - disable_empty_topic
                                       description: |
-                                        Configuration defining the default policy for sending messages in empty topics.
+                                        The organization's default policy for sending channel messages to the
+                                        [empty "general chat" topic](/help/general-chat-topic).
 
-                                        - allow_empty_topic - Topics are not required to send messages in the channels.
-                                        - disable_empty_topic - Topics are required to send messages in the channels.
+                                        - `"allow_empty_topic"`: Channel messages can be sent to the empty topic.
+                                        - `"disable_empty_topic"`: Channel messages cannot be sent to the empty topic.
 
-                                        **Changes**: New in Zulip 11.0 (feature level 392). Previously, this configuration was
-                                        controlled by a boolean realm setting, `mandatory_topics`.
+                                        **Changes**: New in Zulip 11.0 (feature level 392). Previously, this was
+                                        controlled by the boolean realm `mandatory_topics` setting, which is now
+                                        deprecated.
+                                    mandatory_topics:
+                                      type: boolean
+                                      deprecated: true
+                                      description: |
+                                        Whether [topics are required](/help/require-topics) for messages in this
+                                        organization.
+
+                                        **Changes**: Deprecated in Zulip 11.0 (feature level 392). This is now
+                                        controlled by the realm `topics_policy` setting.
                                     max_file_upload_size_mib:
                                       type: integer
                                       description: |
@@ -18902,16 +18905,6 @@ paths:
 
                           Whether this organization has been configured to enable
                           [previews of linked websites](/help/image-video-and-website-previews).
-                      realm_mandatory_topics:
-                        type: boolean
-                        deprecated: true
-                        description: |
-                          Present if `realm` is present in `fetch_event_types`.
-
-                          Whether [topics are required](/help/require-topics) for messages in this organization.
-
-                          **Changes**: Deprecated in Zulip 11.0 (feature level 392). This configuration is
-                          now controlled by `topics_policy` realm setting.
                       realm_topics_policy:
                         type: string
                         enum:
@@ -18920,13 +18913,26 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          Configuration defining the default policy for sending messages in empty topics.
+                          The organization's default policy for sending channel messages to the
+                          [empty "general chat" topic](/help/require-topics).
 
-                          - allow_empty_topic - Topics are not required to send messages in the channels.
-                          - disable_empty_topic - Topics are required to send messages in the channels.
+                          - `"allow_empty_topic"`: Channel messages can be sent to the empty topic.
+                          - `"disable_empty_topic"`: Channel messages cannot be sent to the empty topic.
 
-                          **Changes**: New in Zulip 11.0 (feature level 392). Previously, this configuration was
-                          controlled by a boolean realm setting, `mandatory_topics`.
+                          **Changes**: New in Zulip 11.0 (feature level 392). Previously, this was
+                          controlled by the boolean `realm_mandatory_topics` setting, which is now
+                          deprecated.
+                      realm_mandatory_topics:
+                        type: boolean
+                        deprecated: true
+                        description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
+                          Whether [topics are required](/help/require-topics) for messages in this
+                          organization.
+
+                          **Changes**: Deprecated in Zulip 11.0 (feature level 392). This is now
+                          controlled by the realm `topics_policy` setting.
                       realm_message_retention_days:
                         type: integer
                         description: |
@@ -28000,22 +28006,36 @@ components:
         - allow_empty_topic
         - disable_empty_topic
         - empty_topic_only
+      example: inherit
       description: |
-        Setting defining the policy for sending messages to the empty topic in
-        this channel.
+        Whether [named topics](/help/introduction-to-topics) and the empty
+        topic (i.e., ["general chat" topic](/help/general-chat-topic))
+        are enabled in this channel.
 
-        - inherit - Channel will inherit the organization-level setting, `realm_topics_policy`.
-        - allow_empty_topic - Topics are not required to send messages in the channel.
-        - disable_empty_topic - Topics are required to send messages in the channel.
-        - empty_topic_only - Only the empty topic is available in this channel.
+        - `"inherit"`: Messages can be sent to named topics in this channel,
+          and the [organization-level `realm_topics_policy`][realm-topics-policy]
+          is used for whether messages can be sent to the empty topic in this
+          channel.
+        - `"allow_empty_topic"`: Messages can be sent to both named topics and
+          the empty topic in this channel.
+        - `"disable_empty_topic"`: Messages can be sent to named topics in this
+          channel, but the empty topic is disabled.
+        - `"empty_topic_only"`: Messages can be sent to the empty topic in this
+          channel, but named topics are disabled. See ["general chat"
+          channels](/help/general-chat-channels).
 
-        The `empty_topic_only` policy can only be enabled in a channel if all
-        messages in the channel are already in the empty topic.
+        The `"empty_topic_only"` policy can only be set if all existing messages
+        in the channel are already in the empty topic.
 
-        **Changes**: In Zulip 11.0 (feature level 404), `empty_topic_only` option
-        was added.
+        When creating a new channel, if the `topics_policy` is not specified, the
+        `"inherit"` option will be set.
+
+        **Changes**: In Zulip 11.0 (feature level 404), the `"empty_topic_only"`
+        option was added.
 
         New in Zulip 11.0 (feature level 392).
+
+        [realm-topics-policy]: /help/require-topics#set-the-default-general-chat-topic-configuration
     ChannelCanAddSubscribersGroup:
       allOf:
         - $ref: "#/components/schemas/GroupSettingValue"


### PR DESCRIPTION
Updates the changelog entries for feature levels 404 and 392, and revises the descriptive text for the `topics_policy` channel and realm level settings.

The feature level 404 changes were originally added in commit a77fc6aa7921.
The feature level 392 changes were originally added in commit deaa43c7e6104.

---

**Screenshots and screen captures:**

**[API changelog](https://zulip.com/api/changelog)**
<img width="734" height="162" alt="Screenshot 2025-07-23 at 17 30 10" src="https://github.com/user-attachments/assets/f3791e58-f67b-44b8-b757-9030e4487593" />
<img width="747" height="474" alt="Screenshot 2025-07-23 at 17 30 23" src="https://github.com/user-attachments/assets/877509a2-1437-44ab-9cf4-8f34e30dce84" />

**[topics_policy field](https://zulip.com/api/get-streams#response) on Stream and Subscription objects in API docs**
<img width="716" height="513" alt="Screenshot 2025-07-23 at 17 28 29" src="https://github.com/user-attachments/assets/e11659b8-f519-4f4a-924e-b1ef99352a38" />

**[realm_topics_policy field](https://zulip.com/api/register-queue) on register response API doc**
<img width="738" height="223" alt="Screenshot 2025-07-23 at 17 28 50" src="https://github.com/user-attachments/assets/e9d8a048-2db1-4400-abb4-2a8235191806" />

**org-level [topics_policy field](https://zulip.com/api/get-events#realm-update_dict) on get events API doc**
<img width="683" height="214" alt="Screenshot 2025-07-23 at 17 42 38" src="https://github.com/user-attachments/assets/efc9d4ab-ff87-446e-8248-17688a419581" />

**[topics_policy parameter](https://zulip.com/api/update-stream#parameter-topics_policy) for creating and updating a channel**
<img width="755" height="588" alt="Screenshot 2025-07-23 at 17 29 22" src="https://github.com/user-attachments/assets/4d4cd508-7183-4cc5-8f72-3eb8b1b0854e" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
