### PR TITLE
left-sidebar: Add expand/collapse all options to filter menu.

### DIFF
--- a/web/src/channel_folders_popover.ts
+++ b/web/src/channel_folders_popover.ts
@@ -5,7 +5,10 @@ import type * as tippy from "tippy.js";
 import render_channel_folder_setting_popover from "../templates/popovers/channel_folder_setting_popover.hbs";
 
 import * as channel from "./channel.ts";
+import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area.ts";
+import * as pm_list from "./pm_list.ts";
 import * as popover_menus from "./popover_menus.ts";
+import * as stream_list from "./stream_list.ts";
 import {parse_html} from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
 
@@ -33,6 +36,35 @@ function do_change_show_channel_folders_inbox(instance: tippy.Instance): void {
     popover_menus.hide_current_popover_if_visible(instance);
 }
 
+function expand_all_sections(instance: tippy.Instance): void {
+    // Expand Views section
+    left_sidebar_navigation_area.force_expand_views();
+
+    // Expand Direct Messages section
+    if (pm_list.is_private_messages_collapsed()) {
+        pm_list.expand();
+    }
+
+    // Expand all channel/stream sections
+    stream_list.expand_all_stream_sections();
+
+    popover_menus.hide_current_popover_if_visible(instance);
+}
+
+function collapse_all_sections(instance: tippy.Instance): void {
+    // Collapse Views section
+    left_sidebar_navigation_area.force_collapse_views();
+
+    // Collapse Direct Messages section
+    if (!pm_list.is_private_messages_collapsed()) {
+        pm_list.close();
+    }
+
+    // Collapse all channel/stream sections
+    stream_list.collapse_all_stream_sections();
+    popover_menus.hide_current_popover_if_visible(instance);
+}
+
 export function initialize(): void {
     popover_menus.register_popover_menu("#left-sidebar-search .channel-folders-sidebar-menu-icon", {
         ...popover_menus.left_sidebar_tippy_options,
@@ -42,6 +74,12 @@ export function initialize(): void {
             assert(instance.reference instanceof HTMLElement);
             $popper.one("click", "#left_sidebar_channel_folders", () => {
                 do_change_show_channel_folders_left_sidebar(instance);
+            });
+            $popper.one("click", "#left_sidebar_expand_all", () => {
+                expand_all_sections(instance);
+            });
+            $popper.one("click", "#left_sidebar_collapse_all", () => {
+                collapse_all_sections(instance);
             });
         },
         onShow(instance) {

--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -150,9 +150,47 @@ export function expand_views($views_label_container: JQuery, $views_label_icon: 
     $views_label_icon.removeClass("rotate-icon-right");
 }
 
-function toggle_condensed_navigation_area(): void {
+export function collapse_views($views_label_container: JQuery, $views_label_icon: JQuery): void {
+    $views_label_container.addClass("showing-condensed-navigation");
+    $views_label_container.removeClass("showing-expanded-navigation");
+    $views_label_icon.addClass("rotate-icon-right");
+    $views_label_icon.removeClass("rotate-icon-down");
+}
+
+export function force_expand_views(): void {
+    if (page_params.is_spectator) {
+        // We don't support collapsing VIEWS for spectators, so exit early.
+        return;
+    }
+
     const $views_label_container = $("#views-label-container");
     const $views_label_icon = $("#toggle-top-left-navigation-area-icon");
+
+    if ($views_label_container.hasClass("showing-condensed-navigation")) {
+        expand_views($views_label_container, $views_label_icon);
+        save_state(STATES.EXPANDED);
+        resize.resize_stream_filters_container();
+    }
+}
+
+export function force_collapse_views(): void {
+    if (page_params.is_spectator) {
+        // We don't support collapsing VIEWS for spectators, so exit early.
+        return;
+    }
+
+    const $views_label_container = $("#views-label-container");
+    const $views_label_icon = $("#toggle-top-left-navigation-area-icon");
+
+    if ($views_label_container.hasClass("showing-expanded-navigation")) {
+        collapse_views($views_label_container, $views_label_icon);
+        save_state(STATES.CONDENSED);
+        resize.resize_stream_filters_container();
+    }
+}
+
+function toggle_condensed_navigation_area(): void {
+    const $views_label_container = $("#views-label-container");
 
     if (page_params.is_spectator) {
         // We don't support collapsing VIEWS for spectators, so exit early.
@@ -160,17 +198,10 @@ function toggle_condensed_navigation_area(): void {
     }
 
     if ($views_label_container.hasClass("showing-expanded-navigation")) {
-        // Toggle into the condensed state
-        $views_label_container.addClass("showing-condensed-navigation");
-        $views_label_container.removeClass("showing-expanded-navigation");
-        $views_label_icon.addClass("rotate-icon-right");
-        $views_label_icon.removeClass("rotate-icon-down");
-        save_state(STATES.CONDENSED);
+        force_collapse_views();
     } else {
-        expand_views($views_label_container, $views_label_icon);
-        save_state(STATES.EXPANDED);
+        force_expand_views();
     }
-    resize.resize_stream_filters_container();
 }
 
 export function animate_mention_changes($li: JQuery, new_mention_count: number): void {

--- a/web/templates/popovers/channel_folder_setting_popover.hbs
+++ b/web/templates/popovers/channel_folder_setting_popover.hbs
@@ -1,6 +1,18 @@
 <div class="popover-menu" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" id="left_sidebar_expand_all" class="popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-expand" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Expand all sections" }}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" id="left_sidebar_collapse_all" class="popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-collapse" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Collapse all sections" }}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" id="left_sidebar_channel_folders" class="popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-folder" aria-hidden="true"></i>
                 {{#if show_channel_folders}}


### PR DESCRIPTION
Fixes: #35884

### Summary

This PR adds two new entries to the left-sidebar filter popover:
    - Expand all sections (`zulip-icon-expand`)
    - Collapse all sections (`zulip-icon-collapse`)

They appear above the existing Don't group channels by folder entry. Clicking either entry expands or collapses all sidebar sections (Views, DMs, folders, etc.) at once.

### What changed

- Added two menu items to the left-sidebar filter.
- Implemented handlers that expand/collapse all sidebar sections with a single click.
- Reused existing `toggle_condensed_navigation_area` logic to avoid duplication and ensure consistent behavior.
- Persisted expand/collapse state using the same sidebar state mechanism so the user’s choice survives page reloads.

## **Screenshots and screen captures:**

### Menu options:
| Before | After |
| --- | --- |
| <img width="588" height="196" alt="Screenshot 2025-09-09 195852" src="https://github.com/user-attachments/assets/d8ee12b9-029f-4da7-a6a6-9f35d2b68d9d" /> | <img width="574" height="224" alt="image" src="https://github.com/user-attachments/assets/c1d5514c-21d6-4b22-9535-f28ae75712f6" />

### Demo :

After:



https://github.com/user-attachments/assets/bf36f37d-ef2e-4d4d-997a-0263c4295ec9






<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

