### PR TITLE
tests: Remove unused mocks

### DIFF
--- a/web/tests/left_sidebar_navigation_area.test.cjs
+++ b/web/tests/left_sidebar_navigation_area.test.cjs
@@ -10,13 +10,6 @@ mock_esm("../src/resize", {
     resize_stream_filters_container() {},
 });
 
-const scheduled_messages = mock_esm("../src/scheduled_messages");
-
-scheduled_messages.get_count = () => 555;
-
-const message_reminder = mock_esm("../src/message_reminder");
-message_reminder.get_count = () => 888;
-
 const {Filter} = zrequire("../src/filter");
 const left_sidebar_navigation_area = zrequire("left_sidebar_navigation_area");
 
@@ -149,8 +142,6 @@ run_test("update_count_in_dom", () => {
     assert.equal($("<inactive-count>").text(), "");
 
     counts.mentioned_message_count = 0;
-    scheduled_messages.get_count = () => 0;
-    message_reminder.get_count = () => 0;
 
     left_sidebar_navigation_area.update_dom_with_unread_counts(counts, false);
     left_sidebar_navigation_area.update_starred_count(444, true);

--- a/web/tests/stream_list.test.cjs
+++ b/web/tests/stream_list.test.cjs
@@ -39,11 +39,6 @@ mock_esm("../src/unread", {
     stream_has_any_unread_mentions: () => stream_has_any_unread_mentions,
     stream_has_any_unmuted_mentions: () => noop,
 });
-mock_esm("../src/group_permission_settings", {
-    get_group_permission_setting_config: () => ({
-        allow_everyone_group: true,
-    }),
-});
 // TODO/channel-folders: Don't mock this.
 mock_esm("../src/left_sidebar_navigation_area", {
     update_dom_with_unread_counts: () => noop,
@@ -63,9 +58,6 @@ mock_esm("../src/settings_data", {
     user_can_create_web_public_streams: () => true,
     user_has_permission_for_group_setting: () => true,
     should_mask_unread_count: () => false,
-});
-mock_esm("../src/unread_ui", {
-    update_unread_counts: noop,
 });
 
 // Start with always filtering out inactive streams.


### PR DESCRIPTION
These became unused in #35075 (cc @evykassirer).

```console
$ tools/test-js-with-node
…
running test left_sidebar_navigation_area
You asked to mock /srv/zulip/web/src/scheduled_messages.ts but we never saw it during compilation.
You asked to mock /srv/zulip/web/src/message_reminder.ts but we never saw it during compilation.
…
running test stream_list
You asked to mock /srv/zulip/web/src/group_permission_settings.ts but we never saw it during compilation.
You asked to mock /srv/zulip/web/src/unread_ui.ts but we never saw it during compilation.
```