### PR TITLE
left_sidebar: Rename OTHER CHANNELS folder to CHANNELS.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -858,7 +858,7 @@ function get_folder_name_from_id(folder_id: number): string {
     }
 
     if (folder_id === OTHER_CHANNELS_FOLDER_ID) {
-        return $t({defaultMessage: "OTHER CHANNELS"});
+        return $t({defaultMessage: "CHANNELS"});
     }
 
     return channel_folders.get_channel_folder_by_id(folder_id).name;

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -134,7 +134,7 @@ export function sort_groups(stream_ids: number[], search_term: string): StreamLi
     };
     const normal_section: StreamListSection = {
         id: "normal-streams",
-        section_title: $t({defaultMessage: "OTHER CHANNELS"}),
+        section_title: $t({defaultMessage: "CHANNELS"}),
         streams: [],
         muted_streams: [],
         inactive_streams: [],
@@ -191,15 +191,6 @@ export function sort_groups(stream_ids: number[], search_term: string): StreamLi
 
     // This needs to have the same ordering as the order they're displayed in the sidebar.
     const new_sections = [pinned_section, ...folder_sections_sorted, normal_section];
-
-    // Don't call it "other channels" if there's nothing above it.
-    if (
-        folder_sections_sorted.length === 0 &&
-        pinned_section.streams.length === 0 &&
-        pinned_section.muted_streams.length === 0
-    ) {
-        normal_section.section_title = $t({defaultMessage: "CHANNELS"});
-    }
 
     for (const section of new_sections) {
         section.streams.sort(compare_function);


### PR DESCRIPTION
We're changing this so that in views like inbox (which only shows locations with unreads), it feels a bit weird for it to possibly only have a "DIRECT MESSAGES" and then "OTHER CHANNELS" section, if your only unreads are in non-pinned folders.

More discussion here:
https://chat.zulip.org/#narrow/channel/101-design/topic/channel.20folders.20in.20left.20sidebar.20.2331972/near/2231091
