### PR TITLE
left_sidebar: Make highlighted new-channel area clickable.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -52,12 +52,21 @@
 .add-stream-icon-container {
     grid-area: add-channel;
     display: grid;
-    place-items: center center;
     margin: 2px 0;
     border-radius: 3px;
 
     .add_stream_icon {
+        /* We display as flex to center the icon while
+           keeping the entire highlighted area clickable. */
+        display: flex;
+        place-items: center center;
         color: var(--color-left-sidebar-heads-up-icon);
+
+        &::before {
+            /* To horizontally center the icon within the
+               flex, though, we need this margin adjustment. */
+            margin: 0 auto;
+        }
     }
 
     &:hover {


### PR DESCRIPTION
This adjusts the new-channel icon's hover area to be fully clickable, not just the icon itself.

[#issues > 🎯 click area too small on "add channels" button](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20click.20area.20too.20small.20on.20.22add.20channels.22.20button)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_The arrow cursor here is a side-effect of macOS screen recording._

| Clicking, before (no effect) | Clicking, after |
| --- | --- |
| ![noop-clicks](https://github.com/user-attachments/assets/2816a827-ab4b-4713-aa05-c86b5bd271b8) | ![functional-clicks](https://github.com/user-attachments/assets/b6ea9c06-8481-4f0a-9418-8766784350f3) |

| Layout, before | Layout, after (no change) |
| --- | --- |
| <img width="2000" height="1600" alt="new-channel-icon-layout-before" src="https://github.com/user-attachments/assets/0d814c6b-77a6-435b-b173-735dfdc44d66" /> | <img width="2000" height="1600" alt="new-channel-icon-layout-after" src="https://github.com/user-attachments/assets/d695fd29-db2d-4736-8335-658b7cdba7d9" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>