### PR TITLE
topic_list: Enable left sidebar search when closing topic list.

### DIFF
--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -62,6 +62,7 @@ export function clear(): void {
 export function close(): void {
     zoomed = false;
     clear();
+    ui_util.enable_left_sidebar_search();
 }
 
 export function zoom_out(): void {


### PR DESCRIPTION
Fixes bug reported here: [#issues > Left sidebar filter widget hiding @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/Left.20sidebar.20filter.20widget.20hiding/near/2244418)