### PR TITLE
Scroll user to top on search in left sidebar, topic zoom and DM zoom.

### DIFF
--- a/web/src/scroll_util.ts
+++ b/web/src/scroll_util.ts
@@ -102,3 +102,7 @@ export function scroll_element_into_container(
 
     $container.scrollTop(($container.scrollTop() ?? 0) + delta);
 }
+
+export function get_left_sidebar_scroll_container(): JQuery {
+    return get_scroll_element($("#left_sidebar_scroll_container"));
+}

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -21,6 +21,7 @@ import * as popover_menus from "./popover_menus.ts";
 import * as popovers from "./popovers.ts";
 import * as resize from "./resize.ts";
 import * as scheduled_messages from "./scheduled_messages.ts";
+import * as scroll_util from "./scroll_util.ts";
 import * as search_util from "./search_util.ts";
 import * as settings_config from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
@@ -605,7 +606,34 @@ function actually_update_left_sidebar_for_search(): void {
     );
 }
 
-const update_left_sidebar_for_search = _.throttle(actually_update_left_sidebar_for_search, 50);
+// Scroll position before user started searching.
+let pre_search_scroll_position = 0;
+let previous_search_term = "";
+
+const update_left_sidebar_for_search = _.throttle(() => {
+    const search_term = ui_util.get_left_sidebar_search_term();
+    const is_previous_search_term_empty = previous_search_term === "";
+    previous_search_term = search_term;
+
+    const left_sidebar_scroll_container = scroll_util.get_left_sidebar_scroll_container();
+    if (search_term === "") {
+        requestAnimationFrame(() => {
+            actually_update_left_sidebar_for_search();
+            // Restore previous scroll position.
+            left_sidebar_scroll_container.scrollTop(pre_search_scroll_position);
+        });
+    } else {
+        if (is_previous_search_term_empty) {
+            // Store original scroll position to be restored later.
+            pre_search_scroll_position = left_sidebar_scroll_container.scrollTop()!;
+        }
+        requestAnimationFrame(() => {
+            actually_update_left_sidebar_for_search();
+            // Always scroll to top when there is a search term present.
+            left_sidebar_scroll_container.scrollTop(0);
+        });
+    }
+}, 50);
 
 function focus_left_sidebar_filter(e: JQuery.ClickEvent): void {
     left_sidebar_cursor.reset();

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -34,6 +34,10 @@ export let topic_state_typeahead: Typeahead<TopicFilterPill> | undefined;
 // We know whether we're zoomed or not.
 let zoomed = false;
 
+// Scroll position before user started searching.
+let pre_search_scroll_position = 0;
+let previous_search_term = "";
+
 export function update(): void {
     for (const widget of active_widgets.values()) {
         widget.build();
@@ -430,6 +434,8 @@ export function left_sidebar_scroll_zoomed_in_topic_into_view(): void {
 // handle hiding/showing the non-narrowed streams
 export function zoom_in(): void {
     zoomed = true;
+    previous_search_term = "";
+    pre_search_scroll_position = 0;
     ui_util.disable_left_sidebar_search();
 
     const stream_id = active_stream_id();
@@ -631,9 +637,20 @@ export function initialize({
     $("body").on("input", "#left-sidebar-filter-topic-input", (): void => {
         const stream_id = active_stream_id();
         assert(stream_id !== undefined);
-        active_widgets.get(stream_id)?.build();
 
-        if (get_left_sidebar_topic_search_term() === "") {
+        const search_term = get_left_sidebar_topic_search_term();
+        const is_previous_search_term_empty = previous_search_term === "";
+        previous_search_term = search_term;
+
+        const widget = active_widgets.get(stream_id)!;
+        const left_sidebar_scroll_container = scroll_util.get_left_sidebar_scroll_container();
+        if (search_term === "") {
+            requestAnimationFrame(() => {
+                widget.build();
+                // Restore previous scroll position.
+                left_sidebar_scroll_container.scrollTop(pre_search_scroll_position);
+            });
+
             // When the contenteditable div is empty, the browser
             // adds a <br> element to it, which interferes with
             // the ":empty" selector in the CSS. Hence, we detect
@@ -646,6 +663,16 @@ export function initialize({
             // doesn't work in this particular case.
             // See: https://stackoverflow.com/questions/14638887/br-is-inserted-into-contenteditable-html-element-if-left-empty
             $("#topic_filter_query").empty();
+        } else {
+            if (is_previous_search_term_empty) {
+                // Store original scroll position to be restored later.
+                pre_search_scroll_position = left_sidebar_scroll_container.scrollTop()!;
+            }
+            requestAnimationFrame(() => {
+                widget.build();
+                // Always scroll to top when there is a search term present.
+                left_sidebar_scroll_container.scrollTop(0);
+            });
         }
     });
 }


### PR DESCRIPTION
Also, restore scroll position when input is cleared.

Tested locally that the scroll position is properly restored
in left sidebar search, topic zoom and DM zoom states.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/scroll.20left.20sidebar.20when.20searching.3F/with/2257810