### PR TITLE
dom_selectors: Replace `html` selectors with `:root`, `document`.

### DIFF
--- a/web/src/activity.ts
+++ b/web/src/activity.ts
@@ -192,7 +192,7 @@ export function mark_client_active(): void {
 }
 
 export function initialize(): void {
-    $("html").on("mousemove", () => {
+    $(document).on("mousemove", () => {
         set_new_user_input(true);
     });
 

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1113,7 +1113,7 @@ class InboxTopicListWidget extends TopicListWidget {
                 );
                 return render_inbox_row(topic_context);
             },
-            $simplebar_container: $("html"),
+            $simplebar_container: $(":root"),
             is_scroll_position_for_render: views_util.is_scroll_position_for_render,
             get_min_load_count,
         });

--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -14,7 +14,7 @@ export type MessageViewportInfo = {
     visible_height: number;
 };
 
-export const $scroll_container = $("html");
+export const $scroll_container = $(":root");
 
 let in_stoppable_autoscroll = false;
 

--- a/web/src/overlay_util.ts
+++ b/web/src/overlay_util.ts
@@ -7,9 +7,9 @@ export function disable_scrolling(): void {
     // as part of the document flow, we cannot capture `scroll` events on them and prevent propagation
     // as event bubbling doesn't work naturally.
     const scrollbar_width = window.innerWidth - document.documentElement.clientWidth;
-    $("html").css({"overflow-y": "hidden", "--disabled-scrollbar-width": `${scrollbar_width}px`});
+    $(":root").css({"overflow-y": "hidden", "--disabled-scrollbar-width": `${scrollbar_width}px`});
 }
 
 export function enable_scrolling(): void {
-    $("html").css({"overflow-y": "scroll", "--disabled-scrollbar-width": "0px"});
+    $(":root").css({"overflow-y": "scroll", "--disabled-scrollbar-width": "0px"});
 }

--- a/web/src/realm_logo.ts
+++ b/web/src/realm_logo.ts
@@ -98,7 +98,7 @@ export function render(): void {
     $realm_logo.on("load", () => {
         const logo_width = $realm_logo.width();
         if (logo_width) {
-            $("html").css(
+            $(":root").css(
                 "--realm-logo-current-width",
                 logo_width / user_settings.web_font_size_px + "em",
             );

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1319,7 +1319,7 @@ export function complete_rerender(): void {
     }
 
     if (!page_params.is_node_test) {
-        max_avatars = Number.parseInt($("html").css("--recent-view-max-avatars"), 10);
+        max_avatars = Number.parseInt($(":root").css("--recent-view-max-avatars"), 10);
     }
 
     // Show topics list

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -334,7 +334,7 @@ function set_table_focus(row: number, col: number, using_keyboard = false): bool
     $current_focus_elem = "table";
 
     if (using_keyboard) {
-        const scroll_element = util.the($("html"));
+        const scroll_element = util.the($(":root"));
         const half_height_of_visible_area = scroll_element.offsetHeight / 2;
         const topic_offset = topic_offset_to_visible_area($topic_row);
 
@@ -1370,7 +1370,7 @@ export function complete_rerender(): void {
             ...list_widget.generic_sort_functions("numeric", ["last_msg_id"]),
         },
         html_selector: get_topic_row,
-        $simplebar_container: $("html"),
+        $simplebar_container: $(":root"),
         callback_after_render,
         is_scroll_position_for_render: views_util.is_scroll_position_for_render,
         post_scroll__pre_render_callback() {

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -126,7 +126,7 @@ export function reset_compose_message_max_height(bottom_whitespace_height?: numb
 
 export function resize_bottom_whitespace(): void {
     const bottom_whitespace_height = get_bottom_whitespace_height();
-    $("html").css("--max-unmaximized-compose-height", `${bottom_whitespace_height}px`);
+    $(":root").css("--max-unmaximized-compose-height", `${bottom_whitespace_height}px`);
     // The height of the compose box is tied to that of
     // bottom_whitespace, so update it if necessary.
     //
@@ -174,7 +174,7 @@ export function resize_stream_subscribers_list(): void {
         total_height_of_classes_above_subscribers_list -
         subscribers_list_header_height -
         margin_between_tab_switcher_and_add_subscribers_title;
-    $("html").css("--stream-subscriber-list-max-height", `${subscribers_list_height}px`);
+    $(":root").css("--stream-subscriber-list-max-height", `${subscribers_list_height}px`);
 }
 
 export function resize_stream_filters_container(): void {
@@ -192,7 +192,7 @@ export function resize_sidebars(): void {
 export function update_recent_view(): void {
     const $recent_view_filter_container = $("#recent_view_filter_buttons");
     const recent_view_filters_height = $recent_view_filter_container.outerHeight(true) ?? 0;
-    $("html").css("--recent-topics-filters-height", `${recent_view_filters_height}px`);
+    $(":root").css("--recent-topics-filters-height", `${recent_view_filters_height}px`);
 
     // Update max avatars to prevent participant avatars from overflowing.
     // These numbers are just based on speculation.
@@ -203,9 +203,9 @@ export function update_recent_view(): void {
     const num_avatars_narrow_window = 2;
     const num_avatars_max = 4;
     if (recent_view_filters_width < media_breakpoints_num.md) {
-        $("html").css("--recent-view-max-avatars", num_avatars_narrow_window);
+        $(":root").css("--recent-view-max-avatars", num_avatars_narrow_window);
     } else {
-        $("html").css("--recent-view-max-avatars", num_avatars_max);
+        $(":root").css("--recent-view-max-avatars", num_avatars_max);
     }
 }
 

--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -173,7 +173,7 @@ export function is_scroll_position_for_render(): boolean {
     // new rows to render when the user is scrolling to the bottom of
     // the view. So, we render new rows when user has scrolled 2 / 3
     // of (the total scrollable height - the empty space).
-    const compose_max_height = $("html").css("--max-unmaximized-compose-height");
+    const compose_max_height = $(":root").css("--max-unmaximized-compose-height");
     assert(typeof compose_max_height === "string");
     const scroll_max = document.body.scrollHeight - Number.parseInt(compose_max_height, 10);
     return scroll_position + window_height >= (2 / 3) * scroll_max;

--- a/web/tests/activity.test.cjs
+++ b/web/tests/activity.test.cjs
@@ -740,6 +740,7 @@ test("update_presence_info", ({override, override_rewire}) => {
 });
 
 test("initialize", ({override, override_rewire}) => {
+    override(document, "to_$", () => $("document-stub"));
     override(pm_list, "update_private_messages", noop);
     override(watchdog, "check_for_unsuspend", noop);
     override(buddy_list, "fill_screen_with_content", noop);
@@ -828,7 +829,7 @@ test("initialize", ({override, override_rewire}) => {
 
     // Exercise the mousemove handler, which just
     // sets a flag.
-    $("html").get_on_handler("mousemove")();
+    $(document).get_on_handler("mousemove")();
 
     clear();
 });


### PR DESCRIPTION
[#kandra js errors > $scroll_container initialization @ 💬](https://chat.zulip.org/#narrow/channel/464-kandra-js-errors/topic/.24scroll_container.20initialization/near/2239892)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
