### PR TITLE
web: Improve user group empty state buttons

### DIFF
--- a/web/src/user_group_components.ts
+++ b/web/src/user_group_components.ts
@@ -24,9 +24,10 @@ export const show_user_group_settings_pane = {
         $("#groups_overlay .settings, #user-group-creation").hide();
         reset_active_group_id();
         $("#groups_overlay .nothing-selected").show();
-        $("#groups_overlay .user-group-info-title").text(
+        $("#groups_overlay .user-group-info-title .group-name-text").text(
             $t_html({defaultMessage: "User group settings"}),
         );
+        $("#groups_overlay .user-group-info-title").removeClass("showing-info-title");
         $("#groups_overlay .deactivated-user-group-icon-right").hide();
         resize.resize_settings_overlay($("#groups_overlay_container"));
     },
@@ -35,7 +36,9 @@ export const show_user_group_settings_pane = {
         $("#groups_overlay .settings").show();
         set_active_group_id(group.id);
         const group_name = user_groups.get_display_group_name(group.name);
-        $("#groups_overlay .user-group-info-title").text(group_name).addClass("showing-info-title");
+        $("#groups_overlay .user-group-info-title .group-name-text")
+            .text(group_name)
+            .addClass("showing-info-title");
         if (group.deactivated) {
             $("#groups_overlay .deactivated-user-group-icon-right").show();
         } else {
@@ -46,13 +49,15 @@ export const show_user_group_settings_pane = {
     create_user_group(container_name = "configure_user_group_settings", group_name?: string) {
         $(".user_group_creation").hide();
         if (container_name === "configure_user_group_settings") {
-            $("#groups_overlay .user-group-info-title").text(
+            $("#groups_overlay .user-group-info-title .group-name-text").text(
                 $t_html({defaultMessage: "Configure new group settings"}),
             );
+            $("#groups_overlay .user-group-info-title").removeClass("showing-info-title");
         } else {
-            $("#groups_overlay .user-group-info-title")
-                .text($t_html({defaultMessage: "Add members to {group_name}"}, {group_name}))
-                .addClass("showing-info-title");
+            $("#groups_overlay .user-group-info-title .group-name-text").text(
+                $t_html({defaultMessage: "Add members to {group_name}"}, {group_name}),
+            );
+            $("#groups_overlay .user-group-info-title").addClass("showing-info-title");
         }
         update_footer_buttons(container_name);
         $(`.${CSS.escape(container_name)}`).show();

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1398,3 +1398,15 @@ input.invalid-input {
         }
     }
 }
+
+/* This is the class for left sidebar of text + button in User Groups. */
+.empty-user-group-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.5em;
+    width: 100%;
+    align-self: flex-start;
+    margin-top: -35px;
+}

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -438,6 +438,8 @@ h4.user_group_setting_subsection_title {
         font-weight: 600;
         padding: 10px;
         overflow: hidden;
+        position: relative;
+        width: 100%;
 
         & a {
             color: inherit;
@@ -488,6 +490,14 @@ h4.user_group_setting_subsection_title {
 
         .deactivated-user-group-icon-right {
             margin-right: 5px;
+        }
+
+        .right-section {
+            position: absolute;
+            font-size: 1.5em;
+            right: 25px;
+            top: 50%;
+            transform: translateY(-50%);
         }
     }
 }
@@ -574,9 +584,12 @@ h4.user_group_setting_subsection_title {
         }
     }
 
-    .left .no-streams-to-show,
-    .left .no-groups-to-show {
+    .left .no-streams-to-show {
         margin-top: calc(45vh - 75px);
+    }
+
+    .left .no-groups-to-show {
+        margin-top: 40px;
     }
 
     .right .nothing-selected {

--- a/web/templates/user_group_settings/user_group_settings_empty_notice.hbs
+++ b/web/templates/user_group_settings/user_group_settings_empty_notice.hbs
@@ -1,13 +1,41 @@
 <div class="no-groups-to-show-message">
-    <span class="settings-empty-option-text">
-        {{empty_user_group_list_message}}
+    <span class="settings-empty-option-text empty-user-group-container">
         {{#if all_groups_tab}}
+            {{empty_user_group_list_message}}
+
             {{#if can_create_user_groups}}
-                <a href="#groups/new">{{t "Create a user group"}}</a>
+                {{> ../components/action_button
+                  label=(t "Create a user group")
+                  variant="link"
+                  custom_classes="create-user-group-button"
+                  attention="quiet"
+                  intent="brand"
+                  }}
             {{/if}}
         {{else}}
-            <a href="#groups/all">{{t "View all user groups"}}</a>
+            {{#if (eq groups_count 0)}}
+                {{empty_user_group_list_message}}
+
+                {{#if can_create_user_groups}}
+                    {{> ../components/action_button
+                      label=(t "Create a user group")
+                      variant="link"
+                      custom_classes="create-user-group-button"
+                      attention="quiet"
+                      intent="brand"
+                      }}
+                {{/if}}
+            {{else}}
+                {{empty_user_group_list_message}}
+
+                {{> ../components/action_button
+                  label=(t "View all user groups")
+                  variant="link"
+                  custom_classes="view-all-groups-button"
+                  attention="quiet"
+                  intent="neutral"
+                  }}
+            {{/if}}
         {{/if}}
     </span>
 </div>
-

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -45,6 +45,11 @@
                         <div class="display-type">
                             <div id="user_group_settings_title" class="user-group-info-title">{{t 'User group settings' }}</div>
                             <i class="fa fa-ban deactivated-user-icon deactivated-user-group-icon-right"></i>
+                            <div class="right-section">
+                                <a href="/help/user-groups" target="_blank" class="help_link_widget large-icon" aria-label="{{t 'User groups help'}}">
+                                    <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+                                </a>
+                            </div>
                         </div>
                     </div>
                     <div class="two-pane-settings-body">


### PR DESCRIPTION
- Restyled the link "view groups" to buttons.
- Added functionality that "view groups" button is visible iff groups are there else "create group" is visible iff he is allowed to create groups else no button will show.
- Added functionality that "filter box" is visible iff you have any "active" or "deactivated" groups.
- Restyled the "banner" to "?" icon in header.
- Restyled the "left sidebar" to make the content on top.

Fixes: #35556

**Screenshots and screen captures:**

<table>
  <tr>
    <td>
      <strong>Image of "?" icon</strong><br>
      <img src="https://github.com/user-attachments/assets/bc80555c-6d6e-4590-932a-a4bdbc5a9a02" width="100%" />
    </td>
    <td>
      <strong>Image of left sidebar when "you are not a member of any group" and "you have groups to view"</strong><br>
      <img src="https://github.com/user-attachments/assets/74324a82-efab-4262-9f92-52578010a574" width="100%" />
    </td>
  </tr>
  <tr>
    <td>
      <strong>Image of left sidebar when there are "no groups to view" and "you are not allowed to create groups"</strong><br>
      <img src="https://github.com/user-attachments/assets/578e6442-4b8e-48e8-a32c-758a4d9fb4dc" width="100%" />
    </td>
    <td>
      <strong>Image of "left sidebar" and the group is active (shows filter box)</strong><br>
      <img src="https://github.com/user-attachments/assets/9199ef78-6713-45e6-85e0-9dadfa01aef8" width="100%" />
    </td>
  </tr>
  <tr>
    <td colspan="2">
      <strong>Image of "left sidebar" and the group is deactivated (show filter box with filter dropdown)</strong><br>
      <img src="https://github.com/user-attachments/assets/f12c1471-7d36-4d5c-bb7f-6f5852b5fed8" width="50%" />
    </td>
  </tr>
</table>
