### PR TITLE
docs: Bump minimum recommended disk space.

### DIFF
--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -10,10 +10,11 @@ To run a Zulip server, you will need:
 - A supported CPU architecture:
   - x86-64
   - aarch64
-- At least 2 GB RAM, and 10 GB disk space
+- At least 2 GB RAM
   - If you have < 5 GB RAM, we require some swap space; we recommend configuring
     2 GB of swap
   - If you expect 100+ users: 4 GB RAM, and 2 CPUs
+- 10GB free space (i.e. approximately a 25GB total disk, given OS requirements)
 - A hostname in DNS
 - Credentials for sending email
 
@@ -68,10 +69,10 @@ sudo apt update
   style instances for organizations with hundreds of users (active or
   no).
 
-- Disk space: You'll need at least 10 GB of free disk space for a
-  server with dozens of users. We recommend using an SSD and avoiding
-  cloud storage backends that limit the IOPS per second, since the
-  disk is primarily used for the Zulip database.
+- Disk space: You'll need at least 10 GB of dedicated free disk space
+  for a server with dozens of users. We recommend using an SSD and
+  avoiding cloud storage backends that limit the IOPS per second,
+  since the disk is primarily used for the Zulip database.
 
 See our [documentation on scalability](#scalability) below for advice
 on hardware requirements for larger organizations.


### PR DESCRIPTION
10GB is very tight, and can lead to running out of disk space with large logs or uploaded files.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
