### PR TITLE
help-beta: Make icon + Keyboard Tip: a prefix instead of header.

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -313,6 +313,7 @@ export default tseslint.config(
         files: [
             "help-beta/src/components/ZulipNote.astro",
             "help-beta/src/components/ZulipTip.astro",
+            "help-beta/src/components/KeyboardTip.astro",
         ],
         rules: {
             "import/unambiguous": "off",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -310,9 +310,13 @@ export default tseslint.config(
     },
     ...astroConfigs.recommended,
     {
-        files: ["help-beta/src/components/ZulipNote.astro"],
+        files: [
+            "help-beta/src/components/ZulipNote.astro",
+            "help-beta/src/components/ZulipTip.astro",
+        ],
         rules: {
             "import/unambiguous": "off",
+            "@typescript-eslint/consistent-type-assertions": "off",
         },
     },
 );

--- a/help-beta/src/components/KeyboardTip.astro
+++ b/help-beta/src/components/KeyboardTip.astro
@@ -1,29 +1,47 @@
 ---
-/* eslint-disable-next-line import/extensions */
-import ZulipIconsKeyboard from "~icons/zulip-icon/keyboard";
+import assert from "node:assert/strict";
 
-let {title} = Astro.props;
-if (!title) {
-    title = "Keyboard Shortcut";
-}
+import type {Element} from "hast";
+import {fromHtml} from "hast-util-from-html";
+import {toHtml} from "hast-util-to-html";
+
+import keyboard_svg from "../../../web/shared/icons/keyboard.svg?raw";
+
+const keyboard_icon_fragment = fromHtml(keyboard_svg, {fragment: true});
+const keyboard_icon_first_child = keyboard_icon_fragment.children[0]!;
+assert.ok(
+    keyboard_icon_first_child.type === "element" &&
+        keyboard_icon_first_child.tagName === "svg",
+);
+keyboard_icon_first_child.properties.class = "zulip-unplugin-icon";
+
+const prefix_element_list = [
+    keyboard_icon_first_child,
+    {
+        type: "element",
+        tagName: "strong",
+        properties: {},
+        children: [
+            {
+                type: "text",
+                // Whitespace before the text to ensure space between
+                // this text and the preceding icon.
+                value: " Keyboard tip: ",
+            },
+        ],
+    } as Element,
+];
+
+const tree = fromHtml(await Astro.slots.render("default"), {fragment: true});
+const first_element = tree.children[0];
+assert.ok(first_element?.type === "element");
+
+first_element.children = [...prefix_element_list, ...first_element.children];
+tree.children[0] = first_element;
 ---
 
-<!--
-We have an open PR to the upstream starlight repository to add support
-for custom icons in the Aside starlight component. The PR is stalled
-due to dependency on some of the custom icons work being done on 
-starlight. We should replace the code below with the Aside starlight
-component along with a custom icon (keyboard in out case).
-Link: https://github.com/withastro/starlight/pull/2261
--->
-<aside aria-label={title} class={`starlight-aside starlight-aside--tip`}>
-    <p class="starlight-aside__title" aria-hidden="true">
-        <ZulipIconsKeyboard
-            fill="currentColor"
-            class="starlight-aside__icon"
-        />{title}
-    </p>
+<aside aria-label="Keyboard tip" class=`starlight-aside starlight-aside--tip`>
     <div class="starlight-aside__content">
-        <slot />
+        <Fragment set:html={toHtml(tree)} />
     </div>
 </aside>


### PR DESCRIPTION
Commit 1 fixes failing tests on existing main.

Commit 2:
We do not want icon + `Keyboard Tip:` to occupy it's own row. Our approach for this component and most of the logic is similar to ZulipTip. We prefer having separate components for note, tip and keyboard tip, that is why we have duplicated code between ZulipTip and KeyboardTip, we should think about having a single underlying component for both to avoid duplication in the future.

We do not have any cases of non paragraph content in keyboard tip, so we have removed that chunk of code when copying over logic from ZulipTip.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="772" height="131" alt="Screenshot 2025-07-25 at 1 39 14 AM" src="https://github.com/user-attachments/assets/48975c6d-89ae-4e71-b620-783e555caf7c" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
