### PR TITLE
Changes to reduce usage of `email` property of user in frontend.

### DIFF
--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -231,7 +231,7 @@ export function info_for(user_id: number, direct_message_recipients: Set<number>
     };
 
     return {
-        href: hash_util.pm_with_url(person.email),
+        href: hash_util.pm_with_url(person.user_id.toString()),
         name: person.full_name,
         user_id,
         status_emoji_info,

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -162,8 +162,8 @@ export function by_sender_url(reply_to: string): string {
     return search_terms_to_hash([{operator: "sender", operand: reply_to}]);
 }
 
-export function pm_with_url(reply_to: string): string {
-    const slug = people.emails_to_slug(reply_to);
+export function pm_with_url(user_ids_string: string): string {
+    const slug = people.user_ids_string_to_slug(user_ids_string);
     return "#narrow/dm/" + slug;
 }
 

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -469,8 +469,6 @@ function format_dm(
         recipient_ids.push(people.my_current_user_id());
     }
 
-    const reply_to = people.user_ids_string_to_emails_string(user_ids_string);
-    assert(reply_to !== undefined);
     const rendered_dm_with_html = recipient_ids
         .map((recipient_id) => ({
             name: people.get_display_full_name(recipient_id),
@@ -501,7 +499,7 @@ function format_dm(
         is_group: recipient_ids.length > 1,
         user_circle_class,
         is_bot,
-        dm_url: hash_util.pm_with_url(reply_to),
+        dm_url: hash_util.pm_with_url(user_ids_string),
         user_ids_string,
         unread_count,
         is_hidden: filter_should_hide_dm_row({dm_key: user_ids_string}),

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -653,6 +653,10 @@ export function pm_perma_link(message: Message): string | undefined {
     return url;
 }
 
+export function get_slug_from_full_name(full_name: string): string {
+    return full_name.replaceAll(/[ "%/<>`\p{C}]+/gu, "-");
+}
+
 export function pm_with_url(message: Message | MessageWithBooleans): string | undefined {
     const user_ids = pm_with_user_ids(message);
 
@@ -667,7 +671,7 @@ export function pm_with_url(message: Message | MessageWithBooleans): string | un
     } else {
         const person = maybe_get_user_by_id(user_ids[0]);
         if (person?.full_name) {
-            suffix = person.full_name.replaceAll(/[ "%/<>`\p{C}]+/gu, "-");
+            suffix = get_slug_from_full_name(person.full_name);
         } else {
             blueslip.error("Unknown people in message");
             suffix = "unk";
@@ -759,8 +763,7 @@ export function emails_to_slug(emails_string: string): string | undefined {
     if (emails.length === 1 && emails[0] !== undefined) {
         const person = get_by_email(emails[0]);
         assert(person !== undefined, "Unknown person in emails_to_slug");
-        const name = person.full_name;
-        slug += name.replaceAll(/[ "%/<>`\p{C}]+/gu, "-");
+        slug += get_slug_from_full_name(person.full_name);
     } else {
         slug += "group";
     }

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -771,6 +771,20 @@ export function emails_to_slug(emails_string: string): string | undefined {
     return slug;
 }
 
+export function user_ids_string_to_slug(user_ids_string: string): string | undefined {
+    let slug = user_ids_string;
+    slug += "-";
+    const user_ids = user_ids_string_to_ids_array(user_ids_string);
+    if (user_ids.length === 1 && user_ids[0] !== undefined) {
+        const person = get_by_user_id(user_ids[0]);
+        assert(person !== undefined, "Unknown person in user_ids_string_to_slug");
+        slug += get_slug_from_full_name(person.full_name);
+    } else {
+        slug += "group";
+    }
+    return slug;
+}
+
 export function slug_to_emails(slug: string): string | undefined {
     /*
         It's not super important to be flexible about

--- a/web/src/pm_list_data.ts
+++ b/web/src/pm_list_data.ts
@@ -1,5 +1,3 @@
-import assert from "minimalistic-assert";
-
 import * as buddy_data from "./buddy_data.ts";
 import * as hash_util from "./hash_util.ts";
 import * as narrow_state from "./narrow_state.ts";
@@ -79,8 +77,6 @@ export function get_conversations(search_string = ""): DisplayObject[] {
             continue;
         }
 
-        const reply_to = people.user_ids_string_to_emails_string(user_ids_string);
-        assert(reply_to !== undefined);
         const recipients_string = people.format_recipients(user_ids_string, "narrow");
 
         const num_unread = unread.num_unread_for_user_ids_string(user_ids_string);
@@ -117,7 +113,7 @@ export function get_conversations(search_string = ""): DisplayObject[] {
             unread: num_unread,
             is_zero: num_unread === 0,
             is_active,
-            url: hash_util.pm_with_url(reply_to),
+            url: hash_util.pm_with_url(user_ids_string),
             status_emoji_info,
             user_circle_class,
             is_group,

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -355,7 +355,7 @@ function get_user_card_popover_data(
         is_bot: user.is_bot,
         is_me,
         is_sender_popover,
-        pm_with_url: hash_util.pm_with_url(user.email),
+        pm_with_url: hash_util.pm_with_url(user.user_id.toString()),
         user_circle_class: buddy_data.get_user_circle_class(user.user_id),
         private_message_class: private_msg_class,
         sent_by_url: hash_util.by_sender_url(user.email),

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -207,7 +207,7 @@ run_test("urls", () => {
     people.add_active_user(me);
     people.initialize_current_user(me.user_id);
 
-    let url = hash_util.pm_with_url(ray.email);
+    let url = hash_util.pm_with_url(ray.user_id.toString());
     assert.equal(url, "#narrow/dm/22-Raymond");
 
     url = hash_util.direct_message_group_with_url("22,23");

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -925,6 +925,9 @@ test_people("multi_user_methods", () => {
     assert.equal(slug, "401,402-group");
 
     assert.equal(people.reply_to_to_user_ids_string("invalid@example.com"), undefined);
+
+    assert.equal(people.user_ids_string_to_slug("401,402"), "401,402-group");
+    assert.equal(people.user_ids_string_to_slug("402"), "402-whatever-402");
 });
 
 test_people("user_ids_to_full_names_string", () => {


### PR DESCRIPTION
Extracted from last commit in #34834 (as the first 2 have already been merged).

For further progress on extracting the rest of #34834, waiting for a definite reply of [#frontend > filter operand type: number or string? @ 💬](https://chat.zulip.org/#narrow/channel/6-frontend/topic/filter.20operand.20type.3A.20number.20or.20string.3F/near/2203962)