### PR TITLE
new-help-center: Update left sidebar for current help center state.

### DIFF
--- a/help-beta/astro.config.mjs
+++ b/help-beta/astro.config.mjs
@@ -429,10 +429,6 @@ export default defineConfig({
                         "configure-call-provider",
                         "add-a-custom-linkifier",
                         "require-topics",
-                        "restrict-direct-messages",
-                        "restrict-wildcard-mentions",
-                        "restrict-moving-messages",
-                        "restrict-message-editing-and-deletion",
                         "image-video-and-website-previews",
                         "hide-message-content-in-emails",
                         "message-retention-policy",
@@ -440,6 +436,7 @@ export default defineConfig({
                         "disable-welcome-emails",
                         "configure-automated-notices",
                         "configure-multi-language-search",
+                        "analytics",
                     ],
                 },
                 {


### PR DESCRIPTION
Updates the sidebar in the new help center for what is currently in `help/include/sidebar_index.md`, specifically for the **Organization settings** section:

| Current | New |
| --- | --- |
| <img width="281" height="400" alt="Screenshot 2025-07-30 at 20 44 35" src="https://github.com/user-attachments/assets/144ccbbb-3b6d-4f90-a1dc-52bf8e52575a" /> | <img width="285" height="456" alt="Screenshot 2025-07-30 at 20 44 05" src="https://github.com/user-attachments/assets/02a23c17-2776-4161-915a-7ec3c0a409b9" />

