### PR TITLE
left_sidebar: Correct margin on sticky headers.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -357,9 +357,13 @@
     cursor: pointer;
     background-color: var(--color-background);
     position: sticky;
-    /* Input is 31px tall at 16px/1em.
-       Input container has 8px and 3px top/bottom padding = 11px total padding */
-    top: calc(1.9375em + 11px);
+    /* Input is 54px tall at 16px/1em. That includes the
+       input container's top padding that's 2.5 times
+       the value of the left sidebar vertical gutter,
+       plus 3px of bottom padding. */
+    top: calc(
+        1.9375em + (var(--left-sidebar-sections-vertical-gutter) * 2.5) + 3px
+    );
     /* Must be more than .sidebar-topic-check and less than #stream-search-and-add */
     z-index: 2;
     color: var(--color-text-default);


### PR DESCRIPTION
This corrects a regression from #35553, which neglected to correct the `margin-top` value on sticky headers to match the increased padding above the filter input.

Fixes: [#design > channel folders UI @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/channel.20folders.20UI/near/2236787)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="1800" height="1100" alt="scrolled-sticky-header-before" src="https://github.com/user-attachments/assets/059f1ad8-753d-4a89-b33f-42fdc2fc3db4" /> | <img width="1800" height="1100" alt="scrolled-sticky-header-after" src="https://github.com/user-attachments/assets/f1c672d0-07a7-4f13-b2ab-5405541b5999" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>