### PR TITLE
message_send: Fix update draft error when message send fails.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -182,6 +182,10 @@ export let send_message = (request = create_message_object()) => {
         no_notify: true,
         update_count: false,
         is_sending_saving: true,
+        // Even 2-character messages that you actually tried to send
+        // should be saved as a draft, since it's confusing if a
+        // message can just disappear into the void.
+        force_save: true,
     });
 
     let local_id;

--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -317,10 +317,12 @@ export function rename_stream_recipient(
     }
 }
 
-export function snapshot_message(): LocalStorageDraft | undefined {
-    if (!compose_state.composing() || !compose_state.has_savable_message_content()) {
+export function snapshot_message(force_save = false): LocalStorageDraft | undefined {
+    const can_save_message = force_save || compose_state.has_savable_message_content();
+    if (!compose_state.composing() || !can_save_message) {
         // If you aren't in the middle of composing the body of a
-        // message or the message is shorter than 2 characters long, don't try to snapshot.
+        // message, forcing a save or the message is shorter than 2 characters long,
+        // don't try to snapshot.
         return undefined;
     }
 
@@ -423,6 +425,7 @@ type UpdateDraftOptions = {
     no_notify?: boolean;
     update_count?: boolean;
     is_sending_saving?: boolean;
+    force_save?: boolean;
 };
 
 export let update_draft = (opts: UpdateDraftOptions = {}): string | undefined => {
@@ -430,7 +433,8 @@ export let update_draft = (opts: UpdateDraftOptions = {}): string | undefined =>
     const old_draft = draft_id === undefined ? undefined : draft_model.getDraft(draft_id);
 
     const no_notify = opts.no_notify ?? false;
-    const draft = snapshot_message();
+    const force_save = opts.force_save ?? false;
+    const draft = snapshot_message(force_save);
 
     if (draft === undefined) {
         // The user cleared the compose box, which means


### PR DESCRIPTION
Came across this error while working on another PR.

If we are sending a message with characters less than `MINIMUM_MESSAGE_LENGTH_TO_SAVE_DRAFT` and message send fails, it shows an error as it tries to update the draft state.

This commit fixes this behaviour by only updating draft state if we had saved a copy of the message as draft.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**Before:**
<img width="1311" height="965" alt="Screenshot from 2025-07-25 22-27-04" src="https://github.com/user-attachments/assets/365055a2-b784-46a0-aa57-5e20dfcbd113" />

[Screencast from 2025-07-25 22-25-53.webm](https://github.com/user-attachments/assets/d2d6358c-ab17-4689-a395-a4254ed45360)

**After:**

[Screencast from 2025-07-28 01-15-13.webm](https://github.com/user-attachments/assets/e760e201-d9a8-4269-a711-a01606d677da)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
