### PR TITLE
message_delete: Refactor message delete functions in a new file.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -140,6 +140,7 @@ EXEMPT_FILES = make_set(
         "web/src/local_message.ts",
         "web/src/localstorage.ts",
         "web/src/message_actions_popover.ts",
+        "web/src/message_delete.ts",
         "web/src/message_edit.ts",
         "web/src/message_edit_history.ts",
         "web/src/message_events.ts",

--- a/web/src/message_actions_popover.ts
+++ b/web/src/message_actions_popover.ts
@@ -9,6 +9,7 @@ import * as compose_reply from "./compose_reply.ts";
 import * as condense from "./condense.ts";
 import {show_copied_confirmation} from "./copied_tooltip.ts";
 import * as emoji_picker from "./emoji_picker.ts";
+import * as message_delete from "./message_delete.ts";
 import * as message_edit from "./message_edit.ts";
 import * as message_lists from "./message_lists.ts";
 import type {Message} from "./message_store.ts";
@@ -225,7 +226,7 @@ export function initialize({
 
             $popper.one("click", ".delete_message", (e) => {
                 const message_id = Number($(e.currentTarget).attr("data-message-id"));
-                message_edit.delete_message(message_id);
+                message_delete.delete_message(message_id);
                 e.preventDefault();
                 e.stopPropagation();
                 popover_menus.hide_current_popover_if_visible(instance);

--- a/web/src/message_delete.ts
+++ b/web/src/message_delete.ts
@@ -1,0 +1,158 @@
+import $ from "jquery";
+import assert from "minimalistic-assert";
+import * as z from "zod/mini";
+
+import render_delete_message_modal from "../templates/confirm_dialog/confirm_delete_message.hbs";
+
+import * as channel from "./channel.ts";
+import * as confirm_dialog from "./confirm_dialog.ts";
+import * as dialog_widget from "./dialog_widget.ts";
+import {$t_html} from "./i18n.ts";
+import type {Message} from "./message_store.ts";
+import * as people from "./people.ts";
+import * as settings_data from "./settings_data.ts";
+import {realm} from "./state_data.ts";
+import * as stream_data from "./stream_data.ts";
+import * as ui_report from "./ui_report.ts";
+
+let currently_deleting_messages: number[] = [];
+
+export function is_message_sent_by_my_bot(message: Message): boolean {
+    const user = people.get_by_user_id(message.sender_id);
+    if (!user.is_bot || user.bot_owner_id === null) {
+        // The message was not sent by a bot or the message was sent
+        // by a cross-realm bot which does not have an owner.
+        return false;
+    }
+
+    return people.is_my_user_id(user.bot_owner_id);
+}
+
+export function get_deletability(message: Message): boolean {
+    if (message.type === "stream" && stream_data.is_stream_archived(message.stream_id)) {
+        return false;
+    }
+    if (settings_data.user_can_delete_any_message()) {
+        return true;
+    }
+
+    if (message.type === "stream") {
+        const stream = stream_data.get_sub_by_id(message.stream_id);
+        assert(stream !== undefined);
+
+        const can_delete_any_message_in_channel =
+            settings_data.user_has_permission_for_group_setting(
+                stream.can_delete_any_message_group,
+                "can_delete_any_message_group",
+                "stream",
+            );
+        if (can_delete_any_message_in_channel) {
+            return true;
+        }
+    }
+
+    if (!message.sent_by_me && !is_message_sent_by_my_bot(message)) {
+        return false;
+    }
+    if (message.locally_echoed) {
+        return false;
+    }
+    if (!settings_data.user_can_delete_own_message()) {
+        if (message.type !== "stream") {
+            return false;
+        }
+
+        const stream = stream_data.get_sub_by_id(message.stream_id);
+        assert(stream !== undefined);
+
+        const can_delete_own_message_in_channel =
+            settings_data.user_has_permission_for_group_setting(
+                stream.can_delete_own_message_group,
+                "can_delete_own_message_group",
+                "stream",
+            );
+        if (!can_delete_own_message_in_channel) {
+            return false;
+        }
+    }
+
+    if (realm.realm_message_content_delete_limit_seconds === null) {
+        // This means no time limit for message deletion.
+        return true;
+    }
+
+    if (
+        realm.realm_message_content_delete_limit_seconds + (message.timestamp - Date.now() / 1000) >
+        0
+    ) {
+        return true;
+    }
+    return false;
+}
+
+export function delete_message(msg_id: number): void {
+    const html_body = render_delete_message_modal();
+
+    function do_delete_message(): void {
+        currently_deleting_messages.push(msg_id);
+        void channel.del({
+            url: "/json/messages/" + msg_id,
+            success() {
+                currently_deleting_messages = currently_deleting_messages.filter(
+                    (id) => id !== msg_id,
+                );
+                dialog_widget.hide_dialog_spinner();
+                dialog_widget.close();
+            },
+            error(xhr) {
+                currently_deleting_messages = currently_deleting_messages.filter(
+                    (id) => id !== msg_id,
+                );
+
+                dialog_widget.hide_dialog_spinner();
+                ui_report.error(
+                    $t_html({defaultMessage: "Error deleting message"}),
+                    xhr,
+                    $("#dialog_error"),
+                );
+            },
+        });
+    }
+
+    confirm_dialog.launch({
+        html_heading: $t_html({defaultMessage: "Delete message?"}),
+        html_body,
+        help_link: "/help/delete-a-message#delete-a-message-completely",
+        on_click: do_delete_message,
+        loading_spinner: true,
+    });
+}
+
+export function delete_topic(stream_id: number, topic_name: string, failures = 0): void {
+    void channel.post({
+        url: "/json/streams/" + stream_id + "/delete_topic",
+        data: {
+            topic_name,
+        },
+        success(data) {
+            const {complete} = z.object({complete: z.boolean()}).parse(data);
+            if (!complete) {
+                if (failures >= 9) {
+                    // Don't keep retrying indefinitely to avoid DoSing the server.
+                    return;
+                }
+
+                failures += 1;
+                /* When trying to delete a very large topic, it's
+                   possible for the request to the server to
+                   time out after making some progress. Retry the
+                   request, so that the user can just do nothing and
+                   watch the topic slowly be deleted.
+
+                   TODO: Show a nice loading indicator experience.
+                */
+                delete_topic(stream_id, topic_name, failures);
+            }
+        },
+    });
+}

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -9,6 +9,7 @@ import * as buddy_data from "./buddy_data.ts";
 import * as gear_menu_util from "./gear_menu_util.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
+import * as message_delete from "./message_delete.ts";
 import * as message_edit from "./message_edit.ts";
 import * as message_lists from "./message_lists.ts";
 import * as muted_users from "./muted_users.ts";
@@ -213,7 +214,7 @@ export function get_actions_popover_content_context(message_id: number): ActionP
 
     const conversation_time_url = hash_util.by_conversation_and_time_url(message);
 
-    const should_display_delete_option = message_edit.get_deletability(message);
+    const should_display_delete_option = message_delete.get_deletability(message);
     const should_display_read_receipts_option = realm.realm_enable_read_receipts && not_spectator;
     const should_display_remind_me_option = not_spectator;
 

--- a/web/src/topic_popover.ts
+++ b/web/src/topic_popover.ts
@@ -9,6 +9,7 @@ import * as clipboard_handler from "./clipboard_handler.ts";
 import * as confirm_dialog from "./confirm_dialog.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t_html} from "./i18n.ts";
+import * as message_delete from "./message_delete.ts";
 import * as message_edit from "./message_edit.ts";
 import * as message_summary from "./message_summary.ts";
 import * as popover_menus from "./popover_menus.ts";
@@ -166,7 +167,7 @@ export function initialize(): void {
                         help_link: "/help/delete-a-topic",
                         html_body,
                         on_click() {
-                            message_edit.delete_topic(stream_id, topic_name);
+                            message_delete.delete_topic(stream_id, topic_name);
                         },
                     });
 

--- a/web/tests/message_delete.test.cjs
+++ b/web/tests/message_delete.test.cjs
@@ -1,0 +1,219 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+const {page_params} = require("./lib/zpage_params.cjs");
+
+const message_delete = zrequire("message_delete");
+const stream_data = zrequire("stream_data");
+const people = zrequire("people");
+const {set_current_user, set_realm} = zrequire("state_data");
+const user_groups = zrequire("user_groups");
+
+mock_esm("../src/group_permission_settings", {
+    get_group_permission_setting_config() {
+        return {
+            allow_everyone_group: false,
+        };
+    },
+});
+
+const realm = {};
+set_realm(realm);
+const current_user = {};
+set_current_user(current_user);
+
+const me = {
+    email: "me@zulip.com",
+    full_name: "Current User",
+    user_id: 100,
+};
+
+const moderator = {
+    email: "moderator@zulip.com",
+    full_name: "Moderator",
+    user_id: 2,
+    is_moderator: true,
+};
+
+const admin = {
+    email: "admin@zulip.com",
+    full_name: "Admin",
+    user_id: 3,
+    is_admin: true,
+};
+// set up user data
+const admins_group = {
+    name: "Admins",
+    id: 1,
+    members: new Set([admin.user_id]),
+    is_system_group: true,
+    direct_subgroup_ids: new Set([]),
+};
+
+const moderators_group = {
+    name: "Moderators",
+    id: 2,
+    members: new Set([moderator.user_id]),
+    is_system_group: true,
+    direct_subgroup_ids: new Set([admins_group.id]),
+};
+
+const everyone_group = {
+    name: "Everyone",
+    id: 3,
+    members: new Set([me.user_id]),
+    is_system_group: true,
+    direct_subgroup_ids: new Set([moderators_group.id]),
+};
+
+const nobody_group = {
+    name: "Nobody",
+    id: 4,
+    members: new Set([]),
+    is_system_group: true,
+    direct_subgroup_ids: new Set([]),
+};
+user_groups.initialize({
+    realm_user_groups: [admins_group, moderators_group, everyone_group, nobody_group],
+});
+
+people.init();
+people.add_active_user(me);
+
+function initialize_and_override_current_user(user_id, override) {
+    people.initialize_current_user(user_id);
+    override(current_user, "user_id", user_id);
+}
+
+run_test("get_deletability", ({override}) => {
+    let message = {
+        sent_by_me: false,
+        locally_echoed: true,
+        sender_id: me.user_id,
+    };
+    people.add_active_user(moderator);
+    override(realm, "realm_can_delete_any_message_group", everyone_group.id);
+    override(realm, "realm_can_delete_own_message_group", nobody_group.id);
+    override(realm, "realm_message_content_delete_limit_seconds", null);
+    initialize_and_override_current_user(me.user_id, override);
+
+    // Spectators cannot delete messages
+    page_params.is_spectator = true;
+    assert.equal(message_delete.get_deletability(message), false);
+
+    page_params.is_spectator = false;
+
+    // User can delete any message
+    assert.equal(message_delete.get_deletability(message), true);
+
+    override(realm, "realm_can_delete_any_message_group", nobody_group.id);
+    // User can't delete message sent by others
+    assert.equal(message_delete.get_deletability(message), false);
+
+    // Locally echoed messages are not deletable
+    message.sent_by_me = true;
+    assert.equal(message_delete.get_deletability(message), false);
+
+    message.locally_echoed = false;
+    assert.equal(message_delete.get_deletability(message), false);
+
+    override(realm, "realm_can_delete_own_message_group", everyone_group.id);
+    assert.equal(message_delete.get_deletability(message), true);
+
+    message.sent_by_me = false;
+    assert.equal(message_delete.get_deletability(message), false);
+    message.sent_by_me = true;
+
+    const now = new Date();
+    const current_timestamp = now / 1000;
+    message.timestamp = current_timestamp - 5;
+
+    // Time limit not exceeded
+    override(realm, "realm_message_content_delete_limit_seconds", 10);
+    assert.equal(message_delete.get_deletability(message), true);
+
+    // Time limit exceeded, so user cannot delete messaeges now
+    message.timestamp = current_timestamp - 60;
+    assert.equal(message_delete.get_deletability(message), false);
+
+    initialize_and_override_current_user(admin.user_id, override);
+    assert.equal(message_delete.get_deletability(message), false);
+    // Time limit doesn't apply to users who can delete any message
+    override(realm, "realm_can_delete_any_message_group", admins_group.id);
+    assert.equal(message_delete.get_deletability(message), true);
+
+    message.sent_by_me = false;
+    override(realm, "realm_message_content_delete_limit_seconds", null);
+
+    assert.equal(message_delete.get_deletability(message), true);
+
+    initialize_and_override_current_user(moderator.user_id, override);
+    assert.equal(message_delete.get_deletability(message), false);
+
+    // Test per-channel delete permission for deleting any message in the channel.
+    const social = {
+        subscribed: true,
+        color: "red",
+        name: "social",
+        stream_id: 2,
+        can_delete_any_message_group: moderators_group.id,
+        can_delete_own_message_group: moderators_group.id,
+    };
+    const denmark = {
+        subscribed: true,
+        color: "red",
+        name: "denmark",
+        stream_id: 3,
+        can_delete_any_message_group: nobody_group.id,
+        can_delete_own_message_group: moderators_group.id,
+    };
+    stream_data.add_sub(social);
+    stream_data.add_sub(denmark);
+
+    message = {
+        locally_echoed: true,
+        type: "stream",
+        stream_id: social.stream_id,
+    };
+    people.add_active_user(moderator);
+    override(realm, "realm_can_delete_any_message_group", nobody_group.id);
+    override(realm, "realm_can_delete_own_message_group", nobody_group.id);
+
+    message.sender_id = moderator.user_id;
+    initialize_and_override_current_user(moderator.user_id, override);
+    assert.equal(message_delete.get_deletability(message), true);
+
+    message.sender_id = me.user_id;
+    initialize_and_override_current_user(me.user_id, override);
+    assert.equal(message_delete.get_deletability(message), false);
+
+    message.stream_id = denmark.stream_id;
+    assert.equal(message_delete.get_deletability(message), false);
+
+    message.sender_id = moderator.user_id;
+    initialize_and_override_current_user(moderator.user_id, override);
+    assert.equal(message_delete.get_deletability(message), false);
+
+    // Test per-channel delete permissions for deleting own messages.
+    message.stream_id = social.stream_id;
+
+    message.sender_id = moderator.user_id;
+    initialize_and_override_current_user(moderator.user_id, override);
+    assert.equal(message_delete.get_deletability(message), true);
+
+    message.sender_id = me.user_id;
+    initialize_and_override_current_user(me.user_id, override);
+    assert.equal(message_delete.get_deletability(message), false);
+
+    message.stream_id = denmark.stream_id;
+    assert.equal(message_delete.get_deletability(message), false);
+
+    initialize_and_override_current_user(moderator.user_id, override);
+    assert.equal(message_delete.get_deletability(message), false);
+
+    message.sender_id = moderator.user_id;
+    assert.equal(message_delete.get_deletability(message), false);
+});

--- a/web/tests/message_edit.test.cjs
+++ b/web/tests/message_edit.test.cjs
@@ -4,15 +4,12 @@ const assert = require("node:assert/strict");
 
 const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
-const {page_params} = require("./lib/zpage_params.cjs");
 
 const message_edit = zrequire("message_edit");
-const people = zrequire("people");
 const {set_current_user, set_realm} = zrequire("state_data");
 
 const is_content_editable = message_edit.is_content_editable;
 
-const settings_data = mock_esm("../src/settings_data");
 const stream_data = mock_esm("../src/stream_data");
 
 const realm = {};
@@ -187,85 +184,6 @@ run_test("is_stream_editable", ({override}) => {
 
     override(current_user, "is_moderator", true);
     assert.equal(message_edit.is_stream_editable(message), true);
-});
-
-run_test("get_deletability", ({override}) => {
-    override(current_user, "is_admin", true);
-    override(settings_data, "user_can_delete_any_message", () => true);
-    override(settings_data, "user_can_delete_own_message", () => false);
-    override(realm, "realm_message_content_delete_limit_seconds", null);
-    const test_user = {
-        user_id: 1,
-        full_name: "Test user",
-        email: "test@zulip.com",
-    };
-    people.add_active_user(test_user);
-
-    const bot_user = {
-        user_id: 2,
-        is_bot: true,
-        full_name: "Test bot user",
-        email: "test-bot@zulip.com",
-        bot_owner_id: 1,
-    };
-    people.add_active_user(bot_user);
-
-    const message = {
-        sent_by_me: false,
-        locally_echoed: true,
-        sender_id: 1,
-    };
-
-    page_params.is_spectator = false;
-
-    // User can delete any message
-    assert.equal(message_edit.get_deletability(message), true);
-
-    override(settings_data, "user_can_delete_any_message", () => false);
-    // User can't delete message sent by others
-    assert.equal(message_edit.get_deletability(message), false);
-
-    // Locally echoed messages are not deletable
-    message.sent_by_me = true;
-    assert.equal(message_edit.get_deletability(message), false);
-
-    message.locally_echoed = false;
-    assert.equal(message_edit.get_deletability(message), false);
-
-    override(settings_data, "user_can_delete_own_message", () => true);
-    assert.equal(message_edit.get_deletability(message), true);
-
-    message.sent_by_me = false;
-    assert.equal(message_edit.get_deletability(message), false);
-    message.sent_by_me = true;
-
-    let now = new Date();
-    let current_timestamp = now / 1000;
-    message.timestamp = current_timestamp - 5;
-
-    override(realm, "realm_message_content_delete_limit_seconds", 10);
-    assert.equal(message_edit.get_deletability(message), true);
-
-    message.timestamp = current_timestamp - 60;
-    assert.equal(message_edit.get_deletability(message), false);
-
-    message.sender_id = 2;
-    message.sent_by_me = false;
-    people.initialize_current_user(test_user.user_id);
-    override(realm, "realm_message_content_delete_limit_seconds", null);
-
-    override(settings_data, "user_can_delete_own_message", () => true);
-    assert.equal(message_edit.get_deletability(message), true);
-
-    override(settings_data, "user_can_delete_own_message", () => false);
-    assert.equal(message_edit.get_deletability(message), false);
-
-    now = new Date();
-    current_timestamp = now / 1000;
-    override(realm, "realm_message_content_delete_limit_seconds", 10);
-    message.timestamp = current_timestamp - 60;
-    override(settings_data, "user_can_delete_own_message", () => true);
-    assert.equal(message_edit.get_deletability(message), false);
 });
 
 run_test("stream_and_topic_exist_in_edit_history", () => {

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -15,7 +15,6 @@ const color_data = zrequire("color_data");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const sub_store = zrequire("sub_store");
-const message_edit = zrequire("message_edit");
 const stream_data = zrequire("stream_data");
 const hash_util = zrequire("hash_util");
 const {set_current_user, set_realm} = zrequire("state_data");
@@ -55,12 +54,6 @@ const test_user = {
 const admin_user_id = 1;
 const moderator_user_id = 2;
 
-const moderator = {
-    email: "moderator@zulip.com",
-    full_name: "Moderator",
-    user_id: moderator_user_id,
-    is_moderator: true,
-};
 // set up user data
 const admins_group = {
     name: "Admins",
@@ -2278,70 +2271,4 @@ run_test("is_empty_topic_only_channel", ({override}) => {
     override(current_user, "is_admin", true);
     assert.equal(stream_data.is_empty_topic_only_channel(social.stream_id), true);
     assert.equal(stream_data.is_empty_topic_only_channel(scotland.stream_id), false);
-});
-
-run_test("get_deletability", ({override}) => {
-    const social = {
-        subscribed: true,
-        color: "red",
-        name: "social",
-        stream_id: 2,
-        can_delete_any_message_group: moderators_group.id,
-        can_delete_own_message_group: moderators_group.id,
-    };
-    const denmark = {
-        subscribed: true,
-        color: "red",
-        name: "denmark",
-        stream_id: 3,
-        can_delete_any_message_group: nobody_group.id,
-        can_delete_own_message_group: moderators_group.id,
-    };
-    stream_data.add_sub(social);
-    stream_data.add_sub(denmark);
-
-    const message = {
-        locally_echoed: true,
-        type: "stream",
-        stream_id: social.stream_id,
-    };
-    people.add_active_user(moderator);
-    override(realm, "realm_can_delete_any_message_group", nobody_group.id);
-    override(realm, "realm_can_delete_own_message_group", nobody_group.id);
-
-    // Test per-channel delete permission for deleting any message in the channel.
-    message.sender_id = moderator_user_id;
-    initialize_and_override_current_user(moderator_user_id, override);
-    assert.equal(message_edit.get_deletability(message), true);
-
-    message.sender_id = me.user_id;
-    initialize_and_override_current_user(me.user_id, override);
-    assert.equal(message_edit.get_deletability(message), false);
-
-    message.stream_id = denmark.stream_id;
-    assert.equal(message_edit.get_deletability(message), false);
-
-    message.sender_id = moderator_user_id;
-    initialize_and_override_current_user(moderator_user_id, override);
-    assert.equal(message_edit.get_deletability(message), false);
-
-    // Test per-channel delete permissions for deleting own messages.
-    message.stream_id = social.stream_id;
-
-    message.sender_id = moderator_user_id;
-    initialize_and_override_current_user(moderator_user_id, override);
-    assert.equal(message_edit.get_deletability(message), true);
-
-    message.sender_id = me.user_id;
-    initialize_and_override_current_user(me.user_id, override);
-    assert.equal(message_edit.get_deletability(message), false);
-
-    message.stream_id = denmark.stream_id;
-    assert.equal(message_edit.get_deletability(message), false);
-
-    initialize_and_override_current_user(moderator_user_id, override);
-    assert.equal(message_edit.get_deletability(message), false);
-
-    message.sender_id = moderator_user_id;
-    assert.equal(message_edit.get_deletability(message), false);
 });


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Extracts message delete function in a new file `message_delete.ts`.

Follow-up for https://github.com/zulip/zulip/pull/35045#discussion_r2207446204.
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
