### PR TITLE
Improve channel folders setting UI.

### DIFF
--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -17,6 +17,7 @@ import * as blueslip from "./blueslip.ts";
 import type {Bot} from "./bot_data.ts";
 import * as browser_history from "./browser_history.ts";
 import * as channel from "./channel.ts";
+import * as channel_folders from "./channel_folders.ts";
 import * as channel_folders_ui from "./channel_folders_ui.ts";
 import * as confirm_dialog from "./confirm_dialog.ts";
 import {show_copied_confirmation} from "./copied_tooltip.ts";
@@ -256,6 +257,7 @@ export function show_settings_for(node: HTMLElement): void {
         other_settings.push(setting);
         return false;
     });
+    const realm_has_channel_folders = channel_folders.get_active_folder_ids().size > 0;
 
     const html = render_stream_settings({
         sub,
@@ -275,6 +277,7 @@ export function show_settings_for(node: HTMLElement): void {
         group_setting_labels: settings_config.all_group_setting_labels.stream,
         has_billing_access: settings_data.user_has_billing_access(),
         empty_string_topic_display_name: util.get_final_topic_display_name(""),
+        realm_has_channel_folders,
     });
     scroll_util.get_content_element($("#stream_settings")).html(html);
 

--- a/web/templates/stream_settings/stream_permissions.hbs
+++ b/web/templates/stream_settings/stream_permissions.hbs
@@ -58,6 +58,7 @@
         hardcoded margin and padding values. --}}
         <label class="settings-field-label" for="{{channel_folder_widget_name}}_widget">
             {{t "Channel folder"}}
+            {{> ../help_link_widget link="/help/channel-folders" }}
         </label>
         <span class="prop-element hide" id="id_{{channel_folder_widget_name}}" data-setting-widget-type="dropdown-list-widget" data-setting-value-type="number"></span>
         <div class="dropdown_widget_with_label_wrapper channel-folder-widget-container">

--- a/web/templates/stream_settings/stream_permissions.hbs
+++ b/web/templates/stream_settings/stream_permissions.hbs
@@ -56,6 +56,7 @@
         component so that we can show dropdown button and button to create
         a new folder on same line without having to add much CSS with
         hardcoded margin and padding values. --}}
+        {{#if (or is_admin realm_has_channel_folders)}}
         <label class="settings-field-label" for="{{channel_folder_widget_name}}_widget">
             {{t "Channel folder"}}
             {{> ../help_link_widget link="/help/channel-folders" }}
@@ -74,6 +75,12 @@
                   }}
             {{/if}}
         </div>
+        {{else}}
+        <span class="settings-field-label">
+            {{t "There are no channel folders configured in this organization."}}
+            {{> ../help_link_widget link="/help/channel-folders" }}
+        </span>
+        {{/if}}
     </div>
 </div>
 

--- a/web/tests/channel_folders.test.cjs
+++ b/web/tests/channel_folders.test.cjs
@@ -33,6 +33,10 @@ run_test("basics", () => {
     channel_folders.initialize(params);
 
     assert.deepEqual(channel_folders.get_channel_folders(), [frontend_folder, backend_folder]);
+    assert.deepEqual(
+        channel_folders.get_active_folder_ids(),
+        new Set([frontend_folder.id, backend_folder.id]),
+    );
 
     const devops_folder = {
         name: "Devops",


### PR DESCRIPTION
This PR -
- Adds a ? link to /help/channel-folders to the "Channel folder" channel setting.
- When there are no channel folders configured, for users who are not organization administrators/owners, replaces the setting label and dropdown with:

  >  There are no channel folders configured in this organization. [[?]](https://github.com/help/channel-folders)

Fixes: zulip#35596.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| **Before** | **After** |
|------------------|----------------|
| <img width="547" height="115" alt="Screenshot from 2025-08-06 22-42-38" src="https://github.com/user-attachments/assets/04e2276c-f39e-4594-b427-3ab6df8225f2" /> | <img width="558" height="124" alt="Screenshot from 2025-08-06 22-25-54" src="https://github.com/user-attachments/assets/cdff138f-47f7-4e4f-be6d-f7507995ce4b" /> |
||<img width="455" height="95" alt="Screenshot from 2025-08-06 22-25-42" src="https://github.com/user-attachments/assets/c05fab4d-b909-4a6c-87ee-9e0516d6ae22" />|
|| <video src="https://github.com/user-attachments/assets/0620766a-d949-44ad-9e70-e4fc0ca0a255" /> |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
