### PR TITLE
compose: Restore attention on matching narrows.

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -144,7 +144,6 @@ export function update_on_recipient_change(): void {
     update_fade();
     update_narrow_to_recipient_visibility();
     compose_validate.warn_if_guest_in_dm_recipient();
-    update_recipient_row_attention_level();
     drafts.update_compose_draft_count();
     check_posting_policy_for_compose_box();
     compose_validate.validate_and_update_send_button_status();

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -63,6 +63,13 @@ export let update_recipient_row_attention_level = (): void => {
 
         stream_color.adjust_stream_privacy_icon_colors(stream_id, channel_picker_icon_selector);
     }
+    // If there is any text that hasn't yet been transformed into a pill,
+    // we should consider that the user is not composing to the current
+    // DM narrow -- even though that input is ignored when sending a DM.
+    // The point here is to avoid a state where we have that input hanging
+    // around on a low-attention recipient row, which can also happen when
+    // the DM-recipient typeahead is open.
+    const has_unpilled_input = $("#private_message_recipient").text().length > 0;
 
     // We're piggy-backing here, in a roundabout way, on
     // compose_ui.set_focus(). Any time the topic or DM recipient
@@ -72,7 +79,8 @@ export let update_recipient_row_attention_level = (): void => {
     // logic is handled via the event handlers in compose_setup.js
     // that call set_high_attention_recipient_row().
     if (
-        (composing_to_current_topic_narrow() || composing_to_current_private_message_narrow()) &&
+        (composing_to_current_topic_narrow() ||
+            (composing_to_current_private_message_narrow() && !has_unpilled_input)) &&
         compose_state.has_full_recipient()
     ) {
         $("#compose-recipient").toggleClass("low-attention-recipient-row", true);

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -73,8 +73,7 @@ export let update_recipient_row_attention_level = (): void => {
     // that call set_high_attention_recipient_row().
     if (
         (composing_to_current_topic_narrow() || composing_to_current_private_message_narrow()) &&
-        compose_state.has_full_recipient() &&
-        !compose_state.is_recipient_edited_manually()
+        compose_state.has_full_recipient()
     ) {
         $("#compose-recipient").toggleClass("low-attention-recipient-row", true);
     } else {

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -603,9 +603,9 @@ export function initialize() {
         const $input = $("input#stream_message_recipient_topic");
         compose_recipient.update_topic_displayed_text($input.val(), true);
         compose_recipient.update_compose_area_placeholder_text();
-        // Once the topic input has been focused, we no longer treat
+        // When the topic input is focused, we no longer treat
         // the recipient row as low attention, as we assume the user
-        // has done something that requires keeping attention called
+        // is doing something that requires keeping attention called
         // to the recipient row
         compose_recipient.set_high_attention_recipient_row();
 
@@ -620,11 +620,15 @@ export function initialize() {
     });
 
     $("#private_message_recipient").on("focus", () => {
-        // Once the DM input has been focused, we no longer treat
+        // When the DM input is focused, we no longer treat
         // the recipient row as low attention, as we assume the user
-        // has done something that requires keeping attention called
+        // is doing something that requires keeping attention called
         // to the recipient row
         compose_recipient.set_high_attention_recipient_row();
+    });
+
+    $("input#stream_message_recipient_topic, #private_message_recipient").on("blur", () => {
+        compose_recipient.update_recipient_row_attention_level();
     });
 
     $(window).on("blur", () => {

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -644,7 +644,6 @@ test_ui("update_fade", ({override, override_rewire}) => {
     override_rewire(compose_recipient, "update_narrow_to_recipient_visibility", () => {
         update_narrow_to_recipient_visibility_called = true;
     });
-    override_rewire(compose_recipient, "update_recipient_row_attention_level", noop);
     override_rewire(compose_validate, "validate_and_update_send_button_status", noop);
     override_rewire(drafts, "update_compose_draft_count", noop);
     override(compose_pm_pill, "get_user_ids", () => []);


### PR DESCRIPTION
This PR restores a low-attention-state recipient row when the recipient row and the current narrow match--regardless of whether a user has interacted with the recipient row's topic, channel, or DM recipients.

The row-attention logic is now also tied to focus and blur events on the recipient row, so we no longer calculate the attention on recipient changes.

The row-attention logic now also considers whether there is unpilled content in the DM recipient box to avoid a state where the narrow otherwise matches, but shows that text in a low-attention recipient row. That state would also otherwise appear when the recipient typeahead is open.

[#design > recipient fading logic](https://chat.zulip.org/#narrow/channel/101-design/topic/recipient.20fading.20logic)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Showing restored DM | Showing restored topic |
| --- | --- |
| ![restoring-dm-attention](https://github.com/user-attachments/assets/fb2066ac-1c07-4a4f-bc17-e92af7d61c43) | ![restoring-topic-attention](https://github.com/user-attachments/assets/f0db127b-e522-4f39-81c2-5e47b5c36282) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>