### PR TITLE
reminders: Show vdots with reminders popover open.

### DIFF
--- a/web/src/compose_send_menu_popover.js
+++ b/web/src/compose_send_menu_popover.js
@@ -71,6 +71,9 @@ export function open_schedule_message_menu(
         },
         onMount(instance) {
             if (remind_message_id !== undefined) {
+                // Maintain the vdots visibility, as when the message
+                // actions menu is open
+                $(instance.reference).closest(".message_row").addClass("has_actions_popover");
                 popover_menus.focus_first_popover_item(
                     popover_menus.get_popover_items_for_instance(instance),
                 );
@@ -137,6 +140,10 @@ export function open_schedule_message_menu(
             );
         },
         onHidden(instance) {
+            if (remind_message_id !== undefined) {
+                // Hide the vdots
+                $(instance.reference).closest(".message_row").removeClass("has_actions_popover");
+            }
             clearInterval(interval);
             instance.destroy();
             popover_menus.popover_instances.send_later_options = undefined;


### PR DESCRIPTION
[#issues > vdots while scheduling a reminder](https://chat.zulip.org/#narrow/channel/9-issues/topic/vdots.20while.20scheduling.20a.20reminder)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="640" height="790" alt="reminder-vdots-before" src="https://github.com/user-attachments/assets/cece7858-7e31-4a0a-aab7-cf094b535ec2" /> | <img width="640" height="790" alt="reminder-vdots-after" src="https://github.com/user-attachments/assets/53d4a21e-2d18-481f-97d3-3a8fe487c16a" /> |

