### PR TITLE
echo: Add reactions to LocalMessage.

### DIFF
--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -19,7 +19,7 @@ import * as message_list_data_cache from "./message_list_data_cache.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_live_update from "./message_live_update.ts";
 import * as message_store from "./message_store.ts";
-import type {DisplayRecipientUser, Message, RawMessage} from "./message_store.ts";
+import type {DisplayRecipientUser, Message, MessageReaction, RawMessage} from "./message_store.ts";
 import * as message_util from "./message_util.ts";
 import * as people from "./people.ts";
 import * as pm_list from "./pm_list.ts";
@@ -94,6 +94,7 @@ type LocalMessage = MessageRequestObject & {
     resend: boolean;
     id: number;
     topic_links: TopicLink[];
+    reactions: MessageReaction[];
 } & (
         | (StreamMessageObject & {display_recipient?: string})
         | (PrivateMessageObject & {display_recipient?: DisplayRecipientUser[]})
@@ -279,6 +280,7 @@ export function insert_local_message(
         resend: false,
         is_me_message: false,
         topic_links: topic ? markdown.get_topic_links(topic) : [],
+        reactions: [],
     };
 
     local_message.display_recipient = build_display_recipient(local_message);

--- a/web/src/message_helper.ts
+++ b/web/src/message_helper.ts
@@ -2,6 +2,7 @@ import _ from "lodash";
 import assert from "minimalistic-assert";
 
 import * as alert_words from "./alert_words.ts";
+import * as blueslip from "./blueslip.ts";
 import * as message_store from "./message_store.ts";
 import type {Message, RawMessage} from "./message_store.ts";
 import * as message_user_ids from "./message_user_ids.ts";
@@ -44,9 +45,13 @@ export function process_new_message(raw_message: RawMessage, deliver_locally = f
         status_emoji_info = user_status.get_status_emoji(message_with_booleans.sender_id);
     }
 
+    // TODO: Remove this once we've converted more message code to typescript
+    // and also have confirmed we don't see this error for some period of time.
     if (!raw_message.reactions) {
+        blueslip.error("expected raw_message to have reactions");
         raw_message.reactions = [];
     }
+
     // TODO: Rather than adding this field to the message object, it
     // might be cleaner to create an independent map from message_id
     // => clean_reactions data for the message, with care being taken

--- a/web/tests/example2.test.cjs
+++ b/web/tests/example2.test.cjs
@@ -48,6 +48,7 @@ const messages = {
         type: "stream",
         flags: ["has_alert_word"],
         subject: "copenhagen",
+        reactions: [],
         // note we don't have every field that a "real" message
         // would have, and that can be fine
     },

--- a/web/tests/example5.test.cjs
+++ b/web/tests/example5.test.cjs
@@ -100,6 +100,7 @@ run_test("insert_message", ({override}) => {
         content: "example content",
         topic: "Foo",
         type: "stream",
+        reactions: [],
     };
 
     assert.equal(message_store.get(new_message.id), undefined);

--- a/web/tests/message_events.test.cjs
+++ b/web/tests/message_events.test.cjs
@@ -80,6 +80,7 @@ run_test("update_messages", ({override, override_rewire}) => {
         stream_id: denmark.stream_id,
         topic: "lunch",
         type: "stream",
+        reactions: [],
     };
 
     const original_message = message_helper.process_new_message(raw_message);

--- a/web/tests/message_store.test.cjs
+++ b/web/tests/message_store.test.cjs
@@ -110,6 +110,7 @@ test("process_new_message", () => {
         flags: ["has_alert_word"],
         is_me_message: false,
         id: 2067,
+        reactions: [],
     };
     message = message_helper.process_new_message(message);
 
@@ -130,6 +131,7 @@ test("process_new_message", () => {
         id: 2067,
         match_subject: "topic foo",
         match_content: "bar content",
+        reactions: [],
     };
     message = message_helper.process_new_message(message);
 
@@ -147,6 +149,7 @@ test("process_new_message", () => {
         topic: "cool thing",
         subject: "the_subject",
         id: 2068,
+        reactions: [],
     };
 
     message = message_helper.process_new_message(message);
@@ -160,6 +163,18 @@ test("process_new_message", () => {
         cindy.user_id,
         denise.user_id,
     ]);
+
+    message = {
+        sender_email: denise.email,
+        sender_id: denise.user_id,
+        type: "stream",
+        display_recipient: "Zoolippy",
+        topic: "cool thing",
+        subject: "the_subject",
+        id: 2069,
+    };
+    blueslip.expect("error", "expected raw_message to have reactions", 1);
+    message_helper.process_new_message(message);
 });
 
 test("message_booleans_parity", () => {
@@ -324,6 +339,7 @@ test("update_property", () => {
         topic: "",
         display_recipient: devel.name,
         id: 100,
+        reactions: [],
     };
     let message2 = {
         type: "stream",
@@ -334,6 +350,7 @@ test("update_property", () => {
         topic: "",
         display_recipient: denmark.name,
         id: 101,
+        reactions: [],
     };
     message1 = message_helper.process_new_message(message1);
     message2 = message_helper.process_new_message(message2);
@@ -371,6 +388,7 @@ test("remove", () => {
         display_recipient: devel.name,
         topic: "test",
         id: 100,
+        reactions: [],
     };
     const message2 = {
         type: "stream",
@@ -381,6 +399,7 @@ test("remove", () => {
         display_recipient: denmark.name,
         topic: "test",
         id: 101,
+        reactions: [],
     };
     const message3 = {
         type: "stream",
@@ -391,6 +410,7 @@ test("remove", () => {
         display_recipient: denmark.name,
         topic: "test",
         id: 102,
+        reactions: [],
     };
     for (const message of [message1, message2]) {
         message_helper.process_new_message(message);
@@ -413,6 +433,7 @@ test("get_message_ids_in_stream", () => {
         display_recipient: devel.name,
         topic: "test",
         id: 100,
+        reactions: [],
     };
     const message2 = {
         sender_email: "me@example.com",
@@ -422,6 +443,7 @@ test("get_message_ids_in_stream", () => {
         flags: ["has_alert_word"],
         is_me_message: false,
         id: 101,
+        reactions: [],
     };
     const message3 = {
         type: "stream",
@@ -432,6 +454,7 @@ test("get_message_ids_in_stream", () => {
         display_recipient: denmark.name,
         topic: "test",
         id: 102,
+        reactions: [],
     };
     const message4 = {
         type: "stream",
@@ -442,6 +465,7 @@ test("get_message_ids_in_stream", () => {
         display_recipient: devel.name,
         topic: "test",
         id: 103,
+        reactions: [],
     };
 
     for (const message of [message1, message2, message3, message4]) {


### PR DESCRIPTION
This will make it easier to type the raw message in `process_new_message`. The blueslip error is left here as a precaution, but I'm fairly confident that if `RawMessage` and `LocalMessage` both have reactions then that codeblock will never be called.
