### PR TITLE
links: Fix glitchy underlines in left sidebar.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1568,7 +1568,8 @@ li.active-sub-filter {
     text-decoration: none;
     color: inherit;
 
-    &:hover {
+    &:hover,
+    &:active {
         opacity: 1;
         text-decoration: none;
         color: inherit;
@@ -1646,7 +1647,8 @@ li.active-sub-filter {
     text-decoration: none;
     color: inherit;
 
-    &:hover {
+    &:hover,
+    &:active {
         opacity: 1;
         text-decoration: none;
         color: inherit;


### PR DESCRIPTION
This fixes the underlines and blue color that are
visible when selecting multiple topics/channels.

Comment: https://github.com/zulip/zulip/pull/34977#issuecomment-3181802391

| Before | After |
|----|------|
|![before](https://github.com/user-attachments/assets/6745d9ef-d840-4e18-a553-a1f5a70f50d1)|![after](https://github.com/user-attachments/assets/3950cf78-e9b3-4636-b476-241037de9990)|



