### PR TITLE
message_flag_updates: Fix handling of post failures for flag updates

### DIFF
--- a/web/src/message_flags.ts
+++ b/web/src/message_flags.ts
@@ -1,10 +1,27 @@
 import type {DebouncedFunc} from "lodash";
 import _ from "lodash";
+import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
 import * as channel from "./channel.ts";
+import {localstorage} from "./localstorage.ts";
 import type {Message} from "./message_store.ts";
 import * as starred_messages from "./starred_messages.ts";
+
+const untracked_flag_entry_schema = z.object({
+    add_ids: z.pipe(
+        z.array(z.number()),
+        z.transform((ids) => new Set(ids)),
+    ),
+    remove_ids: z.pipe(
+        z.array(z.number()),
+        z.transform((ids) => new Set(ids)),
+    ),
+});
+const untracked_flag_record_schema = z.record(z.string(), untracked_flag_entry_schema);
+
+type UntrackedFlagEntry = z.infer<typeof untracked_flag_entry_schema>;
+type UntrackedFlagRecord = z.infer<typeof untracked_flag_record_schema>;
 
 export function send_flag_update_for_messages(
     msg_ids: number[],
@@ -18,8 +35,102 @@ export function send_flag_update_for_messages(
             flag,
             op,
         },
+        success() {
+            mutate_local_untracked_flag_changes(flag, (changes) => {
+                // Remove ids for which the latest change has been sent to the server.
+                for (const id of msg_ids) {
+                    changes.add_ids.delete(id);
+                    changes.remove_ids.delete(id);
+                }
+                return changes;
+            });
+        },
+        error() {
+            mutate_local_untracked_flag_changes(flag, (changes) => {
+                for (const id of msg_ids) {
+                    if (op === "add") {
+                        if (changes.remove_ids.has(id)) {
+                            changes.remove_ids.delete(id);
+                        } else {
+                            changes.add_ids.add(id);
+                        }
+                    } else {
+                        if (changes.add_ids.has(id)) {
+                            changes.add_ids.delete(id);
+                        } else {
+                            changes.remove_ids.add(id);
+                        }
+                    }
+                }
+                return changes;
+            });
+        },
     });
 }
+
+export function send_flag_update_for_untracked_messages(): void {
+    const process_entries = (entries: UntrackedFlagRecord): UntrackedFlagRecord | undefined => {
+        for (const [flag, entry] of Object.entries(entries)) {
+            if (entry.add_ids.size > 0) {
+                send_flag_update_for_messages([...entry.add_ids], flag, "add");
+            }
+            if (entry.remove_ids.size > 0) {
+                send_flag_update_for_messages([...entry.remove_ids], flag, "remove");
+            }
+        }
+        // The above API calls are expected to succeed, but even if they fail,
+        // we can still clear the untracked entries here since the failed ones
+        // will be added back.
+        return {};
+    };
+    mutate_all_local_untracked_flag_changes(process_entries);
+}
+
+export function mutate_local_untracked_flag_changes(
+    flag: string,
+    cb: (entries: UntrackedFlagEntry) => UntrackedFlagEntry | undefined,
+): void {
+    mutate_all_local_untracked_flag_changes((untracked_flag_entries) => {
+        const new_entries = cb(
+            untracked_flag_entries[flag] ?? {add_ids: new Set(), remove_ids: new Set()},
+        );
+        if (new_entries === undefined) {
+            return undefined;
+        }
+        untracked_flag_entries[flag] = new_entries;
+        return untracked_flag_entries;
+    });
+}
+
+export function mutate_all_local_untracked_flag_changes(
+    cb: (entries: UntrackedFlagRecord) => UntrackedFlagRecord | undefined,
+): void {
+    if (!localstorage.supported()) {
+        return;
+    }
+    const ls = localstorage();
+    const untracked_flag_entries_value = ls.get("untracked_flag_entries");
+    const result = untracked_flag_record_schema.safeParse(untracked_flag_entries_value);
+
+    const untracked_flag_entries = result.success ? result.data : {};
+    const changed_entries = cb(untracked_flag_entries);
+    if (changed_entries === undefined) {
+        return;
+    }
+
+    // Convert Sets back to arrays for storage
+    const entries_array: Record<string, {add_ids: number[]; remove_ids: number[]}> = {};
+    for (const flag of Object.keys(changed_entries)) {
+        assert(changed_entries[flag] !== undefined);
+        const encode_entry = {
+            add_ids: [...changed_entries[flag].add_ids],
+            remove_ids: [...changed_entries[flag].remove_ids],
+        };
+        entries_array[flag] = encode_entry;
+    }
+    ls.set("untracked_flag_entries", entries_array);
+}
+
 export let _unread_batch_size = 1000;
 
 export function rewire__unread_batch_size(value: typeof _unread_batch_size): void {

--- a/web/src/message_flags.ts
+++ b/web/src/message_flags.ts
@@ -6,7 +6,11 @@ import * as channel from "./channel.ts";
 import type {Message} from "./message_store.ts";
 import * as starred_messages from "./starred_messages.ts";
 
-export function send_flag_update_for_messages(msg_ids: number[], flag: string, op: string): void {
+export function send_flag_update_for_messages(
+    msg_ids: number[],
+    flag: string,
+    op: "add" | "remove",
+): void {
     void channel.post({
         url: "/json/messages/flags",
         data: {

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -71,6 +71,7 @@ import * as markdown_config from "./markdown_config.ts";
 import * as message_actions_popover from "./message_actions_popover.ts";
 import * as message_edit_history from "./message_edit_history.ts";
 import * as message_fetch from "./message_fetch.ts";
+import * as message_flags from "./message_flags.ts";
 import * as message_list_hover from "./message_list_hover.ts";
 import * as message_list_tooltips from "./message_list_tooltips.ts";
 import * as message_lists from "./message_lists.ts";
@@ -736,6 +737,7 @@ export async function initialize_everything(state_data) {
         show_message_view: message_view.show,
     });
     typing.initialize();
+    message_flags.send_flag_update_for_untracked_messages();
     starred_messages_ui.initialize();
     user_status_ui.initialize();
     fenced_code.initialize(pygments_data);


### PR DESCRIPTION
If flag updation requests fail, we store the untracked changes in localStorage.
We make API calls to retry these changes on the next page load.
We optimize it by cancelling out add and remove calls for the same flag, and ignoring duplicate entries (like adding the same flag twice - though it currently isn't done by any of the callers and is included for the sake of completeness).


This PR builds up on #27858 but ended up diverging quite a bit.

[CZO](https://chat.zulip.org/#narrow/stream/137-feedback/topic/Message.20not.20getting.20added.20to.20the.20Starred.20messages.2E)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
