### PR TITLE
typeahead: Add bottom gradient shadow for scrollable suggestions

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -475,11 +475,18 @@ export class Typeahead<ItemType extends string | object> {
             this.$container.show();
         }
 
+        // Set up scroll listener for shadow updates
+        this.setupScrollListener();
+
         return this;
     }
 
     hide(): this {
         this.shown = false;
+
+        // Clean up scroll listener
+        this.removeScrollListener();
+
         if (this.non_tippy_parent_element) {
             this.$container.hide();
         } else {
@@ -580,7 +587,61 @@ export class Typeahead<ItemType extends string | object> {
         // before we render it.
         scroll_util.get_scroll_element(this.$menu);
         scroll_util.get_content_element(this.$menu).empty().append($items);
+
+        // Check if the menu is overflowing and add/remove shadow accordingly
+        // Use a small delay to ensure the DOM is fully updated after simplebar processing
+        setTimeout(() => {
+            this.updateOverflowShadow();
+        }, 0);
+
         return this;
+    }
+
+    updateOverflowShadow(): void {
+        // Check if the typeahead menu content is overflowing and add/remove
+        // the 'overflowing' class accordingly to show/hide the bottom shadow
+
+        // Get the actual scrollable element - this might be wrapped by simplebar
+        const scrollElement = scroll_util.get_scroll_element(this.$menu)[0];
+
+        // Check if there's content that can be scrolled AND if we're not at the bottom
+        const hasOverflow =
+            scrollElement && scrollElement.scrollHeight > scrollElement.clientHeight;
+        const isAtBottom =
+            scrollElement &&
+            Math.abs(
+                scrollElement.scrollHeight - scrollElement.clientHeight - scrollElement.scrollTop,
+            ) < 1;
+
+        if (hasOverflow && !isAtBottom) {
+            this.$container.addClass("overflowing");
+        } else {
+            this.$container.removeClass("overflowing");
+        }
+    }
+
+    onScroll(): void {
+        // Update shadow when user scrolls the typeahead menu
+        this.updateOverflowShadow();
+    }
+
+    setupScrollListener(): void {
+        // Remove any existing scroll listeners first
+        this.removeScrollListener();
+
+        // Attach scroll listener to the actual scrollable element
+        const scrollElement = scroll_util.get_scroll_element(this.$menu);
+        if (scrollElement.length > 0) {
+            scrollElement.on("scroll", this.onScroll.bind(this));
+        }
+    }
+
+    removeScrollListener(): void {
+        // Remove scroll listener from the scrollable element
+        const scrollElement = scroll_util.get_scroll_element(this.$menu);
+        if (scrollElement.length > 0) {
+            scrollElement.off("scroll");
+        }
     }
 
     next(): void {
@@ -645,6 +706,8 @@ export class Typeahead<ItemType extends string | object> {
         for (const event of events) {
             $(this.input_element.$element).off(event);
         }
+        // Clean up any remaining scroll listeners
+        this.removeScrollListener();
     }
 
     resizeHandler(): void {

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -144,6 +144,9 @@
 }
 
 .typeahead.dropdown-menu {
+    /* Position relative to allow absolute positioning of the shadow overlay */
+    position: relative;
+
     .typeahead-menu {
         list-style: none;
         margin: 4px 0;
@@ -233,4 +236,27 @@
     .status-emoji {
         margin-left: 0;
     }
+}
+
+/* Add shadow overlay for scrollable typeaheads */
+.typeahead.dropdown-menu.overflowing::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 25px;
+    pointer-events: none;
+    /* Fade from transparent to the dropdown background color */
+    /* stylelint-disable-next-line declaration-property-value-no-unknown */
+    background: light-dark(
+        linear-gradient(to bottom, transparent, hsl(240deg 20% 98%)),
+        linear-gradient(to bottom, transparent, hsl(240deg 5% 16%))
+    );
+    z-index: 1052;
+}
+
+/* Ensure shadow doesn't appear when not overflowing */
+.typeahead.dropdown-menu:not(.overflowing)::after {
+    display: none;
 }


### PR DESCRIPTION
Fixes: #34478

- This PR adds a subtle shadow gradient at the bottom of all scrollable typeahead dropdowns.
- When the suggestions list is scrollable, a fade-out gradient is shown at the bottom to indicate more content is available.
-  The shadow disappears automatically when there’s nothing to scroll.
- Works in both light and dark themes.

## **Screenshots and screen captures:**
### Light Theme:
| Before | After |
| --- | --- |
| <img width="415" height="135" alt="Screenshot 2025-09-09 120326" src="https://github.com/user-attachments/assets/fc2f1ce6-9daa-4cc5-a249-3f5ae0c1b51d" /> | <img width="406" height="147" alt="Screenshot 2025-09-09 120212" src="https://github.com/user-attachments/assets/2b22e993-62d6-4099-8ef8-26c710972e77" />
 
### Dark Theme:
| Before | After |
| --- | --- |
| <img width="417" height="137" alt="Screenshot 2025-09-09 120344" src="https://github.com/user-attachments/assets/fc2d7b49-3dcd-43ac-af16-01f9f3a581af" /> | <img width="435" height="136" alt="Screenshot 2025-09-09 120134" src="https://github.com/user-attachments/assets/1ada8a07-fe05-4336-b034-de979566d2f5" />


### Demo:

Light Theme: 

https://github.com/user-attachments/assets/96bc6b79-7e33-4ab3-a67d-b043f593f2c4


Dark Theme:

https://github.com/user-attachments/assets/f73d36ca-de07-47d8-8833-6a9bddb6e8af



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

