### PR TITLE
 Show tooltip on long folder name in left sidebar 

### DIFF
--- a/web/src/left_sidebar_tooltips.ts
+++ b/web/src/left_sidebar_tooltips.ts
@@ -17,6 +17,47 @@ import {user_settings} from "./user_settings.ts";
 
 export function initialize(): void {
     tippy.delegate("body", {
+        target: ".stream-list-section-container .left-sidebar-title",
+        placement: "top-start",
+        delay: LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        onShow(instance) {
+            const el = instance.reference;
+            if (!(el instanceof HTMLElement)) {
+                return false;
+            }
+            // Show tooltip only if text is truncated
+            if (el.offsetWidth < el.scrollWidth) {
+                const tooltip_id = el.dataset.tooltipTemplateId;
+                if (tooltip_id) {
+                    const template = document.querySelector<HTMLElement>(
+                        `#${CSS.escape(tooltip_id)}`,
+                    );
+                    if (template) {
+                        instance.setContent(template.innerHTML);
+                    } else {
+                        instance.setContent(el.textContent ?? "");
+                    }
+                } else {
+                    instance.setContent(el.textContent ?? "");
+                }
+                return undefined;
+            }
+            return false;
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
+        popperOptions: {
+            modifiers: [
+                {
+                    name: "flip",
+                    options: {fallbackPlacements: ["bottom"]},
+                },
+            ],
+        },
+    });
+    tippy.delegate("body", {
         target: ".tippy-left-sidebar-tooltip",
         placement: "right",
         delay: EXTRA_LONG_HOVER_DELAY,

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -947,41 +947,6 @@ export function initialize_tippy_tooltips(): void {
         },
         appendTo: () => document.body,
     });
-   tippy.delegate("body", {
-    target: ".tippy-left-sidebar-tooltip",
-    delay: LONG_HOVER_DELAY,
-    placement: "top",   
-    allowHTML: true,
-    appendTo: () => document.body,
-    popperOptions: {
-        modifiers: [
-            {
-                name: 'flip',
-                enabled: false,
-            },
-        ],
-    },
-    onShow(instance) {
-        const reference_element = instance.reference;
-        if (!(reference_element instanceof HTMLElement)) {
-            return false;
-        }
-        if (reference_element.offsetWidth < reference_element.scrollWidth) {
-            const tooltip_id = reference_element.dataset.tooltipTemplateId;
-            if (typeof tooltip_id !== "string") {
-                return false;
-            }
-
-            const template = document.querySelector(`#${CSS.escape(tooltip_id)}`);
-            if (!template) {
-                return false;
-            }
-            instance.setContent(template.innerHTML);
-            return undefined;
-        }
-        return false;
-    },
-});
 }
 
 function on_sidebar_channel_click(

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -947,6 +947,41 @@ export function initialize_tippy_tooltips(): void {
         },
         appendTo: () => document.body,
     });
+   tippy.delegate("body", {
+    target: ".tippy-left-sidebar-tooltip",
+    delay: LONG_HOVER_DELAY,
+    placement: "top",   
+    allowHTML: true,
+    appendTo: () => document.body,
+    popperOptions: {
+        modifiers: [
+            {
+                name: 'flip',
+                enabled: false,
+            },
+        ],
+    },
+    onShow(instance) {
+        const reference_element = instance.reference;
+        if (!(reference_element instanceof HTMLElement)) {
+            return false;
+        }
+        if (reference_element.offsetWidth < reference_element.scrollWidth) {
+            const tooltip_id = reference_element.dataset.tooltipTemplateId;
+            if (typeof tooltip_id !== "string") {
+                return false;
+            }
+
+            const template = document.querySelector(`#${CSS.escape(tooltip_id)}`);
+            if (!template) {
+                return false;
+            }
+            instance.setContent(template.innerHTML);
+            return undefined;
+        }
+        return false;
+    },
+});
 }
 
 function on_sidebar_channel_click(

--- a/web/templates/stream_list_section_container.hbs
+++ b/web/templates/stream_list_section_container.hbs
@@ -1,12 +1,16 @@
 <div id="stream-list-{{id}}-container" data-section-id="{{id}}" class="stream-list-section-container">
     <div class="stream-list-subsection-header zoom-in-hide">
         <i class="stream-list-section-toggle zulip-icon zulip-icon-heading-triangle-right rotate-icon-down" aria-hidden="true"></i>
-        <h4 class="left-sidebar-title">
+        <h4 class="left-sidebar-title tippy-left-sidebar-tooltip" data-tooltip-template-id="section-tooltip-{{id}}" data-placement="top">
             {{section_title}}
         </h4>
+        <template id="section-tooltip-{{id}}">
+            {{section_title}}
+        </template>
         {{#if plus_icon_url}}
-        <a href="{{plus_icon_url}}" class="add-stream-tooltip add-stream-icon-container hidden-for-spectators" data-tippy-content="{{t 'Create a channel' }}">
-            <i class="add_stream_icon zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
+        <a href="{{plus_icon_url}}" class="add-stream-tooltip add-stream-icon-container hidden-for-spectators" data-tippy-content="
+        {{t 'Create a channel' }}">
+            <i class="add_stream_icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
         </a>
         {{/if}}
         <div class="markers-and-unreads">
@@ -18,3 +22,4 @@
     </div>
     <ul id="stream-list-{{id}}" class="stream-list-section"></ul>
 </div>
+ 

--- a/web/templates/stream_list_section_container.hbs
+++ b/web/templates/stream_list_section_container.hbs
@@ -1,18 +1,21 @@
 <div id="stream-list-{{id}}-container" data-section-id="{{id}}" class="stream-list-section-container">
     <div class="stream-list-subsection-header zoom-in-hide">
         <i class="stream-list-section-toggle zulip-icon zulip-icon-heading-triangle-right rotate-icon-down" aria-hidden="true"></i>
-        <h4 class="left-sidebar-title tippy-left-sidebar-tooltip" data-tooltip-template-id="section-tooltip-{{id}}" data-placement="top">
+
+        <h4 class="left-sidebar-title" data-tooltip-template-id="section-tooltip-{{id}}">
             {{section_title}}
         </h4>
+
         <template id="section-tooltip-{{id}}">
             {{section_title}}
         </template>
+
         {{#if plus_icon_url}}
-        <a href="{{plus_icon_url}}" class="add-stream-tooltip add-stream-icon-container hidden-for-spectators" data-tippy-content="
-        {{t 'Create a channel' }}">
+        <a href="{{plus_icon_url}}" class="add-stream-tooltip add-stream-icon-container hidden-for-spectators" data-tooltip-template-id="create-new-stream-tooltip-template">
             <i class="add_stream_icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
         </a>
         {{/if}}
+
         <div class="markers-and-unreads">
             <span class="unread_count normal-count"></span>
             <span class="masked_unread_count">
@@ -20,6 +23,6 @@
             </span>
         </div>
     </div>
+
     <ul id="stream-list-{{id}}" class="stream-list-section"></ul>
 </div>
- 


### PR DESCRIPTION
Long folder names in the left sidebar can be visually truncated due to limited space. This commit integrates tooltips that show the full name on hover.

Fixes #35582 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>📸 Before & After Comparison</summary>

<table>
  <tr>
    <td><strong>Before</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/ec903eb7-7608-4a4b-bbce-d07b5122d654" width="600"></td>
  </tr>
  <tr>
    <td><strong>After</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/6f7f12f0-8ea6-4393-88a9-7a42c1efb56a" width="600"></td>
  </tr>
</table>

</details>




**Screen captures:**

https://github.com/user-attachments/assets/4d252952-4449-4f5c-b571-ed769c56f4bc

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
