### PR TITLE
zerver: Drop support for Zulip API emails in channel creation.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1622,7 +1622,7 @@ Output:
     def create_channel_via_post(
         self,
         user: UserProfile,
-        subscribers: list[str] | list[int] | None = None,
+        subscribers: list[int] | None = None,
         name: str | None = None,
         extra_post_data: Mapping[str, Any] = {},
         invite_only: bool = False,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -23537,15 +23537,10 @@ paths:
                   example: "Channel for discussing all things music!"
                 subscribers:
                   description: |
-                    A list of user IDs (preferred) or Zulip API email
-                    addresses of the users to be subscribed to the new channel specified in the `channel` parameter.
-                  oneOf:
-                    - type: array
-                      items:
-                        type: string
-                    - type: array
-                      items:
-                        type: integer
+                    A list of user IDs of the users to be subscribed to the new channel.
+                  type: array
+                  items:
+                    type: integer
                   example: [16, 12]
                 announce:
                   description: |

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -739,7 +739,7 @@ def create_channel(
     message_retention_days: Json[str] | Json[int] = RETENTION_DEFAULT,
     name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)],
     send_new_subscription_messages: Json[bool] = True,
-    subscribers: Json[list[str] | list[int]],
+    subscribers: Json[list[int]],
     topics_policy: Json[TopicsPolicy] = None,
 ) -> HttpResponse:
     realm = user_profile.realm


### PR DESCRIPTION
Discussion:
https://chat.zulip.org/#narrow/channel/378-api-design/topic/Channel.20creation.20should.20return.20the.20channel.20ID/near/2240040.


