### PR TITLE
push_notification: Remove dev guard from send E2EE notification codepath.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1293,12 +1293,11 @@ def handle_remove_push_notification(user_profile_id: int, message_ids: list[int]
     gcm_payload, gcm_options = get_remove_payload_gcm(user_profile, truncated_message_ids)
     apns_payload = get_remove_payload_apns(user_profile, truncated_message_ids)
 
+    # We need to call both the legacy/non-E2EE and E2EE functions
+    # for sending mobile notifications, since we don't at this time
+    # know which mobile app version the user may be using.
     send_push_notifications_legacy(user_profile, apns_payload, gcm_payload, gcm_options)
-    if settings.DEVELOPMENT:
-        # TODO: Remove the 'settings.DEVELOPMENT' check when mobile clients start
-        # to offer a way to register for E2EE push notifications; otherwise it'll
-        # do needless DB query and logging.
-        send_push_notifications(user_profile, apns_payload, gcm_payload, is_removal=True)
+    send_push_notifications(user_profile, apns_payload, gcm_payload, is_removal=True)
 
     # We intentionally use the non-truncated message_ids here.  We are
     # assuming in this very rare case that the user has manually
@@ -1680,15 +1679,11 @@ def handle_push_notification(user_profile_id: int, missed_message: dict[str, Any
     )
     logger.info("Sending push notifications to mobile clients for user %s", user_profile_id)
 
-    # TODO: We plan to offer a personal, realm-level, and server-level setting
-    # to require all notifications to be end-to-end encrypted. When either setting
-    # is enabled, we skip calling 'send_push_notifications_legacy'.
+    # We need to call both the legacy/non-E2EE and E2EE functions
+    # for sending mobile notifications, since we don't at this time
+    # know which mobile app version the user may be using.
     send_push_notifications_legacy(user_profile, apns_payload, gcm_payload, gcm_options)
-    if settings.DEVELOPMENT:
-        # TODO: Remove the 'settings.DEVELOPMENT' check when mobile clients start
-        # to offer a way to register for E2EE push notifications; otherwise it'll
-        # do needless DB query and logging.
-        send_push_notifications(user_profile, apns_payload, gcm_payload)
+    send_push_notifications(user_profile, apns_payload, gcm_payload)
 
 
 def send_test_push_notification_directly_to_devices(


### PR DESCRIPTION
PR to address https://github.com/zulip/zulip/pull/35432#discussion_r2229763718
> we'll want to release with DEVELOPMENT guard removed next week.                        


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
