### PR TITLE
[11.x] puppet: Add options for allow/deny rules in Smokescreen.

### DIFF
--- a/docs/production/system-configuration.md
+++ b/docs/production/system-configuration.md
@@ -423,10 +423,13 @@ not_ send any requests to Zulip which came in unencrypted.
 
 ### `[http_proxy]`
 
+See "[Customizing the outgoing HTTP
+proxy](deployment.md#customizing-the-outgoing-http-proxy)" for general
+instructions on the outgoing proxy.
+
 #### `host`
 
-The hostname or IP address of an [outgoing HTTP `CONNECT`
-proxy](deployment.md#customizing-the-outgoing-http-proxy). Defaults to
+The hostname or IP address of an outgoing HTTP `CONNECT`. Defaults to
 `localhost` if unspecified.
 
 #### `port`
@@ -445,6 +448,12 @@ Because Camo includes logic to deny access to private subnets, routing
 its requests through Smokescreen is generally not necessary. Set to
 true or false to override the default, which uses the proxy only if
 it is not the default of Smokescreen on a local host.
+
+#### `allow_addresses`, `allow_ranges`, `deny_addresses`, `deny_ranges`
+
+Comma-separated lists of IP addresses or CIDR range rules. All
+private IP addresses (e.g., 127.0.0.0/8, 192.168.0.0/16) are denied by
+default; allow rules override deny rules.
 
 ### `[sentry]`
 

--- a/puppet/zulip/manifests/smokescreen.pp
+++ b/puppet/zulip/manifests/smokescreen.pp
@@ -37,6 +37,11 @@ class zulip::smokescreen {
   }
 
   $listen_address = zulipconf('http_proxy', 'listen_address', '127.0.0.1')
+  $allow_addresses = split(zulipconf('http_proxy', 'allow_addresses', ''), ',')
+  $allow_ranges = split(zulipconf('http_proxy', 'allow_ranges', ''), ',')
+  $deny_addresses = split(zulipconf('http_proxy', 'deny_addresses', ''), ',')
+  $deny_ranges = split(zulipconf('http_proxy', 'deny_ranges', ''), ',')
+
   file { "${zulip::common::supervisor_conf_dir}/smokescreen.conf":
     ensure  => file,
     require => [

--- a/puppet/zulip/templates/supervisor/smokescreen.conf.erb
+++ b/puppet/zulip/templates/supervisor/smokescreen.conf.erb
@@ -1,5 +1,20 @@
+<%
+
+acls = []
+acls.concat(@allow_addresses.map {|a| "--allow-address #{a}"})
+acls.concat(@allow_ranges.map {|a| "--allow-range #{a}"})
+acls.concat(@deny_addresses.map {|a| "--deny-address #{a}"})
+acls.concat(@deny_ranges.map {|a| "--deny-range #{a}"})
+
+if acls.empty?
+  acl = ""
+else
+  acl = " " + acls.join(" ")
+end
+
+-%>
 [program:smokescreen]
-command=<%= @bin %> --listen-ip <%= @listen_address %> --expose-prometheus-metrics --prometheus-port 4760
+command=<%= @bin %> --listen-ip <%= @listen_address %> --expose-prometheus-metrics --prometheus-port 4760<%= acl %>
 priority=15
 autostart=true
 autorestart=true


### PR DESCRIPTION
Backports:
- #35932