### PR TITLE
echo: Make type of content_type more specific.

### DIFF
--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -84,7 +84,7 @@ type LocalMessage = MessageRequestObject & {
     raw_content: string;
     flags: string[];
     is_me_message: boolean;
-    content_type: string;
+    content_type: "text/html";
     sender_email: string;
     sender_full_name: string;
     avatar_url?: string | null | undefined;


### PR DESCRIPTION
The only LocalMessage is created in insert_local_message which has `content_type: "text/html"`.

This change lets us create LocalMessage objects with data parsed from raw_message_schema.
