### PR TITLE
settings: Fix text overflow in banners.

### DIFF
--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -3,11 +3,11 @@ import $ from "jquery";
 import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
+import render_subscription_banner from "../templates/components/subscription_banner.hbs";
 import render_unsubscribe_private_stream_modal from "../templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs";
 import render_inline_decorated_channel_name from "../templates/inline_decorated_channel_name.hbs";
 import render_stream_member_list_entry from "../templates/stream_settings/stream_member_list_entry.hbs";
 import render_stream_members_table from "../templates/stream_settings/stream_members_table.hbs";
-import render_stream_subscription_request_result from "../templates/stream_settings/stream_subscription_request_result.hbs";
 
 import * as add_subscribers_pill from "./add_subscribers_pill.ts";
 import * as blueslip from "./blueslip.ts";
@@ -115,10 +115,13 @@ function show_stream_subscription_request_error_result(error_message: string): v
     const $stream_subscription_req_result_elem = $(
         ".stream_subscription_request_result",
     ).expectOne();
-    const html = render_stream_subscription_request_result({
+    const rendered_error_banner = render_subscription_banner({
         error_message,
+        intent: "danger",
     });
-    scroll_util.get_content_element($stream_subscription_req_result_elem).html(html);
+    scroll_util
+        .get_content_element($stream_subscription_req_result_elem)
+        .html(rendered_error_banner);
 }
 
 function show_stream_subscription_request_success_result({
@@ -149,7 +152,8 @@ function show_stream_subscription_request_success_result({
             ignored_deactivated_users,
         );
     }
-    const html = render_stream_subscription_request_result({
+    const rendered_success_banner = render_subscription_banner({
+        intent: "success",
         subscribe_success_messages,
         subscribed_users,
         already_subscribed_users,
@@ -159,7 +163,9 @@ function show_stream_subscription_request_success_result({
         ignored_deactivated_users,
         ignored_deactivated_users_count,
     });
-    scroll_util.get_content_element($stream_subscription_req_result_elem).html(html);
+    scroll_util
+        .get_content_element($stream_subscription_req_result_elem)
+        .html(rendered_success_banner);
 }
 
 function update_notification_choice_checkbox(added_user_count: number): void {

--- a/web/src/user_group_edit_members.ts
+++ b/web/src/user_group_edit_members.ts
@@ -3,10 +3,10 @@ import $ from "jquery";
 import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
+import render_membership_banner from "../templates/components/membership_banner.hbs";
 import render_leave_user_group_modal from "../templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs";
 import render_user_group_member_list_entry from "../templates/stream_settings/stream_member_list_entry.hbs";
 import render_user_group_members_table from "../templates/user_group_settings/user_group_members_table.hbs";
-import render_user_group_membership_request_result from "../templates/user_group_settings/user_group_membership_request_result.hbs";
 import render_user_group_subgroup_entry from "../templates/user_group_settings/user_group_subgroup_entry.hbs";
 
 import * as add_group_members_pill from "./add_group_members_pill.ts";
@@ -242,10 +242,13 @@ function show_user_group_membership_request_error_result(error_message: string):
     const $user_group_subscription_req_result_elem = $(
         ".user_group_subscription_request_result",
     ).expectOne();
-    const html = render_user_group_membership_request_result({
+    const rendered_error_message = render_membership_banner({
+        intent: "danger",
         error_message,
     });
-    scroll_util.get_content_element($user_group_subscription_req_result_elem).html(html);
+    scroll_util
+        .get_content_element($user_group_subscription_req_result_elem)
+        .html(rendered_error_message);
 }
 
 function show_user_group_membership_request_success_result({
@@ -298,7 +301,8 @@ function show_user_group_membership_request_success_result({
     const $user_group_subscription_req_result_elem = $(
         ".user_group_subscription_request_result",
     ).expectOne();
-    const html = render_user_group_membership_request_result({
+    const rendered_success_banner = render_membership_banner({
+        intent: "success",
         addition_success_messages,
         newly_added_member_count,
         already_added_member_count,
@@ -311,7 +315,9 @@ function show_user_group_membership_request_success_result({
         ignored_deactivated_users_count,
         ignored_deactivated_member_count,
     });
-    scroll_util.get_content_element($user_group_subscription_req_result_elem).html(html);
+    scroll_util
+        .get_content_element($user_group_subscription_req_result_elem)
+        .html(rendered_success_banner);
 }
 
 export function edit_user_group_membership({

--- a/web/templates/components/banner.hbs
+++ b/web/templates/components/banner.hbs
@@ -1,7 +1,11 @@
 <div {{#if process}}data-process="{{process}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}banner banner-{{intent}}">
     <span class="banner-content">
         <span class="banner-label">
-            {{label}}
+            {{#if label}}
+                {{label}}
+            {{else}}
+                {{> @partial-block .}}
+            {{/if}}
         </span>
         <span class="banner-action-buttons">
             {{#each buttons}}

--- a/web/templates/components/membership_banner.hbs
+++ b/web/templates/components/membership_banner.hbs
@@ -1,0 +1,4 @@
+{{#> banner .}}
+    {{> ../user_group_settings/user_group_membership_request_result .}}
+{{/banner}}
+

--- a/web/templates/components/subscription_banner.hbs
+++ b/web/templates/components/subscription_banner.hbs
@@ -1,0 +1,4 @@
+{{#> banner .}}
+    {{> ../stream_settings/stream_subscription_request_result .}}
+{{/banner}}
+

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -5,7 +5,7 @@
     </h4>
     <div class="subscriber_list_settings">
         <div class="subscriber_list_add float-left">
-            <div class="stream_subscription_request_result"></div>
+            <div class="stream_subscription_request_result banner-wrapper"></div>
             {{> add_subscribers_form .}}
         </div>
         <div class="clear-float"></div>

--- a/web/templates/stream_settings/stream_subscription_request_result.hbs
+++ b/web/templates/stream_settings/stream_subscription_request_result.hbs
@@ -1,52 +1,40 @@
 {{#if error_message}}
-    <div class="banner-wrapper">
-        <div class="banner banner-danger">
-            <span class="banner-label">
-                {{error_message}}
-            </span>
-        </div>
-    </div>
+    {{error_message}}
 {{else}}
-    <div class="banner-wrapper">
-        <div class="banner banner-success">
-            <span class="banner-label">
-                {{!-- We want to show ignored deactivated users message even when there are
-                no new subscribers --}}
-                {{#if (and (eq subscribed_users_count 0) (eq ignored_deactivated_users_count 0))}}
-                    {{t "All users were already subscribed."}}
-                {{else}}
-                    {{#if (not is_total_subscriber_more_than_five) }}
-                        {{#if subscribed_users}}
-                            {{t "Subscribed:" }} {{{subscribe_success_messages.subscribed_users_message_html}}}.
-                        {{/if}}
-                        {{#if already_subscribed_users}}
-                            {{t "Already a subscriber:" }} {{{subscribe_success_messages.already_subscribed_users_message_html}}}.
-                        {{/if}}
-                        {{#if ignored_deactivated_users}}
-                            {{t "Ignored deactivated users:" }} {{{subscribe_success_messages.ignored_deactivated_users_message_html}}}.
-                        {{/if}}
-                    {{else}}
-                        {{#if subscribed_users}}
-                            {{t "{subscribed_users_count, plural,
-                              one {Subscribed: {subscribed_users_count} user.}
-                            other {Subscribed: {subscribed_users_count} users.}
-                        }"}}
-                        {{/if}}
-                        {{#if already_subscribed_users}}
-                            {{t "{already_subscribed_users_count, plural,
-                              one {Already subscribed: {already_subscribed_users_count} user.}
-                                other {Already subscribed: {already_subscribed_users_count} users.}
-                            }"}}
-                        {{/if}}
-                        {{#if ignored_deactivated_users}}
-                            {{t "{ignored_deactivated_users_count, plural,
-                              one {Ignored deactivated: {ignored_deactivated_users_count} user.}
-                            other {Ignored deactivated: {ignored_deactivated_users_count} users.}
-                        }"}}
-                        {{/if}}
-                    {{/if}}
-                {{/if}}
-            </span>
-        </div>
-    </div>
+    {{!-- We want to show ignored deactivated users message even when there are
+    no new subscribers --}}
+    {{#if (and (eq subscribed_users_count 0) (eq ignored_deactivated_users_count 0))}}
+        {{t "All users were already subscribed."}}
+    {{else}}
+        {{#if (not is_total_subscriber_more_than_five) }}
+            {{#if subscribed_users}}
+                {{t "Subscribed:" }} {{{subscribe_success_messages.subscribed_users_message_html}}}.
+            {{/if}}
+            {{#if already_subscribed_users}}
+                {{t "Already a subscriber:" }} {{{subscribe_success_messages.already_subscribed_users_message_html}}}.
+            {{/if}}
+            {{#if ignored_deactivated_users}}
+                {{t "Ignored deactivated users:" }} {{{subscribe_success_messages.ignored_deactivated_users_message_html}}}.
+            {{/if}}
+        {{else}}
+            {{#if subscribed_users}}
+                {{t "{subscribed_users_count, plural,
+                  one {Subscribed: {subscribed_users_count} user.}
+                other {Subscribed: {subscribed_users_count} users.}
+            }"}}
+            {{/if}}
+            {{#if already_subscribed_users}}
+                {{t "{already_subscribed_users_count, plural,
+                  one {Already subscribed: {already_subscribed_users_count} user.}
+                    other {Already subscribed: {already_subscribed_users_count} users.}
+                }"}}
+            {{/if}}
+            {{#if ignored_deactivated_users}}
+                {{t "{ignored_deactivated_users_count, plural,
+                  one {Ignored deactivated: {ignored_deactivated_users_count} user.}
+                other {Ignored deactivated: {ignored_deactivated_users_count} users.}
+            }"}}
+            {{/if}}
+        {{/if}}
+    {{/if}}
 {{/if}}

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -5,7 +5,7 @@
     <h4 class="user_group_setting_subsection_title">
         {{t "Add members" }}
     </h4>
-    <div class="user_group_subscription_request_result"></div>
+    <div class="user_group_subscription_request_result banner-wrapper"></div>
     <div class="member_list_settings">
         <div class="member_list_add float-left">
             {{> add_members_form .}}

--- a/web/templates/user_group_settings/user_group_membership_request_result.hbs
+++ b/web/templates/user_group_settings/user_group_membership_request_result.hbs
@@ -1,71 +1,59 @@
 {{#if error_message}}
-    <div class="banner-wrapper">
-        <div class="banner banner-danger">
-            <span class="banner-label">
-                {{error_message}}
-            </span>
-        </div>
-    </div>
+    {{error_message}}
 {{else}}
-    <div class="banner-wrapper">
-        <div class="banner banner-success">
-            <span class="banner-label">
-                {{#if (and (eq newly_added_member_count 0) (eq ignored_deactivated_member_count 0))}}
-                    {{#if (and already_added_user_count already_added_subgroups_count)}}
-                        {{t "All users and groups were already members."}}
-                    {{else if already_added_user_count}}
-                        {{t "All users were already members."}}
-                    {{else}}
-                        {{t "All groups were already members."}}
-                    {{/if}}
-                {{else}}
-                    {{#if (not total_member_count_exceeds_five)}}
-                        {{#if addition_success_messages.newly_added_members_message_html}}
-                            {{t "Added:" }} {{{addition_success_messages.newly_added_members_message_html}}}.&nbsp;
-                        {{/if}}
-                        {{#if addition_success_messages.already_added_members_message_html}}
-                            {{t "Already a member:"}} {{{addition_success_messages.already_added_members_message_html}}}.
-                        {{/if}}
-                        {{#if addition_success_messages.ignored_deactivated_users_message_html}}
-                            {{t "Ignored deactivated users:"}} {{{addition_success_messages.ignored_deactivated_users_message_html}}}.
-                        {{/if}}
-                        {{#if addition_success_messages.ignored_deactivated_groups_message_html}}
-                            {{t "Ignored deactivated groups:"}} {{{addition_success_messages.ignored_deactivated_groups_message_html}}}.
-                        {{/if}}
-                    {{else}}
-                        {{#if newly_added_member_count}}
-                            {{t "Added:"}}
-                            {{#if (and newly_added_user_count newly_added_subgroups_count)}}
-                                {{t "{newly_added_user_count, plural, one {# user} other {# users}} and {newly_added_subgroups_count, plural, one {# group.} other {# groups.}}"}}
-                            {{else if newly_added_user_count}}
-                                {{t "{newly_added_user_count, plural, one {# user.} other {# users.}}"}}
-                            {{else if newly_added_subgroups_count}}
-                                {{t "{newly_added_subgroups_count, plural, one {# group.} other {# groups.}}"}}
-                            {{/if}}
-                        {{/if}}
-                        {{#if already_added_member_count}}
-                            {{t "Already a member:"}}
-                            {{#if (and already_added_user_count already_added_subgroups_count)}}
-                                {{t "{already_added_user_count, plural, one {# user} other {# users}} and {already_added_subgroups_count, plural, one {# group.} other {# groups.}}"}}
-                            {{else if already_added_user_count}}
-                                {{t "{already_added_user_count, plural, one {# user.} other {# users.}}"}}
-                            {{else if already_added_subgroups_count}}
-                                {{t "{already_added_subgroups_count, plural, one {# group.} other {# groups.}}"}}
-                            {{/if}}
-                        {{/if}}
-                        {{#if ignored_deactivated_member_count}}
-                            {{t "Ignored deactivated:"}}
-                            {{#if (and ignored_deactivated_users_count ignored_deactivated_groups_count)}}
-                                {{t "{ignored_deactivated_users_count, plural, one {# user} other {# users}} and {ignored_deactivated_groups_count, plural, one {# group.} other {# groups.}}"}}
-                            {{else if ignored_deactivated_users_count}}
-                                {{t "{ignored_deactivated_users_count, plural, one {# user.} other {# users.}}"}}
-                            {{else if ignored_deactivated_groups_count}}
-                                {{t "{ignored_deactivated_groups_count, plural, one {# group.} other {# groups.}}"}}
-                            {{/if}}
-                        {{/if}}
-                    {{/if}}
+    {{#if (and (eq newly_added_member_count 0) (eq ignored_deactivated_member_count 0))}}
+        {{#if (and already_added_user_count already_added_subgroups_count)}}
+            {{t "All users and groups were already members."}}
+        {{else if already_added_user_count}}
+            {{t "All users were already members."}}
+        {{else}}
+            {{t "All groups were already members."}}
+        {{/if}}
+    {{else}}
+        {{#if (not total_member_count_exceeds_five)}}
+            {{#if addition_success_messages.newly_added_members_message_html}}
+                {{t "Added:" }} {{{addition_success_messages.newly_added_members_message_html}}}.&nbsp;
+            {{/if}}
+            {{#if addition_success_messages.already_added_members_message_html}}
+                {{t "Already a member:"}} {{{addition_success_messages.already_added_members_message_html}}}.
+            {{/if}}
+            {{#if addition_success_messages.ignored_deactivated_users_message_html}}
+                {{t "Ignored deactivated users:"}} {{{addition_success_messages.ignored_deactivated_users_message_html}}}.
+            {{/if}}
+            {{#if addition_success_messages.ignored_deactivated_groups_message_html}}
+                {{t "Ignored deactivated groups:"}} {{{addition_success_messages.ignored_deactivated_groups_message_html}}}.
+            {{/if}}
+        {{else}}
+            {{#if newly_added_member_count}}
+                {{t "Added:"}}
+                {{#if (and newly_added_user_count newly_added_subgroups_count)}}
+                    {{t "{newly_added_user_count, plural, one {# user} other {# users}} and {newly_added_subgroups_count, plural, one {# group.} other {# groups.}}"}}
+                {{else if newly_added_user_count}}
+                    {{t "{newly_added_user_count, plural, one {# user.} other {# users.}}"}}
+                {{else if newly_added_subgroups_count}}
+                    {{t "{newly_added_subgroups_count, plural, one {# group.} other {# groups.}}"}}
                 {{/if}}
-            </span>
-        </div>
-    </div>
+            {{/if}}
+            {{#if already_added_member_count}}
+                {{t "Already a member:"}}
+                {{#if (and already_added_user_count already_added_subgroups_count)}}
+                    {{t "{already_added_user_count, plural, one {# user} other {# users}} and {already_added_subgroups_count, plural, one {# group.} other {# groups.}}"}}
+                {{else if already_added_user_count}}
+                    {{t "{already_added_user_count, plural, one {# user.} other {# users.}}"}}
+                {{else if already_added_subgroups_count}}
+                    {{t "{already_added_subgroups_count, plural, one {# group.} other {# groups.}}"}}
+                {{/if}}
+            {{/if}}
+            {{#if ignored_deactivated_member_count}}
+                {{t "Ignored deactivated:"}}
+                {{#if (and ignored_deactivated_users_count ignored_deactivated_groups_count)}}
+                    {{t "{ignored_deactivated_users_count, plural, one {# user} other {# users}} and {ignored_deactivated_groups_count, plural, one {# group.} other {# groups.}}"}}
+                {{else if ignored_deactivated_users_count}}
+                    {{t "{ignored_deactivated_users_count, plural, one {# user.} other {# users.}}"}}
+                {{else if ignored_deactivated_groups_count}}
+                    {{t "{ignored_deactivated_groups_count, plural, one {# group.} other {# groups.}}"}}
+                {{/if}}
+            {{/if}}
+        {{/if}}
+    {{/if}}
 {{/if}}


### PR DESCRIPTION
Fixes:
https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20User.20add.20success.20banner.20squashed/near/2229035.

We switch to using the banner template to avoid regressions caused by changes in the original banner template which aren't duplicated in the subscription result templates for channel/groups.

The original issue was caused by the introduction of the `.banner-content` class, which wasn't present in the user/group result templates in d00cf1a0e85c19a1238ce438fa67909afa9b3325.

| Before | After |
|----|-----|
|<img width="720" height="155" alt="image" src="https://github.com/user-attachments/assets/5258f104-62da-4303-aeb7-121842b5c720" />| <img width="737" height="313" alt="image" src="https://github.com/user-attachments/assets/70cfcc3d-6545-4e39-aa88-6e833fe2880a" />|
