### PR TITLE
message_edit: Improve how message move/edit history is displayed.

### DIFF
--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -200,6 +200,9 @@ IGNORED_PHRASES = [
     r"strikethrough",
     r"support team",
     r"topic name",
+    # Used in message edit history overlay.
+    r"<z-link></z-link> was marked as resolved",
+    r"<z-link></z-link> was marked as unresolved",
 ]
 
 # Sort regexes in descending order of their lengths. As a result, the

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -7,6 +7,7 @@ import render_message_history_overlay from "../templates/message_history_overlay
 
 import {exit_overlay} from "./browser_history.ts";
 import * as channel from "./channel.ts";
+import {by_stream_topic_url} from "./hash_util.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as loading from "./loading.ts";
 import * as message_lists from "./message_lists.ts";
@@ -16,12 +17,13 @@ import * as overlays from "./overlays.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as rendered_markdown from "./rendered_markdown.ts";
+import {is_resolved} from "./resolved_topic.ts";
 import * as rows from "./rows.ts";
 import {message_edit_history_visibility_policy_values} from "./settings_config.ts";
 import * as spectators from "./spectators.ts";
 import {realm} from "./state_data.ts";
 import {get_recipient_bar_color} from "./stream_color.ts";
-import {get_color} from "./stream_data.ts";
+import {get_color, get_sub_by_id} from "./stream_data.ts";
 import * as sub_store from "./sub_store.ts";
 import * as timerender from "./timerender.ts";
 import * as ui_report from "./ui_report.ts";
@@ -44,6 +46,9 @@ type EditHistoryEntry = {
     prev_stream: string | undefined;
     prev_stream_id: number | undefined;
     new_stream: string | undefined;
+    prev_stream_topic_url: string | undefined;
+    new_stream_topic_url: string | undefined;
+    topic_resolved_or_unresolved: "resolved" | "unresolved" | "none";
 };
 
 const server_message_history_schema = z.object({
@@ -171,6 +176,10 @@ export function fetch_and_render_message_history(message: Message): void {
                 let prev_stream;
                 let prev_stream_id;
                 let initial_entry_for_move_history = false;
+                let prev_stream_topic_url;
+                let new_stream_topic_url;
+                let new_stream;
+                let topic_resolved_or_unresolved: "resolved" | "unresolved" | "none" = "none";
 
                 if (index === 0) {
                     edited_by_notice = $t({defaultMessage: "Posted by {full_name}"}, {full_name});
@@ -191,6 +200,12 @@ export function fetch_and_render_message_history(message: Message): void {
                     new_topic_display_name = util.get_final_topic_display_name(msg.topic);
                     is_empty_string_prev_topic = msg.prev_topic === "";
                     is_empty_string_new_topic = msg.topic === "";
+                    assert("stream_id" in message);
+                    const stream_id = message.stream_id;
+                    new_stream = get_sub_by_id(stream_id)?.name;
+                    prev_stream = new_stream;
+                    prev_stream_topic_url = by_stream_topic_url(stream_id, msg.prev_topic);
+                    new_stream_topic_url = by_stream_topic_url(stream_id, msg.topic);
                 } else if (msg.prev_topic !== undefined && msg.prev_stream) {
                     edited_by_notice = $t({defaultMessage: "Moved by {full_name}"}, {full_name});
                     topic_edited = true;
@@ -204,6 +219,12 @@ export function fetch_and_render_message_history(message: Message): void {
                     if (prev_stream_item !== null) {
                         prev_stream_item.new_stream = get_display_stream_name(msg.prev_stream);
                     }
+                    prev_stream_topic_url = by_stream_topic_url(prev_stream_id, msg.prev_topic);
+                    assert("stream_id" in message);
+                    const new_stream_id = msg.stream;
+                    assert(new_stream_id !== undefined);
+                    new_stream = get_sub_by_id(new_stream_id)?.name;
+                    new_stream_topic_url = by_stream_topic_url(new_stream_id, msg.topic);
                 } else if (msg.prev_topic !== undefined) {
                     edited_by_notice = $t({defaultMessage: "Moved by {full_name}"}, {full_name});
                     topic_edited = true;
@@ -211,6 +232,27 @@ export function fetch_and_render_message_history(message: Message): void {
                     new_topic_display_name = util.get_final_topic_display_name(msg.topic);
                     is_empty_string_prev_topic = msg.prev_topic === "";
                     is_empty_string_new_topic = msg.topic === "";
+                    assert("stream_id" in message);
+                    const stream_id = message.stream_id;
+                    new_stream = get_sub_by_id(stream_id)?.name;
+                    prev_stream = new_stream;
+                    prev_stream_topic_url = by_stream_topic_url(stream_id, msg.prev_topic);
+                    new_stream_topic_url = by_stream_topic_url(stream_id, msg.topic);
+                    if (is_resolved(msg.topic) || is_resolved(msg.prev_topic)) {
+                        if (is_resolved(msg.topic) && msg.topic.slice(2) === msg.prev_topic) {
+                            topic_resolved_or_unresolved = "resolved";
+                            edited_by_notice = $t(
+                                {defaultMessage: "Topic resolved by {full_name}"},
+                                {full_name},
+                            );
+                        } else {
+                            edited_by_notice = $t(
+                                {defaultMessage: "Topic unresolved by {full_name}"},
+                                {full_name},
+                            );
+                            topic_resolved_or_unresolved = "unresolved";
+                        }
+                    }
                 } else if (msg.prev_stream) {
                     edited_by_notice = $t({defaultMessage: "Moved by {full_name}"}, {full_name});
                     stream_changed = true;
@@ -219,6 +261,16 @@ export function fetch_and_render_message_history(message: Message): void {
                     if (prev_stream_item !== null) {
                         prev_stream_item.new_stream = get_display_stream_name(msg.prev_stream);
                     }
+                    is_empty_string_prev_topic = msg.topic === "";
+                    is_empty_string_new_topic = msg.topic === "";
+                    assert("stream_id" in message);
+                    const new_stream_id = msg.stream;
+                    assert(new_stream_id !== undefined);
+                    new_stream = get_sub_by_id(new_stream_id)?.name;
+                    new_stream_topic_url = by_stream_topic_url(new_stream_id, msg.topic);
+                    prev_topic_display_name = util.get_final_topic_display_name(msg.topic);
+                    new_topic_display_name = util.get_final_topic_display_name(msg.topic);
+                    prev_stream_topic_url = by_stream_topic_url(prev_stream_id, msg.topic);
                 } else {
                     // just a content edit
                     edited_by_notice = $t({defaultMessage: "Edited by {full_name}"}, {full_name});
@@ -240,7 +292,10 @@ export function fetch_and_render_message_history(message: Message): void {
                     stream_changed,
                     prev_stream,
                     prev_stream_id,
-                    new_stream: undefined,
+                    new_stream,
+                    prev_stream_topic_url,
+                    new_stream_topic_url,
+                    topic_resolved_or_unresolved,
                 };
 
                 if (msg.prev_stream) {

--- a/web/templates/message_edit_history.hbs
+++ b/web/templates/message_edit_history.hbs
@@ -35,19 +35,51 @@
                             </p>
                         </div>
                         {{else}}
-                        {{#if stream_changed}}
+                        {{#if (or stream_changed topic_edited)}}
                         <div class="message_content message_edit_history_content">
-                            <p>{{t "Channel" }}: <span class="highlight_text_inserted">{{ new_stream }}</span>
-                                <span class="highlight_text_deleted">{{ prev_stream }}</span>
-                            </p>
-                        </div>
-                        {{/if}}
-                        {{#if topic_edited}}
-                        <div class="message_content message_edit_history_content">
-                            <p>{{t "Topic" }}:
-                                <span class="highlight_text_inserted {{#if is_empty_string_new_topic}}empty-topic-display{{/if}}">{{ new_topic_display_name }}</span>
-                                <span class="highlight_text_deleted {{#if is_empty_string_prev_topic}}empty-topic-display{{/if}}">{{ prev_topic_display_name }}</span>
-                            </p>
+                            {{#if (eq topic_resolved_or_unresolved "none")}}
+                            {{#tr}}
+                                Message moved from <prev-link></prev-link> to <new-link></new-link>.
+                                {{#*inline "prev-link"~}}
+                                    <a class="white-space-preserve-wrap" href="{{prev_stream_topic_url}}">
+                                        {{~!-- squash whitespace --~}}
+                                        #{{prev_stream}} &gt; <span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{prev_topic_display_name}}</span>
+                                        {{~!-- squash whitespace --~}}
+                                    </a>
+                                {{~/inline}}
+                                {{#*inline "new-link"~}}
+                                    <a class="white-space-preserve-wrap" href="{{new_stream_topic_url}}">
+                                        {{~!-- squash whitespace --~}}
+                                        #{{new_stream}} &gt; <span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{new_topic_display_name}}</span>
+                                        {{~!-- squash whitespace --~}}
+                                    </a>
+                                {{~/inline}}
+                            {{/tr}}
+                            {{else}}
+                            {{#if (eq topic_resolved_or_unresolved "resolved")}}
+                                {{#tr}}
+                                    <z-link></z-link> was marked as resolved.
+                                    {{#*inline "z-link"~}}
+                                        <a class="white-space-preserve-wrap" href="{{prev_stream_topic_url}}">
+                                            {{~!-- squash whitespace --~}}
+                                            #{{prev_stream}} &gt; <span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{prev_topic_display_name}}</span>
+                                            {{~!-- squash whitespace --~}}
+                                        </a>
+                                    {{~/inline}}
+                                {{/tr}}
+                            {{else}}
+                                {{#tr}}
+                                    <z-link></z-link> was marked as unresolved.
+                                    {{#*inline "z-link"~}}
+                                        <a class="white-space-preserve-wrap" href="{{prev_stream_topic_url}}">
+                                            {{~!-- squash whitespace --~}}
+                                            #{{prev_stream}} &gt; <span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{prev_topic_display_name}}</span>
+                                            {{~!-- squash whitespace --~}}
+                                        </a>
+                                    {{~/inline}}
+                                {{/tr}}
+                            {{/if}}
+                            {{/if}}
                         </div>
                         {{/if}}
                         {{#if body_to_render}}


### PR DESCRIPTION
This PR makes changes to message edit history modal. The changes are as follows:

> - [ ] For message moves, make the content of the message:  
>   > Moved from [#channel > topic](https://github.com/zulip/zulip/issues/34006) to [#channel > topic](https://github.com/zulip/zulip/issues/34006).  
>
>   This is regardless of whether the channel, topic, or both are changed.  
>
> - [ ] For moves that are just resolving/unresolving a topic, make it:  
>   > Header: "Topic {resolved/unresolved} by {user}"  
>   > Content: "[#channel > topic](https://github.com/zulip/zulip/issues/34006) was marked as {resolved/unresolved}."
>

<!-- Describe your pull request here.-->

Fixes: #34006.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Screenshots and screen captures</summary>

- Only topic changed:  
<img width="1130" height="389" alt="image" src="https://github.com/user-attachments/assets/f17b76fa-be20-40a1-8adf-20c8a5f7ecb0" />

- Only channel changed:  
<img width="1129" height="387" alt="image" src="https://github.com/user-attachments/assets/62e9471f-4ca0-42c3-958e-b743f01ac2fa" />

- Both channel and topic changed:  
<img width="1129" height="397" alt="image" src="https://github.com/user-attachments/assets/a0991b48-9433-425b-8e8b-fa65a60a79ce" />

- Resolving a topic:  
<img width="1086" height="151" alt="image" src="https://github.com/user-attachments/assets/007edeb8-1eff-4289-b6f0-a2d999f26297" />

- Unresolving a topic:  
<img width="1130" height="151" alt="image" src="https://github.com/user-attachments/assets/a6a73679-de01-4333-a3b6-00a6333a6cdd" />

</details>




---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
