### PR TITLE
audio_player: Fixups to present browser-native players.

### DIFF
--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -198,6 +198,19 @@ export function postprocess_content(html: string): string {
         }
     }
 
+    for (const audio of template.content.querySelectorAll("audio")) {
+        const audio_wrapper = inertDocument.createElement("span");
+        audio_wrapper.classList.add("media-audio-wrapper");
+        // We want a class to refer to audio elements
+        audio.classList.add("media-audio-element");
+        audio_wrapper.append(audio.cloneNode());
+        // Now we'll use a template to build additional DOM
+        // structures out of the original <audio> element
+        // const audio_html_string = audio.outerHTML;
+        // const rendered_audio_html = render_markdown_audio({audio_html: audio_html_string});
+        audio.replaceWith(audio_wrapper);
+    }
+
     for (const ol of template.content.querySelectorAll("ol")) {
         const list_start = Number(ol.getAttribute("start") ?? 1);
         // We don't count the first item in the list, as it

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -678,6 +678,9 @@
 
     .media-audio-element {
         vertical-align: middle;
+        /* Allow browser-native media players
+           to resize in narrow viewports. */
+        max-width: 100%;
     }
 
     .message_embed {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -876,68 +876,6 @@
         width: 18em;
         height: 2em;
         max-width: 100%;
-
-        &::-webkit-media-controls-panel {
-            display: flex !important;
-            justify-content: space-between !important;
-            flex-wrap: nowrap !important;
-            box-sizing: border-box !important;
-            width: 100% !important;
-            min-width: 0 !important;
-            padding: 0 0.5em !important;
-            opacity: 1 !important;
-        }
-
-        &::-webkit-media-controls-play-button {
-            flex: 0 0 auto !important;
-            width: 1.75em !important;
-            min-width: 1.75em !important;
-        }
-
-        &::-webkit-media-controls-timeline-container,
-        &::-webkit-media-controls-timeline {
-            flex: 1 1 auto !important;
-            min-width: 4em !important;
-            max-width: 6em !important;
-            opacity: 1 !important;
-            margin: 0 0.5em !important;
-        }
-
-        &::-webkit-media-controls-current-time-display,
-        &::-webkit-media-controls-time-remaining-display {
-            flex: 0 0 auto !important;
-            min-width: 0 !important;
-            font-size: 1rem !important;
-        }
-
-        &::-webkit-media-controls-volume-control-container {
-            flex: 0 0 auto !important;
-            width: auto !important;
-            min-width: 0 !important;
-            max-width: 5em !important;
-            margin: 0 0.5em 0 0.25em !important;
-            display: flex !important;
-            flex-direction: row-reverse !important;
-            opacity: 1 !important;
-            visibility: visible !important;
-        }
-
-        &::-webkit-media-controls-volume-slider-container,
-        &::-webkit-media-controls-volume-slider {
-            display: block !important;
-            width: auto !important;
-            min-width: 1.5em !important;
-            max-width: 3em !important;
-            opacity: 1 !important;
-            visibility: visible !important;
-        }
-
-        &::-webkit-media-controls-mute-button {
-            flex: 0 0 auto !important;
-            width: 1.125em !important;
-            min-width: 1.125em !important;
-            margin-right: 0.25em !important;
-        }
     }
 }
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -871,12 +871,6 @@
         /* TODO: This is probably not the best way create space here. */
         padding-top: 0.5em;
     }
-
-    .media-audio-element {
-        width: 18em;
-        height: 2em;
-        max-width: 100%;
-    }
 }
 
 .group_mention,

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -676,6 +676,10 @@
         display: grid;
     }
 
+    .media-audio-element {
+        vertical-align: middle;
+    }
+
     .message_embed {
         display: grid;
         grid-template-columns:
@@ -865,11 +869,6 @@
         font-size: 1.1363em;
         border: 1px solid var(--color-copy-button-square-bg-active);
         backdrop-filter: blur(20px);
-    }
-
-    p:first-child > .media-audio-element:first-child {
-        /* TODO: This is probably not the best way create space here. */
-        padding-top: 0.5em;
     }
 }
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -867,12 +867,12 @@
         backdrop-filter: blur(20px);
     }
 
-    p:first-child > audio:first-child {
+    p:first-child > .media-audio-element:first-child {
         /* TODO: This is probably not the best way create space here. */
         padding-top: 0.5em;
     }
 
-    audio {
+    .media-audio-element {
         width: 18em;
         height: 2em;
         max-width: 100%;

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -43,7 +43,8 @@ run_test("postprocess_content", () => {
                 "</div>" +
                 '<div class="message_embed_description">All about us.</div>' +
                 "</div>" +
-                "</div>",
+                "</div>" +
+                '<p><audio controls preload="metadata" src="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.mp3" title="inline.mp3"></audio></p>',
         ),
         '<a href="http://example.com" target="_blank" rel="noopener noreferrer" title="http://example.com/">good</a> ' +
             '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/file.png" target="_blank" rel="noopener noreferrer" title="translated: Download file.png">upload</a> ' +
@@ -74,7 +75,8 @@ run_test("postprocess_content", () => {
             "</div>" +
             '<div class="message_embed_description">All about us.</div>' +
             "</div>" +
-            "</div>",
+            "</div>" +
+            '<p><span class="media-audio-wrapper"><audio controls="" preload="metadata" src="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.mp3" title="inline.mp3" class="media-audio-element"></audio></span></p>',
     );
 });
 


### PR DESCRIPTION
This PR does a number of cosmetic things to inline audio players:

* It reverts changes from #35257 that attempted to use fragile shadow-DOM styling to modify native audio players with limited success and the likelihood of ongoing maintenance headaches
* It instead allows native audio players to render as they do in whatever browser is displaying them; if we want a more uniform cross-browser experience and better control over how players are rendered, a well-maintained third-party audio player is the likely solution here
* It attaches wraps `<audio>` elements in a span with a `.media-audio-wrapper` class, and also attaches a `.media-audio-element` class to the `<audio>` element itself
* It vertically aligns audio players to `middle`, which was [the design-discussion consensus](https://chat.zulip.org/#narrow/channel/101-design/topic/audio.20player.20vertical.20alignment/near/2233312)

See notes above the screenshots below, however.

[#design > audio player vertical alignment](https://chat.zulip.org/#narrow/channel/101-design/topic/audio.20player.20vertical.20alignment)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_All of these screenshots are as of this PR; a before/after comparison is not useful, because changes to styling merged to `main` were not tenable, as described above._

_The one edge case to note here is an audio player appearing on the first line of a message _after_ some text, which makes the EDITED marker appear a little wonky. Though that appearance is regrettable, it is also correct, as can be seen with EDITED-marker alignment on messages that open with an audio player, with or without text that follows. It is reasonably likely that the first-line-text-followed-by-audio-player case will resolve once we have icon representations of a message's EDITED state._

| Wide, Firefox | Wide, Chrome |
| --- | --- |
| <img width="2000" height="1700" alt="audio-player-wide-firefox" src="https://github.com/user-attachments/assets/ea530cce-2334-4ede-ba28-9ac89f6f5b9b" /> | <img width="2000" height="1698" alt="audio-player-wide-chrome" src="https://github.com/user-attachments/assets/0f6356cb-782f-467f-96c6-e91fd88a432c" /> |

| Medium, Firefox | Medium, Chrome |
| --- | --- |
| <img width="1400" height="1700" alt="audio-player-medium-firefox" src="https://github.com/user-attachments/assets/7c12f13d-e00b-4cc5-9ebf-e712adeb951b" /> | <img width="1400" height="1698" alt="audio-player-medium-chrome" src="https://github.com/user-attachments/assets/9382ab46-bbcd-4363-a77a-630d6d9a3dcb" /> |

| Narrow, Firefox | Narrow, Chrome |
| --- | --- |
| <img width="740" height="1420" alt="audio-player-narrow-firefox" src="https://github.com/user-attachments/assets/9d8da3d7-23e0-40c0-adeb-682ed161a05c" /> | <img width="740" height="1420" alt="audio-player-narrow-chrome" src="https://github.com/user-attachments/assets/b44b6bda-b77e-4331-a140-f99ea9536295" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>