### PR TITLE
api_docs: Mark legacy mobile notifications endpoints as deprecated.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12994,11 +12994,17 @@ paths:
                           An example JSON response for when the user is not previously muted:
   /users/me/apns_device_token:
     post:
+      deprecated: true
       operationId: add-apns-token
       summary: Add an APNs device token
       tags: ["users"]
       description: |
         This endpoint adds an APNs device token to register for iOS push notifications.
+
+        **Changes**: Deprecated in Zulip 11.0 (feature level 406). Clients connecting
+        to newer servers and with E2EE push notifications support should use the
+        [Register E2EE push device](/api/register-push-device) endpoint, as this
+        endpoint will be removed in a future release.
       requestBody:
         required: true
         content:
@@ -13106,11 +13112,17 @@ paths:
                           A typical failed JSON response for when the token does not exist:
   /users/me/android_gcm_reg_id:
     post:
+      deprecated: true
       operationId: add-fcm-token
       summary: Add an FCM registration token
       tags: ["users"]
       description: |
         This endpoint adds an FCM registration token for push notifications.
+
+        **Changes**: Deprecated in Zulip 11.0 (feature level 406). Clients connecting
+        to newer servers and with E2EE push notifications support should use the
+        [Register E2EE push device](/api/register-push-device) endpoint, as this
+        endpoint will be removed in a future release.
       requestBody:
         required: true
         content:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12590,6 +12590,7 @@ paths:
           $ref: "#/components/responses/SimpleSuccess"
   /mobile_push/test_notification:
     post:
+      deprecated: true
       operationId: test-notify
       summary: Send a test notification to mobile device(s)
       tags: ["mobile"]
@@ -12597,7 +12598,13 @@ paths:
         Trigger sending a test push notification to the user's
         selected mobile device or all of their mobile devices.
 
-        **Changes**: Starting with Zulip 8.0 (feature level 234), test
+        **Changes**: Deprecated in Zulip 11.0 (feature level 420).
+        Clients connecting to newer servers and with E2EE push
+        notifications support should use the
+        [Send an E2EE test notification to mobile device(s)](/api/e2ee-test-notify)
+        endpoint, as this endpoint will be removed in a future release.
+
+        Starting with Zulip 8.0 (feature level 234), test
         notifications sent via this endpoint use `test` rather than
         `test-by-device-token` in the `event` field. Also, as of this
         feature level, all mobile push notifications now include a


### PR DESCRIPTION
Fixes part of #35213 
> Once we integrate https://github.com/zulip/zulip/pull/35139, I expect we'll want to go through our API documentation for the old protocol and mark it all as deprecated/legacy.

Remaining endpoints to deprecate ([#api design > unregister push device](https://chat.zulip.org/#narrow/channel/378-api-design/topic/unregister.20push.20device/with/2250939)):
* https://zulip.com/api/remove-apns-token
* https://zulip.com/api/remove-fcm-token

---

<img width="523" height="376" alt="Screenshot 2025-08-28 at 7 53 53 PM" src="https://github.com/user-attachments/assets/e794f5ab-bd8b-429f-93cb-25dc3a9c69d0" />

<img width="526" height="228" alt="Screenshot 2025-08-28 at 7 54 13 PM" src="https://github.com/user-attachments/assets/91201e80-8e8a-447d-88b0-1ebd349e31cd" />

<img width="516" height="221" alt="Screenshot 2025-08-28 at 7 54 38 PM" src="https://github.com/user-attachments/assets/b2c22d3b-45f4-483a-8a55-b0ac3e25ad54" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

