### PR TITLE
sidebar_ui: Fix selection box disappears while navigating to muted row.

### DIFF
--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -487,11 +487,17 @@ function all_rows(): JQuery {
         ".stream-list-section-container.collapsed .topic-list-item:not(.active-sub-filter).bottom_left_row",
     );
 
+    // Exclude toggle inactive / muted channels row from the list of rows if user is searching.
+    const $toggle_inactive_or_muted_channels_row = $(
+        "#streams_list.is_searching .stream-list-toggle-inactive-or-muted-channels.bottom_left_row",
+    );
+
     return $all_rows
         .not($inactive_or_muted_rows)
         .not($collapsed_views)
         .not($collapsed_channels)
-        .not($hidden_topic_rows);
+        .not($hidden_topic_rows)
+        .not($toggle_inactive_or_muted_channels_row);
 }
 
 class LeftSidebarListCursor extends ListCursor<JQuery> {


### PR DESCRIPTION
This happens since the don't exclude the row which toggles muted / inactive channels from all_rows, while user is searching and hence selections box ends up there while navigating to the muted / inactive channel row.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AFkeyboard.20navigation.20not.20working.20w.2F.20muted.2Finactive.20channels/with/2243202