### PR TITLE
help: Add mobile instructions for setting and clearing user status.

### DIFF
--- a/help/include/set-status.md
+++ b/help/include/set-status.md
@@ -1,4 +1,4 @@
-1. Click **Set status**.
+1. Click **Set status** or **Edit status**.
 
 1. Click to select one of the common statuses, *or* choose any emoji and/or
    write a short message.

--- a/help/status-and-availability.md
+++ b/help/status-and-availability.md
@@ -34,13 +34,16 @@ You can set a status emoji, status message, or both.
 
 {tab|mobile}
 
-Access this feature by following the web app instructions in your
-mobile device browser.
+{!mobile-menu.md!}
 
-Implementation of this feature in the mobile app is tracked [on
-GitHub](https://github.com/zulip/zulip-flutter/issues/198). If
-you're interested in this feature, please react to the issue's
-description with 👍.
+1. Tap **My profile**.
+
+1. Tap **Set status** or **Status**.
+
+1. Select one of the common statuses, or choose any emoji and/or write
+   a short message.
+
+1. Tap **Save**.
 
 {end_tabs}
 
@@ -59,6 +62,16 @@ description with 👍.
 {!personal-menu.md!}
 
 {!clear-status.md!}
+
+{tab|mobile}
+
+{!mobile-menu.md!}
+
+1. Tap **My profile**.
+
+1. Tap **Status**.
+
+1. Tap **Clear**, and then **Save** in the top right corner of the app.
 
 {end_tabs}
 


### PR DESCRIPTION
Updates the mobile documentation for setting and clearing a user status.

Relevant mobile issue: https://github.com/zulip/zulip-flutter/issues/198

**Screenshots and screen captures:**

[CURRENT DOC](https://zulip.com/help/status-and-availability#statuses)


<img width="743" height="319" alt="Screenshot 2025-07-29 at 12 09 08" src="https://github.com/user-attachments/assets/46ef95b3-0266-4f79-b874-b0e82c2b8344" />
<img width="748" height="298" alt="Screenshot 2025-07-29 at 12 09 13" src="https://github.com/user-attachments/assets/2c9fa161-dcb4-4058-bc54-ec37660f797f" />
<img width="743" height="319" alt="Screenshot 2025-07-29 at 12 09 18" src="https://github.com/user-attachments/assets/9b6b116f-bb76-4ea6-ba7e-98baa8106c03" />
<img width="747" height="260" alt="Screenshot 2025-07-29 at 12 10 36" src="https://github.com/user-attachments/assets/44070f4a-791c-44b9-838a-996276d3bc61" />