### PR TITLE
Fix user jumping to top when sending a message in a `near` narrow with `old_unreads_missing`.

### DIFF
--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -268,21 +268,8 @@ export function notify_local_mixes(
             continue;
         }
 
-        const jump_to_sent_message_conversation = should_jump_to_sent_message_conversation(message);
-        const show_narrow_to_recipient_banner = should_show_narrow_to_recipient_banner(message);
-
         const link_msg_id = message.id;
-
-        if (!jump_to_sent_message_conversation && !show_narrow_to_recipient_banner) {
-            if (need_user_to_scroll) {
-                show_scroll_to_view_banner(link_msg_id);
-            }
-
-            // This is the HAPPY PATH--for most messages we do nothing
-            // other than maybe sending the above message.
-            continue;
-        }
-
+        const show_narrow_to_recipient_banner = should_show_narrow_to_recipient_banner(message);
         if (show_narrow_to_recipient_banner) {
             const banner_text = $t({
                 defaultMessage: "Sent! Your message is outside your current view.",
@@ -295,6 +282,17 @@ export function notify_local_mixes(
                 get_message_recipient(message),
                 null,
             );
+            continue;
+        }
+
+        const jump_to_sent_message_conversation = should_jump_to_sent_message_conversation(message);
+        if (!jump_to_sent_message_conversation) {
+            if (need_user_to_scroll) {
+                show_scroll_to_view_banner(link_msg_id);
+            }
+
+            // This is the HAPPY PATH--for most messages we do nothing
+            // other than maybe showing the above banner.
             continue;
         }
 

--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -220,6 +220,21 @@ function should_show_narrow_to_recipient_banner(message: Message): boolean {
     return false;
 }
 
+function show_scroll_to_view_banner(link_msg_id: number): void {
+    const banner_text = $t({defaultMessage: "Sent!"});
+    const link_text = $t({defaultMessage: "Scroll down to view your message."});
+    notify_above_composebox(
+        banner_text,
+        compose_banner.CLASSNAMES.sent_scroll_to_view,
+        // Don't display a URL on hover for the "Scroll to bottom" link.
+        null,
+        link_msg_id,
+        null,
+        link_text,
+    );
+    compose_banner.set_scroll_to_message_banner_message_id(link_msg_id);
+}
+
 export function notify_local_mixes(
     messages: Message[],
     need_user_to_scroll: boolean,
@@ -260,18 +275,7 @@ export function notify_local_mixes(
 
         if (!jump_to_sent_message_conversation && !show_narrow_to_recipient_banner) {
             if (need_user_to_scroll) {
-                const banner_text = $t({defaultMessage: "Sent!"});
-                const link_text = $t({defaultMessage: "Scroll down to view your message."});
-                notify_above_composebox(
-                    banner_text,
-                    compose_banner.CLASSNAMES.sent_scroll_to_view,
-                    // Don't display a URL on hover for the "Scroll to bottom" link.
-                    null,
-                    link_msg_id,
-                    null,
-                    link_text,
-                );
-                compose_banner.set_scroll_to_message_banner_message_id(link_msg_id);
+                show_scroll_to_view_banner(link_msg_id);
             }
 
             // This is the HAPPY PATH--for most messages we do nothing

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -820,13 +820,18 @@ export let show = (raw_terms: NarrowTerm[], show_opts: ShowMessageViewOpts): voi
                     ) {
                         // We convert the current narrow into a `near` narrow so that
                         // user doesn't accidentally mark msgs read which they haven't seen.
-                        const terms = [
+                        let terms = [
                             ...msg_list.data.filter.terms(),
                             {
                                 operator: "near",
                                 operand: current_selected_id.toString(),
                             },
                         ];
+                        assert(msg_list.data.filter.is_conversation_view());
+                        // Using both /with/ and /near/ operators in a single view doesn't
+                        // make sense, and checks like is_conversation_view_with_near do not
+                        // handle that combination correctly.
+                        terms = terms.filter((term) => term.operator !== "with");
                         const opts = {
                             trigger: "old_unreads_missing",
                         };


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20view.20jumping.20to.20the.20top.20unexpectedly/with/2231100