### PR TITLE
Fix: update url_encoding.p

### DIFF
--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -1,13 +1,8 @@
-# Standard library
 import urllib.parse
 from typing import Any
 from urllib.parse import urlsplit
-
-# Third-party imports
 import re2
 from django.conf import settings
-
-# Local project imports
 from zerver.lib.topic import get_topic_from_message_info
 from zerver.lib.types import UserDisplayRecipient
 from zerver.models import Realm, Stream, UserProfile

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -1,9 +1,13 @@
+# Standard library
 import urllib.parse
 from typing import Any
 from urllib.parse import urlsplit
 
+# Third-party imports
 import re2
+from django.conf import settings
 
+# Local project imports
 from zerver.lib.topic import get_topic_from_message_info
 from zerver.lib.types import UserDisplayRecipient
 from zerver.models import Realm, Stream, UserProfile
@@ -14,7 +18,7 @@ hash_replacements = {
     ")": ".29",
     ".": ".2E",
 }
-from django.conf import settings
+
 
 def get_realm_url_with_port(realm: Realm) -> str:
     """

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -14,6 +14,21 @@ hash_replacements = {
     ")": ".29",
     ".": ".2E",
 }
+from django.conf import settings
+
+def get_realm_url_with_port(realm: Realm) -> str:
+    """
+    Return realm.url, but ensure that it includes the port if
+    application_server.nginx_listen_port is configured to a
+    non-standard value.
+    """
+    url = realm.url.rstrip("/")
+    port = getattr(settings, "APPLICATION_SERVER_CONFIG", {}).get("nginx_listen_port", 443)
+
+
+    if port not in (80, 443) and f":{port}" not in url:
+        return f"{url}:{port}"
+    return url
 
 
 def encode_hash_component(s: str) -> str:
@@ -95,7 +110,7 @@ def encode_user_full_name_and_id(full_name: str, user_id: int, with_operator: bo
 
 
 def personal_narrow_url(*, realm: Realm, sender_id: int, sender_full_name: str) -> str:
-    base_url = f"{realm.url}/#narrow/dm/"
+    base_url = f"{get_realm_url_with_port(realm)}/#narrow/dm/"
     direct_message_slug = encode_user_full_name_and_id(sender_full_name, sender_id)
     return base_url + direct_message_slug
 
@@ -117,17 +132,17 @@ def direct_message_group_narrow_url(
     # For group DMs with more than 2 users, we use other user IDs to create a slug.
     other_user_ids = [r["id"] for r in display_recipient if r["id"] != user.id]
     direct_message_slug = encode_user_ids(other_user_ids)
-    base_url = f"{realm.url}/#narrow/dm/"
+    base_url = f"{get_realm_url_with_port(realm)}/#narrow/dm/"
     return base_url + direct_message_slug
 
 
 def stream_narrow_url(realm: Realm, stream: Stream) -> str:
-    base_url = f"{realm.url}/#narrow/channel/"
+    base_url = f"{get_realm_url_with_port(realm)}/#narrow/channel/"
     return base_url + encode_channel(stream.id, stream.name)
 
 
 def topic_narrow_url(*, realm: Realm, stream: Stream, topic_name: str) -> str:
-    base_url = f"{realm.url}/#narrow/channel/"
+    base_url = f"{get_realm_url_with_port(realm)}/#narrow/channel/"
     return f"{base_url}{encode_channel(stream.id, stream.name)}/topic/{encode_hash_component(topic_name)}"
 
 
@@ -165,7 +180,7 @@ def stream_message_url(
     encoded_stream = encode_channel(stream_id, stream_name)
 
     parts = [
-        realm.url,
+        get_realm_url_with_port(realm),
         "#narrow",
         "channel",
         encoded_stream,
@@ -192,7 +207,7 @@ def pm_message_url(
     direct_message_slug = encode_user_ids(user_ids)
 
     parts = [
-        realm.url,
+        get_realm_url_with_port(realm),
         "#narrow",
         "dm",
         direct_message_slug,

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -12,6 +12,7 @@ from zerver.lib.topic import get_topic_from_message_info
 from zerver.lib.types import UserDisplayRecipient
 from zerver.models import Realm, Stream, UserProfile
 
+
 hash_replacements = {
     "%": ".",
     "(": ".28",


### PR DESCRIPTION
Fix: Include port in realm URLs when non-standard
When Zulip is deployed on a custom port (e.g. 8443), links generated using realm.url would omit the port, resulting in broken external links.

This PR adds a helper function get_realm_url_with_port() in zerver/lib/url_encoding.py, which ensures that the port is included if it’s non-standard. All narrow and message URL builders have been updated to use this helper.

Fixes: zulip#36017