### PR TITLE
Import 1:1 DMs as DirectMessageGroup if enabled

### DIFF
--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -11,6 +11,7 @@ import orjson
 import responses
 from django.conf import settings
 from django.http import HttpResponse
+from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 from requests.models import PreparedRequest
 
@@ -31,6 +32,7 @@ from zerver.data_import.sequencer import NEXT_ID
 from zerver.data_import.slack import (
     SLACK_IMPORT_TOKEN_SCOPES,
     AddedChannelsT,
+    AddedDMsT,
     AddedMPIMsT,
     DMMembersT,
     SlackBotEmail,
@@ -1023,6 +1025,7 @@ class SlackImporter(ZulipTestCase):
                 realm,
                 added_channels,
                 added_mpims,
+                added_dms,
                 dm_members,
                 slack_recipient_name_to_zulip_recipient_id,
             ) = channels_to_zerver_stream(
@@ -1044,6 +1047,8 @@ class SlackImporter(ZulipTestCase):
             "mpdm-user6--user7--user4-1": ("G6H1Z0ZPS", 1),
             "mpdm-user4--user1--user5-1": ("G6N944JPL", 2),
         }
+        # 1:1 dms are added to dm_members as PREFER_DIRECT_MESSAGE_GROUP is False
+        test_added_dms: dict[str, int] = {}
         test_dm_members = {
             "DJ47BL849": ("U061A1R2R", "U061A5N1G"),
             "DHX1UP7EG": ("U061A5N1G", "U064KUGRJ"),
@@ -1063,6 +1068,7 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(realm["zerver_defaultstream"], [{"id": 0, "realm": 3, "stream": 1}])
 
         self.assertDictEqual(test_added_mpims, added_mpims)
+        self.assertDictEqual(test_added_dms, added_dms)
         self.assertDictEqual(test_dm_members, dm_members)
 
         # We can't do an assertDictEqual since during the construction of personal
@@ -1105,12 +1111,123 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(self.get_set(realm["zerver_huddle"], "id"), {0, 1, 2})
         self.assertEqual(realm["zerver_userpresence"], [])
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
+    def test_channels_to_zerver_stream_using_direct_message_group(self) -> None:
+        slack_user_id_to_zulip_user_id = {
+            "U061A1R2R": 1,
+            "U061A3E0G": 8,
+            "U061A5N1G": 7,
+            "U064KUGRJ": 5,
+        }
+        zerver_userprofile = [{"id": 1}, {"id": 8}, {"id": 7}, {"id": 5}]
+        realm_id = 3
+        realm: ZerverFieldsT = {"zerver_userpresence": [], "zerver_realm": [dict()]}
+        zerver_realm = realm["zerver_realm"]
+
+        with (
+            self.assertLogs(level="INFO"),
+            mock.patch(
+                "zerver.data_import.slack.SLACK_DEFAULT_ANNOUNCEMENTS_CHANNEL_NAME", "random"
+            ),
+        ):
+            (
+                realm,
+                added_channels,
+                added_mpims,
+                added_dms,
+                dm_members,
+                slack_recipient_name_to_zulip_recipient_id,
+            ) = channels_to_zerver_stream(
+                self.fixture_file_name("", "slack_fixtures"),
+                realm_id,
+                realm,
+                slack_user_id_to_zulip_user_id,
+                zerver_userprofile,
+            )
+
+        test_added_channels = {
+            "sharedchannel": ("C061A0HJG", 3),
+            "general": ("C061A0YJG", 1),
+            "general1": ("C061A0YJP", 2),
+            "random": ("C061A0WJG", 0),
+        }
+        test_added_mpims = {
+            "mpdm-user9--user2--user10-1": ("G9HBG2A5D", 0),
+            "mpdm-user6--user7--user4-1": ("G6H1Z0ZPS", 1),
+            "mpdm-user4--user1--user5-1": ("G6N944JPL", 2),
+        }
+        test_added_dms = {
+            "DJ47BL849": 3,
+            "DHX1UP7EG": 4,
+            "DK8HSJDHS": 5,
+            "DRS3PSLDK": 6,
+        }
+        slack_recipient_names = (
+            set(test_added_channels.keys())
+            | set(test_added_mpims.keys())
+            | set(test_added_dms.keys())
+        )
+
+        self.assertDictEqual(added_channels, test_added_channels)
+        # zerver defaultstream already tested in helper functions.
+        # Note that the `random` stream is archived and thus should
+        # not be created as a DefaultStream.
+        self.assertEqual(realm["zerver_defaultstream"], [{"id": 0, "realm": 3, "stream": 1}])
+
+        self.assertDictEqual(added_mpims, test_added_mpims)
+        self.assertDictEqual(added_dms, test_added_dms)
+        self.assertDictEqual(dm_members, {})
+
+        # We can't do an assertDictEqual since during the construction of personal
+        # recipients, slack_user_id_to_zulip_user_id are iterated in different order in Python 3.5 and 3.6.
+        self.assertEqual(
+            set(slack_recipient_name_to_zulip_recipient_id.keys()),
+            slack_recipient_names,
+        )
+        self.assertEqual(
+            set(slack_recipient_name_to_zulip_recipient_id.values()),
+            set(range(11)),
+        )
+
+        # functioning of zerver subscriptions are already tested in the helper functions
+        # This is to check the concatenation of the output lists from the helper functions
+        # subscriptions for stream
+        zerver_subscription = realm["zerver_subscription"]
+        zerver_recipient = realm["zerver_recipient"]
+        zerver_stream = realm["zerver_stream"]
+
+        self.assertEqual(self.get_set(zerver_subscription, "recipient"), set(range(11)))
+        self.assertEqual(self.get_set(zerver_subscription, "user_profile"), {1, 5, 7, 8})
+
+        self.assertEqual(
+            self.get_set(zerver_recipient, "id"), self.get_set(zerver_subscription, "recipient")
+        )
+        self.assertEqual(self.get_set(zerver_recipient, "type_id"), {0, 1, 2, 3, 4, 5, 6})
+        self.assertEqual(self.get_set(zerver_recipient, "type"), {2, 3})
+
+        # stream mapping
+        self.assertEqual(zerver_stream[0]["name"], "random")
+        self.assertEqual(zerver_stream[0]["deactivated"], True)
+        self.assertEqual(zerver_stream[0]["description"], "no purpose")
+        self.assertEqual(zerver_stream[0]["invite_only"], False)
+        self.assertEqual(zerver_stream[0]["history_public_to_subscribers"], True)
+        self.assertEqual(zerver_stream[0]["realm"], realm_id)
+        self.assertEqual(zerver_stream[2]["id"], test_added_channels[zerver_stream[2]["name"]][1])
+
+        self.assertEqual(
+            zerver_realm[0]["zulip_update_announcements_stream"], zerver_stream[0]["id"]
+        )
+        self.assertEqual(zerver_realm[0]["new_stream_announcements_stream"], zerver_stream[0]["id"])
+
+        self.assertEqual(self.get_set(realm["zerver_huddle"], "id"), {0, 1, 2, 3, 4, 5, 6})
+        self.assertEqual(realm["zerver_userpresence"], [])
+
     @mock.patch(
         "zerver.data_import.slack.users_to_zerver_userprofile", return_value=[[], [], {}, [], []]
     )
     @mock.patch(
         "zerver.data_import.slack.channels_to_zerver_stream",
-        return_value=[{"zerver_stream": []}, {}, {}, {}, {}],
+        return_value=[{"zerver_stream": []}, {}, {}, {}, {}, {}],
     )
     def test_slack_workspace_to_realm(
         self, mock_channels_to_zerver_stream: mock.Mock, mock_users_to_zerver_userprofile: mock.Mock
@@ -1123,6 +1240,7 @@ class SlackImporter(ZulipTestCase):
             slack_recipient_name_to_zulip_recipient_id,
             added_channels,
             added_mpims,
+            added_dms,
             _dm_members,
             avatar_list,
             _em,
@@ -1137,6 +1255,7 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(slack_user_id_to_zulip_user_id, {})
         self.assertEqual(added_channels, {})
         self.assertEqual(added_mpims, {})
+        self.assertEqual(added_dms, {})
         self.assertEqual(slack_recipient_name_to_zulip_recipient_id, {})
         self.assertEqual(avatar_list, [])
 
@@ -1415,6 +1534,246 @@ class SlackImporter(ZulipTestCase):
         )
         self.assertEqual(
             zerver_message[7]["recipient"], slack_recipient_name_to_zulip_recipient_id["U061A5N1G"]
+        )
+
+        self.assertEqual(zerver_message[3]["id"], zerver_message[0]["id"] + 3)
+        self.assertEqual(zerver_message[4]["id"], zerver_message[0]["id"] + 4)
+        self.assertEqual(zerver_message[5]["id"], zerver_message[0]["id"] + 5)
+        self.assertEqual(zerver_message[7]["id"], zerver_message[0]["id"] + 7)
+
+        self.assertIsNone(zerver_message[3]["rendered_content"])
+        self.assertEqual(zerver_message[0]["has_image"], False)
+        self.assertEqual(zerver_message[0]["date_sent"], float(all_messages[1]["ts"]))
+        self.assertEqual(zerver_message[2]["rendered_content_version"], 1)
+
+        self.assertEqual(zerver_message[0]["sender"], 43)
+        self.assertEqual(zerver_message[3]["sender"], 24)
+        self.assertEqual(zerver_message[5]["sender"], 43)
+        self.assertEqual(zerver_message[6]["sender"], 24)
+        self.assertEqual(zerver_message[7]["sender"], 43)
+        self.assertEqual(zerver_message[8]["sender"], 5)
+
+        # Test uploads
+        self.assert_length(uploads, 1)
+        self.assertEqual(uploads[0]["path"], "https://files.slack.com/apple.png")
+        self.assert_length(attachment, 1)
+        self.assertEqual(attachment[0]["file_name"], "apple.png")
+        self.assertEqual(attachment[0]["is_realm_public"], True)
+        self.assertEqual(attachment[0]["is_web_public"], False)
+        self.assertEqual(attachment[0]["content_type"], "image/png")
+
+        self.assertEqual(zerver_message[9]["has_image"], True)
+        self.assertEqual(zerver_message[9]["has_attachment"], True)
+        self.assertTrue(zerver_message[9]["content"].startswith("Look!\n[Apple](/user_uploads/"))
+
+    @mock.patch("zerver.data_import.slack.build_usermessages", return_value=(2, 4))
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
+    def test_channel_message_to_zerver_message_using_direct_message_group(
+        self, mock_build_usermessage: mock.Mock
+    ) -> None:
+        user_data = [
+            {"id": "U066MTL5U", "name": "john doe", "deleted": False, "real_name": "John"},
+            {"id": "U061A5N1G", "name": "jane doe", "deleted": False, "real_name": "Jane"},
+            {
+                "id": "U061A1R2R",
+                "name": "jon",
+                "deleted": False,
+                "real_name": "Jon",
+                "profile": {"email": "jon@example.com"},
+            },
+        ]
+
+        slack_user_id_to_zulip_user_id = {"U066MTL5U": 5, "U061A5N1G": 24, "U061A1R2R": 43}
+
+        reactions = [{"name": "grinning", "users": ["U061A5N1G"], "count": 1}]
+
+        all_messages: list[dict[str, Any]] = [
+            {
+                "text": "<@U066MTL5U> has joined the channel",
+                "subtype": "channel_join",
+                "user": "U066MTL5U",
+                "ts": "1434139102.000002",
+                "channel_name": "random",
+            },
+            {
+                "text": "<@U061A5N1G>: hey!",
+                "user": "U061A1R2R",
+                "ts": "1437868294.000006",
+                "has_image": True,
+                "channel_name": "random",
+            },
+            {
+                "text": "random",
+                "user": "U061A5N1G",
+                "reactions": reactions,
+                "ts": "1439868294.000006",
+                "channel_name": "random",
+            },
+            {
+                "text": "without a user",
+                "user": None,  # this message will be ignored as it has no user
+                "ts": "1239868294.000006",
+                "channel_name": "general",
+            },
+            {
+                "text": "<http://journals.plos.org/plosone/article>",
+                "user": "U061A1R2R",
+                "ts": "1463868370.000008",
+                "channel_name": "general",
+            },
+            {
+                "text": "added bot",
+                "user": "U061A5N1G",
+                "subtype": "bot_add",
+                "ts": "1433868549.000010",
+                "channel_name": "general",
+            },
+            # This message will be ignored since it has no user and file is None.
+            # See #9217 for the situation; likely file uploads on archived channels
+            {
+                "upload": False,
+                "file": None,
+                "text": "A file was shared",
+                "channel_name": "general",
+                "type": "message",
+                "ts": "1433868549.000011",
+                "subtype": "file_share",
+            },
+            {
+                "text": "random test",
+                "user": "U061A1R2R",
+                "ts": "1433868669.000012",
+                "channel_name": "general",
+            },
+            {
+                "text": "Hello everyone",
+                "user": "U061A1R2R",
+                "type": "message",
+                "ts": "1433868669.000015",
+                "mpim_name": "mpdm-user9--user2--user10-1",
+            },
+            {
+                "text": "Who is watching the World Cup",
+                "user": "U061A5N1G",
+                "type": "message",
+                "ts": "1433868949.000015",
+                "mpim_name": "mpdm-user6--user7--user4-1",
+            },
+            {
+                "client_msg_id": "998d9229-35aa-424f-8d87-99e00df27dc9",
+                "type": "message",
+                "text": "Who is coming for camping this weekend?",
+                "user": "U061A1R2R",
+                "ts": "1553607595.000700",
+                "pm_name": "DHX1UP7EG",
+            },
+            {
+                "client_msg_id": "998d9229-35aa-424f-8d87-99e00df27dc9",
+                "type": "message",
+                "text": "<@U061A5N1G>: Are you in Kochi?",
+                "user": "U066MTL5U",
+                "ts": "1553607595.000700",
+                "pm_name": "DJ47BL849",
+            },
+            {
+                "text": "Look!",
+                "user": "U061A1R2R",
+                "ts": "1553607596.000700",
+                "has_image": True,
+                "channel_name": "random",
+                "files": [
+                    {
+                        "url_private": "https://files.slack.com/apple.png",
+                        "title": "Apple",
+                        "name": "apple.png",
+                        "mimetype": "image/png",
+                        "timestamp": 9999,
+                        "created": 8888,
+                        "size": 3000000,
+                    }
+                ],
+            },
+        ]
+
+        slack_recipient_name_to_zulip_recipient_id = {
+            "random": 2,
+            "general": 1,
+            "mpdm-user9--user2--user10-1": 5,
+            "mpdm-user6--user7--user4-1": 6,
+            "DJ47BL849": 3,
+            "DHX1UP7EG": 4,
+            "DK8HSJDHS": 5,
+            "DRS3PSLDK": 6,
+        }
+
+        subscriber_map: dict[int, set[int]] = {}
+        added_channels: dict[str, tuple[str, int]] = {"random": ("c5", 1), "general": ("c6", 2)}
+        zerver_usermessage: list[dict[str, Any]] = []
+
+        (
+            zerver_message,
+            zerver_usermessage,
+            attachment,
+            uploads,
+            reaction,
+        ) = channel_message_to_zerver_message(
+            1,
+            user_data,
+            slack_user_id_to_zulip_user_id,
+            slack_recipient_name_to_zulip_recipient_id,
+            all_messages,
+            [],
+            subscriber_map,
+            added_channels,
+            {},
+            "domain",
+            set(),
+            convert_slack_threads=False,
+        )
+        # functioning already tested in helper function
+        self.assertEqual(zerver_usermessage, [])
+        # subtype: channel_join is filtered
+        self.assert_length(zerver_message, 10)
+
+        # Test reactions
+        self.assertEqual(reaction[0]["user_profile"], 24)
+        self.assertEqual(reaction[0]["emoji_name"], reactions[0]["name"])
+
+        # Message conversion already tested in tests.test_slack_message_conversion
+        self.assertEqual(zerver_message[0]["content"], "@**Jane**: hey!")
+        self.assertEqual(zerver_message[0]["has_link"], False)
+        self.assertEqual(zerver_message[2]["content"], "http://journals.plos.org/plosone/article")
+        self.assertEqual(zerver_message[2]["has_link"], True)
+        self.assertEqual(zerver_message[5]["has_link"], False)
+        self.assertEqual(zerver_message[7]["has_link"], False)
+
+        # Test that topic_name is set to '\x07' for direct messages and
+        # group direct messages.
+        self.assertEqual(zerver_message[6][EXPORT_TOPIC_NAME], Message.DM_TOPIC)
+        self.assertEqual(zerver_message[8][EXPORT_TOPIC_NAME], Message.DM_TOPIC)
+
+        self.assertEqual(zerver_message[3][EXPORT_TOPIC_NAME], "imported from Slack")
+        self.assertEqual(zerver_message[3]["content"], "/me added bot")
+        self.assertEqual(
+            zerver_message[4]["recipient"], slack_recipient_name_to_zulip_recipient_id["general"]
+        )
+        self.assertEqual(zerver_message[2][EXPORT_TOPIC_NAME], "imported from Slack")
+        self.assertEqual(
+            zerver_message[1]["recipient"], slack_recipient_name_to_zulip_recipient_id["random"]
+        )
+        self.assertEqual(
+            zerver_message[5]["recipient"],
+            slack_recipient_name_to_zulip_recipient_id["mpdm-user9--user2--user10-1"],
+        )
+        self.assertEqual(
+            zerver_message[6]["recipient"],
+            slack_recipient_name_to_zulip_recipient_id["mpdm-user6--user7--user4-1"],
+        )
+        self.assertEqual(
+            zerver_message[7]["recipient"], slack_recipient_name_to_zulip_recipient_id["DHX1UP7EG"]
+        )
+        self.assertEqual(
+            zerver_message[8]["recipient"], slack_recipient_name_to_zulip_recipient_id["DJ47BL849"]
         )
 
         self.assertEqual(zerver_message[3]["id"], zerver_message[0]["id"] + 3)
@@ -1809,6 +2168,7 @@ by Pieter
             slack_data_dir: str,
             added_channels: AddedChannelsT,
             added_mpims: AddedMPIMsT,
+            added_dms: AddedDMsT,
             dm_members: DMMembersT,
         ) -> Iterator[ZerverFieldsT]:
             import copy
@@ -1838,6 +2198,7 @@ by Pieter
                 {},
                 {},
                 added_channels,
+                {},
                 {},
                 {},
                 realm,


### PR DESCRIPTION
If the `PREFER_DIRECT_MESSAGE_GROUP` setting is enabled, use direct message groups as the recipient type for 1:1 or self messages when importing from Mattermost, RocketChat, and Slack.

This PR should be merged after https://github.com/zulip/zulip/pull/34900.

Please review [these commits](https://github.com/zulip/zulip/pull/35903/files/73af9940a6651795b0d7a9b781d954326d79580e..7debbe88c36d44343c9c1525256ad1b65b23645e) to see the related changes.

Fixes: part of https://github.com/zulip/zulip/issues/25713.
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
