### PR TITLE
starlight_help: Do not use double curly braces for email address.

### DIFF
--- a/starlight_help/src/components/Footer.astro
+++ b/starlight_help/src/components/Footer.astro
@@ -1,7 +1,7 @@
 ---
 import {CORPORATE_ENABLED, SUPPORT_EMAIL} from "astro:env/client";
 
-let footer_html = `<p>Don't see an answer to your question? <a href="mailto:{{ ${SUPPORT_EMAIL} }}">Contact this Zulip server's administrators</a> for support.</p>`;
+let footer_html = `<p>Don't see an answer to your question? <a href="mailto:${SUPPORT_EMAIL}">Contact this Zulip server's administrators</a> for support.</p>`;
 if (CORPORATE_ENABLED) {
     footer_html = `<p>Your feedback helps us make Zulip better for everyone! Please <a href="/starlight_help/contact-support">contact us</a> with questions, suggestions, and feature requests.</p>`;
 }


### PR DESCRIPTION
When we copied over the logic for the footer from the previous help center, I forgot to remove the double curly braces which were getting rendered as is in astro.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
