### PR TITLE
delete_in_topic: Don't unnecessarily fetch .recipient.

### DIFF
--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -1323,10 +1323,8 @@ def delete_in_topic(
         if time.monotonic() >= start_time + 50:
             return json_success(request, data={"complete": False})
         with transaction.atomic(durable=True):
-            messages_to_delete = (
-                messages.select_related("recipient")
-                .order_by("-id")[0:batch_size]
-                .select_for_update(of=("self",))
+            messages_to_delete = messages.order_by("-id")[0:batch_size].select_for_update(
+                of=("self",)
             )
             if not messages_to_delete:
                 break


### PR DESCRIPTION
This reverts commit f119c3378981df50cc43e8ca7b2cbfd4031c38e4. With 51cef01c2921c9c35369f00052c1cba0c0ac35d2 merged, there is no need to fetch .recipient here, as it won't be accessed by the delete messages codepath.

