### PR TITLE
search: Tune colors to Vlad's proposals.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -825,10 +825,14 @@
         hsl(0deg 0% 100% / 19%)
     );
     --color-outline-focus: hsl(215deg 47% 50%);
-    --color-background-search: light-dark(hsl(0deg 0% 100%), hsl(0deg 0% 20%));
+    --color-background-search: light-dark(hsl(0deg 0% 100%), hsl(0deg 0% 17%));
+    --color-background-search-collapsed: light-dark(
+        hsl(0deg 0% 100%),
+        hsl(0deg 0% 20%)
+    );
     --color-background-search-option-hover: light-dark(
         hsl(0deg 0% 94%),
-        hsl(0deg 0% 30%)
+        hsl(0deg 0% 20%)
     );
     --color-search-box-hover-shadow: light-dark(
         hsl(0deg 0% 0% / 10%),
@@ -1804,6 +1808,11 @@
     --color-background-input-pill: light-dark(
         hsl(237deg 68% 94%),
         hsl(240deg 65% 60% / 22%)
+    );
+    /* Tuned pill for the search bar in dark mode. */
+    --color-background-input-pill-search: light-dark(
+        hsl(237deg 68% 94%),
+        hsl(240deg 65% 60% / 30%)
     );
     --color-background-input-pill-hover: light-dark(
         hsl(240deg 70% 70% / 30%),

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -74,6 +74,7 @@
 
     .navbar-search:not(.expanded) {
         right: 0;
+        background-color: var(--color-background-search-collapsed);
 
         .search_close_button {
             display: none;
@@ -240,6 +241,7 @@
         .pill {
             margin: 0;
             min-width: unset;
+            background-color: var(--color-background-input-pill-search);
         }
 
         &:not(.focused) {


### PR DESCRIPTION
[#design > search typeahead background](https://chat.zulip.org/#narrow/channel/101-design/topic/search.20typeahead.20background)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After (no change in light mode) |
| --- | --- |
| <img width="1860" height="650" alt="search-bar-light-before" src="https://github.com/user-attachments/assets/67d83c9c-e7c8-4710-acb6-8e0eab91cdd9" /> | <img width="1860" height="650" alt="search-bar-light-after--no-change" src="https://github.com/user-attachments/assets/5de3b3a8-a841-41b5-a2a6-5f4f31a6d2f4" /> |
| <img width="1860" height="650" alt="search-bar-dark-before" src="https://github.com/user-attachments/assets/088b83d2-1e2b-4431-a6a1-750ef0b5514f" /> | <img width="1860" height="650" alt="search-bar-dark-after" src="https://github.com/user-attachments/assets/4a210690-827a-4cc0-b82e-7f5c5429c488" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>