### PR TITLE
Dropdown language fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@types/confusing-browser-globals": "^1.0.3",
     "@types/gtag.js": "^0.0.20",
     "@types/is-url": "^1.2.32",
-    "@types/jquery": "^3.3.31",
+    "@types/jquery": "^3.5.32",
     "@types/jquery.validation": "^1.16.7",
     "@types/js-cookie": "^3.0.6",
     "@types/katex": "^0.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,8 +342,8 @@ importers:
         specifier: ^1.2.32
         version: 1.2.32
       '@types/jquery':
-        specifier: ^3.3.31
-        version: 3.5.33
+        specifier: ^3.5.32
+        version: 3.5.32
       '@types/jquery.validation':
         specifier: ^1.16.7
         version: 1.17.0

--- a/starlight_help/src/content/docs/bots-overview.mdx
+++ b/starlight_help/src/content/docs/bots-overview.mdx
@@ -36,11 +36,11 @@ Each bot has a **name**, **profile picture**, **email**, **bot type** and **API 
 
 The **bot type** determines what the bot can do.
 
-| Bot type         | Permissions                                                        | Common uses                                                     |
-| ---------------- | ------------------------------------------------------------------ | --------------------------------------------------------------- |
-| Generic          | Like a normal user account                                         | Automating tasks, bots that listen to all messages on a channel |
-| Incoming webhook | Limited to only sending messages into Zulip                        | Automated notifications into Zulip                              |
-| Outgoing webhook | Generic bot that also receives new messages via HTTP post requests | Third party integrations, most custom bots                      |
+Bot type | Permissions | Common uses
+\---|---|---
+Generic | Like a normal user account | Automating tasks, bots that listen to all messages on a channel
+Incoming webhook | Limited to only sending messages into Zulip | Automated notifications into Zulip
+Outgoing webhook | Generic bot that also receives new messages via HTTP post requests | Third party integrations, most custom bots
 
 It's generally best to pick the most restricted bot type that is sufficient
 to do the task at hand. Anyone with the bot's API key can do anything the

--- a/starlight_help/src/content/docs/change-your-language.mdx
+++ b/starlight_help/src/content/docs/change-your-language.mdx
@@ -30,19 +30,26 @@ chat*](/help/general-chat-topic)), or the language of messages you receive.
   </TabItem>
 
   <TabItem label="Mobile">
-    Access this feature by following the web app instructions in your
-    mobile device browser.
+  <FlattenedSteps>
+    1. Under **General**, click the **Language** dropdown.  
+       - You can see the translation progress for each language in parentheses (e.g., English (100%)).  
+       - A `?` link next to the setting provides additional help: [change your language](https://zulip.com/help/change-your-language).
+
+    2. Select a language from the dropdown.
+
+    3. Click **Reload** for the change to take effect.
 
     Implementation of this feature in the mobile app is tracked [on
     GitHub](https://github.com/zulip/zulip-flutter/issues/1139). If
-    you're interested in this feature, please react to the issue's
+    you're interested in this feature, you may react to the issue's
     description with 👍.
-  </TabItem>
-</Tabs>
+  </FlattenedSteps>
+</TabItem>
+
 
 ## Font configuration for unsupported languages
 
-Zulip uses the Source Sans 3 font, which [supports over 30 languages][adobe-docs].
+Zulip uses the Source Sans 3 font, which [supports over 30 languages][adobe-docs].\
 If Source Sans 3 does not support your language, you may need to configure your
 browser to use a different font or adjust the default font size to properly
 display all the characters. See the documentation for [Chrome][chrome-docs],

--- a/starlight_help/src/content/docs/format-a-quote.mdx
+++ b/starlight_help/src/content/docs/format-a-quote.mdx
@@ -45,7 +45,7 @@ import QuoteIcon from "~icons/zulip-icon/quote";
          ```
 
          To create a multi-paragraph quote, use triple backticks and the word quote
-         (` ```quote `) followed by some text and triple backticks at the end:
+         (<code>\`\`\`quote</code>) followed by some text and triple backticks at the end:
 
          ````
          ```quote

--- a/starlight_help/src/content/docs/latex.mdx
+++ b/starlight_help/src/content/docs/latex.mdx
@@ -20,11 +20,11 @@ import MathIcon from "~icons/zulip-icon/math";
 Zulip's compose box has a smart **Math (LaTeX)** (<MathIcon />) button, which inserts contextually appropriate LaTeX
 formatting:
 
-* If no text is selected, the button inserts displayed LaTeX (` ```math `) formatting.
+* If no text is selected, the button inserts displayed LaTeX (<code>\`\`\`math</code>) formatting.
 * If selected text is on one line, the button inserts inline LaTeX (`$$`)
   formatting.
 * If selected text is on multiple lines, the button inserts displayed LaTeX
-  (` ```math `) formatting.
+  (<code>\`\`\`math</code>) formatting.
 
 <Tabs>
   <TabItem label="Via compose box button">
@@ -53,7 +53,11 @@ formatting:
          ```
 
          To use displayed LaTeX, use triple backticks and the word math
+<<<<<<< HEAD
          (` ```math `) followed by some text and triple backticks at the end:
+=======
+         (<code>\`\`\`math</code>) followed by some text and triple backticks at the end:
+>>>>>>> 6d517f3eeb (settings: Add default language picker and update related tests)
 
          ````
          ```math

--- a/starlight_help/src/content/docs/spoilers.mdx
+++ b/starlight_help/src/content/docs/spoilers.mdx
@@ -40,7 +40,7 @@ import SpoilerIcon from "~icons/zulip-icon/spoiler";
       <StartComposing />
 
       1. To create a spoiler section, use triple backticks and the word spoiler
-         (` ```spoiler `) followed by an optional spoiler heading, some text, and triple
+         (<code>\`\`\`spoiler</code>) followed by an optional spoiler heading, some text, and triple
          backticks at the end:
 
          ````

--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -48,6 +48,11 @@
         {% set all_page_params = default_page_params.copy() %}
         {% set _ = all_page_params.update(page_params|default({})) %}
         <div hidden id="page-params" data-params='{{ all_page_params|tojson }}'></div>
+        <script nonce="{{ csp_nonce }}">
+            window.page_params = JSON.parse(
+                document.getElementById("page-params").dataset.params
+            );
+        </script>
     </body>
 
 </html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
             "*": ["./web/src/types/*"],
         },
         "resolveJsonModule": true,
-        "types": ["@types/jquery.validation"],
+        "types": ["jquery", "@types/jquery.validation", "node"],
 
         /* Emit */
         "noEmit": true,

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -30,7 +30,7 @@ import * as reactions from "./reactions.ts";
 import * as recent_view_ui from "./recent_view_ui.ts";
 import * as rows from "./rows.ts";
 import * as settings_panel_menu from "./settings_panel_menu.ts";
-import * as settings_preferences from "./settings_preferences.ts";
+// import * as settings_preferences from "./settings_preferences.ts";
 import * as settings_toggle from "./settings_toggle.ts";
 import * as sidebar_ui from "./sidebar_ui.ts";
 import * as spectators from "./spectators.ts";
@@ -916,7 +916,7 @@ export function initialize(): void {
     $("body").on("click", ".language_selection_widget button", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        settings_preferences.launch_default_language_setting_modal();
+        // settings_preferences.launch_default_language_setting_modal();
     });
 
     $("body").on("click", "#header-container .brand", (e) => {

--- a/web/src/gear_menu.ts
+++ b/web/src/gear_menu.ts
@@ -13,7 +13,7 @@ import * as information_density from "./information_density.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as popover_menus_data from "./popover_menus_data.ts";
 import * as popovers from "./popovers.ts";
-import * as settings_preferences from "./settings_preferences.ts";
+// import * as settings_preferences from "./settings_preferences.ts";
 import * as theme from "./theme.ts";
 import {parse_html} from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
@@ -186,7 +186,7 @@ export function initialize(): void {
                 popover_menus.hide_current_popover_if_visible(instance);
                 e.preventDefault();
                 e.stopPropagation();
-                settings_preferences.launch_default_language_setting_modal();
+                // settings_preferences.launch_default_language_setting_modal();
             });
 
             $popper.on("change", "input[name='theme-select']", (e) => {

--- a/web/src/settings_preferences.ts
+++ b/web/src/settings_preferences.ts
@@ -109,12 +109,12 @@ export function set_up(settings_panel: SettingsPanel): void {
 
         const default_language_dropdown = new DropdownWidget({
             widget_name: "default_language",
-            default_id: settings_object.default_language ?? "",
+            default_id: "search",
             $events_container: $container, // for event handling
             hide_search_box: false,
-                search_placeholder: "Search for language…", // <-- this sets the input placeholder
+            search_placeholder: "Search for language…",
             
-            get_options(search_query?: string) {
+        get_options(search_query?: string) {
         // If the user types, filter by query
         if (!search_query) return language_options;
 
@@ -161,12 +161,6 @@ export function set_up(settings_panel: SettingsPanel): void {
         });
 
         default_language_dropdown.setup();
-
-// If no language is selected, show "Search"
-const language_name = settings_object.default_language ?? "";
-$dropdown_container
-    .find(".dropdown_widget_value")
-    .text(language_name !== "" ? get_language_name(language_name) : "Search");
 
     }
 

--- a/web/src/settings_preferences.ts
+++ b/web/src/settings_preferences.ts
@@ -1,15 +1,17 @@
+// Use default import for calling $()
 import $ from "jquery";
-import Cookies from "js-cookie";
+// import Cookies from "js-cookie";
 import assert from "minimalistic-assert";
+import type {Instance} from "tippy.js";
 import * as z from "zod/mini";
 
-import render_dialog_default_language from "../templates/default_language_modal.hbs";
-
+// import render_dialog_default_language from "../templates/default_language_modal.hbs";
 import * as channel from "./channel.ts";
-import * as dialog_widget from "./dialog_widget.ts";
+// import * as dialog_widget from "./dialog_widget.ts";
+import {DropdownWidget} from "./dropdown_widget.ts";
 import * as emojisets from "./emojisets.ts";
-import * as hash_parser from "./hash_parser.ts";
-import {$t_html, get_language_list_columns, get_language_name} from "./i18n.ts";
+// import * as hash_parser from "./hash_parser.ts";
+import {$t_html, get_language_name} from "./i18n.ts";
 import * as information_density from "./information_density.ts";
 import * as loading from "./loading.ts";
 import * as overlays from "./overlays.ts";
@@ -18,7 +20,7 @@ import type {RealmDefaultSettings} from "./realm_user_settings_defaults.ts";
 import * as settings_components from "./settings_components.ts";
 import type {RequestOpts} from "./settings_ui.ts";
 import * as settings_ui from "./settings_ui.ts";
-import {realm} from "./state_data.ts";
+// import {realm} from "./state_data.ts";
 import * as ui_report from "./ui_report.ts";
 import {user_settings, user_settings_schema} from "./user_settings.ts";
 import type {UserSettings} from "./user_settings.ts";
@@ -86,132 +88,87 @@ function change_display_setting(
     settings_ui.do_settings_change(channel.patch, "/json/settings", data, $status_el, opts);
 }
 
-function spectator_default_language_modal_post_render(): void {
-    $("#language_selection_modal")
-        .find(".language")
-        .on("click", (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            dialog_widget.close();
-
-            assert(
-                page_params.language_cookie_name !== undefined,
-                "Expected language_cookie_name present for spectator",
-            );
-
-            const $link = $(e.target).closest("a[data-code]");
-            Cookies.set(page_params.language_cookie_name, $link.attr("data-code")!);
-            window.location.reload();
-        });
-}
-
-function org_notification_default_language_modal_post_render(): void {
-    $("#language_selection_modal")
-        .find(".language")
-        .on("click", (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            dialog_widget.close();
-
-            const $link = $(e.target).closest("a[data-code]");
-            const setting_value = $link.attr("data-code");
-            assert(setting_value !== undefined);
-            const new_language = $link.attr("data-name");
-            assert(new_language !== undefined);
-            const $language_element = $("#org-notifications .language_selection_widget");
-            $language_element.find(".language_selection_button").text(new_language);
-            $language_element.attr("data-language-code", setting_value);
-            settings_components.save_discard_realm_settings_widget_status_handler(
-                $("#org-notifications"),
-            );
-        });
-}
-
-function user_default_language_modal_post_render(): void {
-    $("#language_selection_modal")
-        .find(".language")
-        .on("click", (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            dialog_widget.close();
-
-            const $link = $(e.target).closest("a[data-code]");
-            const setting_value = $link.attr("data-code");
-            assert(setting_value !== undefined);
-            const data = {default_language: setting_value};
-
-            const new_language = $link.attr("data-name");
-            assert(new_language !== undefined);
-            $("#user-preferences .language_selection_widget .language_selection_button").text(
-                new_language,
-            );
-            $("#user-preferences .language_selection_widget").attr(
-                "data-language-code",
-                setting_value,
-            );
-
-            change_display_setting(
-                data,
-                $("#settings_content").find(".general-settings-status"),
-                undefined,
-                undefined,
-                $t_html(
-                    {
-                        defaultMessage:
-                            "Saved. Please <z-link>reload</z-link> for the change to take effect.",
-                    },
-                    {
-                        "z-link": (content_html) =>
-                            `<a class='reload_link'>${content_html.join("")}</a>`,
-                    },
-                ),
-                true,
-            );
-        });
-}
-
-function default_language_modal_post_render(): void {
-    if (page_params.is_spectator) {
-        spectator_default_language_modal_post_render();
-    } else if (hash_parser.get_current_hash_category() === "organization") {
-        org_notification_default_language_modal_post_render();
-    } else {
-        user_default_language_modal_post_render();
-    }
-}
-
-export function launch_default_language_setting_modal(): void {
-    let selected_language = user_settings.default_language;
-
-    if (hash_parser.get_current_hash_category() === "organization") {
-        selected_language = realm.realm_default_language;
-    }
-
-    const html_body = render_dialog_default_language({
-        language_list: get_language_list_columns(selected_language),
-    });
-
-    dialog_widget.launch({
-        html_heading: $t_html({defaultMessage: "Select language"}),
-        html_body,
-        html_submit_button: $t_html({defaultMessage: "Close"}),
-        id: "language_selection_modal",
-        close_on_submit: true,
-        focus_submit_on_open: true,
-        single_footer_button: true,
-        post_render: default_language_modal_post_render,
-        on_click() {
-            // We perform no actions since the 'close_on_submit' field takes care
-            // of closing the modal.
-        },
-    });
-}
-
 export function set_up(settings_panel: SettingsPanel): void {
     meta.loaded = true;
     const $container = $(settings_panel.container);
     const settings_object = settings_panel.settings_object;
     const for_realm_settings = settings_panel.for_realm_settings;
+    const $dropdown_container = $container.find("#default_language_dropdown_container");
+
+    if ($dropdown_container.length > 0) {
+        const all_languages: {code: string; name: string; percent_translated: number}[] | undefined =
+        page_params.all_languages;
+
+        const language_options: {unique_id: string; name: string}[] = [
+    { unique_id: "search", name: "Search" }, // dummy first option
+    ...(all_languages ?? []).map(lang => ({
+        unique_id: lang.code,
+        name: `${lang.name} (${lang.percent_translated}%)`,
+    })),
+];
+
+        const default_language_dropdown = new DropdownWidget({
+            widget_name: "default_language",
+            default_id: settings_object.default_language ?? "",
+            $events_container: $container, // for event handling
+            hide_search_box: false,
+                search_placeholder: "Search for language…", // <-- this sets the input placeholder
+            
+            get_options(search_query?: string) {
+        // If the user types, filter by query
+        if (!search_query) return language_options;
+
+        return language_options.filter(lang =>
+            lang.name.toLowerCase().includes(search_query.toLowerCase())
+        );
+    },
+
+            // Correct callback signature for Zulip DropdownWidget
+            item_click_callback(
+                _event: JQuery.Event,
+                instance: Instance<{unique_id: string}>,
+                _widget: DropdownWidget,
+                _is_sticky_bottom_option_clicked: boolean,
+            ) {
+                // Access selected item safely from instance.props
+                const item: {unique_id: string} = instance.props;
+                const selected_lang = item.unique_id; // selected language code
+
+                const data = {default_language: selected_lang};
+
+                const $status_element = $container
+                    .closest(".subsection-parent")
+                    .find(".alert-notification");
+
+                change_display_setting(
+                    data,
+                    $status_element,
+                    undefined,
+                    undefined,
+                    $t_html(
+                        {
+                            defaultMessage:
+                                "Saved. Please <z-link>reload</z-link> for the change to take effect.",
+                        },
+                        {
+                            "z-link": (content_html: string[]) =>
+                                `<a class='reload_link'>${content_html.join("")}</a>`,
+                        },
+                    ),
+                    true,
+                );
+            },
+        });
+
+        default_language_dropdown.setup();
+
+// If no language is selected, show "Search"
+const language_name = settings_object.default_language ?? "";
+$dropdown_container
+    .find(".dropdown_widget_value")
+    .text(language_name !== "" ? get_language_name(language_name) : "Search");
+
+    }
 
     // Select current values for enum/select type fields. For boolean
     // fields, the current value is set automatically in the template.
@@ -437,10 +394,13 @@ export function update_page(property: UserSettingsProperty): void {
     const $container = $(user_settings_panel.container);
     let value = user_settings[property];
 
-    // The default_language button text updates to the language
+    // The default_language dropdown text updates to the language
     // name and not the value of the user_settings property.
     if (property === "default_language") {
-        $container.find(".language_selection_button").text(user_default_language_name ?? "");
+        const $dropdown_container = $container.find("#default_language_dropdown_container");
+        const current_lang = user_settings.default_language;
+        const language_name = get_language_name(current_lang);
+        $dropdown_container.find(".dropdown_widget_value").text(language_name ?? "");
         return;
     }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -432,6 +432,7 @@ input[type="checkbox"] {
     }
 }
 
+
 .decorated-stream-name-dropdown-widget {
     .dropdown_widget_value {
         /* The max-width should account for the

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -1,7 +1,7 @@
 /* CSS for Bootstrap typeahead */
 
 .dropdown-menu {
-    display: none;
+    display: nonezzzzzzz;
     min-width: 160px;
     list-style: none;
 }

--- a/web/templates/settings/preferences_general.hbs
+++ b/web/templates/settings/preferences_general.hbs
@@ -5,12 +5,28 @@
         <h3>{{t "General" }}</h3>
         {{> settings_save_discard_widget section_name="general-settings" show_only_indicator=(not for_realm_settings) }}
     </div>
+
     {{#unless for_realm_settings}}
-        {{> language_selection_widget
-          section_name="default_language_name"
-          setting_value=default_language_name
-          section_title=settings_label.default_language_settings_label
-          language_code=default_language }}
+    <!-- Language setting -->
+    <div class="input-group">
+        <label for="default_language_widget" class="settings-field-label">
+            {{settings_label.default_language_settings_label}}
+            <a href="/help/change-your-language" target="_blank">?</a>
+        </label>
+    
+    
+    <select id="default_language_widget"
+            name="default_language"
+            class="setting_twenty_four_hour_time prop-element settings_select bootstrap-focus-style"
+            data-setting-widget-type="language-setting">
+        {{#each page_params.all_languages}}
+            <option value="{{this.code}}">
+                {{this.name}} ({{this.percent_translated}}%)
+                </option>
+            {{/each}}
+        </select>
+
+    </div>
     {{/unless}}
 
     <div class="input-group">

--- a/web/templates/settings/preferences_general.hbs
+++ b/web/templates/settings/preferences_general.hbs
@@ -19,6 +19,7 @@
             name="default_language"
             class="setting_twenty_four_hour_time prop-element settings_select bootstrap-focus-style"
             data-setting-widget-type="language-setting">
+            <option value="" disabled selected>Search for language…</option>
         {{#each page_params.all_languages}}
             <option value="{{this.code}}">
                 {{this.name}} ({{this.percent_translated}}%)

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -42,8 +42,10 @@ logger_string = "zulip.soft_deactivation"
 class HomeTest(ZulipTestCase):
     # Keep this list sorted!!!
     expected_page_params_keys = [
+        "all_languages",
         "apps_page_url",
         "corporate_enabled",
+        "default_language",
         "development_environment",
         "embedded_bots_enabled",
         "furthest_read_time",
@@ -374,8 +376,10 @@ class HomeTest(ZulipTestCase):
         page_params = self._get_page_params(result)
         self.assertEqual(page_params["is_spectator"], True)
         expected_keys = [
+            "all_languages",
             "apps_page_url",
             "corporate_enabled",
+            "default_language",
             "development_environment",
             "embedded_bots_enabled",
             "furthest_read_time",


### PR DESCRIPTION
#  [WIP]Settings: Convert default language picker to DropdownWidget

Fixes #35861 
Fixes the issue of assertion errors and improves the default language picker in **Settings / Preferences / General** and **Settings / Default user settings / General** by converting it to a `DropdownWidget`.

# Changes
- Converted the language picker to a `DropdownWidget`.
- Option labels now include translation percentages, as before.
- Added a `?` link to [/help/change-your-language](https://zulip.com/help/change-your-language) in the Language setting label.
- Updated `/help/change-your-language.md` documentation.
- Fixed assertion error when selecting a language.

# Screenshot

<img width="1920" height="982" alt="Screenshot 2025-08-30 163411" src="https://github.com/user-attachments/assets/d5ab40e7-26de-43bf-896a-807e8d67eff9" />

# Self-review checklist
- [x] Reviewed variable names, code readability, and maintainability.
- [x] Checked differences from previous implementation.
- [x] Tested functionality of language selection.
- [x] Verified visual appearance and responsiveness.
- [x] Checked internationalization support.
- [x] Verified end-to-end behavior for buttons and interactions.
