### PR TITLE
left_sidebar: Fix multiple bugs and regressions.

### DIFF
--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -216,7 +216,7 @@ export function do_new_unread_animation($target: JQuery): void {
     // and any other effects. Doing so also gives us
     // very smooth rendering, as no visual properties
     // get tied to JavaScript's event loop.
-    $target.on("animationend, animationcancel", (): void => {
+    $target.on("animationend animationcancel", (): void => {
         $target.removeClass("new-unread");
         // We remove the transition-managing highlight
         // some time after the animation has run; how

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -927,11 +927,11 @@
     /* When unreads are hovered on the condensed
        views, they should not have an alpha.
        The first color corresponds to
-       --color-background-unread-counter-prominent.
+       --color-background-unread-counter-normal.
        The second color aligns with light mode's
        --color-background. */
     --color-background-unread-counter-no-alpha: light-dark(
-        color-mix(in srgb, hsl(240deg 10% 50%) 70%, hsl(0deg 0% 94%)),
+        color-mix(in srgb, hsl(240deg 10% 50%) 20%, hsl(0deg 0% 94%)),
         color-mix(in srgb, hsl(240deg 10% 50%) 35%, hsl(0deg 0% 11%))
     );
     --color-background-unread-counter-dot: light-dark(

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -384,6 +384,9 @@
     /* Legacy values */
     --legacy-body-line-height-unitless: calc(20 / 14);
 
+    /* Special effects */
+    --pulse-unread-scale-max: 1.5;
+
     /* Message area */
     /* In the legacy layout at 16px/1em density, 918.6px is
        the widest the message area gets, so we preserve this

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1076,8 +1076,23 @@ li.active-sub-filter {
                    the icon width (15px/2) plus 2px. This keeps the
                    unread dot in correct proximity to the view icon,
                    no matter how the row flexes or what information-
-                   density values a user has set. 9.5px at 12px/1em. */
-                transform: translateX(0.7917em);
+                   density values a user has set. 9.5px at 12px/1em.
+
+                   We set this and its scaled counterpart as variables
+                   for use in the pulse-unread animation to maintain the
+                   dot's correct position relative to the view icon. */
+                --unread-dot-x-offset: 0.7917em;
+                /* To make sure the unread dot appears to scale from the
+                   offset dot's center in collapsed Views, we need to
+                   adjust the translateX offset by the same amount we
+                   scale. calc() does not play nicely with animations,
+                   so it's critical that we calculate this value here,
+                   well before its needed. */
+                --unread-dot-x-offset-scaled: calc(
+                    var(--unread-dot-x-offset) / var(--pulse-unread-scale-max)
+                );
+
+                transform: translateX(var(--unread-dot-x-offset));
                 width: 0.5em;
                 height: 0.5em;
                 padding: 0;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -844,16 +844,20 @@ strong {
 }
 
 @keyframes pulse-unread {
+    /* Only unread dots in collapsed Views
+       have offset variables set; all others
+       will fall back to 0 (no offset). */
     0% {
-        transform: scale(1);
+        transform: scale(1) translateX(var(--unread-dot-x-offset, 0));
     }
 
     50% {
-        transform: scale(1.5);
+        transform: scale(var(--pulse-unread-scale-max))
+            translateX(var(--unread-dot-x-offset-scaled, 0));
     }
 
     100% {
-        transform: scale(1);
+        transform: scale(1) translateX(var(--unread-dot-x-offset, 0));
     }
 }
 


### PR DESCRIPTION
This PR does the following:

1. It corrects the color used with the no-alpha variant for hovered unreads in collapsed views.
2. It improves the animation on new mentions, particularly in the collapsed Views, where previously the unread dot would move to the center for the duration of the animation.
3. It removes a comma accidentally introduced with the `animationend` and `animationcancel` events in #35745 

Fixes:
* [#issues > 🎯 no unread counter home view - collapsed shows dot @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20no.20unread.20counter.20home.20view.20-.20collapsed.20shows.20dot/near/2243163)
* [#issues > left sidebar mention always highlighted @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/left.20sidebar.20mention.20always.20highlighted/near/2243105)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Unread hover colors (no change in dark mode):_

| Before | After |
| --- | --- |
| <img width="650" height="560" alt="collapsed-unread-hover-light-before" src="https://github.com/user-attachments/assets/c4b7329c-9d59-4768-86f4-113e1cf92aed" /> | <img width="650" height="560" alt="collapsed-unread-hover-light-after" src="https://github.com/user-attachments/assets/b6d92115-3421-493f-b3e1-a0c84093cb34" /> |
| <img width="650" height="560" alt="collapsed-unread-hover-dark-before" src="https://github.com/user-attachments/assets/ba1993dc-840a-4025-a7c9-53a811de1107" /> | <img width="650" height="560" alt="collapsed-unread-hover-dark-after" src="https://github.com/user-attachments/assets/3d3248ae-2fbb-4a22-b9cc-46faf1258759" /> |

_Collapsed mention effect:_

| Before | After |
| --- | --- |
| ![collapsed-mention-effect-before](https://github.com/user-attachments/assets/c19023c6-ef06-4f00-8f74-6746c98bab18) | ![collapsed-mention-effect-after](https://github.com/user-attachments/assets/a6e5b2c1-1232-45a1-ba0e-a0256c96df6f) |

_Expanded mention effect:_

| Before | After |
| --- | --- |
| ![expanded-mention-effect-before](https://github.com/user-attachments/assets/d59d8182-a7c4-4d20-be89-047d071129db) | ![expanded-mention-effect-after](https://github.com/user-attachments/assets/bc30e162-672f-4ece-8a16-863391033670) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
