### PR TITLE
left_sidebar: Avoid clipping tall glyphs in DM groups, topics.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1659,7 +1659,12 @@ li.top_left_scheduled_messages {
         overflow-wrap: break-word;
 
         line-height: var(--line-height-sidebar-topic-inner);
-        margin: var(--spacing-top-bottom-sidebar-topic-inner) 0;
+        /* To avoid clipping the tops of certain characters,
+           we set the top space with padding. But to make the
+           line-clamp effect work, we set the bottom space
+           with margin. */
+        padding-top: var(--spacing-top-bottom-sidebar-topic-inner);
+        margin: 0 0 var(--spacing-top-bottom-sidebar-topic-inner) 0;
     }
 }
 
@@ -1818,8 +1823,13 @@ li.top_left_scheduled_messages {
     overflow-wrap: break-word;
 
     line-height: var(--line-height-sidebar-topic-inner);
-    margin: var(--spacing-top-bottom-sidebar-topic-inner) 0;
-    padding: 0 var(--left-sidebar-before-unread-count-padding) 0 0;
+    /* To avoid clipping the tops of certain characters,
+       we set the top space with padding. But to make the
+       line-clamp effect work, we set the bottom space
+       with margin. */
+    padding: var(--spacing-top-bottom-sidebar-topic-inner)
+        var(--left-sidebar-before-unread-count-padding) 0 0;
+    margin-bottom: var(--spacing-top-bottom-sidebar-topic-inner);
 }
 
 /*


### PR DESCRIPTION
This PR replaces top margin with top padding to avoid clipping tall glyphs in the DM rows, as reported in the issue below, and also topic rows, where the same approach to space was causing the same clipping.

Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/9-issues/topic/tall.20characters.20cut.20off.20in.20left.20sidebar.20DMs)[#issues > tall characters cut off in left sidebar DMs](https://chat.zulip.org/#narrow/channel/9-issues/topic/tall.20characters.20cut.20off.20in.20left.20sidebar.20DMs)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="760" height="1240" alt="clipped-chars-before" src="https://github.com/user-attachments/assets/8e2c96dc-c848-4c91-9c60-bfeb191c5cf5" /> | <img width="760" height="1240" alt="clipped-chars-after" src="https://github.com/user-attachments/assets/4b1ec55f-3651-4971-95ce-55ba6c4bc1d7" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>