### PR TITLE
left_sidebar: Fix both input and add channel tooltip visible.

### DIFF
--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -1,8 +1,10 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
-    <div id="left-sidebar-search" class="zoom-in-hide tippy-zulip-delayed-tooltip" data-tooltip-template-id="filter-left-sidebar-tooltip-template">
-        {{#> input_wrapper input_type="filter-input" custom_classes="left-sidebar-search-section" icon="search" input_button_icon="close"}}
-            <input type="text" class="input-element left-sidebar-search-input home-page-input" autocomplete="off" placeholder="{{t 'Filter left sidebar' }}" />
-        {{/input_wrapper}}
+    <div id="left-sidebar-search" class="zoom-in-hide">
+        <div class="input-wrapper-for-tooltip tippy-zulip-delayed-tooltip" data-tooltip-template-id="filter-left-sidebar-tooltip-template">
+            {{#> input_wrapper input_type="filter-input" custom_classes="left-sidebar-search-section" icon="search" input_button_icon="close"}}
+                <input type="text" class="input-element left-sidebar-search-input home-page-input" autocomplete="off" placeholder="{{t 'Filter left sidebar' }}" />
+            {{/input_wrapper}}
+        </div>
         <span id="add_streams_tooltip" class="add-stream-icon-container hidden-for-spectators">
             <i id="streams_inline_icon" class="add_stream_icon zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
         </span>


### PR DESCRIPTION
Fixed by restricting tooltip trigger area to input element.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/filter.20left.20sidebar.20tooltip.20not.20disappearing/with/2241699