### PR TITLE
starlight_help: Display gradient for the idle status icon.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -979,6 +979,11 @@ svg_rules = RuleList(
             "pattern": r"fill=(['\"])(.*?)\1",
             "description": "System icons ignore fill values, so do not include the fill property.",
             "include_only": {"web/shared/icons/", "web/images/icons/"},
+            # This file needs the fill property to define the fill as
+            # a linear gradient. We cannot define the gradient in CSS
+            # in a clean way and thus we have decided to define the
+            # gradient in the SVG itself.
+            "exclude": {"web/shared/icons/user-circle-idle.svg"},
         },
         {
             "pattern": "fill:",

--- a/web/shared/icons/user-circle-idle.svg
+++ b/web/shared/icons/user-circle-idle.svg
@@ -1,4 +1,18 @@
+<!--
+The linearGradient in this SVG is trying to emulate the gradient that
+the user-circle-idle class applies to this SVG for the new help center
+built on top of starlight. This linearGradient would not have any
+effect on the current webapp icon since the gradient in this SVG is
+stripped off when the webapp converts this SVG to font.
+-->
 <svg viewBox="0 0 11 11" xmlns="http://www.w3.org/2000/svg">
-    <path d="M 0 5.5 C 0 2.462433 2.462432 0 5.5 0 C 8.53754 0 11 2.462433 11 5.5 C 11 8.53754 8.53754 11 5.5 11 C 2.462432 11 0 8.53754 0 5.5 Z"/>
+  <defs>
+    <linearGradient id="user-circle-idle-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="5%" stop-color="var(--color-user-circle-idle)" stop-opacity="1" />
+      <stop offset="25%" stop-color="var(--color-user-circle-idle)" stop-opacity="0.789" />
+      <stop offset="100%" stop-color="var(--color-user-circle-idle)" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <path d="M 0 5.5 C 0 2.462433 2.462432 0 5.5 0 C 8.53754 0 11 2.462433 11 5.5 C 11 8.53754 8.53754 11 5.5 11 C 2.462432 11 0 8.53754 0 5.5 Z" 
+        fill="url(#user-circle-idle-gradient)"/>
 </svg>
-

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1638,6 +1638,12 @@
         #646671
     );
     --color-user-circle-deactivated: hsl(0deg 0% 50%);
+    /* The gradient is also recreated inside the `user-circle-idle` SVG
+       file. That is needed for the new help center since it does not
+       do the SVG to font conversion that the web app does. We
+       re-apply it here since the linearGradient there is stripped off
+       when that SVG is converted to font for the web app. Any changes
+       to this gradient should be reflected in the SVG file as well. */
     --gradient-user-circle-idle: linear-gradient(
         to right,
         var(--color-user-circle-idle) 5%,


### PR DESCRIPTION
Fixes #35496.

We were displaying a solid color until we figured out how to accurately display the gradient in the SVG itself.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Current help center:
<img width="701" height="170" alt="Screenshot 2025-08-19 at 5 07 26 PM" src="https://github.com/user-attachments/assets/dfe7526c-14fe-462f-bbf0-e6a303bf011d" />

New help center light mode:
<img width="701" height="170" alt="Screenshot 2025-08-19 at 5 07 10 PM" src="https://github.com/user-attachments/assets/61711aac-9972-4f10-a902-f55e01496006" />

New help center dark mode:
<img width="701" height="170" alt="Screenshot 2025-08-19 at 5 07 04 PM" src="https://github.com/user-attachments/assets/a4947fb3-4291-4a68-90dc-5c89f4aff6e0" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
