### PR TITLE
compose_attention: Fixes for channel feed and topic lists, and general chat.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -218,6 +218,15 @@ export let complete_starting_tasks = (opts: ComposeActionsOpts): void => {
     compose_recipient.update_compose_area_placeholder_text();
     compose_recipient.update_narrow_to_recipient_visibility();
     compose_recipient.update_recipient_row_attention_level();
+    // This logic catches the corner case of starting a new topic
+    // from within an existing *general chat* topic via buttons
+    // in the left sidebar and collapsed compose box as well as
+    // the compose hotkey, ensuring that we have a high-attention
+    // recipient row.
+    const is_new_topic_triggered = opts.trigger === "clear topic button" || "compose_hotkey";
+    if (is_new_topic_triggered) {
+        compose_recipient.set_high_attention_recipient_row();
+    }
     // We explicitly call this function here apart from compose_setup.js
     // as this helps to show banner when responding in an interleaved view.
     // While responding, the compose box opens before fading resulting in

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -31,9 +31,11 @@ type MessageType = "stream" | "private";
 let compose_select_recipient_dropdown_widget: DropdownWidget;
 
 function composing_to_current_topic_narrow(): boolean {
-    // If the narrow state's stream ID is undefined, then
-    // the user cannot be composing to a current topic narrow.
-    if (narrow_state.stream_id() === undefined) {
+    // If the narrow state's stream ID or topic is undefined, then
+    // the user cannot be composing to a current topic narrow. Note
+    // that both lists of channel topics and channel feeds have a
+    // stream_id, but not a topic.
+    if (narrow_state.stream_id() === undefined || narrow_state.topic() === undefined) {
         return false;
     }
     return (


### PR DESCRIPTION
This PR corrects several compose-box attention states that were broken at least as of #35367, which removed logic that depended on the focused area of the compose box.

Here, we're avoiding returning to worrying about what's focused and instead adjust the logic so as to:

1. Give a veritable result regarding the current narrow by checking for an `undefined` value on `narrow_state.topic()`; channel feeds and topic lists have a stream ID, but not a topic.
2. Add an `opts.trigger` check for new topic buttons as well as the compose hotkey to catch the corner case of starting a new topic from within a _general chat_ topic narrow. That avoids doing a lot of twisty and likely error-prone checking against the empty-topic string.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_All screen captures show the left-sidebar New topic button, the collapsed compose Start new conversation button; and the `c` hotkey:_

| Channel views, before | Channel views, after |
| --- | --- |
| ![channel-topics-new-topic-before](https://github.com/user-attachments/assets/4a288119-ad43-4829-a95d-7c8bcb32ba22) | ![channel-topics-new-topic-after](https://github.com/user-attachments/assets/de6c2e65-8334-4ea3-9717-fcbc359e2115) |
| ![channel-feed-new-topic-before](https://github.com/user-attachments/assets/cb098d96-2163-42b1-baa0-8fa83c7eb1ca) | ![channel-feed-new-topic-after](https://github.com/user-attachments/assets/10848e58-1ae8-44ea-8ba9-42a6a98e0eed) |

| New topic inside _general chat_, before | New topic inside _general chat_, before |
| --- | --- |
| ![general-chat-new-topic-before](https://github.com/user-attachments/assets/5c6086ec-ba52-44c8-8036-562c6a600e68) | ![general-chat-new-topic-after](https://github.com/user-attachments/assets/63ec6ec3-0cc6-4f81-9936-b35e1616fd46) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>