### PR TITLE
upgrade-banners: Refactor upgrade banners.

### DIFF
--- a/web/src/settings_banner.ts
+++ b/web/src/settings_banner.ts
@@ -2,53 +2,11 @@ import $ from "jquery";
 
 import * as banners from "./banners.ts";
 import type {Banner} from "./banners.ts";
+import type {ActionButton} from "./buttons.ts";
 import {$t} from "./i18n.ts";
 import * as settings_config from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
 import {realm} from "./state_data.ts";
-
-const UPGRADE_ACCESS_BANNER: Banner = {
-    intent: "info",
-    label: $t({defaultMessage: "Available on Zulip Cloud Standard."}),
-    buttons: [
-        {
-            label: $t({defaultMessage: "Upgrade to access"}),
-            custom_classes: "request-upgrade",
-            attention: "quiet",
-        },
-    ],
-    custom_classes: "organization-upgrade-banner",
-    close_button: false,
-};
-
-const AVAILABLE_ON_STANDARD: Banner = {
-    intent: "neutral",
-    label: $t({defaultMessage: "Available on Zulip Cloud Standard."}),
-    buttons: [],
-    custom_classes: "organization-upgrade-banner",
-    close_button: false,
-};
-
-const UPGRADE_OR_SPONSORSHIP_BANNER: Banner = {
-    intent: "info",
-    label: $t({
-        defaultMessage: "Available on Zulip Cloud Standard.",
-    }),
-    buttons: [
-        {
-            label: $t({defaultMessage: "Upgrade"}),
-            custom_classes: "request-upgrade",
-            attention: "quiet",
-        },
-        {
-            label: $t({defaultMessage: "Request sponsorship"}),
-            custom_classes: "request-sponsorship",
-            attention: "borderless",
-        },
-    ],
-    custom_classes: "organization-upgrade-banner",
-    close_button: false,
-};
 
 export function set_up_upgrade_banners(): void {
     const has_billing_access = settings_data.user_has_billing_access();
@@ -60,13 +18,40 @@ export function set_up_upgrade_banners(): void {
         return;
     }
 
-    let banner;
-    if (is_business_type_org) {
-        banner = has_billing_access ? UPGRADE_ACCESS_BANNER : AVAILABLE_ON_STANDARD;
-    } else {
-        banner = has_billing_access ? UPGRADE_OR_SPONSORSHIP_BANNER : AVAILABLE_ON_STANDARD;
+    let upgrade_buttons: ActionButton[] = [];
+    let banner_intent: Banner["intent"] = "neutral";
+
+    if (has_billing_access) {
+        banner_intent = "info";
+        upgrade_buttons = [
+            {
+                label: $t({defaultMessage: "Upgrade"}),
+                custom_classes: "request-upgrade",
+                attention: "quiet",
+            },
+        ];
+
+        if (!is_business_type_org) {
+            upgrade_buttons = [
+                ...upgrade_buttons,
+                {
+                    label: $t({defaultMessage: "Request sponsorship"}),
+                    custom_classes: "request-sponsorship",
+                    attention: "borderless",
+                },
+            ];
+        }
     }
-    banners.open(banner, $upgrade_banner_containers);
+
+    const upgrade_banner: Banner = {
+        intent: banner_intent,
+        label: $t({defaultMessage: "Available on Zulip Cloud Standard."}),
+        buttons: upgrade_buttons,
+        custom_classes: "organization-upgrade-banner",
+        close_button: false,
+    };
+
+    banners.open(upgrade_banner, $upgrade_banner_containers);
 }
 
 export function set_up_banner($container: JQuery, banner: Banner, url?: string): void {


### PR DESCRIPTION
Fixes: [Comment](https://github.com/zulip/zulip/pull/34491/commits/7019e293dece899368a98d20ca7957248f2a7e64#r2248335886)

Instead of defining three separate banner objects with mostly identical properties, dynamically construct the buttons array and intent based on user permissions and organization type.

Also changed "Upgrade to access" button text to just "Upgrade" for consistency.

| Before | After |
|---|---|
| <img width="453" height="60" alt="Screenshot 2025-08-03 at 10 49 24 PM" src="https://github.com/user-attachments/assets/fa3f549d-2d8a-4ccc-a569-6f93636185c6" /> |<img width="415" height="64" alt="Screenshot 2025-08-03 at 10 34 00 PM" src="https://github.com/user-attachments/assets/33ef2288-67e5-439f-ae02-43ee69643532" /> |
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
