### PR TITLE
help: Document folders in the left sidebar setting + misc. touch-ups.

### DIFF
--- a/help/change-the-color-of-a-channel.md
+++ b/help/change-the-color-of-a-channel.md
@@ -32,3 +32,11 @@ channel. Changing a channel's color does not change it for anyone else.
 1. Click **Choose** to save and apply the color change.
 
 {end_tabs}
+
+## Related articles
+
+* [Introduction to channels](/help/introduction-to-channels)
+* [Channel folders](/help/channel-folders)
+* [Pin a channel](/help/pin-a-channel)
+* [Mute or unmute a channel](/help/mute-a-channel)
+* [Hide or reveal inactive channels](/help/manage-inactive-channels)

--- a/help/channel-folders.md
+++ b/help/channel-folders.md
@@ -1,9 +1,10 @@
 # Channel folders
 
-Organizations can sort channels into folders. For example, you can put all
-the channels associated with a team into a dedicated folder. Channels will be
-grouped into folders in the [left sidebar](/help/left-sidebar) and the
-[**Inbox**](/help/inbox) view.
+Organizations can sort channels into folders. For example, you can put all the
+channels associated with a team into a dedicated folder. Channels will be
+grouped into folders in the [**Inbox**](/help/inbox) view, and users can
+[decide](#configure-whether-channels-are-grouped-by-folder-in-the-left-sidebar)
+whether to group them by folder in the [left sidebar](/help/left-sidebar).
 
 Everyone can [pin channels](/help/pin-a-channel) they personally want to pay
 close attention to. Pinned channels appear in a dedicated **pinned channels**
@@ -50,6 +51,19 @@ section above channel folders.
    folder selection dropdown.
 
 1. Fill out the requested information, and click **Create**.
+
+{end_tabs}
+
+## Configure whether channels are grouped by folder in the left sidebar
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{settings_tab|preferences}
+
+1. Under **Information**, toggle **Group channels by folder in the left
+   sidebar**.
 
 {end_tabs}
 

--- a/help/left-sidebar.md
+++ b/help/left-sidebar.md
@@ -17,6 +17,8 @@ section by:
 - [Pinning channels](/help/pin-a-channel) so that they appear in a dedicated
   section at the top of the list of channels.
 - [Changing channel colors](/help/change-the-color-of-a-channel).
+- [Configuring](/help/channel-folders#configure-whether-channels-are-grouped-by-folder-in-the-left-sidebar)
+  whether channels are grouped by folder.
 - [Configuring](/help/manage-inactive-channels) whether inactive channels are
   hidden.
 

--- a/help/pin-a-channel.md
+++ b/help/pin-a-channel.md
@@ -9,11 +9,21 @@ sidebar](/help/left-sidebar) and the [**Inbox**](/help/inbox) view.
 
 {start_tabs}
 
-{tab|desktop-web}
+{tab|via-left-sidebar}
 
 {!channel-actions.md!}
 
 1. Click **Pin channel to top**.
+
+{tab|via-channel-settings}
+
+{relative|gear|channel-settings}
+
+1. Select a channel.
+
+{!select-channel-view-personal.md!}
+
+1. Under **Personal settings**, toggle **Pin channel to top of left sidebar**.
 
 {tab|mobile}
 
@@ -31,11 +41,21 @@ description with 👍.
 
 {start_tabs}
 
-{tab|desktop-web}
+{tab|via-left-sidebar}
 
 {!channel-actions.md!}
 
 1. Click **Unpin channel from top**.
+
+{tab|via-channel-settings}
+
+{relative|gear|channel-settings}
+
+1. Select a channel.
+
+{!select-channel-view-personal.md!}
+
+1. Under **Personal settings**, toggle **Pin channel to top of left sidebar**.
 
 {tab|mobile}
 
@@ -46,22 +66,6 @@ Implementation of this feature in the mobile app is tracked [on
 GitHub](https://github.com/zulip/zulip-flutter/issues/1223). If
 you're interested in this feature, please react to the issue's
 description with 👍.
-
-{end_tabs}
-
-## Alternate method to pin or unpin a channel
-
-{start_tabs}
-
-{tab|desktop-web}
-
-{relative|gear|channel-settings}
-
-1. Select a channel.
-
-{!select-channel-view-personal.md!}
-
-1. Under **Personal settings**, toggle **Pin channel to top of left sidebar**.
 
 {end_tabs}
 


### PR DESCRIPTION
We'll probably want to add some notes about when to use the new left sidebar setting, but let's do that as a follow-up.

<details>
<summary>
Screenshots
</summary>

## https://chat.zulip.org/help/pin-a-channel

<img width="1474" height="1486" alt="Screenshot 2025-08-03 at 22 39 20@2x" src="https://github.com/user-attachments/assets/4ff8e197-f21e-4c3c-afa2-71aa84c674ab" />
<img width="1254" height="1160" alt="Screenshot 2025-08-03 at 22 39 32@2x" src="https://github.com/user-attachments/assets/a5e2a07d-05a2-41f3-951a-0be3ecbb1d57" />

## https://chat.zulip.org/help/channel-folders
<img width="1516" height="474" alt="Screenshot 2025-08-03 at 22 40 00@2x" src="https://github.com/user-attachments/assets/b375ac14-83b6-4a09-a5d8-8e5d5958a110" />
[other sections]
<img width="1450" height="466" alt="Screenshot 2025-08-03 at 22 40 12@2x" src="https://github.com/user-attachments/assets/f9b040ce-d5cf-4d2b-a705-ac585b5bcc17" />

</details>