### PR TITLE
Fix posting policy error banner not displayed when DM to a user is not allowed.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -463,7 +463,6 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
         compose_validate.warn_if_in_search_view();
     }
 
-    compose_recipient.check_posting_policy_for_compose_box();
     drafts.update_compose_draft_count();
 
     // Reset the `max-height` property of `compose-textarea` so that the

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -158,34 +158,11 @@ export function update_on_recipient_change(): void {
     update_narrow_to_recipient_visibility();
     compose_validate.warn_if_guest_in_dm_recipient();
     drafts.update_compose_draft_count();
-    check_posting_policy_for_compose_box();
     compose_validate.validate_and_update_send_button_status();
 
     // Clear the topic moved banner when the recipient
     // is changed or compose box is closed.
     compose_validate.clear_topic_moved_info();
-}
-
-export let check_posting_policy_for_compose_box = (): void => {
-    const banner_text = compose_validate.get_posting_policy_error_message();
-    if (banner_text === "") {
-        compose_banner.clear_errors();
-        return;
-    }
-
-    let banner_classname = compose_banner.CLASSNAMES.no_post_permissions;
-    if (compose_state.selected_recipient_id === "direct") {
-        banner_classname = compose_banner.CLASSNAMES.cannot_send_direct_message;
-        compose_banner.cannot_send_direct_message_error(banner_text);
-    } else {
-        compose_banner.show_error_message(banner_text, banner_classname, $("#compose_banners"));
-    }
-};
-
-export function rewire_check_posting_policy_for_compose_box(
-    value: typeof check_posting_policy_for_compose_box,
-): void {
-    check_posting_policy_for_compose_box = value;
 }
 
 function switch_message_type(message_type: MessageType): void {

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -1075,6 +1075,28 @@ export function check_overflow_text($container: JQuery): number {
     return text.length;
 }
 
+export let check_posting_policy_for_compose_box = (): void => {
+    const banner_text = get_posting_policy_error_message();
+    if (banner_text === "") {
+        compose_banner.clear_errors();
+        return;
+    }
+
+    let banner_classname = compose_banner.CLASSNAMES.no_post_permissions;
+    if (compose_state.selected_recipient_id === "direct") {
+        banner_classname = compose_banner.CLASSNAMES.cannot_send_direct_message;
+        compose_banner.cannot_send_direct_message_error(banner_text);
+    } else {
+        compose_banner.show_error_message(banner_text, banner_classname, $("#compose_banners"));
+    }
+};
+
+export function rewire_check_posting_policy_for_compose_box(
+    value: typeof check_posting_policy_for_compose_box,
+): void {
+    check_posting_policy_for_compose_box = value;
+}
+
 export let validate_and_update_send_button_status = function (): void {
     const is_valid = validate(false, false);
     const $send_button = $("#compose-send-button");
@@ -1086,6 +1108,7 @@ export let validate_and_update_send_button_status = function (): void {
         send_button_element._tippy.hide();
         send_button_element._tippy.show();
     }
+    check_posting_policy_for_compose_box();
 };
 
 export function rewire_validate_and_update_send_button_status(

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -1075,7 +1075,7 @@ export function check_overflow_text($container: JQuery): number {
     return text.length;
 }
 
-export let check_posting_policy_for_compose_box = (): void => {
+export let update_posting_policy_banner_post_validation = (): void => {
     const banner_text = get_posting_policy_error_message();
     if (banner_text === "") {
         compose_banner.clear_errors();
@@ -1091,10 +1091,10 @@ export let check_posting_policy_for_compose_box = (): void => {
     }
 };
 
-export function rewire_check_posting_policy_for_compose_box(
-    value: typeof check_posting_policy_for_compose_box,
+export function rewire_update_posting_policy_banner_post_validation(
+    value: typeof update_posting_policy_banner_post_validation,
 ): void {
-    check_posting_policy_for_compose_box = value;
+    update_posting_policy_banner_post_validation = value;
 }
 
 export let validate_and_update_send_button_status = function (): void {
@@ -1108,7 +1108,7 @@ export let validate_and_update_send_button_status = function (): void {
         send_button_element._tippy.hide();
         send_button_element._tippy.show();
     }
-    check_posting_policy_for_compose_box();
+    update_posting_policy_banner_post_validation();
 };
 
 export function rewire_validate_and_update_send_button_status(

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -5,7 +5,7 @@ import {all_messages_data} from "./all_messages_data.ts";
 import * as blueslip from "./blueslip.ts";
 import * as channel from "./channel.ts";
 import * as compose_closed_ui from "./compose_closed_ui.ts";
-import * as compose_recipient from "./compose_recipient.ts";
+import * as compose_validate from "./compose_validate.ts";
 import * as direct_message_group_data from "./direct_message_group_data.ts";
 import {Filter} from "./filter.ts";
 import * as message_feed_loading from "./message_feed_loading.ts";
@@ -129,7 +129,7 @@ export function fetch_more_if_required_for_current_msg_list(
         narrow_banner.show_empty_narrow_message(message_lists.current.data.filter);
         message_lists.current.update_trailing_bookend();
         compose_closed_ui.update_buttons_for_private();
-        compose_recipient.check_posting_policy_for_compose_box();
+        compose_validate.validate_and_update_send_button_status();
     }
 
     if (looking_for_old_msgs && !has_found_oldest) {

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -409,7 +409,7 @@ export function dispatch_normal_event(event) {
                                 ) {
                                     settings_org.check_disable_direct_message_initiator_group_widget();
                                     compose_closed_ui.update_buttons_for_private();
-                                    compose_recipient.check_posting_policy_for_compose_box();
+                                    compose_validate.validate_and_update_send_button_status();
                                 }
 
                                 if (

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -614,7 +614,7 @@ export async function initialize_everything(state_data) {
     compose_pm_pill.initialize({
         on_pill_create_or_remove() {
             compose_recipient.update_compose_area_placeholder_text();
-            compose_recipient.check_posting_policy_for_compose_box();
+            compose_validate.validate_and_update_send_button_status();
         },
     });
     compose_closed_ui.initialize();

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -92,6 +92,7 @@ const people = zrequire("people");
 const compose_state = zrequire("compose_state");
 const compose_actions = zrequire("compose_actions");
 const compose_reply = zrequire("compose_reply");
+const compose_validate = zrequire("compose_validate");
 const message_lists = zrequire("message_lists");
 const stream_data = zrequire("stream_data");
 const compose_recipient = zrequire("compose_recipient");
@@ -170,7 +171,7 @@ test("start", ({override, override_rewire, mock_template}) => {
     $elem.set_find_results(".message-limit-indicator", $indicator);
 
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
-    override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
+    override_rewire(compose_validate, "check_posting_policy_for_compose_box", noop);
     override_rewire(compose_recipient, "update_recipient_row_attention_level", noop);
     override_rewire(stream_data, "can_post_messages_in_stream", () => true);
     mock_template("inline_decorated_channel_name.hbs", false, noop);
@@ -323,7 +324,7 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
     $elem.set_find_results(".message-limit-indicator", $indicator);
 
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
-    override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
+    override_rewire(compose_validate, "check_posting_policy_for_compose_box", noop);
     override_rewire(compose_recipient, "update_recipient_row_attention_level", noop);
     override_private_message_recipient_ids({override});
     mock_template("inline_decorated_channel_name.hbs", false, noop);
@@ -392,7 +393,6 @@ test("reply_with_mention", ({override, override_rewire, mock_template}) => {
     $elem.set_find_results(".message-limit-indicator", $indicator);
 
     override_private_message_recipient_ids({override});
-    override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
     mock_template("inline_decorated_channel_name.hbs", false, noop);
 
     override_rewire(stream_data, "can_post_messages_in_stream", () => true);

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -171,7 +171,7 @@ test("start", ({override, override_rewire, mock_template}) => {
     $elem.set_find_results(".message-limit-indicator", $indicator);
 
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
-    override_rewire(compose_validate, "check_posting_policy_for_compose_box", noop);
+    override_rewire(compose_validate, "update_posting_policy_banner_post_validation", noop);
     override_rewire(compose_recipient, "update_recipient_row_attention_level", noop);
     override_rewire(stream_data, "can_post_messages_in_stream", () => true);
     mock_template("inline_decorated_channel_name.hbs", false, noop);
@@ -324,7 +324,7 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
     $elem.set_find_results(".message-limit-indicator", $indicator);
 
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
-    override_rewire(compose_validate, "check_posting_policy_for_compose_box", noop);
+    override_rewire(compose_validate, "update_posting_policy_banner_post_validation", noop);
     override_rewire(compose_recipient, "update_recipient_row_attention_level", noop);
     override_private_message_recipient_ids({override});
     mock_template("inline_decorated_channel_name.hbs", false, noop);

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -144,6 +144,7 @@ page_params.test_suite = false;
 // For data-oriented modules, just use them, don't stub them.
 const alert_words = zrequire("alert_words");
 const channel_folders = zrequire("channel_folders");
+const compose_validate = zrequire("compose_validate");
 const emoji = zrequire("emoji");
 const message_store = zrequire("message_store");
 const people = zrequire("people");
@@ -638,7 +639,8 @@ run_test("channel_folders", ({override}) => {
     server_events_dispatch.dispatch_normal_event({type: "channel_folder", op: "other"});
 });
 
-run_test("realm settings", ({override}) => {
+run_test("realm settings", ({override, override_rewire}) => {
+    override_rewire(compose_validate, "validate_and_update_send_button_status", noop);
     override(current_user, "is_admin", true);
     override(realm, "realm_date_created", new Date("2023-01-01Z"));
 
@@ -653,7 +655,6 @@ run_test("realm settings", ({override}) => {
     override(navbar_alerts, "toggle_organization_profile_incomplete_banner", noop);
     override(compose_recipient, "update_topic_inputbox_on_topics_policy_change", noop);
     override(compose_recipient, "update_compose_area_placeholder_text", noop);
-    override(compose_recipient, "check_posting_policy_for_compose_box", noop);
 
     function test_electron_dispatch(event, fake_send_event) {
         with_overrides(({override}) => {

--- a/web/tests/upload.test.cjs
+++ b/web/tests/upload.test.cjs
@@ -241,7 +241,7 @@ test("upload_files", async ({mock_template, override, override_rewire}) => {
         return "<banner-stub>";
     });
     override_rewire(compose_validate, "validate", () => false);
-    override_rewire(compose_validate, "check_posting_policy_for_compose_box", noop);
+    override_rewire(compose_validate, "update_posting_policy_banner_post_validation", noop);
     await upload.upload_files(uppy, config, files);
     assert.ok($("#compose-send-button").hasClass("disabled-message-send-controls"));
     assert.ok(banner_shown);

--- a/web/tests/upload.test.cjs
+++ b/web/tests/upload.test.cjs
@@ -241,6 +241,7 @@ test("upload_files", async ({mock_template, override, override_rewire}) => {
         return "<banner-stub>";
     });
     override_rewire(compose_validate, "validate", () => false);
+    override_rewire(compose_validate, "check_posting_policy_for_compose_box", noop);
     await upload.upload_files(uppy, config, files);
     assert.ok($("#compose-send-button").hasClass("disabled-message-send-controls"));
     assert.ok(banner_shown);


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/error.20banner.20for.20DM.20sending.20permissions/with/2255519


> **Lauryn Menard|21836** [said](https://chat.zulip.org/#narrow/channel/9-issues/topic/error.20banner.20for.20DM.20sending.20permissions/near/2254733):

Reproducer steps:
* Log in as Iago to the dev environment and set permissions to start DM conversations to moderators.
* Log out as Iago and back in as Cordelia (member).
* From the Inbox view (or Recent conversations or a channel/topic view), click the new DM button for the closed compose box.
* Choose a DM recipient who she doesn't currently have a DM conversation with (Zoe for me at the moment).
* Note that no error banner appears in the compose box.
* Type in some text and click send.
* See error message from the server.

 Then:
* Click on another user in the right sidebar who she doesn't have a DM conversation with (King Hamlet for me at the moment).
* Note that the compose box opens with no error banner, but the empty message feed banner is correct.
* Type one letter in the compose box.
* The warning banner appears and the input changes to the recipient box. The send button is disabled and the compose box cannot be focused.


