### PR TITLE
left_sidebar: Fix muted channel visible in collapsed folder on search.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -562,7 +562,7 @@
     display: none;
 }
 
-.stream-list-section-container.collapsed {
+#streams_list .stream-list-section-container.collapsed {
     .narrow-filter:not(.stream-expanded),
     .stream-list-toggle-inactive-or-muted-channels,
     .topic-list-item:not(.active-sub-filter),


### PR DESCRIPTION
While searching in left sidebar, if you collapse a folder, muted or inactive channels are still visible.

This is due specificity of hiding the channel when folder is collapsed was lower than that of showing it when a search is active.

Fixed by increasing the specificity of hiding it when folder is collapsed.
