### PR TITLE
inbox: Use gradients in background color of inbox channel rows.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -704,6 +704,8 @@ html_rules: list["Rule"] = [
         "description": "Avoid using the `style=` attribute; we prefer styling in CSS files",
         "exclude_pattern": r""".*style ?=["'](display: ?none|background: {{|color: {{|background-color: {{).*""",
         "exclude": {
+            # Background color calculated dynamically.
+            "web/templates/inbox_view/inbox_stream_header_row.hbs",
             # 5xx page doesn't have external CSS
             "web/html/5xx.html",
             # exclude_pattern above handles color, but have other issues:

--- a/web/src/inbox_util.ts
+++ b/web/src/inbox_util.ts
@@ -60,6 +60,9 @@ export function update_stream_colors(): void {
             $stream_privacy_icon.css("color", stream_color.get_stream_privacy_icon_color(color));
         }
 
-        $stream_header.css("background", background_color);
+        $stream_header.css(
+            "background",
+            `linear-gradient(to bottom, color-mix(in oklch, ${background_color} 80%, var(--color-background-inbox-row)), color-mix(in oklch, ${background_color} 24%, var(--color-background-inbox-row)) 3%, var(--color-background-inbox-row))`,
+        );
     });
 }

--- a/web/templates/inbox_view/inbox_stream_header_row.hbs
+++ b/web/templates/inbox_view/inbox_stream_header_row.hbs
@@ -1,4 +1,4 @@
-<div id="inbox-stream-header-{{stream_id}}" class="inbox-header {{#if is_hidden}}hidden_by_filters{{/if}} {{#if is_collapsed}}inbox-collapsed-state{{/if}}" data-col-index="{{ column_indexes.FULL_ROW }}" tabindex="0" data-stream-id="{{stream_id}}" style="background: {{stream_header_color}};">
+<div id="inbox-stream-header-{{stream_id}}" class="inbox-header {{#if is_hidden}}hidden_by_filters{{/if}} {{#if is_collapsed}}inbox-collapsed-state{{/if}}" data-col-index="{{ column_indexes.FULL_ROW }}" tabindex="0" data-stream-id="{{stream_id}}" style="background: linear-gradient(to bottom, color-mix(in oklch, {{ stream_header_color }} 80%, var(--color-background-inbox-row)), color-mix(in oklch, {{ stream_header_color }} 24%, var(--color-background-inbox-row)) 3%, var(--color-background-inbox-row));">
     <div class="inbox-focus-border">
         <div class="inbox-left-part-wrapper">
             <div class="inbox-left-part">


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/channel/101-design/topic/Inbox.20collapsed.20channel.20look/with/2256572

| before | after |
| --- | --- |
|  <img width="1120" height="1120" alt="Screenshot from 2025-09-09 12-59-11" src="https://github.com/user-attachments/assets/743ffdd9-f83b-4647-8bcd-0b60bb613205" /> |<img width="1120" height="1120" alt="Screenshot from 2025-09-09 12-58-35" src="https://github.com/user-attachments/assets/7afbeb33-0a40-4e09-aa80-bb998b6cafc9" /> |
| <img width="1120" height="1120" alt="Screenshot from 2025-09-09 12-59-16" src="https://github.com/user-attachments/assets/5fd817f0-e0bc-4aaf-84b1-74a8cc9f27a9" /> | <img width="1120" height="1120" alt="Screenshot from 2025-09-09 12-58-39" src="https://github.com/user-attachments/assets/07bb048d-8002-47ed-a683-e3879694ae5c" /> |
