### PR TITLE
tooltip: Add tooltip showing url for external links with no delay.

### DIFF
--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -444,4 +444,31 @@ export function initialize(): void {
             instance.destroy();
         },
     });
+
+    message_list_tooltip(".message_content a", {
+        onShow(instance) {
+            const $elem = $(instance.reference);
+            const href = $elem.attr("href");
+            assert(href);
+            const url = new URL(href, window.location.href);
+            if (
+                (url.origin === window.location.origin && !href.startsWith("/user_uploads")) ||
+                $elem.hasClass("media-anchor-element")
+            ) {
+                return false;
+            }
+
+            if (href.startsWith("/user_uploads") && !$elem.hasClass("media-anchor-element")) {
+                const filename = decodeURIComponent(href.slice(href.lastIndexOf("/") + 1));
+                instance.setContent(`Download ${filename}`);
+                return undefined;
+            }
+
+            instance.setContent(href);
+            return undefined;
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
 }

--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -191,10 +191,12 @@ export function postprocess_content(html: string): string {
                 title = url.toString();
                 legacy_title = href;
             }
-            elt.setAttribute(
-                "title",
-                ["", legacy_title].includes(elt.title) ? title : `${title}\n${elt.title}`,
-            );
+            if (!elt.hasAttribute("target")) {
+                elt.setAttribute(
+                    "title",
+                    ["", legacy_title].includes(elt.title) ? title : `${title}\n${elt.title}`,
+                );
+            }
         }
     }
 

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -46,8 +46,8 @@ run_test("postprocess_content", () => {
                 "</div>" +
                 '<p><audio controls preload="metadata" src="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.mp3" title="inline.mp3"></audio></p>',
         ),
-        '<a href="http://example.com" target="_blank" rel="noopener noreferrer" title="http://example.com/">good</a> ' +
-            '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/file.png" target="_blank" rel="noopener noreferrer" title="translated: Download file.png">upload</a> ' +
+        '<a href="http://example.com" target="_blank" rel="noopener noreferrer">good</a> ' +
+            '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/file.png" target="_blank" rel="noopener noreferrer">upload</a> ' +
             "<a>invalid</a> " +
             "<a>unsafe</a> " +
             '<a href="/#fragment" title="http://zulip.zulipdev.com/#fragment">fragment</a>' +
@@ -68,10 +68,10 @@ run_test("postprocess_content", () => {
             "</div>" +
             "</div>" +
             '<div class="message_embed">' +
-            '<a class="message_embed_image" href="https://example.com/about" style="background-image: url(&quot;https://example.com/preview.jpeg&quot;)" target="_blank" rel="noopener noreferrer" title="https://example.com/about"></a>' +
+            '<a class="message_embed_image" href="https://example.com/about" style="background-image: url(&quot;https://example.com/preview.jpeg&quot;)" target="_blank" rel="noopener noreferrer"></a>' +
             '<div class="data-container">' +
             '<div class="message_embed_title">' +
-            '<a href="https://example.com/about" target="_blank" rel="noopener noreferrer" class="message-embed-title-link" title="https://example.com/about">About us</a>' +
+            '<a href="https://example.com/about" target="_blank" rel="noopener noreferrer" class="message-embed-title-link">About us</a>' +
             "</div>" +
             '<div class="message_embed_description">All about us.</div>' +
             "</div>" +


### PR DESCRIPTION
Earlier, we had browser show title tooltips for links with a little bit of delay.

This PR adds our own tippy tooltip for external links with no delay.

Fixes: zulip#32973.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|**Before:**|**After:**|
|-----------------|---------------|
||<img width="378" height="119" alt="Screenshot from 2025-08-19 22-55-10" src="https://github.com/user-attachments/assets/fa060bf9-07fd-410b-a901-eae89980e768" />|
||<img width="355" height="88" alt="Screenshot from 2025-08-19 22-55-28" src="https://github.com/user-attachments/assets/c247481e-7f35-4ff2-b848-a09a09795ea8" />|
||<img width="196" height="96" alt="Screenshot from 2025-08-19 22-54-50" src="https://github.com/user-attachments/assets/96cb768c-726d-4449-bf13-2d741d040782" />|
||<img width="196" height="96" alt="Screenshot from 2025-08-19 22-54-55" src="https://github.com/user-attachments/assets/b19b064c-dda4-4c50-8b29-868c68ca66d9" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
