### PR TITLE
left_sidebar: Prevent wrap on channel folder names.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -12,6 +12,7 @@
        or controls in the row. */
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 #left-sidebar .input-element-wrapper {


### PR DESCRIPTION
before:

<img width="354" height="118" alt="Screenshot 2025-07-28 at 4 50 36 PM" src="https://github.com/user-attachments/assets/025bcdbf-a2c7-4134-921e-80270453387a" />


after:

<img width="324" height="120" alt="Screenshot 2025-07-28 at 4 52 05 PM" src="https://github.com/user-attachments/assets/600953e5-5cd3-47eb-a90b-5af62cf9510c" />
