### PR TITLE
recent: Follow current pattern for placeholder text.

### DIFF
--- a/web/templates/recent_view_table.hbs
+++ b/web/templates/recent_view_table.hbs
@@ -3,7 +3,7 @@
         {{> recent_view_filters .}}
     </div>
     {{#> input_wrapper . input_type="filter-input" id="recent-view-search-wrapper" icon="search" input_button_icon="close"}}
-        <input type="text" id="recent_view_search" class="input-element user-list-filter" value="{{ search_val }}" autocomplete="off" placeholder="{{t 'Filter topics (t)' }}" />
+        <input type="text" id="recent_view_search" class="input-element user-list-filter" value="{{ search_val }}" autocomplete="off" placeholder="{{t 'Filter topics' }}" />
     {{/input_wrapper}}
 </div>
 <div class="table_fix_head">


### PR DESCRIPTION
We no longer show keyboard shortcuts in placeholders.

We could consider adding a tooltip (with a long delay).