### PR TITLE
user_events: Fix error on custom_profile_field update event.

### DIFF
--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1972,6 +1972,9 @@ export async function fetch_users(user_ids: Set<number>): Promise<UsersFetchResp
     }
     return new Promise((resolve, reject) => {
         fetch_users_from_server({
+            // POST /register obtains custom profile field data if and only if
+            // the current user is not a spectator. Mimic this behavior.
+            include_custom_profile_fields: !page_params.is_spectator,
             user_ids: JSON.stringify([...user_ids_to_fetch]),
             success(users) {
                 resolve(users);


### PR DESCRIPTION
This can happen if we don't have data for the user for which we received the update.

Fixed by fetching the user and then processing the event.
