### PR TITLE
Backport several API documentation and bug fix changes to 11.x

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -159,6 +159,7 @@
 * [Fetch an API key (development only)](/api/dev-fetch-api-key)
 * [Send an E2EE test notification to mobile device(s)](/api/e2ee-test-notify)
 * [Register E2EE push device](/api/register-push-device)
+* [Register E2EE push device to bouncer](/api/register-remote-push-device)
 * [Mobile notifications](/api/mobile-notifications)
 * [Send a test notification to mobile device(s)](/api/test-notify)
 * [Add an APNs device token](/api/add-apns-token)

--- a/zerver/actions/message_delete.py
+++ b/zerver/actions/message_delete.py
@@ -111,7 +111,7 @@ def do_delete_messages(
     )
     stream_by_recipient_id = {}
     for message in messages:
-        if message.is_stream_message():
+        if message.is_channel_message:
             recipient_id = message.recipient_id
             # topics are case-insensitive.
             topic_name = message.topic_name().lower()

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -126,7 +126,7 @@ def validate_message_edit_payload(
     if topic_name is None and content is None and stream_id is None:
         raise JsonableError(_("Nothing to change"))
 
-    if not message.is_stream_message():
+    if not message.is_channel_message:
         if stream_id is not None:
             raise JsonableError(_("Direct messages cannot be moved to channels."))
         if topic_name is not None:
@@ -1454,7 +1454,7 @@ def build_message_edit_request(
             content = "(deleted)"
         new_content = normalize_body(content)
 
-    if not message.is_stream_message():
+    if not message.is_channel_message:
         # We have already validated that at least one of content, topic, or stream
         # must be modified, and for DMs, only the content can be edited.
         return DirectMessageEditRequest(
@@ -1633,12 +1633,12 @@ def check_update_message(
         )
         links_for_embed |= rendering_result.links_for_preview
 
-        if message.is_stream_message() and rendering_result.mentions_stream_wildcard:
+        if message.is_channel_message and rendering_result.mentions_stream_wildcard:
             stream = access_stream_by_id(user_profile, message.recipient.type_id)[0]
             if not stream_wildcard_mention_allowed(message.sender, stream, message.realm):
                 raise StreamWildcardMentionNotAllowedError
 
-        if message.is_stream_message() and rendering_result.mentions_topic_wildcard:
+        if message.is_channel_message and rendering_result.mentions_topic_wildcard:
             topic_participant_count = len(
                 participants_for_topic(message.realm.id, message.recipient.id, message.topic_name())
             )
@@ -1653,7 +1653,7 @@ def check_update_message(
 
     if isinstance(message_edit_request, StreamMessageEditRequest):
         if message_edit_request.is_stream_edited:
-            assert message.is_stream_message()
+            assert message.is_channel_message
             if not can_move_messages_out_of_channel(user_profile, message_edit_request.orig_stream):
                 raise JsonableError(_("You don't have permission to move this message"))
 

--- a/zerver/actions/message_flags.py
+++ b/zerver/actions/message_flags.py
@@ -212,7 +212,7 @@ def do_update_mobile_push_notification(
     # in a sent notification if a message was edited to mention a
     # group rather than a user (or vice versa), though it is likely
     # not worth the effort to do such a change.
-    if not message.is_stream_message():
+    if not message.is_channel_message:
         return
 
     remove_notify_users = prior_mention_user_ids - mentions_user_ids - stream_push_user_ids

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -608,7 +608,7 @@ def build_message_send_dict(
         message_sender=message.sender,
     )
 
-    if message.is_stream_message():
+    if message.is_channel_message:
         stream_id = message.recipient.type_id
         stream_topic: StreamTopicTarget | None = StreamTopicTarget(
             stream_id=stream_id,
@@ -745,7 +745,7 @@ def create_user_messages(
     # These properties on the Message are set via
     # render_message_markdown by code in the Markdown inline patterns
     ids_with_alert_words = rendering_result.user_ids_with_alert_words
-    is_stream_message = message.is_stream_message()
+    is_stream_message = message.is_channel_message
 
     base_flags = 0
     if rendering_result.mentions_stream_wildcard:
@@ -968,7 +968,7 @@ def do_send_messages(
     # * Adding links to the embed_links queue for open graph processing.
     for send_request in send_message_requests:
         realm_id: int | None = None
-        if send_request.message.is_stream_message():
+        if send_request.message.is_channel_message:
             if send_request.stream is None:
                 stream_id = send_request.message.recipient.type_id
                 send_request.stream = Stream.objects.get(id=stream_id)
@@ -1172,7 +1172,7 @@ def do_send_messages(
             realm_host=send_request.realm.host,
         )
 
-        if send_request.message.is_stream_message():
+        if send_request.message.is_channel_message:
             # Note: This is where authorization for single-stream
             # get_updates happens! We only attach stream data to the
             # notify new_message request if it's a public stream,
@@ -1237,7 +1237,7 @@ def do_send_messages(
 
         # Check if this is a 1:1 DM between a user and the Welcome Bot,
         # in which case we may want to send an automated response.
-        if not send_request.message.is_stream_message() and len(send_request.active_user_ids) == 2:
+        if not send_request.message.is_channel_message and len(send_request.active_user_ids) == 2:
             welcome_bot_id = get_system_bot(settings.WELCOME_BOT, send_request.realm.id).id
             if (
                 welcome_bot_id in send_request.active_user_ids

--- a/zerver/actions/uploads.py
+++ b/zerver/actions/uploads.py
@@ -43,7 +43,13 @@ def do_claim_attachments(
         user_profile = message.sender
         is_message_realm_public = False
         is_message_web_public = False
-        if message.is_stream_message():
+        if isinstance(message, Message):
+            is_channel_message = message.is_channel_message
+        else:
+            assert isinstance(message, ScheduledMessage)
+            is_channel_message = message.is_channel_message()
+
+        if is_channel_message:
             stream = Stream.objects.get(id=message.recipient.type_id)
             is_message_realm_public = stream.is_public()
             is_message_web_public = stream.is_web_public

--- a/zerver/lib/attachments.py
+++ b/zerver/lib/attachments.py
@@ -140,7 +140,7 @@ def validate_attachment_request(
         user_profile=user_profile, message__in=messages
     ).select_related("message", "message__recipient")
     for um in usermessage_rows:
-        if not um.message.is_stream_message():
+        if not um.message.is_channel_message:
             # If the attachment was sent in a direct message or group direct
             # message then anyone who received that message can access it.
             return True, attachment
@@ -164,7 +164,7 @@ def validate_attachment_request(
 
     message_channel_ids = set()
     for message in messages:
-        if message.is_stream_message():
+        if message.is_channel_message:
             message_channel_ids.add(message.recipient.type_id)
 
     if len(message_channel_ids) == 0:

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -685,7 +685,7 @@ def handle_missedmessage_emails(
 
     for msg_list in messages_by_bucket.values():
         msg = min(msg_list, key=lambda msg: msg.date_sent)
-        if msg.is_stream_message() and UserMessage.has_any_mentions(user_profile_id, msg.id):
+        if msg.is_channel_message and UserMessage.has_any_mentions(user_profile_id, msg.id):
             context_messages = get_context_for_message(msg)
             filtered_context_messages = bulk_access_messages(
                 user_profile, context_messages, is_modifying_message=False

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -465,7 +465,7 @@ def access_web_public_message(
     except Message.DoesNotExist:
         raise MissingAuthenticationError
 
-    if not message.is_stream_message():
+    if not message.is_channel_message:
         raise MissingAuthenticationError
 
     queryset = get_web_public_streams_queryset(realm)
@@ -615,7 +615,7 @@ def event_recipient_ids_for_action_on_messages(
         return set(usermessages.values_list("user_profile_id", flat=True))
 
     sample_message = messages[0]
-    if not sample_message.is_stream_message():
+    if not sample_message.is_channel_message:
         # For DM, event is sent to users who actually received the message.
         return get_user_ids_having_usermessage_row_for_messages(message_ids)
 
@@ -1720,7 +1720,7 @@ def should_change_visibility_policy(
 
 def set_visibility_policy_possible(user_profile: UserProfile, message: Message) -> bool:
     """If the user can set a visibility policy."""
-    if not message.is_stream_message():
+    if not message.is_channel_message:
         return False
 
     if user_profile.is_bot:

--- a/zerver/lib/message_report.py
+++ b/zerver/lib/message_report.py
@@ -59,7 +59,7 @@ def send_message_report(
             last_user_mention=last_user_mention,
         )
     else:
-        assert reported_message.is_stream_message() is True
+        assert reported_message.is_channel_message is True
         topic_name = reported_message.topic_name()
         channel_id = reported_message.recipient.type_id
         channel_name = reported_message.recipient.label()

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from email.headerregistry import Address
 from functools import cache
-from typing import TYPE_CHECKING, Any, Final, Literal, Optional, TypeAlias, Union
+from typing import TYPE_CHECKING, Any, Final, Literal, Optional, TypeAlias, Union, cast
 
 import lxml.html
 import orjson
@@ -28,7 +28,8 @@ from firebase_admin import messaging as firebase_messaging
 from firebase_admin.messaging import UnregisteredError as FCMUnregisteredError
 from nacl.encoding import Base64Encoder
 from nacl.public import PublicKey, SealedBox
-from typing_extensions import NotRequired, TypedDict, override
+from pydantic import TypeAdapter
+from typing_extensions import TypedDict, override
 
 from analytics.lib.counts import COUNT_STATS, do_increment_logging_stat
 from zerver.actions.realm_settings import (
@@ -1415,7 +1416,13 @@ class SendNotificationResponseData(TypedDict):
     android_successfully_sent_count: int
     apple_successfully_sent_count: int
     delete_device_ids: list[int]
-    realm_push_status: NotRequired[RealmPushStatusDict]
+
+
+class SendNotificationRemoteResponseData(SendNotificationResponseData):
+    realm_push_status: RealmPushStatusDict
+
+
+send_notification_remote_response_data_adapter = TypeAdapter(SendNotificationRemoteResponseData)
 
 
 FCMPriority: TypeAlias = Literal["high", "normal"]
@@ -1525,10 +1532,11 @@ def send_push_notifications(
 
     # Send push notification
     try:
+        response_data: SendNotificationResponseData | SendNotificationRemoteResponseData
         if settings.ZILENCER_ENABLED:
             from zilencer.lib.push_notifications import send_e2ee_push_notifications
 
-            response_data: SendNotificationResponseData = send_e2ee_push_notifications(
+            response_data = send_e2ee_push_notifications(
                 push_requests,
                 realm=user_profile.realm,
             )
@@ -1538,16 +1546,7 @@ def send_push_notifications(
                 "push_requests": [asdict(push_request) for push_request in push_requests],
             }
             result = send_json_to_push_bouncer("POST", "push/e2ee/notify", post_data)
-            assert isinstance(result["android_successfully_sent_count"], int)  # for mypy
-            assert isinstance(result["apple_successfully_sent_count"], int)  # for mypy
-            assert isinstance(result["delete_device_ids"], list)  # for mypy
-            assert isinstance(result["realm_push_status"], dict)  # for mypy
-            response_data = {
-                "android_successfully_sent_count": result["android_successfully_sent_count"],
-                "apple_successfully_sent_count": result["apple_successfully_sent_count"],
-                "delete_device_ids": result["delete_device_ids"],
-                "realm_push_status": result["realm_push_status"],  # type: ignore[typeddict-item] # TODO: Can't use isinstance() with TypedDict type
-            }
+            response_data = send_notification_remote_response_data_adapter.validate_python(result)
     except (MissingRemoteRealmError, PushNotificationsDisallowedByBouncerError) as e:
         reason = e.reason if isinstance(e, PushNotificationsDisallowedByBouncerError) else e.msg
         logger.warning("Bouncer refused to send E2EE push notification: %s", reason)
@@ -1597,8 +1596,11 @@ def send_push_notifications(
         apple_successfully_sent_count,
     )
 
-    realm_push_status_dict = response_data.get("realm_push_status")
-    if realm_push_status_dict is not None:
+    if "realm_push_status" in response_data:
+        # Cannot use `isinstance` with `TypedDict`s to make mypy know
+        # which of the `TypedDict`s in the Union this is - so just cast it.
+        response_data = cast(SendNotificationRemoteResponseData, response_data)
+        realm_push_status_dict = response_data["realm_push_status"]
         can_push = realm_push_status_dict["can_push"]
         do_set_realm_property(
             user_profile.realm,

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1058,7 +1058,7 @@ def get_apns_alert_title(message: Message, language: str) -> str:
         assert isinstance(recipients, list)
         if len(recipients) > 2:
             return ", ".join(sorted(r["full_name"] for r in recipients))
-    elif message.is_stream_message():
+    elif message.is_channel_message:
         stream_name = get_message_stream_name_from_database(message)
         topic_display_name = get_topic_display_name(message.topic_name(), language)
         return f"#{stream_name} > {topic_display_name}"
@@ -1718,7 +1718,7 @@ def handle_push_notification(user_profile_id: int, missed_message: dict[str, Any
         user_profile, {trigger}, mentioned_user_group_members_count
     )
 
-    if message.is_stream_message():
+    if message.is_channel_message:
         # This will almost always be True. The corner case where you
         # can be receiving a message from a user you cannot access
         # involves your being a guest user whose access is restricted

--- a/zerver/lib/reminders.py
+++ b/zerver/lib/reminders.py
@@ -32,7 +32,7 @@ def get_reminder_formatted_content(
     if note:
         note = normalize_note_text(note)
 
-    if message.is_stream_message():
+    if message.is_channel_message:
         # We don't need to check access here since we already have the message
         # whose access has already been checked by the caller.
         stream = Stream.objects.get(

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -2775,6 +2775,7 @@ class PushNotificationTestCase(BouncerTestCase):
             rendered_content="This is test content",
             date_sent=timezone_now(),
             sending_client=self.sending_client,
+            is_channel_message=type == Recipient.STREAM,
         )
         message.set_topic_name("Test topic")
         message.save()

--- a/zerver/models/messages.py
+++ b/zerver/models/messages.py
@@ -283,16 +283,6 @@ class Message(AbstractMessage):
     def set_topic_name(self, topic_name: str) -> None:
         self.subject = topic_name
 
-    def is_stream_message(self) -> bool:
-        """
-        Find out whether a message is a stream message by
-        looking up its recipient.type.  TODO: Make this
-        an easier operation by denormalizing the message
-        type onto Message, either explicitly (message.type)
-        or implicitly (message.stream_id is not None).
-        """
-        return self.recipient.type == Recipient.STREAM
-
     def get_realm(self) -> Realm:
         return self.realm
 

--- a/zerver/models/messages.py
+++ b/zerver/models/messages.py
@@ -218,7 +218,7 @@ class Message(AbstractMessage):
                 name="zerver_message_realm_sender_recipient",
             ),
             models.Index(
-                # For analytics queries
+                # For analytics and retention queries
                 "realm_id",
                 "date_sent",
                 name="zerver_message_realm_date_sent",

--- a/zerver/models/scheduled_jobs.py
+++ b/zerver/models/scheduled_jobs.py
@@ -225,7 +225,7 @@ class ScheduledMessage(models.Model):
     def set_topic_name(self, topic_name: str) -> None:
         self.subject = topic_name
 
-    def is_stream_message(self) -> bool:
+    def is_channel_message(self) -> bool:
         return self.recipient.type == Recipient.STREAM
 
     def to_dict(self) -> APIScheduledStreamMessageDict | APIScheduledDirectMessageDict:

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -268,8 +268,6 @@ def generate_curl_example(
     endpoint: str,
     method: str,
     api_url: str,
-    auth_email: str = DEFAULT_AUTH_EMAIL,
-    auth_api_key: str = DEFAULT_AUTH_API_KEY,
     exclude: list[str] | None = None,
     include: list[str] | None = None,
 ) -> list[str]:
@@ -321,6 +319,8 @@ def generate_curl_example(
         )
 
     if authentication_required:
+        auth_email = DEFAULT_AUTH_EMAIL
+        auth_api_key = DEFAULT_AUTH_API_KEY
         lines.append("    -u " + shlex.quote(f"{auth_email}:{auth_api_key}"))
 
     for parameter in parameters:
@@ -359,14 +359,8 @@ def render_curl_example(
     admin_config: bool = False,
 ) -> list[str]:
     """A simple wrapper around generate_curl_example."""
-    parts = function.split(":")
-    endpoint = parts[0]
-    method = parts[1]
+    endpoint, method = function.split(":")
     kwargs: dict[str, Any] = {}
-    if len(parts) > 2:
-        kwargs["auth_email"] = parts[2]
-    if len(parts) > 3:
-        kwargs["auth_api_key"] = parts[3]
     kwargs["api_url"] = api_url
     rendered_example = []
     for element in get_curl_include_exclude(endpoint, method):

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -319,8 +319,9 @@ def generate_curl_example(
         )
 
     if authentication_required:
-        auth_email = DEFAULT_AUTH_EMAIL
-        auth_api_key = DEFAULT_AUTH_API_KEY
+        is_zilencer_endpoint = endpoint.startswith("/remotes/")
+        auth_email = "ZULIP_ORG_ID" if is_zilencer_endpoint else DEFAULT_AUTH_EMAIL
+        auth_api_key = "ZULIP_ORG_KEY" if is_zilencer_endpoint else DEFAULT_AUTH_API_KEY
         lines.append("    -u " + shlex.quote(f"{auth_email}:{auth_api_key}"))
 
     for parameter in parameters:

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -1907,12 +1907,17 @@ def update_user_group_members(client: Client, user_group_id: int) -> None:
 @openapi_test_function("/channels/create:post")
 def add_channel(client: Client) -> None:
     # {code_example|start}
+    # Create a new channel.
     request = {
         "name": "music_group",
         "description": "Channel for discussing and learning about music.",
-        "subscribers": [],
+        "subscribers": [12],
     }
-    result = client.call_endpoint(url="channels/create", method="POST", request=request)
+    result = client.call_endpoint(
+        url="channels/create",
+        method="POST",
+        request=request,
+    )
     # {code_example|end}
     assert_success_response(result)
     validate_against_openapi_schema(result, "/channels/create", "post", "200")

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -26,9 +26,10 @@ from zerver.openapi.openapi import get_endpoint_from_operationid
 
 UNTESTED_GENERATED_CURL_EXAMPLES = {
     # Would need push notification bouncer set up to test the
-    # generated curl example for the following two endpoints.
+    # generated curl example for the following three endpoints.
     "e2ee-test-notify",
     "test-notify",
+    "register-remote-push-device",
     # Having a message for a specific user available to test this endpoint
     # is tricky for testing.
     "delete-reminder",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12788,6 +12788,133 @@ paths:
                       }
                     description: |
                       Error when the server is not configured to use push notification service:
+  /remotes/push/e2ee/register:
+    post:
+      operationId: register-remote-push-device
+      summary: Register E2EE push device to bouncer
+      tags: ["mobile"]
+      description: |
+        Register a push device to bouncer to receive end-to-end encrypted
+        mobile push notifications.
+
+        Self-hosted servers use this endpoint to asynchronously register
+        a push device to the bouncer server after receiving a request from
+        the mobile client to [register E2EE push device](/api/register-push-device).
+
+        It is not meant to be used by mobile clients directly.
+
+        **Changes**: New in Zulip 11.0 (feature level 406).
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                realm_uuid:
+                  description: |
+                    The UUID of the realm to which the push device
+                    being registered belongs.
+                  type: string
+                  example: "realm-uuid"
+                push_account_id:
+                  description: |
+                    The `push_account_id` value provided by the mobile client
+                    to [register E2EE push device](/api/register-push-device).
+                  type: integer
+                  example: 2408
+                encrypted_push_registration:
+                  description: |
+                    The `encrypted_push_registration` value provided by the mobile client
+                    to [register E2EE push device](/api/register-push-device).
+                  type: string
+                  example: "encrypted-push-registration-data"
+                bouncer_public_key:
+                  description: |
+                    The `bouncer_public_key` value provided by the mobile client
+                    to [register E2EE push device](/api/register-push-device).
+                  type: string
+                  example: "bouncer-public-key"
+              required:
+                - realm_uuid
+                - push_account_id
+                - encrypted_push_registration
+                - bouncer_public_key
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - required:
+                      - device_id
+                    additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      device_id:
+                        type: integer
+                        description: |
+                          Unique identifier assigned by the bouncer for the registration.
+                        example: 2408
+                    example: {"device_id": 2408, "msg": "", "result": "success"}
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "INVALID_BOUNCER_PUBLIC_KEY",
+                            "msg": "Invalid bouncer_public_key",
+                            "result": "error",
+                          }
+                        description: |
+                          An example JSON response for when the given `bouncer_public_key` is invalid:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "REQUEST_EXPIRED",
+                            "msg": "Request expired",
+                            "result": "error",
+                          }
+                        description: |
+                          An example JSON response for when the given `encrypted_push_registration` is stale:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Invalid encrypted_push_registration",
+                            "result": "error",
+                          }
+                        description: |
+                          An example JSON response for when either the bouncer fails to decrypt
+                          the given `encrypted_push_registration` or the decrypted data is invalid:
+        "403":
+          description: |
+            Forbidden.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - example:
+                      {
+                        "code": "MISSING_REMOTE_REALM",
+                        "msg": "Organization not registered",
+                        "result": "error",
+                      }
+                    description: |
+                      An example JSON response for when no realm is registered for
+                      the authenticated server on the bouncer for the given `realm_uuid`:
   /user_topics:
     post:
       operationId: update-user-topic

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -24957,8 +24957,7 @@ paths:
       tags: ["channels"]
       x-requires-administrator: true
       description: |
-        Create a new channel folder, that will be used to organize
-        channels in left sidebar.
+        Create a new [channel folder](/help/channel-folders).
 
         **Changes**: New in Zulip 11.0 (feature level 389).
       requestBody:
@@ -25036,11 +25035,11 @@ paths:
       summary: Get channel folders
       tags: ["channels"]
       description: |
-        Fetches all of the channel folders in the organization.
-        The folders are sorted by the `order` field.
+        Fetches all of the [channel folders](/help/channel-folders) in the
+        organization, sorted by the `order` field.
 
-        **Changes**: Before Zulip 11.0 (feature level 414),
-        these were sorted by ID. (The `order` field didn't exist).
+        **Changes**: Before Zulip 11.0 (feature level 414), the list of channel
+        folders was sorted by ID as the `order` field didn't exist.
 
         New in Zulip 11.0 (feature level 389).
       requestBody:
@@ -25110,9 +25109,14 @@ paths:
       tags: ["channels"]
       x-requires-administrator: true
       description: |
-        Given an array of channel folder IDs, this method will set the `order`
-        property of all of the channel folders in the organization according to
-        the order of the channel folder IDs specified in the request.
+        Reorder the [channel folders](/help/channel-folders) in the user's
+        organization.
+
+        Channel folders are displayed in Zulip UI in order; this endpoint allows
+        administrative settings UI to change the ordering of channel folders.
+
+        This endpoint is used to implement the dragging feature described in the
+        [manage channel folders documentation](/help/manage-channel-folders).
 
         **Changes**: New in Zulip 11.0 (feature level 414).
       requestBody:
@@ -25127,9 +25131,8 @@ paths:
                   description: |
                     A list of channel folder IDs representing the new order.
 
-                    This list must include the IDs of all the
-                    organization's channel folders, including archived
-                    folders.
+                    This list must include the IDs of [all the organization's channel
+                    folders](/api/get-channel-folders), including archived folders.
                   items:
                     type: integer
                   example: [2, 1]
@@ -25165,10 +25168,11 @@ paths:
       tags: ["channels"]
       x-requires-administrator: true
       description: |
-        Update the name or description of a channel folder.
+        Update the name or description of a [channel folder](/help/channel-folders)
+        with the specified ID.
 
-        This endpoint is also used to archive and unarchive
-        a channel folder.
+        This endpoint is also used to archive or unarchive the specified channel
+        folder.
 
         **Changes**: New in Zulip 11.0 (feature level 389).
       parameters:
@@ -28171,10 +28175,23 @@ components:
       description: |
         Object containing the channel folder's attributes.
       properties:
+        id:
+          type: integer
+          description: |
+            The unique ID of the channel folder.
         name:
           type: string
           description: |
             The name of the channel folder.
+        order:
+          type: integer
+          description: |
+            This value determines in which order the channel folder should be
+            displayed in the UI. The value is 0 indexed, and a channel folder with
+            a lower value should be displayed before channel folders with higher
+            values.
+
+            **Changes**: New in Zulip 11.0 (feature level 414).
         date_created:
           type: integer
           nullable: true
@@ -28185,37 +28202,25 @@ components:
           type: integer
           nullable: true
           description: |
-            The ID of the user who created this channel folder.
+            The ID of the user who created the channel folder.
         description:
           type: string
           description: |
-            The description of the channel folder.
+            The description of the channel folder. Can be an empty string.
 
-            See [Markdown message formatting](/api/message-formatting) for details on Zulip's HTML format.
+            See [Markdown message formatting](/api/message-formatting) for details
+            on Zulip's HTML format.
         rendered_description:
           type: string
           description: |
-            The description of the channel folder rendered as HTML,
-            intended to be used when displaying the channel folder
-            description in a UI.
+            The description of the channel folder rendered as HTML, intended to be
+            used for UI that displays the channel folder description.
 
-            One should use the standard Zulip rendered_markdown CSS when
-            displaying this content so that emoji, LaTeX, and other syntax
-            work correctly. And any client-side security logic for
-            user-generated message content should be applied when displaying
-            this HTML as though it were the body of a Zulip message.
-        order:
-          type: integer
-          description: |
-            This value determines in which order the channel folders will be
-            displayed in the UI. The value is 0 indexed, and the value with
-            the lower order will be displayed first.
-
-            **Changes**: New in Zulip 11.0 (feature level 414).
-        id:
-          type: integer
-          description: |
-            The ID of the channel folder.
+            Clients should use the standard Zulip rendered_markdown CSS when
+            displaying this content so that emoji, LaTeX, and other syntax work
+            correctly. And any client-side security logic for user-generated
+            message content should be applied when displaying this HTML as though
+            it were the body of a Zulip message.
         is_archived:
           type: boolean
           description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -23857,8 +23857,6 @@ paths:
                   example: true
                 folder_id:
                   $ref: "#/components/schemas/FolderId"
-                send_new_subscription_messages:
-                  $ref: "#/components/schemas/SendNewSubscriptionMessages"
                 topics_policy:
                   $ref: "#/components/schemas/TopicsPolicy"
                 history_public_to_subscribers:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -24985,6 +24985,10 @@ paths:
                     Clients should use the `max_channel_folder_description_length`
                     returned by the [`POST /register`](/api/register-queue) endpoint
                     to determine the maximum channel folder description length.
+
+                    Note that this parameter must be passed as part of the request,
+                    but can be an empty string if no description for the new channel
+                    folder is desired.
                   type: string
                   example: Channels for marketing.
               required:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12587,6 +12587,7 @@ paths:
           $ref: "#/components/responses/SimpleSuccess"
   /mobile_push/test_notification:
     post:
+      deprecated: true
       operationId: test-notify
       summary: Send a test notification to mobile device(s)
       tags: ["mobile"]
@@ -12594,7 +12595,13 @@ paths:
         Trigger sending a test push notification to the user's
         selected mobile device or all of their mobile devices.
 
-        **Changes**: Starting with Zulip 8.0 (feature level 234), test
+        **Changes**: Deprecated in Zulip 11.0 (feature level 420).
+        Clients connecting to newer servers and with E2EE push
+        notifications support should use the
+        [Send an E2EE test notification to mobile device(s)](/api/e2ee-test-notify)
+        endpoint, as this endpoint will be removed in a future release.
+
+        Starting with Zulip 8.0 (feature level 234), test
         notifications sent via this endpoint use `test` rather than
         `test-by-device-token` in the `event` field. Also, as of this
         feature level, all mobile push notifications now include a

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -24955,12 +24955,10 @@ paths:
       operationId: create-channel-folder
       summary: Create a channel folder
       tags: ["channels"]
+      x-requires-administrator: true
       description: |
         Create a new channel folder, that will be used to organize
         channels in left sidebar.
-
-        Only organization administrators can create a new channel
-        folder.
 
         **Changes**: New in Zulip 11.0 (feature level 389).
       requestBody:
@@ -25106,6 +25104,7 @@ paths:
       operationId: patch-channel-folders
       summary: Reorder channel folders
       tags: ["channels"]
+      x-requires-administrator: true
       description: |
         Given an array of channel folder IDs, this method will set the `order`
         property of all of the channel folders in the organization according to
@@ -25157,14 +25156,12 @@ paths:
       operationId: update-channel-folder
       summary: Update a channel folder
       tags: ["channels"]
+      x-requires-administrator: true
       description: |
         Update the name or description of a channel folder.
 
         This endpoint is also used to archive and unarchive
         a channel folder.
-
-        Only organization administrators can update a
-        channel folder.
 
         **Changes**: New in Zulip 11.0 (feature level 389).
       parameters:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -25012,7 +25012,7 @@ paths:
                         description: |
                           The unique ID of the created channel folder.
                     example:
-                      {"msg": "", "result": "success", "channel_folder_id": 123}
+                      {"msg": "", "result": "success", "channel_folder_id": 12}
         "400":
           description: Bad request.
           content:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -25132,6 +25132,7 @@ paths:
                     folders.
                   items:
                     type: integer
+                  example: [2, 1]
               required:
                 - order
             encoding:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12109,11 +12109,8 @@ paths:
                   $ref: "#/components/schemas/CanResolveTopicsGroup"
                 folder_id:
                   description: |
-                    This parameter determines the folder to which the newly
-                    created channel will be added.
-
-                    If the value is `None`, the channel will not be added to
-                    any folder.
+                    This parameter adds the newly created channel to the specified
+                    [channel folder](/help/channel-folders).
 
                     **Changes**: New in Zulip 11.0 (feature level 389).
                   type: integer
@@ -23016,10 +23013,11 @@ paths:
                   example: true
                 folder_id:
                   description: |
-                    ID of the new folder to which the channel should belong.
+                    ID of the new [channel folder](/help/channel-folders) to which the
+                    channel should belong.
 
-                    It can be `None` if the user wants to just remove the channel
-                    from its existing folder.
+                    A `null` value indicates the user wants to remove the channel from its
+                    current channel folder.
 
                     **Changes**: New in Zulip 11.0 (feature level 389).
                   type: integer
@@ -23856,7 +23854,13 @@ paths:
                   default: false
                   example: true
                 folder_id:
-                  $ref: "#/components/schemas/FolderId"
+                  description: |
+                    This parameter adds the newly created channel to the specified
+                    [channel folder](/help/channel-folders).
+
+                    **Changes**: New in Zulip 11.0 (feature level 389).
+                  type: integer
+                  example: 1
                 topics_policy:
                   $ref: "#/components/schemas/TopicsPolicy"
                 history_public_to_subscribers:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -28932,17 +28932,20 @@ components:
     SendNewSubscriptionMessages:
       description: |
         Whether any other users newly subscribed via this request should be
-        sent a Notification Bot DM notifying them about their new
-        subscription.
+        sent a direct message, from Notification Bot, notifying them about their
+        new subscription.
 
-        The server will never send Notification Bot DMs if more than
-        `max_bulk_new_subscription_messages` (available in the [`POST
-        /register`](/api/register-queue) response) users were subscribed in
-        this request.
+        No direct messages are sent for any channels that are created as part of
+        this request, regardless of the value of this parameter.
+
+        The server will never send direct messages when the total number of users
+        who were subscribed to channels in this request was more than the value
+        of `max_bulk_new_subscription_messages`, which is available in the [`POST
+        /register`](/api/register-queue) response.
 
         **Changes**: Before Zulip 11.0 (feature level 397), new subscribers
-        were always sent a Notification Bot DM, which was unduly expensive
-        when bulk-subscribing thousands of users to a channel.
+        were always sent a Notification Bot direct message, which was unduly
+        expensive when bulk-subscribing thousands of users to a channel.
       type: boolean
       default: true
       example: true

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -24975,6 +24975,8 @@ paths:
                     Clients should use the `max_channel_folder_name_length` returned
                     by the [`POST /register`](/api/register-queue) endpoint to determine
                     the maximum channel folder name length.
+
+                    Value cannot be an empty string.
                   type: string
                   example: marketing
                 description:
@@ -24986,6 +24988,8 @@ paths:
                     to determine the maximum channel folder description length.
                   type: string
                   example: Channels for marketing.
+              required:
+                - name
       responses:
         "200":
           description: |
@@ -25182,6 +25186,8 @@ paths:
                     Clients should use the `max_channel_folder_name_length` returned
                     by the [`POST /register`](/api/register-queue) endpoint to determine
                     the maximum channel folder name length.
+
+                    Value cannot be an empty string.
                   type: string
                   example: backend
                 description:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -23763,12 +23763,15 @@ paths:
       operationId: create-channel
       summary: Create a channel
       description: |
-        Create a new [channel](/help/create-channels) and optionally
-        subscribe users to the newly created channel. The initial [channel settings](/api/update-stream)
-        will be determined by the optional parameters, like `invite_only`, detailed below.
+        Create a new [channel](/help/create-channels), and optionally subscribe
+        users to the newly created channel.
 
-        **Changes**: New in Zulip 11.0 (feature level 417). Previously, this was only possible via
-        the [`POST /api/subscribe`](/api/subscribe) endpoint, which handled both creation and subscription.
+        The initial [channel settings](/api/update-stream) will be determined
+        by the optional parameters, like `invite_only`, detailed below.
+
+        **Changes**: New in Zulip 11.0 (feature level 417). Previously, this was
+        only possible via the [`POST /api/subscribe`](/api/subscribe) endpoint,
+        which handles both channel subscription and creation.
       x-curl-examples-parameters:
         oneOf:
           - type: include
@@ -23777,12 +23780,11 @@ paths:
                 - name
                 - subscribers
       requestBody:
+        required: true
         content:
           application/x-www-form-urlencoded:
             schema:
               type: object
-              description: |
-                An object containing the top-level fields used to create a channel.
               properties:
                 name:
                   type: string
@@ -23819,11 +23821,11 @@ paths:
                   example: true
                 invite_only:
                   description: |
-                    This parameter and the ones
-                    that follow are used to request an initial configuration of the new channel.
+                    This parameter and the ones that follow are used to request an initial
+                    configuration of the new channel.
 
                     This parameter determines whether the newly created channel will be
-                    a private channel.
+                    a [private channel](/help/channel-permissions#private-channels).
                   type: boolean
                   default: false
                   example: true
@@ -23923,15 +23925,12 @@ paths:
                 contentType: application/json
               topics_policy:
                 contentType: application/json
-        required: true
-
       responses:
         "200":
           description: Success.
           content:
             application/json:
               schema:
-                description: "Success response for creating a channel."
                 allOf:
                   - $ref: "#/components/schemas/JsonSuccessBase"
                   - type: object
@@ -23949,27 +23948,17 @@ paths:
           content:
             application/json:
               schema:
-                description: "Bad request as channel already exists."
                 allOf:
                   - $ref: "#/components/schemas/CodedError"
-                  - type: object
-                    properties:
-                      result:
-                        type: string
-                        example: "error"
-                      msg:
-                        type: string
-                        example: "Channel 'discussions' already exists"
-                      code:
-                        type: string
-                        example: "CHANNEL_ALREADY_EXISTS"
-                example:
-                  {
-                    result: "error",
-                    msg: "Channel 'discussions' already exists",
-                    code: "CHANNEL_ALREADY_EXISTS",
-                  }
-
+                  - example:
+                      {
+                        result: "error",
+                        msg: "Channel 'discussions' already exists",
+                        code: "CHANNEL_ALREADY_EXISTS",
+                      }
+                    description: |
+                      An example JSON error response for when a channel with the submitted
+                      name already exists.
   /user_groups/create:
     post:
       operationId: create-user-group

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13118,11 +13118,17 @@ paths:
                           An example JSON response for when the user is not previously muted:
   /users/me/apns_device_token:
     post:
+      deprecated: true
       operationId: add-apns-token
       summary: Add an APNs device token
       tags: ["users"]
       description: |
         This endpoint adds an APNs device token to register for iOS push notifications.
+
+        **Changes**: Deprecated in Zulip 11.0 (feature level 406). Clients connecting
+        to newer servers and with E2EE push notifications support should use the
+        [Register E2EE push device](/api/register-push-device) endpoint, as this
+        endpoint will be removed in a future release.
       requestBody:
         required: true
         content:
@@ -13230,11 +13236,17 @@ paths:
                           A typical failed JSON response for when the token does not exist:
   /users/me/android_gcm_reg_id:
     post:
+      deprecated: true
       operationId: add-fcm-token
       summary: Add an FCM registration token
       tags: ["users"]
       description: |
         This endpoint adds an FCM registration token for push notifications.
+
+        **Changes**: Deprecated in Zulip 11.0 (feature level 406). Clients connecting
+        to newer servers and with E2EE push notifications support should use the
+        [Register E2EE push device](/api/register-push-device) endpoint, as this
+        endpoint will be removed in a future release.
       requestBody:
         required: true
         content:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -25128,6 +25128,8 @@ paths:
                     folders.
                   items:
                     type: integer
+              required:
+                - order
             encoding:
               order:
                 contentType: application/json

--- a/zerver/tests/test_channel_creation.py
+++ b/zerver/tests/test_channel_creation.py
@@ -330,12 +330,19 @@ class TestCreateStreams(ZulipTestCase):
             user_profile,
             "/api/v1/channels/create",
             post_data,
-            intentionally_undocumented=True,
         )
         self.assert_json_success(result)
         stream = get_stream("no-sub-channel", user_profile.realm)
         self.assertEqual(stream.name, "no-sub-channel")
         self.assertEqual(stream.subscriber_count, 0)
+
+        # Test creating channel with invalid user ID.
+        result = self.create_channel_via_post(
+            user_profile,
+            name="invalid-user-channel",
+            subscribers=[12, 1000],
+        )
+        self.assert_json_error(result, "No such user")
 
     def test_channel_creation_miscellaneous(self) -> None:
         iago = self.example_user("iago")

--- a/zerver/tests/test_e2ee_push_notifications.py
+++ b/zerver/tests/test_e2ee_push_notifications.py
@@ -56,6 +56,7 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
             self.mock_apns() as send_notification,
             self.assertLogs("zerver.lib.push_notifications", level="INFO") as zerver_logger,
             self.assertLogs("zilencer.lib.push_notifications", level="INFO") as zilencer_logger,
+            mock.patch("time.perf_counter", side_effect=[10.0, 15.0]),
         ):
             mock_fcm_messaging.send_each.return_value = self.make_fcm_success_response()
             send_notification.return_value.is_successful = True
@@ -87,7 +88,7 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
             )
             self.assertEqual(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs in 5.000s",
                 zerver_logger.output[3],
             )
 
@@ -153,6 +154,7 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
             self.mock_apns() as send_notification,
             self.assertLogs("zerver.lib.push_notifications", level="INFO") as zerver_logger,
             self.assertLogs("zilencer.lib.push_notifications", level="INFO") as zilencer_logger,
+            mock.patch("time.perf_counter", side_effect=[10.5, 11.0]),
         ):
             mock_fcm_messaging.send_each.return_value = self.make_fcm_error_response(
                 UnregisteredError("Token expired")
@@ -187,7 +189,7 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
             )
             self.assertEqual(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 0 via FCM, 0 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 0 via FCM, 0 via APNs in 0.500s",
                 zerver_logger.output[4],
             )
 
@@ -218,6 +220,7 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
             mock.patch("zilencer.lib.push_notifications.get_apns_context", return_value=None),
             self.assertLogs("zerver.lib.push_notifications", level="INFO") as zerver_logger,
             self.assertLogs("zilencer.lib.push_notifications", level="DEBUG") as zilencer_logger,
+            mock.patch("time.perf_counter", side_effect=[10.0, 12.0]),
         ):
             mock_fcm_messaging.send_each.return_value = self.make_fcm_error_response(
                 InternalError("fcm-error")
@@ -245,7 +248,7 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
             )
             self.assertEqual(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 0 via FCM, 0 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 0 via FCM, 0 via APNs in 2.000s",
                 zerver_logger.output[2],
             )
 
@@ -269,6 +272,7 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
             ),
             self.assertLogs("zerver.lib.push_notifications", level="INFO") as zerver_logger,
             self.assertLogs("zilencer.lib.push_notifications", level="WARNING") as zilencer_logger,
+            mock.patch("time.perf_counter", side_effect=[10.0, 12.0]),
         ):
             mock_fcm_messaging.send_each.side_effect = InternalError("server error")
             handle_push_notification(hamlet.id, missed_message)
@@ -284,7 +288,7 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
             )
             self.assertEqual(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 0 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 0 via FCM, 1 via APNs in 2.000s",
                 zerver_logger.output[2],
             )
 
@@ -366,6 +370,7 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
             ),
             self.assertLogs("zerver.lib.push_notifications", level="INFO") as zerver_logger,
             self.assertLogs("zilencer.lib.push_notifications", level="INFO") as zilencer_logger,
+            mock.patch("time.perf_counter", side_effect=[10.05, 12.10]),
         ):
             mock_fcm_messaging.send_each.return_value = self.make_fcm_success_response()
             send_notification.return_value.is_successful = True
@@ -397,7 +402,7 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
             )
             self.assertEqual(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs in 2.050s",
                 zerver_logger.output[3],
             )
 
@@ -564,6 +569,7 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
             ),
             self.assertLogs("zerver.lib.push_notifications", level="INFO") as zerver_logger,
             self.assertLogs("zilencer.lib.push_notifications", level="INFO") as zilencer_logger,
+            mock.patch("time.perf_counter", side_effect=[10.0, 12.0]),
         ):
             mock_fcm_messaging_legacy.send_each.return_value = self.make_fcm_success_response(
                 for_legacy=True
@@ -608,7 +614,7 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
             )
             self.assertEqual(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs in 2.000s",
                 zerver_logger.output[7],
             )
 
@@ -716,6 +722,7 @@ class RemovePushNotificationTest(E2EEPushNotificationTestCase):
             self.mock_apns() as send_notification,
             self.assertLogs("zerver.lib.push_notifications", level="INFO") as zerver_logger,
             self.assertLogs("zilencer.lib.push_notifications", level="INFO"),
+            mock.patch("time.perf_counter", side_effect=[10.0, 12.0]),
         ):
             mock_fcm_messaging.send_each.return_value = self.make_fcm_success_response()
             send_notification.return_value.is_successful = True
@@ -730,7 +737,7 @@ class RemovePushNotificationTest(E2EEPushNotificationTestCase):
 
             self.assertEqual(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs in 2.000s",
                 zerver_logger.output[2],
             )
 
@@ -759,6 +766,7 @@ class RemovePushNotificationTest(E2EEPushNotificationTestCase):
             ),
             self.assertLogs("zerver.lib.push_notifications", level="INFO") as zerver_logger,
             self.assertLogs("zilencer.lib.push_notifications", level="INFO"),
+            mock.patch("time.perf_counter", side_effect=[10.0, 12.0]),
         ):
             mock_fcm_messaging.send_each.return_value = self.make_fcm_success_response()
             send_notification.return_value.is_successful = True
@@ -773,7 +781,7 @@ class RemovePushNotificationTest(E2EEPushNotificationTestCase):
 
             self.assertEqual(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs in 2.000s",
                 zerver_logger.output[2],
             )
 
@@ -891,6 +899,7 @@ class SendTestPushNotificationTest(E2EEPushNotificationTestCase):
             self.mock_apns() as send_notification,
             self.assertLogs("zilencer.lib.push_notifications", level="INFO"),
             self.assertLogs("zerver.lib.push_notifications", level="INFO") as zerver_logger,
+            mock.patch("time.perf_counter", side_effect=[10.0, 12.0, 13.0, 16.0]),
         ):
             mock_fcm_messaging.send_each.return_value = self.make_fcm_success_response()
             send_notification.return_value.is_successful = True
@@ -911,7 +920,7 @@ class SendTestPushNotificationTest(E2EEPushNotificationTestCase):
             )
             self.assertEqual(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs in 2.000s",
                 zerver_logger.output[-1],
             )
 
@@ -931,7 +940,7 @@ class SendTestPushNotificationTest(E2EEPushNotificationTestCase):
             )
             self.assertEqual(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 0 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 0 via APNs in 3.000s",
                 zerver_logger.output[-1],
             )
 
@@ -952,6 +961,7 @@ class SendTestPushNotificationTest(E2EEPushNotificationTestCase):
             ),
             self.assertLogs("zilencer.lib.push_notifications", level="INFO"),
             self.assertLogs("zerver.lib.push_notifications", level="INFO") as zerver_logger,
+            mock.patch("time.perf_counter", side_effect=[10.0, 12.0]),
         ):
             mock_fcm_messaging.send_each.return_value = self.make_fcm_success_response()
             send_notification.return_value.is_successful = True
@@ -972,7 +982,7 @@ class SendTestPushNotificationTest(E2EEPushNotificationTestCase):
             )
             self.assertEqual(
                 "INFO:zerver.lib.push_notifications:"
-                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs",
+                f"Sent E2EE mobile push notifications for user {hamlet.id}: 1 via FCM, 1 via APNs in 2.000s",
                 zerver_logger.output[-1],
             )
 

--- a/zerver/tests/test_e2ee_push_notifications.py
+++ b/zerver/tests/test_e2ee_push_notifications.py
@@ -28,6 +28,7 @@ from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.models import PushDevice, UserMessage
 from zerver.models.realms import get_realm
 from zerver.models.scheduled_jobs import NotificationTriggers
+from zilencer.lib.push_notifications import SentPushNotificationResult
 from zilencer.models import RemoteRealm, RemoteRealmCount
 
 
@@ -260,7 +261,11 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
         with (
             self.mock_fcm() as mock_fcm_messaging,
             mock.patch(
-                "zilencer.lib.push_notifications.send_e2ee_push_notification_apple", return_value=1
+                "zilencer.lib.push_notifications.send_e2ee_push_notification_apple",
+                return_value=SentPushNotificationResult(
+                    successfully_sent_count=1,
+                    delete_device_ids=[],
+                ),
             ),
             self.assertLogs("zerver.lib.push_notifications", level="INFO") as zerver_logger,
             self.assertLogs("zilencer.lib.push_notifications", level="WARNING") as zilencer_logger,

--- a/zerver/tests/test_message_delete.py
+++ b/zerver/tests/test_message_delete.py
@@ -914,7 +914,7 @@ class DeleteMessageTest(ZulipTestCase):
         self.assertEqual(stream.first_message_id, message_ids[1])
 
         all_messages = Message.objects.filter(id__in=message_ids)
-        with self.assert_database_query_count(27):
+        with self.assert_database_query_count(25):
             do_delete_messages(realm, all_messages, acting_user=None)
         stream = get_stream(stream_name, realm)
         self.assertEqual(stream.first_message_id, None)

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -2433,7 +2433,7 @@ class GetOldMessagesTest(ZulipTestCase):
         self.assertFalse(aaron.is_active)
 
         personals = [
-            m for m in get_user_messages(self.example_user("hamlet")) if not m.is_stream_message()
+            m for m in get_user_messages(self.example_user("hamlet")) if not m.is_channel_message
         ]
         for personal in personals:
             emails = dr_emails(get_display_recipient(personal.recipient))
@@ -2748,7 +2748,7 @@ class GetOldMessagesTest(ZulipTestCase):
         self.send_personal_message(hamlet, hamlet)
 
         messages = get_user_messages(hamlet)
-        channel_messages = [msg for msg in messages if msg.is_stream_message()]
+        channel_messages = [msg for msg in messages if msg.is_channel_message]
         self.assertGreater(len(messages), len(channel_messages))
         self.assert_length(channel_messages, num_messages_per_channel * len(channel_names))
 
@@ -2804,7 +2804,7 @@ class GetOldMessagesTest(ZulipTestCase):
         )
 
         messages = get_user_messages(self.mit_user("starnine"))
-        channel_messages = [msg for msg in messages if msg.is_stream_message()]
+        channel_messages = [msg for msg in messages if msg.is_channel_message]
 
         self.assert_length(result["messages"], 2)
         for i, message in enumerate(result["messages"]):
@@ -2835,7 +2835,7 @@ class GetOldMessagesTest(ZulipTestCase):
         )
 
         messages = get_user_messages(mit_user_profile)
-        channel_messages = [msg for msg in messages if msg.is_stream_message()]
+        channel_messages = [msg for msg in messages if msg.is_channel_message]
         self.assert_length(result["messages"], 5)
         for i, message in enumerate(result["messages"]):
             self.assertEqual(message["type"], "stream")
@@ -2869,7 +2869,7 @@ class GetOldMessagesTest(ZulipTestCase):
         )
 
         messages = get_user_messages(mit_user_profile)
-        channel_messages = [msg for msg in messages if msg.is_stream_message()]
+        channel_messages = [msg for msg in messages if msg.is_channel_message]
         self.assert_length(result["messages"], 7)
         for i, message in enumerate(result["messages"]):
             self.assertEqual(message["type"], "stream")

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -263,7 +263,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/jwt/fetch_api_key",
         #### Bouncer endpoints
         # Higher priority to document
-        "/remotes/push/e2ee/register",
         "/remotes/push/e2ee/notify",
         # Lower priority to document
         "/remotes/server/register",

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -853,12 +853,12 @@ class TestCurlExampleGeneration(ZulipTestCase):
 
     def test_generate_and_render_curl_wrapper(self) -> None:
         generated_curl_example = render_curl_example(
-            "/get_stream_id:GET:email:key", api_url="https://zulip.example.com/api"
+            "/get_stream_id:GET", api_url="https://zulip.example.com/api"
         )
         expected_curl_example = [
             "```curl",
             "curl -sSX GET -G https://zulip.example.com/api/v1/get_stream_id \\",
-            "    -u email:key \\",
+            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
             "    --data-urlencode stream=Denmark",
             "```",
         ]

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -1151,7 +1151,7 @@ class TestDoDeleteMessages(ZulipTestCase):
         message_ids = [self.send_stream_message(cordelia, "Verona", str(i)) for i in range(10)]
         messages = Message.objects.filter(id__in=message_ids)
 
-        with self.assert_database_query_count(32):
+        with self.assert_database_query_count(23):
             do_delete_messages(realm, messages, acting_user=None)
         self.assertFalse(Message.objects.filter(id__in=message_ids).exists())
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4416,7 +4416,7 @@ class SubscriptionAPITest(ZulipTestCase):
         with (
             self.assert_database_query_count(23),
             self.assert_memcached_count(11),
-            mock.patch("zerver.views.streams.send_messages_for_new_subscribers"),
+            mock.patch("zerver.views.streams.send_user_subscribed_and_new_channel_notifications"),
         ):
             self.subscribe_via_post(
                 desdemona,

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -5147,8 +5147,11 @@ class SubscriptionAPITest(ZulipTestCase):
             recipient__type_id=announce.id,
             date_sent__gt=now,
         )
-        # Currently, this notification is not sent even though it should be.
-        self.assertEqual(announcement_channel_message.count(), 0)
+        self.assertEqual(announcement_channel_message.count(), 1)
+        self.assertEqual(
+            announcement_channel_message[0].content,
+            f"@_**{desdemona.full_name}|{desdemona.id}** created a new channel #**test D**.",
+        )
 
         new_channel = get_stream("test D", realm)
         new_channel_message = Message.objects.filter(
@@ -5158,8 +5161,15 @@ class SubscriptionAPITest(ZulipTestCase):
             recipient__type_id=new_channel.id,
             date_sent__gt=now,
         )
-        # Currently, this notification is not sent even though it should be.
-        self.assert_length(new_channel_message.values(), 0)
+        self.assert_length(new_channel_message.values(), 1)
+        self.assertEqual(
+            new_channel_message[0].topic_name(), Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME
+        )
+        self.assertEqual(
+            new_channel_message[0].content,
+            f"**Public** channel created by @_**{desdemona.full_name}|{desdemona.id}**. **Description:**\n"
+            "```` quote\n*No description.*\n````",
+        )
 
 
 class InviteOnlyStreamTest(ZulipTestCase):

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4985,8 +4985,12 @@ class SubscriptionAPITest(ZulipTestCase):
 
     def test_notification_bot_dm_on_subscription(self) -> None:
         desdemona = self.example_user("desdemona")
+        realm = desdemona.realm
         self.login_user(desdemona)
-
+        bot = self.notification_bot(realm)
+        test_channel = self.make_stream("test A")
+        announce = realm.new_stream_announcements_stream
+        assert announce is not None
         user_ids = [
             desdemona.id,
             self.example_user("cordelia").id,
@@ -4995,19 +4999,167 @@ class SubscriptionAPITest(ZulipTestCase):
             self.example_user("iago").id,
             self.example_user("prospero").id,
         ]
-
+        principals_dict = dict(
+            principals=orjson.dumps(user_ids).decode(), announce=orjson.dumps(True).decode()
+        )
+        # When subscribing to an already existing channel with announce=True,
+        # the bot should send DMs to all the newly subscribed users, but
+        # no announcement message.
+        now = timezone_now()
         response = self.subscribe_via_post(
-            desdemona, ["Test stream 1"], dict(principals=orjson.dumps(user_ids).decode())
+            desdemona,
+            [test_channel.name],
+            principals_dict,
         )
         data = self.assert_json_success(response)
         self.assertEqual(data["new_subscription_messages_sent"], True)
 
+        notification_bot_dms = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.PERSONAL,
+            date_sent__gt=now,
+        )
+        self.assert_length(notification_bot_dms, 5)
+        notif_bot_dm_recipients = [
+            dm["recipient__type_id"] for dm in notification_bot_dms.values("recipient__type_id")
+        ]
+        self.assertSetEqual(
+            {id for id in user_ids if id != desdemona.id}, set(notif_bot_dm_recipients)
+        )
+
+        announcement_channel_message = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.STREAM,
+            recipient__type_id=announce.id,
+            date_sent__gt=now,
+        )
+        self.assertEqual(announcement_channel_message.count(), 0)
+
+        # When subscribing to a newly created channel with announce=True,
+        # we expect an announcement message and new channel message,
+        # but no DM notifications.
+        now = timezone_now()
+        response = self.subscribe_via_post(
+            desdemona,
+            ["test B"],
+            principals_dict,
+        )
+        data = self.assert_json_success(response)
+        self.assertEqual(data["new_subscription_messages_sent"], True)
+
+        notification_bot_dms = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.PERSONAL,
+            date_sent__gt=now,
+        )
+        self.assertEqual(notification_bot_dms.count(), 0)
+
+        announcement_channel_message = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.STREAM,
+            recipient__type_id=announce.id,
+            date_sent__gt=now,
+        )
+        self.assert_length(announcement_channel_message.values(), 1)
+        self.assertEqual(
+            announcement_channel_message[0].content,
+            f"@_**{desdemona.full_name}|{desdemona.id}** created a new channel #**test B**.",
+        )
+
+        new_channel = get_stream("test B", realm)
+        new_channel_message = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.STREAM,
+            recipient__type_id=new_channel.id,
+            date_sent__gt=now,
+        )
+        self.assert_length(new_channel_message.values(), 1)
+        self.assertEqual(
+            new_channel_message[0].topic_name(), Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME
+        )
+        self.assertEqual(
+            new_channel_message[0].content,
+            f"**Public** channel created by @_**{desdemona.full_name}|{desdemona.id}**. **Description:**\n"
+            "```` quote\n*No description.*\n````",
+        )
+
+        # When subscribing to an already existing channel, if the number of new
+        # subscriptions exceeds the limit, no DMs or announcement message should
+        # be sent.
+        now = timezone_now()
+        test_channel = self.make_stream("test C")
         with self.settings(MAX_BULK_NEW_SUBSCRIPTION_MESSAGES=5):
             response = self.subscribe_via_post(
-                desdemona, ["Test stream 2"], dict(principals=orjson.dumps(user_ids).decode())
+                desdemona,
+                [test_channel.name],
+                principals_dict,
             )
         data = self.assert_json_success(response)
         self.assertEqual(data["new_subscription_messages_sent"], False)
+
+        notification_bot_dms = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.PERSONAL,
+            date_sent__gt=now,
+        )
+        self.assertEqual(notification_bot_dms.count(), 0)
+
+        announcement_channel_message = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.STREAM,
+            recipient__type_id=announce.id,
+            date_sent__gt=now,
+        )
+        self.assertEqual(announcement_channel_message.count(), 0)
+
+        # When subscribing to an already existing channel, if the number of new
+        # subscriptions exceeds the limit, no DMs are sent, but an announcement
+        # message and new channel message should be sent.
+        now = timezone_now()
+        with self.settings(MAX_BULK_NEW_SUBSCRIPTION_MESSAGES=5):
+            response = self.subscribe_via_post(
+                desdemona,
+                ["test D"],
+                principals_dict,
+            )
+        data = self.assert_json_success(response)
+        self.assertEqual(data["new_subscription_messages_sent"], False)
+
+        notification_bot_dms = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.PERSONAL,
+            date_sent__gt=now,
+        )
+        self.assertEqual(notification_bot_dms.count(), 0)
+
+        announcement_channel_message = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.STREAM,
+            recipient__type_id=announce.id,
+            date_sent__gt=now,
+        )
+        # Currently, this notification is not sent even though it should be.
+        self.assertEqual(announcement_channel_message.count(), 0)
+
+        new_channel = get_stream("test D", realm)
+        new_channel_message = Message.objects.filter(
+            realm_id=realm.id,
+            sender=bot.id,
+            recipient__type=Recipient.STREAM,
+            recipient__type_id=new_channel.id,
+            date_sent__gt=now,
+        )
+        # Currently, this notification is not sent even though it should be.
+        self.assert_length(new_channel_message.values(), 0)
 
 
 class InviteOnlyStreamTest(ZulipTestCase):

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -5171,6 +5171,17 @@ class SubscriptionAPITest(ZulipTestCase):
             "```` quote\n*No description.*\n````",
         )
 
+        response = self.subscribe_via_post(
+            desdemona,
+            ["Test stream 3"],
+            dict(
+                principals=orjson.dumps(user_ids).decode(),
+                send_new_subscription_messages=orjson.dumps(False).decode(),
+            ),
+        )
+        data = self.assert_json_success(response)
+        self.assertNotIn("new_subscription_messages_sent", data)
+
 
 class InviteOnlyStreamTest(ZulipTestCase):
     def test_must_be_subbed_to_send(self) -> None:

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -46,7 +46,7 @@ def fill_edit_history_entries(
     """
     prev_content = message.content
     prev_rendered_content = message.rendered_content
-    is_channel_message = message.is_stream_message()
+    is_channel_message = message.is_channel_message
     if is_channel_message:
         prev_topic_name = maybe_rename_empty_topic_to_general_chat(
             message.topic_name(), is_channel_message, allow_empty_topic_name
@@ -185,7 +185,7 @@ def validate_can_delete_message(user_profile: UserProfile, message: Message) -> 
         return
 
     stream: Stream | None = None
-    if message.is_stream_message():
+    if message.is_channel_message:
         stream = get_stream_by_id_in_realm(message.recipient.type_id, user_profile.realm)
         if can_delete_any_message_in_channel(user_profile, stream):
             return
@@ -195,7 +195,7 @@ def validate_can_delete_message(user_profile: UserProfile, message: Message) -> 
         raise JsonableError(_("You don't have permission to delete this message"))
 
     if not user_profile.can_delete_own_message():
-        if not message.is_stream_message():
+        if not message.is_channel_message:
             raise JsonableError(_("You don't have permission to delete this message"))
 
         assert stream is not None

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -1323,10 +1323,8 @@ def delete_in_topic(
         if time.monotonic() >= start_time + 50:
             return json_success(request, data={"complete": False})
         with transaction.atomic(durable=True):
-            messages_to_delete = (
-                messages.select_related("recipient")
-                .order_by("-id")[0:batch_size]
-                .select_for_update(of=("self",))
+            messages_to_delete = messages.order_by("-id")[0:batch_size].select_for_update(
+                of=("self",)
             )
             if not messages_to_delete:
                 break

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -829,7 +829,7 @@ def create_channel(
         send_new_subscription_messages
         and len(new_subscribers) <= settings.MAX_BULK_NEW_SUBSCRIPTION_MESSAGES
     ):
-        send_messages_for_new_subscribers(
+        send_user_subscribed_and_new_channel_notifications(
             user_profile=user_profile,
             subscribers=new_subscribers,
             new_subscriptions={str(user.id): [name] for user in new_subscribers},
@@ -1017,7 +1017,7 @@ def add_subscriptions_backend(
 
     if send_new_subscription_messages:
         if len(result["subscribed"]) <= settings.MAX_BULK_NEW_SUBSCRIPTION_MESSAGES:
-            send_messages_for_new_subscribers(
+            send_user_subscribed_and_new_channel_notifications(
                 user_profile=user_profile,
                 subscribers=subscribers,
                 new_subscriptions=result["subscribed"],
@@ -1036,7 +1036,7 @@ def add_subscriptions_backend(
     return json_success(request, data=result)
 
 
-def send_messages_for_new_subscribers(
+def send_user_subscribed_and_new_channel_notifications(
     user_profile: UserProfile,
     subscribers: set[UserProfile],
     new_subscriptions: dict[str, list[str]],

--- a/zilencer/auth.py
+++ b/zilencer/auth.py
@@ -172,6 +172,7 @@ def remote_server_dispatch(request: HttpRequest, /, **kwargs: Any) -> HttpRespon
 
 def remote_server_path(
     route: str,
-    **handlers: Callable[Concatenate[HttpRequest, RemoteZulipServer, ParamT], HttpResponse],
+    **handlers: Callable[Concatenate[HttpRequest, RemoteZulipServer, ParamT], HttpResponse]
+    | tuple[Callable[Concatenate[HttpRequest, RemoteZulipServer, ParamT], HttpResponse], set[str]],
 ) -> URLPattern:
     return path(route, remote_server_dispatch, handlers)

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -1039,14 +1039,23 @@ class Command(ZulipBaseCommand):
                     name=SystemGroups.ADMINISTRATORS, realm=zulip_realm, is_system_group=True
                 )
 
-                channel_folder = check_add_channel_folder(
+                engineering_channel_folder = check_add_channel_folder(
                     zulip_realm,
                     "Engineering",
                     "For convenient *channel folder* testing! :octopus:",
                     acting_user=iago,
                 )
+                information_channel_folder = check_add_channel_folder(
+                    zulip_realm,
+                    "Information",
+                    "For user-facing information and questions",
+                    acting_user=iago,
+                )
                 zulip_stream_dict: dict[str, dict[str, Any]] = {
-                    "devel": {"description": "For developing", "folder_id": channel_folder.id},
+                    "devel": {
+                        "description": "For developing",
+                        "folder_id": engineering_channel_folder.id,
+                    },
                     # ビデオゲーム - VideoGames (japanese)
                     "ビデオゲーム": {
                         "description": f"Share your favorite video games!  {raw_emojis[2]}",
@@ -1055,12 +1064,22 @@ class Command(ZulipBaseCommand):
                     "announce": {
                         "description": "For announcements",
                         "can_send_message_group": admins_system_group,
+                        "folder_id": information_channel_folder.id,
                     },
                     "design": {"description": "For design", "creator": hamlet},
-                    "support": {"description": "For support"},
+                    "support": {
+                        "description": "For support",
+                        "folder_id": information_channel_folder.id,
+                    },
                     "social": {"description": "For socializing"},
-                    "test": {"description": "For testing `code`", "folder_id": channel_folder.id},
-                    "errors": {"description": "For errors", "folder_id": channel_folder.id},
+                    "test": {
+                        "description": "For testing `code`",
+                        "folder_id": engineering_channel_folder.id,
+                    },
+                    "errors": {
+                        "description": "For errors",
+                        "folder_id": engineering_channel_folder.id,
+                    },
                     # 조리법 - Recipes (Korean), Пельмени - Dumplings (Russian)
                     "조리법 " + raw_emojis[0]: {
                         "description": "Everything cooking, from pasta to Пельмени"

--- a/zilencer/urls.py
+++ b/zilencer/urls.py
@@ -24,16 +24,31 @@ from zilencer.views import (
 i18n_urlpatterns: Any = []
 
 # Zilencer views following the REST API style
+# The endpoints marked "intentionally_undocumented" are part of the older system
+# for sending non-E2EE push notifications, and will be removed in the future.
 push_bouncer_patterns = [
-    remote_server_path("remotes/push/register", POST=register_remote_push_device),
+    remote_server_path(
+        "remotes/push/register", POST=(register_remote_push_device, {"intentionally_undocumented"})
+    ),
     remote_server_path(
         "remotes/push/e2ee/register", POST=register_remote_push_device_for_e2ee_push_notification
     ),
-    remote_server_path("remotes/push/unregister", POST=unregister_remote_push_device),
-    remote_server_path("remotes/push/unregister/all", POST=unregister_all_remote_push_devices),
-    remote_server_path("remotes/push/notify", POST=remote_server_notify_push),
+    remote_server_path(
+        "remotes/push/unregister",
+        POST=(unregister_remote_push_device, {"intentionally_undocumented"}),
+    ),
+    remote_server_path(
+        "remotes/push/unregister/all",
+        POST=(unregister_all_remote_push_devices, {"intentionally_undocumented"}),
+    ),
+    remote_server_path(
+        "remotes/push/notify", POST=(remote_server_notify_push, {"intentionally_undocumented"})
+    ),
     remote_server_path("remotes/push/e2ee/notify", POST=remote_server_send_e2ee_push_notification),
-    remote_server_path("remotes/push/test_notification", POST=remote_server_send_test_notification),
+    remote_server_path(
+        "remotes/push/test_notification",
+        POST=(remote_server_send_test_notification, {"intentionally_undocumented"}),
+    ),
     # Push signup doesn't use the REST API, since there's no auth.
     path("remotes/server/register", register_remote_server),
     path("remotes/server/register/transfer", transfer_remote_server_registration),
@@ -49,7 +64,8 @@ push_bouncer_patterns = [
 
 billing_patterns = [remote_server_path("remotes/server/billing", POST=remote_realm_billing_entry)]
 
+v1_api_bouncer_patterns = push_bouncer_patterns + billing_patterns
+
 urlpatterns = [
-    path("api/v1/", include(push_bouncer_patterns)),
-    path("api/v1/", include(billing_patterns)),
+    path("api/v1/", include(v1_api_bouncer_patterns)),
 ]


### PR DESCRIPTION
Several of these PRs are backported to avoid merge conflicts with things that are important to backport, but would otherwise be too minor of a benefit to both backporting.

- #35798
- #35875
- #35845
- #35760
- #35842
- #35761
- #35781
- #35836
- #35784
- #35832
- #35816
- #35757

The actual impact is just to have the current E2EE push notifications code in 11.1, as well as some API documentation fixes for the new channel API endpoint. (With some small perf improvements).