### PR TITLE
css: Fix slow-send-spinner not applying on all messagebox-content.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -135,7 +135,9 @@
 
     .slow-send-spinner {
         display: none;
-        justify-self: end;
+        place-self: center end;
+        position: unset;
+        margin-top: 1px;
         margin-right: 10px;
         text-align: end;
         grid-area: time;
@@ -395,12 +397,6 @@
                     var(--message-box-markdown-aligned-vertical-space)
             );
             grid-area: message;
-        }
-
-        .slow-send-spinner {
-            align-self: center;
-            position: unset;
-            margin-top: 1px;
         }
 
         .message_edit_notice {


### PR DESCRIPTION
Earlier, slow-send-spinner was working correctly for message with messagebox-includes-sender. Any subsequent messages with slow-send-spinner would result in broken animated because of rules not applying properly.

This PR fixes this behaviour by applying the rules for all messagebox-content and fixing the animation.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
|**Before:**|**After:**|
|-|-|
|<video src="https://github.com/user-attachments/assets/a73b2450-4984-4505-bc3a-0206508786a5" />|<video src="https://github.com/user-attachments/assets/7a97b84e-719f-42ae-9416-8a0d01225958" />|
|<img width="241" height="145" alt="Screenshot from 2025-08-22 22-57-32" src="https://github.com/user-attachments/assets/d8227523-01fc-4d5e-b2c7-515688d3bff8" />|<img width="241" height="145" alt="Screenshot from 2025-08-22 22-56-26" src="https://github.com/user-attachments/assets/f5fff0f2-8d0b-43e2-9fe7-07cb3b852ed6" />|





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
