### PR TITLE
api_docs: Fix 500 error on `/api/register-remote-push-device`.

### DIFF
--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -50,7 +50,7 @@ def add_api_url_context(
     context.update(zulip_default_context(request))
 
     if is_zilencer_endpoint:
-        context["api_url"] = settings.ZULIP_SERVICES_URL + "/api"
+        context["api_url"] = (settings.ZULIP_SERVICES_URL or "https://push.zulipchat.com") + "/api"
         return
 
     subdomain = get_subdomain(request)

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -231,7 +231,7 @@ PASSWORD_MIN_GUESSES = 10000
 SESSION_EXPIRE_AT_BROWSER_CLOSE = False
 SESSION_COOKIE_AGE = 60 * 60 * 24 * 7 * 2  # 2 weeks
 
-ZULIP_SERVICES_URL = "https://push.zulipchat.com"
+ZULIP_SERVICES_URL: str | None = "https://push.zulipchat.com"
 ZULIP_SERVICE_PUSH_NOTIFICATIONS = False
 
 # For this setting, we need to have None as the default value, so


### PR DESCRIPTION
`settings.ZULIP_SERVICES_URL` is used to contruct curl example for `/api/register-remote-push-device`.

On zulip cloud `settings.ZULIP_SERVICES_URL=None`, it resulted in 500 error on visiting that page.

This commit fixes the bug by using "https://push.zulipchat.com" as the default value if `settings.ZULIP_SERVICES_URL=None`.

The doc already mentions that the endpoint is meant to be used by self-hosted servers, so the default value makes sense if `ZULIP_SERVICES_URL=None`.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="522" height="283" alt="Screenshot 2025-09-04 at 7 17 24 PM" src="https://github.com/user-attachments/assets/6eeba9c8-0248-4ab4-a6e8-e4fdac1b7f3f" />

<img width="534" height="286" alt="Screenshot 2025-09-04 at 7 22 42 PM" src="https://github.com/user-attachments/assets/274442e8-c194-44bc-8e3b-ff9e021759e9" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
