### PR TITLE
stream_list: Fix focus behavior for topic list search box.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -468,7 +468,6 @@ export function zoom_in_topics(options: {stream_id: number | undefined}): void {
             $elt.toggleClass("hide", false);
             // Add search box for topics list.
             $elt.children("div.bottom_left_row").append($(render_filter_topics()));
-            $("#topic_filter_query").trigger("focus");
             topic_list.setup_topic_search_typeahead();
         } else {
             $elt.toggleClass("hide", true);
@@ -896,6 +895,11 @@ export function initialize({
 
     $("#stream_filters").on("click", ".show-more-topics", (e) => {
         zoom_in();
+        // We define the focus behavior for the topic list search box
+        // outside of the `zoom_in` method, since we want the focus
+        // to only happen when the user clicks on the "SHOW ALL TOPICS"
+        // button, and not interfere with the narrow change handling.
+        $("#topic_filter_query").trigger("focus");
         browser_history.update_current_history_state_data({show_more_topics: true});
 
         e.preventDefault();


### PR DESCRIPTION
This PR ensures that the focus on the topic list search box is only triggered when the user clicks on the "SHOW ALL TOPICS" button, and not when the narrow changes. This prevents unwanted focus behavior when switching between different narrows/views which interfered with the focus states of the compose box.

<!-- Describe your pull request here.-->

Fixes: [#issues > 🎯 "Filter topics" incorrectly gaining focus with back @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20.22Filter.20topics.22.20incorrectly.20gaining.20focus.20with.20back/near/2236393)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![topic_filter_focus_behavior-before](https://github.com/user-attachments/assets/5f4adcc8-9685-4566-9730-cd480a718e74) | ![topic_filter_focus_behavior-after](https://github.com/user-attachments/assets/b83866e3-d2ed-4846-9d32-6f1ed136636a) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
