### PR TITLE
push_notifications: Revert parallel-device sending.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -4,7 +4,7 @@ import asyncio
 import copy
 import logging
 import re
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from email.headerregistry import Address
 from functools import cache
@@ -331,28 +331,24 @@ def send_apple_push_notification(
     if have_missing_app_id:
         devices = [device for device in devices if device.ios_app_id is not None]
 
-    async def send_all_notifications() -> Iterable[
-        tuple[DeviceToken, aioapns.common.NotificationResult | BaseException]
-    ]:
-        requests = [
-            aioapns.NotificationRequest(
-                apns_topic=device.ios_app_id,
-                device_token=device.token,
-                message=message,
-                time_to_live=24 * 3600,
-            )
-            for device in devices
-        ]
-        results = await asyncio.gather(
-            *(apns_context.apns.send_notification(request) for request in requests),
-            return_exceptions=True,
+    results: dict[DeviceToken, NotificationResult | BaseException] = {}
+    for device in devices:
+        # TODO obviously this should be made to actually use the async
+        request = aioapns.NotificationRequest(
+            apns_topic=device.ios_app_id,
+            device_token=device.token,
+            message=message,
+            time_to_live=24 * 3600,
         )
-        return zip(devices, results, strict=False)
-
-    results = apns_context.loop.run_until_complete(send_all_notifications())
+        try:
+            results[device] = apns_context.loop.run_until_complete(
+                apns_context.apns.send_notification(request)
+            )
+        except BaseException as e:
+            results[device] = e
 
     successfully_sent_count = 0
-    for device, result in results:
+    for device, result in results.items():
         log_context = f"for user {user_identity} to device {device.token}"
         result_info = get_info_from_apns_result(result, device, log_context)
 


### PR DESCRIPTION
This reverts #26594, due to unexpected ConnectionClosed errors observed in Django.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
