### PR TITLE
left_sidebar: Display folder unread counters like channel counters.

### DIFF
--- a/web/templates/stream_list_section_container.hbs
+++ b/web/templates/stream_list_section_container.hbs
@@ -10,7 +10,7 @@
         </a>
         {{/if}}
         <div class="markers-and-unreads">
-            <span class="unread_count quiet-count"></span>
+            <span class="unread_count normal-count"></span>
             <span class="masked_unread_count">
                 <i class="zulip-icon zulip-icon-masked-unread"></i>
             </span>


### PR DESCRIPTION
Discussion here:
https://chat.zulip.org/#narrow/channel/101-design/topic/channel.20folder.20unread.20count.20styling/with/2232873

