### PR TITLE
views_util: Use ".input-element" selector to check for focused inputs.

### DIFF
--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -156,9 +156,8 @@ export function is_in_focus(): boolean {
         !sidebar_ui.any_sidebar_expanded_as_overlay() &&
         !overlays.any_active() &&
         !modals.any_active_or_animating() &&
-        !$(".home-page-input").is(":focus") &&
+        !$(".input-element").is(":focus") &&
         !$("#search_query").is(":focus") &&
-        !$("#topic_filter_query").is(":focus") &&
         !$(".navbar-item").is(":focus")
     );
 }


### PR DESCRIPTION
Previously, we were using the ".home-page-input" selector to check for any focused input elements in the home page view of the Zulip Web UI. Since all of these inputs, other than the navbar search input have now been converted to filter inputs, we can simplify the logic to check for any focused input elements with the ".input-element" selector.

The navbar search input has a different selector, "#search_query", which is already accounted for in the views_util.is_in_focus() method.

Now, ".input-element" class will potentially be used for several other inputs in the UI other than the home page view, but the is_in_focus() method already accounts for other focused elements like compose, overlays, popovers, etc, and thus the logic remains unaffected.

Fixes part of #35135.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
