### PR TITLE
help: Add headings between imports for `on this page` overview.

### DIFF
--- a/starlight_help/src/content/docs/follow-a-topic.mdx
+++ b/starlight_help/src/content/docs/follow-a-topic.mdx
@@ -119,7 +119,11 @@ messages just in followed topics, without counting other channel messages.
 
 ## Automatically follow topics
 
-<AutomaticallyFollowTopics />
+<AutomaticallyFollowTopics>
+  ### Follow topics you start or participate in
+
+  ### Follow topics where you are mentioned
+</AutomaticallyFollowTopics>
 
 ## Manage configured topics
 

--- a/starlight_help/src/content/docs/getting-started-with-zulip.mdx
+++ b/starlight_help/src/content/docs/getting-started-with-zulip.mdx
@@ -31,7 +31,15 @@ it, you'll never want to use a different team chat app!
 
 ## Reading your messages
 
-<ReadingConversations />
+<ReadingConversations>
+  ### Finding a conversation to read from the Inbox view
+
+  ### Finding a conversation to read from Recent conversations
+
+  ### Finding a conversation to read from the left sidebar
+
+  ### Reading conversations
+</ReadingConversations>
 
 ## Sending messages
 

--- a/starlight_help/src/content/docs/import-from-mattermost.mdx
+++ b/starlight_help/src/content/docs/import-from-mattermost.mdx
@@ -273,7 +273,13 @@ keep in mind about the import process:
 
 ## Decide how users will log in
 
-<ImportHowUsersWillLogIn />
+<ImportHowUsersWillLogIn>
+  ### Allow users to log in with non-password authentication
+
+  ### Send password reset emails to all users
+
+  ### Manual password resets
+</ImportHowUsersWillLogIn>
 
 ## Related articles
 

--- a/starlight_help/src/content/docs/import-from-rocketchat.mdx
+++ b/starlight_help/src/content/docs/import-from-rocketchat.mdx
@@ -154,7 +154,13 @@ any problems using this tool.
 
 ## Decide how users will log in
 
-<ImportHowUsersWillLogIn />
+<ImportHowUsersWillLogIn>
+  ### Allow users to log in with non-password authentication
+
+  ### Send password reset emails to all users
+
+  ### Manual password resets
+</ImportHowUsersWillLogIn>
 
 ## Related articles
 

--- a/starlight_help/src/content/docs/import-from-slack.mdx
+++ b/starlight_help/src/content/docs/import-from-slack.mdx
@@ -188,7 +188,13 @@ token from being used to access your Slack workspace in the future.
 
 ## Decide how users will log in
 
-<ImportHowUsersWillLogIn />
+<ImportHowUsersWillLogIn>
+  ### Allow users to log in with non-password authentication
+
+  ### Send password reset emails to all users
+
+  ### Manual password resets
+</ImportHowUsersWillLogIn>
 
 ## Related articles
 

--- a/starlight_help/src/content/docs/reading-conversations.mdx
+++ b/starlight_help/src/content/docs/reading-conversations.mdx
@@ -4,7 +4,15 @@ title: Reading conversations
 
 import ReadingConversations from "./include/_ReadingConversations.mdx";
 
-<ReadingConversations />
+<ReadingConversations>
+  ### Finding a conversation to read from the Inbox view
+
+  ### Finding a conversation to read from Recent conversations
+
+  ### Finding a conversation to read from the left sidebar
+
+  ### Reading conversations
+</ReadingConversations>
 
 ## Related articles
 

--- a/starlight_help/src/content/docs/reading-strategies.mdx
+++ b/starlight_help/src/content/docs/reading-strategies.mdx
@@ -22,7 +22,15 @@ in Zulip.
 
 ## Conversation by conversation
 
-<ReadingConversations />
+<ReadingConversations>
+  ### Finding a conversation to read from the Inbox view
+
+  ### Finding a conversation to read from Recent conversations
+
+  ### Finding a conversation to read from the left sidebar
+
+  ### Reading conversations
+</ReadingConversations>
 
 ### Following, muting and unmuting conversations
 

--- a/starlight_help/src/content/docs/topic-notifications.mdx
+++ b/starlight_help/src/content/docs/topic-notifications.mdx
@@ -19,7 +19,11 @@ unmute topics.
 
 ## Automatically follow topics
 
-<AutomaticallyFollowTopics />
+<AutomaticallyFollowTopics>
+  ### Follow topics you start or participate in
+
+  ### Follow topics where you are mentioned
+</AutomaticallyFollowTopics>
 
 ## Automatically unmute topics in muted channels
 


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip/issues/35127.

Headings inside the import will not be rendered anywhere, but the `On this page` component on the right needs those headings in the main file to read it and then make it a part of `On this page`.

We have skipped includes with `What you type` and `What it looks like` in them as we don't need to show them in the `on this page` overview.

We have skipped adding any headings with four hashes `####`, since they do not appear in `on this page`
overview.`ImportIntoAZulipCloudOrganization` and `ImportIntoASelfHostedServerDescription` are two examples of this.

See https://chat.zulip.org/#narrow/channel/19-documentation/topic/new.20help.20center.3A.20on.20this.20page.20overview/near/2249466

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
