### PR TITLE
recent_view: Correct a Safari bug with line-clamping.

### DIFF
--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -491,6 +491,18 @@
             -webkit-box-orient: vertical;
             overflow: hidden;
         }
+
+        /* We don't want to apply line clamping to 1:1 DMs,
+           as that causes an odd problem with Safari collapsing
+           the grid on .user-status-microlayout so that usernames
+           always have an ellipsis--no matter how short they are,
+           nor how much space is available in the Topic column.
+
+           `display: inherit` here will set the value to what is
+           already established on .recent_view_focusable. */
+        .line_clamp:has(.recent-view-dm) {
+            display: inherit;
+        }
     }
 
     & thead .last_msg_time_header {

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -32,7 +32,7 @@
         <div class="flex_container">
             <div class="left_part recent_view_focusable line_clamp" data-col-index="{{ column_indexes.topic }}">
                 {{#if is_private}}
-                <a href="{{pm_url}}" class="recent-view-table-link {{#if is_group}}recent-view-dm-group{{/if}}">{{{rendered_pm_with}}}</a>
+                <a href="{{pm_url}}" class="recent-view-table-link {{#if is_group}}recent-view-dm-group{{else}}recent-view-dm{{/if}}">{{{rendered_pm_with}}}</a>
                 {{else}}
                 <a class="white-space-preserve-wrap recent-view-table-link {{#if is_empty_string_topic}}empty-topic-display{{/if}}" href="{{topic_url}}">{{topic_display_name}}</a>
                 {{/if}}


### PR DESCRIPTION
This PR fixes an odd and ironic bug (given that line-clamping is a WebKit-native thing) where Safari always incorrectly applies an ellipsis to usernames in 1:1 DM rows, no matter the length of the username or the amount of space available in the Topics column to display it.

[#issues > Safari truncates 1:1 DM usernames in recents](https://chat.zulip.org/#narrow/channel/9-issues/topic/Safari.20truncates.201.3A1.20DM.20usernames.20in.20recents)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Safari:_

| Before | After |
| --- | --- |
| <img width="2694" height="2016" alt="safari-recent-widest-before" src="https://github.com/user-attachments/assets/01c86968-1b7c-4e9a-a316-c5ec26249896" /> | <img width="2694" height="2016" alt="safari-recent-widest-after" src="https://github.com/user-attachments/assets/2467654b-d7b4-4d85-9b26-0053d0769c6e" /> |
| <img width="1148" height="2016" alt="safari-recent-wider-before" src="https://github.com/user-attachments/assets/1d54e6af-81e6-4921-b5c4-b3cbcae5b62f" /> | <img width="1148" height="2016" alt="safari-recent-wider-after" src="https://github.com/user-attachments/assets/6cd0aa81-e079-4c6f-b35a-ce8911259e16" /> |
| <img width="1572" height="2016" alt="safari-recent-narrow-before" src="https://github.com/user-attachments/assets/8ad0c803-64c3-442a-8e77-c6a4abdd9c5c" /> | <img width="1572" height="2016" alt="safari-recent-narrow-after" src="https://github.com/user-attachments/assets/889b2f1d-d746-48e2-a9e6-527dec6fcdbb" /> |

_Firefox (no change; Chrome is likewise unaffected, but I have not provided screenshots here):_

| Before | After |
| --- | --- |
| <img width="1400" height="1200" alt="firefox-recent-wider-before" src="https://github.com/user-attachments/assets/ffee5944-cefe-4d1e-a81e-dca33a57a014" /> | <img width="1400" height="1200" alt="firefox-recent-wider-after-no-change" src="https://github.com/user-attachments/assets/ced6df7c-adf4-4ffe-931e-9a5bd5e83a68" /> |
| <img width="732" height="1200" alt="firefox-recent-narrow-before" src="https://github.com/user-attachments/assets/d1c154c9-e718-43af-9a45-b754ee689640" /> | <img width="732" height="1200" alt="firefox-recent-narrow-after-no-change" src="https://github.com/user-attachments/assets/6d04aa43-8c66-4041-8ea5-abc6b4e8af98" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>