### PR TITLE
left_sidebar: Show home unread count in condensed views.

### DIFF
--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -96,10 +96,12 @@ export function update_dom_with_unread_counts(
     // mentioned/home views have simple integer counts
     const $mentioned_li = $(".top_left_mentions");
     const $home_view_li = $(".selected-home-view");
+    const $condensed_view_li = $(".top_left_condensed_unread_marker");
     const $back_to_streams = $("#topics_header");
 
     ui_util.update_unread_count_in_dom($mentioned_li, counts.mentioned_message_count);
     ui_util.update_unread_count_in_dom($home_view_li, counts.home_unread_messages);
+    ui_util.update_unread_count_in_dom($condensed_view_li, counts.home_unread_messages);
     ui_util.update_unread_count_in_dom($back_to_streams, counts.stream_unread_messages);
 
     const pinned_unread_counts: SectionUnreadCount = {

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -133,7 +133,10 @@ export function update_invite_user_option(): void {
 
 export function update_unread_counts_visibility(): void {
     const hidden = !user_settings.web_left_sidebar_unreads_count_summary;
-    $(".top_left_row").toggleClass("hide-unread-messages-count", hidden);
+    $(".top_left_row, #left-sidebar-navigation-list-condensed").toggleClass(
+        "hide-unread-messages-count",
+        hidden,
+    );
     // Note: Channel folder count visibilities are handled in
     // `update_section_unread_count`, since they depend on unread counts.
 }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -982,12 +982,23 @@ li.active-sub-filter {
             }
         }
 
+        /* Hide the unread dot, assuming that message
+           counts are not hidden. */
+        &.selected-home-view .unread_count {
+            display: none;
+        }
+
         &.top_left_starred_messages .unread_count {
             display: none;
         }
     }
 
     &.hide-unread-messages-count {
+        /* Restore the unread dot when message counts
+           are hidden. */
+        .selected-home-view .unread_count {
+            display: block;
+        }
         /* We suppress the entire unread area
            for users who prefer masked unreads. */
         .top_left_condensed_unread_marker {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -976,7 +976,15 @@ li.active-sub-filter {
                 /* .unread_count has its based font-size set to 12px at 14px/em. */
                 /* 2px, 6px at 12px/1em */
                 top: 0.1667em;
-                right: 0.1667em;
+                /* With positioning, we center the dot over the icon
+                   by subtracting half its width from the 50% mark. */
+                right: calc(50% - 0.25em);
+                /* But then we shift it left the em equivalent of half
+                   the icon width (15px/2) plus 2px. This keeps the
+                   unread dot in correct proximity to the view icon,
+                   no matter how the row flexes or what information-
+                   density values a user has set. 9.5px at 12px/1em. */
+                transform: translateX(0.7917em);
                 width: 0.5em;
                 height: 0.5em;
                 padding: 0;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -102,20 +102,6 @@
     }
 }
 
-#left-sidebar-navigation-list .selected-home-view:hover,
-.selected-home-view.top-left-active-filter {
-    &.hide-unread-messages-count {
-        .masked_unread_count {
-            visibility: hidden;
-            position: absolute;
-        }
-
-        .unread_count {
-            visibility: visible;
-        }
-    }
-}
-
 #stream_filters {
     overflow: visible;
     margin-bottom: 5px;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1464,7 +1464,10 @@ li.top_left_scheduled_messages {
         display: flex;
         align-items: center;
         justify-content: center;
-        margin-right: 2px;
+        /* These margin and padding values should be
+           coordinated with those on .sidebar-menu-icon. */
+        margin: 2px 2px 2px 1px;
+        padding-left: 1px;
         border-radius: 3px;
         color: var(--color-vdots-visible);
 
@@ -1798,6 +1801,9 @@ li.top_left_scheduled_messages {
        centering regime for the row. */
     align-self: stretch;
     border-radius: 3px;
+    /* These margin and padding values should be
+       coordinated with those on
+       .left-sidebar-navigation-menu-icon. */
     margin: 2px 2px 2px 1px;
     /* This helps horizontally align the vdots,
        given the reduced margin-left above. */

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -937,12 +937,15 @@ li.active-sub-filter {
     justify-content: center;
 
     .left-sidebar-navigation-condensed-item {
-        /* 24px minimum width from Vlad's design.
-           however, we want to permit growing and
-           shrinking to keep icons reasonably spaced
-           across different information-density
-           settings. */
-        flex: 1 1 24px;
+        /* 26px minimum width gives a bit more
+           breathing room for unread markers when
+           unreads are displayed.
+           However, we want to permit growing but
+           not shrinking to keep icons reasonably
+           spaced across different information-density
+           settings. So we convert this value to ems:
+           26px at 16px/1em. */
+        flex: 1 0 1.625em;
         /* Unset padding from individual top_left items */
         padding: 0;
         border-radius: 4px;
@@ -991,6 +994,27 @@ li.active-sub-filter {
         &.top_left_starred_messages .unread_count {
             display: none;
         }
+
+        &.top_left_condensed_unread_marker {
+            /* Flex to just the unread's width, to keep the
+               unreads aligned on the righthand side with others
+               up and down the left sidebar. */
+            flex: 0 0 auto;
+            display: flex;
+            align-content: center;
+
+            &:has(.unread_count:empty) {
+                /* When the unread count is empty (no unreads),
+                   we flex shut to 0 across the board so the
+                   unread count takes up no space. */
+                flex: 0 0 0;
+            }
+
+            .unread_count:not(:empty) {
+                margin: 0 var(--left-sidebar-unread-offset);
+                align-self: center;
+            }
+        }
     }
 
     &.hide-unread-messages-count {
@@ -1003,17 +1027,6 @@ li.active-sub-filter {
            for users who prefer masked unreads. */
         .top_left_condensed_unread_marker {
             display: none;
-        }
-    }
-
-    .top_left_condensed_unread_marker {
-        display: flex;
-        align-content: center;
-
-        .unread_count {
-            flex: 0 0 auto;
-            margin: 0 var(--left-sidebar-unread-offset);
-            align-self: center;
         }
     }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1393,6 +1393,18 @@ li.top_left_scheduled_messages {
                 height: var(--line-height-sidebar-row);
             }
         }
+
+        /* When unread counts display in the condensed-view
+           row for users who do not prefer to mask their unread
+           counts, we suppress the count on the highlighted
+           home-view row. */
+        &:not(:has(.hide-unread-messages-count)) {
+            + #left-sidebar-navigation-list {
+                .selected-home-view .unread_count {
+                    display: none;
+                }
+            }
+        }
     }
 
     /* Remove the cursor: pointer property of Views label for the spectators. */

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -949,39 +949,60 @@ li.active-sub-filter {
         /* Set a positioning context for the unread dot. */
         position: relative;
 
-        .unread_count {
-            position: absolute;
-        }
-
-        /* Show the same styles when each item is
-           hovered or, via the keyboard, the `<a>`
-           element within receives focus. */
-        &:hover,
-        &:focus-within {
-            background: var(--color-background-navigation-item-hover);
-
+        &:not(.top_left_condensed_unread_marker) {
             .unread_count {
-                /* 6px at 12px/1em */
-                top: -0.5em;
-                right: -0.5em;
-                background: var(--color-background-unread-counter-no-alpha);
+                position: absolute;
             }
-        }
 
-        &:not(:hover) .unread_count {
-            /* .unread_count has its based font-size set to 12px at 14px/em. */
-            /* 2px, 6px at 12px/1em */
-            top: 0.1667em;
-            right: 0.1667em;
-            width: 0.5em;
-            height: 0.5em;
-            padding: 0;
-            color: transparent;
-            background-color: var(--color-background-unread-counter-dot);
+            /* Show the same styles when each item is
+               hovered or, via the keyboard, the `<a>`
+               element within receives focus. */
+            &:hover,
+            &:focus-within {
+                background: var(--color-background-navigation-item-hover);
+
+                .unread_count {
+                    /* 6px at 12px/1em */
+                    top: -0.5em;
+                    right: -0.5em;
+                    background: var(--color-background-unread-counter-no-alpha);
+                }
+            }
+
+            &:not(:hover) .unread_count {
+                /* .unread_count has its based font-size set to 12px at 14px/em. */
+                /* 2px, 6px at 12px/1em */
+                top: 0.1667em;
+                right: 0.1667em;
+                width: 0.5em;
+                height: 0.5em;
+                padding: 0;
+                color: transparent;
+                background-color: var(--color-background-unread-counter-dot);
+            }
         }
 
         &.top_left_starred_messages .unread_count {
             display: none;
+        }
+    }
+
+    &.hide-unread-messages-count {
+        /* We suppress the entire unread area
+           for users who prefer masked unreads. */
+        .top_left_condensed_unread_marker {
+            display: none;
+        }
+    }
+
+    .top_left_condensed_unread_marker {
+        display: flex;
+        align-content: center;
+
+        .unread_count {
+            flex: 0 0 auto;
+            margin: 0 var(--left-sidebar-unread-offset);
+            align-self: center;
         }
     }
 

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -8,6 +8,9 @@
                 {{#each primary_condensed_views}}
                     {{> left_sidebar_primary_condensed_view_item . }}
                 {{/each}}
+                <li class="top_left_condensed_unread_marker left-sidebar-navigation-condensed-item">
+                    <span class="unread_count normal-count"></span>
+                </li>
             </ul>
             <div class="left-sidebar-navigation-menu-icon">
                 <i class="zulip-icon zulip-icon-more-vertical" aria-label="{{t 'Other views'}}"></i>


### PR DESCRIPTION
[#design > unread counts in condensed views](https://chat.zulip.org/#narrow/channel/101-design/topic/unread.20counts.20in.20condensed.20views), with initial discussion at [#feedback > show unreads when collapsing VIEWS](https://chat.zulip.org/#narrow/channel/137-feedback/topic/show.20unreads.20when.20collapsing.20VIEWS/with/2234548)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="660" height="422" alt="condensed-views-with-unreads-home-view-active-before" src="https://github.com/user-attachments/assets/4a053b65-95a6-4897-8977-6ae60bd327c9" /> | <img width="660" height="422" alt="condensed-views-with-unreads-home-view-active-after" src="https://github.com/user-attachments/assets/693067ad-3917-435e-adf5-364a9a1bcad5" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
