### PR TITLE
markdown: Reduce space when paragraphs precede lists.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -13,6 +13,13 @@
 .rendered_markdown {
     & p {
         margin: 0 0 var(--markdown-interelement-space-px);
+
+        &:has(+ ul, + ol) {
+            /* When a paragraph is immediately followed
+               by a list sibling, we reduce the paragraph's
+               ordinary bottom space by half. */
+            margin-bottom: calc(var(--markdown-interelement-space-px) / 2);
+        }
     }
 
     /* The spacing between two paragraphs is double the usual value.
@@ -79,16 +86,6 @@
 
         & > li::marker {
             content: counter(count, decimal) ". ";
-        }
-    }
-
-    & ul,
-    & ol {
-        & p:has(+ ul, + ol) {
-            /* When a paragraph inside a list is immediately followed
-               by a list sibling, we reduce the paragraph's ordinary
-               bottom space by half. */
-            margin-bottom: calc(var(--markdown-interelement-space-px) / 2);
         }
     }
 


### PR DESCRIPTION
This PR expands the rule introduced in #35613, reducing the space after all paragraphs that precede lists (and not just in the case of nested lists).

[#issues > spacing above bulleted list @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/spacing.20above.20bulleted.20list/near/2238136)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="1400" height="1800" alt="paragraph-list-space-before" src="https://github.com/user-attachments/assets/72204f4c-6552-40f0-b236-ae8dd66399ec" /> | <img width="1400" height="1800" alt="paragraph-list-space-after" src="https://github.com/user-attachments/assets/0435bd19-193e-4300-908e-39c0c8d32135" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>