### PR TITLE
test_e2ee_push_notification: Improve tests to cover more cases.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1317,11 +1317,7 @@ def send_push_notifications_legacy(
         PushDeviceToken.objects.filter(user=user_profile, kind=PushDeviceToken.APNS).order_by("id")
     )
 
-    # Added this nocoverage check for this commit. We plan to add a commit
-    # which will remove the mocking of 'send_push_notifications_legacy'
-    # in 'test_e2ee_push_notifications' - and this case will be covered
-    # there as a part of that broader effort.
-    if len(android_devices) + len(apple_devices) == 0:  # nocoverage
+    if len(android_devices) + len(apple_devices) == 0:
         logger.info(
             "Skipping legacy push notifications for user %s because there are no registered devices",
             user_profile.id,

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -590,13 +590,7 @@ def send_notifications_to_bouncer(
     android_devices: Sequence[DeviceToken],
     apple_devices: Sequence[DeviceToken],
 ) -> None:
-    if len(android_devices) + len(apple_devices) == 0:
-        logger.info(
-            "Skipping contacting the bouncer for user %s because there are no registered devices",
-            user_profile.id,
-        )
-
-        return
+    assert len(android_devices) + len(apple_devices) != 0
 
     post_data = {
         "user_uuid": str(user_profile.uuid),
@@ -1322,6 +1316,17 @@ def send_push_notifications_legacy(
     apple_devices = list(
         PushDeviceToken.objects.filter(user=user_profile, kind=PushDeviceToken.APNS).order_by("id")
     )
+
+    # Added this nocoverage check for this commit. We plan to add a commit
+    # which will remove the mocking of 'send_push_notifications_legacy'
+    # in 'test_e2ee_push_notifications' - and this case will be covered
+    # there as a part of that broader effort.
+    if len(android_devices) + len(apple_devices) == 0:  # nocoverage
+        logger.info(
+            "Skipping legacy push notifications for user %s because there are no registered devices",
+            user_profile.id,
+        )
+        return
 
     if uses_notification_bouncer():
         send_notifications_to_bouncer(

--- a/zerver/tests/test_handle_push_notification.py
+++ b/zerver/tests/test_handle_push_notification.py
@@ -362,6 +362,9 @@ class HandlePushNotificationTest(PushNotificationTestCase):
     @mock.patch("zerver.lib.push_notifications.push_notifications_configured", return_value=True)
     @override_settings(ZULIP_SERVICE_PUSH_NOTIFICATIONS=False, ZULIP_SERVICES=set())
     def test_read_message(self, mock_push_notifications: mock.MagicMock) -> None:
+        self.setup_apns_tokens()
+        self.setup_fcm_tokens()
+
         user_profile = self.example_user("hamlet")
         message = self.get_message(
             Recipient.PERSONAL,

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2138,23 +2138,6 @@ class TestGetGCMPayload(PushNotificationTestCase):
 
 
 class TestSendNotificationsToBouncer(PushNotificationTestCase):
-    def test_send_notifications_to_bouncer_when_no_devices(self) -> None:
-        user = self.example_user("hamlet")
-
-        with (
-            mock.patch("zerver.lib.remote_server.send_to_push_bouncer") as mock_send,
-            self.assertLogs("zerver.lib.push_notifications", level="INFO") as mock_logging_info,
-        ):
-            send_notifications_to_bouncer(
-                user, {"apns": True}, {"gcm": True}, {}, android_devices=[], apple_devices=[]
-            )
-
-        self.assertIn(
-            f"INFO:zerver.lib.push_notifications:Skipping contacting the bouncer for user {user.id} because there are no registered devices",
-            mock_logging_info.output,
-        )
-        mock_send.assert_not_called()
-
     @mock.patch("zerver.lib.remote_server.send_to_push_bouncer")
     def test_send_notifications_to_bouncer(self, mock_send: mock.MagicMock) -> None:
         user = self.example_user("hamlet")


### PR DESCRIPTION
First commit: Small change to return early in legacy codepath. - See commit message.
Second commit: Tests improvement.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
