### PR TITLE
message: Remove unused sender_realm_str and client fields

### DIFF
--- a/tools/zulip-export/zulip-export
+++ b/tools/zulip-export/zulip-export
@@ -77,7 +77,6 @@ for msg in result["messages"]:
         "avatar_url",
         "recipient_id",
         "content_type",
-        "client",
         "id",
         "type",
     ]:

--- a/tools/zulip-export/zulip-export
+++ b/tools/zulip-export/zulip-export
@@ -78,7 +78,6 @@ for msg in result["messages"]:
         "recipient_id",
         "content_type",
         "client",
-        "sender_realm_str",
         "id",
         "type",
     ]:

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -80,7 +80,6 @@ export const raw_message_schema = z.intersection(
             sender_email: z.string(),
             sender_full_name: z.string(),
             sender_id: z.number(),
-            sender_realm_str: z.string(),
             submessages: z.array(submessage_schema),
             timestamp: z.number(),
             flags: z.array(z.string()),

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -66,7 +66,6 @@ export const raw_message_schema = z.intersection(
     z.intersection(
         z.object({
             avatar_url: z.nullable(z.string()),
-            client: z.string(),
             content: z.string(),
             content_type: z.literal("text/html"),
             display_recipient: display_recipient_schema,

--- a/web/src/server_message.ts
+++ b/web/src/server_message.ts
@@ -41,7 +41,6 @@ const submessage_schema = z.array(
 export const server_message_schema = z.intersection(
     z.object({
         avatar_url: z.nullish(z.string()),
-        client: z.string(),
         content: z.string(),
         content_type: z.enum(["text/html", "text/x-markdown"]),
         display_recipient: z.union([z.string(), z.array(display_recipient_users_schema)]),

--- a/web/src/server_message.ts
+++ b/web/src/server_message.ts
@@ -55,7 +55,6 @@ export const server_message_schema = z.intersection(
         sender_email: z.string(),
         sender_full_name: z.string(),
         sender_id: z.number(),
-        sender_realm_str: z.string(),
         submessages: submessage_schema,
         timestamp: z.number(),
     }),

--- a/web/tests/server_events.test.cjs
+++ b/web/tests/server_events.test.cjs
@@ -75,7 +75,6 @@ const message = {
     submessages: [],
     sender_full_name: "user1",
     sender_email: "user2@foo.com",
-    sender_realm_str: "foo",
     display_recipient: "test",
     type: "stream",
     stream_id: 1,

--- a/web/tests/server_events.test.cjs
+++ b/web/tests/server_events.test.cjs
@@ -55,7 +55,6 @@ const message = {
     content: "hello",
     recipient_id: 3,
     timestamp: 100000000,
-    client: "website",
     subject: "server_test",
     topic_links: [],
     is_me_message: false,

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -167,7 +167,6 @@ class DirectMessageDisplayRecipient(BaseModel):
 
 class MessageFieldForEventDirectMessage(BaseModel):
     avatar_url: str | None
-    client: str
     content: str
     content_type: Literal["text/html"]
     id: int
@@ -237,7 +236,6 @@ class EventInvitesChanged(BaseEvent):
 
 class MessageFieldForEventMessage(BaseModel):
     avatar_url: str | None
-    client: str
     content: str
     content_type: Literal["text/html"]
     id: int

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -174,7 +174,6 @@ class MessageFieldForEventDirectMessage(BaseModel):
     is_me_message: bool
     reactions: list[dict[str, object]]
     recipient_id: int
-    sender_realm_str: str
     sender_email: str
     sender_full_name: str
     sender_id: int
@@ -245,7 +244,6 @@ class MessageFieldForEventMessage(BaseModel):
     is_me_message: bool
     reactions: list[dict[str, object]]
     recipient_id: int
-    sender_realm_str: str
     sender_email: str
     sender_full_name: str
     sender_id: int

--- a/zerver/lib/message_cache.py
+++ b/zerver/lib/message_cache.py
@@ -508,7 +508,6 @@ class MessageDict:
             obj["sender_full_name"] = user_row["full_name"]
             obj["sender_email"] = user_row["email"]
             obj["sender_delivery_email"] = user_row["delivery_email"]
-            obj["sender_realm_str"] = user_row["realm__string_id"]
             obj["sender_avatar_source"] = user_row["avatar_source"]
             obj["sender_avatar_version"] = user_row["avatar_version"]
             obj["sender_is_mirror_dummy"] = user_row["is_mirror_dummy"]

--- a/zerver/lib/message_cache.py
+++ b/zerver/lib/message_cache.py
@@ -385,7 +385,6 @@ class MessageDict:
             rendered_content_version=row["rendered_content_version"],
             sender_id=row["sender_id"],
             sender_realm_id=row["sender__realm_id"],
-            sending_client_name=row["sending_client__name"],
             rendering_realm_id=row.get("rendering_realm_id", row["sender__realm_id"]),
             recipient_id=row["recipient_id"],
             recipient_type=row["recipient__type"],
@@ -406,7 +405,6 @@ class MessageDict:
         rendered_content_version: int | None,
         sender_id: int,
         sender_realm_id: int,
-        sending_client_name: str,
         rendering_realm_id: int,
         recipient_id: int,
         recipient_type: int,
@@ -422,7 +420,6 @@ class MessageDict:
             recipient_type=recipient_type,
             recipient_id=recipient_id,
             timestamp=datetime_to_timestamp(date_sent),
-            client=sending_client_name,
         )
 
         obj[TOPIC_NAME] = topic_name

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -81,7 +81,6 @@ class TestGenericOutgoingWebhookService(ZulipTestCase):
 
         expected_message_data = {
             "avatar_url": gravatar_url,
-            "client": "test suite",
             "content": "@**test**",
             "content_type": "text/x-markdown",
             "display_recipient": "Denmark",

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -93,7 +93,6 @@ class TestGenericOutgoingWebhookService(ZulipTestCase):
             "sender_email": othello.email,
             "sender_full_name": "Othello, the Moor of Venice",
             "sender_id": othello.id,
-            "sender_realm_str": "zulip",
             "stream_id": stream.id,
             TOPIC_NAME: "test",
             "submessages": [],
@@ -169,7 +168,6 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
             "message": {
                 "content": "test_content",
                 "type": "stream",
-                "sender_realm_str": "zulip",
                 "sender_email": "sampleuser@zulip.com",
                 "stream_id": "123",
                 "display_recipient": "integrations",
@@ -186,7 +184,6 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
             "trigger": NotificationTriggers.DIRECT_MESSAGE,
             "message": {
                 "sender_id": 3,
-                "sender_realm_str": "zulip",
                 "timestamp": 1529821610,
                 "sender_email": "cordelia@zulip.com",
                 "type": "private",

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -58,7 +58,6 @@ class DoRestCallTests(ZulipTestCase):
                 "sender_recipient_id": bot_user.recipient_id,
                 "sender_email": bot_user.email,
                 "sender_realm_id": bot_user.realm.id,
-                "sender_realm_str": bot_user.realm.string_id,
                 "sender_delivery_email": bot_user.delivery_email,
                 "sender_full_name": bot_user.full_name,
                 "sender_avatar_source": UserProfile.AVATAR_FROM_GRAVATAR,


### PR DESCRIPTION
Briefly discussed here: https://chat.zulip.org/#narrow/channel/6-frontend/topic/sender_realm_str.20and.20.20client.20in.20message.20objects/near/2254334