### PR TITLE
create-channel: Remove send_new_subscription_messages parameter.

### DIFF
--- a/api_docs/unmerged.d/ZF-ee485d.md
+++ b/api_docs/unmerged.d/ZF-ee485d.md
@@ -1,0 +1,4 @@
+* [`POST channels/create`](/api/create-channel): Removed the
+  `send_new_subscription_messages` parameter from this endpoint because
+  Notification Bot DMs are never sent to users who are subscribed to
+  a channel during its creation process.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -23638,12 +23638,20 @@ paths:
       operationId: create-channel
       summary: Create a channel
       description: |
-        Create a new [channel](/help/create-channels) and optionally
-        subscribe users to the newly created channel. The initial [channel settings](/api/update-stream)
-        will be determined by the optional parameters, like `invite_only`, detailed below.
+        Create a new [channel](/help/create-channels), and optionally subscribe
+        users to the newly created channel.
 
-        **Changes**: New in Zulip 11.0 (feature level 417). Previously, this was only possible via
-        the [`POST /api/subscribe`](/api/subscribe) endpoint, which handled both creation and subscription.
+        The initial [channel settings](/api/update-stream) will be determined by
+        the optional parameters, like `invite_only`, detailed below.
+
+        **Changes**: In Zulip 12.0 (feature level ZF-ee485d), removed the
+        `send_new_subscription_messages` parameter from this endpoint because
+        Notification Bot DMs are never sent to users who are subscribed to a
+        channel during the channel creation process.
+
+        New in Zulip 11.0 (feature level 417). Previously, this was only possible
+        via the [`POST /api/subscribe`](/api/subscribe) endpoint, which handles
+        both channel creation and subscription.
       x-curl-examples-parameters:
         oneOf:
           - type: include
@@ -23730,8 +23738,6 @@ paths:
                   example: true
                 folder_id:
                   $ref: "#/components/schemas/FolderId"
-                send_new_subscription_messages:
-                  $ref: "#/components/schemas/SendNewSubscriptionMessages"
                 topics_policy:
                   $ref: "#/components/schemas/TopicsPolicy"
                 history_public_to_subscribers:

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4416,7 +4416,7 @@ class SubscriptionAPITest(ZulipTestCase):
         with (
             self.assert_database_query_count(23),
             self.assert_memcached_count(11),
-            mock.patch("zerver.views.streams.send_messages_for_new_subscribers"),
+            mock.patch("zerver.views.streams.send_user_subscribed_and_new_channel_notifications"),
         ):
             self.subscribe_via_post(
                 desdemona,

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -829,7 +829,7 @@ def create_channel(
         send_new_subscription_messages
         and len(new_subscribers) <= settings.MAX_BULK_NEW_SUBSCRIPTION_MESSAGES
     ):
-        send_messages_for_new_subscribers(
+        send_user_subscribed_and_new_channel_notifications(
             user_profile=user_profile,
             subscribers=new_subscribers,
             new_subscriptions={str(user.id): [name] for user in new_subscribers},
@@ -1017,7 +1017,7 @@ def add_subscriptions_backend(
 
     if send_new_subscription_messages:
         if len(result["subscribed"]) <= settings.MAX_BULK_NEW_SUBSCRIPTION_MESSAGES:
-            send_messages_for_new_subscribers(
+            send_user_subscribed_and_new_channel_notifications(
                 user_profile=user_profile,
                 subscribers=subscribers,
                 new_subscriptions=result["subscribed"],
@@ -1036,7 +1036,7 @@ def add_subscriptions_backend(
     return json_success(request, data=result)
 
 
-def send_messages_for_new_subscribers(
+def send_user_subscribed_and_new_channel_notifications(
     user_profile: UserProfile,
     subscribers: set[UserProfile],
     new_subscriptions: dict[str, list[str]],


### PR DESCRIPTION
See [#api design > Channel creation should return the channel ID](https://chat.zulip.org/#narrow/channel/378-api-design/topic/Channel.20creation.20should.20return.20the.20channel.20ID/with/2246434) and [#api design > options for notifying new channel subscribers](https://chat.zulip.org/#narrow/channel/378-api-design/topic/options.20for.20notifying.20new.20channel.20subscribers/with/2246430) for discussion about these changes.

**Notes**:
- Initial prep commit renames `send_messages_for_new_subscribers` so that it's clearer what notification messages are being processed in this helper function: `send_user_subscribed_and_new_channel_notifications`.
- Additionally, there's a prep commit to clean up the comments in that helper function and where some of the variables are declared.
- Final commit makes the API change to remove the `send_new_subscription_messages` parameter from the new `/channel/create` API endpoint.

---

**Screenshots and screen captures:**

*Updated main description for ["create-channel" endpoint](https://zulip.com/api/create-channel) with changes note*:
<img width="1120" height="516" alt="Screenshot From 2025-08-25 16-59-49" src="https://github.com/user-attachments/assets/a9889b08-e538-4e17-b078-78a67d57d4c2" />

*New API changelog entry*:
<img width="1120" height="306" alt="Screenshot From 2025-08-25 17-00-06" src="https://github.com/user-attachments/assets/0ea33741-d465-4c47-afd4-22ef78a7f7ec" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
