### PR TITLE
stripe: Return 400 error instead of 500 on invalid tier.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -452,7 +452,7 @@ class InvalidBillingScheduleError(Exception):
         super().__init__(self.message)
 
 
-class InvalidTierError(Exception):
+class InvalidTierError(JsonableError):
     def __init__(self, tier: int) -> None:
         self.message = f"Unknown tier: {tier}"
         super().__init__(self.message)


### PR DESCRIPTION
[discussion](https://chat.zulip.org/#narrow/channel/343-kandra-errors/topic/InvalidTierError.3A.20Unknown.20tier.3A.203/near/2226502)