### PR TITLE
left_sidebar_mention: Fix mention highlight always visible.

### DIFF
--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -216,7 +216,7 @@ export function do_new_unread_animation($target: JQuery): void {
     // and any other effects. Doing so also gives us
     // very smooth rendering, as no visual properties
     // get tied to JavaScript's event loop.
-    $target.on("animationend", (): void => {
+    $target.on("animationend, animationcancel", (): void => {
         $target.removeClass("new-unread");
         // We remove the transition-managing highlight
         // some time after the animation has run; how


### PR DESCRIPTION
Reproducer:

Mark a message where current user is mention as unread and then read the message before animation ends. This prevents the `animationend` from being triggered.

Fixed by also listening for `animationcancel` which fixes the bug.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20left.20sidebar.20mention.20always.20highlighted/with/2243255
