### PR TITLE
api_docs: Deprecate 'remove-fcm-token' & 'remove-apns-token'.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13188,11 +13188,19 @@ paths:
                         description: |
                           A typical failed JSON response for when the APNs token is invalid:
     delete:
+      deprecated: true
       operationId: remove-apns-token
       summary: Remove an APNs device token
       tags: ["users"]
       description: |
         This endpoint removes an APNs device token for iOS push notifications.
+
+        **Changes**: Deprecated in Zulip 11.0 (feature level 406) and will be
+        removed in a future release. Clients connecting to newer servers and
+        with E2EE push notifications support should delete the account record
+        in their local accounts table that corresponds to the `push_account_id`
+        supplied when registering via the [Register E2EE push device](/api/register-push-device)
+        endpoint, to stop displaying notifications for that registration.
       requestBody:
         required: true
         content:
@@ -13284,11 +13292,19 @@ paths:
                         "code": "BAD_REQUEST",
                       }
     delete:
+      deprecated: true
       operationId: remove-fcm-token
       summary: Remove an FCM registration token
       tags: ["users"]
       description: |
         This endpoint removes an FCM registration token for push notifications.
+
+        **Changes**: Deprecated in Zulip 11.0 (feature level 406) and will be
+        removed in a future release. Clients connecting to newer servers and
+        with E2EE push notifications support should delete the account record
+        in their local accounts table that corresponds to the `push_account_id`
+        supplied when registering via the [Register E2EE push device](/api/register-push-device)
+        endpoint, to stop displaying notifications for that registration.
       requestBody:
         required: true
         content:


### PR DESCRIPTION
We deprecated the other legacy endpoints in #35870.

Before marking these two endpoints deprecated, the [plan was to introduce](https://chat.zulip.org/#narrow/channel/378-api-design/topic/unregister.20push.20device/near/2250938) similar endpoints (to unregister push device) for the E2EE case:
* https://zulip.com/api/remove-apns-token
* https://zulip.com/api/remove-fcm-token

Later we decided that we don't need such endpoints for the E2EE case, so this PR marks the legacy endpoints deprecated. See [#api design > unregister push device @ 💬](https://chat.zulip.org/#narrow/channel/378-api-design/topic/unregister.20push.20device/near/2254195)

Fixes: #35213

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="646" height="251" alt="Screenshot 2025-09-04 at 1 37 22 PM" src="https://github.com/user-attachments/assets/00aa5b31-2eca-4756-a3d6-9d09338bb683" />

<img width="628" height="251" alt="Screenshot 2025-09-04 at 1 37 55 PM" src="https://github.com/user-attachments/assets/a6ddbfb0-7716-4136-be04-bea2611ab453" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
