### PR TITLE
help-beta: Add icons to NavigationSteps data.

### DIFF
--- a/help-beta/src/components/NavigationSteps.astro
+++ b/help-beta/src/components/NavigationSteps.astro
@@ -4,20 +4,20 @@ import assert from "node:assert";
 import {CORPORATE_ENABLED, SHOW_RELATIVE_LINKS} from "astro:env/client";
 
 /* eslint-disable import/extensions */
-import RawZulipIconBarChart from "~icons/zulip-icon/bar-chart?raw";
-import RawZulipIconBuilding from "~icons/zulip-icon/building?raw";
-import RawZulipIconCreditCard from "~icons/zulip-icon/credit-card?raw";
-import RawZulipIconEdit from "~icons/zulip-icon/edit?raw";
-import RawZulipIconGear from "~icons/zulip-icon/gear?raw";
-import RawZulipIconGitPullRequest from "~icons/zulip-icon/git-pull-request?raw";
-import RawZulipIconHash from "~icons/zulip-icon/hash?raw";
-import RawZulipIconHelp from "~icons/zulip-icon/help?raw";
-import RawZulipIconInfo from "~icons/zulip-icon/info?raw";
-import RawZulipIconKeyboard from "~icons/zulip-icon/keyboard?raw";
-import RawZulipIconManageSearch from "~icons/zulip-icon/manage-search?raw";
-import RawZulipIconRocket from "~icons/zulip-icon/rocket?raw";
-import RawZulipIconTool from "~icons/zulip-icon/tool?raw";
-import RawZulipIconUserGroupCog from "~icons/zulip-icon/user-group-cog?raw";
+import RawBarChartIcon from "~icons/zulip-icon/bar-chart?raw";
+import RawBuildingIcon from "~icons/zulip-icon/building?raw";
+import RawCreditCardIcon from "~icons/zulip-icon/credit-card?raw";
+import RawEditIcon from "~icons/zulip-icon/edit?raw";
+import RawGearIcon from "~icons/zulip-icon/gear?raw";
+import RawGitPullRequestIcon from "~icons/zulip-icon/git-pull-request?raw";
+import RawHashIcon from "~icons/zulip-icon/hash?raw";
+import RawHelpIcon from "~icons/zulip-icon/help?raw";
+import RawInfoIcon from "~icons/zulip-icon/info?raw";
+import RawKeyboardIcon from "~icons/zulip-icon/keyboard?raw";
+import RawManageSearchIcon from "~icons/zulip-icon/manage-search?raw";
+import RawRocketIcon from "~icons/zulip-icon/rocket?raw";
+import RawToolIcon from "~icons/zulip-icon/tool?raw";
+import RawUserGroupCogIcon from "~icons/zulip-icon/user-group-cog?raw";
 /* eslint-enable import/extensions */
 
 const PERSONAL_SETTINGS_TYPE = "Personal settings";
@@ -168,7 +168,7 @@ type RelativeLinkInfo = {
 
 const default_template_for_relative_links = `
 <ol>
-  <li>Click on the <strong>gear</strong> (${RawZulipIconGear}) icon in the upper right corner of the web or desktop app.</li>
+  <li>Click on the <strong>gear</strong> (${RawGearIcon}) icon in the upper right corner of the web or desktop app.</li>
   <li class="navigation-step-relative-type">Select {item}.</li>
 </ol>
 `;
@@ -184,27 +184,27 @@ const relative_link_mapping: Record<
     gear: {
         data: {
             "channel-settings": {
-                label: `${RawZulipIconHash}Channel settings`,
+                label: `${RawHashIcon}Channel settings`,
                 relative_link: "/#channels/subscribed",
             },
             settings: {
-                label: `${RawZulipIconTool}Personal Settings`,
+                label: `${RawToolIcon}Personal Settings`,
                 relative_link: "/#settings/profile",
             },
             "organization-settings": {
-                label: `${RawZulipIconBuilding}Organization settings`,
+                label: `${RawBuildingIcon}Organization settings`,
                 relative_link: "/#organization/organization-profile",
             },
             "group-settings": {
-                label: `${RawZulipIconUserGroupCog}Group settings`,
+                label: `${RawUserGroupCogIcon}Group settings`,
                 relative_link: "/#groups/your",
             },
             stats: {
-                label: `${RawZulipIconBarChart}Usage statistics`,
+                label: `${RawBarChartIcon}Usage statistics`,
                 relative_link: "/stats",
             },
             integrations: {
-                label: `${RawZulipIconGitPullRequest}Integrations`,
+                label: `${RawGitPullRequestIcon}Integrations`,
                 relative_link: "/integrations/",
             },
             "about-zulip": {
@@ -218,11 +218,11 @@ const relative_link_mapping: Record<
     "gear-billing": {
         data: {
             plans: {
-                label: `${RawZulipIconRocket}Plans and pricing`,
+                label: `${RawRocketIcon}Plans and pricing`,
                 relative_link: "/plans/",
             },
             billing: {
-                label: `${RawZulipIconCreditCard}Billing`,
+                label: `${RawCreditCardIcon}Billing`,
                 relative_link: "/billing/",
             },
         },
@@ -232,25 +232,25 @@ const relative_link_mapping: Record<
     help: {
         data: {
             "keyboard-shortcuts": {
-                label: `${RawZulipIconKeyboard}Keyboard shortcuts`,
+                label: `${RawKeyboardIcon}Keyboard shortcuts`,
                 relative_link: "/#keyboard-shortcuts",
             },
             "message-formatting": {
-                label: `${RawZulipIconEdit}Message formatting`,
+                label: `${RawEditIcon}Message formatting`,
                 relative_link: "/#message-formatting",
             },
             "search-filters": {
-                label: `${RawZulipIconManageSearch}Search filters`,
+                label: `${RawManageSearchIcon}Search filters`,
                 relative_link: "/#search-operators",
             },
             "about-zulip": {
-                label: `${RawZulipIconInfo}About Zulip`,
+                label: `${RawInfoIcon}About Zulip`,
                 relative_link: "/#about-zulip",
             },
         },
         template: `
 <ol>
-  <li>Click on the <strong>Help menu</strong> (${RawZulipIconHelp}) icon in the upper right corner of the app.</li>
+  <li>Click on the <strong>Help menu</strong> (${RawHelpIcon}) icon in the upper right corner of the app.</li>
   <li class="navigation-step-relative-type">Select {item}.</li>
 </ol>
 `,
@@ -269,8 +269,8 @@ const relative_link_mapping: Record<
         },
         template: `
 <ol>
-  <li>Click on the <strong>gear</strong> (${RawZulipIconGear}) icon in the upper right corner of the web or desktop app.</li>
-  <li>Select ${RawZulipIconHash} <strong>Channel settings</strong>.</li>
+  <li>Click on the <strong>gear</strong> (${RawGearIcon}) icon in the upper right corner of the web or desktop app.</li>
+  <li>Select ${RawHashIcon} <strong>Channel settings</strong>.</li>
   <li>Click {item} in the upper left.</li>
 </ol>
 `,
@@ -285,8 +285,8 @@ const relative_link_mapping: Record<
         },
         template: `
 <ol>
-  <li>Click on the <strong>gear</strong> (${RawZulipIconGear}) icon in the upper right corner of the web or desktop app.</li>
-  <li>Select ${RawZulipIconUserGroupCog} <strong>Group settings</strong>.</li>
+  <li>Click on the <strong>gear</strong> (${RawGearIcon}) icon in the upper right corner of the web or desktop app.</li>
+  <li>Select ${RawUserGroupCogIcon} <strong>Group settings</strong>.</li>
   <li>Click {item} in the upper left.</li>
 </ol>
 `,
@@ -297,7 +297,7 @@ const relative_link_mapping: Record<
 const getSettingsMarkdown = (setting_type: string, setting_name: string) => `
 <ol>
     <li>
-        Click on the <b>gear</b> (${RawZulipIconGear}) icon in the upper
+        Click on the <b>gear</b> (${RawGearIcon}) icon in the upper
         right corner of the web or desktop app.
     </li>
     <li>

--- a/help-beta/src/components/NavigationSteps.astro
+++ b/help-beta/src/components/NavigationSteps.astro
@@ -307,14 +307,18 @@ const relative_link_mapping: Record<
     },
 };
 
-const getSettingsMarkdown = (setting_type: string, setting_name: string) => `
+const getSettingsMarkdown = (
+    setting_type: string,
+    setting_type_icon: string,
+    setting_name: string,
+) => `
 <ol>
     <li>
         Click on the <b>gear</b> (${RawGearIcon}) icon in the upper
         right corner of the web or desktop app.
     </li>
     <li>
-        Select <b>${setting_type}</b>.
+        Select <b>${setting_type_icon} ${setting_type}</b>.
     </li>
     <li>
         On the left, click <b>${setting_name}</b>.
@@ -330,7 +334,15 @@ const getSettingsHTML = (
         setting_link_mapping[setting_key]!;
 
     if (!SHOW_RELATIVE_LINKS) {
-        return getSettingsMarkdown(setting_type, setting_name);
+        const setting_type_icon =
+            setting_type === ORGANIZATION_SETTINGS_TYPE
+                ? `${RawBuildingIcon}`.trim()
+                : `${RawToolIcon}`.trim();
+        return getSettingsMarkdown(
+            setting_type,
+            setting_type_icon,
+            setting_name,
+        );
     }
 
     const relativeLink = `<a href="${setting_link}">${setting_name}</a>`;

--- a/help-beta/src/components/NavigationSteps.astro
+++ b/help-beta/src/components/NavigationSteps.astro
@@ -164,6 +164,7 @@ const setting_link_mapping: Record<
 type RelativeLinkInfo = {
     label: string;
     relative_link: string;
+    icon?: string | undefined;
 };
 
 const default_template_for_relative_links = `
@@ -184,28 +185,34 @@ const relative_link_mapping: Record<
     gear: {
         data: {
             "channel-settings": {
-                label: `${RawHashIcon}Channel settings`,
+                label: "Channel settings",
                 relative_link: "/#channels/subscribed",
+                icon: `${RawHashIcon}`,
             },
             settings: {
-                label: `${RawToolIcon}Personal Settings`,
+                label: "Personal Settings",
                 relative_link: "/#settings/profile",
+                icon: `${RawToolIcon}`,
             },
             "organization-settings": {
-                label: `${RawBuildingIcon}Organization settings`,
+                label: "Organization settings",
                 relative_link: "/#organization/organization-profile",
+                icon: `${RawBuildingIcon}`,
             },
             "group-settings": {
-                label: `${RawUserGroupCogIcon}Group settings`,
+                label: "Group settings",
                 relative_link: "/#groups/your",
+                icon: `${RawUserGroupCogIcon}`,
             },
             stats: {
-                label: `${RawBarChartIcon}Usage statistics`,
+                label: "Usage statistics",
                 relative_link: "/stats",
+                icon: `${RawBarChartIcon}`,
             },
             integrations: {
-                label: `${RawGitPullRequestIcon}Integrations`,
+                label: "Integrations",
                 relative_link: "/integrations/",
+                icon: `${RawGitPullRequestIcon}`,
             },
             "about-zulip": {
                 label: "About Zulip",
@@ -218,12 +225,14 @@ const relative_link_mapping: Record<
     "gear-billing": {
         data: {
             plans: {
-                label: `${RawRocketIcon}Plans and pricing`,
+                label: "Plans and pricing",
                 relative_link: "/plans/",
+                icon: `${RawRocketIcon}`,
             },
             billing: {
-                label: `${RawCreditCardIcon}Billing`,
+                label: "Billing",
                 relative_link: "/billing/",
+                icon: `${RawCreditCardIcon}`,
             },
         },
         template: default_template_for_relative_links,
@@ -232,20 +241,24 @@ const relative_link_mapping: Record<
     help: {
         data: {
             "keyboard-shortcuts": {
-                label: `${RawKeyboardIcon}Keyboard shortcuts`,
+                label: "Keyboard shortcuts",
                 relative_link: "/#keyboard-shortcuts",
+                icon: `${RawKeyboardIcon}`,
             },
             "message-formatting": {
-                label: `${RawEditIcon}Message formatting`,
+                label: "Message formatting",
                 relative_link: "/#message-formatting",
+                icon: `${RawEditIcon}`,
             },
             "search-filters": {
-                label: `${RawManageSearchIcon}Search filters`,
+                label: "Search filters",
                 relative_link: "/#search-operators",
+                icon: `${RawManageSearchIcon}`,
             },
             "about-zulip": {
-                label: `${RawInfoIcon}About Zulip`,
+                label: "About Zulip",
                 relative_link: "/#about-zulip",
+                icon: `${RawInfoIcon}`,
             },
         },
         template: `
@@ -347,10 +360,15 @@ for (const type of Object.keys(relative_link_mapping)) {
     const {data, template, is_link_relative} = relative_link_mapping[type]!;
 
     RELATIVE_NAVIGATION_HANDLERS_BY_TYPE[type] = (key: string) => {
-        const {label, relative_link} = data[key]!;
+        const {label, relative_link, icon} = data[key]!;
+        let formattedLabel = label;
+        if (icon !== undefined) {
+            const trimmedIcon = `${icon}`.trim();
+            formattedLabel = trimmedIcon + label;
+        }
         const formattedItem = is_link_relative()
-            ? `<a href="${relative_link}">${label}</a>`
-            : `<strong>${label}</strong>`;
+            ? `<a href="${relative_link}">${formattedLabel}</a>`
+            : `<strong>${formattedLabel}</strong>`;
         return template.replace("{item}", formattedItem);
     };
 }


### PR DESCRIPTION
Because some of the raw icon files have a trailing new line, add the raw icon svg to the data used for the `NavigationStep` component and format the label with the trimmed icon svg.

Relevant CZO converasation: [#documentation > new help center: icons that are links](https://chat.zulip.org/#narrow/channel/19-documentation/topic/new.20help.20center.3A.20icons.20that.20are.20links)

**Notes**:
- There's a prep commit to update the import icon class names to better match help center content icon class names ([#documentation > ✔ new help center: Icon class names](https://chat.zulip.org/#narrow/channel/19-documentation/topic/.E2.9C.94.20new.20help.20center.3A.20Icon.20class.20names)).
- The final commit adds the icon for the non-relative link settings instruction for selecting either organization or personal settings from the gear menu, which is more consistent with our other relative links in `NavigationSteps`.

*The vertical alignment of icons in the new help center in my dev environment in Firefox on my Linux system is a bit off, probably due to the font.*

---

**Removing new line from links screenshots:**

| Before | After |
| --- | --- |
| <img width="984" height="631" alt="Screenshot From 2025-08-05 17-07-55" src="https://github.com/user-attachments/assets/9ac005f5-d187-4e49-8852-bd0d7c7ed514" /> | <img width="984" height="625" alt="Screenshot From 2025-08-05 17-03-18" src="https://github.com/user-attachments/assets/477e7e75-1f85-49e3-9eb5-72992cc06207" />

| Before | After |
| --- | --- |
| <img width="984" height="372" alt="Screenshot From 2025-08-05 17-07-35" src="https://github.com/user-attachments/assets/873fe503-5293-4836-8139-66203a1a91c8" /> | <img width="984" height="372" alt="Screenshot From 2025-08-05 17-04-20" src="https://github.com/user-attachments/assets/8d327c68-0875-48ea-9890-e032d3944c7d" />

**Adding icons screenshots:**

| Before | After |
| --- | --- |
| <img width="984" height="694" alt="Screenshot From 2025-08-05 17-10-44" src="https://github.com/user-attachments/assets/8ed5ab75-f01e-41ce-9134-bcc782082b43" /> | <img width="984" height="679" alt="Screenshot From 2025-08-05 17-01-01" src="https://github.com/user-attachments/assets/83c3fcbe-2a75-4c50-8b68-4adef09e7d8f" />

| Before | After |
| --- | --- |
| <img width="984" height="754" alt="Screenshot From 2025-08-05 17-11-16" src="https://github.com/user-attachments/assets/25df9474-10b4-468b-b11e-b419386316c2" /> | <img width="984" height="753" alt="Screenshot From 2025-08-05 17-01-24" src="https://github.com/user-attachments/assets/239bb98e-03a1-44bd-89e7-c3e58ef2c216" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
