### PR TITLE
inbox: Move lefthand padding to avoid disturbing grid.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -417,11 +417,6 @@
         margin-bottom: 1px;
         background-color: transparent;
 
-        .inbox-focus-border {
-            /* Align the folder title with the channel privacy icons; 5px at 16px */
-            padding-left: 0.3125em;
-        }
-
         .inbox-header-name-text,
         .unread_mention_info {
             color: var(--color-folder-header);
@@ -437,6 +432,12 @@
             outline: none;
             /* 16px at 16px / 1em */
             font-size: 1em;
+            /* Align the folder title with the channel privacy icons; 5px at 16px/1em.
+
+            TODO: Reduce the depth of selectors in this file,
+            so that the use of !important becomes unnecessary
+            here. */
+            padding-left: 0.3125em !important;
         }
 
         &:hover {


### PR DESCRIPTION
This fixes a subtle alignment issue with unreads in the DM header row versus the actual DM rows that follow.

Fixes: [#issues > 🎯 inbox direct messages unread count alignment](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20inbox.20direct.20messages.20unread.20count.20alignment)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="2200" height="1600" alt="dm-header-unread-alignment-before" src="https://github.com/user-attachments/assets/231a4829-82d2-4f56-a63a-984f460ac67f" /> | <img width="2200" height="1600" alt="dm-header-unread-alignment-after" src="https://github.com/user-attachments/assets/7cd8b7e0-6513-407f-bb49-bab87d92fed9" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>