### PR TITLE
topic_popover: Update topic URL to permalink for message header popover.

### DIFF
--- a/web/src/topic_popover.ts
+++ b/web/src/topic_popover.ts
@@ -36,7 +36,7 @@ function get_conversation(instance: tippy.Instance): {
         const $message_header = $elt.closest(".message_header").expectOne();
         stream_id = Number.parseInt($message_header.attr("data-stream-id")!, 10);
         topic_name = $message_header.attr("data-topic-name")!;
-        const topic_narrow_url = hash_util.by_stream_topic_url(stream_id, topic_name);
+        const topic_narrow_url = hash_util.by_channel_topic_permalink(stream_id, topic_name);
         url = new URL(topic_narrow_url, realm.realm_url).href;
     } else if (!instance.reference.classList.contains("topic-sidebar-menu-icon")) {
         const $elt = $(instance.reference);


### PR DESCRIPTION
This PR updates the topic URL in the message header topic menu popover, introduced in feedb6ea2de8e9e4ac1370e0d1fca719d4598623 to a permalink having a `with` operator attached to it.

<!-- Describe your pull request here.-->

Fixes: [#issues > copy link to topic URL doesn't have "with" operator @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/copy.20link.20to.20topic.20URL.20doesn't.20have.20.22with.22.20operator/near/2248021)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Topic URL — Before | Topic URL — After |
|--------|--------|
| `[#Denmark > big WEB APP isn't running](http://localhost:9991/#narrow/channel/4-Denmark/topic/big.20WEB.20APP.20isn't.20running)` | `[#Denmark > big WEB APP isn't running](http://localhost:9991/#narrow/channel/4-Denmark/topic/big.20WEB.20APP.20isn't.20running/with/51)` | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
