### PR TITLE
uv: Add setuptools-scm<9 to build-constraint-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,6 +313,9 @@ dev = [
 ]
 
 [tool.uv]
+build-constraint-dependencies = [
+  "setuptools-scm<9",
+]
 no-binary-package = ["lxml", "xmlsec"]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[manifest]
+build-constraints = [{ name = "setuptools-scm", specifier = "<9" }]
+
 [[package]]
 name = "aioapns"
 version = "4.0"


### PR DESCRIPTION
- https://github.com/xmlsec/python-xmlsec/issues/366
- https://github.com/pypa/setuptools-scm/issues/1191
- [Discussion](https://chat.zulip.org/#narrow/channel/43-automated-testing/topic/main.20failing/near/2237251)