### PR TITLE
inbox: Remove empty space below filters for hidden folders.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -641,9 +641,17 @@
 .inbox-folder-components {
     border-radius: 5px;
     border: 0.5px solid hsl(0deg 0% 0% / 13%);
-    /* 8px at 16px / 1em */
-    margin-bottom: 0.5em;
     overflow: hidden;
+}
+
+.inbox-folder-components
+    .inbox-folder-channel:last-child
+    .inbox-topic-container,
+#inbox-direct-messages-container {
+    .inbox-row:last-child {
+        /* 8px at 16px / 1em */
+        margin-bottom: 0.5em;
+    }
 }
 
 .inbox-folder.inbox-collapsed-state,

--- a/web/templates/inbox_view/inbox_folder_with_channels.hbs
+++ b/web/templates/inbox_view/inbox_folder_with_channels.hbs
@@ -11,7 +11,7 @@
     {{#each topics_dict as |key_value_list _index|}}
         {{#each ../streams_dict as |stream_key_value _stream_index|}}
             {{#if (and (eq stream_key_value.[1].folder_id ../../id) (eq stream_key_value.[0] key_value_list.[0]))}}
-            <div id="{{key_value_list.[0]}}">
+            <div id="{{key_value_list.[0]}}" class="inbox-folder-channel">
                 {{> inbox_row stream_key_value.[1]}}
                 <div class="inbox-topic-container">
                     {{#each key_value_list.[1]}}


### PR DESCRIPTION
Hidden folders occupied space due to bottom margin.

Fixed by moving the margin to elements which have `display: none` property so that margin is removed.

Reproducer: Mute all the channels in a folder. They folder occupies 8px space at top in standard view. The more such folders, the more space is occupied at top. Also, when there are no unread DMs, 8px is occupied by DM section.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/extra.20space.20in.20inbox.3F

| before | after |
| --- | --- |
| <img width="692" height="210" alt="image" src="https://github.com/user-attachments/assets/b2b18eef-4c51-43b0-9317-d16b2e1bea29" /> | <img width="692" height="184" alt="image" src="https://github.com/user-attachments/assets/23201c0f-4753-4d09-a9b0-1ede1d6b718c" /> |
