### PR TITLE
channel_folders: Don't label section OTHER if there are no folders above it.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -858,7 +858,7 @@ function get_folder_name_from_id(folder_id: number): string {
     }
 
     if (folder_id === OTHER_CHANNELS_FOLDER_ID) {
-        return $t({defaultMessage: "CHANNELS"});
+        return $t({defaultMessage: "OTHER CHANNELS"});
     }
 
     return channel_folders.get_channel_folder_by_id(folder_id).name;

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -223,6 +223,15 @@ export function sort_groups(
         (section_a, section_b) => section_a.order! - section_b.order!,
     );
 
+    if (
+        pinned_section.streams.length > 0 ||
+        pinned_section.muted_streams.length > 0 ||
+        pinned_section.inactive_streams.length > 0 ||
+        folder_sections.size > 0
+    ) {
+        normal_section.section_title = $t({defaultMessage: "OTHER"});
+    }
+
     // This needs to have the same ordering as the order they're displayed in the sidebar.
     const new_sections = [pinned_section, ...folder_sections_sorted, normal_section];
 


### PR DESCRIPTION
Fixes #35878.

<img width="1962" height="1734" alt="image" src="https://github.com/user-attachments/assets/51363764-bcbf-4a8a-b02b-a986de014a8f" />

<img width="976" height="661" alt="image" src="https://github.com/user-attachments/assets/065575f7-cd57-48ef-9e06-ef4cdf7f7cc8" />
