### PR TITLE
embeds: Propagate group membership before updating UserMessage flags.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -442,10 +442,15 @@ def do_update_embedded_data(
     user_profile: UserProfile,
     message: Message,
     rendered_content: str | MessageRenderingResult,
+    mention_data: MentionData | None = None,
 ) -> None:
     ums = UserMessage.objects.filter(message=message.id)
     update_fields = ["rendered_content"]
     if isinstance(rendered_content, MessageRenderingResult):
+        assert mention_data is not None
+        for group_id in rendered_content.mentions_user_group_ids:
+            members = mention_data.get_group_members(group_id)
+            rendered_content.mentions_user_ids.update(members)
         update_user_message_flags(rendered_content, ums)
         message.rendered_content = rendered_content.rendered_content
         message.rendered_content_version = markdown_version

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1051,9 +1051,14 @@ class NormalActionsTest(BaseAction):
 
         # Verify special case of embedded content update
         content = "embed_content"
-        rendering_result = render_message_markdown(message, content)
+        mention_data = MentionData(
+            mention_backend=MentionBackend(message.realm_id),
+            content=content,
+            message_sender=message.sender,
+        )
+        rendering_result = render_message_markdown(message, content, mention_data=mention_data)
         with self.verify_action(state_change_expected=False) as events:
-            do_update_embedded_data(self.user_profile, message, rendering_result)
+            do_update_embedded_data(self.user_profile, message, rendering_result, mention_data)
         check_update_message(
             "events[0]",
             events[0],


### PR DESCRIPTION
Doing this generally, in markdown rendering, broke things because we're not consistent about if `mentions_user_ids` is "any user, no matter how they're mentioned" (as we need it for UserMessage flags) or "users that are specifically mentioned" (as we use it for event construction)

