### PR TITLE
help-beta: Fix loose bullet list spacing where possible

### DIFF
--- a/api_docs/integrations-overview.md
+++ b/api_docs/integrations-overview.md
@@ -17,10 +17,8 @@ If you don't find an integration you need, you can:
 pull
 request](https://zulip.readthedocs.io/en/latest/contributing/reviewable-prs.html)
 to get your integration merged into the main Zulip repository.
-
 - [File an issue](https://github.com/zulip/zulip/issues/new/choose) to request
   an integration (if it's a nice-to-have).
-
 - [Contact Zulip Sales](mailto:sales@zulip.com) to inquire about a custom
   development contract.
 
@@ -106,13 +104,10 @@ Sales](mailto:sales@zulip.com).
 
 * If the third-party service supports outgoing webhooks, you likely want to
   build an [incoming webhook integration](/api/incoming-webhooks-overview).
-
 * If it doesn't, you may want to write a
   [script or plugin integration](/api/non-webhook-integrations).
-
 * The [`zulip-send` tool](/api/send-message) makes it easy to send Zulip
   messages from shell scripts.
-
 * Finally, you can
   [send messages using Zulip's API](/api/send-message), with bindings for
   Python, JavaScript and [other languages](/api/client-libraries).
@@ -122,7 +117,6 @@ Sales](mailto:sales@zulip.com).
 * To react to activity inside Zulip, look at Zulip's
   [Python framework for interactive bots](/api/running-bots) or
   [Zulip's real-time events API](/api/get-events).
-
 * If what you want isn't covered by the above, check out the full
   [REST API](/api/rest). The web, mobile, desktop, and terminal apps are
   built on top of this API, so it can do anything a human user can do. Most

--- a/help/deactivate-or-reactivate-a-user.md
+++ b/help/deactivate-or-reactivate-a-user.md
@@ -19,7 +19,6 @@ When you deactivate a user:
   [availability](/help/status-and-availability) will be replaced with a
   deactivated icon
   (<i class="user-circle user-circle-deactivated zulip-icon zulip-icon-user-circle-deactivated"></i>).
-
 * Even if your organization [allows users to join without an
   invitation](/help/restrict-account-creation#set-whether-invitations-are-required-to-join),
   this user will not be able to rejoin with the same email account.

--- a/help/status-and-availability.md
+++ b/help/status-and-availability.md
@@ -134,11 +134,9 @@ There are three availability states:
 * **Active** (<i class="user-circle user-circle-active zulip-icon
   zulip-icon-user-circle-active"></i>): Zulip is open and in focus on web,
   desktop or mobile, or was in the last 140 seconds.
-
 * **Idle** (<i class="user-circle user-circle-idle zulip-icon
   zulip-icon-user-circle-idle"></i>): Zulip is open on your computer (either
   desktop or web), but you are not active.
-
 * **Offline** (<i class="user-circle user-circle-offline zulip-icon
   zulip-icon-user-circle-offline"></i>): Zulip is not open on your computer,
   or you have turned on invisible mode.

--- a/tools/convert-help-center-docs-to-mdx
+++ b/tools/convert-help-center-docs-to-mdx
@@ -411,7 +411,11 @@ def convert_admonitions_to_asides(
             admonition_content, post_admonition_content_text = detab(
                 post_admonition_declaration_text
             )
-            admonition_content = indent(admonition_content, INDENT_SPACES)
+            # We strip newline since we add explicit newlines before
+            # and after the component in the conversion code that
+            # follows this. Extra blank lines in between the components
+            # will make a tight list loose, which we do not desire.
+            admonition_content = indent(admonition_content, INDENT_SPACES).strip("\n")
 
             klass, title = get_admonition_class_and_title(match)
             # We ignore the title obtained above in each of the if


### PR DESCRIPTION
[help-beta: Stop asides from making a tight list loose.](https://github.com/zulip/zulip/pull/35534/commits/39d64945f0f843d103d1c1d878fe3eb68360c14b)

A lot of our admonition declaration had an empty new line in the beginning which was getting ported over in the conversion. This caused the asides to unintentionally mark a tight list as loose which we do not want.

[help: Make loose lists tight.](https://github.com/zulip/zulip/pull/35534/commits/52b4f911e8b1cccf8fa7a03c4f5f02bf7390f824)

I missed converting `integrations-overview.md` since it was a file in `api_docs` without realising that we had a symlink in help/ that pointed to that file. I'm not sure how the other two files were missed but we corrrect here nonetheless.

We have a few files where we have blank lines before tables and tips, we need these blank lines for the current help center to render those tables and tips properly. But those same blank lines make the list loose when converted to MDX. We cannot make these changes before we have the ability to modify MDX directly. We track this issue in https://github.com/zulip/zulip/issues/35533.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
