### PR TITLE
push_notifications: Use `SentPushNotificationResult` dataclass.

### DIFF
--- a/zerver/tests/test_e2ee_push_notifications.py
+++ b/zerver/tests/test_e2ee_push_notifications.py
@@ -28,6 +28,7 @@ from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.models import PushDevice, UserMessage
 from zerver.models.realms import get_realm
 from zerver.models.scheduled_jobs import NotificationTriggers
+from zilencer.lib.push_notifications import SentPushNotificationResult
 from zilencer.models import RemoteRealm, RemoteRealmCount
 
 
@@ -260,7 +261,11 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
         with (
             self.mock_fcm() as mock_fcm_messaging,
             mock.patch(
-                "zilencer.lib.push_notifications.send_e2ee_push_notification_apple", return_value=1
+                "zilencer.lib.push_notifications.send_e2ee_push_notification_apple",
+                return_value=SentPushNotificationResult(
+                    successfully_sent_count=1,
+                    delete_device_ids=[],
+                ),
             ),
             self.assertLogs("zerver.lib.push_notifications", level="INFO") as zerver_logger,
             self.assertLogs("zilencer.lib.push_notifications", level="WARNING") as zilencer_logger,


### PR DESCRIPTION
PR to address: https://github.com/zulip/zulip/pull/35139#discussion_r2224020504

Fixes part of #35368
- [x] Consider refactoring of delete_device_ids calling convention: https://github.com/zulip/zulip/pull/35139#discussion_r2224020504

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
