### PR TITLE
left_sidebar: Make muted mention indicator more faded than unmuted.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -642,7 +642,7 @@ input.settings_text_input {
 .unread_mention_info:not(:empty) {
     margin-right: 5px;
     margin-left: 2px;
-    opacity: 0.5;
+    opacity: var(--opacity-unread-mention-info);
 }
 
 /* Implement the web app's default-hidden convention for alert

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -408,6 +408,10 @@
     --opacity-sidebar-heading-hover: 0.9;
     --opacity-left-sidebar-muted: 0.55;
     --opacity-left-sidebar-muted-hover: 0.75;
+    --opacity-unread-mention-info: 0.5;
+    /* Since --opacity-unread-mention-info is too close to
+       --opacity-left-sidebar-muted */
+    --opacity-left-sidebar-muted-mentions: 0.3;
     --opacity-right-sidebar-subheading: 0.65;
     --opacity-right-sidebar-subheading-hover: 0.9;
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -799,7 +799,7 @@ ul.filters {
 
     .has-only-muted-mentions {
         .unread_mention_info {
-            opacity: var(--opacity-left-sidebar-muted);
+            opacity: var(--opacity-left-sidebar-muted-mentions);
         }
 
         &:hover .unread_mention_info {
@@ -848,6 +848,12 @@ ul.filters {
         .masked_unread_count,
         .sidebar-menu-icon {
             opacity: var(--opacity-left-sidebar-muted);
+        }
+
+        .unread_mention_info {
+            /* Default opacity for this icon is too close to
+               --opacity-left-sidebar-muted */
+            opacity: var(--opacity-left-sidebar-muted-mentions);
         }
 
         &:hover {


### PR DESCRIPTION
Discussed here: [#frontend > muted vs unmuted mention indicator @ 💬](https://chat.zulip.org/#narrow/channel/6-frontend/topic/muted.20vs.20unmuted.20mention.20indicator/near/2238070)

~~**Looking for feedback on if this is a good level of opacity.**~~


<img width="566" height="338" alt="image" src="https://github.com/user-attachments/assets/b23886d1-12e6-4486-a331-6e635f6890cb" />
