### PR TITLE
Rename `dm-including` filter to `dm-with`

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -25,6 +25,13 @@ format used by the Zulip server that they are interacting with.
 * [`POST /register`](/api/register-queue): Removed the
   `realm_is_zephyr_mirror_realm` property from the response.
 
+**Feature level 425**
+
+* [`GET /messages`](/api/get-messages), [`POST /register`](/api/register-queue):
+  The `dm-including` narrow filter has been renamed to `dm-with`. The old
+  `dm-including` name continues to work for backwards compatibility, but
+  `dm-with` is now the preferred and documented name.
+
 Feature levels 421-424 reserved for future use in 11.x maintenance
 releases.
 

--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -85,14 +85,14 @@ as an empty string.
   reaction](/help/emoji-reactions).
 
 * In Zulip 7.0 (feature level 177), support was added for three filters
-  related to direct messages: `is:dm`, `dm` and `dm-including`. The
+  related to direct messages: `is:dm`, `dm` and `dm-with`. The
   `dm` operator replaced and deprecated the `pm-with` operator. The
   `is:dm` filter replaced and deprecated the `is:private` filter. The
-  `dm-including` operator replaced and deprecated the `group-pm-with`
+  `dm-with` operator replaced and deprecated the `group-pm-with`
   operator.
 
-    * The `dm-including` and `group-pm-with` operators return slightly
-      different results. For example, `dm-including:1234` returns all
+    * The `dm-with` and `group-pm-with` operators return slightly
+      different results. For example, `dm-with:1234` returns all
       direct messages (1-on-1 and group) that include the current user
       and the user with the unique user ID of `1234`. On the other hand,
       `group-pm-with:1234` returned only group direct messages that

--- a/starlight_help/src/content/docs/search-for-messages.mdx
+++ b/starlight_help/src/content/docs/search-for-messages.mdx
@@ -94,7 +94,7 @@ Zulip offers the following filters based on the location of the message.
 * `dm:Bo Lin`: Search 1-on-1 direct messages between you and Bo.
 * `dm:Bo Lin, Elena García`: Search group direct messages
   between you, Bo, and Elena.
-* `dm-including:Bo Lin`: Search all direct message conversations
+* `dm-with:Bo Lin`: Search all direct message conversations
   (1-on-1 and group) that include you and Bo, as well as any other users.
 
 ### Search shared history

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -206,7 +206,9 @@ function message_matches_search_term(message: Message, operator: string, operand
             return _.isEqual(operand_ids, user_ids);
         }
 
+        case "dm-with":
         case "dm-including": {
+            // Legacy alias handled by falling through to the same logic
             const operand_user = people.get_by_email(operand);
             if (operand_user === undefined) {
                 return false;
@@ -236,7 +238,8 @@ export function create_user_pill_context(user: User): UserPillItem {
 }
 
 const USER_OPERATORS = new Set([
-    "dm-including",
+    "dm-with",
+    "dm-including", // Legacy alias
     "dm",
     "sender",
     "from",
@@ -268,9 +271,14 @@ export class Filter {
             return "dm";
         }
 
+        if (operator === "dm-including") {
+            // "dm-including:" was renamed to "dm-with:"
+            return "dm-with";
+        }
+
         if (operator === "group-pm-with") {
-            // "group-pm-with:" was replaced with "dm-including:"
-            return "dm-including";
+            // "group-pm-with:" was replaced with "dm-with:"
+            return "dm-with";
         }
 
         if (operator === "from") {
@@ -319,7 +327,8 @@ export class Filter {
                     operand = people.my_current_email();
                 }
                 break;
-            case "dm-including":
+            case "dm-with":
+            case "dm-including": // Legacy alias
                 operand = operand.toLowerCase();
                 break;
             case "search":
@@ -542,7 +551,8 @@ export class Filter {
             case "dm":
             case "pm":
             case "pm-with":
-            case "dm-including":
+            case "dm-with":
+            case "dm-including": // Legacy alias
             case "pm-including":
                 if (term.operand === "me") {
                     return true;
@@ -608,7 +618,8 @@ export class Filter {
             "channel",
             "topic",
             "dm",
-            "dm-including",
+            "dm-with",
+            "dm-including", // Legacy alias
             "with",
             "sender",
             "near",
@@ -679,8 +690,11 @@ export class Filter {
             case "dm":
                 return verb + "direct messages with";
 
-            case "dm-including":
-                return verb + "direct messages including";
+            case "dm-with":
+                return verb + "direct messages with";
+
+            case "dm-including": // Legacy alias
+                return verb + "direct messages with";
 
             case "in":
                 return verb + "messages in";
@@ -1094,8 +1108,10 @@ export class Filter {
             "topic",
             "not-topic",
             "dm",
-            "dm-including",
+            "dm-with",
+            "dm-including", // Legacy alias
             "not-dm-including",
+            "not-dm-with",
             "is-dm",
             "not-is-dm",
             "is-resolved",
@@ -1545,7 +1561,8 @@ export class Filter {
         return (
             (this.has_operator("is") && this.operands("is")[0] === "dm") ||
             this.has_operator("dm") ||
-            this.has_operator("dm-including")
+            this.has_operator("dm-with") ||
+            this.has_operator("dm-including") // Legacy alias
         );
     }
 
@@ -1685,7 +1702,8 @@ export class Filter {
     update_email(user_id: number, new_email: string): void {
         for (const term of this._terms) {
             switch (term.operator) {
-                case "dm-including":
+                case "dm-with":
+                case "dm-including": // Legacy alias
                 case "group-pm-with":
                 case "dm":
                 case "pm-with":

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -31,6 +31,7 @@ export function build_reload_url(): string {
 export function encode_operand(operator: string, operand: string): string {
     if (
         operator === "group-pm-with" ||
+        operator === "dm-with" ||
         operator === "dm-including" ||
         operator === "dm" ||
         operator === "sender" ||
@@ -61,6 +62,7 @@ export function encode_stream_id(stream_id: number): string {
 export function decode_operand(operator: string, operand: string): string {
     if (
         operator === "group-pm-with" ||
+        operator === "dm-with" ||
         operator === "dm-including" ||
         operator === "dm" ||
         operator === "sender" ||

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -260,7 +260,7 @@ function handle_operators_supporting_id_based_api(narrow_parameter: string): str
     // We use the canonical operator when checking these sets, so legacy
     // operators, such as "pm-with" and "stream", are not included here.
     const operators_supporting_ids = new Set(["dm"]);
-    const operators_supporting_id = new Set(["id", "channel", "sender", "dm-including"]);
+    const operators_supporting_id = new Set(["id", "channel", "sender", "dm-with", "dm-including"]);
     const parsed_narrow_data = z.array(narrow_term_schema).parse(JSON.parse(narrow_parameter));
 
     const narrow_terms: {

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -450,7 +450,9 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                 title: $t({defaultMessage: "This user does not exist!"}),
             };
         }
+        case "dm-with":
         case "dm-including": {
+            // Legacy alias
             const person_in_dms = people.get_by_email(first_operand);
             if (!person_in_dms) {
                 return {

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -46,7 +46,7 @@ type SearchPill =
 export type SearchPillWidget = InputPillContainer<SearchPill>;
 
 // These operator types use user pills as operands.
-const user_pill_operators = new Set(["dm", "dm-including", "sender"]);
+const user_pill_operators = new Set(["dm", "dm-with", "dm-including", "sender"]);
 
 export function create_item_from_search_string(search_string: string): SearchPill | undefined {
     const search_term = util.the(Filter.parse(search_string));

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -29,7 +29,8 @@ type TermPattern = Omit<NarrowTerm, "operand"> & Partial<Pick<NarrowTerm, "opera
 const channel_incompatible_patterns = [
     {operator: "is", operand: "dm"},
     {operator: "channel"},
-    {operator: "dm-including"},
+    {operator: "dm-with"},
+    {operator: "dm-including"}, // Legacy alias
     {operator: "dm"},
     {operator: "in"},
     {operator: "channels"},
@@ -43,7 +44,8 @@ const incompatible_patterns: Record<string, TermPattern[]> = {
     topic: [
         {operator: "dm"},
         {operator: "is", operand: "dm"},
-        {operator: "dm-including"},
+        {operator: "dm-with"},
+        {operator: "dm-including"}, // Legacy alias
         {operator: "topic"},
     ],
     dm: [
@@ -58,18 +60,21 @@ const incompatible_patterns: Record<string, TermPattern[]> = {
         {operator: "channel"},
         {operator: "is", operand: "resolved"},
     ],
-    "dm-including": [{operator: "channel"}, {operator: "stream"}],
+    "dm-with": [{operator: "channel"}, {operator: "stream"}],
+    "dm-including": [{operator: "channel"}, {operator: "stream"}], // Legacy alias
     "is:resolved": [
         {operator: "is", operand: "resolved"},
         {operator: "is", operand: "dm"},
         {operator: "dm"},
-        {operator: "dm-including"},
+        {operator: "dm-with"},
+        {operator: "dm-including"}, // Legacy alias
     ],
     "-is:resolved": [
         {operator: "is", operand: "resolved"},
         {operator: "is", operand: "dm"},
         {operator: "dm"},
-        {operator: "dm-including"},
+        {operator: "dm-with"},
+        {operator: "dm-including"}, // Legacy alias
     ],
     "is:dm": [
         {operator: "is", operand: "dm"},
@@ -87,7 +92,8 @@ const incompatible_patterns: Record<string, TermPattern[]> = {
         {operator: "is", operand: "followed"},
         {operator: "is", operand: "dm"},
         {operator: "dm"},
-        {operator: "dm-including"},
+        {operator: "dm-with"},
+        {operator: "dm-including"}, // Legacy alias
     ],
     "is:alerted": [{operator: "is", operand: "alerted"}],
     "is:unread": [{operator: "is", operand: "unread"}],
@@ -356,7 +362,7 @@ function make_people_getter(last: NarrowTerm): () => User[] {
     };
 }
 
-// Possible args for autocomplete_operator: dm, pm-with, sender, from, dm-including
+// Possible args for autocomplete_operator: dm, pm-with, sender, from, dm-with
 function get_person_suggestions(
     people_getter: () => User[],
     last: NarrowTerm,
@@ -803,6 +809,7 @@ function get_operator_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugges
             "channel",
             "topic",
             "dm",
+            "dm-with",
             "dm-including",
             "sender",
             "near",
@@ -827,6 +834,11 @@ function get_operator_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugges
         // who have "pm-with" in their muscle memory.
         if (choice === "pm-with") {
             choice = "dm";
+        }
+        // Map results for "dm-with:" operator for users
+        // who have "dm-including" in their muscle memory.
+        if (choice === "dm-including") {
+            choice = "dm-with";
         }
         // Map results for "channel:" operator for users
         // who have "stream" in their muscle memory.
@@ -992,7 +1004,7 @@ export function get_search_result(
         last = text_search_terms.at(-1)!;
     }
 
-    const person_suggestion_ops = ["sender", "dm", "dm-including", "from", "pm-with"];
+    const person_suggestion_ops = ["sender", "dm", "dm-with", "dm-including", "from", "pm-with"];
 
     // Handle spaces in person name in new suggestions only. Checks if the last operator is 'search'
     // and the second last operator in search_terms is one out of person_suggestion_ops.
@@ -1064,6 +1076,7 @@ export function get_search_result(
         get_channel_suggestions,
         get_people("dm"),
         get_people("sender"),
+        get_people("dm-with"),
         get_people("dm-including"),
         get_people("from"),
         get_topic_suggestions,

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -52,7 +52,7 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="operator">dm-including:<span class="operator_value">user</span></td>
+                        <td class="operator">dm-with:<span class="operator_value">user</span></td>
                         <td class="definition">
                             {{#tr}}
                                 Narrow to direct messages that include <z-value></z-value>.

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -472,7 +472,7 @@ test("basics", () => {
     assert.ok(!filter.is_channel_view());
     assert.ok(!filter.has_exactly_channel_topic_operators());
 
-    terms = [{operator: "dm-including", operand: "joe@example.com"}];
+    terms = [{operator: "dm-with", operand: "joe@example.com"}];
     filter = new Filter(terms);
     assert.ok(!filter.is_non_group_direct_message());
     assert.ok(filter.contains_only_private_messages());
@@ -486,10 +486,10 @@ test("basics", () => {
     assert.ok(!filter.is_channel_view());
     assert.ok(!filter.has_exactly_channel_topic_operators());
 
-    // "group-pm-with" was replaced with "dm-including"
+    // "group-pm-with" was replaced with "dm-with"
     terms = [{operator: "group-pm-with", operand: "joe@example.com"}];
     filter = new Filter(terms);
-    assert.ok(filter.has_operator("dm-including"));
+    assert.ok(filter.has_operator("dm-with"));
     assert.ok(!filter.has_operator("group-pm-with"));
     assert.ok(!filter.is_channel_view());
     assert.ok(!filter.has_exactly_channel_topic_operators());
@@ -987,9 +987,14 @@ test("canonicalization", () => {
     assert.equal(term.operator, "dm");
     assert.equal(term.operand, "me@example.com");
 
-    // "group-pm-with" was replaced with "dm-including"
+    // "group-pm-with" was replaced with "dm-with"
     term = Filter.canonicalize_term({operator: "group-pm-with", operand: "joe@example.com"});
-    assert.equal(term.operator, "dm-including");
+    assert.equal(term.operator, "dm-with");
+    assert.equal(term.operand, "joe@example.com");
+
+    // "dm-including" is now a legacy alias for "dm-with"
+    term = Filter.canonicalize_term({operator: "dm-including", operand: "joe@example.com"});
+    assert.equal(term.operator, "dm-with");
     assert.equal(term.operand, "joe@example.com");
 
     term = Filter.canonicalize_term({operator: "search", operand: "foo"});
@@ -1299,7 +1304,7 @@ test("predicate_basics", ({override}) => {
         }),
     );
 
-    predicate = get_predicate([["dm-including", "nobody@example.com"]]);
+    predicate = get_predicate([["dm-with", "nobody@example.com"]]);
     assert.ok(
         !predicate({
             type: direct_message,
@@ -1307,7 +1312,7 @@ test("predicate_basics", ({override}) => {
         }),
     );
 
-    predicate = get_predicate([["dm-including", "Joe@example.com"]]);
+    predicate = get_predicate([["dm-with", "Joe@example.com"]]);
     assert.ok(
         predicate({
             type: direct_message,
@@ -1739,6 +1744,13 @@ test("describe", ({mock_template, override}) => {
     string = "messages in home";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
+    narrow = [
+        {operator: "in", operand: "all"},
+        {operator: "is", operand: "starred"},
+    ];
+    string = "messages in all, starred messages";
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
+
     narrow = [{operator: "is", operand: "mentioned"}];
     string = "messages that mention you";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
@@ -1852,6 +1864,18 @@ test("describe", ({mock_template, override}) => {
     narrow = [{operator: "topic", operand: ""}];
     string = "topic ";
     assert.equal(Filter.search_description_as_html(narrow, true), string);
+});
+
+test("operator_to_prefix_aliases", () => {
+    // Test dm-with alias coverage.
+    assert.equal(Filter.operator_to_prefix("dm-with", false), "direct messages with");
+    assert.equal(Filter.operator_to_prefix("dm-with", true), "exclude direct messages with");
+});
+
+test("operator_to_prefix_legacy_aliases", () => {
+    // Test dm-including legacy alias coverage - should behave same as dm-with
+    assert.equal(Filter.operator_to_prefix("dm-including", false), "direct messages with");
+    assert.equal(Filter.operator_to_prefix("dm-including", true), "exclude direct messages with");
 });
 
 test("can_bucket_by", () => {
@@ -2062,7 +2086,7 @@ test("is_valid_search_term", () => {
         ["channels:public", true],
         ["channels:private", false],
         ["topic:GhostTown", true],
-        ["dm-including:alice@example.com", true],
+        ["dm-with:alice@example.com", true],
         ["sender:ghost@zulip.com", false],
         ["sender:me", true],
         ["dm:alice@example.com,ghost@example.com", false],
@@ -2828,6 +2852,10 @@ run_test("is_spectator_compatible", () => {
     assert.ok(Filter.is_spectator_compatible([{operator: "sender", operand: "hamlet@zulip.com"}]));
     assert.ok(!Filter.is_spectator_compatible([{operator: "dm", operand: "hamlet@zulip.com"}]));
     assert.ok(
+        !Filter.is_spectator_compatible([{operator: "dm-with", operand: "hamlet@zulip.com"}]),
+    );
+    // Test backwards compatibility with dm-including
+    assert.ok(
         !Filter.is_spectator_compatible([{operator: "dm-including", operand: "hamlet@zulip.com"}]),
     );
 
@@ -2859,7 +2887,7 @@ run_test("is_spectator_compatible", () => {
     assert.ok(Filter.is_spectator_compatible([{operator: "stream", operand: "Denmark"}]));
     // "streams" was renamed to "channels"
     assert.ok(Filter.is_spectator_compatible([{operator: "streams", operand: "public"}]));
-    // "group-pm-with:" was replaced with "dm-including:"
+    // "group-pm-with:" was replaced with "dm-with:"
     assert.ok(
         !Filter.is_spectator_compatible([{operator: "group-pm-with", operand: "hamlet@zulip.com"}]),
     );

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -501,14 +501,14 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     override(realm, "realm_direct_message_permission_group", nobody.id);
 
     // prioritize information about invalid user in narrow/search
-    current_filter = set_filter([["dm-including", "Yo"]]);
+    current_filter = set_filter([["dm-with", "Yo"]]);
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: This user does not exist!"),
     );
 
-    current_filter = set_filter([["dm-including", "alice@example.com"]]);
+    current_filter = set_filter([["dm-with", "alice@example.com"]]);
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
@@ -520,7 +520,7 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
 
     // direct messages with a bot are possible even though
     // the organization has disabled sending direct messages
-    current_filter = set_filter([["dm-including", "bot@example.com"]]);
+    current_filter = set_filter([["dm-with", "bot@example.com"]]);
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
@@ -530,14 +530,14 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     // sending direct messages enabled
     override(realm, "realm_direct_message_permission_group", everyone.id);
     override(realm, "realm_direct_message_permission_group", everyone.id);
-    current_filter = set_filter([["dm-including", "alice@example.com"]]);
+    current_filter = set_filter([["dm-with", "alice@example.com"]]);
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: You have no direct messages including Alice Smith yet."),
     );
 
-    current_filter = set_filter([["dm-including", me.email]]);
+    current_filter = set_filter([["dm-with", me.email]]);
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -132,10 +132,10 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             const search_suggestions = {
                 lookup_table: new Map([
                     [
-                        "dm-including:zo",
+                        "dm-with:zo",
                         {
-                            description_html: "group direct messages including",
-                            search_string: "dm-including:user7@zulipdev.com",
+                            description_html: "group direct messages with",
+                            search_string: "dm-with:user7@zulipdev.com",
                         },
                     ],
                     [
@@ -160,7 +160,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
                         },
                     ],
                 ]),
-                strings: ["zo", "sender:zo", "dm:zo", "dm-including:zo"],
+                strings: ["zo", "sender:zo", "dm:zo", "dm-with:zo"],
             };
 
             /* Test source */
@@ -186,7 +186,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">dm:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n</span>\n    \n</div>\n`;
             assert.equal(opts.item_html(source[2]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">dm-including:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n</span>\n    \n</div>\n`;
+            expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">dm-with:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n</span>\n    \n</div>\n`;
             assert.equal(opts.item_html(source[3]), expected_value);
 
             /* Test sorter */

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -172,7 +172,8 @@ test("dm_suggestions", ({override, mock_template}) => {
         "is:dm is:alerted",
         "is:dm dm:alice@zulip.com",
         "is:dm sender:alice@zulip.com",
-        "is:dm dm-including:alice@zulip.com",
+        "is:dm dm-with:alice@zulip.com",
+        "is:dm",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -262,7 +263,10 @@ test("dm_suggestions", ({override, mock_template}) => {
         "is:starred has:link is:dm is:alerted",
         "is:starred has:link is:dm dm:alice@zulip.com",
         "is:starred has:link is:dm sender:alice@zulip.com",
-        "is:starred has:link is:dm dm-including:alice@zulip.com",
+        "is:starred has:link is:dm dm-with:alice@zulip.com",
+        "is:starred has:link is:dm",
+        "is:starred has:link",
+        "is:starred",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -298,7 +302,8 @@ test("group_suggestions", ({mock_template}) => {
         "dm:bob@zulip.com alice",
         "dm:bob@zulip.com,alice@zulip.com",
         "dm:bob@zulip.com sender:alice@zulip.com",
-        "dm:bob@zulip.com dm-including:alice@zulip.com",
+        "dm:bob@zulip.com dm-with:alice@zulip.com",
+        "dm:bob@zulip.com",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -309,7 +314,8 @@ test("group_suggestions", ({mock_template}) => {
     expected = [
         "dm:ted@zulip.com my",
         "dm:ted@zulip.com sender:myself@zulip.com",
-        "dm:ted@zulip.com dm-including:myself@zulip.com",
+        "dm:ted@zulip.com dm-with:myself@zulip.com",
+        "dm:ted@zulip.com",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -330,7 +336,8 @@ test("group_suggestions", ({mock_template}) => {
         "dm:bob@zulip.com alice",
         "dm:bob@zulip.com,alice@zulip.com",
         "dm:bob@zulip.com sender:alice@zulip.com",
-        "dm:bob@zulip.com dm-including:alice@zulip.com",
+        "dm:bob@zulip.com dm-with:alice@zulip.com",
+        "dm:bob@zulip.com",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -342,7 +349,10 @@ test("group_suggestions", ({mock_template}) => {
         "is:starred has:link dm:bob@zulip.com Smit",
         "is:starred has:link dm:bob@zulip.com,ted@zulip.com",
         "is:starred has:link dm:bob@zulip.com sender:ted@zulip.com",
-        "is:starred has:link dm:bob@zulip.com dm-including:ted@zulip.com",
+        "is:starred has:link dm:bob@zulip.com dm-with:ted@zulip.com",
+        "is:starred has:link dm:bob@zulip.com",
+        "is:starred has:link",
+        "is:starred",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -492,7 +502,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
         "is:resolved",
         "dm:alice@zulip.com",
         "sender:alice@zulip.com",
-        "dm-including:alice@zulip.com",
+        "dm-with:alice@zulip.com",
         "has:image",
     ];
     assert.deepEqual(suggestions.strings, expected);
@@ -658,7 +668,7 @@ test("topic_suggestions", ({override, mock_template}) => {
     stream_data.add_sub({stream_id: office_id, name: "office", subscribed: true});
 
     suggestions = get_suggestions("te");
-    expected = ["te", "dm:ted@zulip.com", "sender:ted@zulip.com", "dm-including:ted@zulip.com"];
+    expected = ["te", "dm:ted@zulip.com", "sender:ted@zulip.com", "dm-with:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     stream_topic_history.add_message({
@@ -678,7 +688,7 @@ test("topic_suggestions", ({override, mock_template}) => {
         "te",
         "dm:ted@zulip.com",
         "sender:ted@zulip.com",
-        "dm-including:ted@zulip.com",
+        "dm-with:ted@zulip.com",
         `channel:${office_id} topic:team`,
         `channel:${office_id} topic:test`,
     ];
@@ -871,8 +881,8 @@ test("people_suggestions", ({override, mock_template}) => {
         "dm:ted@zulip.com",
         "sender:bob@zulip.com",
         "sender:ted@zulip.com",
-        "dm-including:bob@zulip.com",
-        "dm-including:ted@zulip.com",
+        "dm-with:bob@zulip.com",
+        "dm-with:ted@zulip.com",
     ];
 
     assert.deepEqual(suggestions.strings, expected);
@@ -893,9 +903,9 @@ test("people_suggestions", ({override, mock_template}) => {
         "sender:bob@zulip.com",
         "sender:ted@zulip.com",
         "sender:user299@zulipdev.com",
-        "dm-including:bob@zulip.com",
-        "dm-including:ted@zulip.com",
-        "dm-including:user299@zulipdev.com",
+        "dm-with:bob@zulip.com",
+        "dm-with:ted@zulip.com",
+        "dm-with:user299@zulipdev.com",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -906,7 +916,7 @@ test("people_suggestions", ({override, mock_template}) => {
     }
     test_describe("dm:ted@zulip.com", "Direct messages with");
     test_describe("sender:ted@zulip.com", "Sent by");
-    test_describe("dm-including:ted@zulip.com", "Direct messages including");
+    test_describe("dm-with:ted@zulip.com", "Direct messages with");
 
     let expectedString = "Ted Smith";
 
@@ -915,7 +925,7 @@ test("people_suggestions", ({override, mock_template}) => {
     }
     test_full_name("sender:ted@zulip.com", expectedString);
     test_full_name("dm:ted@zulip.com", expectedString);
-    test_full_name("dm-including:ted@zulip.com", expectedString);
+    test_full_name("dm-with:ted@zulip.com", expectedString);
 
     expectedString = example_avatar_url;
 
@@ -924,11 +934,11 @@ test("people_suggestions", ({override, mock_template}) => {
     }
     test_avatar_url("dm:bob@zulip.com", expectedString);
     test_avatar_url("sender:bob@zulip.com", expectedString);
-    test_avatar_url("dm-including:bob@zulip.com", expectedString);
+    test_avatar_url("dm-with:bob@zulip.com", expectedString);
 
     suggestions = get_suggestions("Ted "); // note space
 
-    expected = ["Ted", "dm:ted@zulip.com", "sender:ted@zulip.com", "dm-including:ted@zulip.com"];
+    expected = ["Ted", "dm:ted@zulip.com", "sender:ted@zulip.com", "dm-with:ted@zulip.com"];
 
     assert.deepEqual(suggestions.strings, expected);
 

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -118,6 +118,7 @@ class NarrowParameter(BaseModel):
             "id",
             "sender",
             "group-pm-with",
+            "dm-with",
             "dm-including",
             "with",
         ]
@@ -291,8 +292,10 @@ class NarrowBuilder:
             "dm": self.by_dm,
             # "pm-with:" is a legacy alias for "dm:"
             "pm-with": self.by_dm,
-            "dm-including": self.by_dm_including,
-            # "group-pm-with:" was deprecated by the addition of "dm-including:"
+            "dm-with": self.by_dm_with,
+            # "dm-including:" is a legacy alias for "dm-with:"
+            "dm-including": self.by_dm_with,
+            # "group-pm-with:" was deprecated by the addition of "dm-with:"
             "group-pm-with": self.by_group_pm_with,
             # TODO/compatibility: Prior to commit a9b3a9c, the server implementation
             # for documented search operators with dashes, also implicitly supported
@@ -623,7 +626,7 @@ class NarrowBuilder:
 
         return set(self_recipient_ids) & set(narrow_recipient_ids)
 
-    def by_dm_including(
+    def by_dm_with(
         self, query: Select, operand: str | int, maybe_negate: ConditionTransform
     ) -> Select:
         # This operator does not support is_web_public_query.
@@ -642,7 +645,7 @@ class NarrowBuilder:
         except UserProfile.DoesNotExist:
             raise BadNarrowOperatorError("unknown user " + str(operand))
 
-        # "dm-including" when combined with the user's own ID/email as the operand
+        # "dm-with" when combined with the user's own ID/email as the operand
         # should return all group and 1:1 direct messages (including direct messages
         # with self), so the simplest query to get these messages is the same as "is:dm".
         if narrow_user_profile.id == self.user_profile.id:

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -35,8 +35,10 @@ OPERATOR_SYNONYMS = {
     **CHANNEL_SYNONYMS,
     # "pm-with:" was renamed to "dm:"
     "pm-with": "dm",
-    # "group-pm-with:" was replaced with "dm-including:"
-    "group-pm-with": "dm-including",
+    # "group-pm-with:" was replaced with "dm-with:"
+    "group-pm-with": "dm-with",
+    # "dm-including:" is a legacy alias for "dm-with:"
+    "dm-including": "dm-with",
     "from": "sender",
     DB_TOPIC_NAME: "topic",
 }
@@ -86,7 +88,7 @@ def decode_hash_component(string: str) -> str:
 def decode_narrow_operand(operator: str, operand: str) -> str | int | list[int]:
     # These have the similar slug formatting for their operands which
     # contain object ID(s).
-    if operator in ["dm-including", "dm", "sender", "channel"]:
+    if operator in ["dm-with", "dm-including", "dm", "sender", "channel"]:
         result = parse_recipient_slug(operand)
         return result[0] if isinstance(result, tuple) else ""
 

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -503,13 +503,13 @@ class NarrowBuilderTest(ZulipTestCase):
         )
         self.assertRaises(BadNarrowOperatorError, self._build_query, term)
 
-    def test_add_term_using_dm_including_operator_with_logged_in_user_email(self) -> None:
-        term = NarrowParameter(operator="dm-including", operand=self.hamlet_email)
+    def test_add_term_using_dm_with_operator_with_logged_in_user_email(self) -> None:
+        term = NarrowParameter(operator="dm-with", operand=self.hamlet_email)
         self._do_add_term_test(term, "WHERE (flags & %(flags_1)s) != %(param_1)s")
 
-    def test_add_term_using_dm_including_operator_with_different_user_email(self) -> None:
+    def test_add_term_using_dm_with_operator_with_different_user_email(self) -> None:
         # Test without any such group direct messages existing
-        term = NarrowParameter(operator="dm-including", operand=self.othello_email)
+        term = NarrowParameter(operator="dm-with", operand=self.othello_email)
         self._do_add_term_test(
             term,
             "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s OR recipient_id IN (__[POSTCOMPILE_recipient_id_3]))",
@@ -520,7 +520,7 @@ class NarrowBuilderTest(ZulipTestCase):
             self.user_profile, [self.example_user("othello"), self.example_user("cordelia")]
         )
 
-        term = NarrowParameter(operator="dm-including", operand=self.othello_email)
+        term = NarrowParameter(operator="dm-with", operand=self.othello_email)
         self._do_add_term_test(
             term,
             "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s OR recipient_id IN (__[POSTCOMPILE_recipient_id_3]))",
@@ -529,7 +529,7 @@ class NarrowBuilderTest(ZulipTestCase):
     def test_add_term_using_dm_including_operator_with_different_user_email_and_negated(
         self,
     ) -> None:  # NEGATED
-        term = NarrowParameter(operator="dm-including", operand=self.othello_email, negated=True)
+        term = NarrowParameter(operator="dm-with", operand=self.othello_email, negated=True)
         self._do_add_term_test(
             term,
             "WHERE NOT ((flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s OR recipient_id IN (__[POSTCOMPILE_recipient_id_3])))",
@@ -694,8 +694,13 @@ class NarrowBuilderTest(ZulipTestCase):
             "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s",
         )
 
-    # Test that deprecated "group-pm-with" (replaced by "dm-including" ) works.
-    def test_add_term_using_dm_including_operator_with_non_existing_user(self) -> None:
+    # Test that deprecated "group-pm-with" (replaced by "dm-with" ) works.
+    def test_add_term_using_dm_with_operator_with_non_existing_user(self) -> None:
+        term = NarrowParameter(operator="dm-with", operand="non-existing@zulip.com")
+        self.assertRaises(BadNarrowOperatorError, self._build_query, term)
+
+    def test_add_term_using_dm_including_legacy_operator_with_non_existing_user(self) -> None:
+        # Test backwards compatibility with dm-including
         term = NarrowParameter(operator="dm-including", operand="non-existing@zulip.com")
         self.assertRaises(BadNarrowOperatorError, self._build_query, term)
 
@@ -1085,6 +1090,12 @@ class NarrowLibraryTest(ZulipTestCase):
         )
         self.assertFalse(
             is_spectator_compatible(
+                [NarrowParameter(operator="dm-with", operand="hamlet@zulip.com")]
+            )
+        )
+        # Test backwards compatibility with dm-including
+        self.assertFalse(
+            is_spectator_compatible(
                 [NarrowParameter(operator="dm-including", operand="hamlet@zulip.com")]
             )
         )
@@ -1117,7 +1128,7 @@ class NarrowLibraryTest(ZulipTestCase):
                 [NarrowParameter(operator="pm-with", operand="hamlet@zulip.com")]
             )
         )
-        # "group-pm-with:" was deprecated by the addition of "dm-including:"
+        # "group-pm-with:" was deprecated by the addition of "dm-with:"
         self.assertFalse(
             is_spectator_compatible(
                 [NarrowParameter(operator="group-pm-with", operand="hamlet@zulip.com")]
@@ -2527,9 +2538,9 @@ class GetOldMessagesTest(ZulipTestCase):
         narrow = [dict(operator="dm", operand=self.example_user("iago").email)]
         self.message_visibility_test(narrow, message_ids, 2)
 
-    def test_get_messages_with_narrow_dm_including(self) -> None:
+    def test_get_messages_with_narrow_dm_with(self) -> None:
         """
-        A request for old messages with a narrow by "dm-including" only
+        A request for old messages with a narrow by "dm-with" only
         returns direct messages (both group and 1:1) with that user.
         """
         me = self.example_user("hamlet")
@@ -2582,7 +2593,7 @@ class GetOldMessagesTest(ZulipTestCase):
         self.login_user(me)
         test_operands = [cordelia.email, cordelia.id]
         for operand in test_operands:
-            narrow = [dict(operator="dm-including", operand=operand)]
+            narrow = [dict(operator="dm-with", operand=operand)]
             result = self.get_and_check_messages(dict(narrow=orjson.dumps(narrow).decode()))
             for message in result["messages"]:
                 self.assertIn(message["id"], matching_message_ids)
@@ -2613,7 +2624,7 @@ class GetOldMessagesTest(ZulipTestCase):
             ),
         ]
 
-        narrow = [dict(operator="dm-including", operand=cordelia.email)]
+        narrow = [dict(operator="dm-with", operand=cordelia.email)]
         self.message_visibility_test(narrow, message_ids, 2)
 
     def test_get_messages_with_narrow_group_pm_with(self) -> None:
@@ -3999,7 +4010,7 @@ class GetOldMessagesTest(ZulipTestCase):
     def test_invalid_narrow_operand_in_dict(self) -> None:
         self.login("hamlet")
 
-        # str or int is required for "id", "sender", "channel", "dm-including" and "group-pm-with"
+        # str or int is required for "id", "sender", "channel", "dm-with" and "group-pm-with"
         # operators
         invalid_operands: list[InvalidParam] = [
             InvalidParam(value=["1"], expected_error="operand is not a string or integer"),
@@ -4009,7 +4020,7 @@ class GetOldMessagesTest(ZulipTestCase):
             ),
         ]
 
-        for operand in ["id", "sender", "channel", "dm-including", "group-pm-with", "with"]:
+        for operand in ["id", "sender", "channel", "dm-with", "group-pm-with", "with"]:
             self.exercise_bad_narrow_operand_using_dict_api(operand, invalid_operands)
 
         # str or int list is required for "dm" and "pm-with" operator


### PR DESCRIPTION
This commit updates the API documentation and related code to reflect the renaming of the `dm-including` narrow filter to `dm-with`. The old name remains supported for backward compatibility. Changes include updates to the changelog, documentation, and codebase to ensure all references are consistent with the new naming convention.

The issue: https://github.com/zulip/zulip/issues/34932

**Screenshots and screen captures:**

<img width="457" height="309" alt="image" src="https://github.com/user-attachments/assets/95228086-7fa9-4583-b70d-2dfac6422f5e" />
<img width="731" height="157" alt="image" src="https://github.com/user-attachments/assets/96c6f62a-b01d-4632-bb0f-0e6df36d907b" />
<img width="764" height="150" alt="image" src="https://github.com/user-attachments/assets/123aa563-bee0-4979-8005-245cfe18afb5" />


<details>
<summary>Self-review checklist</summary>

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

**Technical Choices Made:**
- Followed the same backwards compatibility pattern used for `stream:` → `channel:` rename
- Renamed backend method from `by_dm_including` to `by_dm_with` for consistency
- Added `dm-including` as legacy alias in both backend `by_method_map` and frontend `canonicalize_term`
- Updated search suggestions to map `dm-including` → `dm-with` for user guidance
- Maintained both operators in all relevant sets and switch statements for full compatibility

**Decisions and Concerns:**
- Search suggestion descriptions remain consistent with existing pattern
- All existing bookmarks, saved searches, and API calls using `dm-including` continue to work


**Manual Testing Completed:**
- ✅ Search with `dm-with:user` works correctly
- ✅ Legacy `dm-including:user` still functions and maps to `dm-with`
- ✅ Search suggestions show `dm-with` when typing `dm-including`
- ✅ Help menu (`?`) displays updated `dm-with:` operator
- ✅ Both operators work with user emails and user IDs
- ✅ Backwards compatibility maintained for existing searches
- ✅ All test suites pass with updated operator names

**Areas Updated:**
- Backend: `narrow.py`, `url_decoding.py`, backend tests
- Frontend: `filter.ts`, `search_suggestion.ts`, `search_pill.ts`, `narrow_banner.ts`, `message_fetch.ts`, `hash_util.ts`
- UI: Search operator help template
- Documentation: Help center docs, API docs, changelog
- Tests: All frontend and backend test suites updated
</details>
