### PR TITLE
pill_input: Use flex-grow 1 on all input pills.

### DIFF
--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -206,6 +206,7 @@
 
         min-width: 2px;
         overflow-wrap: anywhere;
+        flex: 1 1 auto;
 
         outline: none;
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -952,13 +952,9 @@ input[type="checkbox"] {
     /* Subtract 2 * (2px padding) + 2 * (1px border) */
     min-width: calc(var(--modal-input-width) - 6px);
 
-    .input {
-        flex-grow: 1;
-
-        &:first-child:empty::before {
-            opacity: 0.5;
-            content: attr(data-placeholder);
-        }
+    .input:first-child:empty::before {
+        opacity: 0.5;
+        content: attr(data-placeholder);
     }
 }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1337,13 +1337,9 @@ div.settings-radio-input-parent {
     /* Subtract 2 * (2px padding) + 2 * (1px border) */
     min-width: calc(var(--modal-input-width) - 6px);
 
-    .input {
-        flex-grow: 1;
-
-        &:first-child:empty::before {
-            opacity: 0.5;
-            content: attr(data-placeholder);
-        }
+    .input:first-child:empty::before {
+        opacity: 0.5;
+        content: attr(data-placeholder);
     }
 }
 


### PR DESCRIPTION
This extends existing styling for pills for search and org permissions, to fix a bug in the invite users modal. Continues work in #34371, which tested other input elements.

Fixes bug reported here:
https://chat.zulip.org/#narrow/channel/9-issues/topic/pasting.20invite.20email.20addresses
