### PR TITLE
reload: Remove event listeners to handle reload logic for compose.

### DIFF
--- a/web/src/compose.ts
+++ b/web/src/compose.ts
@@ -20,6 +20,7 @@ import type {PostMessageAPIData} from "./echo.ts";
 import * as message_events from "./message_events.ts";
 import type {LocalMessage} from "./message_helper.ts";
 import * as onboarding_steps from "./onboarding_steps.ts";
+import * as reload from "./reload.ts";
 import * as scheduled_messages from "./scheduled_messages.ts";
 import * as sent_messages from "./sent_messages.ts";
 import * as server_events_state from "./server_events_state.ts";
@@ -401,6 +402,7 @@ export function do_post_send_tasks(): void {
     // TODO: Do we want to fire the event even if the send failed due
     // to a server-side error?
     $(document).trigger("compose_finished.zulip");
+    reload.maybe_reset_pending_reload_timeout("compose_end");
 }
 
 function schedule_message_to_custom_date(): void {

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -26,6 +26,7 @@ import * as message_viewport from "./message_viewport.ts";
 import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as popovers from "./popovers.ts";
+import * as reload from "./reload.ts";
 import * as reload_state from "./reload_state.ts";
 import * as resize from "./resize.ts";
 import * as saved_snippets_ui from "./saved_snippets_ui.ts";
@@ -216,7 +217,7 @@ export let complete_starting_tasks = (opts: ComposeActionsOpts): void => {
 
     maybe_scroll_up_selected_message(opts);
     compose_fade.start_compose(opts.message_type);
-    $(document).trigger(new $.Event("compose_started.zulip", opts));
+    reload.maybe_reset_pending_reload_timeout("compose_start");
     compose_recipient.update_compose_area_placeholder_text();
     compose_recipient.update_narrow_to_recipient_visibility();
     compose_recipient.update_recipient_row_attention_level();
@@ -526,6 +527,7 @@ export let cancel = (): void => {
     compose_state.set_message_type(undefined);
     compose_pm_pill.clear();
     $(document).trigger("compose_canceled.zulip");
+    reload.maybe_reset_pending_reload_timeout("compose_end");
 };
 
 export function rewire_cancel(value: typeof cancel): void {

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -435,6 +435,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
 test_ui("handle_enter_key_with_preview_open", ({override, override_rewire}) => {
     mock_banners();
     override_rewire(compose_banner, "clear_message_sent_banners", noop);
+    window.addEventListener = noop;
 
     disable_document_triggers(override);
 

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -62,6 +62,8 @@ const narrow_state = mock_esm("../src/narrow_state", {
 
 mock_esm("../src/reload_state", {
     is_in_progress: () => false,
+    set_csrf_failed_handler: noop,
+    is_pending: () => true,
 });
 mock_esm("../src/drafts", {
     update_draft: noop,
@@ -157,6 +159,7 @@ test("initial_state", () => {
 
 test("start", ({override, override_rewire, mock_template}) => {
     mock_banners();
+    window.addEventListener = noop;
     override_private_message_recipient_ids({override});
     override_rewire(compose_actions, "autosize_message_content", noop);
     override_rewire(compose_actions, "expand_compose_box", noop);

--- a/web/tests/reload.test.cjs
+++ b/web/tests/reload.test.cjs
@@ -2,12 +2,16 @@
 
 const assert = require("node:assert/strict");
 
-const {zrequire} = require("./lib/namespace.cjs");
+const {mock_esm, set_global, zrequire} = require("./lib/namespace.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
+
+const channel = mock_esm("../src/channel");
 
 // override file-level function call in reload.ts
 window.addEventListener = noop;
 const reload = zrequire("reload");
+
+set_global("document", {});
 
 run_test("old_metadata_string_is_stale", () => {
     assert.ok(reload.is_stale_refresh_token({reload_data: {hash: ""}}, Date.now()), true);
@@ -35,4 +39,55 @@ run_test("old_token_is_stale ", () => {
             Date.parse("23 Jan 2022 00:00:00 GMT"),
         ),
     );
+});
+
+run_test("reload", ({override}) => {
+    let idle_timeout_created = false;
+    let idle_timeout_canceled = false;
+    override(document, "to_$", () => ({
+        idle() {
+            idle_timeout_created = true;
+            return {
+                cancel() {
+                    idle_timeout_canceled = true;
+                },
+            };
+        },
+    }));
+    channel.get = (opts) => {
+        assert.equal(opts.url, "/compatibility");
+        opts.success();
+    };
+
+    // No reload has been initiated so "maybe_reload_*" shouldn't
+    // do anything
+    reload.maybe_reset_pending_reload_timeout("compose_start");
+    assert.equal(idle_timeout_created, false);
+    assert.equal(idle_timeout_canceled, false);
+    assert.equal(reload.reset_reload_timeout, undefined);
+
+    reload.maybe_reset_pending_reload_timeout("compose_end");
+    assert.equal(idle_timeout_created, false);
+    assert.equal(idle_timeout_canceled, false);
+    assert.equal(reload.reset_reload_timeout, undefined);
+
+    // Initiate reload should create a new timeout and creates
+    // reset_reload_timeout
+    reload.initiate({});
+    assert.equal(idle_timeout_created, true);
+    assert.equal(idle_timeout_canceled, false);
+    assert.equal(typeof reload.reset_reload_timeout, "function");
+
+    idle_timeout_created = false;
+
+    reload.maybe_reset_pending_reload_timeout("compose_start");
+    assert.equal(idle_timeout_canceled, true);
+    assert.equal(idle_timeout_created, true);
+
+    idle_timeout_created = false;
+    idle_timeout_canceled = false;
+
+    reload.maybe_reset_pending_reload_timeout("compose_end");
+    assert.equal(idle_timeout_canceled, true);
+    assert.equal(idle_timeout_created, true);
 });


### PR DESCRIPTION
Earlier, we would trigger events when compose opened or closed to reset reload timeout.

This PR removes this in favor of normal function calls to `compose_started_handler` and `compose_done_handler` to do this.

<!-- Describe your pull request here.-->
Preparatory PR

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
