### PR TITLE
desktop-notification-banner: Remove the banner form the org settings.

### DIFF
--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -371,8 +371,6 @@ export function set_up(settings_panel: SettingsPanel): void {
         settings_object.automatically_unmute_topics_in_muted_streams_policy,
     );
 
-    update_desktop_notification_banner();
-
     $container.on("click", ".desktop-notifications-request", (e) => {
         e.preventDefault();
         // This is only accessed via the notifications banner, so we

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -131,7 +131,9 @@
             {{> settings_save_discard_widget section_name="desktop-message-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
 
+        {{#if (eq prefix "user_")}}
         <div class="desktop-notification-settings-banners banner-wrapper"></div>
+        {{/if}}
 
         {{#unless for_realm_settings}}
         {{> ../components/action_button


### PR DESCRIPTION
<!-- Describe your pull request here.-->
As @alya notes in PR #34491 that "This banner should not appear in org settings, only in personal settings"



Fixes: [Thread Link](https://github.com/zulip/zulip/pull/34491#issuecomment-3137137775).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
