### PR TITLE
help: Inline h4 headers that are directly after h3 headers.

### DIFF
--- a/help/connect-through-a-proxy.md
+++ b/help/connect-through-a-proxy.md
@@ -53,7 +53,7 @@ the URL of the proxy server (it may look something like
 If either of those apply, you can skip the rest of this guide. If not, we
 document the syntax for **Proxy rules** and **Proxy bypass rules** below.
 
-#### Proxy rules
+### Proxy rules
 
 A semicolon-separated list of `protocolRule`s.
 
@@ -74,7 +74,7 @@ Some examples:
 * `http=http://foo;socks5://bar` -  Use proxy `http://foo` for `http://` URLs,
   and use `socks5://bar` for all other URLs.
 
-#### Proxy bypass rules
+### Proxy bypass rules
 
 A comma-separated list of URIs. The URIs can be hostnames, IP address
 literals, or IP ranges in CIDR notation. Hostnames can use the `*`

--- a/help/getting-started-with-zulip.md
+++ b/help/getting-started-with-zulip.md
@@ -20,28 +20,6 @@ it, you'll never want to use a different team chat app!
 
 ## Reading your messages
 
-{!conversation-definition.md!}
-
-{!conversation-recommendation.md!}
-
-### Finding a conversation to read
-
-#### From the Inbox view
-
-{!inbox-intro.md!}
-
-{!inbox-instructions.md!}
-
-#### From Recent conversations
-
-{!recent-conversations.md!}
-
-#### From the left sidebar
-
-{!left-sidebar-conversations.md!}
-
-### Reading conversations
-
 {!reading-conversations.md!}
 
 ## Sending messages

--- a/help/include/reading-conversations.md
+++ b/help/include/reading-conversations.md
@@ -1,3 +1,23 @@
+{!conversation-definition.md!}
+
+{!conversation-recommendation.md!}
+
+### Finding a conversation to read from the Inbox view
+
+{!inbox-intro.md!}
+
+{!inbox-instructions.md!}
+
+### Finding a conversation to read from Recent conversations
+
+{!recent-conversations.md!}
+
+### Finding a conversation to read from the left sidebar
+
+{!left-sidebar-conversations.md!}
+
+### Reading conversations
+
 {start_tabs}
 
 {tab|desktop-web}

--- a/help/reading-strategies.md
+++ b/help/reading-strategies.md
@@ -10,28 +10,6 @@ in Zulip.
 
 ## Conversation by conversation
 
-{!conversation-definition.md!}
-
-{!conversation-recommendation.md!}
-
-### Finding a conversation to read
-
-#### From the Inbox view
-
-{!inbox-intro.md!}
-
-{!inbox-instructions.md!}
-
-#### From Recent conversations
-
-{!recent-conversations.md!}
-
-#### From the left sidebar
-
-{!left-sidebar-conversations.md!}
-
-### Reading conversations
-
 {!reading-conversations.md!}
 
 ### Following, muting and unmuting conversations


### PR DESCRIPTION
[#documentation > new help center: headings](https://chat.zulip.org/#narrow/channel/19-documentation/topic/new.20help.20center.3A.20headings)

**Updates**:
- Revises headers in "Connect through a proxy" to be sequential.
- Inlines headers and updates shared content include file used in "Reading strategies" and "Getting started with Zulip" articles.

---

**Screenshots and screen captures:**

### CURRENT DOC: [Reading strategies](https://zulip.com/help/reading-strategies)
| Current | New |
| --- | --- |
| <img width="759" height="1057" alt="Screenshot 2025-07-26 at 16 37 27" src="https://github.com/user-attachments/assets/96ecc95e-c2f5-48c4-94a3-cf90a439fc63" /> | <img width="756" height="995" alt="Screenshot 2025-07-26 at 16 38 21" src="https://github.com/user-attachments/assets/a3f66a32-65d4-4221-b6cf-43a37701ee71" />

### CURRENT DOC: Getting started with Zulip -> [Reading your messages](https://zulip.com/help/getting-started-with-zulip#reading-your-messages)
<img width="763" height="1038" alt="Screenshot 2025-07-26 at 16 38 00" src="https://github.com/user-attachments/assets/f9465e10-c001-4585-a4da-160c470df0d9" />

### CURRENT DOC: Connect through a proxy -> [Additional tips](https://zulip.com/help/connect-through-a-proxy#additional-tips-for-custom-proxy-settings)
<img width="762" height="824" alt="Screenshot 2025-07-26 at 16 39 05" src="https://github.com/user-attachments/assets/89c1c05b-45fb-400a-ade6-90d599755844" />
