### PR TITLE
left_sidebar: Fix keyboard navigation and focus styles for left sidebar items.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -560,6 +560,14 @@ function handle_popover_events(event_name) {
 
 // Returns true if we handled it, false if the browser should.
 export function process_enter_key(e) {
+    if ($(e.currentTarget).hasClass("trigger-click-on-enter")) {
+        // If the target has the class "trigger-click-on-enter", explicitly
+        // trigger a click event on it to call the associated click handler.
+        e.preventDefault();
+        $(e.currentTarget).trigger("click");
+        return true;
+    }
+
     if (popovers.any_active() && $(e.target).hasClass("navigate-link-on-enter")) {
         // If a popover is open and we pressed Enter on a menu item,
         // call click directly on the item to navigate to the `href`.

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -481,7 +481,8 @@
     .bottom_left_row:has(a.topic-box:focus-visible),
 #direct-messages-list .dm-list .bottom_left_row:has(a.dm-box:focus-visible),
 #show-more-direct-messages:has(a.dm-name:focus-visible),
-#hide-more-direct-messages:focus-visible {
+#hide-more-direct-messages:focus-visible,
+#topics_header .show-all-streams:focus-visible {
     outline: 2px solid var(--color-outline-focus);
     outline-offset: -2px;
     background-color: var(--color-background-hover-narrow-filter);
@@ -1735,19 +1736,20 @@ li.topic-list-item {
     .show-all-streams {
         grid-area: topics-content-area;
         padding-left: var(--left-sidebar-toggle-width-offset);
+        border-radius: 4px;
         font-size: var(--font-size-sidebar-action-heading);
         font-weight: var(--font-weight-sidebar-action-heading);
         font-variant: var(--font-variant-sidebar-action-heading);
         text-transform: var(--text-transform-sidebar-action-heading);
         color: var(--color-text-sidebar-action-heading);
         text-decoration: none;
+        outline: none;
 
         &:hover {
             background-color: var(
                 --color-background-sidebar-action-heading-hover
             );
             box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
-            border-radius: 4px;
         }
     }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -450,7 +450,7 @@
     }
 }
 
-#stream_filters .narrow-filter:has(a.stream-name:focus-visible),
+#stream_filters .narrow-filter:has(a.subscription_block:focus-visible),
 #stream_filters .narrow-filter.highlighted_stream {
     &.active-filter > .bottom_left_row {
         background-color: var(--color-background-hover-narrow-filter);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -328,6 +328,7 @@
             & a {
                 text-decoration: none;
                 color: inherit;
+                outline: none;
             }
 
             .zulip-icon:not(.user-circle) {
@@ -474,9 +475,7 @@
     .narrow-filter
     .topic-list
     .bottom_left_row:has(a.topic-box:focus-visible),
-#direct-messages-list
-    .dm-list
-    .bottom_left_row:has(a.conversation-partners:focus-visible) {
+#direct-messages-list .dm-list .bottom_left_row:has(a.dm-box:focus-visible) {
     outline: 2px solid var(--color-outline-focus);
     outline-offset: -2px;
     background-color: var(--color-background-hover-narrow-filter);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -473,7 +473,7 @@
 #stream_filters
     .narrow-filter
     .topic-list
-    .bottom_left_row:has(a.sidebar-topic-name:focus-visible),
+    .bottom_left_row:has(a.topic-box:focus-visible),
 #direct-messages-list
     .dm-list
     .bottom_left_row:has(a.conversation-partners:focus-visible) {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -482,7 +482,9 @@
 #direct-messages-list .dm-list .bottom_left_row:has(a.dm-box:focus-visible),
 #show-more-direct-messages:has(a.dm-name:focus-visible),
 #hide-more-direct-messages:focus-visible,
-#topics_header .show-all-streams:focus-visible {
+#topics_header .show-all-streams:focus-visible,
+#subscribe-to-more-streams:has(.subscribe-more-link:focus-visible),
+#login-to-more-streams:has(.subscribe-more-link:focus-visible) {
     outline: 2px solid var(--color-outline-focus);
     outline-offset: -2px;
     background-color: var(--color-background-hover-narrow-filter);
@@ -534,6 +536,7 @@
         line-height: 1;
         color: var(--color-text-sidebar-action-heading);
         text-decoration: none;
+        outline: none;
     }
 
     .subscribe-more-label {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -475,7 +475,8 @@
     .narrow-filter
     .topic-list
     .bottom_left_row:has(a.topic-box:focus-visible),
-#direct-messages-list .dm-list .bottom_left_row:has(a.dm-box:focus-visible) {
+#direct-messages-list .dm-list .bottom_left_row:has(a.dm-box:focus-visible),
+#show-more-direct-messages:has(a.dm-name:focus-visible) {
     outline: 2px solid var(--color-outline-focus);
     outline-offset: -2px;
     background-color: var(--color-background-hover-narrow-filter);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -221,6 +221,7 @@
     display: none;
     margin-right: var(--left-sidebar-right-margin);
     line-height: var(--line-height-sidebar-row);
+    border-radius: 4px;
     text-decoration: none;
     color: inherit;
 
@@ -236,7 +237,10 @@
     &:hover {
         background-color: var(--color-background-sidebar-action-heading-hover);
         box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
-        border-radius: 4px;
+    }
+
+    &:focus {
+        outline: none;
     }
 }
 
@@ -476,7 +480,8 @@
     .topic-list
     .bottom_left_row:has(a.topic-box:focus-visible),
 #direct-messages-list .dm-list .bottom_left_row:has(a.dm-box:focus-visible),
-#show-more-direct-messages:has(a.dm-name:focus-visible) {
+#show-more-direct-messages:has(a.dm-name:focus-visible),
+#hide-more-direct-messages:focus-visible {
     outline: 2px solid var(--color-outline-focus);
     outline-offset: -2px;
     background-color: var(--color-background-hover-narrow-filter);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -198,11 +198,10 @@
     }
 }
 
-.left-sidebar-navigation-area {
-    & li a {
-        &:hover {
-            text-decoration: none;
-        }
+.left-sidebar-navigation-icon-container,
+.left-sidebar-navigation-label-container {
+    &:hover {
+        text-decoration: none;
     }
 }
 
@@ -329,7 +328,8 @@
         line-height: var(--line-height-sidebar-row-prominent);
 
         & li.dm-list-item {
-            & a {
+            .dm-box,
+            .dm-name {
                 text-decoration: none;
                 color: inherit;
                 outline: none;

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -165,7 +165,7 @@
         </ul>
     </div>
 
-    <a id="hide-more-direct-messages" tabindex="0">
+    <a id="hide-more-direct-messages" class="trigger-click-on-enter" tabindex="0">
         <span class="hide-more-direct-messages-text"> {{t 'back to channels' }}</span>
     </a>
     <div id="direct-messages-section-header" class="direct-messages-container hidden-for-spectators zoom-out zoom-in-sticky">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -165,7 +165,7 @@
         </ul>
     </div>
 
-    <a id="hide-more-direct-messages">
+    <a id="hide-more-direct-messages" tabindex="0">
         <span class="hide-more-direct-messages-text"> {{t 'back to channels' }}</span>
     </a>
     <div id="direct-messages-section-header" class="direct-messages-container hidden-for-spectators zoom-out zoom-in-sticky">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -224,7 +224,7 @@
                     <div id="subscribe-to-more-streams"></div>
                 {{/unless}}
                 <div id="login-to-more-streams" class="only-visible-for-spectators login_button">
-                    <a class="subscribe-more-link">
+                    <a class="subscribe-more-link" tabindex="0">
                         <i class="subscribe-more-icon zulip-icon zulip-icon-log-in" aria-hidden="true" ></i>
                         <span class="subscribe-more-label">{{~t "LOG IN TO BROWSE MORE" ~}}</span>
                     </a>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -216,7 +216,7 @@
                 </div>
             </div>
             <div id="topics_header">
-                <a class="show-all-streams" tabindex="0">{{t 'Back to channels' }}</a> <span class="unread_count quiet-count"></span>
+                <a class="show-all-streams trigger-click-on-enter" tabindex="0">{{t 'Back to channels' }}</a> <span class="unread_count quiet-count"></span>
             </div>
             <div id="stream-filters-container">
                 <ul id="stream_filters" class="filters"></ul>

--- a/web/templates/more_pms.hbs
+++ b/web/templates/more_pms.hbs
@@ -1,5 +1,5 @@
 <li id="show-more-direct-messages" class="dm-list-item dm-box bottom_left_row {{#unless more_conversations_unread_count}}zero-dm-unreads{{/unless}}">
-    <a class="dm-name" tabindex="0">{{t "more conversations" }}</a>
+    <a class="dm-name trigger-click-on-enter" tabindex="0">{{t "more conversations" }}</a>
     <span class="unread_count {{#unless more_conversations_unread_count}}zero_count{{/unless}}">
         {{more_conversations_unread_count}}
     </span>


### PR DESCRIPTION
This PR consists of multiple commits aimed at improving the keyboard navigation (certain links were not tab-able and certain links did not react to ENTER key being pressed) and fixes the focus styles for certain other links.

Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Tab.20from.20topic.20filter.20not.20working.20as.20expected)[#issues > 🎯 Tab from topic filter not working as expected](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Tab.20from.20topic.20filter.20not.20working.20as.20expected) and several other issues with keyboard navigation/focus styles in the left sidebar on debugging.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![stream_topic_list-before](https://github.com/user-attachments/assets/e6bc1ffe-adab-4d14-b7aa-7e9967452d26) | ![stream_topic_list-after](https://github.com/user-attachments/assets/12e4739c-8eb2-491a-8114-f1d4bcb8e67c) |
| ![dm_list-before](https://github.com/user-attachments/assets/4d11a0cc-f1b7-47db-86f0-40ca93a914a5) | ![dm_list-after](https://github.com/user-attachments/assets/2b8cbd8f-7058-4aed-b5ef-433cf0f5a525) |
| ![create_a_channel-before](https://github.com/user-attachments/assets/20e197c8-1ab4-479d-85f6-0d47a9d2438c) | ![create_a_channel-after](https://github.com/user-attachments/assets/67b93392-cfea-4023-bc47-77acb66ef49e) | 
| ![login_browse-before](https://github.com/user-attachments/assets/e6e9d926-5a2c-4ac6-85f7-de615915ca2a) | ![login_browse-after](https://github.com/user-attachments/assets/2efcf247-5e77-4ebb-b230-bff8668a06f5) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
