### PR TITLE
dark_theme: Clean up Tippy box styles.

### DIFF
--- a/web/src/bundles/app.ts
+++ b/web/src/bundles/app.ts
@@ -17,7 +17,6 @@ import "tippy.js/dist/tippy.css";
 // Adds color inheritance to the borders when using the default CSS Arrow.
 // https://atomiks.github.io/tippyjs/v6/themes/#arrow-border
 import "tippy.js/dist/border.css";
-import "tippy.js/themes/light-border.css";
 import "katex/dist/katex.css";
 import "flatpickr/dist/flatpickr.css";
 import "flatpickr/dist/plugins/confirmDate/confirmDate.css";

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -196,10 +196,6 @@ export const default_popover_props: Partial<tippy.Props> = {
     trigger: "click",
     interactive: true,
     hideOnClick: true,
-    /* The light-border TippyJS theme is a bit of a misnomer; it
-       is a popover styling similar to Bootstrap.  We've also customized
-       its CSS to support Zulip's dark theme. */
-    theme: "light-border",
     // The maxWidth has been set to "none" to avoid the default value of 300px.
     maxWidth: "none",
     touch: true,

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1459,7 +1459,18 @@
         hsl(200deg 79% 66%)
     );
 
+    /* Tippy colors */
+    --color-background-tippy-box: light-dark(hsl(0deg 0% 20%), hsl(0deg 0% 0%));
+
     /* Widgets colors */
+    --color-background-dropdown-widget: light-dark(
+        hsl(240deg 20% 98%),
+        hsl(240deg 5% 16%)
+    );
+    --color-border-dropdown-widget: light-dark(
+        hsl(0deg 0% 0% / 40%),
+        hsl(0deg 0% 0%)
+    );
     --color-border-dropdown-widget-button: light-dark(
         hsl(0deg 0% 80%),
         hsl(0deg 0% 0% / 60%)

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -27,17 +27,6 @@
         }
     }
 
-    /* Extend the 'light-border' TippyJS theme, which is intended for
-       popovers/menus that should use default background colors, to use
-       our dark theme colors in Zulip's dark theme.
-     */
-    .tippy-box[data-theme~="light-border"] {
-        .tippy-content a,
-        p {
-            color: hsl(236deg 33% 90%);
-        }
-    }
-
     .dropdown-list-delete {
         /* hsl(7deg 100% 74%) corresponds to var(--red-250) */
         color: color-mix(

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -38,35 +38,6 @@
         }
     }
 
-    .tippy-box:not([data-theme]) {
-        background: hsl(0deg 0% 0%);
-
-        &[data-placement^="top"] > .tippy-arrow::before {
-            border-top-color: hsl(0deg 0% 0%);
-        }
-
-        &[data-placement^="bottom"] > .tippy-arrow::before {
-            border-bottom-color: hsl(0deg 0% 0%);
-        }
-
-        &[data-placement^="left"] > .tippy-arrow::before {
-            border-left-color: hsl(0deg 0% 0%);
-        }
-
-        &[data-placement^="right"] > .tippy-arrow::before {
-            border-right-color: hsl(0deg 0% 0%);
-        }
-    }
-
-    .tippy-box[data-theme="dropdown-widget"] {
-        background-color: hsl(240deg 5% 16%);
-        border: 1px solid hsl(0deg 0% 0%);
-        box-shadow:
-            0 7px 13px hsl(0deg 0% 0% / 35%),
-            0 5px 8px hsl(0deg 0% 0% / 32%),
-            0 2px 4px hsl(0deg 0% 0% / 20%);
-    }
-
     .dropdown-list-delete {
         /* hsl(7deg 100% 74%) corresponds to var(--red-250) */
         color: color-mix(

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -56,12 +56,12 @@
 
 .tippy-box[data-theme="dropdown-widget"] {
     border-radius: 6px;
-    background-color: hsl(240deg 20% 98%);
-    border: 1px solid hsl(0deg 0% 0% / 40%);
+    background-color: var(--color-background-dropdown-widget);
+    border: 1px solid var(--color-border-dropdown-widget);
     box-shadow:
-        0 7px 13px hsl(0deg 0% 0% / 15%),
-        0 5px 8px hsl(0deg 0% 0% / 12%),
-        0 2px 4px hsl(0deg 0% 0% / 10%);
+        0 7px 13px light-dark(hsl(0deg 0% 0% / 15%), hsl(0deg 0% 0% / 35%)),
+        0 5px 8px light-dark(hsl(0deg 0% 0% / 12%), hsl(0deg 0% 0% / 32%)),
+        0 2px 4px light-dark(hsl(0deg 0% 0% / 10%), hsl(0deg 0% 0% / 20%));
     /* Tippy dropdown widgets scale with the base font-size. */
     font-size: var(--base-font-size-px);
 

--- a/web/styles/tooltips.css
+++ b/web/styles/tooltips.css
@@ -10,7 +10,7 @@
 
     /* Affects all tippy tooltips not using any theme. */
     .tippy-box:not([data-theme]) {
-        background: hsl(0deg 0% 20%);
+        background: var(--color-background-tippy-box);
         border-radius: 5px;
         /* 14px at 14px/1em */
         font-size: var(--base-font-size-px);
@@ -47,19 +47,19 @@
         }
 
         &[data-placement^="top"] > .tippy-arrow::before {
-            border-top-color: hsl(0deg 0% 20%);
+            border-top-color: var(--color-background-tippy-box);
         }
 
         &[data-placement^="bottom"] > .tippy-arrow::before {
-            border-bottom-color: hsl(0deg 0% 20%);
+            border-bottom-color: var(--color-background-tippy-box);
         }
 
         &[data-placement^="left"] > .tippy-arrow::before {
-            border-left-color: hsl(0deg 0% 20%);
+            border-left-color: var(--color-background-tippy-box);
         }
 
         &[data-placement^="right"] > .tippy-arrow::before {
-            border-right-color: hsl(0deg 0% 20%);
+            border-right-color: var(--color-background-tippy-box);
         }
     }
 


### PR DESCRIPTION
This PR cleans up the Tippy box styles from `web/styles/dark_theme.css`, and also has a follow-up commit removing the unused "light-border" which was no longer in use, since all of our current popovers either use the "popover-menu" theme or the "dropdown-widget" theme.

Fixes: Part 5 of #35880.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Desc | Header | Header |
|--------|--------|--------|
| No theme | <img width="498" height="216" alt="Screenshot 2025-09-11 at 7 43 27 PM" src="https://github.com/user-attachments/assets/51b93107-0f32-4a02-88de-f5c85bf549f6" /> | <img width="498" height="216" alt="Screenshot 2025-09-11 at 7 42 37 PM" src="https://github.com/user-attachments/assets/68e10345-1eca-4513-b227-bc02c9bd5485" /> |
| Dropdown widget theme | <img width="512" height="554" alt="Screenshot 2025-09-11 at 7 33 53 PM" src="https://github.com/user-attachments/assets/fdc3fa27-d96a-49f7-9a67-d61defc0f28e" /> | <img width="512" height="554" alt="Screenshot 2025-09-11 at 7 32 26 PM" src="https://github.com/user-attachments/assets/8bb91c51-643a-4564-a2ad-11a52ff6e78d" /> | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
