### PR TITLE
help: Add default help page when astro server is not running in development

### DIFF
--- a/templates/zerver/development/dev_help.html
+++ b/templates/zerver/development/dev_help.html
@@ -1,0 +1,60 @@
+{% extends "zerver/portico.html" %}
+{% set entrypoint = "dev-help" %}
+
+{% block title %}
+<title>Help center server not running | Zulip Dev</title>
+{% endblock %}
+
+{% block portico_content %}
+
+<div class="dev-help-page flex">
+    <div class="white-box markdown">
+        {% if mdx_file_exists %}
+            <h2 class="dev-help-header">Help center server not running</h2>
+            <p>
+                To minimize resource requirements for the development
+                environment, the help center's development server does
+                not run by default. Below are our recommendations for
+                accessing this help center page:
+            </p>
+            <ul>
+                <li>
+                    <b>Quick reference</b>: If you aren't planning to modify the help center, you can
+                    <a target="_blank" rel="noopener noreferrer"
+                      href="https://zulip.com/help/{{ subpath }}">view it on
+                    zulip.com</a>. Pages may be slightly behind the version
+                    currently in <code>main</code>.
+                </li>
+                <li>
+                    <b>Up-to-date reference</b>: You can
+                    <a target="_blank" rel="noopener noreferrer" href="{{
+                      raw_url }}">view the current raw MDX file</a>, which is recommended for documentation
+                    that touches brand new or recently modified features.
+                </li>
+                <li>
+                    <b>Modifying the help center</b>: If you're making changes to
+                    the help center files, be sure to <b>test</b> and provide
+                    screenshots in your pull request description. As
+                    with other code, untested documentation is often buggy.
+                    {% include "zerver/development/help_center_instructions_macro.html" %}
+                </li>
+            </ul>
+        {% else %}
+            <p class="invalid-path-error">
+                This is not a valid help path and not a valid MDX file. Please re-check the URL subpath you have provided.
+            </p>
+        {% endif %}
+
+        <div class="dev-help-actions">
+            {% if mdx_file_exists %}
+                <a target="_blank" rel="noopener noreferrer" href="https://zulip.com/help/{{ subpath }}" class="dev-help-action-button">
+                    View page on zulip.com
+                </a>
+                <a target="_blank" rel="noopener noreferrer" href="{{ raw_url }}" class="dev-help-action-button">
+                    View page source
+                </a>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/zerver/development/dev_tools.html
+++ b/templates/zerver/development/dev_tools.html
@@ -166,7 +166,7 @@
         <h3> Serve static build (supports search but not hot reload)</h3>
         <p>
             Please run <code>./tools/build-help-center</code> to generate a static build of the help center.
-            <code>./tools/run-dev --help-center</code> will host the generated build on
+            <code>./tools/run-dev --help-center-static-build</code> will host the generated build on
             <code>/help</code>. Note that you need to generate a build and pass the flag mentioned for the search
             to work.
         </p>

--- a/templates/zerver/development/dev_tools.html
+++ b/templates/zerver/development/dev_tools.html
@@ -138,38 +138,7 @@
             </li>
         </ul>
         <h2>Development instructions for help center</h2>
-        <p>
-            Running <code>./tools/run-dev</code> without any flags will not run the help center at all.
-            The development server for the help center takes significant resources to run and we don't
-            want to increase the minimum requirements to run Zulip for development.
-        </p>
-        <h3> Dev server (supports hot reload but not search)</h3>
-        <p>
-            This mode is useful when you are editing a help center file, and want to visualize the changes
-            quickly in the help center documentation.
-        </p>
-        <p>
-            <code>./tools/run-dev --only-help-center</code> will run a dev server at
-            <code>/help</code> that supports hot reload. Note that, with this flag, search will not work
-            in the help center docs. In this mode, the Zulip web app and other related services will not run.
-            Since the dev server consumes a significant amount of memory, this is the recommended way to run
-            the dev server for the help center.
-        </p>
-        <p>
-            If you have a machine with resources significantly more than minimum requirements to run Zulip in
-            development, you can choose to run the dev server alongside Zulip using
-            <code>./tools/run-dev --help-center-dev-server</code>.
-            The dev server makes a bunch of request to base Zulip URL instead of scoping it to the astro/starlight
-            base url. For this reason, in this mode, we run the dev server on it's own port and redirect help center
-            requests to the appropriate port (9995 by default).
-        </p>
-        <h3> Serve static build (supports search but not hot reload)</h3>
-        <p>
-            Please run <code>./tools/build-help-center</code> to generate a static build of the help center.
-            <code>./tools/run-dev --help-center-static-build</code> will host the generated build on
-            <code>/help</code>. Note that you need to generate a build and pass the flag mentioned for the search
-            to work.
-        </p>
+        {% include "zerver/development/help_center_instructions_macro.html" %}
     </div>
 </div>
 

--- a/templates/zerver/development/dev_tools.html
+++ b/templates/zerver/development/dev_tools.html
@@ -137,51 +137,39 @@
                 </ul>
             </li>
         </ul>
-        <h2>Development instructions for help center (Beta)</h2>
+        <h2>Development instructions for help center</h2>
         <p>
-            These commands are to run the project for an ongoing migration for our help center docs to use
-            <a href="https://github.com/withastro/starlight">@astrojs/starlight</a>. You can track the
-            progress for the project at <a href="https://github.com/zulip/zulip/issues/30450">#30450</a>.
+            Running <code>./tools/run-dev</code> without any flags will not run the help center at all.
+            The development server for the help center takes significant resources to run and we don't
+            want to increase the minimum requirements to run Zulip for development.
         </p>
-        <ul>
-            <li>
-                <code>./tools/build-help-center</code> will convert the existing help center MD files to MDX,
-                and create a production build for the converted MDX files.
-                <ul>
-                    <li>
-                        You can run <code>./tools/convert-help-center-docs-to-mdx</code> to convert the help
-                        center MD files without the build step; see running a dev server that supports hot
-                        reload below.
-                    </li>
-                    <li>
-                        You can run <code>pnpm build</code> within the <code>starlight_help</code> directory to run
-                        the build step separately.
-                    </li>
-                </ul>
-            </li>
-            <li>
-                <code>./tools/run-dev --help-center</code> will host the generated build on
-                <code>/help</code>. Note that search will work in the beta help center docs with
-                this flag. For testing changes related to the migration of the help center docs, using the tool
-                to build the beta help center docs and running the dev server with this flag should be fine.
-            </li>
-            <li>
-                <code>./tools/run-dev --help-center-dev-server</code> will run a dev server at
-                <code>/help</code> that supports hot reload. Note that, with this flag, search will not work
-                in the beta help center docs. This mode is useful when you are editing a help center file, and
-                want to visualize the changes quickly in the beta help center documentation. You will need the
-                converted MDX files to be already generated through
-                <code>./tools/convert-help-center-docs-to-mdx</code> before you run the dev server with this flag.
-
-                <ul>
-                    <li>
-                        The dev server makes a bunch of request to base Zulip URL instead of scoping it to the astro/starlight
-                        base url. For this reason, we run the dev server on it's own port and redirect help center requests to
-                        the appropriate port (9995 by default).
-                    </li>
-                </ul>
-            </li>
-        </ul>
+        <h3> Dev server (supports hot reload but not search)</h3>
+        <p>
+            This mode is useful when you are editing a help center file, and want to visualize the changes
+            quickly in the help center documentation.
+        </p>
+        <p>
+            <code>./tools/run-dev --only-help-center</code> will run a dev server at
+            <code>/help</code> that supports hot reload. Note that, with this flag, search will not work
+            in the help center docs. In this mode, the Zulip web app and other related services will not run.
+            Since the dev server consumes a significant amount of memory, this is the recommended way to run
+            the dev server for the help center.
+        </p>
+        <p>
+            If you have a machine with resources significantly more than minimum requirements to run Zulip in
+            development, you can choose to run the dev server alongside Zulip using
+            <code>./tools/run-dev --help-center-dev-server</code>.
+            The dev server makes a bunch of request to base Zulip URL instead of scoping it to the astro/starlight
+            base url. For this reason, in this mode, we run the dev server on it's own port and redirect help center
+            requests to the appropriate port (9995 by default).
+        </p>
+        <h3> Serve static build (supports search but not hot reload)</h3>
+        <p>
+            Please run <code>./tools/build-help-center</code> to generate a static build of the help center.
+            <code>./tools/run-dev --help-center</code> will host the generated build on
+            <code>/help</code>. Note that you need to generate a build and pass the flag mentioned for the search
+            to work.
+        </p>
     </div>
 </div>
 

--- a/templates/zerver/development/help_center_instructions_macro.html
+++ b/templates/zerver/development/help_center_instructions_macro.html
@@ -1,0 +1,19 @@
+<ul>
+    <li>
+        To run just the help center dev server without
+        running the rest of the Zulip app, use
+        <code>./tools/run-dev --only-help-center</code>.
+    </li>
+    <li>
+        To run the help center dev server alongside the
+        Zulip app, use
+        <code>./tools/run-dev --help-center-dev-server</code> (requires more resources).
+    </li>
+    <li>
+        To test help center search, run <code>./tools/build-help-center</code> followed by
+        <code>./tools/run-dev --help-center-static-build</code>. Hot reloads won't
+        work: rerun <code>./tools/build-help-center</code>
+        and reload your browser to see updates. Search will not
+        work with other methods of running the help center.
+    </li>
+</ul>

--- a/tools/lib/test_server.py
+++ b/tools/lib/test_server.py
@@ -77,7 +77,7 @@ def test_server_running(
         if skip_provision_check:
             run_dev_server_command.append("--skip-provision-check")
         if enable_help_center:
-            run_dev_server_command.append("--help-center")
+            run_dev_server_command.append("--help-center-static-build")
         server = subprocess.Popen(run_dev_server_command, stdout=log, stderr=log)
 
         try:

--- a/tools/run-dev
+++ b/tools/run-dev
@@ -71,7 +71,12 @@ parser.add_argument(
 parser.add_argument(
     "--help-center-dev-server",
     action="store_true",
-    help="Run dev server for help center. Hot reload will work for this mode, but search will not work in the generated website.",
+    help="Run dev server for help center alongside the Zulip app. Hot reload will work for this mode, but search will not work in the generated website.",
+)
+parser.add_argument(
+    "--only-help-center",
+    action="store_true",
+    help="Run help center dev server on port 9991 without running the Zulip web app and related services",
 )
 add_provision_check_override_param(parser)
 options = parser.parse_args()
@@ -294,13 +299,15 @@ async def forward(upstream_port: int, request: web.Request) -> web.StreamRespons
     return response
 
 
-def run_help_center_dev_server(external_host: str) -> "subprocess.Popen[bytes]":
+def run_help_center_dev_server(
+    external_host: str, port: int = help_center_port
+) -> "subprocess.Popen[bytes]":
     return subprocess.Popen(
         [
             "/usr/local/bin/corepack",
             "pnpm",
             "dev",
-            f"--port={help_center_port}",
+            f"--port={port}",
             "--host",
             f"--allowed-hosts={urlsplit(external_host).hostname}",
         ],
@@ -368,6 +375,12 @@ build step and rerun `run-dev`.""")
 
 
 def print_listeners(external_host_url: str) -> None:
+    if options.only_help_center:
+        print(
+            f"\n{CYAN}Help center dev server running on:{ENDC} {external_host_url}/help\nZulip web app and other related services will not run in this mode."
+        )
+        return
+
     print(f"\nStarting Zulip on:\n\n\t{CYAN}{external_host_url}/{ENDC}\n\nInternal ports:")
     ports = [
         (proxy_port, "Development server proxy (connect here)"),
@@ -431,6 +444,11 @@ async def serve() -> None:
     external_host = os.getenv("EXTERNAL_HOST", f"{default_hostname}:{proxy_port}")
     http_protocol = "https" if options.behind_https_proxy else "http"
     external_host_url = f"{http_protocol}://{external_host}"
+
+    if options.only_help_center:
+        children.append(run_help_center_dev_server(external_host_url, proxy_port))
+        print_listeners(external_host_url)
+        return
 
     if options.test:
         do_one_time_webpack_compile()

--- a/tools/run-dev
+++ b/tools/run-dev
@@ -66,7 +66,9 @@ parser.add_argument(
     help="Start app server in HTTPS mode, using reverse proxy",
 )
 parser.add_argument(
-    "--help-center", action="store_true", help="Build and host help center with search"
+    "--help-center-static-build",
+    action="store_true",
+    help="Host existing static build of help center with search",
 )
 parser.add_argument(
     "--help-center-dev-server",
@@ -80,7 +82,9 @@ parser.add_argument(
 )
 add_provision_check_override_param(parser)
 options = parser.parse_args()
-help_center_dev_server_enabled = options.help_center_dev_server and not options.help_center
+help_center_dev_server_enabled = (
+    options.help_center_dev_server and not options.help_center_static_build
+)
 
 assert_provisioning_status_ok(options.skip_provision_check)
 
@@ -333,7 +337,7 @@ async def help_center_middleware(
 
 
 middlewares = []
-if options.help_center:
+if options.help_center_static_build:
     middlewares.append(help_center_middleware)
 
 app = web.Application(middlewares=middlewares)
@@ -458,7 +462,7 @@ async def serve() -> None:
     if help_center_dev_server_enabled:
         children.append(run_help_center_dev_server(external_host_url))
 
-    setup_routes(options.help_center, options.help_center_dev_server)
+    setup_routes(options.help_center_static_build, options.help_center_dev_server)
 
     children.extend(subprocess.Popen(cmd) for cmd in server_processes())
 

--- a/web/styles/portico/dev_help.css
+++ b/web/styles/portico/dev_help.css
@@ -1,0 +1,44 @@
+.dev-help-page {
+    .white-box {
+        width: 40%;
+        margin: 0 auto;
+    }
+
+    .dev-help-header {
+        text-align: center;
+        margin-bottom: 1em;
+    }
+
+    .invalid-path-error {
+        color: hsl(1.1deg 44.7% 50.4%);
+        font-weight: 400;
+        display: block;
+        text-align: center;
+        margin-top: 1em;
+    }
+
+    .dev-help-actions {
+        margin-top: 1.5em;
+        display: flex;
+        justify-content: center;
+        gap: 5px;
+
+        .dev-help-action-button {
+            display: inline-block;
+            font-weight: 400;
+            color: hsl(170deg 41% 52%);
+            border: 1px solid hsl(170deg 41% 52%);
+            border-radius: 4px;
+            padding: 6px 12px;
+
+            transition:
+                color 0.3s ease,
+                border-color 0.3s ease;
+
+            &:hover {
+                color: hsl(156deg 62% 61%);
+                border-color: hsl(156deg 62% 61%);
+            }
+        }
+    }
+}

--- a/web/webpack.dev-assets.json
+++ b/web/webpack.dev-assets.json
@@ -15,5 +15,10 @@
         "./src/reload_state.ts",
         "./src/channel.ts"
     ],
+    "dev-help": [
+        "./src/bundles/portico.ts",
+        "./styles/portico/dev_help.css",
+        "./styles/portico/markdown.css"
+    ],
     "showroom": ["./src/bundles/showroom.ts"]
 }

--- a/zerver/views/development/help.py
+++ b/zerver/views/development/help.py
@@ -1,0 +1,57 @@
+import os
+
+import werkzeug
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+
+
+def help_dev_mode_view(request: HttpRequest, subpath: str = "") -> HttpResponse:
+    """
+    Dev only view that displays help information for setting up the
+    help center dev server in the default `run-dev` mode where the
+    help center server is not running. Also serves raw MDX content when
+    `raw` query param is passed is passed.
+    """
+
+    def read_mdx_file(filename: str) -> HttpResponse:
+        file_path = os.path.join(
+            settings.DEPLOY_ROOT, "starlight_help", "src", "content", "docs", f"{filename}.mdx"
+        )
+        try:
+            with open(file_path, encoding="utf-8") as f:
+                content = f.read()
+            return HttpResponse(content, content_type="text/plain")
+        except OSError:
+            return HttpResponse("Error reading MDX file", status=500)
+
+    mdx_file_exists = False
+    is_requesting_raw_file = request.GET.get("raw") == ""
+
+    if subpath:
+        subpath = werkzeug.utils.secure_filename(subpath)
+        raw_url = f"/help/{subpath}?raw"
+        mdx_path = os.path.join(
+            settings.DEPLOY_ROOT, "starlight_help", "src", "content", "docs", f"{subpath}.mdx"
+        )
+        mdx_file_exists = os.path.exists(mdx_path) and "/include/" not in mdx_path
+        if mdx_file_exists and is_requesting_raw_file:
+            return read_mdx_file(subpath)
+    else:
+        if request.path.endswith("/"):
+            raw_url = "/help/?raw"
+        else:
+            raw_url = "/help?raw"
+        mdx_file_exists = True
+        if is_requesting_raw_file:
+            return read_mdx_file("index")
+
+    return render(
+        request,
+        "zerver/development/dev_help.html",
+        {
+            "subpath": subpath,
+            "mdx_file_exists": mdx_file_exists,
+            "raw_url": raw_url,
+        },
+    )

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -19,6 +19,7 @@ from zerver.views.development.dev_login import (
     dev_direct_login,
 )
 from zerver.views.development.email_log import clear_emails, email_page, generate_all_emails
+from zerver.views.development.help import help_dev_mode_view
 from zerver.views.development.integrations import (
     check_send_webhook_fixture_message,
     dev_panel,
@@ -106,6 +107,11 @@ urls = [
     path("devtools/buttons/", showroom_component_buttons),
     path("devtools/banners/", showroom_component_banners),
     path("devtools/inputs/", showroom_component_inputs),
+    # Development server for the help center in not run by default, we
+    # show this page with zulip.com and view source links instead.
+    path("help", help_dev_mode_view),
+    path("help/", help_dev_mode_view),
+    path("help/<path:subpath>", help_dev_mode_view),
 ]
 
 v1_api_mobile_patterns = [


### PR DESCRIPTION
Instead of repurposing `--help-center-dev-server` as discussed on CZO, I have added `--only-help-center` as an additional option instead giving the freedom for people with higher spec machines to run the dev server side by side to the zulip app.

I tested all 3 flags with run-dev. For `--help-center-static-build` and `--help-center-dev-server`, I also checked whether typing a non existed help URL would lead to the new default error page and it did not. 

**Screenshots and screen captures:**
Devtools page:
<img width="868" height="609" alt="Screenshot 2025-09-12 at 11 30 41 AM" src="https://github.com/user-attachments/assets/2b0861c1-9e14-4138-a04c-e2ee17d23173" />

Invalid path:
<img width="1903" height="609" alt="Screenshot 2025-09-12 at 10 48 55 AM" src="https://github.com/user-attachments/assets/ba1f4e3a-ba0d-48c6-932f-623471da3404" />

/help/status-and-availability:
<img width="1905" height="883" alt="Screenshot 2025-09-15 at 12 23 06 PM" src="https://github.com/user-attachments/assets/a7c0a17c-421e-4b6e-840c-1c85af6e02e5" />

<img width="1903" height="609" alt="Screenshot 2025-09-12 at 10 48 10 AM" src="https://github.com/user-attachments/assets/d843bba0-c92f-48c8-868e-d3927f70ae42" />

/help root:

<img width="1905" height="883" alt="Screenshot 2025-09-15 at 12 23 23 PM" src="https://github.com/user-attachments/assets/4875f17a-e679-4a58-b5fa-09fef802d10b" />
<img width="1903" height="609" alt="Screenshot 2025-09-12 at 10 47 55 AM" src="https://github.com/user-attachments/assets/25aa3423-f8b1-4dbe-9102-3a62461822f2" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
