### PR TITLE
Apply hide unread summary count setting only to the home view & clean up related CSS

### DIFF
--- a/help/configure-unread-message-counters.md
+++ b/help/configure-unread-message-counters.md
@@ -27,7 +27,7 @@ opening it.
 ## Configure unread summary counters
 
 You can configure whether Zulip displays unread count summaries on your home
-view and channels section in the left sidebar. You will still be able to see the
+view in the left sidebar. You will still be able to see the
 summary counts by moving your mouse over them in the left sidebar. The counter
 on your home view will also be shown when you're in that view.
 
@@ -46,8 +46,7 @@ on your home view will also be shown when you're in that view.
 
 {settings_tab|preferences}
 
-1. Under **Information**, toggle **Show unread count summaries in the
-   left sidebar**.
+1. Under **Information**, toggle **Show unread count total on home view**.
 
 {end_tabs}
 

--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -172,7 +172,7 @@ export function update_dom_with_unread_counts(
         }
         $header.toggleClass("has-only-muted-unreads", show_muted_count);
         $header.toggleClass(
-            "hide-unread-messages-count",
+            "hide_unread_counts",
             should_mask_header_unread_count(show_muted_count, unmuted_count),
         );
     }

--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -16,7 +16,6 @@ import * as stream_list_sort from "./stream_list_sort.ts";
 import * as sub_store from "./sub_store.ts";
 import * as ui_util from "./ui_util.ts";
 import * as unread from "./unread.ts";
-import {user_settings} from "./user_settings.ts";
 
 let last_mention_count = 0;
 const ls_key = "left_sidebar_views_state";
@@ -75,16 +74,6 @@ export function update_reminders_row(): void {
         $reminders_li.removeClass("show-with-reminders");
     }
     ui_util.update_unread_count_in_dom($reminders_li, count);
-}
-
-function should_mask_header_unread_count(
-    show_muted: boolean,
-    unmuted_unread_count: number,
-): boolean {
-    if (!user_settings.web_left_sidebar_unreads_count_summary) {
-        return true;
-    }
-    return settings_data.should_mask_unread_count(show_muted, unmuted_unread_count);
 }
 
 type SectionUnreadCount = {
@@ -173,7 +162,7 @@ export function update_dom_with_unread_counts(
         $header.toggleClass("has-only-muted-unreads", show_muted_count);
         $header.toggleClass(
             "hide_unread_counts",
-            should_mask_header_unread_count(show_muted_count, unmuted_count),
+            settings_data.should_mask_unread_count(show_muted_count, unmuted_count),
         );
     }
 

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -956,7 +956,7 @@ export function dispatch_normal_event(event) {
                 }
             }
             if (event.property === "web_stream_unreads_count_display_policy") {
-                stream_list.update_dom_unread_counts_visibility();
+                stream_list.build_stream_list(true);
             }
             if (event.property === "user_list_style") {
                 settings_preferences.report_user_list_style_change(

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -636,7 +636,7 @@ export const preferences_settings_labels = {
     receives_typing_notifications: $t({defaultMessage: "Show when other users are typing"}),
     starred_message_counts: $t({defaultMessage: "Show counts for starred messages"}),
     web_left_sidebar_unreads_count_summary: $t({
-        defaultMessage: "Show unread count summaries in the left sidebar",
+        defaultMessage: "Show unread count total on home view",
     }),
     twenty_four_hour_time: $t({defaultMessage: "Time format"}),
     translate_emoticons: new Handlebars.SafeString(

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -133,13 +133,9 @@ export function update_invite_user_option(): void {
 
 export function update_unread_counts_visibility(): void {
     const hidden = !user_settings.web_left_sidebar_unreads_count_summary;
-
-    const $channel_sections: JQuery = $(".stream-list-subsection-header");
-    const $home_view_li: JQuery = $(".top_left_row");
-
-    for (const $el of [$home_view_li, $channel_sections]) {
-        $el.toggleClass("hide-unread-messages-count", hidden);
-    }
+    $(".top_left_row").toggleClass("hide-unread-messages-count", hidden);
+    // Note: Channel folder count visibilities are handled in
+    // `update_section_unread_count`, since they depend on unread counts.
 }
 
 export function hide_all(): void {

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -685,25 +685,6 @@ function toggle_hide_unread_counts(
     $subscription_block.toggleClass("hide_unread_counts", hide_count);
 }
 
-export function update_dom_unread_counts_visibility(): void {
-    // TODO: It's not obviously why this function exists; can't we
-    // just do a full left sidebar rebuild?
-    for (const stream of stream_sidebar.rows.values()) {
-        const $subscription_block = stream.get_li().find(".subscription_block");
-
-        const is_muted = stream_data.is_muted(stream.sub.stream_id);
-        // Technically, we just need to know if there's at least one
-        // unmuted unread here, so this could be optimized by using a
-        // faster `unread.ts` API optimized to compute just the set of
-        // channels with at least one unmuted unread.
-        //
-        // That optimization is inessential as long as this function
-        // is only called when changing a global personal setting.
-        const stream_counts = unread.unread_count_info_for_stream(stream.sub.stream_id);
-        toggle_hide_unread_counts($subscription_block, is_muted, stream_counts.unmuted_count);
-    }
-}
-
 export function rename_stream(sub: StreamSubscription): void {
     // The sub object is expected to already have the updated name
     build_stream_sidebar_row(sub);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -796,7 +796,8 @@ ul.filters {
     }
 
     .has-only-muted-unreads {
-        .unread_count {
+        .unread_count,
+        .masked_unread_count {
             opacity: var(--opacity-left-sidebar-muted);
         }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -79,21 +79,14 @@
     width: var(--left-sidebar-single-digit-unread-width);
 }
 
-.selected-home-view {
-    &.hide-unread-messages-count {
-        .masked_unread_count {
-            /* Adding margin-right aligns the .masked_unread_count with the rest of the masked unread counts. */
-            margin-right: var(--left-sidebar-unread-offset);
-        }
-    }
-}
-
-#left-sidebar-navigation-list .selected-home-view,
-.show-inactive-channels {
+#left-sidebar-navigation-list .selected-home-view {
     &.hide-unread-messages-count {
         .masked_unread_count {
             display: flex;
             grid-area: markers-and-unreads;
+            /* Adding margin-right aligns the .masked_unread_count  */
+            /* with the rest of the masked unread counts. */
+            margin-right: var(--left-sidebar-unread-offset);
             justify-self: end;
             visibility: visible;
         }
@@ -109,7 +102,6 @@
 }
 
 #left-sidebar-navigation-list .selected-home-view:hover,
-.stream-list-toggle-inactive-channels:hover .show-inactive-channels,
 .selected-home-view.top-left-active-filter {
     &.hide-unread-messages-count {
         .masked_unread_count {
@@ -147,13 +139,25 @@
         }
     }
 
-    .stream-with-count.hide_unread_counts {
+    .stream-with-count.hide_unread_counts,
+    .stream-list-subsection-header.hide_unread_counts,
+    .show-inactive-channels.hide_unread_counts {
         .masked_unread_count {
             display: flex;
         }
 
         .unread_count {
             display: none;
+        }
+
+        &:hover {
+            .masked_unread_count {
+                display: none;
+            }
+
+            .unread_count {
+                display: inline;
+            }
         }
     }
 
@@ -363,7 +367,8 @@
        below. This extra margin prevents that overlap. */
     margin-bottom: 1px;
 
-    .unread_count {
+    .unread_count,
+    .masked_unread_count {
         margin-right: var(--left-sidebar-unread-offset);
     }
 
@@ -464,6 +469,10 @@
         "content markers-and-unreads three-dot-placeholder" auto
         / minmax(0, 1fr) minmax(0, max-content) var(--left-sidebar-vdots-width);
     align-items: center;
+
+    .markers-and-unreads {
+        margin-right: var(--left-sidebar-unread-offset);
+    }
 }
 
 .stream-list-section {
@@ -1615,8 +1624,7 @@ li.top_left_scheduled_messages {
 
 .dm-markers-and-unreads,
 .stream-markers-and-unreads,
-.topic-markers-and-unreads,
-.show-inactive-channels .markers-and-unreads {
+.topic-markers-and-unreads {
     grid-area: markers-and-unreads;
     display: flex;
     /* Present a uniform space between icons */

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -1286,7 +1286,7 @@ run_test("user_settings", ({override}) => {
     {
         const stub = make_stub();
         event = event_fixtures.user_settings__web_stream_unreads_count_display_policy;
-        override(stream_list, "update_dom_unread_counts_visibility", stub.f);
+        override(stream_list, "build_stream_list", stub.f);
         override(user_settings, "web_stream_unreads_count_display_policy", 1);
         dispatch(event);
         assert.equal(stub.num_calls, 1);


### PR DESCRIPTION
Fixes #35326. More details in individual commit messages.