### PR TITLE
Improvements to the logic to avoid sending notification bot DMs on channel sub.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -28812,17 +28812,20 @@ components:
     SendNewSubscriptionMessages:
       description: |
         Whether any other users newly subscribed via this request should be
-        sent a Notification Bot DM notifying them about their new
-        subscription.
+        sent a direct message, from Notification Bot, notifying them about their
+        new subscription.
 
-        The server will never send Notification Bot DMs if more than
-        `max_bulk_new_subscription_messages` (available in the [`POST
-        /register`](/api/register-queue) response) users were subscribed in
-        this request.
+        No direct messages are sent for any channels that are created as part of
+        this request, regardless of the value of this parameter.
+
+        The server will never send direct messages when the total number of users
+        who were subscribed to channels in this request was more than the value
+        of `max_bulk_new_subscription_messages`, which is available in the [`POST
+        /register`](/api/register-queue) response.
 
         **Changes**: Before Zulip 11.0 (feature level 397), new subscribers
-        were always sent a Notification Bot DM, which was unduly expensive
-        when bulk-subscribing thousands of users to a channel.
+        were always sent a Notification Bot direct message, which was unduly
+        expensive when bulk-subscribing thousands of users to a channel.
       type: boolean
       default: true
       example: true

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -5147,8 +5147,11 @@ class SubscriptionAPITest(ZulipTestCase):
             recipient__type_id=announce.id,
             date_sent__gt=now,
         )
-        # Currently, this notification is not sent even though it should be.
-        self.assertEqual(announcement_channel_message.count(), 0)
+        self.assertEqual(announcement_channel_message.count(), 1)
+        self.assertEqual(
+            announcement_channel_message[0].content,
+            f"@_**{desdemona.full_name}|{desdemona.id}** created a new channel #**test D**.",
+        )
 
         new_channel = get_stream("test D", realm)
         new_channel_message = Message.objects.filter(
@@ -5158,8 +5161,15 @@ class SubscriptionAPITest(ZulipTestCase):
             recipient__type_id=new_channel.id,
             date_sent__gt=now,
         )
-        # Currently, this notification is not sent even though it should be.
-        self.assert_length(new_channel_message.values(), 0)
+        self.assert_length(new_channel_message.values(), 1)
+        self.assertEqual(
+            new_channel_message[0].topic_name(), Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME
+        )
+        self.assertEqual(
+            new_channel_message[0].content,
+            f"**Public** channel created by @_**{desdemona.full_name}|{desdemona.id}**. **Description:**\n"
+            "```` quote\n*No description.*\n````",
+        )
 
 
 class InviteOnlyStreamTest(ZulipTestCase):

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4985,8 +4985,12 @@ class SubscriptionAPITest(ZulipTestCase):
 
     def test_notification_bot_dm_on_subscription(self) -> None:
         desdemona = self.example_user("desdemona")
+        realm = desdemona.realm
         self.login_user(desdemona)
-
+        bot = self.notification_bot(realm)
+        test_channel = self.make_stream("test A")
+        announce = realm.new_stream_announcements_stream
+        assert announce is not None
         user_ids = [
             desdemona.id,
             self.example_user("cordelia").id,
@@ -4995,19 +4999,167 @@ class SubscriptionAPITest(ZulipTestCase):
             self.example_user("iago").id,
             self.example_user("prospero").id,
         ]
-
+        principals_dict = dict(
+            principals=orjson.dumps(user_ids).decode(), announce=orjson.dumps(True).decode()
+        )
+        # When subscribing to an already existing channel with announce=True,
+        # the bot should send DMs to all the newly subscribed users, but
+        # no announcement message.
+        now = timezone_now()
         response = self.subscribe_via_post(
-            desdemona, ["Test stream 1"], dict(principals=orjson.dumps(user_ids).decode())
+            desdemona,
+            [test_channel.name],
+            principals_dict,
         )
         data = self.assert_json_success(response)
         self.assertEqual(data["new_subscription_messages_sent"], True)
 
+        notification_bot_dms = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.PERSONAL,
+            date_sent__gt=now,
+        )
+        self.assert_length(notification_bot_dms, 5)
+        notif_bot_dm_recipients = [
+            dm["recipient__type_id"] for dm in notification_bot_dms.values("recipient__type_id")
+        ]
+        self.assertSetEqual(
+            {id for id in user_ids if id != desdemona.id}, set(notif_bot_dm_recipients)
+        )
+
+        announcement_channel_message = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.STREAM,
+            recipient__type_id=announce.id,
+            date_sent__gt=now,
+        )
+        self.assertEqual(announcement_channel_message.count(), 0)
+
+        # When subscribing to a newly created channel with announce=True,
+        # we expect an announcement message and new channel message,
+        # but no DM notifications.
+        now = timezone_now()
+        response = self.subscribe_via_post(
+            desdemona,
+            ["test B"],
+            principals_dict,
+        )
+        data = self.assert_json_success(response)
+        self.assertEqual(data["new_subscription_messages_sent"], True)
+
+        notification_bot_dms = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.PERSONAL,
+            date_sent__gt=now,
+        )
+        self.assertEqual(notification_bot_dms.count(), 0)
+
+        announcement_channel_message = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.STREAM,
+            recipient__type_id=announce.id,
+            date_sent__gt=now,
+        )
+        self.assert_length(announcement_channel_message.values(), 1)
+        self.assertEqual(
+            announcement_channel_message[0].content,
+            f"@_**{desdemona.full_name}|{desdemona.id}** created a new channel #**test B**.",
+        )
+
+        new_channel = get_stream("test B", realm)
+        new_channel_message = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.STREAM,
+            recipient__type_id=new_channel.id,
+            date_sent__gt=now,
+        )
+        self.assert_length(new_channel_message.values(), 1)
+        self.assertEqual(
+            new_channel_message[0].topic_name(), Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME
+        )
+        self.assertEqual(
+            new_channel_message[0].content,
+            f"**Public** channel created by @_**{desdemona.full_name}|{desdemona.id}**. **Description:**\n"
+            "```` quote\n*No description.*\n````",
+        )
+
+        # When subscribing to an already existing channel, if the number of new
+        # subscriptions exceeds the limit, no DMs or announcement message should
+        # be sent.
+        now = timezone_now()
+        test_channel = self.make_stream("test C")
         with self.settings(MAX_BULK_NEW_SUBSCRIPTION_MESSAGES=5):
             response = self.subscribe_via_post(
-                desdemona, ["Test stream 2"], dict(principals=orjson.dumps(user_ids).decode())
+                desdemona,
+                [test_channel.name],
+                principals_dict,
             )
         data = self.assert_json_success(response)
         self.assertEqual(data["new_subscription_messages_sent"], False)
+
+        notification_bot_dms = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.PERSONAL,
+            date_sent__gt=now,
+        )
+        self.assertEqual(notification_bot_dms.count(), 0)
+
+        announcement_channel_message = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.STREAM,
+            recipient__type_id=announce.id,
+            date_sent__gt=now,
+        )
+        self.assertEqual(announcement_channel_message.count(), 0)
+
+        # When subscribing to an already existing channel, if the number of new
+        # subscriptions exceeds the limit, no DMs are sent, but an announcement
+        # message and new channel message should be sent.
+        now = timezone_now()
+        with self.settings(MAX_BULK_NEW_SUBSCRIPTION_MESSAGES=5):
+            response = self.subscribe_via_post(
+                desdemona,
+                ["test D"],
+                principals_dict,
+            )
+        data = self.assert_json_success(response)
+        self.assertEqual(data["new_subscription_messages_sent"], False)
+
+        notification_bot_dms = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.PERSONAL,
+            date_sent__gt=now,
+        )
+        self.assertEqual(notification_bot_dms.count(), 0)
+
+        announcement_channel_message = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.STREAM,
+            recipient__type_id=announce.id,
+            date_sent__gt=now,
+        )
+        # Currently, this notification is not sent even though it should be.
+        self.assertEqual(announcement_channel_message.count(), 0)
+
+        new_channel = get_stream("test D", realm)
+        new_channel_message = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.STREAM,
+            recipient__type_id=new_channel.id,
+            date_sent__gt=now,
+        )
+        # Currently, this notification is not sent even though it should be.
+        self.assert_length(new_channel_message.values(), 0)
 
 
 class InviteOnlyStreamTest(ZulipTestCase):

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -5171,6 +5171,17 @@ class SubscriptionAPITest(ZulipTestCase):
             "```` quote\n*No description.*\n````",
         )
 
+        response = self.subscribe_via_post(
+            desdemona,
+            ["Test stream 3"],
+            dict(
+                principals=orjson.dumps(user_ids).decode(),
+                send_new_subscription_messages=orjson.dumps(False).decode(),
+            ),
+        )
+        data = self.assert_json_success(response)
+        self.assertNotIn("new_subscription_messages_sent", data)
+
 
 class InviteOnlyStreamTest(ZulipTestCase):
     def test_must_be_subbed_to_send(self) -> None:


### PR DESCRIPTION
These are follow-ups to #31206:
- The first commit fixes a bug where stream notification messages were not being sent along with the DMs. The stream messages are fewer in number and won't be a big load on the server.
- The second commit introduces a test case for the sake of completion.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
