### PR TITLE
event_types: Remove defunct PersonIsBillingAdmin

### DIFF
--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -720,10 +720,6 @@ class PersonFullName(BaseModel):
     full_name: str
 
 
-class PersonIsBillingAdmin(BaseModel):
-    user_id: int
-
-
 class PersonRole(BaseModel):
     user_id: int
     role: Literal[100, 200, 300, 400, 600]
@@ -750,7 +746,6 @@ class EventRealmUserUpdate(BaseEvent):
         | PersonDeliveryEmail
         | PersonEmail
         | PersonFullName
-        | PersonIsBillingAdmin
         | PersonRole
         | PersonTimezone
         | PersonIsActive


### PR DESCRIPTION
Commit c049259d077b3ba9c1348cd8da278107149d6ee0 (#33739) should have removed this completely, rather than merely removing its is_billing_admin member.

- Cc @Vector73 (#33739).