### PR TITLE
 Abbreviate long bot owner names in bot management modal.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1133,6 +1133,12 @@ input.settings_text_input {
     }
 }
 
+#edit_bot_owner_widget .dropdown_widget_value {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .dropdown_widget_with_label_wrapper {
     margin-top: 0 !important;
 }


### PR DESCRIPTION
Previously, long owner names could wrap onto multiple lines in the bot management modal, breaking the layout. This commit adds CSS to keep names on a single line and abbreviate with an ellipsis if too long.
Scoped the change to only affect the bot owner dropdown to avoid impacting other parts of the UI

Fixes #23266.

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**BEFORE**
<img width="380" height="380" alt="Screenshot 2025-08-25 at 21 04 54" src="https://github.com/user-attachments/assets/c8abfdd8-d1c3-4356-86c1-b75d1786ebdb" />
**AFTER**
<img width="380" height="380" alt="Screenshot 2025-08-25 at 21 06 48" src="https://github.com/user-attachments/assets/533aeb41-de1f-4234-87c5-5c9242031405" />

<details>
<summary>📹 Screen recording demo</summary>


https://github.com/user-attachments/assets/8f8cd815-f986-440e-a715-f455d63b8ac6



</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
