### PR TITLE
help: Standardize Welcome Bot and Notification Bot styling.

### DIFF
--- a/help/configure-automated-notices.md
+++ b/help/configure-automated-notices.md
@@ -1,6 +1,6 @@
 # Configure automated notices
 
-The Zulip sends automated notices via **Notification Bot** to notify users about
+The Zulip sends automated notices via Notification Bot to notify users about
 changes in their organization or account. Some types of notices can be
 configured, or disabled altogether.
 
@@ -64,7 +64,7 @@ channel](/help/subscribe-users-to-a-channel), or changes your
 
 {!admin-only.md!}
 
-You can configure where **Notification Bot** will post an announcement when new
+You can configure where Notification Bot will post an announcement when new
 users join your organization, or disable new user announcement messages
 entirely. The topic for these messages is “signups”.
 

--- a/help/include/automated-dm-channel-subscription.md
+++ b/help/include/automated-dm-channel-subscription.md
@@ -1,6 +1,4 @@
 !!! warn ""
 
       **Note**: Subscribing someone else to a channel sends them an
-      automated direct message from [notification bot][notification-bot].
-
-[notification-bot]: /help/configure-automated-notices
+      automated direct message from Notification Bot.

--- a/help/include/automated-notice-channel-event.md
+++ b/help/include/automated-notice-channel-event.md
@@ -1,7 +1,4 @@
 !!! warn ""
 
-    **Note**: This sends an automated notice from [notification
-    bot][notification-bot] to the "channel events" topic in the
-    modified channel.
-
-[notification-bot]: /help/configure-automated-notices
+    **Note**: This sends an automated notice from Notification Bot
+    to the "channel events" topic in the modified channel.

--- a/help/include/configure-resolved-notices-marked-as-read.md
+++ b/help/include/configure-resolved-notices-marked-as-read.md
@@ -1,7 +1,6 @@
-Zulip lets you automatically mark as read [notification
-bot](/help/configure-automated-notices) notices indicating that someone
-[resolved or unresolved](/help/resolve-a-topic) a topic, or do so just for
-topics you don't follow.
+Zulip lets you automatically mark as read Notification Bot notices
+indicating that someone [resolved or unresolved](/help/resolve-a-topic)
+a topic, or do so just for topics you don't follow.
 
 {start_tabs}
 

--- a/help/move-content-to-another-channel.md
+++ b/help/move-content-to-another-channel.md
@@ -5,9 +5,9 @@ channel. Organization administrators can
 [configure](/help/restrict-moving-messages) who can move messages between
 channels.
 
-To help others find moved content, you can have [Notification
-Bot][notification-bot] send automated notices to the source topic, the
-destination topic, or both. These notices include:
+To help others find moved content, you can have Notification Bot send
+automated notices to the source topic, the destination topic, or both.
+These notices include:
 
 * A link to the source or destination topic.
 * How many messages were moved, or whether the whole topic was moved.
@@ -82,8 +82,8 @@ users who both:
 In [private channels with protected
 history](/help/channel-permissions#private-channels), Zulip determines whether
 to treat the entire topic as moved using the access permissions of the user
-requesting the topic move. This means that the automated notices sent by the
-notification bot will report that the entire topic was moved if the requesting
+requesting the topic move. This means that the automated notices sent by
+Notification Bot will report that the entire topic was moved if the requesting
 user moved every message in the topic that they can access, regardless of
 whether older messages exist that they cannot access.
 
@@ -100,5 +100,3 @@ that one does not have permission to access.
 * [Rename a topic](/help/rename-a-topic)
 * [Move content to another topic](/help/move-content-to-another-topic)
 * [Restrict moving messages](/help/restrict-moving-messages)
-
-[notification-bot]: /help/configure-automated-notices

--- a/help/resolve-a-topic.md
+++ b/help/resolve-a-topic.md
@@ -10,16 +10,15 @@ Marking a topic as resolved:
 
 * Puts a ✔ at the beginning of the topic name, e.g., `example topic`
   becomes `✔ example topic`.
-* Triggers an automated notice from the [notification
-  bot](/help/configure-automated-notices) indicating that you resolved the
-  topic. Users can
+* Triggers an automated notice from Notification Bot indicating that
+  you resolved the topic. Users can
   [configure](/help/marking-messages-as-read#configure-whether-resolved-topic-notices-are-marked-as-read)
   whether these notices are automatically marked as read.
 * Changes whether the topic appears when using the `is:resolved` and
   `-is:resolved` [search filters](/help/search-for-messages#search-filters).
 
 Marking a topic as unresolved removes the ✔ and also triggers an
-automated notice from the notification bot.
+automated notice from Notification Bot.
 
 It's often helpful to define a policy for when to resolve topics that
 fits how topics are used in a given channel. Here are some common
@@ -66,8 +65,8 @@ Users can resolve or unresolve a topic if they have
 
 ## Mark a topic as unresolved
 
-Marking a topic as unresolved normally triggers an automated notice from the
-notification bot. However, unresolving a topic right after you resolved it
+Marking a topic as unresolved normally triggers an automated notice from
+Notification Bot. However, unresolving a topic right after you resolved it
 removes the original notice instead. This is helpful if you resolved a topic by
 accident.
 


### PR DESCRIPTION
In the help center, we want these two system bots to be referred to as names:
- capitalize both words
- no bold
- no links
- no "the" before the bot's name

[#documentation > bot name styling](https://chat.zulip.org/#narrow/channel/19-documentation/topic/bot.20name.20styling)

**Notes**:
- The references to "Welcome Bot" in the help center were all fine with the guidelines above, so the changes are all for "Notification Bot", which is mentioned more.

---

**Screenshots and screen captures:**

[CURRENT DOC](https://zulip.com/help/configure-automated-notices)
<img width="761" height="225" alt="Screenshot 2025-07-31 at 17 56 45" src="https://github.com/user-attachments/assets/e8f7f18c-eb96-4658-ace4-8253a57eacf0" />
<img width="753" height="249" alt="Screenshot 2025-07-31 at 17 57 04" src="https://github.com/user-attachments/assets/85c597c8-e20a-4c3a-b0d1-30ff06ff0c0b" />

[CURRENT DOC](https://zulip.com/help/subscribe-users-to-a-channel)
<img width="749" height="732" alt="Screenshot 2025-07-31 at 17 57 53" src="https://github.com/user-attachments/assets/30a39310-24d0-4170-8e3b-095f4697d3fc" />

[CURRENT DOC](https://zulip.com/help/rename-a-channel)
<img width="753" height="611" alt="Screenshot 2025-07-31 at 17 58 02" src="https://github.com/user-attachments/assets/13a652ac-e418-44c8-8b27-75be3465b34e" />

[CURRENT DOC](https://zulip.com/help/move-content-to-another-channel)
<img width="754" height="305" alt="Screenshot 2025-07-31 at 18 09 48" src="https://github.com/user-attachments/assets/fd6f796a-ab3d-412e-86f4-1de440f91b68" />
<img width="754" height="294" alt="Screenshot 2025-07-31 at 18 12 13" src="https://github.com/user-attachments/assets/fa54c4b5-007e-4db7-92d8-b34bb57ca327" />

[CURRENT DOC](https://zulip.com/help/resolve-a-topic)
<img width="764" height="678" alt="Screenshot 2025-07-31 at 18 18 57" src="https://github.com/user-attachments/assets/4b721ae6-221d-46ed-b3f2-2c82eecffd10" />
<img width="760" height="381" alt="Screenshot 2025-07-31 at 18 19 09" src="https://github.com/user-attachments/assets/676a11c7-07fe-48db-8640-4ca9c04c17a2" />
<img width="752" height="255" alt="Screenshot 2025-07-31 at 18 19 23" src="https://github.com/user-attachments/assets/f25bbc59-aca1-49e3-a9f5-20083fd0e0dd" />

[CURRENT DOC](https://zulip.com/help/schedule-a-reminder)
<img width="757" height="204" alt="Screenshot 2025-07-31 at 18 20 15" src="https://github.com/user-attachments/assets/995ea9dd-e93f-4b76-a7cb-34567afa1ec4" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
