### PR TITLE
left_sidebar: Show add-stream icon when focused during keyboard navigation.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -415,6 +415,10 @@
         visibility: hidden;
     }
 
+    .add-stream-icon-container:focus-visible .add_stream_icon {
+        visibility: visible;
+    }
+
     &:hover {
         background-color: var(--color-background-opaque-hover-narrow-filter);
         box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);


### PR DESCRIPTION
Discussed here: [#issues > 🎯 weird keyboard nav UI with &#96;+&#96; in left sidebar @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20weird.20keyboard.20nav.20UI.20with.20.60.2B.60.20in.20left.20sidebar/near/2241918)