### PR TITLE
Groups: Improve groups list sidebar when there are no groups to show

### DIFF
--- a/web/templates/user_group_settings/user_group_settings_empty_notice.hbs
+++ b/web/templates/user_group_settings/user_group_settings_empty_notice.hbs
@@ -3,10 +3,12 @@
         {{empty_user_group_list_message}}
         {{#if all_groups_tab}}
             {{#if can_create_user_groups}}
-                <a href="#groups/new">{{t "Create a user group"}}</a>
+                <button type="button" class="create_user_group_button animated-purple-button">{{t "Create a user group"}}</button>
             {{/if}}
-        {{else}}
-            <a href="#groups/all">{{t "View all user groups"}}</a>
+        {{else if current_realm_has_any_group}}
+            <button type="button" class="view-all-groups-button animated-gray-button">{{t "View all groups"}}</button>
+        {{else if can_create_user_groups}}
+            <button type="button" class="create-realm-group-button animated-purple-button">{{t "Create a user group"}}</button>
         {{/if}}
     </span>
 </div>


### PR DESCRIPTION
Show empty state message and "Create user group" button in 'Your groups' panel when no groups are viewable.
Fixes #35556

If there are no groups in the realm then 'Your groups' would display the "There are no user groups you can view in this organization."
Now based on whether the user has permission to create groups the create groups button would be displayed accordingly.

The screenshots:
| Feature / Change | Before Screenshot | After Screenshot |
|------------------|-------------------|------------------|
| When Groups exist but you're not member of any group (Your Groups Tab) | <img width="1203" height="803" alt="image" src="https://github.com/user-attachments/assets/953230d9-2e25-43f7-8b26-49ac641f572a" />| <img width="1202" height="822" alt="image" src="https://github.com/user-attachments/assets/e8318e5d-41f3-4984-bb01-1cdeb5c9a6f6" /> |
|When Groups exist but you're not member of any group (All Groups Tab) | <img width="1215" height="822" alt="image" src="https://github.com/user-attachments/assets/654767a9-8ed2-419b-89f4-ed8cb6678cac" />| <img width="1210" height="832" alt="image" src="https://github.com/user-attachments/assets/137310f9-2eac-400f-8e34-bfff77499b87" />|
| When there are no groups in the org/realm at all + Don't have permission to create group (Your Groups Tab)          |  <img width="1118" height="820" alt="image" src="https://github.com/user-attachments/assets/0ef6db58-c31c-4c71-b71c-38cbb0d85394" />|<img width="1124" height="818" alt="image" src="https://github.com/user-attachments/assets/722c5b4d-8c76-4503-a5fc-65ff1383236b" /> |
| When there are no groups in the org/realm at all + Don't have permission to create group (All Groups Table) | <img width="1127" height="820" alt="image" src="https://github.com/user-attachments/assets/bc6f3d4e-ce3b-4efe-a8a6-2b0614aae181" />  | <img width="1130" height="826" alt="image" src="https://github.com/user-attachments/assets/b1247f2d-ce81-4b21-b9e8-b08988b2f06b" />|
| When there are no groups in the org/realm at all + Do have permission to create group (Your Groups Tab)| Not able to test |Not able to test|
| When there are no groups in the org/realm at all + Don't have permission to create group (All Groups Tab) | Not able to test  | Not able to test|
| When there are activated or deactivated groups but filter is not showing an group (Your Groups Tab)       | <img width="1208" height="816" alt="image" src="https://github.com/user-attachments/assets/53d197e6-2335-49ed-acc5-a1cf3da7bfea" /> | <img width="1203" height="821" alt="image" src="https://github.com/user-attachments/assets/4e798e24-df8f-4f7f-bb89-6a527825662f" />| 




<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
