### PR TITLE
Stream settings channel folders permissions fix

### DIFF
--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -11,6 +11,7 @@ import render_stream_settings_overlay from "../templates/stream_settings/stream_
 import type {Banner} from "./banners.ts";
 import * as blueslip from "./blueslip.ts";
 import * as browser_history from "./browser_history.ts";
+import * as channel_folders from "./channel_folders.ts";
 import * as components from "./components.ts";
 import type {Toggle} from "./components.ts";
 import * as compose_banner from "./compose_banner.ts";
@@ -894,6 +895,7 @@ function setup_page(callback: () => void): void {
             new_stream_announcements_stream,
         );
         const realm_has_archived_channels = stream_data.get_archived_subs().length > 0;
+        const realm_has_channel_folders = channel_folders.get_active_folder_ids().size > 0;
 
         const template_data = {
             new_stream_announcements_stream_sub,
@@ -923,6 +925,7 @@ function setup_page(callback: () => void): void {
             has_billing_access: settings_data.user_has_billing_access(),
             is_admin: current_user.is_admin,
             empty_string_topic_display_name: util.get_final_topic_display_name(""),
+            realm_has_channel_folders,
         };
 
         const rendered = render_stream_settings_overlay(template_data);

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -91,6 +91,7 @@
               group_setting_labels=../group_setting_labels
               channel_folder_widget_name="folder_id"
               is_admin=../is_admin
+              realm_has_channel_folders=../realm_has_channel_folders
               }}
             {{/with}}
             <div class="stream_details_box">


### PR DESCRIPTION
This PR passes the `realm_has_channel_folders` properly to the templates.
Fixes bug from #35629

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**After:**
#### Admins
<img width="739" height="624" alt="Screenshot from 2025-08-12 19-18-51" src="https://github.com/user-attachments/assets/01004d12-5529-4ee0-9545-c66892621db9" />
<img width="739" height="624" alt="Screenshot from 2025-08-12 19-20-12" src="https://github.com/user-attachments/assets/526eda26-170c-4dc0-8206-0ab511252a1c" />

#### Normal users
<img width="739" height="624" alt="Screenshot from 2025-08-12 19-18-55" src="https://github.com/user-attachments/assets/190698ab-e0fe-49db-9f55-d4dd7abb076f" />
<img width="739" height="624" alt="Screenshot from 2025-08-12 19-20-06" src="https://github.com/user-attachments/assets/e9ca570b-555c-4d55-b0d9-bec2d30b5588" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
