### PR TITLE
import: Set Stream.subscriber_count for imported channels.

### DIFF
--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -1773,6 +1773,12 @@ class RealmImportExportTest(ExportFile):
                 stream.recipient_id,
                 Recipient.objects.get(type=Recipient.STREAM, type_id=stream.id).id,
             )
+            self.assertEqual(
+                stream.subscriber_count,
+                Subscription.objects.filter(
+                    recipient=stream.recipient, active=True, is_user_active=True
+                ).count(),
+            )
 
         # Check folder field for imported streams
         for stream in Stream.objects.filter(realm=imported_realm):


### PR DESCRIPTION
The import code wasn't setting subscriber_count at all, resulting in a value of 0 when dealing with imports from 3rd party apps. We run this unconditionally, also for imports from Zulip, since this ensures we won't inherit incorrect values, if the data we're import has them - e.g. due to some bugs that affected the server the data came from.

