### PR TITLE
Save messages as drafts when window loses focus

### DIFF
--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -18,6 +18,7 @@ import * as compose_state from "./compose_state.ts";
 import * as compose_ui from "./compose_ui.ts";
 import * as compose_validate from "./compose_validate.ts";
 import * as dialog_widget from "./dialog_widget.ts";
+import * as drafts from "./drafts.ts";
 import * as flatpickr from "./flatpickr.ts";
 import {$t_html} from "./i18n.ts";
 import * as message_edit from "./message_edit.ts";
@@ -624,6 +625,12 @@ export function initialize() {
         // has done something that requires keeping attention called
         // to the recipient row
         compose_recipient.set_high_attention_recipient_row();
+    });
+
+    $(window).on("blur", () => {
+        // Save drafts when the window loses focus to help
+        // ensure no work is lost
+        drafts.update_draft();
     });
 
     $("body").on("click", ".formatting_button", function (e) {

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -156,11 +156,16 @@ function initialize_handlers({override}) {
     override(realm, "realm_available_video_chat_providers", {disabled: {id: 0}});
     override(realm, "realm_video_chat_provider", 0);
     override(resize, "watch_manual_resize", noop);
+    disable_window_triggers(override);
     compose_setup.initialize();
 }
 
 function disable_document_triggers(override) {
     override(document, "to_$", () => $("document-stub"));
+}
+
+function disable_window_triggers(override) {
+    override(window, "to_$", () => $("window-stub"));
 }
 
 function on_compose_finished_trigger_do(f) {
@@ -543,6 +548,8 @@ test_ui("finish", ({override, override_rewire}) => {
 });
 
 test_ui("initialize", ({override}) => {
+    disable_window_triggers(override);
+
     let compose_actions_expected_opts;
     let compose_actions_start_checked;
 

--- a/web/tests/compose_video.test.cjs
+++ b/web/tests/compose_video.test.cjs
@@ -78,6 +78,7 @@ function test(label, f) {
 
 test("videos", ({override}) => {
     override(realm, "realm_video_chat_provider", realm_available_video_chat_providers.disabled.id);
+    override(window, "to_$", () => $("window-stub"));
 
     stub_out_video_calls();
 
@@ -280,6 +281,7 @@ test("videos", ({override}) => {
 
 test("test_video_chat_button_toggle disabled", ({override}) => {
     override(realm, "realm_video_chat_provider", realm_available_video_chat_providers.disabled.id);
+    override(window, "to_$", () => $("window-stub"));
     compose_setup.initialize();
     assert.equal($(".compose-control-buttons-container .video_link").visible(), false);
 });
@@ -290,6 +292,7 @@ test("test_video_chat_button_toggle no url", ({override}) => {
         "realm_video_chat_provider",
         realm_available_video_chat_providers.jitsi_meet.id,
     );
+    override(window, "to_$", () => $("window-stub"));
     page_params.jitsi_server_url = null;
     compose_setup.initialize();
     assert.equal($(".compose-control-buttons-container .video_link").visible(), false);
@@ -302,6 +305,7 @@ test("test_video_chat_button_toggle enabled", ({override}) => {
         realm_available_video_chat_providers.jitsi_meet.id,
     );
     override(realm, "realm_jitsi_server_url", "https://meet.jit.si");
+    override(window, "to_$", () => $("window-stub"));
     compose_setup.initialize();
     assert.equal($(".compose-control-buttons-container .video_link").visible(), true);
 });


### PR DESCRIPTION
This pull request makes it so any message being written saves as a draft when the user switches tabs.
 
The update_draft function from drafts.ts is called in the on-blur handler for window to prevent message loss. 

Fixes [#35262: Save open draft on window blur](https://github.com/zulip/zulip/issues/35262)

**Screen capture**


https://github.com/user-attachments/assets/f8c50ce6-55e6-4f89-b18f-1979a8653de5

An example of typing a message, switching tabs, and the message saving as a draft.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
