### PR TITLE
links: Fix unnecessary blocking of click behavior.

### DIFF
--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -122,7 +122,7 @@ async function test_previously_created_drafts_rendered(page: Page): Promise<void
     assert.strictEqual(
         await common.get_text_from_selector(
             page,
-            "#drafts_table .overlay-message-row:nth-last-child(2) .rendered_markdown.restore-overlay-message",
+            "#drafts_table .overlay-message-row .private-message .rendered_markdown.restore-overlay-message",
         ),
         "Test direct message.",
     );
@@ -136,7 +136,7 @@ async function test_previously_created_drafts_rendered(page: Page): Promise<void
     assert.strictEqual(
         await common.get_text_from_selector(
             page,
-            "#drafts_table .overlay-message-row:last-child .rendered_markdown.restore-overlay-message",
+            "#drafts_table .overlay-message-row .message_row:not(.private-message) .rendered_markdown.restore-overlay-message",
         ),
         "Test stream message.",
     );

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -20,6 +20,7 @@ import * as message_edit from "./message_edit.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_store from "./message_store.ts";
 import * as message_view from "./message_view.ts";
+import * as mouse_drag from "./mouse_drag.ts";
 import * as narrow_state from "./narrow_state.ts";
 import * as navigate from "./navigate.ts";
 import {page_params} from "./page_params.ts";
@@ -939,11 +940,14 @@ export function initialize(): void {
         }
 
         if (compose_state.composing() && $(e.target).parents("#compose").length === 0) {
-            const is_inside_link = $(e.target).closest("a").length > 0;
-            if (is_inside_link || $(e.target).closest(".copy_codeblock").length > 0) {
+            const should_prevent_click_behavior = mouse_drag.is_drag(e);
+            if (
+                should_prevent_click_behavior ||
+                $(e.target).closest(".copy_codeblock").length > 0
+            ) {
                 // We want to avoid blurring a selected link by triggering a
                 // focus event on the compose textarea.
-                if (is_inside_link && document.getSelection()?.type === "Range") {
+                if (should_prevent_click_behavior) {
                     // To avoid the click behavior if a link is selected.
                     e.preventDefault();
                     return;


### PR DESCRIPTION
CZO: [#issues > Link clicks are blocked when something is selected @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/Link.20clicks.20are.20blocked.20when.20something.20is.20selected/near/2244013)

This fixes the problem which happens when the following is true:
1. Composebox is open.
2. You select something on the page.
3. You click on some link.

Currently doing this will prevent the default click behavior which is not right and can get quite annoying.

We now switch to a more robust check which only prevents the click behavior on a link when the click lies inside the link which is selected, instead of blocking it when any selection exists.

Before: 

https://github.com/user-attachments/assets/ee4a463e-5cd6-4668-a7ef-6a83bfbfdf86


After:

https://github.com/user-attachments/assets/51bd383b-d7ed-4716-8011-4e64c6d0e15a



<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
