### PR TITLE
pm_list: Fix dm filter not cleared on zooming out.

### DIFF
--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -237,6 +237,7 @@ function zoom_out(): void {
 
 export function clear_search(): void {
     const $filter = $(".direct-messages-list-filter").expectOne();
+    $filter.val("");
     update_private_messages();
     $filter.trigger("blur");
 }


### PR DESCRIPTION
`clear_search` doesn't reset the filter text which causes the issue, hence fixed by clearning the filter text here.

Here are the steps to reproduce:

In the sidebar, under "Direct Messages" click "More Conversations"

In the "Filter direct messages" box, enter some search term

Without clearing the search term, click "Back to channels"