### PR TITLE
inbox: Color chevrons according to Vlad's Figma spec.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1918,6 +1918,9 @@
     );
     --color-icons-inbox: light-dark(hsl(0deg 0% 0%), hsl(0deg 0% 100%));
     --color-folder-header: light-dark(hsl(216deg 43% 20%), hsl(216deg 50% 75%));
+    /* Light mode uses the --grey-600 equivalent;
+       dark mode uses the --grey-300 equivalent. */
+    --color-inbox-row-chevron: light-dark(#535663, #aaadba);
 
     /* Navbar dropdown menu constants - Values from Figma design */
     --box-shadow-popover-menu:

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -584,6 +584,17 @@
     }
 }
 
+.channel-row-chevron {
+    color: var(--color-inbox-row-chevron);
+}
+
+.inbox-collapsed-state {
+    .folder-row-chevron,
+    .channel-row-chevron {
+        opacity: 0.5;
+    }
+}
+
 .inbox-container #inbox-pane .inbox-folder .unread_mention_info {
     display: none;
 }

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -393,7 +393,6 @@
         }
 
         .inbox-header-name-text,
-        .collapsible-button .zulip-icon,
         .unread_mention_info,
         .unread_count {
             color: var(--color-folder-header);
@@ -582,6 +581,10 @@
     .zulip-icon-chevron-down {
         transform: rotate(0deg);
     }
+}
+
+.folder-row-chevron {
+    color: var(--color-folder-header);
 }
 
 .channel-row-chevron {

--- a/web/templates/inbox_view/inbox_folder_row.hbs
+++ b/web/templates/inbox_view/inbox_folder_row.hbs
@@ -12,7 +12,7 @@
                         {{/if}}
                     </span>
                 </div>
-                <div class="collapsible-button"><i class="zulip-icon zulip-icon-chevron-down"></i></div>
+                <div class="collapsible-button"><i class="folder-row-chevron zulip-icon zulip-icon-chevron-down"></i></div>
                 <span class="unread_mention_info tippy-zulip-tooltip
                   {{#unless has_unread_mention}}hidden{{/unless}}"
                   data-tippy-content="{{t 'You have unread mentions' }}">@</span>

--- a/web/templates/inbox_view/inbox_stream_header_row.hbs
+++ b/web/templates/inbox_view/inbox_stream_header_row.hbs
@@ -13,7 +13,7 @@
                         </span>
                     {{/if}}
                 </div>
-                <div class="collapsible-button toggle-inbox-header-icon {{#if is_collapsed}}icon-collapsed-state{{/if}}"><i class="zulip-icon zulip-icon-chevron-down"></i></div>
+                <div class="collapsible-button toggle-inbox-header-icon {{#if is_collapsed}}icon-collapsed-state{{/if}}"><i class="channel-row-chevron zulip-icon zulip-icon-chevron-down"></i></div>
                 <span class="unread_mention_info tippy-zulip-tooltip
                   {{#unless mention_in_unread}}hidden{{/unless}}"
                   data-tippy-content="{{t 'You have unread mentions'}}">@</span>


### PR DESCRIPTION
This PR implements the light-mode chevron colors (based on the `--grey-600` color) and collapsed-state opacity Vlad has called for; it interpolates a dark-mode scheme using the brighter `--grey-300` color.

[#design > channel folders UI: Inbox @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/channel.20folders.20UI.3A.20Inbox/near/2229545)

Vlad's [Figma file](https://www.figma.com/design/jbNOiBWvbtLuHaiTj4CW0G/Zulip-Web-App?node-id=8733-68284&t=otdkL0LuC5GIBVqu-0)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_With header colors on folder rows, and Vlad's spec'd colors on channel rows:_

| Light mode | Dark mode |
| --- | --- |
| <img width="1106" height="700" alt="inbox-chevrons-header-colors-light" src="https://github.com/user-attachments/assets/962b32c3-58be-40a5-b95e-cf5b73a8ba55" /> | <img width="1106" height="700" alt="inbox-chevrons-header-color-dark" src="https://github.com/user-attachments/assets/d1509dbb-01d7-41a2-b7a4-3b8aeb9c9d59" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>