### PR TITLE
Update email_mirror.py

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -495,7 +495,6 @@ def process_missed_message(to: str, message: EmailMessage) -> None:
         recipient_user = get_user_profile_by_id(recipient_user_id)
         recipient_str = recipient_user.email
         internal_send_private_message(user_profile, recipient_user, body)
-  
     elif recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
     display_recipient = get_display_recipient(recipient)
     active_emails = []
@@ -506,23 +505,23 @@ def process_missed_message(to: str, message: EmailMessage) -> None:
                 active_emails.append(user_dict["email"])
         except UserProfile.DoesNotExist:
             pass
-    
+
     if not active_emails:
         logger.warning(
             "No active recipients left in DM group for missed-message reply from %s",
             user_profile.email,
         )
         return
-    
+
     recipient_str = ", ".join(active_emails)
     internal_send_group_direct_message(
-        user_profile.realm, 
-        user_profile, 
-        body, 
+        user_profile.realm,
+        user_profile,
+        body,
         emails=active_emails
     )
-    else:
-        raise AssertionError("Invalid recipient type!")
+else:
+    raise AssertionError("Invalid recipient type!")
 
     logger.info(
         "Successfully processed email from user %s to %s",


### PR DESCRIPTION
email_mirror: Handle replies from inactive users gracefully. Previously, when an inactive user replied to a Zulip email (via missed message or stream email gateway), the email_mirror process would still attempt to generate a reply address, leading to confusing behavior or silent failures.
This change updates `create_missed_message_address()` to check the user's active status before generating the address. If the user is inactive, we now:
- Skip generating the reply address.
- Return an appropriate error or message (as per Zulip guidelines). This prevents unnecessary processing for inactive accounts and provides clearer feedback for email-based message processing.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
