### PR TITLE
deactivated_redirect: Preserve URL hash when redirecting.

### DIFF
--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -503,7 +503,15 @@ $(() => {
             if (current_countdown > 0) {
                 $countdown_elt.text((current_countdown - 1).toString());
             } else {
-                window.location.href = $("a#deactivated-org-auto-redirect").attr("href")!;
+                let new_org_url = $("a#deactivated-org-auto-redirect").attr("href")!;
+                const url_hash = window.location.hash;
+                if (url_hash.startsWith("#")) {
+                    // Ensure we don't double-add hashes and handle query parameters properly
+                    const url = new URL(new_org_url);
+                    url.hash = url_hash;
+                    new_org_url = url.toString();
+                }
+                window.location.href = new_org_url;
                 clearInterval(interval_id);
             }
         }, 1000);


### PR DESCRIPTION
URL hash from old url is lost using this JS method for redirecting, preserved by extracting the hash and appending it to the new URL.

Tested locally as well.
