### PR TITLE
Modal settings: Fix right margin for channel name input in narrow windows.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -470,7 +470,7 @@
     }
 }
 
-#change_stream_name{
+#change_stream_name {
     width: 72%;
 }
 


### PR DESCRIPTION
Previously, the channel name input lost its right margin in narrow windows,
unlike the description box. This PR fixes the CSS so both inputs are aligned.

Fixes: #35301 

After(margin fixed)
<img width="226" height="174" alt="Screenshot 2025-09-11 172528" src="https://github.com/user-attachments/assets/14535112-0572-4e6a-a1f9-5445432096c4" />
