### PR TITLE
help-beta: Rename "identifier" to "target" in NavigationSteps.

### DIFF
--- a/help-beta/src/components/NavigationSteps.astro
+++ b/help-beta/src/components/NavigationSteps.astro
@@ -35,7 +35,7 @@ const setting_link_mapping: Record<
         setting_link: string;
     }
 > = {
-    // a mapping from the setting identifier that is the same as the final URL
+    // a mapping from the setting target that is the same as the final URL
     // breadcrumb to that setting to the name of its setting type, the setting
     // name as it appears in the user interface, and a relative link that can
     // be used to get to that setting
@@ -355,8 +355,8 @@ for (const type of Object.keys(relative_link_mapping)) {
     };
 }
 
-const {identifier} = Astro.props;
-const navigation_link_type = identifier.split("/")[0];
+const {target} = Astro.props;
+const navigation_link_type = target.split("/")[0];
 
 if (
     navigation_link_type !== "settings" &&
@@ -369,10 +369,10 @@ if (
 
 let resultHTML: string | undefined;
 if (navigation_link_type === "settings") {
-    resultHTML = getSettingsHTML(identifier.split("/")[1], SHOW_RELATIVE_LINKS);
+    resultHTML = getSettingsHTML(target.split("/")[1], SHOW_RELATIVE_LINKS);
 } else {
-    const link_type = identifier.split("/")[1];
-    const key = identifier.split("/")[2];
+    const link_type = target.split("/")[1];
+    const key = target.split("/")[2];
     resultHTML = RELATIVE_NAVIGATION_HANDLERS_BY_TYPE[link_type]!(key);
 }
 assert.ok(resultHTML !== undefined);

--- a/tools/convert-help-center-docs-to-mdx
+++ b/tools/convert-help-center-docs-to-mdx
@@ -67,7 +67,7 @@ def replace_setting_links(
             f'import NavigationSteps from "{import_relative_base_path}/NavigationSteps.astro"'
         )
         setting_identifier = match.group("setting_identifier")
-        return f'<NavigationSteps identifier="settings/{setting_identifier}" />'
+        return f'<NavigationSteps target="settings/{setting_identifier}" />'
 
     return setting_links_pattern.sub(replace_setting_links_match, markdown_string)
 
@@ -81,7 +81,7 @@ def replace_relative_links(
         )
         link_type = match.group("link_type")
         key = match.group("key")
-        return f'<NavigationSteps identifier="relative/{link_type}/{key}" />'
+        return f'<NavigationSteps target="relative/{link_type}/{key}" />'
 
     return RELATIVE_LINKS_PATTERN.sub(replace_relative_links_match, markdown_string)
 


### PR DESCRIPTION
[#documentation > new help center: NavigationSteps naming](https://chat.zulip.org/#narrow/channel/19-documentation/topic/new.20help.20center.3A.20NavigationSteps.20naming)

| Before | After |
| --- | --- |
| `<NavigationSteps identifier="settings/your-bots" />` | `<NavigationSteps target="settings/your-bots" />`

Manually tested by building the new hep center docs with these changes.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
