### PR TITLE
help-beta: Change color for asides and change styling for keyboard shortcuts.

### DIFF
--- a/help-beta/src/components/KeyboardTip.astro
+++ b/help-beta/src/components/KeyboardTip.astro
@@ -40,7 +40,10 @@ first_element.children = [...prefix_element_list, ...first_element.children];
 tree.children[0] = first_element;
 ---
 
-<aside aria-label="Keyboard tip" class=`starlight-aside starlight-aside--tip`>
+<aside
+    aria-label="Keyboard tip"
+    class=`starlight-aside starlight-aside--tip keyboard-tip`
+>
     <div class="starlight-aside__content">
         <Fragment set:html={toHtml(tree)} />
     </div>

--- a/help-beta/src/scripts/client/adjust_mac_kbd_tags.ts
+++ b/help-beta/src/scripts/client/adjust_mac_kbd_tags.ts
@@ -59,12 +59,7 @@ function adjust_mac_kbd_tags(): void {
 
         // In web/src/common.ts, we use zulip icon for ⌘ due to centering
         // problems, we don't have that problem in the new help center and
-        // thus don't do that transformation here. We do need to make these
-        // symbols appear larger than they do by default since they are too
-        // small to see in the default font-size of 0.85em for kbd elements.
-        if (key_text === "⌘" || key_text === "⌥") {
-            element.style.fontSize = "1em";
-        }
+        // thus don't do that transformation here.
     }
 }
 

--- a/help-beta/src/styles/main.css
+++ b/help-beta/src/styles/main.css
@@ -65,6 +65,12 @@
         hsl(204deg 58% 92%),
         hsl(204deg 100% 12%)
     );
+
+    /* Keyboard shortcuts */
+    --color-keyboard-shortcuts: light-dark(
+        hsl(225deg 57.09% 42.9%),
+        hsl(225deg 100% 84%)
+    );
 }
 
 .non-clickable-sidebar-heading {
@@ -222,26 +228,12 @@
     }
 
     & kbd {
-        /* Same as kbd in app_components.css */
-        display: inline-block;
-        border: 1px solid hsl(0deg 0% 80%);
-        border-radius: 4px;
-        font-weight: 600;
+        font-size: 1.2em;
+        padding: 0.15em 0.4em 0.05em;
+        border: 1px solid var(--color-keyboard-shortcuts);
+        border-radius: 3px;
+        color: var(--color-keyboard-shortcuts);
+        text-align: center;
         white-space: nowrap;
-        background-color: hsl(0deg 0% 98%);
-        color: hsl(0deg 0% 20%);
-        text-shadow: 0 1px 0 hsl(0deg 0% 100%);
-        /* Different from app_components.css */
-        /* Removed margin setting */
-        font-size: 0.85em;
-        padding: 0 0.4em;
-
-        &.arrow-key {
-            /* Same as in informational_overlays.css */
-            line-height: 1;
-            padding: 0 0.2em 0.2em;
-            /* Different from informational_overlays.css */
-            font-size: 1.2em;
-        }
     }
 }

--- a/help-beta/src/styles/main.css
+++ b/help-beta/src/styles/main.css
@@ -21,6 +21,50 @@
     --color-user-circle-offline: light-dark(#c1c6d7, #454854);
     --color-user-circle-deactivated: hsl(0deg 0% 50%);
     /* stylelint-enable color-no-hex */
+
+    /* NOTE: These colors are also used in zulip web app for banner
+       colors. Do grep for these variables when changing them and
+       confirm on CZO on whether the colors there need to change as
+       well. */
+    /* Banners - Neutral Variant */
+    --color-text-neutral-banner: light-dark(
+        hsl(229deg 12% 25%),
+        hsl(231deg 11% 76%)
+    );
+    --color-border-neutral-banner: light-dark(
+        color-mix(in oklch, hsl(240deg 2% 30%) 40%, transparent),
+        color-mix(in oklch, hsl(240deg 7% 66%) 40%, transparent)
+    );
+    --color-background-neutral-banner: light-dark(
+        hsl(240deg 7% 93%),
+        hsl(240deg 7% 17%)
+    );
+    /* Banners - Brand Variant */
+    --color-text-brand-banner: light-dark(
+        hsl(264deg 95% 34%),
+        hsl(244deg 96% 82%)
+    );
+    --color-border-brand-banner: light-dark(
+        color-mix(in oklch, hsl(254deg 60% 50%) 40%, transparent),
+        color-mix(in oklch, hsl(253deg 70% 89%) 40%, transparent)
+    );
+    --color-background-brand-banner: light-dark(
+        hsl(254deg 42% 94%),
+        hsl(253deg 49% 16%)
+    );
+    /* Banners - Info Variant */
+    --color-text-info-banner: light-dark(
+        hsl(241deg 95% 25%),
+        hsl(221deg 93% 89%)
+    );
+    --color-border-info-banner: light-dark(
+        color-mix(in oklch, hsl(204deg 49% 29%) 40%, transparent),
+        color-mix(in oklch, hsl(205deg 58% 69%) 40%, transparent)
+    );
+    --color-background-info-banner: light-dark(
+        hsl(204deg 58% 92%),
+        hsl(204deg 100% 12%)
+    );
 }
 
 .non-clickable-sidebar-heading {
@@ -71,6 +115,24 @@
     steps have a relative link. So we add a right margin to the
     icon to add the white space without any text decoration. */
     margin-right: 4px;
+}
+
+.starlight-aside--tip {
+    --sl-color-asides-text-accent: var(--color-text-brand-banner);
+    --sl-color-asides-border: var(--color-border-brand-banner);
+    background-color: var(--color-background-brand-banner);
+}
+
+.starlight-aside--note {
+    --sl-color-asides-text-accent: var(--color-text-neutral-banner);
+    --sl-color-asides-border: var(--color-border-neutral-banner);
+    background-color: var(--color-background-neutral-banner);
+}
+
+.keyboard-tip {
+    --sl-color-asides-text-accent: var(--color-text-info-banner);
+    --sl-color-asides-border: var(--color-border-info-banner);
+    background-color: var(--color-background-info-banner);
 }
 
 .aside-icon-lightbulb {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2547,6 +2547,10 @@
     );
 
     /* Banners */
+    /* NOTE: These colors are also used in starlight help center for
+       aside colors. Do grep for these variable when changing them
+       and confirm on CZO on whether the colors there need to change
+       as well. */
     --color-text-link-banner: hsl(210deg 94% 42%);
     /* Banners - Neutral Variant */
     --color-text-neutral-banner: light-dark(


### PR DESCRIPTION
Commit 1:

Fixes https://github.com/zulip/zulip/issues/35122.

The existing colors were attracting too much attention.

Design discussion was done on https://chat.zulip.org/#narrow/channel/19-documentation/topic/new.20help.20center.3A.20design.

Commit 2:

Fixes https://github.com/zulip/zulip/issues/35118.

Visual tuning for this was done on a call, some of it was done in https://chat.zulip.org/#narrow/channel/19-documentation/topic/new.20help.20center.3A.20design

For dark theme, we use the same color as we use in styling `.tooltip-hotkey-hint`. For light theme, we brainstormed a color that looked fine to us. Padding and font-size was also experimented and set. Since we just took inspiration from `tooltip-hotkey-hint` and did not use the same styling i.e. tweaked them, we do not add any comments declaring dependency b/w both styles.

We increase the font-size from 0.85em to 1.2em, so we don't need to increase font-size for ⌘ and ⌥ in scripts/adjust_mac_kbd_tags.ts.

Current help center had special styling for arrow keys, we don't port that over here, since the styling we do for our keyboard shortcuts does not necessitate that.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

## Asides:

Light mode:
<img width="799" height="291" alt="Screenshot 2025-07-29 at 1 34 32 AM" src="https://github.com/user-attachments/assets/f8e4a562-e0e7-4653-ace5-08c9ade28bdf" />
<img width="791" height="179" alt="Screenshot 2025-07-29 at 1 35 59 AM" src="https://github.com/user-attachments/assets/411d9e9a-f649-420c-b4a7-4ea01ceec578" />



Dark mode:
<img width="799" height="291" alt="Screenshot 2025-07-29 at 1 34 59 AM" src="https://github.com/user-attachments/assets/ce082131-bf24-4a30-843c-9445d7e92fd7" />
<img width="791" height="179" alt="Screenshot 2025-07-29 at 1 35 47 AM" src="https://github.com/user-attachments/assets/13826ce9-fa69-474c-8dc1-446fec54c318" />

## Keyboard shortcuts:
<img width="813" height="858" alt="Screenshot 2025-07-29 at 1 39 25 AM" src="https://github.com/user-attachments/assets/ede954d9-ec2d-4435-900e-e906669e3c83" />
<img width="813" height="858" alt="Screenshot 2025-07-29 at 1 39 20 AM" src="https://github.com/user-attachments/assets/d6b1f22e-1dab-4c92-8dd1-eb64c365ce82" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
