### PR TITLE
retention: Eliminate join with Recipient table when archiving DMs.

### DIFF
--- a/zerver/models/messages.py
+++ b/zerver/models/messages.py
@@ -218,7 +218,7 @@ class Message(AbstractMessage):
                 name="zerver_message_realm_sender_recipient",
             ),
             models.Index(
-                # For analytics queries
+                # For analytics and retention queries
                 "realm_id",
                 "date_sent",
                 name="zerver_message_realm_date_sent",


### PR DESCRIPTION
We can use the is_channel_message column instead of doing the join to filter on recipient type.

