### PR TITLE
inbox: Fix left alignment of user full name in DM rows.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -178,6 +178,11 @@
             .user_block .zulip-icon {
                 /* 0 5px at 16px/1em */
                 padding: 0 0.3125em;
+
+                &.user-circle {
+                    /* 5px at 16px / ~ 0.5em */
+                    padding: 0 0.586em;
+                }
             }
 
             .inbox-row {
@@ -321,8 +326,6 @@
                     .user_block {
                         display: flex;
                         align-items: center;
-                        /* 3px at 16px / 1em */
-                        margin-left: 0.1875em;
                     }
                 }
             }


### PR DESCRIPTION
They were misaligned since `user-circle` uses a different font-size than rest of the icons and thus needed a different padding in `em`.


| before | after |
| --- | --- |
| <img width="117" height="866" alt="Screenshot from 2025-07-29 11-43-40" src="https://github.com/user-attachments/assets/ce37ccb8-7874-46bf-8baf-d99e71a7602a" /> | <img width="117" height="866" alt="image" src="https://github.com/user-attachments/assets/d8f5e4a6-7e39-4fe8-81ec-65e640a54bdd" /> |