### PR TITLE
left_sidebar: Correct bugged unreads in collapsed Views.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1120,8 +1120,9 @@ li.active-sub-filter {
 
     &.hide-unread-messages-count {
         /* Restore the unread dot when message counts
-           are hidden. */
-        .selected-home-view .unread_count {
+           are hidden, unless there are no unreads,
+           of course. */
+        .selected-home-view .unread_count:not(:empty) {
             display: block;
         }
         /* We suppress the entire unread area


### PR DESCRIPTION
This PR corrects two bugs in the collapsed views area:

1. It removes a no-longer-necessary `z-index` value on the left-sidebar search filter. Now that it sits outside the SimpleBar area and doesn't participate in collapsing headers, we don't need to manage its `z-index`. This keeps hovered unreads in the collapsed views area from being cut off at the top.
2. It makes a minor CSS correction to prevent the unread dot from showing when there are no unreads, for users who opt not to show unread counts in the homeview.

Fixes: [#issues > no unread counter home view - collapsed shows dot](https://chat.zulip.org/#narrow/channel/9-issues/topic/no.20unread.20counter.20home.20view.20-.20collapsed.20shows.20dot)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_When there are unreads (2):_

| Hover, before | Hover, after |
| --- | --- |
| <img width="1148" height="630" alt="hovered-unreads-before" src="https://github.com/user-attachments/assets/c2baaf8f-cfab-4770-a608-5aeafe758b01" /> | <img width="1148" height="630" alt="hovered-unreads-after" src="https://github.com/user-attachments/assets/c94e258b-2f1e-405c-919c-523f287bc7bc" /> |


_When there are zero unreads:_

| Before | After |
| --- | --- |
| <img width="1148" height="630" alt="zero-unreads-before" src="https://github.com/user-attachments/assets/259d3b75-e7b2-4e83-8e03-57dda7ed7533" /> | <img width="1148" height="630" alt="zero-unreads-after" src="https://github.com/user-attachments/assets/698e13bd-80bf-4f13-9a23-9d27fdb44723" /> |
| <img width="1148" height="630" alt="zero-unreads-hover-before" src="https://github.com/user-attachments/assets/78d5b6a1-7dc8-48c5-bd29-c27fd355eb17" /> | <img width="1148" height="630" alt="zero-unreads-hover-after" src="https://github.com/user-attachments/assets/0129b213-6459-4524-93aa-bbe87da1785a" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
