### PR TITLE
site_previews: Don't hide overflow on data-container.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -744,7 +744,6 @@
 
         .data-container {
             grid-area: data-container;
-            overflow: hidden;
         }
     }
 


### PR DESCRIPTION
This fixes a bug where the tops of link-preview titles can be clipped off at the top.

Because both `.message_embed_title` and `.message_embed_description` manage their own overflow, there's no need to set it on the outer container, which can clip the top of the letters on message titles under certain circumstances.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_There is no apparent change on these before and after shots..._

| Before | After |
| --- | --- |
| <img width="1400" height="1800" alt="site-previews-before" src="https://github.com/user-attachments/assets/ab731829-3af3-4487-ba4a-20785e5a1558" /> | <img width="1400" height="1800" alt="site-previews-after" src="https://github.com/user-attachments/assets/44dbcecd-f226-4308-9cf8-cded36a21deb" /> |

_However, if I exaggerate the negative margin in devtools on _`.message_embed_title`_, it's clear that this fix is correct._

| Before | After |
| --- | --- |
| <img width="1400" height="1800" alt="exaggerated-negative-margin-before" src="https://github.com/user-attachments/assets/f8d01bb7-e14c-49eb-aa0b-a2ff539137b6" /> | <img width="1400" height="1800" alt="exaggerated-negative-margin-after" src="https://github.com/user-attachments/assets/5a4a8231-cefc-4edd-9d30-33de644222e1" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>