### PR TITLE
integrations: Make screenshot_configs a field in Integration class.

### DIFF
--- a/api_docs/incoming-webhooks-overview.md
+++ b/api_docs/incoming-webhooks-overview.md
@@ -110,10 +110,7 @@ below are for a webhook named `MyWebHook`.
   `WEBHOOK_INTEGRATIONS`. This will automatically register a
   URL for the incoming webhook of the form `api/v1/external/mywebhook` and
   associate it with the function called `api_mywebhook_webhook` in
-  `zerver/webhooks/mywebhook/view.py`. Also add your integration to
-  `DOC_SCREENSHOT_CONFIG`. This will allow you to automatically generate
-  a screenshot for the documentation by running
-  `tools/screenshots/generate-integration-docs-screenshot --integration mywebhook`.
+  `zerver/webhooks/mywebhook/view.py`.
 
 ## Common Helpers
 

--- a/docs/documentation/integrations.md
+++ b/docs/documentation/integrations.md
@@ -29,11 +29,11 @@ Typically, the documentation process involves the following steps:
   See [Markdown macros](#markdown-macros) for further details.
 
 - Make sure you've added your integration to `zerver/lib/integrations.py` in
-  both the `WEBHOOK_INTEGRATIONS` section (or `INTEGRATIONS` if not a
-  webhook), and the `DOC_SCREENSHOT_CONFIG` sections.
+  the `WEBHOOK_INTEGRATIONS` section (or `INTEGRATIONS` if not a
+  webhook).
 
-  These registries configure your integration to appear on the
-  `/integrations` page, and make it possible to automatically generate the
+  This registry configures your integration to appear on the
+  `/integrations` page, and makes it possible to automatically generate the
   screenshot of an example message, which is important for the screenshots
   to be updated as Zulip's design changes.
 
@@ -59,8 +59,8 @@ Typically, the documentation process involves the following steps:
   Then, add your integration's name to `FIXTURELESS_INTEGRATIONS_WITH_SCREENSHOTS`
   in `zerver/lib/integrations.py`.
 
-  Otherwise, you should have already added your integration to
-  `WEBHOOK_SCREENSHOT_CONFIG`.
+  Otherwise, you should have already added your integration along with its
+  screenshot config to `WEBHOOK_INTEGRATIONS`.
 
   Generate the screenshot using `tools/screenshots/generate-integration-docs-screenshot`,
   where `integrationname` is the name of the integration:

--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -40,10 +40,9 @@ from zerver.actions.create_user import do_create_user, notify_created_bot
 from zerver.actions.streams import bulk_add_subscriptions
 from zerver.actions.user_settings import do_change_avatar_fields
 from zerver.lib.integrations import (
-    DOC_SCREENSHOT_CONFIG,
-    FIXTURELESS_SCREENSHOT_CONFIG,
+    FIXTURELESS_INTEGRATIONS_WITH_SCREENSHOTS,
     INTEGRATIONS,
-    WEBHOOK_SCREENSHOT_CONFIG,
+    WEBHOOK_INTEGRATIONS,
     FixturelessScreenshotConfig,
     Integration,
     WebhookIntegration,
@@ -238,6 +237,12 @@ def capture_last_message_screenshot(bot: UserProfile, image_path: str) -> None:
     subprocess.check_call(["node", screenshot_script, message_id, image_path, realm.url])
 
 
+def generate_screenshots_for_integration(integration: Integration) -> None:
+    if integration.screenshot_configs is not None:
+        for screenshot_config in integration.screenshot_configs:
+            generate_screenshot_from_config(integration.name, screenshot_config)
+
+
 def generate_screenshot_from_config(
     integration_name: str, screenshot_config: WebhookScreenshotConfig | FixturelessScreenshotConfig
 ) -> None:
@@ -336,29 +341,27 @@ def build_config(options: argparse.Namespace, config_keys: list[str]) -> dict[st
 
 def generate_full_batch_screenshots(
     option_key: str,
-    config_dict: dict[str, list[WebhookScreenshotConfig]]
-    | dict[str, list[FixturelessScreenshotConfig]]
-    | dict[str, list[WebhookScreenshotConfig] | list[FixturelessScreenshotConfig]],
+    integration_list: list[Integration] | list[WebhookIntegration],
     batch_type: str,
 ) -> None:
     for key, value in vars(options).items():
         if key != option_key and value:
             print(f"Generating screenshots for {batch_type}. Ignoring all command-line options")
             break
-    for integration_name, screenshot_configs in config_dict.items():
-        for screenshot_config in screenshot_configs:
-            generate_screenshot_from_config(integration_name, screenshot_config)
+    for integration in integration_list:
+        generate_screenshots_for_integration(integration)
 
 
 if options.all:
-    generate_full_batch_screenshots("all", DOC_SCREENSHOT_CONFIG, "all integrations")
+    generate_full_batch_screenshots("all", list(INTEGRATIONS.values()), "all integrations")
 elif options.all_webhook:
-    generate_full_batch_screenshots(
-        "all_webhook", WEBHOOK_SCREENSHOT_CONFIG, "all webhook integrations"
-    )
+    generate_full_batch_screenshots("all_webhook", WEBHOOK_INTEGRATIONS, "all webhook integrations")
 elif options.all_fixtureless:
+    fixtureless_integrations_list = [
+        INTEGRATIONS[name] for name in FIXTURELESS_INTEGRATIONS_WITH_SCREENSHOTS
+    ]
     generate_full_batch_screenshots(
-        "all_fixtureless", FIXTURELESS_SCREENSHOT_CONFIG, "all fixtureless integrations"
+        "all_fixtureless", fixtureless_integrations_list, "all fixtureless integrations"
     )
 elif options.skip_until:
     for key, value in vars(options).items():
@@ -368,21 +371,20 @@ elif options.skip_until:
             )
             break
     skip = True
-    for integration_name, screenshot_configs in DOC_SCREENSHOT_CONFIG.items():
+    for integration_name in sorted(INTEGRATIONS):
         if integration_name == options.skip_until:
             skip = False
         if skip:
             continue
-        for screenshot_config in screenshot_configs:
-            generate_screenshot_from_config(integration_name, screenshot_config)
+        generate_screenshots_for_integration(INTEGRATIONS[integration_name])
 
 elif options.fixture_name:
     validate_integration_count(options, parser, "fixture-name")
     webhook_options = [action.dest for action in webhook_group._group_actions]
     common_options = [action.dest for action in common_group._group_actions]
     config = build_config(options, webhook_options + common_options)
-    screenshot_config = WebhookScreenshotConfig(**config)
-    generate_screenshot_from_config(options.integration[0], screenshot_config)
+    webhook_screenshot_config = WebhookScreenshotConfig(**config)
+    generate_screenshot_from_config(options.integration[0], webhook_screenshot_config)
 
 elif options.topic or options.message:
     if not options.topic or not options.message:
@@ -396,8 +398,10 @@ elif options.topic or options.message:
 
 elif options.integration:
     for integration in options.integration:
-        assert integration in DOC_SCREENSHOT_CONFIG
-        configs = DOC_SCREENSHOT_CONFIG[integration]
+        assert integration in INTEGRATIONS
+        configs = INTEGRATIONS[integration].screenshot_configs
+        if configs is None:
+            parser.error(f"Could not find screenshot configuration for integration {integration}. ")
         for screenshot_config in configs:
             generate_screenshot_from_config(integration, screenshot_config)
 
@@ -405,5 +409,5 @@ else:
     parser.error(
         "Could not find configuration for integration. "
         "You can specify a fixture file to use, using the --fixture flag. "
-        "Or add a configuration to zerver.lib.integrations.DOC_SCREENSHOT_CONFIG",
+        "Or add a configuration to the corresponding integration in zerver.lib.integrations.INTEGRATIONS.",
     )

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -1,6 +1,7 @@
 import os
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
+from itertools import zip_longest
 from typing import Any, TypeAlias
 
 from django.contrib.staticfiles.storage import staticfiles_storage
@@ -93,6 +94,60 @@ FIXTURELESS_SCREENSHOT_CONTENT: dict[str, list[fixtureless_integrations.Screensh
 }
 
 
+@dataclass
+class WebhookScreenshotConfig:
+    fixture_name: str
+    image_name: str = "001.png"
+    image_dir: str | None = None
+    bot_name: str | None = None
+    channel: str | None = None
+    payload_as_query_param: bool = False
+    payload_param_name: str = "payload"
+    extra_params: dict[str, str] = field(default_factory=dict)
+    use_basic_auth: bool = False
+    custom_headers: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class FixturelessScreenshotConfigOptions:
+    # These configured values for individual integrations are written
+    # over an object with defaults for content and topic to construct
+    # a FixturelessScreenshotConfig.
+    channel: str | None = None
+    image_name: str = "001.png"
+    image_dir: str | None = None
+    bot_name: str | None = None
+
+
+@dataclass
+class FixturelessScreenshotConfig:
+    message: str
+    topic: str
+    channel: str | None = None
+    image_name: str = "001.png"
+    image_dir: str | None = None
+    bot_name: str | None = None
+
+
+def get_screenshot_configs(
+    integration_name: str,
+    screenshot_config_options: list[FixturelessScreenshotConfigOptions] | None,
+) -> list[FixturelessScreenshotConfig] | None:
+    screenshot_contents = FIXTURELESS_SCREENSHOT_CONTENT.get(integration_name, [])
+    if not screenshot_contents:
+        return None  # nocoverage
+    return [
+        FixturelessScreenshotConfig(
+            screenshot_content["content"],
+            screenshot_content["topic"],
+            **vars(screenshot_config_option) if screenshot_config_option else {},
+        )
+        for screenshot_content, screenshot_config_option in zip_longest(
+            screenshot_contents, screenshot_config_options or []
+        )
+    ]
+
+
 class Integration:
     DEFAULT_LOGO_STATIC_PATH_PNG = "images/integrations/logos/{name}.png"
     DEFAULT_LOGO_STATIC_PATH_SVG = "images/integrations/logos/{name}.svg"
@@ -103,6 +158,9 @@ class Integration:
         self,
         name: str,
         categories: list[str],
+        fixtureless_screenshot_config_options: list[FixturelessScreenshotConfigOptions]
+        | None = None,
+        webhook_screenshot_configs: list[WebhookScreenshotConfig] | None = None,
         client_name: str | None = None,
         logo: str | None = None,
         secondary_line_text: str | None = None,
@@ -118,6 +176,16 @@ class Integration:
         self.legacy = legacy
         self.doc = doc
         self.url_options = url_options
+
+        self.screenshot_configs: (
+            list[WebhookScreenshotConfig] | list[FixturelessScreenshotConfig] | None
+        ) = None
+        if webhook_screenshot_configs is not None:
+            self.screenshot_configs = webhook_screenshot_configs
+        elif self.name in FIXTURELESS_INTEGRATIONS_WITH_SCREENSHOTS:
+            self.screenshot_configs = get_screenshot_configs(
+                name, fixtureless_screenshot_config_options
+            )
 
         # Note: Currently only incoming webhook type bots use this list for
         # defining how the bot's BotConfigData should be. Embedded bots follow
@@ -187,6 +255,8 @@ class BotIntegration(Integration):
         self,
         name: str,
         categories: list[str],
+        fixtureless_screenshot_config_options: list[FixturelessScreenshotConfigOptions]
+        | None = None,
         logo: str | None = None,
         secondary_line_text: str | None = None,
         display_name: str | None = None,
@@ -196,6 +266,7 @@ class BotIntegration(Integration):
             name,
             client_name=name,
             categories=categories,
+            fixtureless_screenshot_config_options=fixtureless_screenshot_config_options,
             secondary_line_text=secondary_line_text,
         )
 
@@ -225,6 +296,8 @@ class PythonAPIIntegration(Integration):
         self,
         name: str,
         categories: list[str],
+        fixtureless_screenshot_config_options: list[FixturelessScreenshotConfigOptions]
+        | None = None,
         client_name: str | None = None,
         logo: str | None = None,
         secondary_line_text: str | None = None,
@@ -245,6 +318,7 @@ class PythonAPIIntegration(Integration):
         super().__init__(
             name,
             categories,
+            fixtureless_screenshot_config_options=fixtureless_screenshot_config_options,
             client_name=client_name,
             logo=logo,
             secondary_line_text=secondary_line_text,
@@ -264,6 +338,7 @@ class WebhookIntegration(Integration):
         self,
         name: str,
         categories: list[str],
+        webhook_screenshot_configs: list[WebhookScreenshotConfig] | None = None,
         client_name: str | None = None,
         logo: str | None = None,
         secondary_line_text: str | None = None,
@@ -281,6 +356,7 @@ class WebhookIntegration(Integration):
         super().__init__(
             name,
             categories,
+            webhook_screenshot_configs=webhook_screenshot_configs,
             client_name=client_name,
             logo=logo,
             secondary_line_text=secondary_line_text,
@@ -328,30 +404,6 @@ def split_fixture_path(path: str) -> tuple[str, str]:
     return integration_name, fixture_name
 
 
-@dataclass
-class WebhookScreenshotConfig:
-    fixture_name: str
-    image_name: str = "001.png"
-    image_dir: str | None = None
-    bot_name: str | None = None
-    channel: str | None = None
-    payload_as_query_param: bool = False
-    payload_param_name: str = "payload"
-    extra_params: dict[str, str] = field(default_factory=dict)
-    use_basic_auth: bool = False
-    custom_headers: dict[str, str] = field(default_factory=dict)
-
-
-@dataclass
-class FixturelessScreenshotConfig:
-    message: str
-    topic: str
-    channel: str | None = None
-    image_name: str = "001.png"
-    image_dir: str | None = None
-    bot_name: str | None = None
-
-
 def get_fixture_path(
     integration: WebhookIntegration, screenshot_config: WebhookScreenshotConfig
 ) -> str:
@@ -379,6 +431,8 @@ class HubotIntegration(Integration):
         self,
         name: str,
         categories: list[str],
+        fixtureless_screenshot_config_options: list[FixturelessScreenshotConfigOptions]
+        | None = None,
         display_name: str | None = None,
         logo: str | None = None,
         git_url: str | None = None,
@@ -391,6 +445,7 @@ class HubotIntegration(Integration):
         super().__init__(
             name,
             categories,
+            fixtureless_screenshot_config_options=fixtureless_screenshot_config_options,
             logo=logo,
             secondary_line_text=self.SECONDARY_LINE_TEXT,
             display_name=display_name,
@@ -423,29 +478,81 @@ EMBEDDED_BOTS: list[EmbeddedBotIntegration] = [
 ]
 
 WEBHOOK_INTEGRATIONS: list[WebhookIntegration] = [
-    WebhookIntegration("airbrake", ["monitoring"]),
-    WebhookIntegration("airbyte", ["monitoring"]),
+    WebhookIntegration("airbrake", ["monitoring"], [WebhookScreenshotConfig("error_message.json")]),
+    WebhookIntegration(
+        "airbyte", ["monitoring"], [WebhookScreenshotConfig("airbyte_job_payload_success.json")]
+    ),
     WebhookIntegration(
         "alertmanager",
         ["monitoring"],
+        [
+            WebhookScreenshotConfig(
+                "alert.json", extra_params={"name": "topic", "desc": "description"}
+            )
+        ],
         display_name="Prometheus Alertmanager",
         logo="images/integrations/logos/prometheus.svg",
     ),
-    WebhookIntegration("ansibletower", ["deployment"], display_name="Ansible Tower"),
-    WebhookIntegration("appfollow", ["customer-support"], display_name="AppFollow"),
-    WebhookIntegration("appveyor", ["continuous-integration"], display_name="AppVeyor"),
+    WebhookIntegration(
+        "ansibletower",
+        ["deployment"],
+        [WebhookScreenshotConfig("job_successful_multiple_hosts.json")],
+        display_name="Ansible Tower",
+    ),
+    WebhookIntegration(
+        "appfollow",
+        ["customer-support"],
+        [WebhookScreenshotConfig("review.json")],
+        display_name="AppFollow",
+    ),
+    WebhookIntegration(
+        "appveyor",
+        ["continuous-integration"],
+        [WebhookScreenshotConfig("appveyor_build_success.json")],
+        display_name="AppVeyor",
+    ),
     WebhookIntegration(
         "azuredevops",
         ["version-control"],
+        [WebhookScreenshotConfig("code_push.json")],
         display_name="AzureDevOps",
         url_options=[WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES)],
     ),
-    WebhookIntegration("beanstalk", ["version-control"]),
-    WebhookIntegration("basecamp", ["project-management"]),
-    WebhookIntegration("beeminder", ["misc"], display_name="Beeminder"),
+    WebhookIntegration(
+        "beanstalk",
+        ["version-control"],
+        [
+            WebhookScreenshotConfig(
+                "git_multiple.json",
+                channel="commits",
+                use_basic_auth=True,
+                payload_as_query_param=True,
+            )
+        ],
+    ),
+    WebhookIntegration(
+        "basecamp", ["project-management"], [WebhookScreenshotConfig("doc_active.json")]
+    ),
+    WebhookIntegration(
+        "beeminder",
+        ["misc"],
+        # The fixture's goal.losedate needs to be modified dynamically
+        # before uncommenting the screenshot config below.
+        # [WebhookScreenshotConfig("derail_worried.json")],
+        display_name="Beeminder",
+    ),
     WebhookIntegration(
         "bitbucket3",
         ["version-control"],
+        [
+            WebhookScreenshotConfig(
+                "repo_push_update_single_branch.json",
+                "004.png",
+                "bitbucket",
+                bot_name="Bitbucket Server Bot",
+                channel="commits",
+            )
+        ],
         logo="images/integrations/logos/bitbucket.svg",
         display_name="Bitbucket Server",
         url_options=[WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES)],
@@ -453,6 +560,15 @@ WEBHOOK_INTEGRATIONS: list[WebhookIntegration] = [
     WebhookIntegration(
         "bitbucket2",
         ["version-control"],
+        [
+            WebhookScreenshotConfig(
+                "issue_created.json",
+                "003.png",
+                "bitbucket",
+                bot_name="Bitbucket Bot",
+                channel="commits",
+            )
+        ],
         logo="images/integrations/logos/bitbucket.svg",
         display_name="Bitbucket",
         url_options=[WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES)],
@@ -460,33 +576,84 @@ WEBHOOK_INTEGRATIONS: list[WebhookIntegration] = [
     WebhookIntegration(
         "bitbucket",
         ["version-control"],
+        [
+            WebhookScreenshotConfig(
+                "push.json",
+                "002.png",
+                channel="commits",
+                use_basic_auth=True,
+                payload_as_query_param=True,
+            )
+        ],
         display_name="Bitbucket",
         secondary_line_text="(Enterprise)",
         legacy=True,
     ),
-    WebhookIntegration("buildbot", ["continuous-integration"]),
-    WebhookIntegration("canarytoken", ["monitoring"], display_name="Thinkst Canarytokens"),
-    WebhookIntegration("circleci", ["continuous-integration"], display_name="CircleCI"),
-    WebhookIntegration("clubhouse", ["project-management"]),
-    WebhookIntegration("codeship", ["continuous-integration", "deployment"]),
-    WebhookIntegration("crashlytics", ["monitoring"]),
-    WebhookIntegration("dialogflow", ["customer-support"]),
-    WebhookIntegration("delighted", ["customer-support", "marketing"]),
-    WebhookIntegration("dropbox", ["productivity"]),
-    WebhookIntegration("errbit", ["monitoring"]),
-    WebhookIntegration("flock", ["customer-support"]),
-    WebhookIntegration("freshdesk", ["customer-support"]),
-    WebhookIntegration("freshping", ["monitoring"]),
-    WebhookIntegration("freshstatus", ["monitoring", "customer-support"]),
-    WebhookIntegration("front", ["customer-support"]),
+    WebhookIntegration(
+        "buildbot", ["continuous-integration"], [WebhookScreenshotConfig("started.json")]
+    ),
+    WebhookIntegration(
+        "canarytoken",
+        ["monitoring"],
+        [WebhookScreenshotConfig("canarytoken_real.json")],
+        display_name="Thinkst Canarytokens",
+    ),
+    WebhookIntegration(
+        "circleci",
+        ["continuous-integration"],
+        [WebhookScreenshotConfig("github_job_completed.json")],
+        display_name="CircleCI",
+    ),
+    WebhookIntegration(
+        "clubhouse", ["project-management"], [WebhookScreenshotConfig("story_create.json")]
+    ),
+    WebhookIntegration(
+        "codeship",
+        ["continuous-integration", "deployment"],
+        [WebhookScreenshotConfig("error_build.json")],
+    ),
+    WebhookIntegration(
+        "crashlytics", ["monitoring"], [WebhookScreenshotConfig("issue_message.json")]
+    ),
+    WebhookIntegration(
+        "dialogflow",
+        ["customer-support"],
+        [WebhookScreenshotConfig("weather_app.json", extra_params={"email": "iago@zulip.com"})],
+    ),
+    WebhookIntegration(
+        "delighted",
+        ["customer-support", "marketing"],
+        [WebhookScreenshotConfig("survey_response_updated_promoter.json")],
+    ),
+    WebhookIntegration("dropbox", ["productivity"], [WebhookScreenshotConfig("file_updated.json")]),
+    WebhookIntegration("errbit", ["monitoring"], [WebhookScreenshotConfig("error_message.json")]),
+    WebhookIntegration("flock", ["customer-support"], [WebhookScreenshotConfig("messages.json")]),
+    WebhookIntegration(
+        "freshdesk",
+        ["customer-support"],
+        [WebhookScreenshotConfig("ticket_created.json", image_name="004.png", use_basic_auth=True)],
+    ),
+    WebhookIntegration(
+        "freshping", ["monitoring"], [WebhookScreenshotConfig("freshping_check_unreachable.json")]
+    ),
+    WebhookIntegration(
+        "freshstatus",
+        ["monitoring", "customer-support"],
+        [WebhookScreenshotConfig("freshstatus_incident_open.json")],
+    ),
+    WebhookIntegration(
+        "front", ["customer-support"], [WebhookScreenshotConfig("inbound_message.json")]
+    ),
     WebhookIntegration(
         "gitea",
         ["version-control"],
+        [WebhookScreenshotConfig("pull_request__merged.json", channel="commits")],
         url_options=[WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES)],
     ),
     WebhookIntegration(
         "github",
         ["version-control"],
+        [WebhookScreenshotConfig("push__1_commit.json", channel="commits")],
         display_name="GitHub",
         url_options=[
             WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES),
@@ -496,6 +663,7 @@ WEBHOOK_INTEGRATIONS: list[WebhookIntegration] = [
     WebhookIntegration(
         "githubsponsors",
         ["financial"],
+        [WebhookScreenshotConfig("created.json", channel="github")],
         display_name="GitHub Sponsors",
         logo="images/integrations/logos/github.svg",
         dir_name="github",
@@ -504,43 +672,138 @@ WEBHOOK_INTEGRATIONS: list[WebhookIntegration] = [
     WebhookIntegration(
         "gitlab",
         ["version-control"],
+        [
+            WebhookScreenshotConfig(
+                "push_hook__push_local_branch_without_commits.json", channel="commits"
+            )
+        ],
         display_name="GitLab",
         url_options=[WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES)],
     ),
-    WebhookIntegration("gocd", ["continuous-integration"], display_name="GoCD"),
+    WebhookIntegration(
+        "gocd",
+        ["continuous-integration"],
+        [WebhookScreenshotConfig("pipeline_with_mixed_job_result.json")],
+        display_name="GoCD",
+    ),
     WebhookIntegration(
         "gogs",
         ["version-control"],
+        [WebhookScreenshotConfig("pull_request__opened.json", channel="commits")],
         url_options=[WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES)],
     ),
-    WebhookIntegration("gosquared", ["marketing"], display_name="GoSquared"),
-    WebhookIntegration("grafana", ["monitoring"]),
-    WebhookIntegration("greenhouse", ["hr"]),
-    WebhookIntegration("groove", ["customer-support"]),
-    WebhookIntegration("harbor", ["deployment", "productivity"]),
-    WebhookIntegration("hellosign", ["productivity", "hr"], display_name="HelloSign"),
-    WebhookIntegration("helloworld", ["misc"], display_name="Hello World"),
-    WebhookIntegration("heroku", ["deployment"]),
-    WebhookIntegration("homeassistant", ["misc"], display_name="Home Assistant"),
+    WebhookIntegration(
+        "gosquared",
+        ["marketing"],
+        [WebhookScreenshotConfig("traffic_spike.json")],
+        display_name="GoSquared",
+    ),
+    WebhookIntegration(
+        "grafana", ["monitoring"], [WebhookScreenshotConfig("alert_values_v11.json")]
+    ),
+    WebhookIntegration(
+        "greenhouse", ["hr"], [WebhookScreenshotConfig("candidate_stage_change.json")]
+    ),
+    WebhookIntegration(
+        "groove", ["customer-support"], [WebhookScreenshotConfig("ticket_started.json")]
+    ),
+    WebhookIntegration(
+        "harbor",
+        ["deployment", "productivity"],
+        [WebhookScreenshotConfig("scanning_completed.json")],
+    ),
+    WebhookIntegration(
+        "hellosign",
+        ["productivity", "hr"],
+        [
+            WebhookScreenshotConfig(
+                "signatures_signed_by_one_signatory.json",
+                payload_as_query_param=True,
+                payload_param_name="json",
+            )
+        ],
+        display_name="HelloSign",
+    ),
+    WebhookIntegration(
+        "helloworld", ["misc"], [WebhookScreenshotConfig("hello.json")], display_name="Hello World"
+    ),
+    WebhookIntegration("heroku", ["deployment"], [WebhookScreenshotConfig("deploy.txt")]),
+    WebhookIntegration(
+        "homeassistant",
+        ["misc"],
+        [WebhookScreenshotConfig("reqwithtitle.json")],
+        display_name="Home Assistant",
+    ),
     WebhookIntegration("ifttt", ["meta-integration"], display_name="IFTTT"),
-    WebhookIntegration("insping", ["monitoring"]),
-    WebhookIntegration("intercom", ["customer-support"]),
+    WebhookIntegration(
+        "insping", ["monitoring"], [WebhookScreenshotConfig("website_state_available.json")]
+    ),
+    WebhookIntegration(
+        "intercom",
+        ["customer-support"],
+        [WebhookScreenshotConfig("conversation_admin_replied.json")],
+    ),
     # Avoid collision with jira-plugin's doc "jira/doc.md".
-    WebhookIntegration("jira", ["project-management"], doc="jira/jira-doc.md"),
-    WebhookIntegration("jotform", ["misc"]),
-    WebhookIntegration("json", ["misc"], display_name="JSON formatter"),
-    WebhookIntegration("librato", ["monitoring"]),
-    WebhookIntegration("lidarr", ["entertainment"]),
-    WebhookIntegration("linear", ["project-management"]),
-    WebhookIntegration("mention", ["marketing"]),
-    WebhookIntegration("netlify", ["continuous-integration", "deployment"]),
-    WebhookIntegration("newrelic", ["monitoring"], display_name="New Relic"),
-    WebhookIntegration("opencollective", ["financial"], display_name="Open Collective"),
-    WebhookIntegration("openproject", ["project-management"], display_name="OpenProject"),
-    WebhookIntegration("opensearch", ["monitoring"], display_name="OpenSearch"),
+    WebhookIntegration(
+        "jira",
+        ["project-management"],
+        [WebhookScreenshotConfig("created_v1.json")],
+        doc="jira/jira-doc.md",
+    ),
+    WebhookIntegration(
+        "jotform", ["misc"], [WebhookScreenshotConfig("screenshot_response.multipart")]
+    ),
+    WebhookIntegration(
+        "json",
+        ["misc"],
+        [WebhookScreenshotConfig("json_github_push__1_commit.json")],
+        display_name="JSON formatter",
+    ),
+    WebhookIntegration(
+        "librato",
+        ["monitoring"],
+        [WebhookScreenshotConfig("three_conditions_alert.json", payload_as_query_param=True)],
+    ),
+    WebhookIntegration(
+        "lidarr", ["entertainment"], [WebhookScreenshotConfig("lidarr_album_grabbed.json")]
+    ),
+    WebhookIntegration(
+        "linear", ["project-management"], [WebhookScreenshotConfig("issue_create_complex.json")]
+    ),
+    WebhookIntegration("mention", ["marketing"], [WebhookScreenshotConfig("webfeeds.json")]),
+    WebhookIntegration(
+        "netlify",
+        ["continuous-integration", "deployment"],
+        [WebhookScreenshotConfig("deploy_building.json")],
+    ),
+    WebhookIntegration(
+        "newrelic",
+        ["monitoring"],
+        [WebhookScreenshotConfig("incident_activated_new_default_payload.json")],
+        display_name="New Relic",
+    ),
+    WebhookIntegration(
+        "opencollective",
+        ["financial"],
+        [WebhookScreenshotConfig("one_time_donation.json")],
+        display_name="Open Collective",
+    ),
+    WebhookIntegration(
+        "openproject",
+        ["project-management"],
+        [WebhookScreenshotConfig("project_created__without_parent.json")],
+        display_name="OpenProject",
+    ),
+    WebhookIntegration(
+        "opensearch",
+        ["monitoring"],
+        [WebhookScreenshotConfig("example_template.txt")],
+        display_name="OpenSearch",
+    ),
     WebhookIntegration(
         "opsgenie",
         ["meta-integration", "monitoring"],
+        [WebhookScreenshotConfig("addrecipient.json")],
         url_options=[
             WebhookUrlOption(
                 name="eu_region",
@@ -549,23 +812,55 @@ WEBHOOK_INTEGRATIONS: list[WebhookIntegration] = [
             )
         ],
     ),
-    WebhookIntegration("pagerduty", ["monitoring"], display_name="PagerDuty"),
-    WebhookIntegration("papertrail", ["monitoring"]),
-    WebhookIntegration("patreon", ["financial"]),
-    WebhookIntegration("pingdom", ["monitoring"]),
-    WebhookIntegration("pivotal", ["project-management"], display_name="Pivotal Tracker"),
-    WebhookIntegration("radarr", ["entertainment"]),
-    WebhookIntegration("raygun", ["monitoring"]),
-    WebhookIntegration("reviewboard", ["version-control"], display_name="Review Board"),
+    WebhookIntegration(
+        "pagerduty",
+        ["monitoring"],
+        [WebhookScreenshotConfig("trigger_v2.json")],
+        display_name="PagerDuty",
+    ),
+    WebhookIntegration(
+        "papertrail",
+        ["monitoring"],
+        [WebhookScreenshotConfig("short_post.json", payload_as_query_param=True)],
+    ),
+    WebhookIntegration(
+        "patreon", ["financial"], [WebhookScreenshotConfig("members_pledge_create.json")]
+    ),
+    WebhookIntegration(
+        "pingdom", ["monitoring"], [WebhookScreenshotConfig("http_up_to_down.json")]
+    ),
+    WebhookIntegration(
+        "pivotal",
+        ["project-management"],
+        [WebhookScreenshotConfig("v5_type_changed.json")],
+        display_name="Pivotal Tracker",
+    ),
+    WebhookIntegration(
+        "radarr", ["entertainment"], [WebhookScreenshotConfig("radarr_movie_grabbed.json")]
+    ),
+    WebhookIntegration("raygun", ["monitoring"], [WebhookScreenshotConfig("new_error.json")]),
+    WebhookIntegration(
+        "reviewboard",
+        ["version-control"],
+        [WebhookScreenshotConfig("review_request_published.json")],
+        display_name="Review Board",
+    ),
     WebhookIntegration(
         "rhodecode",
         ["version-control"],
+        [WebhookScreenshotConfig("push.json", channel="commits")],
         display_name="RhodeCode",
         url_options=[WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES)],
     ),
-    WebhookIntegration("rundeck", ["deployment"]),
-    WebhookIntegration("semaphore", ["continuous-integration", "deployment"]),
-    WebhookIntegration("sentry", ["monitoring"]),
+    WebhookIntegration("rundeck", ["deployment"], [WebhookScreenshotConfig("start.json")]),
+    WebhookIntegration(
+        "semaphore",
+        ["continuous-integration", "deployment"],
+        [WebhookScreenshotConfig("pull_request.json")],
+    ),
+    WebhookIntegration(
+        "sentry", ["monitoring"], [WebhookScreenshotConfig("event_for_exception_python.json")]
+    ),
     WebhookIntegration(
         "slack_incoming",
         ["communication", "meta-integration"],
@@ -573,24 +868,91 @@ WEBHOOK_INTEGRATIONS: list[WebhookIntegration] = [
         logo="images/integrations/logos/slack.svg",
     ),
     WebhookIntegration("slack", ["communication"]),
-    WebhookIntegration("sonarqube", ["continuous-integration"], display_name="SonarQube"),
-    WebhookIntegration("sonarr", ["entertainment"]),
-    WebhookIntegration("splunk", ["monitoring"]),
-    WebhookIntegration("statuspage", ["customer-support"]),
-    WebhookIntegration("stripe", ["financial"]),
-    WebhookIntegration("taiga", ["project-management"]),
-    WebhookIntegration("teamcity", ["continuous-integration"]),
-    WebhookIntegration("thinkst", ["monitoring"]),
-    WebhookIntegration("transifex", ["misc"]),
-    WebhookIntegration("travis", ["continuous-integration"], display_name="Travis CI"),
-    WebhookIntegration("trello", ["project-management"]),
-    WebhookIntegration("updown", ["monitoring"]),
-    WebhookIntegration("uptimerobot", ["monitoring"], display_name="UptimeRobot"),
-    WebhookIntegration("wekan", ["productivity"]),
-    WebhookIntegration("wordpress", ["marketing"], display_name="WordPress"),
+    WebhookIntegration(
+        "sonarqube",
+        ["continuous-integration"],
+        [WebhookScreenshotConfig("error.json")],
+        display_name="SonarQube",
+    ),
+    WebhookIntegration(
+        "sonarr", ["entertainment"], [WebhookScreenshotConfig("sonarr_episode_grabbed.json")]
+    ),
+    WebhookIntegration(
+        "splunk", ["monitoring"], [WebhookScreenshotConfig("search_one_result.json")]
+    ),
+    WebhookIntegration(
+        "statuspage", ["customer-support"], [WebhookScreenshotConfig("incident_created.json")]
+    ),
+    WebhookIntegration(
+        "stripe", ["financial"], [WebhookScreenshotConfig("charge_succeeded__card.json")]
+    ),
+    WebhookIntegration(
+        "taiga", ["project-management"], [WebhookScreenshotConfig("userstory_changed_status.json")]
+    ),
+    WebhookIntegration(
+        "teamcity", ["continuous-integration"], [WebhookScreenshotConfig("success.json")]
+    ),
+    WebhookIntegration(
+        "thinkst", ["monitoring"], [WebhookScreenshotConfig("canary_consolidated_port_scan.json")]
+    ),
+    WebhookIntegration(
+        "transifex",
+        ["misc"],
+        [
+            WebhookScreenshotConfig(
+                "",
+                extra_params={
+                    "project": "Zulip Mobile",
+                    "language": "en",
+                    "resource": "file",
+                    "event": "review_completed",
+                    "reviewed": "100",
+                },
+            )
+        ],
+    ),
+    WebhookIntegration(
+        "travis",
+        ["continuous-integration"],
+        [WebhookScreenshotConfig("build.json", payload_as_query_param=True)],
+        display_name="Travis CI",
+    ),
+    WebhookIntegration(
+        "trello", ["project-management"], [WebhookScreenshotConfig("adding_comment_to_card.json")]
+    ),
+    WebhookIntegration(
+        "updown", ["monitoring"], [WebhookScreenshotConfig("check_multiple_events.json")]
+    ),
+    WebhookIntegration(
+        "uptimerobot",
+        ["monitoring"],
+        [WebhookScreenshotConfig("uptimerobot_monitor_up.json")],
+        display_name="UptimeRobot",
+    ),
+    WebhookIntegration("wekan", ["productivity"], [WebhookScreenshotConfig("add_comment.json")]),
+    WebhookIntegration(
+        "wordpress",
+        ["marketing"],
+        [WebhookScreenshotConfig("publish_post.txt", "wordpress_post_created.png")],
+        display_name="WordPress",
+    ),
     WebhookIntegration("zapier", ["meta-integration"]),
-    WebhookIntegration("zendesk", ["customer-support"]),
-    WebhookIntegration("zabbix", ["monitoring"]),
+    WebhookIntegration(
+        "zendesk",
+        ["customer-support"],
+        [
+            WebhookScreenshotConfig(
+                "",
+                use_basic_auth=True,
+                extra_params={
+                    "ticket_title": "Hardware Ecosystem Compatibility Inquiry",
+                    "ticket_id": "4837",
+                    "message": "Hi, I am planning to purchase the X5000 smartphone and want to ensure compatibility with my existing devices - WDX10 wireless earbuds and Z600 smartwatch. Are there any known issues?",
+                },
+            )
+        ],
+    ),
+    WebhookIntegration("zabbix", ["monitoring"], [WebhookScreenshotConfig("zabbix_alert.json")]),
 ]
 
 INTEGRATIONS: dict[str, Integration] = {
@@ -604,10 +966,17 @@ INTEGRATIONS: dict[str, Integration] = {
     "errbot": Integration("errbot", ["meta-integration", "bots"]),
     "giphy": Integration("giphy", ["misc"], display_name="GIPHY"),
     "github-actions": Integration(
-        "github-actions", ["continuous-integration"], display_name="GitHub Actions"
+        "github-actions",
+        ["continuous-integration"],
+        [FixturelessScreenshotConfigOptions(channel="github-actions updates")],
+        display_name="GitHub Actions",
     ),
     "hubot": Integration("hubot", ["meta-integration", "bots"]),
-    "jenkins": Integration("jenkins", ["continuous-integration"]),
+    "jenkins": Integration(
+        "jenkins",
+        ["continuous-integration"],
+        [FixturelessScreenshotConfigOptions(image_name="004.png")],
+    ),
     "jitsi": Integration("jitsi", ["video-calling", "communication"], display_name="Jitsi Meet"),
     "mastodon": Integration("mastodon", ["communication"]),
     "notion": Integration("notion", ["productivity"]),
@@ -619,9 +988,15 @@ INTEGRATIONS: dict[str, Integration] = {
 
 PYTHON_API_INTEGRATIONS: list[PythonAPIIntegration] = [
     PythonAPIIntegration("codebase", ["version-control"]),
-    PythonAPIIntegration("git", ["version-control"]),
     PythonAPIIntegration(
-        "google-calendar", ["productivity"], display_name="Google Calendar", directory_name="google"
+        "git", ["version-control"], [FixturelessScreenshotConfigOptions(channel="commits")]
+    ),
+    PythonAPIIntegration(
+        "google-calendar",
+        ["productivity"],
+        [FixturelessScreenshotConfigOptions(image_name="003.png", image_dir="google/calendar")],
+        display_name="Google Calendar",
+        directory_name="google",
     ),
     PythonAPIIntegration(
         "irc", ["communication"], display_name="IRC", directory_name="bridge_with_irc"
@@ -629,6 +1004,7 @@ PYTHON_API_INTEGRATIONS: list[PythonAPIIntegration] = [
     PythonAPIIntegration(
         "jira-plugin",
         ["project-management"],
+        [FixturelessScreenshotConfigOptions(channel="jira")],
         logo="images/integrations/logos/jira.svg",
         secondary_line_text="(locally installed)",
         display_name="Jira",
@@ -637,10 +1013,19 @@ PYTHON_API_INTEGRATIONS: list[PythonAPIIntegration] = [
     ),
     PythonAPIIntegration("matrix", ["communication"], directory_name="bridge_with_matrix"),
     PythonAPIIntegration(
-        "mercurial", ["version-control"], display_name="Mercurial (hg)", directory_name="hg"
+        "mercurial",
+        ["version-control"],
+        [FixturelessScreenshotConfigOptions(channel="commits", image_dir="hg")],
+        display_name="Mercurial (hg)",
+        directory_name="hg",
     ),
     PythonAPIIntegration("nagios", ["monitoring"]),
-    PythonAPIIntegration("openshift", ["deployment"], display_name="OpenShift"),
+    PythonAPIIntegration(
+        "openshift",
+        ["deployment"],
+        [FixturelessScreenshotConfigOptions(channel="deployments")],
+        display_name="OpenShift",
+    ),
     PythonAPIIntegration("perforce", ["version-control"]),
     PythonAPIIntegration("rss", ["communication"], display_name="RSS"),
     PythonAPIIntegration("svn", ["version-control"], display_name="Subversion"),
@@ -696,7 +1081,8 @@ for bot_integration in BOT_INTEGRATIONS:
 
 # Add webhook integrations that don't have automated screenshots here
 NO_SCREENSHOT_WEBHOOKS = (
-    # FIXME: fixture's goal.losedate needs to be modified dynamically
+    # The fixture's goal.losedate needs to be modified dynamically,
+    # so the screenshot config is commented out.
     {"beeminder"}
     # Meta integrations - Docs won't have a screenshot
     | {"ifttt", "slack_incoming", "zapier"}
@@ -731,194 +1117,6 @@ NO_SCREENSHOT_CONFIG = (
     | NO_SCREENSHOT_WEBHOOKS
     | hubot_integration_names
 )
-
-
-WEBHOOK_SCREENSHOT_CONFIG: dict[str, list[WebhookScreenshotConfig]] = {
-    "airbrake": [WebhookScreenshotConfig("error_message.json")],
-    "airbyte": [WebhookScreenshotConfig("airbyte_job_payload_success.json")],
-    "alertmanager": [
-        WebhookScreenshotConfig("alert.json", extra_params={"name": "topic", "desc": "description"})
-    ],
-    "ansibletower": [WebhookScreenshotConfig("job_successful_multiple_hosts.json")],
-    "appfollow": [WebhookScreenshotConfig("review.json")],
-    "appveyor": [WebhookScreenshotConfig("appveyor_build_success.json")],
-    "azuredevops": [WebhookScreenshotConfig("code_push.json")],
-    "basecamp": [WebhookScreenshotConfig("doc_active.json")],
-    "beanstalk": [
-        WebhookScreenshotConfig(
-            "git_multiple.json", channel="commits", use_basic_auth=True, payload_as_query_param=True
-        )
-    ],
-    # 'beeminder': [WebhookScreenshotConfig('derail_worried.json')],
-    "bitbucket": [
-        WebhookScreenshotConfig(
-            "push.json",
-            "002.png",
-            channel="commits",
-            use_basic_auth=True,
-            payload_as_query_param=True,
-        )
-    ],
-    "bitbucket2": [
-        WebhookScreenshotConfig(
-            "issue_created.json",
-            "003.png",
-            "bitbucket",
-            bot_name="Bitbucket Bot",
-            channel="commits",
-        )
-    ],
-    "bitbucket3": [
-        WebhookScreenshotConfig(
-            "repo_push_update_single_branch.json",
-            "004.png",
-            "bitbucket",
-            bot_name="Bitbucket Server Bot",
-            channel="commits",
-        )
-    ],
-    "buildbot": [WebhookScreenshotConfig("started.json")],
-    "canarytoken": [WebhookScreenshotConfig("canarytoken_real.json")],
-    "circleci": [WebhookScreenshotConfig("github_job_completed.json")],
-    "clubhouse": [WebhookScreenshotConfig("story_create.json")],
-    "codeship": [WebhookScreenshotConfig("error_build.json")],
-    "crashlytics": [WebhookScreenshotConfig("issue_message.json")],
-    "delighted": [WebhookScreenshotConfig("survey_response_updated_promoter.json")],
-    "dialogflow": [
-        WebhookScreenshotConfig("weather_app.json", extra_params={"email": "iago@zulip.com"})
-    ],
-    "dropbox": [WebhookScreenshotConfig("file_updated.json")],
-    "errbit": [WebhookScreenshotConfig("error_message.json")],
-    "flock": [WebhookScreenshotConfig("messages.json")],
-    "freshdesk": [
-        WebhookScreenshotConfig("ticket_created.json", image_name="004.png", use_basic_auth=True)
-    ],
-    "freshping": [WebhookScreenshotConfig("freshping_check_unreachable.json")],
-    "freshstatus": [WebhookScreenshotConfig("freshstatus_incident_open.json")],
-    "front": [WebhookScreenshotConfig("inbound_message.json")],
-    "gitea": [WebhookScreenshotConfig("pull_request__merged.json", channel="commits")],
-    "github": [WebhookScreenshotConfig("push__1_commit.json", channel="commits")],
-    "githubsponsors": [WebhookScreenshotConfig("created.json", channel="github")],
-    "gitlab": [
-        WebhookScreenshotConfig(
-            "push_hook__push_local_branch_without_commits.json", channel="commits"
-        )
-    ],
-    "gocd": [WebhookScreenshotConfig("pipeline_with_mixed_job_result.json")],
-    "gogs": [WebhookScreenshotConfig("pull_request__opened.json", channel="commits")],
-    "gosquared": [WebhookScreenshotConfig("traffic_spike.json")],
-    "grafana": [WebhookScreenshotConfig("alert_values_v11.json")],
-    "greenhouse": [WebhookScreenshotConfig("candidate_stage_change.json")],
-    "groove": [WebhookScreenshotConfig("ticket_started.json")],
-    "harbor": [WebhookScreenshotConfig("scanning_completed.json")],
-    "hellosign": [
-        WebhookScreenshotConfig(
-            "signatures_signed_by_one_signatory.json",
-            payload_as_query_param=True,
-            payload_param_name="json",
-        )
-    ],
-    "helloworld": [WebhookScreenshotConfig("hello.json")],
-    "heroku": [WebhookScreenshotConfig("deploy.txt")],
-    "homeassistant": [WebhookScreenshotConfig("reqwithtitle.json")],
-    "insping": [WebhookScreenshotConfig("website_state_available.json")],
-    "intercom": [WebhookScreenshotConfig("conversation_admin_replied.json")],
-    "jira": [WebhookScreenshotConfig("created_v1.json")],
-    "jotform": [WebhookScreenshotConfig("screenshot_response.multipart")],
-    "json": [WebhookScreenshotConfig("json_github_push__1_commit.json")],
-    "librato": [
-        WebhookScreenshotConfig("three_conditions_alert.json", payload_as_query_param=True)
-    ],
-    "lidarr": [WebhookScreenshotConfig("lidarr_album_grabbed.json")],
-    "linear": [WebhookScreenshotConfig("issue_create_complex.json")],
-    "mention": [WebhookScreenshotConfig("webfeeds.json")],
-    "netlify": [WebhookScreenshotConfig("deploy_building.json")],
-    "newrelic": [WebhookScreenshotConfig("incident_activated_new_default_payload.json")],
-    "opencollective": [WebhookScreenshotConfig("one_time_donation.json")],
-    "openproject": [WebhookScreenshotConfig("project_created__without_parent.json")],
-    "opensearch": [WebhookScreenshotConfig("example_template.txt")],
-    "opsgenie": [WebhookScreenshotConfig("addrecipient.json")],
-    "pagerduty": [WebhookScreenshotConfig("trigger_v2.json")],
-    "papertrail": [WebhookScreenshotConfig("short_post.json", payload_as_query_param=True)],
-    "patreon": [WebhookScreenshotConfig("members_pledge_create.json")],
-    "pingdom": [WebhookScreenshotConfig("http_up_to_down.json")],
-    "pivotal": [WebhookScreenshotConfig("v5_type_changed.json")],
-    "radarr": [WebhookScreenshotConfig("radarr_movie_grabbed.json")],
-    "raygun": [WebhookScreenshotConfig("new_error.json")],
-    "reviewboard": [WebhookScreenshotConfig("review_request_published.json")],
-    "rhodecode": [WebhookScreenshotConfig("push.json", channel="commits")],
-    "rundeck": [WebhookScreenshotConfig("start.json")],
-    "semaphore": [WebhookScreenshotConfig("pull_request.json")],
-    "sentry": [WebhookScreenshotConfig("event_for_exception_python.json")],
-    "sonarqube": [WebhookScreenshotConfig("error.json")],
-    "sonarr": [WebhookScreenshotConfig("sonarr_episode_grabbed.json")],
-    "splunk": [WebhookScreenshotConfig("search_one_result.json")],
-    "statuspage": [WebhookScreenshotConfig("incident_created.json")],
-    "stripe": [WebhookScreenshotConfig("charge_succeeded__card.json")],
-    "taiga": [WebhookScreenshotConfig("userstory_changed_status.json")],
-    "teamcity": [WebhookScreenshotConfig("success.json")],
-    "thinkst": [WebhookScreenshotConfig("canary_consolidated_port_scan.json")],
-    "transifex": [
-        WebhookScreenshotConfig(
-            "",
-            extra_params={
-                "project": "Zulip Mobile",
-                "language": "en",
-                "resource": "file",
-                "event": "review_completed",
-                "reviewed": "100",
-            },
-        )
-    ],
-    "travis": [WebhookScreenshotConfig("build.json", payload_as_query_param=True)],
-    "trello": [WebhookScreenshotConfig("adding_comment_to_card.json")],
-    "updown": [WebhookScreenshotConfig("check_multiple_events.json")],
-    "uptimerobot": [WebhookScreenshotConfig("uptimerobot_monitor_up.json")],
-    "wekan": [WebhookScreenshotConfig("add_comment.json")],
-    "wordpress": [WebhookScreenshotConfig("publish_post.txt", "wordpress_post_created.png")],
-    "zabbix": [WebhookScreenshotConfig("zabbix_alert.json")],
-    "zendesk": [
-        WebhookScreenshotConfig(
-            "",
-            use_basic_auth=True,
-            extra_params={
-                "ticket_title": "Hardware Ecosystem Compatibility Inquiry",
-                "ticket_id": "4837",
-                "message": "Hi, I am planning to purchase the X5000 smartphone and want to ensure compatibility with my existing devices - WDX10 wireless earbuds and Z600 smartwatch. Are there any known issues?",
-            },
-        )
-    ],
-}
-
-FIXTURELESS_SCREENSHOT_CONFIG: dict[str, list[FixturelessScreenshotConfig]] = {}
-for integration, screenshots_contents in FIXTURELESS_SCREENSHOT_CONTENT.items():
-    FIXTURELESS_SCREENSHOT_CONFIG[integration] = [
-        FixturelessScreenshotConfig(screenshot_content["content"], screenshot_content["topic"])
-        for screenshot_content in screenshots_contents
-    ]
-
-FIXTURELESS_SCREENSHOT_CONFIG_OPTIONAL_FIELDS = {
-    "git": {"channel": "commits"},
-    "github-actions": {"channel": "github-actions updates"},
-    "google-calendar": {"image_name": "003.png", "image_dir": "google/calendar"},
-    "jenkins": {"image_name": "004.png"},
-    "jira-plugin": {"channel": "jira"},
-    "mercurial": {"image_dir": "hg", "channel": "commits"},
-    "openshift": {"channel": "deployments"},
-}
-
-for integration, fields in FIXTURELESS_SCREENSHOT_CONFIG_OPTIONAL_FIELDS.items():
-    assert integration in FIXTURELESS_SCREENSHOT_CONFIG
-    for field_name, value in fields.items():
-        # Assume a single screenshot config for each integration
-        setattr(FIXTURELESS_SCREENSHOT_CONFIG[integration][0], field_name, value)
-
-DOC_SCREENSHOT_CONFIG: dict[
-    str, list[WebhookScreenshotConfig] | list[FixturelessScreenshotConfig]
-] = {
-    **WEBHOOK_SCREENSHOT_CONFIG,
-    **FIXTURELESS_SCREENSHOT_CONFIG,
-}
 
 
 def get_all_event_types_for_integration(integration: Integration) -> list[str] | None:

--- a/zerver/tests/test_integrations.py
+++ b/zerver/tests/test_integrations.py
@@ -1,7 +1,6 @@
 import os
 
 from zerver.lib.integrations import (
-    DOC_SCREENSHOT_CONFIG,
     INTEGRATIONS,
     NO_SCREENSHOT_CONFIG,
     WebhookIntegration,
@@ -41,7 +40,11 @@ class IntegrationsTestCase(ZulipTestCase):
 
     def test_no_missing_doc_screenshot_config(self) -> None:
         integration_names = {integration.name for integration in INTEGRATIONS.values()}
-        integrations_with_screenshot_configs = set(DOC_SCREENSHOT_CONFIG.keys())
+        integrations_with_screenshot_configs = {
+            integration_name
+            for integration_name, integration in INTEGRATIONS.items()
+            if integration.screenshot_configs
+        }
 
         missing_integration_screenshots = (
             integration_names - integrations_with_screenshot_configs - NO_SCREENSHOT_CONFIG
@@ -60,12 +63,12 @@ class IntegrationsTestCase(ZulipTestCase):
             construct_message(
                 "The following integrations are missing their example screenshot configuration:",
                 missing_integration_screenshots,
-                "Add them to zerver.lib.integrations.DOC_SCREENSHOT_CONFIG",
+                "Add them to zerver.lib.integrations.INTEGRATIONS",
             )
             + construct_message(
                 "The following integrations have a screenshot configuration but no longer exist:",
                 extra_integration_configs,
-                "Remove them from zerver.lib.integrations.DOC_SCREENSHOT_CONFIG",
+                "Remove them from zerver.lib.integrations.INTEGRATIONS",
             )
             + construct_message(
                 "The following integrations are listed in NO_SCREENSHOT_CONFIG but no longer exist:",
@@ -76,12 +79,13 @@ class IntegrationsTestCase(ZulipTestCase):
 
     def test_no_missing_screenshot_path(self) -> None:
         message = '"{path}" does not exist for integration {integration_name}.\n'
-        tip = '\nConsider updating zerver.lib.integrations.DOC_SCREENSHOT_CONFIG\n and running "tools/screenshots/generate-integration-docs-screenshot" to keep the screenshots up-to-date.'
+        tip = '\nConsider updating screenshot configs in zerver.lib.integrations.INTEGRATIONS\n and running "tools/screenshots/generate-integration-docs-screenshot" to keep the screenshots up-to-date.'
         error_message = ""
 
-        for integration_name, screenshot_configs in DOC_SCREENSHOT_CONFIG.items():
-            for screenshot_config in screenshot_configs:
-                integration = INTEGRATIONS[integration_name]
+        for integration in INTEGRATIONS.values():
+            if integration.screenshot_configs is None:
+                continue
+            for screenshot_config in integration.screenshot_configs:
                 if isinstance(integration, WebhookIntegration):
                     assert isinstance(screenshot_config, WebhookScreenshotConfig)
                     if screenshot_config.fixture_name == "":
@@ -90,14 +94,14 @@ class IntegrationsTestCase(ZulipTestCase):
                     fixture_path = get_fixture_path(integration, screenshot_config)
                     error_message = (
                         error_message
-                        + message.format(path=fixture_path, integration_name=integration_name)
+                        + message.format(path=fixture_path, integration_name=integration.name)
                         if not os.path.isfile(fixture_path)
                         else error_message
                     )
                 image_path = get_image_path(integration, screenshot_config)
                 error_message = (
                     error_message
-                    + message.format(path=image_path, integration_name=integration_name)
+                    + message.format(path=image_path, integration_name=integration.name)
                     if not os.path.isfile(image_path)
                     else error_message
                 )


### PR DESCRIPTION
Continued from #35241.
Only the last commit is new in this PR.

Previously, we maintained separate registeries for the screenshot configurations - `WEBHOOK_SCREENSHOT_CONFIG`,
`FIXTURELESS_SCREENSHOT_CONFIG`, `DOC_SCREENSHOT_CONFIG`. Now, all integration-related configuration is in a single registry `INTEGRATIONS`.

Manually tested the functioning of the screenshots script.

### Implementation
- Added new optional constructor parameters `fixtureless_screenshot_config_options` and `webhook_screenshot_configs`  to `Integration`'s `__init__`. The subclasses of `Integration` directly pass  in one of the two. I placed them as the first parameters with default values so that the keyword can be skipped.
- Both `fixtureless_screenshot_config_options` and `webhook_screenshot_configs` parameters map to the class field `screenshot_configs`.
- Removed `WEBHOOK_SCREENSHOT_CONFIG`, `FIXTURELESS_SCREENSHOT_CONFIG`, `DOC_SCREENSHOT_CONFIG`. Also removed the `FIXTURELESS_SCREENSHOT_CONFIG_OPTIONAL_FIELDS` and the loop that loads `FIXTURELESS_SCREENSHOT_CONFIG` that was recently added.  Updated the docs to remove all references to `DOC_SCREENSHOT_CONFIG`.

<details>
<summary><h3>Doc Screenshots</h3></summary>

Doc Links:
[Documenting integrations](https://zulip.readthedocs.io/en/latest/documentation/integrations.html)
[Incoming webhooks overview](https://zulip.com/api/incoming-webhooks-overview)

| Before | After |
|---|---|
| <img width="471" height="196" alt="Pasted image 20250812135405" src="https://github.com/user-attachments/assets/54cfa96c-5d0b-4b26-af6c-4a254311eec2" /> | <img width="471" height="146" alt="Pasted image 20250812135351" src="https://github.com/user-attachments/assets/68320ede-e9d1-4a67-b9cc-c699abb58d85" /> |
| <img width="460" height="115" alt="image" src="https://github.com/user-attachments/assets/f8d4308f-78f8-4f6b-a1cd-0b8890afc2ea" /> | <img width="460" height="98" alt="image" src="https://github.com/user-attachments/assets/17a86a29-8eef-4417-a993-cd19ac4f0282" /> |



</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
