### PR TITLE
composebox: Fix composebox closing on clicking links.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -941,18 +941,16 @@ export function initialize(): void {
         }
 
         if (compose_state.composing() && $(e.target).parents("#compose").length === 0) {
-            const should_prevent_click_behavior = mouse_drag.is_drag(e);
-            if (
-                should_prevent_click_behavior ||
-                $(e.target).closest(".copy_codeblock").length > 0
-            ) {
-                // We want to avoid blurring a selected link by triggering a
-                // focus event on the compose textarea.
-                if (should_prevent_click_behavior) {
-                    // To avoid the click behavior if a link is selected.
+            const is_click_within_link = $(e.target).closest("a").length > 0;
+            if (is_click_within_link || $(e.target).closest(".copy_codeblock").length > 0) {
+                const is_selecting_link_text = is_click_within_link && mouse_drag.is_drag(e);
+                if (is_selecting_link_text) {
+                    // Avoid triggering the click handler for a link
+                    // when just dragging over it to select the text.
                     e.preventDefault();
                     return;
                 }
+
                 // Refocus compose message text box if one clicks an external
                 // link/url to view something else while composing a message.
                 // See issue #4331 for more details.


### PR DESCRIPTION
Previously, clicking on links with the composebox open didn't close it.

7391a2983fa8d338d19a73c318b79d57e07ad635 introduced a bug where the composebox focus logic wasn't triggered at all if drag evidence wasn't present on the target.

We now do a `e.target.closest("a").length > 0` check like before and only prevent the default click behavior if dragging on the target link is detected.
This allows normal link clicks to trigger the
previous composebox focus trigger logic.

Fixes: https://chat.zulip.org/#narrow/channel/9-issues/topic/composebox.20closes.20when.20going.20to.20recent.20conversations





<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**Before:**
https://github.com/user-attachments/assets/4ba68783-5f1a-48be-96b8-4957f5343b66

**After:**
https://github.com/user-attachments/assets/0ca11997-5909-4ad5-b170-7c7174e9b09f

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
