### PR TITLE
test_urls: Skip `api_docs/unmerged.d/` while testing api doc pages.

### DIFF
--- a/zerver/tests/test_urls.py
+++ b/zerver/tests/test_urls.py
@@ -30,13 +30,13 @@ class PublicURLTest(ZulipTestCase):
 
     def test_api_doc_pages(self) -> None:
         # Test all files in api_docs documentation directory (except for 'index.md',
-        # 'missing.md', "api-doc-template.md" and `api_docs/include/` files).
+        # 'missing.md', "api-doc-template.md", `api_docs/include/` and `api_docs/unmerged.d/` files).
 
         api_doc_urls = []
         for doc in os.listdir("./api_docs/"):
             if doc.startswith(".") or "~" in doc or "#" in doc:
                 continue  # nocoverage -- just here for convenience
-            if doc in {"index.md", "include", "missing.md", "api-doc-template.md"}:
+            if doc in {"index.md", "include", "missing.md", "api-doc-template.md", "unmerged.d"}:
                 continue
             url = "/api/" + os.path.splitext(doc)[0]  # Strip the extension.
             api_doc_urls.append(url)


### PR DESCRIPTION
We missed to skip `api_docs/unmerged.d/` in 9ec15e99bd30064d9695, resulting in test failure in pull requests where it is present.

Results in error: https://github.com/zulip/zulip/actions/runs/16890603023/job/47849146216?pr=35641#step:19:5441
```sh
======================================================================
FAIL: test_api_doc_pages (zerver.tests.test_urls.PublicURLTest.test_api_doc_pages)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.11/unittest/case.py", line 57, in testPartExecutor
    yield
  File "/usr/lib/python3.11/unittest/case.py", line 623, in run
    self._callTestMethod(testMethod)
    ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/unittest/case.py", line 579, in _callTestMethod
    if method() is not None:
    ^^^^^^^^^^^^^^^^^
  File "/__w/zulip/zulip/zerver/tests/test_urls.py", line 56, in test_api_doc_pages
    self.assertEqual(response.status_code, 200)
    ^^^^^^^^^^^^^^^^^
  File "/__w/zulip/zulip/zerver/lib/test_classes.py", line 308, in assertEqual
    super().assertEqual(first, second, msg)
    ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/unittest/case.py", line 873, in assertEqual
    assertion_func(first, second, msg=msg)
    ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/unittest/case.py", line 866, in _baseAssertEqual
    raise self.failureException(msg)
    ^^^^^^^^^^^^^^^^^
AssertionError: 404 != 200 : 
```

Did print debugging and the reason was `unmerged.d`.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
