### PR TITLE
help: Add reactions view to "Reading strategies: Special views".

### DIFF
--- a/help/emoji-reactions.md
+++ b/help/emoji-reactions.md
@@ -14,13 +14,10 @@ message.
 
 {!message-actions.md!}
 
-1. Click the **smiley face** (<i class="zulip-icon zulip-icon-smile"></i>) icon.
-
-    !!! warn ""
-
-        For messages that you've sent, click on the **ellipsis**
-        (<i class="zulip-icon zulip-icon-more-vertical-spread"></i>) and then
-        **Add emoji reaction**.
+1. Click the **Add emoji reaction** (<i class="zulip-icon
+   zulip-icon-smile"></i>) icon. On messages that you sent, click on the
+   **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical-spread"></i>),
+   then **Add emoji reaction**.
 
 1. Select an emoji. Type to search, use the arrow keys, or click on an emoji
    with your mouse.
@@ -32,7 +29,8 @@ message.
 
 !!! keyboard_tip ""
 
-    You can react to the selected message with 👍 by using the <kbd>+</kbd> shortcut.
+    Use <kbd>:</kbd> to add any reaction, <kbd>=</kbd> to add the first
+    emoji reaction added by others, or <kbd>+</kbd> to react with 👍.
 
 {tab|mobile}
 
@@ -111,28 +109,7 @@ so](#toggle-whether-names-of-reacting-users-are-displayed) is enabled.
 
 ## View your messages with reactions
 
-To see how others have responded to your messages, you can view all your
-messages which have received at least one reaction.
-
-{start_tabs}
-
-{tab|desktop-web}
-
-1. Click on <i class="zulip-icon zulip-icon-smile"></i> **Reactions** in the left
-   sidebar. If the **views** section is collapsed, click on
-   the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>),
-   and select <i class="zulip-icon zulip-icon-smile"></i> **Reactions**.
-
-1. Browse your reactions. You can click on a message recipient bar to go
-   to the [conversation](/help/reading-conversations) where you sent the message.
-
-!!! tip ""
-
-    You can also [search all messages with reactions](/help/search-for-messages) using the
-    `has:reaction` filter.
-
-{end_tabs}
-
+{!view-emoji-reactions.md!}
 
 ## Related articles
 

--- a/help/include/view-emoji-reactions.md
+++ b/help/include/view-emoji-reactions.md
@@ -1,0 +1,22 @@
+The reactions view lets you see all of your messages that have received at least
+one [emoji reaction](/help/emoji-reactions). You can see what resonated with
+others, or confirm that key stakeholders have seen and responded to a message.
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click on <i class="zulip-icon zulip-icon-smile"></i> **Reactions** in the left
+   sidebar. If the **views** section is collapsed, click on
+   the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>),
+   and select <i class="zulip-icon zulip-icon-smile"></i> **Reactions**.
+
+1. Browse your reactions. You can click on a message recipient bar to go
+   to the [conversation](/help/reading-conversations) where you sent the message.
+
+!!! tip ""
+
+    You can also [search all messages with reactions](/help/search-for-messages) using the
+    `has:reaction` filter.
+
+{end_tabs}

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -129,6 +129,7 @@ reference in the Zulip app to add more to your repertoire as needed.
 
 ### For a selected message (outlined in blue)
 
+* **Toggle message actions menu**: <kbd>I</kbd>
 * **Edit message or view original message**: <kbd>E</kbd>
 * **Show message sender's user card**: <kbd>U</kbd>
 * **View read receipts**: <kbd>Shift</kbd> + <kbd>V</kbd> — Same shortcut
@@ -139,8 +140,9 @@ reference in the Zulip app to add more to your repertoire as needed.
   <kbd>H</kbd>. Viewing message edit history [must be
   allowed](/help/restrict-message-edit-history-access).
 * **Star message**: <kbd>Ctrl</kbd> + <kbd>S</kbd>
-* **React with 👍**: <kbd>+</kbd>
+* **Add emoji reaction**: <kbd>:</kbd>
 * **Toggle first emoji reaction**: <kbd>=</kbd>
+* **React with 👍**: <kbd>+</kbd>
 * **Mark as unread from selected message**: <kbd>Shift</kbd> + <kbd>U</kbd>
 * **Collapse/show message**: <kbd>-</kbd>
 * **Toggle topic mute**: <kbd>Shift</kbd> + <kbd>M</kbd>. This works in both
@@ -175,11 +177,8 @@ Keyboard navigation (e.g., arrow keys) works as expected.
 * **Toggle gear menu**: <kbd>G</kbd>
 * **Open personal menu**: <kbd>G</kbd> + <kbd class="arrow-key">→</kbd>
 * **Open help menu**: <kbd>G</kbd> + <kbd class="arrow-key">←</kbd>
-
-### For a selected message (outlined in blue)
-
-* **Toggle emoji reactions menu**: <kbd>:</kbd>
-* **Toggle message actions menu**: <kbd>I</kbd>
+* **Toggle message actions menu** for a selected message (outlined in blue):
+  <kbd>I</kbd>
 
 ## Channel settings
 

--- a/help/reading-strategies.md
+++ b/help/reading-strategies.md
@@ -76,6 +76,10 @@ You can [star messages](/help/star-a-message) that you plan to follow up on late
 
 {!view-starred-messages.md!}
 
+### Reactions
+
+{!view-emoji-reactions.md!}
+
 ## Related articles
 
 * [Getting started with Zulip](/help/getting-started-with-zulip)

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -294,6 +294,14 @@
                     <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>S</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'Add emoji reaction to selected message' }}</td>
+                    <td><span class="hotkey"><kbd>:</kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Toggle first emoji reaction on selected message' }}</td>
+                    <td><span class="hotkey"><kbd>=</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition rendered_markdown">
                         {{t 'React to selected message with' }}
                         <img alt=":thumbs_up:"
@@ -302,10 +310,6 @@
                           title=":thumbs_up:"/>
                     </td>
                     <td><span class="hotkey"><kbd>+</kbd></span></td>
-                </tr>
-                <tr>
-                    <td class="definition">{{t 'Toggle first emoji reaction on selected message' }}</td>
-                    <td><span class="hotkey"><kbd>=</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Mark as unread from selected message' }}</td>
@@ -381,10 +385,6 @@
                 <tr>
                     <td class="definition">{{t 'Open message menu' }}</td>
                     <td><span class="hotkey"><kbd>I</kbd></span></td>
-                </tr>
-                <tr>
-                    <td class="definition">{{t 'Open reactions menu' }}</td>
-                    <td><span class="hotkey"><kbd>:</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Show keyboard shortcuts' }}</td>


### PR DESCRIPTION
Adds a section on the **Reactions** view to the **Special views** section in the **Reading strategies** article, and generally updates reactions docs.


<details>
<summary>
**Screenshots and screen captures:**
</summary>

## https://zulip.com/help/emoji-reactions
<img width="740" height="560" alt="Screenshot 2025-07-29 at 11 49 59" src="https://github.com/user-attachments/assets/9cf4e84f-1814-4e19-b26c-c565d9238c80" />

## https://zulip.com/help/emoji-reactions, https://zulip.com/help/reading-strategies#special-views
<img width="726" height="364" alt="Screenshot 2025-07-29 at 11 27 17" src="https://github.com/user-attachments/assets/9ae3e8bb-da5f-4f59-a837-5d575b2c7545" />

## https://zulip.com/help/keyboard-shortcuts
<img width="736" height="684" alt="Screenshot 2025-07-29 at 11 43 53" src="https://github.com/user-attachments/assets/fc9178cf-d97d-4a54-aba9-df350da76a99" />
<img width="576" height="226" alt="Screenshot 2025-07-29 at 11 44 10" src="https://github.com/user-attachments/assets/d45784ad-7c57-499d-b9a5-12e94096ef4f" />

## `?` menu
<img width="495" height="252" alt="Screenshot 2025-07-29 at 11 51 06" src="https://github.com/user-attachments/assets/469c51ce-cb45-4c29-8b3c-26e97b5e35c9" />


</details>
