### PR TITLE
org_settings: Preserve custom Welcome Bot message when testing or viewing message.

### DIFF
--- a/web/src/settings.ts
+++ b/web/src/settings.ts
@@ -16,6 +16,7 @@ import * as people from "./people.ts";
 import * as settings_bots from "./settings_bots.ts";
 import * as settings_config from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
+import * as settings_org from "./settings_org.ts";
 import * as settings_panel_menu from "./settings_panel_menu.ts";
 import * as settings_preferences from "./settings_preferences.ts";
 import * as settings_sections from "./settings_sections.ts";
@@ -167,6 +168,7 @@ export function open_settings_overlay(): void {
             browser_history.exit_overlay();
             flatpickr.close_all();
             settings_panel_menu.mobile_deactivate_section();
+            settings_org.maybe_store_unsaved_welcome_message_custom_text();
         },
     });
 }

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -18,12 +18,11 @@ import {
     type RealmGroupSettingNameSupportingAnonymousGroups,
     realm_group_setting_name_supporting_anonymous_groups_schema,
 } from "./group_permission_settings.ts";
-import * as hash_util from "./hash_util.ts";
 import {$t, $t_html, get_language_name} from "./i18n.ts";
 import * as information_density from "./information_density.ts";
 import * as keydown_util from "./keydown_util.ts";
 import * as loading from "./loading.ts";
-import * as message_store from "./message_store.ts";
+import * as people from "./people.ts";
 import * as pygments_data from "./pygments_data.ts";
 import * as realm_icon from "./realm_icon.ts";
 import * as realm_logo from "./realm_logo.ts";
@@ -406,13 +405,9 @@ function update_view_welcome_bot_custom_message_button_status(
     }
 
     assert(message_id !== undefined);
-    $view_message_button.attr("data-message-id", message_id);
     $view_message_button.on("click", (e) => {
         e.preventDefault();
-        const message_id = Number($view_message_button.attr("data-message-id"));
-        const message = message_store.get(message_id);
-        assert(message !== undefined);
-        window.location.href = hash_util.by_conversation_and_time_url(message);
+        window.location.href = `#narrow/dm/${people.WELCOME_BOT.user_id}/near/${message_id}`;
     });
 }
 

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -63,6 +63,8 @@ export function reset(): void {
 
 const DISABLED_STATE_ID = -1;
 
+let unsaved_welcome_message_custom_text = "";
+
 export function maybe_disable_widgets(): void {
     if (current_user.is_owner) {
         return;
@@ -361,6 +363,37 @@ function disable_create_user_groups_if_on_limited_plan(): void {
     }
 }
 
+export function maybe_store_unsaved_welcome_message_custom_text(): void {
+    if ($("#org-notifications").find(".save-button[data-status='unsaved']").length === 0) {
+        return;
+    }
+
+    const message_text = $<HTMLTextAreaElement>("#id_realm_welcome_message_custom_text")
+        .val()!
+        .trim();
+    if (message_text.length === 0) {
+        return;
+    }
+
+    unsaved_welcome_message_custom_text = message_text;
+}
+
+function maybe_restore_unsaved_welcome_message_custom_text(): void {
+    if (unsaved_welcome_message_custom_text.length === 0) {
+        return;
+    }
+
+    $("input#id_realm_enable_welcome_message_custom_text").prop("checked", true);
+    settings_components.change_element_block_display_property(
+        "id_realm_welcome_message_custom_text",
+        true,
+    );
+    $("#id_realm_welcome_message_custom_text")
+        .val(unsaved_welcome_message_custom_text)
+        .trigger("input");
+    update_test_welcome_bot_custom_message_button_status();
+}
+
 function set_welcome_message_custom_text_visibility(): void {
     const welcome_message_custom_text_is_configured =
         realm.realm_welcome_message_custom_text.length > 0;
@@ -646,6 +679,7 @@ export function discard_realm_property_element_changes(elem: HTMLElement): void 
             set_realm_waiting_period_setting();
             break;
         case "realm_welcome_message_custom_text":
+            unsaved_welcome_message_custom_text = "";
             set_welcome_message_custom_text_visibility();
             break;
         default:
@@ -1100,6 +1134,14 @@ export function save_organization_settings(
         success() {
             $failed_alert_elem.hide();
             settings_components.change_save_button_state($save_button_container, "succeeded");
+            if ("welcome_message_custom_text" in data) {
+                // If we just confirmed a change to welcome_message_custom_text,
+                // clear our stored unsaved value. Notably, we don't do this via
+                // the server_events_dispatch code path, because we don't want
+                // to discard our unsaved work just because another client made
+                // a change.
+                unsaved_welcome_message_custom_text = "";
+            }
         },
         error(xhr) {
             settings_components.change_save_button_state($save_button_container, "failed");
@@ -1435,6 +1477,7 @@ export function build_page(): void {
     set_welcome_message_custom_text_visibility();
 
     register_save_discard_widget_handlers($(".admin-realm-form"), "/json/realm", false);
+    maybe_restore_unsaved_welcome_message_custom_text();
 
     $(".org-permissions-form").on(
         "input change",

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -131,14 +131,13 @@ h3,
 
 .admin-realm-description,
 .admin-realm-welcome-message-custom-text {
-    height: 16em;
+    height: 12em;
     width: 100%;
     max-width: 500px;
     box-sizing: border-box;
 }
 
-#id_realm_welcome_message_custom_text {
-    height: auto;
+.admin-realm-welcome-message-custom-text {
     margin-bottom: 10px;
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1352,6 +1352,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 }
 
 #invite_welcome_custom_message_text {
+    resize: vertical;
     width: 100%;
     box-sizing: border-box;
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1353,6 +1353,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 #invite_welcome_custom_message_text {
     resize: vertical;
+    height: 8em;
     width: 100%;
     box-sizing: border-box;
 }


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR aims solves the following follow-ups from #32862, as mentioned in issue #35664:
> - We could make the "View message" button open in a new tab. This seems simplest and would be quite easy, so we should > default to that as a first step.
> - We could do something to preserve what you've typed in the textarea, even after the overlay is closed. This may be a 
> finicky, since we'd need it to reopen with that changed text and a save/change widget.

Fixes: #35664.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
- "View message" button opens the message in a new tab:
![new tab view msg](https://github.com/user-attachments/assets/2b65fee1-6142-4829-80ea-d9c987ce32a1)



- Unsaved welcome bot message is saved on closing the overlay. The message is restored if we open the overlay again.
![restored msg](https://github.com/user-attachments/assets/cea5d7af-cc2b-4a3e-b3e5-038c507bf9eb)





---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
