### PR TITLE
stream-settings: Replace "Not subscribed" tab with "Available" tab.

### DIFF
--- a/starlight_help/src/components/NavigationSteps.astro
+++ b/starlight_help/src/components/NavigationSteps.astro
@@ -280,9 +280,9 @@ const relative_link_mapping: Record<
                 label: "All",
                 relative_link: "/#channels/all",
             },
-            "not-subscribed": {
-                label: "Not subscribed",
-                relative_link: "/#channels/notsubscribed",
+            available: {
+                label: "Available",
+                relative_link: "/#channels/available",
             },
         },
         template: `

--- a/starlight_help/src/content/docs/channel-feed.mdx
+++ b/starlight_help/src/content/docs/channel-feed.mdx
@@ -58,7 +58,7 @@ quick overview of recent messages in a channel.
 <Tabs>
   <TabItem label="Desktop/Web">
     <FlattenedSteps>
-      <NavigationSteps target="relative/channel/not-subscribed" />
+      <NavigationSteps target="relative/channel/available" />
 
       1. Select a channel.
       1. Click the channel name in the top bar.

--- a/starlight_help/src/content/docs/introduction-to-channels.mdx
+++ b/starlight_help/src/content/docs/introduction-to-channels.mdx
@@ -27,7 +27,7 @@ subscribe to [private](/help/channel-permissions#private-channels) channels.
 <Tabs>
   <TabItem label="Desktop/Web">
     <FlattenedSteps>
-      <NavigationSteps target="relative/channel/not-subscribed" />
+      <NavigationSteps target="relative/channel/available" />
 
       1. Scroll through the list of channels. You can use the **search box** near the
          top of the menu to filter the list by channel name or description.

--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -560,7 +560,7 @@ export async function open_streams_modal(page: Page): Promise<void> {
 
     await page.waitForSelector("#subscription_overlay", {visible: true});
     const url = await page_url_with_fragment(page);
-    assert.ok(url.includes("#channels/notsubscribed"));
+    assert.ok(url.includes("#channels/available"));
 }
 
 export async function open_personal_menu(page: Page): Promise<void> {

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -253,7 +253,7 @@ export function channels_settings_edit_url(
 }
 
 export function channels_settings_section_url(section = "subscribed"): string {
-    const valid_section_values = new Set(["new", "subscribed", "all", "notsubscribed"]);
+    const valid_section_values = new Set(["new", "subscribed", "all", "available"]);
     if (!valid_section_values.has(section)) {
         blueslip.warn("invalid section for channels settings: " + section);
         return "#channels/subscribed";

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -89,8 +89,8 @@ export function setup_subscriptions_tab_hash(tab_key_value: string): void {
             browser_history.update("#channels/subscribed");
             break;
         }
-        case "not-subscribed": {
-            browser_history.update("#channels/notsubscribed");
+        case "available": {
+            browser_history.update("#channels/available");
             break;
         }
         default: {

--- a/web/src/stream_ui_updates.ts
+++ b/web/src/stream_ui_updates.ts
@@ -39,7 +39,7 @@ function settings_button_for_sub(sub: StreamSubscription): JQuery {
 }
 
 export let show_subscribed = true;
-export let show_not_subscribed = false;
+export let show_available = false;
 
 export function is_subscribed_stream_tab_active(): boolean {
     // Returns true if "Subscribed" tab in stream settings is open
@@ -47,18 +47,18 @@ export function is_subscribed_stream_tab_active(): boolean {
     return show_subscribed;
 }
 
-export function is_not_subscribed_stream_tab_active(): boolean {
-    // Returns true if "not-subscribed" tab in stream settings is open
+export function is_available_stream_tab_active(): boolean {
+    // Returns true if "available" tab in stream settings is open
     // otherwise false.
-    return show_not_subscribed;
+    return show_available;
 }
 
 export function set_show_subscribed(value: boolean): void {
     show_subscribed = value;
 }
 
-export function set_show_not_subscribed(value: boolean): void {
-    show_not_subscribed = value;
+export function set_show_available(value: boolean): void {
+    show_available = value;
 }
 
 export function update_web_public_stream_privacy_option_state($container: JQuery): void {
@@ -483,15 +483,17 @@ export function update_stream_row_in_settings_tab(sub: StreamSubscription): void
     // This function display/hide stream row in stream settings tab,
     // used to display immediate effect of add/removal subscription event.
     // If user is subscribed or unsubscribed to stream, it will show sub or unsub
-    // row under "Subscribed" or "Not subscribed" (only if the stream is public) tab, otherwise
+    // row under "Subscribed" or "Available" (only if the stream is public) tab, otherwise
     // if stream is not public hide stream row under tab.
 
-    if (is_subscribed_stream_tab_active() || is_not_subscribed_stream_tab_active()) {
+    if (is_subscribed_stream_tab_active() || is_available_stream_tab_active()) {
         const $row = row_for_stream_id(sub.stream_id);
 
         if (
             (is_subscribed_stream_tab_active() && sub.subscribed) ||
-            (is_not_subscribed_stream_tab_active() && !sub.subscribed)
+            (is_available_stream_tab_active() &&
+                !sub.subscribed &&
+                stream_data.can_toggle_subscription(sub))
         ) {
             if (stream_settings_components.filter_includes_channel(sub)) {
                 $row.removeClass("notdisplayed");

--- a/web/src/stream_ui_updates.ts
+++ b/web/src/stream_ui_updates.ts
@@ -480,11 +480,11 @@ export function update_notification_setting_checkbox(
 
 export function update_stream_row_in_settings_tab(sub: StreamSubscription): void {
     // This is in the left panel.
-    // This function display/hide stream row in stream settings tab,
-    // used to display immediate effect of add/removal subscription event.
-    // If user is subscribed or unsubscribed to stream, it will show sub or unsub
-    // row under "Subscribed" or "Available" (only if the stream is public) tab, otherwise
-    // if stream is not public hide stream row under tab.
+    // This function is used to display immediate effect of add/removal subscription
+    // event.
+    // If user is subscribed or unsubscribed to stream, the stream row is kept in
+    // the tab view if user can toggle the state again, otherwise the stream row
+    // is removed.
 
     if (is_subscribed_stream_tab_active() || is_available_stream_tab_active()) {
         const $row = row_for_stream_id(sub.stream_id);
@@ -498,7 +498,7 @@ export function update_stream_row_in_settings_tab(sub: StreamSubscription): void
             if (stream_settings_components.filter_includes_channel(sub)) {
                 $row.removeClass("notdisplayed");
             }
-        } else if (sub.invite_only || current_user.is_guest) {
+        } else if (current_user.is_guest || !stream_data.can_toggle_subscription(sub)) {
             $row.addClass("notdisplayed");
         }
     }

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -443,7 +443,7 @@ export function initialize(): void {
 
     tippy.delegate("body", {
         target: [
-            "[data-tab-key='not-subscribed'].disabled",
+            "[data-tab-key='available'].disabled",
             "[data-tab-key='all-streams'].disabled",
         ].join(","),
         content: $t({

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_setting_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_setting_popover.hbs
@@ -1,7 +1,7 @@
 <div class="popover-menu" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         <li role="none" class="link-item popover-menu-list-item">
-            <a href="#channels/notsubscribed" role="menuitem" class="popover-menu-link navigate_and_close_popover" tabindex="0">
+            <a href="#channels/available" role="menuitem" class="popover-menu-link navigate_and_close_popover" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-browse-channels" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Browse channels" }}</span>
             </a>

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -48,7 +48,7 @@
                                 {{/if}}
                             </span>
                         </div>
-                        <div class="not_subscribed_streams_tab_empty_text">
+                        <div class="available_streams_tab_empty_text">
                             <span class="settings-empty-option-text">
                                 {{t 'No channels to show.'}}
                                 <a href="#channels/all">{{t 'View all channels'}}</a>

--- a/web/templates/subscribe_to_more_streams.hbs
+++ b/web/templates/subscribe_to_more_streams.hbs
@@ -1,10 +1,10 @@
 {{#if exactly_one_unsubscribed_stream}}
-    <a class="subscribe-more-link" href="#channels/notsubscribed">
+    <a class="subscribe-more-link" href="#channels/available">
         <i class="subscribe-more-icon zulip-icon zulip-icon-browse-channels" aria-hidden="true" ></i>
         <span class="subscribe-more-label">{{~t "BROWSE 1 MORE CHANNEL" ~}}</span>
     </a>
 {{else if can_subscribe_stream_count}}
-    <a class="subscribe-more-link" href="#channels/notsubscribed">
+    <a class="subscribe-more-link" href="#channels/available">
         <i class="subscribe-more-icon zulip-icon zulip-icon-browse-channels" aria-hidden="true" ></i>
         <span class="subscribe-more-label">{{~t "BROWSE {can_subscribe_stream_count} MORE CHANNELS" ~}}</span>
     </a>

--- a/web/tests/stream_settings_ui.test.cjs
+++ b/web/tests/stream_settings_ui.test.cjs
@@ -263,58 +263,46 @@ run_test("redraw_left_panel", ({override, mock_template}) => {
     }
 
     // Search with single keyword
-    test_filter({input: "Po", show_subscribed: false, show_not_subscribed: false}, [
-        poland,
-        pomona,
-    ]);
+    test_filter({input: "Po", show_subscribed: false, show_available: false}, [poland, pomona]);
     assert.ok(ui_called);
 
     // The denmark row is active, even though it's not displayed.
     assert.ok($denmark_row.hasClass("active"));
 
     // Search with multiple keywords
-    test_filter({input: "Denmark, Pol", show_subscribed: false, show_not_subscribed: false}, [
+    test_filter({input: "Denmark, Pol", show_subscribed: false, show_available: false}, [
         denmark,
         poland,
     ]);
-    test_filter({input: "Den, Pol", show_subscribed: false, show_not_subscribed: false}, [
+    test_filter({input: "Den, Pol", show_subscribed: false, show_available: false}, [
         denmark,
         poland,
     ]);
 
     // Search is case-insensitive
-    test_filter({input: "po", show_subscribed: false, show_not_subscribed: false}, [
-        poland,
-        pomona,
-    ]);
+    test_filter({input: "po", show_subscribed: false, show_available: false}, [poland, pomona]);
 
     // Search handles unusual characters like C++
-    test_filter({input: "c++", show_subscribed: false, show_not_subscribed: false}, [cpp]);
+    test_filter({input: "c++", show_subscribed: false, show_available: false}, [cpp]);
 
     // Search subscribed streams only
-    test_filter({input: "d", show_subscribed: true, show_not_subscribed: false}, [poland]);
+    test_filter({input: "d", show_subscribed: true, show_available: false}, [poland]);
 
     // Search unsubscribed streams only
-    test_filter({input: "d", show_subscribed: false, show_not_subscribed: true}, [abcd, denmark]);
+    test_filter({input: "d", show_subscribed: false, show_available: true}, [abcd, denmark]);
 
     // Search terms match stream description
-    test_filter({input: "Co", show_subscribed: false, show_not_subscribed: false}, [
-        denmark,
-        pomona,
-    ]);
+    test_filter({input: "Co", show_subscribed: false, show_available: false}, [denmark, pomona]);
 
     // Search names AND descriptions
-    test_filter({input: "Mon", show_subscribed: false, show_not_subscribed: false}, [
-        pomona,
-        poland,
-    ]);
+    test_filter({input: "Mon", show_subscribed: false, show_available: false}, [pomona, poland]);
 
     // Explicitly order streams by name
     test_filter(
         {
             input: "",
             show_subscribed: false,
-            show_not_subscribed: false,
+            show_available: false,
             sort_order: "by-stream-name",
         },
         [abcd, cpp, denmark, jerry, poland, pomona, utopia, zzyzx],
@@ -325,7 +313,7 @@ run_test("redraw_left_panel", ({override, mock_template}) => {
         {
             input: "",
             show_subscribed: false,
-            show_not_subscribed: false,
+            show_available: false,
             sort_order: "by-subscriber-count",
         },
         [utopia, abcd, poland, cpp, zzyzx, denmark, jerry, pomona],
@@ -336,7 +324,7 @@ run_test("redraw_left_panel", ({override, mock_template}) => {
         {
             input: "",
             show_subscribed: false,
-            show_not_subscribed: false,
+            show_available: false,
             sort_order: "by-weekly-traffic",
         },
         [poland, utopia, cpp, zzyzx, jerry, abcd, pomona, denmark],
@@ -347,7 +335,7 @@ run_test("redraw_left_panel", ({override, mock_template}) => {
         {
             input: "",
             show_subscribed: true,
-            show_not_subscribed: false,
+            show_available: false,
             sort_order: "by-subscriber-count",
         },
         [poland, cpp, zzyzx, pomona],
@@ -358,7 +346,7 @@ run_test("redraw_left_panel", ({override, mock_template}) => {
         {
             input: "",
             show_subscribed: false,
-            show_not_subscribed: true,
+            show_available: true,
             sort_order: "by-subscriber-count",
         },
         [utopia, abcd, denmark, jerry],


### PR DESCRIPTION
This PR replaces "Not subscribed" tab in stream settings with "Available" tab where
only streams which the user can subscribe to are shown.

Fixes #35919.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Peek 2025-09-03 17-09](https://github.com/user-attachments/assets/2eb613a3-67cd-4a92-8294-0890b0b3d663)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
