### PR TITLE
leflt_sidebar: Topic filter-input fixes.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1081,7 +1081,7 @@ li.top_left_scheduled_messages {
 
         .input {
             white-space: nowrap;
-            overflow-x: hidden;
+            overflow: hidden;
             text-overflow: ellipsis;
         }
     }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1082,6 +1082,13 @@ li.top_left_scheduled_messages {
         .input {
             white-space: nowrap;
             overflow: hidden;
+        }
+
+        /* We only establish the ellipsis when
+           the input is not focused, thanks to a
+           Safari bug that makes long inputs
+           unreachable and unscrollable. */
+        .input:not(:focus) {
             text-overflow: ellipsis;
         }
     }


### PR DESCRIPTION
This PR corrects a couple of issues with the left sidebar filter inputs:

* It hides a scroll artifact that may be visible on operating systems like macOS when "always show scrollbars" or similar is selected.
* It corrects for an annoying ellipsis bug in Safari that makes it impossible to see or scroll to the end of long inputs.

[#issues > left-sidebar topic input issues](https://chat.zulip.org/#narrow/channel/9-issues/topic/left-sidebar.20topic.20input.20issues)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Scroll artifacts:_

| Before | After |
| --- | --- |
| <img width="640" height="250" alt="scroll-artifact-before" src="https://github.com/user-attachments/assets/ee67e4f8-197d-452a-9d19-66abc4db18b3" /> | <img width="640" height="250" alt="scroll-artifact-after" src="https://github.com/user-attachments/assets/78efb894-3df1-4971-9d5f-9ac469dce5a5" /> |

_Focus and blur states as of this PR:_

| Firefox, focus | Firefox, blur |
| --- | --- |
| <img width="640" height="250" alt="firefox-input-focus" src="https://github.com/user-attachments/assets/42eab303-12ef-4c05-b45d-4e8453d768f2" /> | <img width="640" height="250" alt="firefox-input-blur" src="https://github.com/user-attachments/assets/1eb85ba1-e803-479c-8c56-15b3eabf8a53" /> |

| Safari, focus | Safari, blur |
| --- | --- |
| <img width="640" height="250" alt="safari-input-focus" src="https://github.com/user-attachments/assets/c76da868-9d01-4a12-b2e6-eb3bab71040a" /> | <img width="640" height="250" alt="safari-input-blur" src="https://github.com/user-attachments/assets/68791df0-78b3-4f44-bcec-099891cdf575" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>