### PR TITLE
filter: Use encoding for topic narrows when generating redirect url.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import assert from "minimalistic-assert";
 
+import * as internal_url from "../shared/src/internal_url.ts";
 import * as resolved_topic from "../shared/src/resolved_topic.ts";
 import render_search_description from "../templates/search_description.hbs";
 
@@ -18,6 +19,7 @@ import type {UserPillItem} from "./search_suggestion.ts";
 import {current_user, realm} from "./state_data.ts";
 import type {NarrowTerm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
+import * as sub_store from "./sub_store.ts";
 import * as user_topics from "./user_topics.ts";
 import * as util from "./util.ts";
 
@@ -1311,12 +1313,12 @@ export class Filter {
             if (!sub) {
                 return "#";
             }
-            return (
-                "/#narrow/channel/" +
-                stream_data.id_to_slug(sub.stream_id) +
-                "/topic/" +
-                this.operands("topic")[0]
-            );
+
+            return `/${internal_url.by_stream_topic_url(
+                sub.stream_id,
+                this.operands("topic")[0]!,
+                sub_store.maybe_get_stream_name,
+            )}`;
         }
 
         // eliminate "complex filters"
@@ -1332,7 +1334,10 @@ export class Filter {
                     if (!sub) {
                         return "#";
                     }
-                    return "/#narrow/channel/" + stream_data.id_to_slug(sub.stream_id);
+                    return `/${internal_url.by_stream_url(
+                        sub.stream_id,
+                        sub_store.maybe_get_stream_name,
+                    )}`;
                 }
                 case "is-dm":
                     return "/#narrow/is/dm";

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -2399,6 +2399,14 @@ test("navbar_helpers", ({override}) => {
         {operator: "channel", operand: invalid_channel_id.toString()},
         {operator: "topic", operand: "bar"},
     ];
+    // channel/topic name using special character for url encoding.
+    const special_sub_id = new_stream_id();
+    make_sub("Foo2.0", special_sub_id);
+    const char_channel_term = [{operator: "channel", operand: special_sub_id.toString()}];
+    const char_channel_topic_term = [
+        {operator: "channel", operand: special_sub_id.toString()},
+        {operator: "topic", operand: "bar2.0"},
+    ];
     const public_sub_id = new_stream_id();
     make_private_sub("psub", public_sub_id);
     const private_channel_term = [{operator: "channel", operand: public_sub_id.toString()}];
@@ -2524,6 +2532,20 @@ test("navbar_helpers", ({override}) => {
             zulip_icon: "hashtag",
             title: "Foo",
             redirect_url_with_search: `/#narrow/channel/${foo_stream_id}-Foo/topic/bar`,
+        },
+        {
+            terms: char_channel_term,
+            is_common_narrow: true,
+            zulip_icon: "hashtag",
+            title: "Foo2.0",
+            redirect_url_with_search: `/#narrow/channel/${special_sub_id}-Foo2.2E0`,
+        },
+        {
+            terms: char_channel_topic_term,
+            is_common_narrow: true,
+            zulip_icon: "hashtag",
+            title: "Foo2.0",
+            redirect_url_with_search: `/#narrow/channel/${special_sub_id}-Foo2.2E0/topic/bar2.2E0`,
         },
         {
             terms: invalid_channel_with_topic,


### PR DESCRIPTION
Earlier, when generating redirect url for search exit, we did not encode the url in case of channel/topic narrows. We expect some characters to be replaced when generating hash.

This PR encodes the url for channels and topic narrows and prevents redirecting to broken hashes.

<!-- Describe your pull request here.-->

Fixes: [#issues > Invalid URL after clicking "x" in search bar @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/Invalid.20URL.20after.20clicking.20.22x.22.20in.20search.20bar/near/2248011)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
|**Before:**|**After:**|
|------------------|---------------|
|<video src="https://github.com/user-attachments/assets/f8ca5c43-78b2-4cc5-8c1b-344f6c4a67d0" />|<video src="https://github.com/user-attachments/assets/31d3caca-5c1e-4fe2-965a-230909af2e45" />|



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
