### PR TITLE
dark_theme: Cleanup todo and poll widgets.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1472,6 +1472,37 @@
         hsl(0deg 0% 93%),
         hsl(0deg 0% 0% / 20%)
     );
+    /* Poll Widget */
+    --color-poll-vote: light-dark(hsl(156deg 41% 40%), hsl(185deg 35% 65%));
+    --color-poll-vote-hover: light-dark(
+        hsl(156deg 41% 40%),
+        hsl(185deg 50% 70%)
+    );
+    --color-poll-vote-focus: light-dark(
+        hsl(156deg 41% 40%),
+        hsl(185deg 50% 65%)
+    );
+    --color-border-poll-vote: light-dark(
+        hsl(156deg 28% 70%),
+        hsl(185deg 35% 35%)
+    );
+    --color-border-poll-vote-hover: light-dark(
+        hsl(156deg 30% 50%),
+        hsl(185deg 40% 40%)
+    );
+    --color-border-poll-vote-focus: light-dark(
+        hsl(156deg 30% 50%),
+        hsl(185deg 40% 50%)
+    );
+    --color-background-poll-vote-hover: light-dark(
+        var(--color-background-widget-button),
+        hsl(185deg 20% 20%)
+    );
+    --color-background-poll-vote-focus: light-dark(
+        hsl(156deg 41% 90%),
+        hsl(185deg 40% 35%)
+    );
+    --color-poll-names: light-dark(hsl(0deg 0% 45%), hsl(236deg 15% 70%));
 
     /* KBD colors */
     --color-kbd-background: light-dark(hsl(0deg 0% 98%), hsl(211deg 29% 14%));

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1503,6 +1503,27 @@
         hsl(185deg 40% 35%)
     );
     --color-poll-names: light-dark(hsl(0deg 0% 45%), hsl(236deg 15% 70%));
+    /* TODO Widget */
+    --color-border-todo-checkbox: light-dark(
+        hsl(156deg 28% 70%),
+        color-mix(in oklch, hsl(185deg 40% 45%) 70%, transparent)
+    );
+    --color-border-todo-checkbox-hover: light-dark(
+        hsl(156deg 30% 50%),
+        hsl(185deg 40% 35%)
+    );
+    --color-border-todo-checkbox-checked: light-dark(
+        hsl(156deg 41% 40%),
+        hsl(185deg 40% 45%)
+    );
+    --color-background-todo-checkbox-hover: light-dark(
+        transparent,
+        hsl(185deg 20% 20%)
+    );
+    --color-background-todo-checkbox-checked: light-dark(
+        hsl(156deg 41% 40%),
+        hsl(185deg 40% 45%)
+    );
 
     /* KBD colors */
     --color-kbd-background: light-dark(hsl(0deg 0% 98%), hsl(211deg 29% 14%));

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -446,31 +446,6 @@
         }
     }
 
-    /* Widgets: Todo */
-    .todo-widget {
-        & label.checkbox {
-            & input[type="checkbox"] {
-                ~ .custom-checkbox {
-                    border-color: hsl(185deg 40% 45%);
-                    opacity: 0.7;
-                }
-
-                &:hover ~ .custom-checkbox {
-                    background-color: hsl(185deg 20% 20%);
-                    border-color: hsl(185deg 40% 35%);
-                }
-
-                &:checked ~ .custom-checkbox {
-                    background-color: hsl(185deg 40% 45%);
-                }
-
-                &:focus ~ .custom-checkbox {
-                    outline-color: hsl(0deg 0% 100% / 0%);
-                }
-            }
-        }
-    }
-
     .panel_user_list > .pill-container,
     .creator_details > .display_only_pill {
         &:hover {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -446,30 +446,6 @@
         }
     }
 
-    /* Widgets: Poll */
-    .poll-widget {
-        .poll-vote {
-            color: hsl(185deg 35% 65%);
-            border-color: hsl(185deg 35% 35%);
-
-            &:hover {
-                color: hsl(185deg 50% 70%);
-                border-color: hsl(185deg 40% 40%);
-                background-color: hsl(185deg 20% 20%);
-            }
-
-            &:focus {
-                color: hsl(185deg 50% 65%);
-                border-color: hsl(185deg 40% 50%);
-                background-color: hsl(185deg 40% 35%);
-            }
-        }
-
-        .poll-names {
-            color: hsl(236deg 15% 70%);
-        }
-    }
-
     /* Widgets: Todo */
     .todo-widget {
         & label.checkbox {

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -170,8 +170,8 @@
     }
 
     .poll-vote {
-        color: hsl(156deg 41% 40%);
-        border-color: hsl(156deg 28% 70%);
+        color: var(--color-poll-vote);
+        border-color: var(--color-border-poll-vote);
         border-style: solid;
         font-weight: 600;
         border-radius: 3px;
@@ -184,17 +184,21 @@
         background-color: var(--color-background-widget-button);
 
         &:hover {
-            border-color: hsl(156deg 30% 50%);
+            color: var(--color-poll-vote-hover);
+            background-color: var(--color-background-poll-vote-hover);
+            border-color: var(--color-border-poll-vote-hover);
         }
 
         &:focus {
             outline: 0;
-            background-color: hsl(156deg 41% 90%);
+            color: var(--color-poll-vote-focus);
+            background-color: var(--color-background-poll-vote-focus);
+            border-color: var(--color-border-poll-vote-focus);
         }
     }
 
     .poll-names {
-        color: hsl(0deg 0% 45%);
+        color: var(--color-poll-names);
         /* Aim for 50% of the flexbox for voting names,
            but also shrink modestly (.5) adjacent a long
            option. */

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -70,7 +70,7 @@
                 font-weight: 300;
                 line-height: 0.8;
                 text-align: center;
-                border: 2px solid hsl(156deg 28% 70%);
+                border: 2px solid var(--color-border-todo-checkbox);
 
                 border-radius: 4px;
                 filter: brightness(1);
@@ -83,8 +83,8 @@
                 background-size: 75%;
                 background-position: 50% 50%;
                 background-repeat: no-repeat;
-                background-color: hsl(156deg 41% 40%);
-                border: 2px solid hsl(156deg 41% 40%);
+                background-color: var(--color-background-todo-checkbox-checked);
+                border-color: var(--color-border-todo-checkbox-checked);
             }
 
             &:disabled ~ .custom-checkbox {
@@ -93,7 +93,13 @@
             }
 
             &:hover ~ .custom-checkbox {
-                border-color: hsl(156deg 30% 50%);
+                border-color: var(--color-border-todo-checkbox-hover);
+            }
+
+            &:not(:checked):hover ~ .custom-checkbox {
+                /* We only change the background color on hover,
+                   when the checkbox is not checked. */
+                background-color: var(--color-background-todo-checkbox-hover);
             }
 
             &:focus ~ .custom-checkbox {


### PR DESCRIPTION
NOTE: The mismatch between After/Before of the TODO widget in dark mode is because previously a `opacity: 0.7` was being applied to all the states of the checkbox in the `dark_theme.css`. When inspecting from a visual perspective, it was mostly only meant for the unchecked + unhovered state of the checkbox but was bleeding into other states of the checkbox as an unintentional consequence of the way the CSS was written.

Fixes: Part 2 of #35880.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

### **Screenshots and screen captures:**

<details><summary>Poll Widget</summary>
<p>

| Desc | Before | After |
|--------|--------|--------|
| Light + Hovered | <img width="1802" height="1024" alt="Screenshot 2025-09-09 at 12 19 31 PM" src="https://github.com/user-attachments/assets/5f1f3af2-e888-4eeb-8421-b5184c45aebf" /> | <img width="1802" height="1024" alt="Screenshot 2025-09-09 at 12 15 51 PM" src="https://github.com/user-attachments/assets/8e3f00cf-9737-4b6b-b4aa-c0e7a5ed0a5d" /> |
| Light + Focused | <img width="1802" height="1024" alt="Screenshot 2025-09-09 at 12 19 39 PM" src="https://github.com/user-attachments/assets/73050b0c-d91a-4590-b69f-c89bab7bb2d2" /> | <img width="1802" height="1024" alt="Screenshot 2025-09-09 at 12 16 19 PM" src="https://github.com/user-attachments/assets/65ebd36e-b6b9-4b8b-9c7f-9d43a620ae96" /> |
| Dark + Hovered | <img width="1802" height="1024" alt="Screenshot 2025-09-09 at 12 19 46 PM" src="https://github.com/user-attachments/assets/4350746a-13f0-41d5-be25-f7ceb218c3bd" /> | <img width="1802" height="1024" alt="Screenshot 2025-09-09 at 12 15 39 PM" src="https://github.com/user-attachments/assets/40ea5669-bd10-4afc-99df-8885420d2446" /> |
| Dark + Focused | <img width="1802" height="1024" alt="Screenshot 2025-09-09 at 12 19 51 PM" src="https://github.com/user-attachments/assets/de493ea6-7330-46c5-9ac2-2fdbd648015e" /> | <img width="1802" height="1024" alt="Screenshot 2025-09-09 at 12 16 36 PM" src="https://github.com/user-attachments/assets/787aec6c-fa64-4f13-8581-4fc2f59dfcc7" /> | 

</p>
</details> 

<details><summary>TODO Widget</summary>
<p>

| Desc | Before | After |
|--------|--------|--------|
| Light + Unchecked + Hovered | <img width="1802" height="992" alt="Screenshot 2025-09-09 at 12 01 16 PM" src="https://github.com/user-attachments/assets/73383cf1-8ee0-47ae-8a6a-8135ebdd3bf4" /> | <img width="1802" height="992" alt="Screenshot 2025-09-09 at 11 59 50 AM" src="https://github.com/user-attachments/assets/22e30177-3707-4ac7-8306-634f7cce52f6" /> |
| Light + Checked + Hovered | <img width="1802" height="992" alt="Screenshot 2025-09-09 at 12 01 19 PM" src="https://github.com/user-attachments/assets/431cbc4b-18ab-4610-a324-d0d39e570b7a" /> | <img width="1802" height="992" alt="Screenshot 2025-09-09 at 11 59 53 AM" src="https://github.com/user-attachments/assets/747fd2b5-0555-433d-9ba5-121a12792b9c" /> |
| Dark + Unchecked + Hovered | <img width="1802" height="992" alt="Screenshot 2025-09-09 at 12 01 32 PM" src="https://github.com/user-attachments/assets/44e363a5-09e7-4aa5-bbbd-829367009f3a" /> | <img width="1802" height="992" alt="Screenshot 2025-09-09 at 11 56 44 AM" src="https://github.com/user-attachments/assets/ebf650ba-047a-4367-b7bc-a64d92580260" /> |
| Dark + Checked + Hovered  | <img width="1802" height="992" alt="Screenshot 2025-09-09 at 12 01 35 PM" src="https://github.com/user-attachments/assets/ee297989-158e-44da-85dd-8383d2efc595" /> | <img width="1802" height="992" alt="Screenshot 2025-09-09 at 11 56 57 AM" src="https://github.com/user-attachments/assets/706a85f9-c5d3-461a-9012-e35338a9e1d7" /> | 

</p>
</details> 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
