### PR TITLE
inbox_ui: Clarify inbox state when all sections are collapsed.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -335,6 +335,29 @@
             }
         }
 
+        #inbox-collapsed-note {
+            display: none;
+            overflow: hidden;
+            max-width: calc(
+                var(--width-inbox-search) +
+                    var(--width-inbox-filters-dropdown) + 0.25em
+            );
+
+            .inbox-collapsed-note-and-button-wrapper {
+                margin-top: 3px;
+                padding-left: 8px;
+
+                .inbox-collpased-note-span {
+                    font-size: 1em;
+                }
+
+                #inbox-expand-all-button {
+                    display: block;
+                    margin-top: 5px;
+                }
+            }
+        }
+
         .inbox-right-part-wrapper {
             display: flex;
             align-items: center;

--- a/web/templates/inbox_view/inbox_view.hbs
+++ b/web/templates/inbox_view/inbox_view.hbs
@@ -27,6 +27,16 @@
             {{> inbox_list .}}
         {{/if}}
     </div>
+    <div id="inbox-collapsed-note">
+        <div class="inbox-collapsed-note-and-button-wrapper">
+            <span class="inbox-collpased-note-span">
+                {{t "All unread conversations are hidden. Click on a section, folder, or channel to expand it."}}
+            </span>
+            <button id="inbox-expand-all-button" class="action-button action-button-quiet-neutral" tabindex="0">
+                <span class="action-button-label">{{t "Show all"}}</span>
+            </button>
+        </div>
+    </div>
     <div id="inbox-loading-indicator">
         {{#unless normal_view}}
         {{> ../view_bottom_loading_indicator}}


### PR DESCRIPTION
It was reported that the UI is pretty confusing when there is just a collapsed folder in inbox view. To fix this, this PR does the following two tasks: 

- [x] Adds a note below the folders which says "All of your unread conversations are hidden. Click on a section, folder, or channel to see what's inside.
- [x] The note is displayed for the following situtation:
       -  All folders collapsed.
       -  If all folders are not collapsed, all channels are collapsed (all visible channels should be collapsed).
- [x] Adds an "Show all" button to expand all the collapsed folders at once.

<img width="950" height="310" alt="image" src="https://github.com/user-attachments/assets/9a37a41d-375d-44f2-80e8-c24e5258b112" />  
<img width="911" height="286" alt="image" src="https://github.com/user-attachments/assets/b3e4fa2d-a6fa-48db-aee1-0337f552332e" />

</br>

<img width="950" height="481" alt="image" src="https://github.com/user-attachments/assets/d5c663f8-20b7-486a-92da-4d917aca7570" /> 
<img width="924" height="451" alt="image" src="https://github.com/user-attachments/assets/ce3a0290-bbc5-469a-8cf5-06874f62c909" />

</br>

<img width="920" height="388" alt="image" src="https://github.com/user-attachments/assets/87742188-4654-491a-9d75-0bc8e9221a05" /> 
<img width="924" height="451" alt="image" src="https://github.com/user-attachments/assets/759308d3-a7bf-4a8b-80a8-f13ee9f729d5" /> 


<img width="920" height="388" alt="image" src="https://github.com/user-attachments/assets/d9b93693-3a23-4e06-9145-1c0bdf1560d4" /> <img width="924" height="451" alt="image" src="https://github.com/user-attachments/assets/914e17bc-309d-4fb1-a9df-ad17bc686f56" />


**Video demostration**

![demo.gif](https://github.com/user-attachments/assets/0232c019-66df-4bf3-99f3-2ce261956642)

**Responsive design**

![responsive.gif](https://github.com/user-attachments/assets/85719991-4b72-4a82-8290-757a435353a5)


Fixes: #35555

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
