### PR TITLE
Fix always auto redirect behaviour for moved realms.

### DIFF
--- a/zerver/lib/subdomains.py
+++ b/zerver/lib/subdomains.py
@@ -34,7 +34,7 @@ def get_subdomain_from_hostname(
     m = re.search(rf"\.{settings.EXTERNAL_HOST}(:\d+)?$", host)
     if m:
         subdomain = host[: m.start()]
-        if subdomain in settings.ROOT_SUBDOMAIN_ALIASES:
+        if default_subdomain is not None and subdomain in settings.ROOT_SUBDOMAIN_ALIASES:
             return default_subdomain
         return subdomain
 

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -827,7 +827,7 @@ def show_deactivation_notice(request: HttpRequest, next: str = "/") -> HttpRespo
             split = urlsplit(realm.deactivated_redirect)
             host = f"{split.scheme}://{split.netloc}"
             # If the redirect is in the same domain, do an automatic redirect.
-            if get_subdomain_from_hostname(host) is not None:
+            if get_subdomain_from_hostname(host, None) is not None:
                 redirect_to = get_safe_redirect_to(next, realm.deactivated_redirect)
                 context["auto_redirect_to"] = redirect_to
         return render(request, "zerver/deactivated.html", context=context)


### PR DESCRIPTION
Tested:

```
./manage.py deactivate_realm -r 4 --redirect_url "http://google.com" --deactivation_reason "abcd"
```

| before | after |
| --- | --- |
| <img width="851" height="299" alt="Screenshot from 2025-07-28 11-45-30" src="https://github.com/user-attachments/assets/c0a179da-abb4-42c3-bbf8-911e7d8e4e7e" /> | <img width="851" height="299" alt="Screenshot from 2025-07-28 11-44-48" src="https://github.com/user-attachments/assets/faab2381-2abc-4c24-b351-78a955b0e638" /> |

```
./manage.py deactivate_realm -r 4 --redirect_url "http://xyz.zulipdev.com:9991" --deactivation_reason "abcd"
````

<img width="851" height="299" alt="Screenshot from 2025-07-28 11-44-59" src="https://github.com/user-attachments/assets/61b197ee-10ef-4b12-bac8-f22541692d9b" />

Thanks @laurynmm for pointing out this bug.