### PR TITLE
left_sidebar: Attempt to correct selection-box cutoffs.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -206,14 +206,6 @@
     }
 }
 
-#left_sidebar_scroll_container {
-    outline: none;
-
-    .direct-messages-container {
-        margin-left: 0;
-    }
-}
-
 #hide-more-direct-messages,
 #direct-messages-section-header {
     grid-template-columns:

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -208,10 +208,6 @@
 
 #left_sidebar_scroll_container {
     outline: none;
-    overflow: hidden auto;
-    position: relative;
-    z-index: 0;
-    width: 100%;
 
     .direct-messages-container {
         margin-left: 0;


### PR DESCRIPTION
I have been unable to reproduce the error reported at [#issues > 🎯 "channels" selection box cut off](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20.22channels.22.20selection.20box.20cut.20off), but the some of the CSS removed in this PR may help with the situation.

Here is a breakdown of the removed lines' origins:

```
#left_sidebar_scroll_container {
    outline: none;           // Added originally in 6f9e97921d39e87637c654337c77daa809080c7b,
                             // though there is no reason that a <div> element would take an
                             // outline/focus to begin with.
    overflow: hidden auto;   // Added originally in d4e1f0a9a88d1da4e6f11d1603b3a313d4426bb9,
                             // as part of a clear-search button that has long since been 
                             // superseded; hiding the overflow-x here could very well be
                             // what makes the lefthand edge of the selection box to be
                             // cut off.
    position: relative;      // This is already set on the `[data-simplebar] selector that
                             // ships in SimpleBar's own CSS.
    z-index: 0;              // This was set in b837221e0577ccd1c146d4d069945f63ac39c61e,
                             // ostensibly to correct a 2016 WebKit bug. Removing it has
                             // no ill effect on Safari.
    width: 100%;             // This was set years ago to correct a zoom bug, but the <div>
                             // should already occupy the full width of the container. And
                             // setting a width here could also contribute to the cut-off
                             // box problem.

    .direct-messages-container { // I introduced this with some cleanup instructions in
                                 // 4e03209c7667a2253953327a2d1b07296f7ee58f, but there is
                                 // nothing else setting a `margin-left` value here of any
                                 // sort, so it should be safe to remove.
        margin-left: 0;
    }
}
```

May help fix: [#issues > 🎯 "channels" selection box cut off](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20.22channels.22.20selection.20box.20cut.20off)

| Before | After (no change) |
| --- | --- |
| <img width="2000" height="1600" alt="cutoff-css-removal-attempt-before" src="https://github.com/user-attachments/assets/6f34b863-6841-4e27-a198-802de935a347" /> | <img width="2000" height="1600" alt="cutoff-css-removal-attempt-after" src="https://github.com/user-attachments/assets/5078c922-05bb-4505-95bb-450a993fb0df" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>