### PR TITLE
Restructure overlays template

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -180,8 +180,7 @@ Accessing messages requires an account and Zulip API key.
 <div id="drafts_table"></div>
 <div id="scheduled_messages_overlay_container"></div>
 <div id="reminders-overlay-container"></div>
-<div id="settings_overlay_container" class="overlay" data-overlay="settings" aria-hidden="true">
-</div>
+<div id="settings_overlay_container"></div>
 <div id="message-edit-history-overlay-container"></div>
 <div class="informational-overlays overlay" data-overlay="informationalOverlays" aria-hidden="true">
     <div class="overlay-content overlay-container">

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -183,7 +183,7 @@ Accessing messages requires an account and Zulip API key.
 <div id="settings_overlay_container"></div>
 <div id="message-edit-history-overlay-container"></div>
 <div class="informational-overlays overlay" data-overlay="informationalOverlays" aria-hidden="true">
-    <div class="overlay-content overlay-container">
+    <div class="overlay-container">
         <div class="overlay-tabs">
             <span class="exit">&times;</span>
         </div>

--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -578,7 +578,7 @@ export async function manage_organization(page: Page): Promise<void> {
     const organization_settings = '.link-item a[href="#organization"]';
     await page.waitForSelector(organization_settings, {visible: true});
     await page.click(organization_settings);
-    await page.waitForSelector("#settings_overlay_container.show", {visible: true});
+    await page.waitForSelector("#settings_overlay_container .overlay.show", {visible: true});
 
     const url = await page_url_with_fragment(page);
     assert.match(url, /^http:\/\/[^/]+\/#organization/, "Unexpected organization settings URL");

--- a/web/e2e-tests/mark-messages-read-near.test.ts
+++ b/web/e2e-tests/mark-messages-read-near.test.ts
@@ -18,7 +18,7 @@ async function navigate_to_settings_preferences(page: Page): Promise<void> {
     await common.open_personal_menu(page);
     await page.waitForSelector("#personal-menu-dropdown a[href^='#settings']", {visible: true});
     await page.click("#personal-menu-dropdown a[href^='#settings']");
-    await page.waitForSelector("#settings_overlay_container.show", {visible: true});
+    await page.waitForSelector("#settings_overlay_container .overlay.show", {visible: true});
     await page.waitForSelector('[data-section="preferences"]', {visible: true});
     await page.click('[data-section="preferences"]');
     await page.waitForSelector("#user_web_mark_read_on_scroll_policy", {visible: true});
@@ -29,7 +29,7 @@ async function change_mark_read_policy(page: Page, value: string): Promise<void>
     await page.select("#user_web_mark_read_on_scroll_policy", value);
     await page.waitForSelector("#user-preferences .general-settings-status", {visible: true});
     await page.click("#settings_page .content-wrapper .exit");
-    await page.waitForSelector("#settings_overlay_container", {hidden: true});
+    await page.waitForSelector("#settings_overlay_container .overlay", {hidden: true});
 }
 
 // Test 1: A /near/ narrow is treated as a conversation view.

--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -33,7 +33,7 @@ async function navigate_to_settings(page: Page): Promise<void> {
 
     await page.click("#settings_page .content-wrapper .exit");
     // Wait until the overlay is completely closed.
-    await page.waitForSelector("#settings_overlay_container", {hidden: true});
+    await page.waitForSelector("#settings_overlay_container .overlay", {hidden: true});
 }
 
 async function navigate_to_subscriptions(page: Page): Promise<void> {

--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -39,7 +39,7 @@ async function open_settings(page: Page): Promise<void> {
         `Page url: ${page_url} does not contain /#settings/`,
     );
     // Wait for settings overlay to open.
-    await page.waitForSelector("#settings_overlay_container", {visible: true});
+    await page.waitForSelector("#settings_overlay_container .overlay", {visible: true});
 }
 
 async function close_settings_and_date_picker(page: Page): Promise<void> {
@@ -50,7 +50,7 @@ async function close_settings_and_date_picker(page: Page): Promise<void> {
 
     await page.keyboard.press("Escape");
     await page.waitForSelector(".flatpickr-calendar", {hidden: true});
-    await page.waitForSelector("#settings_overlay_container", {hidden: true});
+    await page.waitForSelector("#settings_overlay_container .overlay", {hidden: true});
 }
 
 async function test_change_full_name(page: Page): Promise<void> {
@@ -443,7 +443,7 @@ async function test_default_language_setting(page: Page): Promise<void> {
     // we need to switch back to the Personal Settings tab to proceed with further testing.
     await page.waitForSelector('.tab-switcher .ind-tab[data-tab-key="settings"]', {visible: true});
     await page.click('.tab-switcher .ind-tab[data-tab-key="settings"]');
-    await page.waitForSelector("#settings_overlay_container", {visible: true});
+    await page.waitForSelector("#settings_overlay_container .overlay", {visible: true});
 
     const preferences_section = '[data-section="preferences"]';
     await page.click(preferences_section);

--- a/web/e2e-tests/user-deactivation.test.ts
+++ b/web/e2e-tests/user-deactivation.test.ts
@@ -13,7 +13,7 @@ async function navigate_to_user_list(page: Page): Promise<void> {
     await page.waitForSelector(organization_settings, {visible: true});
     await page.click(organization_settings);
 
-    await page.waitForSelector("#settings_overlay_container.show", {visible: true});
+    await page.waitForSelector("#settings_overlay_container .overlay.show", {visible: true});
     await page.waitForSelector("li[data-section='users']", {visible: true});
     await page.click("li[data-section='users']");
     await page.waitForSelector("#admin-user-list.show", {visible: true});

--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -184,7 +184,7 @@ export function initialize(): void {
 
         // if the target is not the div.overlay element, search up the node tree
         // until it is found.
-        if ($target.is(".exit, .exit-sign, .overlay-content, .exit span")) {
+        if ($target.is(".exit, .exit-sign, .exit span")) {
             $target = $target.closest("[data-overlay]");
         } else if (!$target.is("div.overlay")) {
             // not a valid click target then.

--- a/web/src/settings.ts
+++ b/web/src/settings.ts
@@ -182,7 +182,7 @@ export function build_page(): void {
 export function open_settings_overlay(): void {
     overlays.open_overlay({
         name: "settings",
-        $overlay: $("#settings_overlay_container"),
+        $overlay: $("#settings_page"),
         on_close() {
             browser_history.exit_overlay();
             flatpickr.close_all();

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -221,7 +221,8 @@ div.overlay {
     transition-property: opacity, visibility;
     overflow: hidden;
 
-    .overlay-content {
+    .overlay-container {
+        background-color: var(--color-background-modal);
         transform: translateY(20px);
         transition: transform 0.2s ease-in;
         z-index: 102;
@@ -233,7 +234,7 @@ div.overlay {
         visibility: visible;
         transition: opacity 0.2s ease-out;
 
-        .overlay-content {
+        .overlay-container {
             transform: translateY(0);
             transition-timing-function: ease-out;
         }
@@ -242,10 +243,6 @@ div.overlay {
     .overlay-scroll-container {
         max-height: 60vh;
         padding: 15px;
-    }
-
-    .overlay-container {
-        background-color: var(--color-background-modal);
     }
 }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -999,7 +999,8 @@ div.overlay:not(#about-zulip) .overlay-container {
     box-shadow: var(--box-shadow-overlay);
 }
 
-#subscription_overlay.overlay .overlay-container {
+#subscription_overlay.overlay .overlay-container,
+#draft_overlay.overlay .overlay-container {
     margin: 2.5vh auto;
 }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1002,7 +1002,8 @@ div.overlay:not(#about-zulip) .overlay-container {
 #subscription_overlay.overlay .overlay-container,
 #draft_overlay.overlay .overlay-container,
 #message-history-overlay.overlay .overlay-container,
-#reminders-overlay.overlay .overlay-container {
+#reminders-overlay.overlay .overlay-container,
+#scheduled_messages_overlay.overlay .overlay-container {
     margin: 2.5vh auto;
 }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -999,6 +999,10 @@ div.overlay:not(#about-zulip) .overlay-container {
     box-shadow: var(--box-shadow-overlay);
 }
 
+#subscription_overlay.overlay .overlay-container {
+    margin: 2.5vh auto;
+}
+
 .delete-selected-drafts-button-container {
     display: flex;
 }

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1000,7 +1000,8 @@ div.overlay:not(#about-zulip) .overlay-container {
 }
 
 #subscription_overlay.overlay .overlay-container,
-#draft_overlay.overlay .overlay-container {
+#draft_overlay.overlay .overlay-container,
+#message-history-overlay.overlay .overlay-container {
     margin: 2.5vh auto;
 }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -995,9 +995,7 @@ input.settings_text_input {
     }
 }
 
-div.overlay .flex.overlay-content > .overlay-container,
-#settings_page,
-.informational-overlays .overlay-content {
+div.overlay:not(#about-zulip) .overlay-container {
     box-shadow: var(--box-shadow-overlay);
 }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1001,7 +1001,8 @@ div.overlay:not(#about-zulip) .overlay-container {
 
 #subscription_overlay.overlay .overlay-container,
 #draft_overlay.overlay .overlay-container,
-#message-history-overlay.overlay .overlay-container {
+#message-history-overlay.overlay .overlay-container,
+#reminders-overlay.overlay .overlay-container {
     margin: 2.5vh auto;
 }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1003,7 +1003,8 @@ div.overlay:not(#about-zulip) .overlay-container {
 #draft_overlay.overlay .overlay-container,
 #message-history-overlay.overlay .overlay-container,
 #reminders-overlay.overlay .overlay-container,
-#scheduled_messages_overlay.overlay .overlay-container {
+#scheduled_messages_overlay.overlay .overlay-container,
+#groups_overlay.overlay .overlay-container {
     margin: 2.5vh auto;
 }
 

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -1,5 +1,5 @@
 .informational-overlays {
-    .overlay-content {
+    .overlay-container {
         width: var(--informational-overlay-max-width);
         margin: 0 auto;
         position: relative;
@@ -101,7 +101,7 @@
 
 @media only screen and (width < $md_min) {
     .informational-overlays {
-        .overlay-content {
+        .overlay-container {
             width: calc(100% - 20px);
             /* Constrain to same width as in larger viewports. */
             max-width: var(--informational-overlay-max-width);

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -828,7 +828,7 @@
 }
 
 .modal__body,
-.overlay-content {
+.overlay-container {
     .dropdown-widget-button,
     .dropdown_widget_with_label_wrapper {
         width: var(--modal-input-width);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1454,12 +1454,14 @@ label.preferences-radio-choice-label {
 
 /* -- new settings overlay -- */
 #settings_page {
-    height: 95vh;
-    width: 97vw;
-    max-width: 73.1429em; /* 1024px at 14px em */
-    margin: 2.5vh auto;
-    overflow: hidden;
-    border-radius: 4px;
+    .overlay-container {
+        height: 95vh;
+        width: 97vw;
+        max-width: 73.1429em; /* 1024px at 14px em */
+        margin: 2.5vh auto;
+        overflow: hidden;
+        border-radius: 4px;
+    }
 
     .time-limit-custom-input {
         width: 5ch;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1531,7 +1531,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
         color: hsl(0deg 0% 67%);
     }
 
-    .overlay-content {
+    .overlay-container {
         width: 440px;
         border-radius: 4px;
     }

--- a/web/templates/about_zulip.hbs
+++ b/web/templates/about_zulip.hbs
@@ -1,5 +1,5 @@
 <div id="about-zulip" class="overlay flex" tabindex="-1" role="dialog" data-overlay="about-zulip" aria-label="{{t 'About Zulip' }}" aria-hidden="true">
-    <div class="overlay-content overlay-container">
+    <div class="overlay-container">
         <button type="button" class="exit" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <div class="overlay-body">
             <div class="about-zulip-logo">

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -1,34 +1,32 @@
 <div id="draft_overlay" class="overlay" data-overlay="drafts">
-    <div class="flex overlay-content">
-        <div class="drafts-container overlay-messages-container overlay-container">
-            <div class="overlay-messages-header">
-                <h1>{{t 'Drafts' }}</h1>
-                <div class="exit">
-                    <span class="exit-sign">&times;</span>
+    <div class="drafts-container overlay-messages-container overlay-container">
+        <div class="overlay-messages-header">
+            <h1>{{t 'Drafts' }}</h1>
+            <div class="exit">
+                <span class="exit-sign">&times;</span>
+            </div>
+            <div id="draft_overlay_banner_container" class="banner-container banner-wrapper"></div>
+            <div class="header-body">
+                <div class="drafts-header-note">
+                    <div class="overlay-keyboard-shortcuts">
+                        {{#tr}}
+                            To restore a draft, click on it or press <z-shortcut></z-shortcut>.
+                            {{#*inline "z-shortcut"}}{{popover_hotkey_hints "Enter"}}{{/inline}}
+                        {{/tr}}
+                    </div>
+                    <div>{{t "Drafts are not synced to other devices and browsers." }}</div>
                 </div>
-                <div id="draft_overlay_banner_container" class="banner-container banner-wrapper"></div>
-                <div class="header-body">
-                    <div class="drafts-header-note">
-                        <div class="overlay-keyboard-shortcuts">
-                            {{#tr}}
-                                To restore a draft, click on it or press <z-shortcut></z-shortcut>.
-                                {{#*inline "z-shortcut"}}{{popover_hotkey_hints "Enter"}}{{/inline}}
-                            {{/tr}}
-                        </div>
-                        <div>{{t "Drafts are not synced to other devices and browsers." }}</div>
+                <div class="delete-drafts-group">
+                    <div class="delete-selected-drafts-button-container">
+                        {{> ./components/icon_button intent="danger" custom_classes="delete-selected-drafts-button" icon="trash" disabled=true  }}
                     </div>
-                    <div class="delete-drafts-group">
-                        <div class="delete-selected-drafts-button-container">
-                            {{> ./components/icon_button intent="danger" custom_classes="delete-selected-drafts-button" icon="trash" disabled=true  }}
-                        </div>
-                        <button class="action-button action-button-subtle-neutral select-drafts-button" role="checkbox" aria-checked="false">
-                            <span>{{t "Select all drafts" }}</span>
-                            <i class="fa fa-square-o select-state-indicator" aria-hidden="true"></i>
-                        </button>
-                    </div>
+                    <button class="action-button action-button-subtle-neutral select-drafts-button" role="checkbox" aria-checked="false">
+                        <span>{{t "Select all drafts" }}</span>
+                        <i class="fa fa-square-o select-state-indicator" aria-hidden="true"></i>
+                    </button>
                 </div>
             </div>
-            {{> drafts_list context }}
         </div>
+        {{> drafts_list context }}
     </div>
 </div>

--- a/web/templates/message_history_overlay.hbs
+++ b/web/templates/message_history_overlay.hbs
@@ -1,29 +1,27 @@
 <div id="message-history-overlay" class="overlay" data-overlay="message_edit_history">
-    <div class="flex overlay-content">
-        <div class="message-edit-history-container overlay-messages-container overlay-container">
-            <div class="overlay-messages-header">
-                {{#if move_history_only}}
-                <h1>{{t "Message move history" }}</h1>
+    <div class="message-edit-history-container overlay-messages-container overlay-container">
+        <div class="overlay-messages-header">
+            {{#if move_history_only}}
+            <h1>{{t "Message move history" }}</h1>
+            {{else}}
+            {{#if edited}}
+                {{#if moved}}
+                <h1>{{t "Message edit and move history" }}</h1>
                 {{else}}
-                {{#if edited}}
-                    {{#if moved}}
-                    <h1>{{t "Message edit and move history" }}</h1>
-                    {{else}}
-                    <h1>{{t "Message edit history" }}</h1>
-                    {{/if}}
-                {{else if moved}}
-                    <h1>{{t "Message move history" }}</h1>
+                <h1>{{t "Message edit history" }}</h1>
                 {{/if}}
-                {{/if}}
-                <div class="exit">
-                    <span class="exit-sign">&times;</span>
-                </div>
+            {{else if moved}}
+                <h1>{{t "Message move history" }}</h1>
+            {{/if}}
+            {{/if}}
+            <div class="exit">
+                <span class="exit-sign">&times;</span>
             </div>
-            <div class="message-edit-history-list overlay-messages-list">
-            </div>
-            <div class="loading_indicator"></div>
-            <div id="message-history-error" class="alert">
-            </div>
+        </div>
+        <div class="message-edit-history-list overlay-messages-list">
+        </div>
+        <div class="loading_indicator"></div>
+        <div id="message-history-error" class="alert">
         </div>
     </div>
 </div>

--- a/web/templates/reminders_overlay.hbs
+++ b/web/templates/reminders_overlay.hbs
@@ -1,16 +1,14 @@
 <div id="reminders-overlay" class="overlay" data-overlay="reminders">
-    <div class="flex overlay-content">
-        <div class="overlay-messages-container overlay-container reminders-container">
-            <div class="overlay-messages-header">
-                <h1>{{t 'Scheduled reminders' }}</h1>
-                <div class="exit">
-                    <span class="exit-sign">&times;</span>
-                </div>
+    <div class="overlay-messages-container overlay-container reminders-container">
+        <div class="overlay-messages-header">
+            <h1>{{t 'Scheduled reminders' }}</h1>
+            <div class="exit">
+                <span class="exit-sign">&times;</span>
             </div>
-            <div class="reminders-list overlay-messages-list">
-                <div class="no-overlay-messages">
-                    {{t 'No reminders scheduled.'}}
-                </div>
+        </div>
+        <div class="reminders-list overlay-messages-list">
+            <div class="no-overlay-messages">
+                {{t 'No reminders scheduled.'}}
             </div>
         </div>
     </div>

--- a/web/templates/scheduled_messages_overlay.hbs
+++ b/web/templates/scheduled_messages_overlay.hbs
@@ -1,24 +1,22 @@
 <div id="scheduled_messages_overlay" class="overlay" data-overlay="scheduled">
-    <div class="flex overlay-content">
-        <div class="overlay-messages-container overlay-container scheduled-messages-container">
-            <div class="overlay-messages-header">
-                <h1>{{t 'Scheduled messages' }}</h1>
-                <div class="exit">
-                    <span class="exit-sign">&times;</span>
-                </div>
-                <div class="removed-drafts">
-                    <div class="overlay-keyboard-shortcuts">
-                        {{#tr}}
-                            To edit or reschedule a message, click on it or press <z-shortcut></z-shortcut>.
-                            {{#*inline "z-shortcut"}}{{popover_hotkey_hints "Enter"}}{{/inline}}
-                        {{/tr}}
-                    </div>
+    <div class="overlay-messages-container overlay-container scheduled-messages-container">
+        <div class="overlay-messages-header">
+            <h1>{{t 'Scheduled messages' }}</h1>
+            <div class="exit">
+                <span class="exit-sign">&times;</span>
+            </div>
+            <div class="removed-drafts">
+                <div class="overlay-keyboard-shortcuts">
+                    {{#tr}}
+                        To edit or reschedule a message, click on it or press <z-shortcut></z-shortcut>.
+                        {{#*inline "z-shortcut"}}{{popover_hotkey_hints "Enter"}}{{/inline}}
+                    {{/tr}}
                 </div>
             </div>
-            <div class="scheduled-messages-list overlay-messages-list">
-                <div class="no-overlay-messages">
-                    {{t 'No scheduled messages.'}}
-                </div>
+        </div>
+        <div class="scheduled-messages-list overlay-messages-list">
+            <div class="no-overlay-messages">
+                {{t 'No scheduled messages.'}}
             </div>
         </div>
     </div>

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -1,4 +1,4 @@
-<div id="settings_page" class="overlay-content overlay-container">
+<div id="settings_page" class="overlay-container">
     <div class="settings-header mobile">
         <i class="fa fa-chevron-left" aria-hidden="true"></i>
         <h1>{{t "Settings" }}<span class="section"></span></h1>

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -1,162 +1,164 @@
-<div id="settings_page" class="overlay-container">
-    <div class="settings-header mobile">
-        <i class="fa fa-chevron-left" aria-hidden="true"></i>
-        <h1>{{t "Settings" }}<span class="section"></span></h1>
-        <div class="exit">
-            <span class="exit-sign">&times;</span>
-        </div>
-    </div>
-    <div class="sidebar-wrapper">
-        <div class="tab-container"></div>
-        <div class="sidebar left" data-simplebar data-simplebar-tab-index="-1">
-            <div class="sidebar-list dark-grey small-text">
-                <ul class="normal-settings-list">
-                    <li class="sidebar-item" tabindex="0" data-section="profile">
-                        <i class="sidebar-item-icon fa fa-user" aria-hidden="true"></i>
-                        <div class="text">{{t "Profile" }}</div>
-                    </li>
-                    <li class="sidebar-item" tabindex="0" data-section="account-and-privacy">
-                        <i class="sidebar-item-icon fa fa-lock" aria-hidden="true"></i>
-                        <div class="text">{{t "Account & privacy" }}</div>
-                    </li>
-                    <li class="sidebar-item" tabindex="0" data-section="preferences">
-                        <i class="sidebar-item-icon fa fa-sliders" aria-hidden="true"></i>
-                        <div class="text">{{t "Preferences" }}</div>
-                    </li>
-                    <li class="sidebar-item" tabindex="0" data-section="notifications">
-                        <i class="sidebar-item-icon fa fa-exclamation-triangle" aria-hidden="true"></i>
-                        <div class="text">{{t "Notifications" }}</div>
-                    </li>
-                    {{#unless is_guest}}
-                        <li class="sidebar-item" tabindex="0" data-section="bots">
-                            <i class="sidebar-item-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
-                            <div class="text">{{t 'Bots'}}</div>
-                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if (or can_create_new_bots can_manage_bot)}}style="display: none;"{{/if}} data-tippy-content="{{t 'You do not have permission to create or manage bots.' }}"></i>
-                        </li>
-                    {{/unless}}
-                    <li class="sidebar-item" tabindex="0" data-section="alert-words">
-                        <i class="sidebar-item-icon fa fa-book" aria-hidden="true"></i>
-                        <div class="text">{{t "Alert words" }}</div>
-                    </li>
-                    {{#if show_uploaded_files_section}}
-                    <li class="sidebar-item" tabindex="0" data-section="uploaded-files">
-                        <i class="sidebar-item-icon fa fa-paperclip" aria-hidden="true"></i>
-                        <div class="text">{{t "Uploaded files" }}</div>
-                    </li>
-                    {{/if}}
-                    <li class="sidebar-item" tabindex="0" data-section="topics">
-                        <i class="sidebar-item-icon zulip-icon zulip-icon-topic" aria-hidden="true"></i>
-                        <div class="text">{{t "Topics" }}</div>
-                    </li>
-                    <li class="sidebar-item" tabindex="0" data-section="muted-users">
-                        <i class="sidebar-item-icon fa fa-eye-slash" aria-hidden="true"></i>
-                        <div class="text">{{t "Muted users" }}</div>
-                    </li>
-                </ul>
-
-                <ul class="org-settings-list">
-                    <li class="sidebar-item" tabindex="0" data-section="organization-profile">
-                        <i class="sidebar-item-icon fa fa-id-card" aria-hidden="true"></i>
-                        <div class="text">{{t "Organization profile" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-settings">
-                        <i class="sidebar-item-icon fa fa-sliders" aria-hidden="true"></i>
-                        <div class="text">{{t "Organization settings" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings' }}"></i>
-                    </li>
-                    <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-permissions">
-                        <i class="sidebar-item-icon fa fa-lock" aria-hidden="true"></i>
-                        <div class="text">{{t "Organization permissions" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    <li class="sidebar-item" tabindex="0" data-section="emoji-settings">
-                        <i class="sidebar-item-icon fa fa-smile-o" aria-hidden="true"></i>
-                        <div class="text">{{t "Custom emoji" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#unless show_emoji_settings_lock}}style="display: none;"{{/unless}} data-tippy-content="{{t 'You do not have permission to add custom emoji.'}}"></i>
-                    </li>
-                    <li class="sidebar-item" tabindex="0" data-section="linkifier-settings">
-                        <i class="sidebar-item-icon fa fa-font" aria-hidden="true"></i>
-                        <div class="text">{{t "Linkifiers" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    <li class="sidebar-item" tabindex="0" data-section="playground-settings">
-                        <i class="sidebar-item-icon fa fa-external-link" aria-hidden="true"></i>
-                        <div class="text">{{t "Code playgrounds" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    {{#unless is_guest}}
-                    <li class="sidebar-item" tabindex="0" data-section="users">
-                        <i class="sidebar-item-icon fa fa-user" aria-hidden="true"></i>
-                        <div class="text">{{t "Users" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if can_edit_user_panel }}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    {{/unless}}
-                    {{#unless is_guest}}
-                    <li class="sidebar-item" tabindex="0" data-section="bots">
-                        <i class="sidebar-item-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
-                        <div class="text">{{t "Bots" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if (or can_create_new_bots can_manage_bot)}}style="display: none;"{{/if}} data-tippy-content="{{t 'You do not have permission to create or manage bots.' }}"></i>
-                    </li>
-                    {{/unless}}
-                    {{#if is_admin}}
-                    <li class="sidebar-item" tabindex="0" data-section="profile-field-settings">
-                        <i class="sidebar-item-icon fa fa-id-card" aria-hidden="true"></i>
-                        <div class="text">{{t "Custom profile fields" }}</div>
-                    </li>
-                    {{/if}}
-                    <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-level-user-defaults">
-                        <i class="sidebar-item-icon fa fa-cog" aria-hidden="true"></i>
-                        <div class="text">{{t "Default user settings" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="channel-folders">
-                        <i class="sidebar-item-icon zulip-icon zulip-icon-folder"></i>
-                        <div class="text">{{t "Channel folders" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    {{#unless is_guest}}
-                    <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="default-channels-list">
-                        <i class="sidebar-item-icon fa fa-exchange" aria-hidden="true"></i>
-                        <div class="text">{{t "Default channels" }}</div>
-                        {{#unless is_admin}}
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                        {{/unless}}
-                    </li>
-                    {{/unless}}
-                    <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="auth-methods">
-                        <i class="sidebar-item-icon fa fa-key" aria-hidden="true"></i>
-                        <div class="text">{{t "Authentication methods" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_owner}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization owners can edit these settings.' }}"></i>
-                    </li>
-                    {{#if is_admin}}
-                    <li class="sidebar-item" tabindex="0" data-section="data-exports-admin">
-                        <i class="sidebar-item-icon fa fa-database" aria-hidden="true"></i>
-                        <div class="text">{{t "Data exports" }}</div>
-                    </li>
-                    {{/if}}
-                    {{#unless is_admin}}
-                    <li class="sidebar-item collapse-settings-button">
-                        <i id='toggle_collapse_chevron' class='sidebar-item-icon fa fa-angle-double-down'></i>
-                        <div class="text" id='toggle_collapse'>{{t "Show more" }}</div>
-                    </li>
-                    {{/unless}}
-                </ul>
-            </div>
-        </div>
-    </div>
-    <div class="content-wrapper right">
-        <div class="settings-header">
-            <h1><span class="header-prefix"></span><span class="section"></span></h1>
+<div id="settings_page" class="overlay" data-overlay="settings" aria-hidden="true">
+    <div class="overlay-container">
+        <div class="settings-header mobile">
+            <i class="fa fa-chevron-left" aria-hidden="true"></i>
+            <h1>{{t "Settings" }}<span class="section"></span></h1>
             <div class="exit">
                 <span class="exit-sign">&times;</span>
             </div>
         </div>
-        <div id="settings_content" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
-            <div class="organization-box organization">
+        <div class="sidebar-wrapper">
+            <div class="tab-container"></div>
+            <div class="sidebar left" data-simplebar data-simplebar-tab-index="-1">
+                <div class="sidebar-list dark-grey small-text">
+                    <ul class="normal-settings-list">
+                        <li class="sidebar-item" tabindex="0" data-section="profile">
+                            <i class="sidebar-item-icon fa fa-user" aria-hidden="true"></i>
+                            <div class="text">{{t "Profile" }}</div>
+                        </li>
+                        <li class="sidebar-item" tabindex="0" data-section="account-and-privacy">
+                            <i class="sidebar-item-icon fa fa-lock" aria-hidden="true"></i>
+                            <div class="text">{{t "Account & privacy" }}</div>
+                        </li>
+                        <li class="sidebar-item" tabindex="0" data-section="preferences">
+                            <i class="sidebar-item-icon fa fa-sliders" aria-hidden="true"></i>
+                            <div class="text">{{t "Preferences" }}</div>
+                        </li>
+                        <li class="sidebar-item" tabindex="0" data-section="notifications">
+                            <i class="sidebar-item-icon fa fa-exclamation-triangle" aria-hidden="true"></i>
+                            <div class="text">{{t "Notifications" }}</div>
+                        </li>
+                        {{#unless is_guest}}
+                            <li class="sidebar-item" tabindex="0" data-section="bots">
+                                <i class="sidebar-item-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
+                                <div class="text">{{t 'Bots'}}</div>
+                                <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if (or can_create_new_bots can_manage_bot)}}style="display: none;"{{/if}} data-tippy-content="{{t 'You do not have permission to create or manage bots.' }}"></i>
+                            </li>
+                        {{/unless}}
+                        <li class="sidebar-item" tabindex="0" data-section="alert-words">
+                            <i class="sidebar-item-icon fa fa-book" aria-hidden="true"></i>
+                            <div class="text">{{t "Alert words" }}</div>
+                        </li>
+                        {{#if show_uploaded_files_section}}
+                        <li class="sidebar-item" tabindex="0" data-section="uploaded-files">
+                            <i class="sidebar-item-icon fa fa-paperclip" aria-hidden="true"></i>
+                            <div class="text">{{t "Uploaded files" }}</div>
+                        </li>
+                        {{/if}}
+                        <li class="sidebar-item" tabindex="0" data-section="topics">
+                            <i class="sidebar-item-icon zulip-icon zulip-icon-topic" aria-hidden="true"></i>
+                            <div class="text">{{t "Topics" }}</div>
+                        </li>
+                        <li class="sidebar-item" tabindex="0" data-section="muted-users">
+                            <i class="sidebar-item-icon fa fa-eye-slash" aria-hidden="true"></i>
+                            <div class="text">{{t "Muted users" }}</div>
+                        </li>
+                    </ul>
 
+                    <ul class="org-settings-list">
+                        <li class="sidebar-item" tabindex="0" data-section="organization-profile">
+                            <i class="sidebar-item-icon fa fa-id-card" aria-hidden="true"></i>
+                            <div class="text">{{t "Organization profile" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-settings">
+                            <i class="sidebar-item-icon fa fa-sliders" aria-hidden="true"></i>
+                            <div class="text">{{t "Organization settings" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings' }}"></i>
+                        </li>
+                        <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-permissions">
+                            <i class="sidebar-item-icon fa fa-lock" aria-hidden="true"></i>
+                            <div class="text">{{t "Organization permissions" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        <li class="sidebar-item" tabindex="0" data-section="emoji-settings">
+                            <i class="sidebar-item-icon fa fa-smile-o" aria-hidden="true"></i>
+                            <div class="text">{{t "Custom emoji" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#unless show_emoji_settings_lock}}style="display: none;"{{/unless}} data-tippy-content="{{t 'You do not have permission to add custom emoji.'}}"></i>
+                        </li>
+                        <li class="sidebar-item" tabindex="0" data-section="linkifier-settings">
+                            <i class="sidebar-item-icon fa fa-font" aria-hidden="true"></i>
+                            <div class="text">{{t "Linkifiers" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        <li class="sidebar-item" tabindex="0" data-section="playground-settings">
+                            <i class="sidebar-item-icon fa fa-external-link" aria-hidden="true"></i>
+                            <div class="text">{{t "Code playgrounds" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        {{#unless is_guest}}
+                        <li class="sidebar-item" tabindex="0" data-section="users">
+                            <i class="sidebar-item-icon fa fa-user" aria-hidden="true"></i>
+                            <div class="text">{{t "Users" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if can_edit_user_panel }}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        {{/unless}}
+                        {{#unless is_guest}}
+                        <li class="sidebar-item" tabindex="0" data-section="bots">
+                            <i class="sidebar-item-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
+                            <div class="text">{{t "Bots" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if (or can_create_new_bots can_manage_bot)}}style="display: none;"{{/if}} data-tippy-content="{{t 'You do not have permission to create or manage bots.' }}"></i>
+                        </li>
+                        {{/unless}}
+                        {{#if is_admin}}
+                        <li class="sidebar-item" tabindex="0" data-section="profile-field-settings">
+                            <i class="sidebar-item-icon fa fa-id-card" aria-hidden="true"></i>
+                            <div class="text">{{t "Custom profile fields" }}</div>
+                        </li>
+                        {{/if}}
+                        <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-level-user-defaults">
+                            <i class="sidebar-item-icon fa fa-cog" aria-hidden="true"></i>
+                            <div class="text">{{t "Default user settings" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="channel-folders">
+                            <i class="sidebar-item-icon zulip-icon zulip-icon-folder"></i>
+                            <div class="text">{{t "Channel folders" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        </li>
+                        {{#unless is_guest}}
+                        <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="default-channels-list">
+                            <i class="sidebar-item-icon fa fa-exchange" aria-hidden="true"></i>
+                            <div class="text">{{t "Default channels" }}</div>
+                            {{#unless is_admin}}
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                            {{/unless}}
+                        </li>
+                        {{/unless}}
+                        <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="auth-methods">
+                            <i class="sidebar-item-icon fa fa-key" aria-hidden="true"></i>
+                            <div class="text">{{t "Authentication methods" }}</div>
+                            <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_owner}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization owners can edit these settings.' }}"></i>
+                        </li>
+                        {{#if is_admin}}
+                        <li class="sidebar-item" tabindex="0" data-section="data-exports-admin">
+                            <i class="sidebar-item-icon fa fa-database" aria-hidden="true"></i>
+                            <div class="text">{{t "Data exports" }}</div>
+                        </li>
+                        {{/if}}
+                        {{#unless is_admin}}
+                        <li class="sidebar-item collapse-settings-button">
+                            <i id='toggle_collapse_chevron' class='sidebar-item-icon fa fa-angle-double-down'></i>
+                            <div class="text" id='toggle_collapse'>{{t "Show more" }}</div>
+                        </li>
+                        {{/unless}}
+                    </ul>
+                </div>
             </div>
-            <div class="settings-box">
+        </div>
+        <div class="content-wrapper right">
+            <div class="settings-header">
+                <h1><span class="header-prefix"></span><span class="section"></span></h1>
+                <div class="exit">
+                    <span class="exit-sign">&times;</span>
+                </div>
+            </div>
+            <div id="settings_content" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+                <div class="organization-box organization">
+
+                </div>
+                <div class="settings-box">
+                </div>
             </div>
         </div>
     </div>

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -1,99 +1,97 @@
 <div id="subscription_overlay" class="overlay two-pane-settings-overlay" data-overlay="subscriptions">
-    <div class="flex overlay-content">
-        <div class="two-pane-settings-container overlay-container">
-            <div class="two-pane-settings-header">
-                <div class="fa fa-chevron-left"></div>
-                <span class="subscriptions-title">{{t 'Channels' }}</span>
-                <div class="exit">
-                    <span class="exit-sign">&times;</span>
+    <div class="two-pane-settings-container overlay-container">
+        <div class="two-pane-settings-header">
+            <div class="fa fa-chevron-left"></div>
+            <span class="subscriptions-title">{{t 'Channels' }}</span>
+            <div class="exit">
+                <span class="exit-sign">&times;</span>
+            </div>
+        </div>
+        <div class="two-pane-settings-content">
+            <div class="left">
+                <div class="two-pane-settings-subheader">
+                    <div class="list-toggler-container">
+                        <div id="add_new_subscription">
+                            {{#if can_create_streams}}
+                            <button class="create_stream_button two-pane-settings-plus-button tippy-zulip-delayed-tooltip" data-tooltip-template-id="create-new-stream-tooltip-template" data-tippy-placement="bottom">
+                                <i class="create_button_plus_sign zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
+                            </button>
+                            {{/if}}
+                            <div class="float-clear"></div>
+                        </div>
+                    </div>
+                </div>
+                <div class="two-pane-settings-body">
+                    <div class="input-append stream_name_search_section two-pane-settings-search" id="stream_filter">
+                        <div id="folder_filter_container">
+                            <button type="button" id="folder_filter_button" class="filter-folders-dropdown-widget-button icon-button icon-button-neutral" tabindex="0" aria-label="{{t 'Filter channels' }}">
+                                <i class="zulip-icon zulip-icon-folder-chevron" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                        <input type="text" name="stream_name" id="search_stream_name" class="filter_text_input" autocomplete="off"
+                          placeholder="{{t 'Filter' }}" value=""/>
+                        <button type="button" class="clear_search_button" id="clear_search_stream_name">
+                            <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
+                        </button>
+                        <div class="stream_settings_filter_container {{#unless realm_has_archived_channels}}hide_filter{{/unless}}">
+                            {{> ../dropdown_widget widget_name="stream_settings_filter"}}
+                        </div>
+                    </div>
+                    <div class="no-streams-to-show">
+                        <div class="subscribed_streams_tab_empty_text">
+                            <span class="settings-empty-option-text">
+                                {{t 'You are not subscribed to any channels.'}}
+                                {{#if can_view_all_streams}}
+                                <a href="#channels/all">{{t 'View all channels'}}</a>
+                                {{/if}}
+                            </span>
+                        </div>
+                        <div class="available_streams_tab_empty_text">
+                            <span class="settings-empty-option-text">
+                                {{t 'No channels to show.'}}
+                                <a href="#channels/all">{{t 'View all channels'}}</a>
+                            </span>
+                        </div>
+                        <div class="no_stream_match_filter_empty_text">
+                            <span class="settings-empty-option-text">
+                                {{t 'No channels match your filter.'}}
+                            </span>
+                        </div>
+                        <div class="all_streams_tab_empty_text">
+                            <span class="settings-empty-option-text">
+                                {{t 'There are no channels you can view in this organization.'}}
+                                {{#if can_create_streams}}
+                                    <a href="#channels/new">{{t 'Create a channel'}}</a>
+                                {{/if}}
+                            </span>
+                        </div>
+                    </div>
+                    <div class="streams-list two-pane-settings-left-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
+                    </div>
                 </div>
             </div>
-            <div class="two-pane-settings-content">
-                <div class="left">
-                    <div class="two-pane-settings-subheader">
-                        <div class="list-toggler-container">
-                            <div id="add_new_subscription">
-                                {{#if can_create_streams}}
-                                <button class="create_stream_button two-pane-settings-plus-button tippy-zulip-delayed-tooltip" data-tooltip-template-id="create-new-stream-tooltip-template" data-tippy-placement="bottom">
-                                    <i class="create_button_plus_sign zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
-                                </button>
-                                {{/if}}
-                                <div class="float-clear"></div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="two-pane-settings-body">
-                        <div class="input-append stream_name_search_section two-pane-settings-search" id="stream_filter">
-                            <div id="folder_filter_container">
-                                <button type="button" id="folder_filter_button" class="filter-folders-dropdown-widget-button icon-button icon-button-neutral" tabindex="0" aria-label="{{t 'Filter channels' }}">
-                                    <i class="zulip-icon zulip-icon-folder-chevron" aria-hidden="true"></i>
-                                </button>
-                            </div>
-                            <input type="text" name="stream_name" id="search_stream_name" class="filter_text_input" autocomplete="off"
-                              placeholder="{{t 'Filter' }}" value=""/>
-                            <button type="button" class="clear_search_button" id="clear_search_stream_name">
-                                <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
-                            </button>
-                            <div class="stream_settings_filter_container {{#unless realm_has_archived_channels}}hide_filter{{/unless}}">
-                                {{> ../dropdown_widget widget_name="stream_settings_filter"}}
-                            </div>
-                        </div>
-                        <div class="no-streams-to-show">
-                            <div class="subscribed_streams_tab_empty_text">
-                                <span class="settings-empty-option-text">
-                                    {{t 'You are not subscribed to any channels.'}}
-                                    {{#if can_view_all_streams}}
-                                    <a href="#channels/all">{{t 'View all channels'}}</a>
-                                    {{/if}}
-                                </span>
-                            </div>
-                            <div class="available_streams_tab_empty_text">
-                                <span class="settings-empty-option-text">
-                                    {{t 'No channels to show.'}}
-                                    <a href="#channels/all">{{t 'View all channels'}}</a>
-                                </span>
-                            </div>
-                            <div class="no_stream_match_filter_empty_text">
-                                <span class="settings-empty-option-text">
-                                    {{t 'No channels match your filter.'}}
-                                </span>
-                            </div>
-                            <div class="all_streams_tab_empty_text">
-                                <span class="settings-empty-option-text">
-                                    {{t 'There are no channels you can view in this organization.'}}
-                                    {{#if can_create_streams}}
-                                        <a href="#channels/new">{{t 'Create a channel'}}</a>
-                                    {{/if}}
-                                </span>
-                            </div>
-                        </div>
-                        <div class="streams-list two-pane-settings-left-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
-                        </div>
+            <div class="right">
+                <div class="two-pane-settings-subheader">
+                    <div class="display-type">
+                        <div id="stream_settings_title" class="stream-info-title">{{t 'Channel settings' }}</div>
                     </div>
                 </div>
-                <div class="right">
-                    <div class="two-pane-settings-subheader">
-                        <div class="display-type">
-                            <div id="stream_settings_title" class="stream-info-title">{{t 'Channel settings' }}</div>
+                <div class="two-pane-settings-body">
+                    <div class="nothing-selected">
+                        <div class="stream-info-banner banner-wrapper"></div>
+                        <div class="create-stream-button-container">
+                            <button type="button" class="create_stream_button animated-purple-button" {{#unless can_create_streams}}disabled{{/unless}}>{{t 'Create channel' }}</button>
+                            {{#unless can_create_streams}}
+                            <span class="settings-empty-option-text">
+                                {{t 'You do not have permission to create channels.' }}
+                            </span>
+                            {{/unless}}
                         </div>
                     </div>
-                    <div class="two-pane-settings-body">
-                        <div class="nothing-selected">
-                            <div class="stream-info-banner banner-wrapper"></div>
-                            <div class="create-stream-button-container">
-                                <button type="button" class="create_stream_button animated-purple-button" {{#unless can_create_streams}}disabled{{/unless}}>{{t 'Create channel' }}</button>
-                                {{#unless can_create_streams}}
-                                <span class="settings-empty-option-text">
-                                    {{t 'You do not have permission to create channels.' }}
-                                </span>
-                                {{/unless}}
-                            </div>
-                        </div>
-                        <div id="stream_settings" class="two-pane-settings-right-simplebar-container settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
-                            {{!-- edit stream here --}}
-                        </div>
-                        {{> stream_creation_form . }}
+                    <div id="stream_settings" class="two-pane-settings-right-simplebar-container settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+                        {{!-- edit stream here --}}
                     </div>
+                    {{> stream_creation_form . }}
                 </div>
             </div>
         </div>

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -1,67 +1,65 @@
 <div id="groups_overlay" class="two-pane-settings-overlay overlay" data-overlay="group_subscriptions">
-    <div class="flex overlay-content">
-        <div class="two-pane-settings-container overlay-container">
-            <div class="two-pane-settings-header">
-                <div class="fa fa-chevron-left"></div>
-                <span class="user-groups-title">{{t 'User groups' }}</span>
-                <div class="exit">
-                    <span class="exit-sign">&times;</span>
+    <div class="two-pane-settings-container overlay-container">
+        <div class="two-pane-settings-header">
+            <div class="fa fa-chevron-left"></div>
+            <span class="user-groups-title">{{t 'User groups' }}</span>
+            <div class="exit">
+                <span class="exit-sign">&times;</span>
+            </div>
+        </div>
+        <div class="two-pane-settings-content">
+            <div class="left">
+                <div class="two-pane-settings-subheader">
+                    <div class="list-toggler-container">
+                        <div id="add_new_user_group">
+                            <button class="create_user_group_button two-pane-settings-plus-button">
+                                <i class="create_button_plus_sign zulip-icon zulip-icon-user-group-plus" aria-hidden="true"></i>
+                            </button>
+                            <div class="float-clear"></div>
+                        </div>
+                    </div>
+                </div>
+                <div class="two-pane-settings-body">
+                    <div class="input-append group_name_search_section two-pane-settings-search" id="group_filter">
+                        <input type="text" name="group_name" id="search_group_name" class="filter_text_input" autocomplete="off"
+                          placeholder="{{t 'Filter' }}" value=""/>
+                        <button type="button" class="clear_search_button" id="clear_search_group_name">
+                            <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
+                        </button>
+                        <span>
+                            <label class="checkbox" id="user-group-edit-filter-options">
+                                {{> ../dropdown_widget widget_name="user_group_visibility_settings"}}
+                            </label>
+                        </span>
+                    </div>
+                    <div class="no-groups-to-show">
+                    </div>
+                    <div class="user-groups-list-wrapper two-pane-settings-left-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
+                        <div class="user-groups-list"></div>
+                    </div>
                 </div>
             </div>
-            <div class="two-pane-settings-content">
-                <div class="left">
-                    <div class="two-pane-settings-subheader">
-                        <div class="list-toggler-container">
-                            <div id="add_new_user_group">
-                                <button class="create_user_group_button two-pane-settings-plus-button">
-                                    <i class="create_button_plus_sign zulip-icon zulip-icon-user-group-plus" aria-hidden="true"></i>
-                                </button>
-                                <div class="float-clear"></div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="two-pane-settings-body">
-                        <div class="input-append group_name_search_section two-pane-settings-search" id="group_filter">
-                            <input type="text" name="group_name" id="search_group_name" class="filter_text_input" autocomplete="off"
-                              placeholder="{{t 'Filter' }}" value=""/>
-                            <button type="button" class="clear_search_button" id="clear_search_group_name">
-                                <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
-                            </button>
-                            <span>
-                                <label class="checkbox" id="user-group-edit-filter-options">
-                                    {{> ../dropdown_widget widget_name="user_group_visibility_settings"}}
-                                </label>
-                            </span>
-                        </div>
-                        <div class="no-groups-to-show">
-                        </div>
-                        <div class="user-groups-list-wrapper two-pane-settings-left-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
-                            <div class="user-groups-list"></div>
-                        </div>
+            <div class="right">
+                <div class="two-pane-settings-subheader">
+                    <div class="display-type">
+                        <div id="user_group_settings_title" class="user-group-info-title">{{t 'User group settings' }}</div>
                     </div>
                 </div>
-                <div class="right">
-                    <div class="two-pane-settings-subheader">
-                        <div class="display-type">
-                            <div id="user_group_settings_title" class="user-group-info-title">{{t 'User group settings' }}</div>
+                <div class="two-pane-settings-body">
+                    <div class="nothing-selected">
+                        <div class="group-info-banner banner-wrapper"></div>
+                        <div class="create-group-button-container">
+                            {{> ../settings/upgrade_tip_widget . }}
+                            <button type="button" class="create_user_group_button animated-purple-button">{{t 'Create user group' }}</button>
+                            <span class="settings-empty-option-text creation-permission-text">
+                                {{t 'You do not have permission to create user groups.' }}
+                            </span>
                         </div>
                     </div>
-                    <div class="two-pane-settings-body">
-                        <div class="nothing-selected">
-                            <div class="group-info-banner banner-wrapper"></div>
-                            <div class="create-group-button-container">
-                                {{> ../settings/upgrade_tip_widget . }}
-                                <button type="button" class="create_user_group_button animated-purple-button">{{t 'Create user group' }}</button>
-                                <span class="settings-empty-option-text creation-permission-text">
-                                    {{t 'You do not have permission to create user groups.' }}
-                                </span>
-                            </div>
-                        </div>
-                        <div id="user_group_settings" class="two-pane-settings-right-simplebar-container settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
-                            {{!-- edit user group here --}}
-                        </div>
-                        {{> user_group_creation_form . }}
+                    <div id="user_group_settings" class="two-pane-settings-right-simplebar-container settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+                        {{!-- edit user group here --}}
                     </div>
+                    {{> user_group_creation_form . }}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR:
- removes `overlay-content` from all overlays html structure which was used earlier to position the overlay at the centre.

Fixes: https://github.com/zulip/zulip/pull/34624#issuecomment-3221735020

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|Before|After|
|-|-|
|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-45-11" src="https://github.com/user-attachments/assets/a6560b78-f465-4fa4-b4c6-1316284b565c" />|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-52-04" src="https://github.com/user-attachments/assets/90a0fda6-7095-4160-b349-06152313af4a" />|
|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-44-59" src="https://github.com/user-attachments/assets/cf4116d2-51f2-4cc1-b8f0-158a0a09ab54" />|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-38-45" src="https://github.com/user-attachments/assets/f34ebecc-777e-4a89-8b87-7ce686aee101" />|
|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-44-52" src="https://github.com/user-attachments/assets/99c53a2c-0803-4d21-8ac5-a1f6c9ae4c09" />|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-38-25" src="https://github.com/user-attachments/assets/596e1ee0-8316-4377-958e-ee8cb10cc6cb" />|
|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-43-54" src="https://github.com/user-attachments/assets/1f6ca195-ac43-4f2c-9344-4ca0ac04ef63" />|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-37-53" src="https://github.com/user-attachments/assets/5868fe8d-4496-4338-9e88-586962d17b0d" />|
|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-43-44" src="https://github.com/user-attachments/assets/4784d68d-9a96-40c9-83dd-4761df6a9df0" />|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-37-38" src="https://github.com/user-attachments/assets/7cd94ced-3645-4a40-97bc-1d13772b9c08" />|
|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-43-32" src="https://github.com/user-attachments/assets/8fc7fd9e-1b3e-4f10-96e5-1f1f8eb0f884" />|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-36-57" src="https://github.com/user-attachments/assets/edf66f7c-2e0f-42bc-85ee-ef31efa1a3e7" />|
|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-43-16" src="https://github.com/user-attachments/assets/5694529f-6b9f-4bfc-93e4-259fbd1632bb" />|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-35-24" src="https://github.com/user-attachments/assets/45963549-aeb2-4174-abdf-7aa717a4c3e3" />|
|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-43-06" src="https://github.com/user-attachments/assets/66a88141-805e-44fc-a07e-9f10ccebc336" />|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-34-53" src="https://github.com/user-attachments/assets/8a56c65d-1557-4df6-b8ee-96e248ab29d5" />|
|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-42-56" src="https://github.com/user-attachments/assets/b1128bb7-328a-436d-ba8c-c8295074957f" />|<img width="1854" height="965" alt="Screenshot from 2025-11-26 00-34-44" src="https://github.com/user-attachments/assets/cf4c0502-f45a-49cf-9b54-cb7a625b5213" />|


### Narrowed overlays
|Before|After|
|-|-|
|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-05-31" src="https://github.com/user-attachments/assets/5bf7f896-a864-403c-a36e-081962c4c0e8" />|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-00-59" src="https://github.com/user-attachments/assets/d1af4773-67a7-456a-b098-8b8646d3ee61" />|
|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-05-23" src="https://github.com/user-attachments/assets/9c10e8e6-72fa-4e03-a8f6-f5ffecf00346" />|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-00-54" src="https://github.com/user-attachments/assets/82110085-fdc0-4c01-b3b5-457121b424c3" />|
|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-05-17" src="https://github.com/user-attachments/assets/06321a23-48b9-4008-8cbe-6f1fd2ee6761" />|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-00-45" src="https://github.com/user-attachments/assets/f1de2c4e-92f0-41de-9cd9-a19958ef1bc2" />|
|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-05-14" src="https://github.com/user-attachments/assets/ade70f20-a3f8-4ea9-9aec-e083fccb6643" />|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-00-41" src="https://github.com/user-attachments/assets/c6988dc3-5ebf-4acd-8152-17d5755d063b" />|
|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-05-04" src="https://github.com/user-attachments/assets/93f116c7-1f90-4579-b5b3-8cfd597cb298" />|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-00-27" src="https://github.com/user-attachments/assets/1e1db37e-fc94-4859-a103-e13317df01f7" />|
|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-05-00" src="https://github.com/user-attachments/assets/42fd633e-967a-4011-971b-5a5c351da16b" />|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-00-22" src="https://github.com/user-attachments/assets/6872cd0c-a1cb-4d2a-8c29-7b0edb8cb0c5" />|
|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-04-48" src="https://github.com/user-attachments/assets/071d67ba-a787-43c2-9e64-4bdb9f346bbd" />|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-00-11" src="https://github.com/user-attachments/assets/f4f78655-9c2b-43a0-aeb6-8d80a254a530" />|
|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-04-41" src="https://github.com/user-attachments/assets/8fac176c-6c3d-43c9-983e-1968a6da4c9c" />|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-00-02" src="https://github.com/user-attachments/assets/561bf275-b16d-40dc-9672-b31e9092f931" />|
|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-04-31" src="https://github.com/user-attachments/assets/dd277525-5ea0-4058-afc3-dcc4f9f02371" />|<img width="559" height="889" alt="Screenshot from 2025-11-26 00-59-46" src="https://github.com/user-attachments/assets/e6b32251-17b9-4500-bedd-d41d2281c2a6" />|
|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-04-16" src="https://github.com/user-attachments/assets/c88c215c-9fff-4eef-80a5-f6d88a6b52af" />|<img width="559" height="889" alt="Screenshot from 2025-11-26 00-59-34" src="https://github.com/user-attachments/assets/2fff63c1-626c-43cf-8a08-27a65d6746b2" />|
|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-03-48" src="https://github.com/user-attachments/assets/ce9ddd4d-c196-433a-ae67-c8a78006cd30" />|<img width="559" height="889" alt="Screenshot from 2025-11-26 00-59-27" src="https://github.com/user-attachments/assets/c7aa440a-441e-4ea4-9508-a5fde2aa6c2c" />|
|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-05-39" src="https://github.com/user-attachments/assets/5e128a23-7fdd-4c91-80e2-c24ff5228883" />|<img width="559" height="889" alt="Screenshot from 2025-11-26 01-14-03" src="https://github.com/user-attachments/assets/f05b7424-0c7f-4736-ae04-c0a6172b0f75" />|





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
