### PR TITLE
recents: Bring filters into concord with left, right sidebars.

### DIFF
--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -191,8 +191,6 @@ export function resize_sidebars(): void {
 
 export function update_recent_view(): void {
     const $recent_view_filter_container = $("#recent_view_filter_buttons");
-    const recent_view_filters_height = $recent_view_filter_container.outerHeight(true) ?? 0;
-    $(":root").css("--recent-topics-filters-height", `${recent_view_filters_height}px`);
 
     // Update max avatars to prevent participant avatars from overflowing.
     // These numbers are just based on speculation.

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -570,9 +570,12 @@
     --width-simplebar-scroll: 11px;
     --width-simplebar-scroll-hover: 15px;
 
-    /* This is a rough estimate for height occupied by Recent Conversations filters.
-       We expect `resize.ts` to update this once UI is initialized. */
-    --recent-topics-filters-height: 50px;
+    /* This is the height occupied by Recent Conversations filters,
+       based on the height of the new filter elements in the sidebars
+       and for the topics filter. 31px at 16px/1em. */
+    --recent-topics-filters-height: 1.9375em;
+    /* Legacy margin/flex-gap value for filters. 10px at 14px/1em. */
+    --recent-topics-filters-gap: 0.7142em;
 
     /* Pill dimensions. */
     /* 1.5714em is 22px (border-inclusive) at 14px/1em */

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -156,6 +156,7 @@
            should match the height of the sidebar filters. */
         padding: 10px 10px 0;
         display: flex;
+        gap: var(--recent-topics-filters-gap);
         /* Search box has no height without this in safari. */
         flex: 0 0 auto;
         flex-wrap: wrap;
@@ -163,9 +164,15 @@
         background: var(--color-background);
     }
 
+    #recent_filters_group {
+        display: flex;
+        flex-flow: row wrap;
+        gap: var(--recent-topics-filters-gap);
+    }
+
     #recent-view-search-wrapper {
         flex-grow: 1;
-        margin-bottom: 0.7142em; /* Legacy 10px at 14px/1em. */
+        margin-bottom: var(--recent-topics-filters-gap);
     }
 
     .button-recent-filters {
@@ -173,12 +180,14 @@
         background-color: var(--color-background-zulip-button);
         border: 1px solid var(--color-border-zulip-button);
         border-radius: 40px;
-        /* Legacy 5px 10px at 14px/1em. */
-        margin: 0 0.3571em 0.7142em 0;
-        /* 5px at 16px/1em and legacy 12px at 14px/1em. */
-        padding: 0.3125em 0.8571em;
-        line-height: 100%;
-        display: inline-flex;
+        /* Matching to the height of the filter search box. */
+        height: var(--recent-topics-filters-height);
+        /* Legacy 12px at 14px/1em. */
+        padding: 0 0.8571em;
+
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
 
         &:hover {
             background-color: var(--color-background-zulip-button-hover);
@@ -609,10 +618,10 @@
 #recent-view-filter_widget {
     display: inline-flex;
     width: 10.7142em; /* 150px at 14px em */
-    /* Legacy 5px 10px at 14px/1em. */
-    margin: 0 0.3571em 0.7142em 0;
     /* 1.5px 6px at 16px/1em */
-    padding: 0.0937em 0.375em;
+    padding: 0 0.375em;
+    /* Matching to the height of the filter search box. */
+    height: var(--recent-topics-filters-height);
 
     &:hover {
         background-color: var(--color-background-inbox-search-hover);

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -622,13 +622,22 @@
     padding: 0 0.375em;
     /* Matching to the height of the filter search box. */
     height: var(--recent-topics-filters-height);
+    /* Matching to the input styles otherwise defined on
+       .input-element in inputs.css */
+    color: var(--color-text-input);
+    background: var(--color-background-input);
+    border: none;
+    outline: 1px solid var(--color-outline-input);
+    outline-offset: -1px;
 
     &:hover {
-        background-color: var(--color-background-inbox-search-hover);
+        outline-color: var(--color-outline-input-hover);
     }
 
     &:focus {
-        outline: 2px solid var(--color-outline-focus);
+        background-color: var(--color-background-input-focus);
+        outline-color: var(--color-outline-input-focus);
+        box-shadow: 0 0 5px var(--color-box-shadow-input-focus);
     }
 }
 


### PR DESCRIPTION
In addition to matching the heights of all of the recents filters, this also adjusts the filter-widget dropdown to look like the filter input. Other recents filters are left as-is, deferring that work as part of a planned design pass.

[#design > recents filters layout, design](https://chat.zulip.org/#narrow/channel/101-design/topic/recents.20filters.20layout.2C.20design/with/2251809)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="1000" height="1600" alt="recent-filters-narrow-before" src="https://github.com/user-attachments/assets/1064a7f1-4d8c-4fb4-9539-8f1f43969c12" /> | <img width="1000" height="1600" alt="recent-filters-narrow-after" src="https://github.com/user-attachments/assets/2875736f-88ab-4416-a706-8985b7445c39" /> |
| <img width="2000" height="1600" alt="recent-filters-medium-before" src="https://github.com/user-attachments/assets/d85f545d-7d28-4659-9c64-7b469f832daa" /> | <img width="2000" height="1600" alt="recent-filters-medium-after" src="https://github.com/user-attachments/assets/7207aacd-64f7-4c47-b132-7368380c88a0" /> |
| <img width="2400" height="1600" alt="recent-filters-wide-before" src="https://github.com/user-attachments/assets/6a363ea4-1bbf-40f0-b58e-dde983652b80" /> | <img width="2400" height="1600" alt="recent-filters-wide-after" src="https://github.com/user-attachments/assets/f06df562-5cb0-44f3-9ac2-096fb84fd37d" /> |

| Extreme font sizes, before | Extreme font sizes, after |
| --- | --- |
| <img width="1000" height="1600" alt="recent-filters-smallest-before" src="https://github.com/user-attachments/assets/18312faa-4e14-4e09-a554-d98301a0033c" /> | <img width="1000" height="1600" alt="recent-filters-smallest-after" src="https://github.com/user-attachments/assets/d1a6f30f-cbe1-4064-b2d7-02078e9259f0" /> |
| <img width="1000" height="1600" alt="recent-filters-largest-before" src="https://github.com/user-attachments/assets/ab597a2f-6d12-402a-b945-268e279f0b99" /> | <img width="1000" height="1600" alt="recent-filters-largest-after" src="https://github.com/user-attachments/assets/4f97f8ae-fd23-490a-8525-7f55bf09d8b3" /> |

| Filter widget focus, before | Filter widget focus, after |
| --- | --- |
| <img width="1000" height="1600" alt="filter-widget-focus-before" src="https://github.com/user-attachments/assets/2aeb46b3-78ec-4bbc-af07-df80ce4c6850" /> | <img width="1000" height="1600" alt="filter-widget-focus-after" src="https://github.com/user-attachments/assets/f1a5264d-b98f-4df7-a3fe-aaf2f4fa62e4" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>