### PR TITLE
sidebar_ui: Fix broken zoomed in topic list.

### DIFF
--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -609,6 +609,9 @@ export function set_event_handlers(): void {
             $(row).trigger("click");
             return;
         }
+        // Clear search input so that there is no confusion
+        // about which search input is active.
+        $search_input.val("");
         const $nearest_link = $(row).find("a").first();
         if ($nearest_link.length > 0) {
             // If the row has a link, we click it.
@@ -618,8 +621,9 @@ export function set_event_handlers(): void {
             // let the browser handle it or add special
             // handling logic for it here.
         }
-        $search_input.val("");
-        $search_input.trigger("input");
+        // Don't trigger `input` which confuses the search input
+        // for zoomed in topic search.
+        update_left_sidebar_for_search();
         $search_input.trigger("blur");
     }
 


### PR DESCRIPTION
The zoomed in topic list search doesn't work if user searches something and presses `enter` on `Show all topics` after navigating via keyboard.

Fixed by not triggering `input` event on left sidebar search input which seems to confuse the zoomed in topic search.

Reproducer:

* Search a term in left sidebar.
* Navigate to show all topics
* We are navigated to zoomed in topics but search doesn't work.