### PR TITLE
docs and portico: Update contributor numbers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Zulip every day. Zulip is the only [modern team chat app][features] that is
 designed for both live and asynchronous conversations.
 
 Zulip is built by a distributed community of developers from all around the
-world, with 74+ people who have each contributed 100+ commits. With
-over 1000 contributors merging over 500 commits a month, Zulip is the
+world, with 97+ people who have each contributed 100+ commits. With
+over 1,500 contributors merging over 500 commits a month, Zulip is the
 largest and fastest growing open source team chat project.
 
 Come find us on the [development community chat](https://zulip.com/development-community/)!

--- a/templates/corporate/team.html
+++ b/templates/corporate/team.html
@@ -4,8 +4,8 @@
 {% set PAGE_TITLE = "The Zulip team" %}
 
 {% set PAGE_DESCRIPTION = "Zulip has the most active open-source
-development community of any team chat software, with over 1100 code
-contributors, and more than 75 with 100+ commits." %}
+development community of any team chat software, with over 1,500 code
+contributors, and 97+ people with 100+ commits." %}
 
 {% block portico_content %}
 
@@ -24,7 +24,7 @@ contributors, and more than 75 with 100+ commits." %}
         <div class="padded-content markdown">
             <div class="inner-content team">
                 <p>
-                    Over 1000 people have contributed to the Zulip
+                    Over 1,500 people have contributed to the Zulip
                     codebase, from high school students to 30 year
                     industry veterans, from people launching new careers
                     to people looking for community. Meet the team


### PR DESCRIPTION
Fixes #35350.

We've moved to using `,` in numbers over 1,000 in the blog post, so I did that here as well.