### PR TITLE
puppet: Stop using an unnecessary concat.

### DIFF
--- a/puppet/zulip/manifests/supervisor.pp
+++ b/puppet/zulip/manifests/supervisor.pp
@@ -81,23 +81,14 @@ class zulip::supervisor {
   }
 
   $file_descriptor_limit = zulipconf('application_server', 'service_file_descriptor_limit', 40000)
-  concat { $zulip::common::supervisor_conf_file:
-    ensure  => 'present',
+  file { $zulip::common::supervisor_conf_file:
+    ensure  => file,
     require => Package[supervisor],
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
+    content => template('zulip/supervisor/supervisord.conf.erb'),
     notify  => Exec['supervisor-restart'],
-  }
-  concat::fragment { '00-supervisor-top':
-    order   => '01',
-    target  => $zulip::common::supervisor_conf_file,
-    content => rstrip(template('zulip/supervisor/supervisord.conf.erb')),
-  }
-  concat::fragment { '99-supervisor-end':
-    order   => '99',
-    target  => $zulip::common::supervisor_conf_file,
-    content => "\n",
   }
 
   file { '/usr/local/bin/secret-env-wrapper':


### PR DESCRIPTION
This was added in 6975417acfa8, to support `zmirror` deployments, which are no longer necessary.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
