### PR TITLE
search: Fix outer spacing for wrapped search pills

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -137,6 +137,11 @@
             /* Pill container should display the same background
                color as the search typeahead. */
             background-color: var(--color-background-search);
+            padding: 0;
+
+            .search-input-and-pills {
+                padding: 0.25em; /* 4px at 16px em */
+            }
         }
 
         @media (width < $md_min) {


### PR DESCRIPTION
Fixes #35426.

This pull request resolves a UI layout bug in the main search bar where search filter pills would lose their outer spacing when wrapping to a new line.

When enough search pills were added to the search query, pills on subsequent lines would appear flush against the container's edges, creating a cramped and inconsistent look. This was caused by a CSS rule that explicitly set the container's padding to zero.

The fix applies a consistent padding to the pill container, ensuring that proper spacing is maintained regardless of whether the pills are on a single line or have wrapped.

Fixes: https://github.com/zulip/zulip/issues/35426

Screenshots and screen captures:

Before: The pills on the second line are flush with the edges of the search box.
<img width="1131" height="87" alt="Before-padding" src="https://github.com/user-attachments/assets/e2c457a4-4798-4130-b9ea-59b637a97175" />


After: The pills now have consistent outer padding on all lines.
<img width="1127" height="108" alt="After-Padding" src="https://github.com/user-attachments/assets/634749a1-2ef8-4062-963a-d735305b6556" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
