### PR TITLE
stream_data: Rename `is_stream_archived` function.

### DIFF
--- a/web/src/message_delete.ts
+++ b/web/src/message_delete.ts
@@ -29,7 +29,7 @@ export function is_message_sent_by_my_bot(message: Message): boolean {
 }
 
 export function get_deletability(message: Message): boolean {
-    if (message.type === "stream" && stream_data.is_stream_archived(message.stream_id)) {
+    if (message.type === "stream" && stream_data.is_stream_archived_by_id(message.stream_id)) {
         return false;
     }
     if (settings_data.user_can_delete_any_message()) {

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -104,7 +104,7 @@ export function is_topic_editable(message: Message, edit_limit_seconds_buffer = 
         return false;
     }
 
-    if (message.type === "stream" && stream_data.is_stream_archived(message.stream_id)) {
+    if (message.type === "stream" && stream_data.is_stream_archived_by_id(message.stream_id)) {
         return false;
     }
 
@@ -192,7 +192,7 @@ export function is_content_editable(message: Message, edit_limit_seconds_buffer 
         return false;
     }
 
-    if (message.type === "stream" && stream_data.is_stream_archived(message.stream_id)) {
+    if (message.type === "stream" && stream_data.is_stream_archived_by_id(message.stream_id)) {
         return false;
     }
 
@@ -228,7 +228,7 @@ export function is_stream_editable(message: Message, edit_limit_seconds_buffer =
         return false;
     }
 
-    if (message.type === "stream" && stream_data.is_stream_archived(message.stream_id)) {
+    if (message.type === "stream" && stream_data.is_stream_archived_by_id(message.stream_id)) {
         return false;
     }
 

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -383,7 +383,7 @@ function populate_group_from_message(
         const is_empty_string_topic = topic === "";
         const match_topic_html = util.get_match_topic(message);
         const stream_url = hash_util.channel_url_by_user_setting(message.stream_id);
-        const is_archived = stream_data.is_stream_archived(message.stream_id);
+        const is_archived = stream_data.is_stream_archived_by_id(message.stream_id);
         const topic_url = internal_url.by_stream_topic_url(
             message.stream_id,
             message.topic,

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -232,7 +232,7 @@ export function get_actions_popover_content_context(message_id: number): ActionP
         !message.is_me_message &&
         !is_add_reaction_icon_visible() &&
         not_spectator &&
-        !(stream_id && stream_data.is_stream_archived(stream_id));
+        !(stream_id && stream_data.is_stream_archived_by_id(stream_id));
 
     return {
         message_id: message.id,

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -939,7 +939,9 @@ export function get_stream_privacy_policy(stream_id: number): string {
     return settings_config.stream_privacy_policy_values.private_with_public_history.code;
 }
 
-export function is_stream_archived(stream_id: number): boolean {
+export function is_stream_archived_by_id(stream_id: number): boolean {
+    // If you've already got a channel object, you can just use
+    // `sub.is_archived` directly instead of calling this function.
     const sub = sub_store.get(stream_id);
     return sub ? sub.is_archived : false;
 }

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -739,7 +739,7 @@ export function get_sidebar_stream_topic_info(filter: Filter): {
         return result;
     }
 
-    if (!stream_data.is_subscribed(stream_id) || stream_data.is_stream_archived(stream_id)) {
+    if (!stream_data.is_subscribed(stream_id) || stream_data.is_stream_archived_by_id(stream_id)) {
         return result;
     }
 

--- a/web/tests/message_edit.test.cjs
+++ b/web/tests/message_edit.test.cjs
@@ -93,7 +93,7 @@ run_test("is_topic_editable", ({override}) => {
         type: "stream",
     };
     override(realm, "realm_allow_message_editing", true);
-    override(stream_data, "is_stream_archived", () => false);
+    override(stream_data, "is_stream_archived_by_id", () => false);
     override(stream_data, "user_can_move_messages_within_channel", () => true);
     override(stream_data, "get_sub_by_id", () => ({}));
     override(stream_data, "is_empty_topic_only_channel", () => false);
@@ -153,7 +153,7 @@ run_test("is_stream_editable", ({override}) => {
     override(stream_data, "user_can_move_messages_out_of_channel", () => true);
     override(stream_data, "get_sub_by_id", () => ({}));
     override(current_user, "is_moderator", true);
-    override(stream_data, "is_stream_archived", () => false);
+    override(stream_data, "is_stream_archived_by_id", () => false);
 
     assert.equal(message_edit.is_stream_editable(message), false);
 

--- a/web/tests/popover_menus_data.test.cjs
+++ b/web/tests/popover_menus_data.test.cjs
@@ -53,7 +53,7 @@ mock_esm("../src/hash_util", {
 });
 mock_esm("../src/stream_data", {
     is_subscribed: () => true,
-    is_stream_archived: () => false,
+    is_stream_archived_by_id: () => false,
     get_sub_by_id: () => noop,
     user_can_move_messages_within_channel: () => true,
     is_empty_topic_only_channel: () => false,

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -937,10 +937,10 @@ test("mark_archived", () => {
     assert.ok(stream_data.is_subscribed(canada.stream_id));
     assert.equal(stream_data.get_sub("Canada").stream_id, canada.stream_id);
     assert.equal(sub_store.get(canada.stream_id).name, "Canada");
-    assert.equal(stream_data.is_stream_archived(canada.stream_id), false);
+    assert.equal(stream_data.is_stream_archived_by_id(canada.stream_id), false);
 
     stream_data.mark_archived(canada.stream_id);
-    assert.ok(stream_data.is_stream_archived(canada.stream_id));
+    assert.ok(stream_data.is_stream_archived_by_id(canada.stream_id));
     assert.ok(stream_data.is_subscribed(canada.stream_id));
     assert.ok(stream_data.get_sub("Canada"));
     assert.ok(sub_store.get(canada.stream_id));
@@ -960,11 +960,11 @@ test("mark_unarchived", () => {
     };
 
     stream_data.add_sub(canada);
-    assert.ok(stream_data.is_stream_archived(canada.stream_id));
+    assert.ok(stream_data.is_stream_archived_by_id(canada.stream_id));
     assert.ok(stream_data.is_subscribed(canada.stream_id));
 
     stream_data.mark_unarchived(canada.stream_id);
-    assert.ok(!stream_data.is_stream_archived(canada.stream_id));
+    assert.ok(!stream_data.is_stream_archived_by_id(canada.stream_id));
     assert.ok(stream_data.is_subscribed(canada.stream_id));
     const sub = stream_data.get_sub("Canada");
     assert.equal(sub.stream_id, canada.stream_id);

--- a/web/tests/stream_events.test.cjs
+++ b/web/tests/stream_events.test.cjs
@@ -388,7 +388,7 @@ test("update_property", ({override}) => {
 
         stream_events.update_property(stream_id, "is_archived", true);
 
-        assert.ok(stream_data.is_stream_archived(stream_id));
+        assert.ok(stream_data.is_stream_archived_by_id(stream_id));
         assert.ok(stream_data.is_subscribed(stream_id));
 
         const args = stub.get_args("sub");
@@ -418,7 +418,7 @@ test("update_property", ({override}) => {
 
         // Unarchive the stream
         stream_events.update_property(stream_id, "is_archived", false);
-        assert.ok(!stream_data.is_stream_archived(stream_id));
+        assert.ok(!stream_data.is_stream_archived_by_id(stream_id));
         assert.ok(stream_data.is_subscribed(stream_id));
 
         const args = stub.get_args("sub");


### PR DESCRIPTION
Renames `is_stream_archived` function to `is_stream_archived_by_id`.

Follow-up for https://github.com/zulip/zulip/pull/35045#discussion_r2214405609.
<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
