### PR TITLE
help: Add missing space after icons in instruction blocks.

### DIFF
--- a/help/emoji-reactions.md
+++ b/help/emoji-reactions.md
@@ -118,10 +118,10 @@ messages which have received at least one reaction.
 
 {tab|desktop-web}
 
-1. Click on <i class="zulip-icon zulip-icon-smile"></i>**Reactions** in the left
+1. Click on <i class="zulip-icon zulip-icon-smile"></i> **Reactions** in the left
    sidebar. If the **views** section is collapsed, click on
    the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>),
-   and select <i class="zulip-icon zulip-icon-smile"></i>**Reactions**.
+   and select <i class="zulip-icon zulip-icon-smile"></i> **Reactions**.
 
 1. Browse your reactions. You can click on a message recipient bar to go
    to the [conversation](/help/reading-conversations) where you sent the message.

--- a/help/include/go-to-draft-messages.md
+++ b/help/include/go-to-draft-messages.md
@@ -1,4 +1,4 @@
-1. Click on <i class="zulip-icon zulip-icon-drafts"></i>**Drafts**
+1. Click on <i class="zulip-icon zulip-icon-drafts"></i> **Drafts**
    in the left sidebar. If the **views** section is collapsed, click on
    the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>),
-   and select <i class="zulip-icon zulip-icon-drafts"></i>**Drafts**.
+   and select <i class="zulip-icon zulip-icon-drafts"></i> **Drafts**.

--- a/help/include/go-to-reminders.md
+++ b/help/include/go-to-reminders.md
@@ -1,4 +1,4 @@
-1. Click on <i class="zulip-icon zulip-icon-alarm-clock"></i>**Reminders**
+1. Click on <i class="zulip-icon zulip-icon-alarm-clock"></i> **Reminders**
    in the left sidebar. If the **views** section is collapsed, click on
    the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>), and
-   select <i class="zulip-icon zulip-icon-alarm-clock"></i>**Reminders**.
+   select <i class="zulip-icon zulip-icon-alarm-clock"></i> **Reminders**.

--- a/help/include/go-to-scheduled-messages.md
+++ b/help/include/go-to-scheduled-messages.md
@@ -1,4 +1,4 @@
-1. Click on <i class="zulip-icon zulip-icon-calendar-days"></i>**Scheduled messages**
+1. Click on <i class="zulip-icon zulip-icon-calendar-days"></i> **Scheduled messages**
    in the left sidebar. If the **views** section is collapsed, click on
    the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>), and
-   select <i class="zulip-icon zulip-icon-calendar-days"></i>**Scheduled messages**.
+   select <i class="zulip-icon zulip-icon-calendar-days"></i> **Scheduled messages**.


### PR DESCRIPTION
When reviewing the new help center docs, noticed that some of the instruction blocks did not have a space between the icon and the label (reactions view, drafts, scheduled messages, reminders). This is not as visible in the current help center, but definitely an improvement in the new help center...

| Before | After |
| --- | --- |
| <img width="747" height="342" alt="Screenshot 2025-07-26 at 16 15 50" src="https://github.com/user-attachments/assets/4247c37f-d2d2-453d-be5b-96e9670d83ac" /> | <img width="751" height="342" alt="Screenshot 2025-07-26 at 16 25 30" src="https://github.com/user-attachments/assets/b6a867dd-e4c7-492d-9b81-e00e0a62003c" />

---

**Current help center screenshots:**

| Before | After |
| --- | --- |
| <img width="757" height="347" alt="Screenshot 2025-07-26 at 16 15 01" src="https://github.com/user-attachments/assets/94613d99-3830-400a-92e7-dde95b2f605f" /> | <img width="756" height="351" alt="Screenshot 2025-07-26 at 16 12 37" src="https://github.com/user-attachments/assets/2b9c5820-e5ae-4b1c-8d4d-31361a7a8203" />

| Before | After |
| --- | --- |
| <img width="758" height="367" alt="Screenshot 2025-07-26 at 16 15 12" src="https://github.com/user-attachments/assets/5a99efd5-45e4-4328-8c85-676ce8a5ca42" /> | <img width="760" height="379" alt="Screenshot 2025-07-26 at 16 13 42" src="https://github.com/user-attachments/assets/8ea0923f-69d7-4849-851b-4027b96cc58f" />

| Before | After |
| --- | --- |
| <img width="761" height="388" alt="Screenshot 2025-07-26 at 16 15 22" src="https://github.com/user-attachments/assets/1a305c38-9a12-4b0e-9738-85f4fcd56a48" /> | <img width="756" height="392" alt="Screenshot 2025-07-26 at 16 13 54" src="https://github.com/user-attachments/assets/f9693d30-aaf1-4ec9-8e62-ea0e2fd2a08c" />

| Before | After |
| --- | --- |
| <img width="754" height="295" alt="Screenshot 2025-07-26 at 16 15 29" src="https://github.com/user-attachments/assets/e5a673e9-375c-4ddf-a626-ace5087b3ca5" /> | <img width="753" height="292" alt="Screenshot 2025-07-26 at 16 14 09" src="https://github.com/user-attachments/assets/d038ae63-e50c-4c62-8126-893294d7dc32" />
