### PR TITLE
inbox: Fix user scrolling to top on rerender if filters are focused.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1171,7 +1171,7 @@ function inbox_view_dropdown_options(
     return views_util.filters_dropdown_options(current_value, inbox_util.is_channel_view());
 }
 
-export function complete_rerender(): void {
+export function complete_rerender(coming_from_other_views = false): void {
     if (!inbox_util.is_visible()) {
         return;
     }
@@ -1222,15 +1222,17 @@ export function complete_rerender(): void {
             first_filter = filters.values().next();
         }
 
-        // If the focus is not on the inbox rows, the inbox view scrolls
-        // down when moving from other views to the inbox view. To avoid
-        // this, we scroll to top before restoring focus via revive_current_focus.
-        if (!is_list_focused()) {
-            window.scrollTo(0, 0);
-        } else if (last_scroll_offset !== undefined) {
-            // It is important to restore the scroll position as soon
-            // as the rendering is complete to avoid scroll jumping.
-            window.scrollTo(0, last_scroll_offset);
+        if (coming_from_other_views) {
+            if (last_scroll_offset !== undefined) {
+                // It is important to restore the scroll position as soon
+                // as the rendering is complete to avoid scroll jumping.
+                window.scrollTo(0, last_scroll_offset);
+            } else {
+                // If the focus is not on the inbox rows, the inbox view scrolls
+                // down when moving from other views to the inbox view. To avoid
+                // this, we scroll to top before restoring focus via revive_current_focus.
+                window.scrollTo(0, 0);
+            }
         }
 
         revive_current_focus();

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1310,7 +1310,7 @@ function get_list_data_for_widget(): ConversationData[] {
     return [...recent_view_data.get_conversations().values()];
 }
 
-export function complete_rerender(): void {
+export function complete_rerender(coming_from_other_views = false): void {
     if (!recent_view_util.is_visible()) {
         return;
     }
@@ -1327,10 +1327,12 @@ export function complete_rerender(): void {
         return;
     }
 
-    // This is the first time we are rendering the Recent Conversations view.
-    // So, we always scroll to the top to avoid any scroll jumping in case
-    // user is returning from another view.
-    window.scrollTo(0, 0);
+    if (coming_from_other_views) {
+        // This is the first time we are rendering the Recent Conversations view.
+        // So, we always scroll to the top to avoid any scroll jumping in case
+        // user is returning from another view.
+        window.scrollTo(0, 0);
+    }
 
     const rendered_body = render_recent_view_body({
         search_val: $("#recent_view_search").val() ?? "",

--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -88,7 +88,7 @@ export function show(opts: {
     update_compose: () => void;
     is_visible: () => boolean;
     set_visible: (value: boolean) => void;
-    complete_rerender: () => void;
+    complete_rerender: (coming_from_other_views?: boolean) => void;
     is_recent_view?: boolean;
 }): void {
     if (opts.is_visible()) {
@@ -112,7 +112,7 @@ export function show(opts: {
     narrow_title.update_narrow_title(narrow_state.filter());
     message_view_header.render_title_area();
     compose_recipient.handle_middle_pane_transition();
-    opts.complete_rerender();
+    opts.complete_rerender(true);
     compose_actions.on_show_navigation_view();
 
     // This has to happen after resetting the current narrow filter, so


### PR DESCRIPTION
If one of the filters is focused or if we cannot determine the current focus location, any rerender call will scroll user to top.

Fixed by only scrolling to top when navigating from other views and when we don't have a cached scroll position.

Tested by calling `complete_rerender` at 1s intervals.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Inbox.20view.20scroll.20position.20issues/with/2257437
