### PR TITLE
dark_theme: Clean up input styles in dark_theme.css.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2751,6 +2751,20 @@
     );
 
     /* Inputs */
+    /* Legacy input colors */
+    /* TODO: Remove these variables after migrating all the inputs to use the new input colors. */
+    --color-background-legacy-input: light-dark(
+        hsl(0deg 0% 100%),
+        hsl(0deg 0% 0% / 20%)
+    );
+    --color-border-legacy-input: light-dark(
+        hsl(0deg 0% 80%),
+        hsl(0deg 0% 0% / 60%)
+    );
+    --color-border-legacy-input-focus: light-dark(
+        hsl(206deg 80% 62% / 80%),
+        hsl(0deg 0% 0% / 90%)
+    );
     --color-text-input: light-dark(hsl(0deg 0% 14%), hsl(0deg 0% 95%));
     /* TODO: Light mode uses browser-default white
        backgrounds; we should extend the use of this

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -75,22 +75,6 @@
         border-color: hsl(0deg 0% 0% / 60%);
     }
 
-    input:not(.input-element) {
-        &[type="text"],
-        &[type="email"],
-        &[type="password"],
-        &[type="number"],
-        &[type="url"],
-        &[type="date"] {
-            background-color: hsl(0deg 0% 0% / 20%);
-            border-color: hsl(0deg 0% 0% / 60%);
-
-            &:focus {
-                border-color: hsl(0deg 0% 0% / 90%);
-            }
-        }
-    }
-
     .popover-filter-input-wrapper .popover-filter-input:focus {
         background-color: hsl(225deg 6% 7%);
         border: 1px solid hsl(0deg 0% 100% / 50%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -727,6 +727,12 @@ input:not(.input-element) {
     &[type="color"] {
         font-size: inherit;
         height: 1.4em;
+        background-color: var(--color-background-legacy-input);
+        border-color: var(--color-border-legacy-input);
+
+        &:focus {
+            border-color: var(--color-border-legacy-input-focus);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes: Part of #35135.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details><summary>Before</summary>
<p>

| Desc | Light | Dark |
|--------|--------|--------|
| Normal | <img width="814" height="172" alt="Screenshot 2025-09-12 at 4 29 10 AM" src="https://github.com/user-attachments/assets/5c692320-2632-496d-80d4-005ca70a9415" /> | <img width="814" height="172" alt="Screenshot 2025-09-12 at 4 28 55 AM" src="https://github.com/user-attachments/assets/540c6ae7-62e5-4688-bbd3-3c000d0f125d" /> |
| Focused | <img width="814" height="172" alt="Screenshot 2025-09-12 at 4 29 13 AM" src="https://github.com/user-attachments/assets/0f2f66fb-ecad-4b27-a129-23e60ec33d37" /> | <img width="814" height="172" alt="Screenshot 2025-09-12 at 4 29 03 AM" src="https://github.com/user-attachments/assets/3bda8628-1329-4fbb-a82f-1e80cd6b6735" /> |

</p>
</details> 

<details><summary>After</summary>
<p>

| Desc | Light | Dark |
|--------|--------|--------|
| Normal | <img width="814" height="172" alt="Screenshot 2025-09-12 at 4 24 58 AM" src="https://github.com/user-attachments/assets/280e7835-92a7-4e66-a893-15e2762fc052" /> | <img width="814" height="172" alt="Screenshot 2025-09-12 at 4 25 30 AM" src="https://github.com/user-attachments/assets/946427b2-035c-476b-aea3-cc225914038d" /> |
| Focused | <img width="814" height="172" alt="Screenshot 2025-09-12 at 4 25 19 AM" src="https://github.com/user-attachments/assets/37459bdc-059a-4024-83fe-8616f86f28d9" /> | <img width="814" height="172" alt="Screenshot 2025-09-12 at 4 25 34 AM" src="https://github.com/user-attachments/assets/7a2b9b82-c86b-4925-8081-a0e5c9ca5f99" /> | 

</p>
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
