### PR TITLE
Hide mention marker on expanded folder

### DIFF
--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -194,12 +194,12 @@ export function update_unread_mention_info_in_dom(
 ): void {
     const $unread_mention_info_span = $unread_mention_info_elem.find(".unread_mention_info");
     if (!stream_has_any_unread_mention_messages) {
-        $unread_mention_info_span.hide();
+        $unread_mention_info_span.toggleClass("no-display", true);
         $unread_mention_info_span.text("");
         return;
     }
 
-    $unread_mention_info_span.show();
+    $unread_mention_info_span.toggleClass("no-display", false);
     $unread_mention_info_span.text("@");
 }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -645,6 +645,10 @@ input.settings_text_input {
     opacity: var(--opacity-unread-mention-info);
 }
 
+.unread_mention_info.no-display {
+    display: none;
+}
+
 /* Implement the web app's default-hidden convention for alert
    elements.  Portico pages lack this CSS and thus show them by
    default. */

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -567,7 +567,7 @@
         }
     }
 
-    .stream-list-subsection-header .unread_mention_info {
+    .stream-list-subsection-header:not(:hover) .unread_mention_info {
         display: none;
     }
 }


### PR DESCRIPTION
Reported here: [#issues > 🎯 @ marker on expanded folder @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20.40.20marker.20on.20expanded.20folder/near/2241907)