### PR TITLE
buttons: Redesign sticky-bottom-option button.

### DIFF
--- a/web/src/dropdown_widget.ts
+++ b/web/src/dropdown_widget.ts
@@ -267,11 +267,11 @@ export class DropdownWidget {
         $popper.find(".list-item.current_selection").removeClass("current_selection");
         if (this.sticky_bottom_option) {
             $popper
-                .find(".sticky-bottom-option.current_selection")
+                .find(".sticky-bottom-option-button.current_selection")
                 .removeClass("current_selection");
         }
         if (this.current_hover_index === list_items.length && this.sticky_bottom_option) {
-            $popper.find(".sticky-bottom-option").addClass("current_selection");
+            $popper.find(".sticky-bottom-option-button").addClass("current_selection");
         } else {
             const current_hover_item = list_items[this.current_hover_index];
             assert(current_hover_item !== undefined);
@@ -382,7 +382,7 @@ export class DropdownWidget {
                     }
 
                     const $search_input = $popper.find(".dropdown-list-search-input");
-                    const $sticky_bottom_option = $popper.find(".sticky-bottom-option");
+                    const $sticky_bottom_option = $popper.find(".sticky-bottom-option-button");
                     assert(this.list_widget !== undefined);
                     const list_items = this.list_widget.get_current_list();
                     if (
@@ -627,7 +627,7 @@ export class DropdownWidget {
                 });
 
                 // Click on $sticky_bottom_option.
-                $popper.on("click", ".sticky-bottom-option", (event) => {
+                $popper.on("click", ".sticky-bottom-option-button", (event) => {
                     this.item_click_callback(event, instance, this, true);
                     this.current_hover_index = 0;
                 });

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1350,16 +1350,19 @@ input.settings_text_input {
 .sticky-bottom-option {
     width: 100%;
     display: flex;
+    padding: 7px 14px;
+    background-color: var(--color-background-zulip-button);
     justify-content: flex-start;
     color: var(--color-dropdown-item);
     border: none;
     border-top: 1px solid var(--color-border-zulip-button);
-    border-top-left-radius: 0 !important;
-    border-top-right-radius: 0 !important;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
 
     &:hover {
         color: var(--color-dropdown-item);
         background-color: var(--background-color-active-dropdown-item);
+        border-color: var(--color-border-zulip-button-interactive);
     }
 
     &:focus,

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1347,7 +1347,7 @@ input.settings_text_input {
     color: hsl(1.06deg 44.66% 50.39%);
 }
 
-.sticky-bottom-option {
+.sticky-bottom-option-button {
     width: 100%;
     display: flex;
     padding: 7px 14px;

--- a/web/templates/dropdown_list_container.hbs
+++ b/web/templates/dropdown_list_container.hbs
@@ -9,7 +9,7 @@
         {{t 'No matching results'}}
     </div>
     {{#if sticky_bottom_option}}
-    <button class="button rounded sticky-bottom-option">
+    <button class="sticky-bottom-option">
         {{sticky_bottom_option}}
     </button>
     {{/if}}

--- a/web/templates/dropdown_list_container.hbs
+++ b/web/templates/dropdown_list_container.hbs
@@ -9,7 +9,7 @@
         {{t 'No matching results'}}
     </div>
     {{#if sticky_bottom_option}}
-    <button class="sticky-bottom-option">
+    <button class="sticky-bottom-option-button">
         {{sticky_bottom_option}}
     </button>
     {{/if}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR remove the `button` and `rounded` class from `sticky-bottom-option button`, which don't do much useful.
Added some additional rules on the `sticky-bottom-option` which were previously there via `button` class.

Also rename `sticky-bottom-option` to `sticky-bottom-option-button`.

Fixes: <!-- Issue link, or clear description.--> [Comment](https://github.com/zulip/zulip/issues/35006#issuecomment-3085758087)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| State | Before | After |
|--|---|---|
| Normal | <img width="348" height="61" alt="Screenshot 2025-08-07 at 3 38 41 PM" src="https://github.com/user-attachments/assets/488a30e1-32ce-4120-9471-0ddbc30d42b3" /> | <img width="326" height="54" alt="Screenshot 2025-08-07 at 3 35 00 PM" src="https://github.com/user-attachments/assets/960b267c-513e-464d-bac7-e3277c33f398" /> |
| Hovered | <img width="340" height="53" alt="Screenshot 2025-08-07 at 3 38 46 PM" src="https://github.com/user-attachments/assets/677df967-9edb-4c61-99b3-e3ac72c4f8e1" /> | <img width="325" height="53" alt="Screenshot 2025-08-07 at 3 35 05 PM" src="https://github.com/user-attachments/assets/d9a5270d-52bb-472d-8d75-d308aa86931c" /> |
| Normal | <img width="329" height="55" alt="Screenshot 2025-08-07 at 3 38 56 PM" src="https://github.com/user-attachments/assets/f7de907e-ba69-4742-b2f1-9ad8a351f2ce" /> | <img width="332" height="66" alt="Screenshot 2025-08-07 at 3 34 45 PM" src="https://github.com/user-attachments/assets/a9584a54-9cae-4e4d-ac00-04884aae060e" /> |
| Hovered | <img width="337" height="58" alt="Screenshot 2025-08-07 at 3 39 00 PM" src="https://github.com/user-attachments/assets/c3f568ef-4925-4e7c-8a04-6734830b805a" /> | <img width="324" height="62" alt="Screenshot 2025-08-07 at 3 34 50 PM" src="https://github.com/user-attachments/assets/ca648ab6-0c69-4fbf-82dc-e032156901ce" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
