### PR TITLE
Indicate characters exceeding maxlength in message-edit UI #22525

### DIFF
--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -37,7 +37,7 @@
                                 </button>
                             </div>
                             <button type="button" class="message-actions-button message_edit_cancel"><span>{{t "Cancel" }}</span></button>
-                            <span class="tippy-zulip-tooltip message-limit-indicator" data-tippy-content="{{t 'Maximum message length: {max_message_length} characters' }}"></span>
+                            <div class="message-limit-indicator"></div>
                             <div class="message-edit-timer">
                                 <span class="message_edit_countdown_timer
                                   tippy-zulip-tooltip" data-tippy-content="{{t 'This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.' }}"></span>


### PR DESCRIPTION
Indicate characters exceeding maxlength in message-edit UI

Fixes: #22525

This PR update message edit UI to indicate user's messages exceeds maximum of characters that needed to removed. 

<img width="1274" height="947" alt="Zulip PR edit message extra" src="https://github.com/user-attachments/assets/0da43040-6660-405d-9b78-e0b5487d1da6" />

In web/templates/message_edit_form.hbs, I replaced the span element line with div element 

<img width="1629" height="953" alt="image" src="https://github.com/user-attachments/assets/8138d355-44f2-46b9-875c-ab9729f4483c" />

<img width="1363" height="892" alt="Zulip PR Pic" src="https://github.com/user-attachments/assets/406be324-dcda-451e-9c27-39f4de662989" />

Old line 40 
```<span class="tippy-zulip-tooltip message-limit-indicator" data-tippy-content="{{t 'Maximum message length: {max_message_length} characters' }}"></span>```

 New line 40 
```<div class="message-limit-indicator"></div>```

Reason for the change: 
With this update, it will indicate characters exceeding maxlength in message-edit UI. It appears that origin line 40 already indicates how many characters users need to remove, but my change in line 40 with <div> is more practical and suitable for Zulip codebase. It’s safer to use div block element for multiline or style content. Using div can avoid layout issues. With span’s long message can overflow on CSS, whereas div is a default block level that is easy to manage and format. Also, using div is more consistent with Zulip’s codebase.  

<img width="879" height="540" alt="image" src="https://github.com/user-attachments/assets/983cd03e-7eee-4888-9dcc-2e7caac2c8e8" />

<img width="843" height="518" alt="image" src="https://github.com/user-attachments/assets/c6d23e86-c743-4b59-9ce6-63b061e6a4ca" />

<details>
<summary>Self-review checklist</summary>


- [ x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x ] Each commit is a coherent idea.
- [ x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x ] Visual appearance of the changes.
- [ x] Responsiveness and internationalization.
- [x ] Strings and tooltips.
- [ x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
