### PR TITLE
test-subs: Fix comment in test_notification_bot_dm_on_subscription.

### DIFF
--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -5172,9 +5172,12 @@ class SubscriptionAPITest(ZulipTestCase):
             "```` quote\n*No description.*\n````",
         )
 
+        # When send_new_subscription_messages is false, confirm that the
+        # response doesn't include new_subscription_messages_sent boolean
+        # field.
         response = self.subscribe_via_post(
             desdemona,
-            ["Test stream 3"],
+            ["test E"],
             dict(
                 principals=orjson.dumps(user_ids).decode(),
                 send_new_subscription_messages=orjson.dumps(False).decode(),


### PR DESCRIPTION
[#api design > options for notifying new channel subscribers @ 💬](https://chat.zulip.org/#narrow/channel/378-api-design/topic/options.20for.20notifying.20new.20channel.20subscribers/near/2254976)

Fixes code comment in test that was incorrect.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
