### PR TITLE
reminders: Stop interpolating user-provided values in format string.

### DIFF
--- a/zerver/lib/reminders.py
+++ b/zerver/lib/reminders.py
@@ -88,11 +88,12 @@ def get_reminder_formatted_content(
         content += "\n"
         fence = get_unused_fence(content)
         quoted_message = "{fence}quote\n{msg_content}\n{fence}"
-        content += quoted_message
-        length_without_message_content = len(content.format(fence=fence, msg_content=""))
+        length_without_message_content = len(
+            content + quoted_message.format(fence=fence, msg_content="")
+        )
         max_length = settings.MAX_MESSAGE_LENGTH - length_without_message_content
         msg_content = truncate_content(message.content, max_length, "\n[message truncated]")
-        content = content.format(
+        content += quoted_message.format(
             fence=fence,
             msg_content=msg_content,
         )

--- a/zerver/tests/test_reminders.py
+++ b/zerver/tests/test_reminders.py
@@ -463,3 +463,20 @@ class RemindersTest(ZulipTestCase):
                 f"Maximum reminder note length: {len(note) - 1} characters",
                 status_code=400,
             )
+
+        # Test with note containing formatting characters
+        note = "{123}"
+        content = "{456}"
+        message_id = self.send_stream_message(
+            self.example_user("hamlet"), "Verona", content, topic_name="{789}"
+        )
+        result = self.do_schedule_reminder(message_id, scheduled_delivery_timestamp, note)
+        self.assert_json_success(result)
+        scheduled_message = self.last_scheduled_reminder()
+        self.assertEqual(
+            scheduled_message.content,
+            "You requested a reminder for #**Verona>{789}@"
+            + str(message_id)
+            + "**. Note:\n > {123}\n\n"
+            f"@_**King Hamlet|10** [said](http://zulip.testserver/#narrow/channel/3-Verona/topic/.7B789.7D/near/{message_id}):\n```quote\n{content}\n```",
+        )


### PR DESCRIPTION
We must not intermix Markdown strings which are ready for the message, with format strings which we intend to interpolate on.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
