### PR TITLE
docs: fix wording in "Moderating the Zulip community"

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -110,7 +110,7 @@ aware of the [community guidelines](https://zulip.com/development-community/)
 and this Code of Conduct, and that we maintain a positive and respectful
 atmosphere.
 
-Here are some guidelines for you how can help:
+Here are some guidelines for how you can help:
 
 - Be friendly! Welcoming folks, thanking them for their feedback, ideas and effort,
   and just trying to keep the atmosphere warm make the whole community function


### PR DESCRIPTION
# Summary
Fixed a small wording issue in the "Moderating the Zulip community" section of the Code of Conduct.

# Changes
- Replaced "Here are some guidelines for you how can help:" with
  "Here are some guidelines for how you can help:" for clarity.

# Notes
- This is a docs-only change (no code logic affected).
- No screenshots required since this does not affect UI.

# Checklist
- [x] Self-reviewed for clarity
- [x] Commit message follows Zulip guidelines
- [x] Docs-only change
