### PR TITLE
banners: Hide empty banner-action-buttons using CSS.

### DIFF
--- a/web/styles/banners.css
+++ b/web/styles/banners.css
@@ -63,6 +63,10 @@
     gap: 0.5em; /* 8px at 16px/1em */
 }
 
+.banner-action-buttons:empty {
+    display: none;
+}
+
 .banner-close-button {
     display: flex;
     grid-area: banner-close-button;

--- a/web/templates/components/banner.hbs
+++ b/web/templates/components/banner.hbs
@@ -9,6 +9,8 @@
         </span>
         {{#if buttons}}
             <span class="banner-action-buttons">
+                {{!-- squash whitespace so :empty selector works when no buttons --}}
+                {{~!-- squash whitespace --~}}
                 {{#each buttons}}
                     {{#if this.intent}}
                         {{> action_button .}}
@@ -16,6 +18,7 @@
                         {{> action_button . intent=../intent}}
                     {{/if}}
                 {{/each}}
+                {{~!-- squash whitespace --~}}
             </span>
         {{/if}}
     </span>


### PR DESCRIPTION
Previously, the Handlebars template rendered the action buttons container only when buttons were present. This commit changes the approach to always render the container but hide it in CSS when it is empty, using the :empty pseudo-class.

<!-- Describe your pull request here.-->

Follow-up of #35670.
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
