### PR TITLE
compose: Suppress low-attention styles with keyboard focus.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1283,7 +1283,10 @@ textarea.new_message_textarea {
     }
 }
 
-.low-attention-recipient-row {
+/* For the sake of keyboard use, we do not want to apply
+   these styles when any element (the picker, user pills)
+   has focus. */
+.low-attention-recipient-row:not(:focus-within) {
     &#compose-recipient {
         .decorated-channel-name,
         .conversation-arrow,


### PR DESCRIPTION
This PR makes sure that keyboard focus within the recipient row overrides the low-attention styles.

Fixes: [#design > recipient fading logic @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/recipient.20fading.20logic/near/2241251)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![low-att-keyboard-before](https://github.com/user-attachments/assets/46546e8c-caf3-4d6b-8d18-d52b9009075c) | ![low-att-keyboard-after](https://github.com/user-attachments/assets/d581413f-4832-4fc9-a3ad-848940458dd6) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
