### PR TITLE
settings-ui: Display API key in monospace font

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1198,6 +1198,10 @@ input[type="checkbox"] {
     margin: 0 0 10px;
 }
 
+#api_key_value {
+  font-family: monospace;
+}
+
 #download_zuliprc {
     color: hsl(0deg 0% 100%);
     text-decoration: none;


### PR DESCRIPTION
This commit switches the API key modal input to use a monospace font to improve readability and copying accuracy.

Fixes: #35189

---

<details>
<summary>Before/after comparison screenshot</summary>

<img width="1920" height="2160" alt="zulip-api-key-monospace" src="https://github.com/user-attachments/assets/44f935ef-b16e-4dd5-b874-b5ef58c07404" />

</details>

<details>
<summary>Self-review checklist</summary>

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.)
- [ ] Explains differences from previous plans (e.g., issue description)
- [ ] Highlights technical choices and bugs encountered
- [ ] Calls out remaining decisions and concerns
- [ ] Automated tests verify logic where appropriate

**Commit structure:**

- [ ] Each commit is a coherent idea
- [ ] Commit message(s) explain reasoning and motivation

**Manual testing:**

- [ ] Verified visual appearance
- [ ] Verified responsiveness and internationalization
- [ ] Reviewed strings/tooltips
- [ ] Verified buttons and flows end-to-end
- [ ] Checked corner cases and potential bugs

</details>
