### PR TITLE
Further clean up the topic list filtering typeahead logic.

### DIFF
--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -176,6 +176,10 @@ IGNORED_PHRASES = [
     r"archived",
     # Used in pills for deactivated users.
     r"deactivated",
+    # Used in pills for resolved topics.
+    r"resolved",
+    # Used in pills for unresolved topics.
+    r"unresolved",
     # This is a reference to a setting/secret and should be lowercase.
     r"zulip_org_id",
     # These are custom time unit options for modal dropdowns

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -271,6 +271,7 @@ EXEMPT_FILES = make_set(
         "web/src/timerender.ts",
         "web/src/tippyjs.ts",
         "web/src/todo_widget.ts",
+        "web/src/topic_filter_pill.ts",
         "web/src/topic_list.ts",
         "web/src/topic_popover.ts",
         "web/src/typing.ts",

--- a/web/src/topic_filter_pill.ts
+++ b/web/src/topic_filter_pill.ts
@@ -1,0 +1,68 @@
+import render_input_pill from "../templates/input_pill.hbs";
+
+import {$t} from "./i18n.ts";
+import type {InputPillConfig, InputPillContainer} from "./input_pill.ts";
+import * as input_pill from "./input_pill.ts";
+
+export type TopicFilterPill = {
+    type: "topic_filter";
+    label: string;
+    syntax: string;
+};
+
+export type TopicFilterPillWidget = InputPillContainer<TopicFilterPill>;
+
+export const filter_options: TopicFilterPill[] = [
+    {
+        type: "topic_filter",
+        label: $t({defaultMessage: "unresolved"}),
+        syntax: "-is:resolved",
+    },
+    {
+        type: "topic_filter",
+        label: $t({defaultMessage: "resolved"}),
+        syntax: "is:resolved",
+    },
+];
+
+export function create_item_from_syntax(
+    syntax: string,
+    current_items: TopicFilterPill[],
+): TopicFilterPill | undefined {
+    const existing_syntaxes = current_items.map((item) => item.syntax);
+    if (existing_syntaxes.includes(syntax)) {
+        return undefined;
+    }
+
+    // Find the matching filter option
+    const filter_option = filter_options.find((option) => option.syntax === syntax);
+    if (!filter_option) {
+        return undefined;
+    }
+    return filter_option;
+}
+
+export function get_syntax_from_item(item: TopicFilterPill): string {
+    return item.syntax;
+}
+
+export function create_pills(
+    $pill_container: JQuery,
+    pill_config?: InputPillConfig,
+): TopicFilterPillWidget {
+    const pill_container = input_pill.create({
+        $container: $pill_container,
+        pill_config,
+        create_item_from_text: create_item_from_syntax,
+        get_text_from_item: get_syntax_from_item,
+        get_display_value_from_item: get_syntax_from_item,
+        generate_pill_html(item: TopicFilterPill, disabled?: boolean) {
+            return render_input_pill({
+                display_value: item.label,
+                disabled,
+            });
+        },
+    });
+    pill_container.createPillonPaste(() => false);
+    return pill_container;
+}

--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -174,9 +174,9 @@ export function filter_topics_by_search_term(
         word_separator_regex,
     );
 
-    if (topics_state === "is: resolved") {
+    if (topics_state === "is:resolved") {
         topic_names = topic_names.filter((name) => resolved_topic.is_resolved(name));
-    } else if (topics_state === "-is: resolved") {
+    } else if (topics_state === "-is:resolved") {
         topic_names = topic_names.filter((name) => !resolved_topic.is_resolved(name));
     }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1331,14 +1331,6 @@ li.top_left_scheduled_messages {
             white-space: nowrap;
             overflow: hidden;
         }
-
-        /* We only establish the ellipsis when
-           the input is not focused, thanks to a
-           Safari bug that makes long inputs
-           unreachable and unscrollable. */
-        .input:not(:focus) {
-            text-overflow: ellipsis;
-        }
     }
 }
 

--- a/web/templates/input_pill.hbs
+++ b/web/templates/input_pill.hbs
@@ -1,4 +1,8 @@
-<div class='pill {{#if deactivated}} deactivated-pill {{/if}}'{{#if user_id}}data-user-id="{{user_id}}"{{/if}}{{#if group_id}}data-user-group-id="{{group_id}}"{{/if}}{{#if stream_id}}data-stream-id="{{stream_id}}"{{/if}} tabindex=0>
+<div class='pill {{#if deactivated}} deactivated-pill {{/if~}}'
+  {{~#if user_id}}data-user-id="{{user_id}}"{{/if~}}
+  {{~#if group_id}}data-user-group-id="{{group_id}}"{{/if~}}
+  {{~#if stream_id}}data-stream-id="{{stream_id}}"{{/if~}}
+  {{~#if data_syntax}}data-syntax="{{data_syntax}}"{{/if}} tabindex=0>
     {{#if has_image}}
     <img class="pill-image" src="{{img_src}}" />
     <div class="pill-image-border"></div>

--- a/web/tests/topic_list_data.test.cjs
+++ b/web/tests/topic_list_data.test.cjs
@@ -62,7 +62,7 @@ test("filter_topics_by_search_term with resolved topics_state", () => {
     const search_term = "";
 
     // Filter for resolved topics.
-    let topics_state = "is: resolved";
+    let topics_state = "is:resolved";
 
     let result = topic_list_data.filter_topics_by_search_term(
         topic_names,
@@ -73,7 +73,7 @@ test("filter_topics_by_search_term with resolved topics_state", () => {
     assert.deepEqual(result, ["✔ resolved topic"]);
 
     // Filter for unresolved topics.
-    topics_state = "-is: resolved";
+    topics_state = "-is:resolved";
     result = topic_list_data.filter_topics_by_search_term(topic_names, search_term, topics_state);
 
     assert.deepEqual(result, ["topic 1", "topic 2"]);


### PR DESCRIPTION
This PR addresses several improvements related to how pills are implemented and displayed:

* **Replaces usage of `search_pill`** with a minimal wrapper module (`topic_filter_pill.ts`), similar to the approach used in `web/src/integration_branch_pill.ts`.
* **Refactors `get_typeahead_search_term`** to use `data-syntax` attribute instead of relying on text/string matching to determine filtering logic.
* **Restores display of description labels** instead of raw syntax in the pill UI, now that filtering logic is decoupled from the displayed text.

Fixes part of: #35284.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| After | Before |
|-----|--|
| <img width="330" height="56" alt="Screenshot 2025-07-28 at 6 41 52 PM" src="https://github.com/user-attachments/assets/13305690-d662-44ab-be35-dfdf57c94360" /> | <img width="329" height="62" alt="Screenshot 2025-08-06 at 3 55 26 PM" src="https://github.com/user-attachments/assets/a1cc064f-14f5-46fa-b926-cbc9867b0e20" /> |
| <img width="326" height="51" alt="Screenshot 2025-07-28 at 6 41 58 PM" src="https://github.com/user-attachments/assets/43b7df00-e5c0-45d6-a081-75a976fa639c" /> | <img width="339" height="52" alt="Screenshot 2025-08-06 at 3 55 34 PM" src="https://github.com/user-attachments/assets/713289ea-73e0-45aa-9dd6-6c7a778a2ef1" /> |
| <img width="320" height="110" alt="Screenshot 2025-08-07 at 4 05 42 PM" src="https://github.com/user-attachments/assets/3d5f8eff-f207-4eb3-afd1-45e198ebe9d3" /> | <img width="328" height="161" alt="Screenshot 2025-08-06 at 3 55 21 PM" src="https://github.com/user-attachments/assets/736ab6ad-b246-4e16-b602-24c14bcdf532" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
