### PR TITLE
left_sidebar: Always show unread count in channel section headings.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -574,13 +574,6 @@
 /* Only show section header unread counts when the section is collapsed
    or when the header is being hovered over. */
 #streams_list .stream-list-section-container:not(.collapsed) {
-    .stream-list-subsection-header:not(:hover) {
-        .unread_count,
-        .masked_unread_count {
-            visibility: hidden;
-        }
-    }
-
     .stream-list-subsection-header:not(:hover) .unread_mention_info {
         display: none;
     }


### PR DESCRIPTION
Fixes issue reported here:
https://chat.zulip.org/#narrow/channel/137-feedback/topic/Channel.20folder.20not.20showing.20unread.20when.20open.2C.20except.20on.20hover/near/2246982
