### PR TITLE
help: Add mobile instructions for unsubscribing from a channel.

### DIFF
--- a/help/unsubscribe-from-a-channel.md
+++ b/help/unsubscribe-from-a-channel.md
@@ -12,13 +12,11 @@ You can always unsubscribe from any channel in Zulip.
 
 {tab|mobile}
 
-Access this feature by following the web app instructions in your
-mobile device browser.
+{!mobile-channels.md!}
 
-Implementation of this feature in the mobile app is tracked [on
-GitHub](https://github.com/zulip/zulip-flutter/issues/1224). If
-you're interested in this feature, please react to the issue's
-description with 👍.
+{!channel-long-press-menu.md!}
+
+1. Tap **Unsubscribe**.
 
 {end_tabs}
 


### PR DESCRIPTION
Updates the mobile tab instructions for unsubscribing from a channel.

Relevant Flutter issue and PR:
- issue: https://github.com/zulip/zulip-flutter/issues/1224
- PR: https://github.com/zulip/zulip-flutter/pull/1790

**Notes**:
- While it's also possible to subscribe to a channel via the channel actions menu in the mobile app, there isn't a way to currently browse unsubscribed channels.
  - Flutter issue for that is https://github.com/zulip/zulip-flutter/issues/188.
  - CZO conversation about how to potentially document the subscribe action at: [#documentation > subscribe to a channel - adding mobile instructions #F1790](https://chat.zulip.org/#narrow/channel/19-documentation/topic/subscribe.20to.20a.20channel.20-.20adding.20mobile.20instructions.20.23F1790).

---

**Screenshots and screen captures:**

[CURRENT DOC](https://zulip.com/help/unsubscribe-from-a-channel)
<img width="1162" height="442" alt="Screenshot From 2025-08-13 12-22-00" src="https://github.com/user-attachments/assets/9d910f16-c51a-4933-b953-b8fdb459bb71" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
