### PR TITLE
push_notifications: Guard reference to RemotePushDevice

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -256,7 +256,7 @@ def get_info_from_apns_result(
         logger.info(
             "APNs: Removing invalid/expired token %s (%s)", device.token, result.description
         )
-        if isinstance(device, RemotePushDevice):
+        if settings.ZILENCER_ENABLED and isinstance(device, RemotePushDevice):
             result_info.delete_device_id = device.device_id
         else:
             result_info.delete_device_token = device.token


### PR DESCRIPTION
This doesn’t exist when `ZILENCER_ENABLED` is `False`.

- Cc @prakhar1144 (#35139)
- [Discussion](https://chat.zulip.org/#narrow/channel/2-general/topic/Zulip.2011.2E0.20upgrades/near/2236632)