### PR TITLE
help-beta: Adjust icon class names in the conversion process.

### DIFF
--- a/tools/convert-help-center-docs-to-mdx
+++ b/tools/convert-help-center-docs-to-mdx
@@ -154,11 +154,10 @@ def insert_string_at_line(text: str, destination_str: str, n: int) -> str:
 def replace_icon_with_unplugin_component(
     match: re.Match[str],
     icon_package_name: str,
-    icon_component_prefix: str,
     import_statement_set: set[str],
 ) -> str:
     icon_name = match.group(1)
-    component_name = icon_component_prefix + to_pascal(icon_name).replace("-", "")
+    component_name = to_pascal(icon_name).replace("-", "") + "Icon"
     import_statement = f'import {component_name} from "~icons/{icon_package_name}/{icon_name}"'
     import_statement_set.add(import_statement)
     return f"<{component_name} />"
@@ -174,7 +173,7 @@ def replace_icons(markdown_string: str, import_statement_set: set[str]) -> str:
     )
 
     def replace_font_awesome_icon_with_unplugin_component(match: re.Match[str]) -> str:
-        return replace_icon_with_unplugin_component(match, "fa", "Fa", import_statement_set)
+        return replace_icon_with_unplugin_component(match, "fa", import_statement_set)
 
     result = re.sub(
         font_awesome_pattern, replace_font_awesome_icon_with_unplugin_component, markdown_string
@@ -185,9 +184,7 @@ def replace_icons(markdown_string: str, import_statement_set: set[str]) -> str:
     )
 
     def replace_zulip_icon_with_unplugin_component(match: re.Match[str]) -> str:
-        return replace_icon_with_unplugin_component(
-            match, "zulip-icon", "ZulipIcons", import_statement_set
-        )
+        return replace_icon_with_unplugin_component(match, "zulip-icon", import_statement_set)
 
     result = re.sub(zulip_icon_pattern, replace_zulip_icon_with_unplugin_component, result)
 


### PR DESCRIPTION
Use the icon's name, in camelcase, with the suffix "Icon" for icon class names in the new help center documentation. E.g., `zulip-icon-external-link` becomes `ExternalLinkIcon` and `fa fa-plus` becomes `PlusIcon`.

[#documentation > new help center: Icon class names](https://chat.zulip.org/#narrow/channel/19-documentation/topic/new.20help.20center.3A.20Icon.20class.20names)

**Notes**:
- After building the help-beta docs with these changes and calling `pnpm run format` on that directory, there were no syntax errors reported for duplicate identifiers. Therefore, none of the zulip and 'fa fa' icons with the same name (e.g., download and pencil) are imported/used in the same file.

| Before | After |
| --- | --- |
| `import ZulipIconsDownload from "~icons/zulip-icon/download"` | `import DownloadIcon from "~icons/zulip-icon/download"`
| `import FaDownload from "~icons/fa/download"` | `import DownloadIcon from "~icons/fa/download"`

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
