### PR TITLE
help: Update notifications docs, including E2EE.

### DIFF
--- a/help/desktop-notifications.md
+++ b/help/desktop-notifications.md
@@ -1,17 +1,16 @@
 # Desktop notifications
 
-Zulip offers visual and audible desktop notifications. You can
-customize whether [channel messages](/help/channel-notifications),
-[direct messages](/help/dm-mention-alert-notifications) and
-[mentions](/help/dm-mention-alert-notifications#wildcard-mentions)
-trigger desktop notifications.
+Zulip can be configured to send visual and audible desktop notifications for
+[DMs, mentions, and alerts](/help/dm-mention-alert-notifications), as well as
+[channel messages](/help/channel-notifications) and [followed
+topics](/help/follow-a-topic#configure-notifications-for-followed-topics).
 
 {start_tabs}
 
 {settings_tab|notifications}
 
-1. Toggle the checkboxes for **Channels** and **DMs, mentions, and alerts**
-   in the **Desktop** column of the **Notification triggers** table.
+1. Toggle the checkboxes in the **Desktop** column of the **Notification
+   triggers** table.
 
 {end_tabs}
 

--- a/help/email-notifications.md
+++ b/help/email-notifications.md
@@ -2,7 +2,7 @@
 
 ## Message notification emails
 
-Zulip can be configured to send message notification emails for [DMs mentions,
+Zulip can be configured to send message notification emails for [DMs, mentions,
 and alerts](/help/dm-mention-alert-notifications), as well as [channel
 messages](/help/channel-notifications) and [followed
 topics](/help/follow-a-topic#configure-notifications-for-followed-topics).

--- a/help/hide-message-content-in-emails.md
+++ b/help/hide-message-content-in-emails.md
@@ -24,3 +24,4 @@ being sent through the email system.
 
 * [Hide message content in emails](/help/email-notifications#hide-message-content),
   as an individual.
+* [End-to-end encryption (E2EE) for mobile push notifications](/help/mobile-notifications#end-to-end-encryption-e2ee-for-mobile-push-notifications)

--- a/help/mobile-notifications.md
+++ b/help/mobile-notifications.md
@@ -1,10 +1,10 @@
 # Mobile notifications
 
-You can customize whether [channel messages](/help/channel-notifications),
-[direct messages](/help/dm-mention-alert-notifications) and
-[mentions][notifications-wildcard-mentions] trigger notifications in Zulip's
-[Android](https://zulip.com/apps/ios) and [iOS](https://zulip.com/apps/ios)
-apps.
+Zulip can be configured to send [mobile](/help/mobile-app-install-guide)
+notifications for [DMs, mentions, and
+alerts](/help/dm-mention-alert-notifications), as well as [channel
+messages](/help/channel-notifications) and [followed
+topics](/help/follow-a-topic#configure-notifications-for-followed-topics).
 
 {start_tabs}
 
@@ -12,8 +12,8 @@ apps.
 
 {settings_tab|notifications}
 
-1. Toggle the checkboxes for **Channels** and **DMs, mentions, and alerts**
-   in the **Mobile** column of the **Notification triggers** table.
+1. Toggle the checkboxes in the **Mobile** column of the **Notification
+   triggers** table.
 
 {end_tabs}
 
@@ -141,6 +141,7 @@ To enable push notifications for your organization:
 
 ## Related articles
 
+* [Mobile app installation guides](/help/mobile-app-install-guide)
 * [Channel notifications](/help/channel-notifications)
 * [DMs, mentions, and alerts](/help/dm-mention-alert-notifications)
 * [Email notifications](/help/email-notifications)

--- a/help/mobile-notifications.md
+++ b/help/mobile-notifications.md
@@ -19,6 +19,36 @@ apps.
 
 [notifications-wildcard-mentions]: /help/dm-mention-alert-notifications#wildcard-mentions
 
+## End-to-end encryption (E2EE) for mobile push notifications
+
+Zulip Server 11.0+ and Zulip Cloud support end-to-end encryption for mobile push
+notifications. Support is [coming soon][e2ee-flutter-issue] to the Zulip mobile
+app. Once implemented, all push notifications sent from an up-to-date version of
+the server to an updated version of the app will be end-to-end encrypted.
+
+[e2ee-flutter-issue]: https://github.com/zulip/zulip-flutter/issues/1764
+
+Organization administrators can require end-to-end encryption for
+message content in mobile push notifications. When this setting is
+enabled, message content will be omitted when sending notifications to
+an app that doesn't support end-to-end encryption. Users will see “New
+message” in place of message text. See [technical
+documentation](https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#security-and-privacy)
+for details.
+
+### Require end-to-end encryption for mobile push notifications
+
+{!admin-only.md!}
+
+{start_tabs}
+
+{settings_tab|organization-settings}
+
+1. Under **Notifications security**, toggle
+   **Require end-to-end encryption for push notification content**.
+
+{end_tabs}
+
 ## Mobile notifications while online
 
 You can customize whether or not Zulip will send mobile push
@@ -109,12 +139,6 @@ To enable push notifications for your organization:
 
 {end_tabs}
 
-### Why am I seeing “New message” in place of message text?
-
-Administrators of self-hosted Zulip servers can
-[configure](https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html#security-and-privacy)
-push notifications not to include any message content.
-
 ## Related articles
 
 * [Channel notifications](/help/channel-notifications)
@@ -122,3 +146,4 @@ push notifications not to include any message content.
 * [Email notifications](/help/email-notifications)
 * [Desktop notifications](/help/desktop-notifications)
 * [Do not disturb](/help/do-not-disturb)
+* [Hide message content in emails](/help/hide-message-content-in-emails)


### PR DESCRIPTION
Note:
- We'll need to add a link to the help center documentation from production docs, but I think that's easier to do once this PR has been deployed?

## https://zulip.com/help/mobile-notifications
<img width="840" height="281" alt="Screenshot 2025-07-29 at 13 04 51" src="https://github.com/user-attachments/assets/b3fa33bf-2636-4ae7-b62a-ac59a9a7469f" />
<img width="745" height="485" alt="Screenshot 2025-07-29 at 12 55 18" src="https://github.com/user-attachments/assets/9c3a2b64-ac5f-462c-9690-ab52dbbcd058" />

## https://zulip.com/help/desktop-notifications
<img width="765" height="277" alt="Screenshot 2025-07-29 at 13 06 31" src="https://github.com/user-attachments/assets/326240db-3ac0-41f6-9e11-a58d1935c406" />
