### PR TITLE
Revert "ci: Disable coverage on Debian 12."

### DIFF
--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Run backend tests
         run: |
           source tools/ci/activate-venv
-          ./tools/test-backend ${{ matrix.os != 'bookworm' && '--coverage' || '' }} --xml-report --no-html-report --include-webhooks --include-transaction-tests --no-cov-cleanup --ban-console-output
+          ./tools/test-backend --coverage --xml-report --no-html-report --include-webhooks --include-transaction-tests --no-cov-cleanup --ban-console-output
 
       - name: Run mypy
         run: |


### PR DESCRIPTION
This reverts commit 4f27381ebce60212ffb5da12469e77639736251e (#27456).

The fix entered Debian 12 in python3.11 3.11.2-6+deb12u1.