### PR TITLE
help: Remove unnecessary "with Zulip".

### DIFF
--- a/starlight_help/astro.config.mjs
+++ b/starlight_help/astro.config.mjs
@@ -93,7 +93,10 @@ export default defineConfig({
                 {
                     label: "Guides for getting started",
                     items: [
-                        "getting-started-with-zulip",
+                        {
+                            label: "Getting started",
+                            link: "/getting-started-with-zulip",
+                        },
                         {
                             label: "Choosing a team chat app",
                             link: "https://blog.zulip.com/2024/11/04/choosing-a-team-chat-app/",


### PR DESCRIPTION
@terpimost pointed out that we repeat "with Zulip" a lot of at the top of the left sidebar. I think this is better? I'm not sure how I'd reword anything else, though.

I manually tested the link.

<img width="2198" height="956" alt="Screenshot 2025-09-05 at 12 15 46@2x" src="https://github.com/user-attachments/assets/7d54323f-092b-4e21-bd98-5480fef82983" />
