### PR TITLE
left_sidebar: Hide counts in section header when no unreads.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -146,12 +146,17 @@
             display: none;
         }
 
+        /* When count is 0, we dont want to show unread_count or masked_unread_count. */
+        .unread_count.hide + .masked_unread_count {
+            display: none;
+        }
+
         &:hover {
             .masked_unread_count {
                 display: none;
             }
 
-            .unread_count {
+            .unread_count:not(.hide) {
                 display: inline;
             }
         }


### PR DESCRIPTION
Reported here: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20broken.20unread.20marker.20w.2F.20.22No.20channels.22.20configuration/near/2241414

I'm pretty sure this has been a bug ever since channel folders were introduced!