### PR TITLE
portico: Prevent label styling from affecting altcha-label.

### DIFF
--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -530,7 +530,17 @@ html {
             margin-bottom: 10px;
         }
 
-        & label {
+        /* TODO: We need to audit all the portico <label> elements
+           and:
+           1) Add a unifying class so that these side-effect-prone
+              element selectors don't continue to introduce ugly
+              regressions
+           2) Rework the containing layout of `.input-box` so as to
+              not use fiddly positioning
+           3) Clean up other related .altcha-label references in
+              this file.
+        */
+        & label:not(.altcha-label) {
             position: absolute;
             top: 0;
             left: 0;
@@ -540,6 +550,11 @@ html {
             transition: 0.3s ease;
             transition-property:
                 color, font-size, font-weight, transform; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
+        }
+
+        .altcha-label {
+            /* Push back against Bootstrap. */
+            margin-bottom: 0;
         }
 
         &.moving-label {
@@ -954,7 +969,7 @@ button#register_auth_button_gitlab {
             width: calc(100% - 20px);
         }
 
-        & label {
+        & label:not(.altcha-label) {
             position: absolute;
             margin: 0;
             top: 0;


### PR DESCRIPTION
Fixes: [#issues > 🎯 layout issue on /new](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20layout.20issue.20on.20.2Fnew)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![altcha-before](https://github.com/user-attachments/assets/fa6b5b5e-183a-4a87-a3a5-647af5d10b96) | ![alctcha-after](https://github.com/user-attachments/assets/12506d7e-f269-4b3a-942d-b567801f35ca) |
