### PR TITLE
compose_paste: Show banner before pasting very large text.

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -2,6 +2,7 @@ import $ from "jquery";
 
 import render_cannot_send_direct_message_error from "../templates/compose_banner/cannot_send_direct_message_error.hbs";
 import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
+import render_long_paste_options from "../templates/compose_banner/long_paste_options.hbs";
 import render_stream_does_not_exist_error from "../templates/compose_banner/stream_does_not_exist_error.hbs";
 import render_topics_required_error_banner from "../templates/compose_banner/topics_required_error_banner.hbs";
 import render_unknown_zoom_user_error from "../templates/compose_banner/unknown_zoom_user_error.hbs";
@@ -296,19 +297,25 @@ export function has_error(): boolean {
     return $("#compose_banners .error").length > 0;
 }
 
-export function show_convert_pasted_text_to_file_banner(cb: () => void): JQuery {
+export function show_convert_pasted_text_to_file_banner({
+    show_paste_button,
+    convert_to_file_cb,
+    paste_to_compose_cb,
+}: {
+    show_paste_button: boolean;
+    convert_to_file_cb: () => void;
+    paste_to_compose_cb: () => void;
+}): JQuery {
     $(`#compose_banners .${CSS.escape(CLASSNAMES.convert_pasted_text_to_file)}`).remove();
     const $new_row = $(
-        render_compose_banner({
+        render_long_paste_options({
             banner_type: INFO,
-            banner_text: $t({
-                defaultMessage: "Do you want to convert the pasted text into a file?",
-            }),
-            button_text: $t({defaultMessage: "Yes, convert"}),
             classname: CLASSNAMES.convert_pasted_text_to_file,
+            show_paste_button,
         }),
     );
-    $new_row.on("click", ".main-view-banner-action-button", cb);
+    $new_row.on("click", ".main-view-banner-action-button.convert-to-file", convert_to_file_cb);
+    $new_row.on("click", ".main-view-banner-action-button.paste-to-compose", paste_to_compose_cb);
     append_compose_banner_to_banner_list($new_row, $("#compose_banners"));
     return $new_row;
 }

--- a/web/src/compose_paste.ts
+++ b/web/src/compose_paste.ts
@@ -635,6 +635,24 @@ function create_text_file(text: string, filename: string): File {
     return new File([blob], filename, {type: "text/plain"});
 }
 
+function do_paste_text(
+    paste_html: string,
+    paste_text: string,
+    $textarea: JQuery<HTMLTextAreaElement>,
+): void {
+    paste_html = maybe_transform_html(paste_html, paste_text);
+    const text = paste_handler_converter(paste_html, $textarea);
+    const trimmed_paste_text = paste_text.trim();
+    if (trimmed_paste_text !== text) {
+        // Pasting formatted text is a two-step process: First
+        // we paste unformatted text, then overwrite it with
+        // formatted text, so that undo restores the
+        // pre-formatting syntax.
+        add_text_and_select(trimmed_paste_text, $textarea);
+    }
+    compose_ui.insert_and_scroll_into_view(text, $textarea);
+}
+
 export function paste_handler(
     this: HTMLTextAreaElement,
     event: JQuery.TriggeredEvent,
@@ -736,16 +754,7 @@ export function paste_handler(
             }
             event.preventDefault();
             event.stopPropagation();
-            paste_html = maybe_transform_html(paste_html, paste_text);
-            const text = paste_handler_converter(paste_html, $textarea);
-            if (trimmed_paste_text !== text) {
-                // Pasting formatted text is a two-step process: First
-                // we paste unformatted text, then overwrite it with
-                // formatted text, so that undo restores the
-                // pre-formatting syntax.
-                add_text_and_select(trimmed_paste_text, $textarea);
-            }
-            compose_ui.insert_and_scroll_into_view(text, $textarea);
+            do_paste_text(paste_html, paste_text, $textarea);
         }
     }
 }

--- a/web/src/compose_paste.ts
+++ b/web/src/compose_paste.ts
@@ -14,6 +14,7 @@ import * as topic_link_util from "./topic_link_util.ts";
 import * as util from "./util.ts";
 
 const MINIMUM_PASTE_SIZE_FOR_FILE_TREATMENT = 2000;
+const MINIMUM_PASTE_SIZE_TO_AVOID_DIRECT_PASTE = 5000;
 
 declare global {
     // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -640,17 +641,21 @@ function do_paste_text(
     paste_text: string,
     $textarea: JQuery<HTMLTextAreaElement>,
 ): void {
-    paste_html = maybe_transform_html(paste_html, paste_text);
-    const text = paste_handler_converter(paste_html, $textarea);
-    const trimmed_paste_text = paste_text.trim();
-    if (trimmed_paste_text !== text) {
-        // Pasting formatted text is a two-step process: First
-        // we paste unformatted text, then overwrite it with
-        // formatted text, so that undo restores the
-        // pre-formatting syntax.
-        add_text_and_select(trimmed_paste_text, $textarea);
+    if (paste_html) {
+        paste_html = maybe_transform_html(paste_html, paste_text);
+        const text = paste_handler_converter(paste_html, $textarea);
+        const trimmed_paste_text = paste_text.trim();
+        if (trimmed_paste_text !== text) {
+            // Pasting formatted text is a two-step process: First
+            // we paste unformatted text, then overwrite it with
+            // formatted text, so that undo restores the
+            // pre-formatting syntax.
+            add_text_and_select(trimmed_paste_text, $textarea);
+        }
+        compose_ui.insert_and_scroll_into_view(text, $textarea);
+    } else {
+        compose_ui.insert_and_scroll_into_view(paste_text, $textarea);
     }
-    compose_ui.insert_and_scroll_into_view(text, $textarea);
 }
 
 export function paste_handler(
@@ -669,11 +674,12 @@ export function paste_handler(
         return;
     }
 
+    let avoid_direct_paste = false;
     if (clipboardData.getData) {
         const $textarea = $(this);
         const existing_text = $textarea.val() ?? "";
         const paste_text = clipboardData.getData("text");
-        let paste_html = clipboardData.getData("text/html");
+        const paste_html = clipboardData.getData("text/html");
         // Trim the paste_text to accommodate sloppy copying
         const trimmed_paste_text = paste_text.trim();
         const pasted_text_length = paste_text.length;
@@ -683,18 +689,24 @@ export function paste_handler(
         // putting the content into the compose box.
         const is_paste_large_enough_for_file =
             pasted_text_length >= MINIMUM_PASTE_SIZE_FOR_FILE_TREATMENT;
-
+        avoid_direct_paste = pasted_text_length >= MINIMUM_PASTE_SIZE_TO_AVOID_DIRECT_PASTE;
         // If the pasted or combined text is too large, present a
         // banner offering to upload as a file.
         if (is_paste_large_enough_for_file) {
             const filename = `${$t({defaultMessage: "PastedText"})}.txt`;
             const pasted_file = create_text_file(paste_text, filename);
-            const $banner = compose_banner.show_convert_pasted_text_to_file_banner(() => {
-                // Important: This undo mechanism is only correct if
-                // the compose area hasn't changed since the banner
-                // was created.
-                $textarea.val(existing_text);
-                upload_pasted_file(this, pasted_file);
+            const $banner = compose_banner.show_convert_pasted_text_to_file_banner({
+                show_paste_button: avoid_direct_paste,
+                convert_to_file_cb: () => {
+                    // Important: This undo mechanism is only correct if
+                    // the compose area hasn't changed since the banner
+                    // was created.
+                    $textarea.val(existing_text);
+                    upload_pasted_file(this, pasted_file);
+                },
+                paste_to_compose_cb() {
+                    do_paste_text(paste_html, paste_text, $textarea);
+                },
             });
             setTimeout(() => {
                 $("textarea#compose-textarea").one("input", () => {
@@ -754,7 +766,13 @@ export function paste_handler(
             }
             event.preventDefault();
             event.stopPropagation();
-            do_paste_text(paste_html, paste_text, $textarea);
+            if (!avoid_direct_paste) {
+                do_paste_text(paste_html, paste_text, $textarea);
+            }
+        }
+        if (avoid_direct_paste) {
+            event.preventDefault();
+            event.stopPropagation();
         }
     }
 }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1000,6 +1000,10 @@
             }
         }
     }
+
+    .secondary-button {
+        margin-left: 10px;
+    }
 }
 
 .upload_banner {

--- a/web/templates/compose_banner/long_paste_options.hbs
+++ b/web/templates/compose_banner/long_paste_options.hbs
@@ -1,0 +1,14 @@
+<div
+  class="main-view-banner {{banner_type}} {{classname}}">
+    <div class="main-view-banner-elements-wrapper">
+        {{#if show_paste_button}}
+        <p class="banner_content">{{t 'Do you want to paste directly into the compose box, or convert the pasted text into a file?'}}</p>
+        <button class="main-view-banner-action-button paste-to-compose">{{t 'Paste'}}</button>
+        <button class="main-view-banner-action-button convert-to-file secondary-button">{{t 'Convert'}}</button>
+        {{else}}
+        <p class="banner_content">{{t 'Do you want to convert the pasted text into a file?'}}</p>
+        <button class="main-view-banner-action-button convert-to-file">{{t 'Yes, convert'}}</button>
+        {{/if}}
+    </div>
+    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button"></a>
+</div>


### PR DESCRIPTION
On pasting very large text, the pasting logic takes a long
time to update the UI, (around 10 seconds for 30K characters).
So before actually pasting the text, we offer the user to
rather put the text into a file and upload it.

This builds upon and differs from #35187 in that,
in that PR we pasted the text before showing the button
to rather upload the text to a file, but here we defer the
actual pasting until after the user makes a choice to paste.

Fixes: #35187 

**Screenshots and screen captures:**
<img width="851" height="214" alt="image" src="https://github.com/user-attachments/assets/e3cf3290-fd51-4e80-a639-a7127f71c435" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
