### PR TITLE
banners: Fix asymmetric margin on banners.

### DIFF
--- a/web/templates/components/banner.hbs
+++ b/web/templates/components/banner.hbs
@@ -7,15 +7,17 @@
                 {{> @partial-block .}}
             {{/if}}
         </span>
-        <span class="banner-action-buttons">
-            {{#each buttons}}
-                {{#if this.intent}}
-                    {{> action_button .}}
-                {{else}}
-                    {{> action_button . intent=../intent}}
-                {{/if}}
-            {{/each}}
-        </span>
+        {{#if buttons}}
+            <span class="banner-action-buttons">
+                {{#each buttons}}
+                    {{#if this.intent}}
+                        {{> action_button .}}
+                    {{else}}
+                        {{> action_button . intent=../intent}}
+                    {{/if}}
+                {{/each}}
+            </span>
+        {{/if}}
     </span>
     {{#if close_button}}
         {{> icon_button custom_classes="banner-close-action banner-close-button" icon="close" intent=intent}}


### PR DESCRIPTION
This commit fixes the asymmetric margin on banners by conditionally rendering the action buttons only if buttons are present. Otherwise, empty action buttons were being rendered in the DOM, applying the gap property between the banner label and the empty action buttons.

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/asymmetric.20margin.20on.20banner)



<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--|--|
| <img width="453" height="66" alt="Screenshot 2025-08-09 at 11 13 57 PM" src="https://github.com/user-attachments/assets/2e9144c6-6c6c-44b8-b498-84924bbe553c" /> | <img width="437" height="68" alt="Screenshot 2025-08-09 at 11 12 55 PM" src="https://github.com/user-attachments/assets/de41f5e7-380f-4eb7-bd1d-452ffcf27542" /> |
| <img width="301" height="60" alt="Screenshot 2025-08-09 at 11 14 08 PM" src="https://github.com/user-attachments/assets/37c23b8c-c21c-4019-acc5-98a5b8a7060e" /> | <img width="290" height="66" alt="Screenshot 2025-08-09 at 11 13 30 PM" src="https://github.com/user-attachments/assets/feac7968-e7fc-4ef2-b23e-093b8dfb7d51" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
