### PR TITLE
delete_in_topic: Don't fetch .recipient for each message in a loop.

### DIFF
--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -1323,8 +1323,10 @@ def delete_in_topic(
         if time.monotonic() >= start_time + 50:
             return json_success(request, data={"complete": False})
         with transaction.atomic(durable=True):
-            messages_to_delete = messages.order_by("-id")[0:batch_size].select_for_update(
-                of=("self",)
+            messages_to_delete = (
+                messages.select_related("recipient")
+                .order_by("-id")[0:batch_size]
+                .select_for_update(of=("self",))
             )
             if not messages_to_delete:
                 break


### PR DESCRIPTION
The grouping logic in `do_delete_messages` calls
`message.is_stream_message()` in a loop, which needs to access message.recipient. This is obviously super inefficient if .recipient hasn't been prefetched for the message objects.

`delete_in_topic` is the only function that calls `do_delete_messages` with many messages, so this is the only spot we need to fix, to address the immediate bug.
Of course a better improvement would be to fix `do_delete_messages` to do something smarter than naively accessing message.recipient in a loop.

