### PR TITLE
push_notifications: Log roundtrip time since worker decided to send.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -4,6 +4,7 @@ import asyncio
 import copy
 import logging
 import re
+import time
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from email.headerregistry import Address
@@ -1521,6 +1522,7 @@ def send_push_notifications(
 
     # Send push notification
     try:
+        start_time = time.perf_counter()
         if settings.ZILENCER_ENABLED:
             from zilencer.lib.push_notifications import send_e2ee_push_notifications
 
@@ -1544,6 +1546,7 @@ def send_push_notifications(
                 "delete_device_ids": result["delete_device_ids"],
                 "realm_push_status": result["realm_push_status"],  # type: ignore[typeddict-item] # TODO: Can't use isinstance() with TypedDict type
             }
+        send_push_notifications_latency = time.perf_counter() - start_time
     except (MissingRemoteRealmError, PushNotificationsDisallowedByBouncerError) as e:
         reason = e.reason if isinstance(e, PushNotificationsDisallowedByBouncerError) else e.msg
         logger.warning("Bouncer refused to send E2EE push notification: %s", reason)
@@ -1587,10 +1590,12 @@ def send_push_notifications(
     )
 
     logger.info(
-        "Sent E2EE mobile push notifications for user %s: %s via FCM, %s via APNs",
+        "Sent E2EE mobile push notifications for user %s: %s via FCM, %s via APNs. "
+        "Roundtrip since worker decided to send took %.3f seconds.",
         user_profile.id,
         android_successfully_sent_count,
         apple_successfully_sent_count,
+        send_push_notifications_latency,
     )
 
     realm_push_status_dict = response_data.get("realm_push_status")

--- a/zerver/tests/test_e2ee_push_notifications.py
+++ b/zerver/tests/test_e2ee_push_notifications.py
@@ -84,9 +84,10 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
                 f"FCM: Sent message with ID: 0 to (push_account_id={registered_device_android.push_account_id}, device={registered_device_android.token})",
                 zilencer_logger.output[0],
             )
-            self.assertEqual(
+            self.assertIn(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs. "
+                "Roundtrip since worker decided to send took ",
                 zerver_logger.output[3],
             )
 
@@ -184,9 +185,10 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
                 f"Deleting PushDevice rows with the following device IDs based on response from bouncer: [{registered_device_apple.device_id}, {registered_device_android.device_id}]",
                 zerver_logger.output[3],
             )
-            self.assertEqual(
+            self.assertIn(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 0 via FCM, 0 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 0 via FCM, 0 via APNs. "
+                "Roundtrip since worker decided to send took ",
                 zerver_logger.output[4],
             )
 
@@ -242,9 +244,10 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
                 f"FCM: Delivery failed for (push_account_id={registered_device_android.push_account_id}, device={registered_device_android.token})",
                 zilencer_logger.output[1],
             )
-            self.assertEqual(
+            self.assertIn(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 0 via FCM, 0 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 0 via FCM, 0 via APNs. "
+                "Roundtrip since worker decided to send took ",
                 zerver_logger.output[2],
             )
 
@@ -277,9 +280,10 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
                 "WARNING:zilencer.lib.push_notifications:Error while pushing to FCM",
                 zilencer_logger.output[0],
             )
-            self.assertEqual(
+            self.assertIn(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 0 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 0 via FCM, 1 via APNs. "
+                "Roundtrip since worker decided to send took ",
                 zerver_logger.output[2],
             )
 
@@ -390,9 +394,10 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
                 f"FCM: Sent message with ID: 0 to (push_account_id={registered_device_android.push_account_id}, device={registered_device_android.token})",
                 zilencer_logger.output[0],
             )
-            self.assertEqual(
+            self.assertIn(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs. "
+                "Roundtrip since worker decided to send took ",
                 zerver_logger.output[3],
             )
 
@@ -601,9 +606,10 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
                 f"FCM: Sent message with ID: 0 to (push_account_id={registered_device_android.push_account_id}, device={registered_device_android.token})",
                 zilencer_logger.output[0],
             )
-            self.assertEqual(
+            self.assertIn(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs. "
+                "Roundtrip since worker decided to send took ",
                 zerver_logger.output[7],
             )
 
@@ -723,9 +729,10 @@ class RemovePushNotificationTest(E2EEPushNotificationTestCase):
             user_message.refresh_from_db()
             self.assertFalse(user_message.flags.active_mobile_push_notification)
 
-            self.assertEqual(
+            self.assertIn(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs. "
+                "Roundtrip since worker decided to send took ",
                 zerver_logger.output[2],
             )
 
@@ -766,9 +773,10 @@ class RemovePushNotificationTest(E2EEPushNotificationTestCase):
             user_message.refresh_from_db()
             self.assertFalse(user_message.flags.active_mobile_push_notification)
 
-            self.assertEqual(
+            self.assertIn(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs. "
+                "Roundtrip since worker decided to send took ",
                 zerver_logger.output[2],
             )
 
@@ -904,9 +912,10 @@ class SendTestPushNotificationTest(E2EEPushNotificationTestCase):
                 f"Sending E2EE test push notification for user {hamlet.id}",
                 zerver_logger.output[0],
             )
-            self.assertEqual(
+            self.assertIn(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs. "
+                "Roundtrip since worker decided to send took ",
                 zerver_logger.output[-1],
             )
 
@@ -924,9 +933,10 @@ class SendTestPushNotificationTest(E2EEPushNotificationTestCase):
                 f"Sending E2EE test push notification for user {hamlet.id}",
                 zerver_logger.output[0],
             )
-            self.assertEqual(
+            self.assertIn(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 0 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 0 via APNs. "
+                "Roundtrip since worker decided to send took ",
                 zerver_logger.output[-1],
             )
 
@@ -965,9 +975,10 @@ class SendTestPushNotificationTest(E2EEPushNotificationTestCase):
                 f"Sending E2EE test push notification for user {hamlet.id}",
                 zerver_logger.output[0],
             )
-            self.assertEqual(
+            self.assertIn(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs. "
+                "Roundtrip since worker decided to send took ",
                 zerver_logger.output[-1],
             )
 


### PR DESCRIPTION
PR to address [#backend > E2EE - remote_queue_latency @ 💬](https://chat.zulip.org/#narrow/channel/3-backend/topic/E2EE.20-.20remote_queue_latency/near/2223997):
> The one thing I might consider filing an issue for is the server's mobile push worker's logs have the information to see the end-to-end latency from when the service decided to send a notification until it got a 200 back from the bouncer confirming that it's sent.

Fixes part of #35368.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
