### PR TITLE
sidebars: Consolidate and correct icon, hover colors.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -774,6 +774,14 @@
         hsl(0deg 0% 0% / 30%),
         hsl(0deg 0% 100% / 30%)
     );
+    --color-sidebar-action: light-dark(
+        hsl(240deg 30% 40%),
+        hsl(240deg 35% 68%)
+    );
+    --color-sidebar-action-hover: light-dark(
+        hsl(240deg 100% 15%),
+        hsl(240deg 100% 90%)
+    );
     --color-background-sidebar-action-hover: light-dark(
         hsl(240deg 100% 93%),
         hsl(240deg 25% 35%)
@@ -1669,21 +1677,9 @@
         hsl(240deg 30% 40%),
         hsl(240deg 35% 68%)
     );
-    --color-left-sidebar-heads-up-icon: light-dark(
-        hsl(240deg 30% 40%),
-        hsl(240deg 35% 68%)
-    );
-    --color-left-sidebar-heads-up-icon-hover: light-dark(
-        hsl(240deg 100% 15%),
-        hsl(240deg 100% 90%)
-    );
     --color-left-sidebar-dm-partners-icon: light-dark(
         hsl(240deg 30% 60%),
         hsl(240deg 35% 58%)
-    );
-    --background-color-left-sidebar-heads-up-icon-hover: light-dark(
-        hsl(240deg 100% 50% / 7%),
-        hsl(240deg 100% 75% / 20%)
     );
     --color-vdots-hint: light-dark(hsl(240deg 30% 80%), hsl(240deg 35% 38%));
     --color-vdots-visible: light-dark(hsl(240deg 30% 40%), hsl(240deg 35% 68%));

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -58,13 +58,11 @@
     /* 2px right margin here to match the new topic margin-right */
     margin: 2px 1px 2px 0;
     border-radius: 3px;
-    color: var(--color-left-sidebar-heads-up-icon);
+    color: var(--color-sidebar-action);
 
     &:hover {
-        color: var(--color-left-sidebar-heads-up-icon-hover);
-        background-color: var(
-            --background-color-left-sidebar-heads-up-icon-hover
-        );
+        color: var(--color-sidebar-action-hover);
+        background-color: var(--color-background-sidebar-action-hover);
         cursor: pointer;
     }
 
@@ -307,7 +305,7 @@
 
     #compose-new-direct-message,
     #show-all-direct-messages {
-        color: var(--color-left-sidebar-heads-up-icon);
+        color: var(--color-sidebar-action);
         display: none;
         align-items: center;
         justify-content: center;
@@ -317,10 +315,8 @@
         grid-row: 1 / 1;
 
         &:hover {
-            color: var(--color-left-sidebar-heads-up-icon-hover);
-            background-color: var(
-                --background-color-left-sidebar-heads-up-icon-hover
-            );
+            color: var(--color-sidebar-action-hover);
+            background-color: var(--color-background-sidebar-action-hover);
         }
 
         @media (hover: none) {
@@ -1854,15 +1850,13 @@ li.active-sub-filter {
     display: none;
     align-items: center;
     justify-content: center;
-    color: var(--color-left-sidebar-heads-up-icon);
+    color: var(--color-sidebar-action);
     margin: 2px 0;
     border-radius: 3px;
 
     &:hover {
-        color: var(--color-left-sidebar-heads-up-icon-hover);
-        background-color: var(
-            --background-color-left-sidebar-heads-up-icon-hover
-        );
+        color: var(--color-sidebar-action-hover);
+        background-color: var(--color-background-sidebar-action-hover);
     }
 }
 


### PR DESCRIPTION
This PR consolidates the colors for sidebar icons, standardizing on the brighter, higher-contrast background hover color currently used only on vdots. It also corrects some inconsistencies on the icon colors on hover, which are most noticeable--and noticeably inconsistent--in dark mode. In particular, the icon color remains unchanged on channel-folder rows, in contrast to both the Direct Messages heading row and individual channel rows.

[#design > different backgrounds on sidebar hovers](https://chat.zulip.org/#narrow/channel/101-design/topic/different.20backgrounds.20on.20sidebar.20hovers/with/2254816)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Dark mode:_

| Before | After |
| --- | --- |
| <img width="690" height="1110" alt="left-filter-row-dark-hover-before" src="https://github.com/user-attachments/assets/f876d466-a379-4b6b-885e-d1fb7ca29718" /> | <img width="690" height="1110" alt="left-filter-row-dark-hover-after" src="https://github.com/user-attachments/assets/bc9bd295-85ba-4295-a456-f4eb76b6a26a" /> |
| <img width="690" height="1110" alt="left-channel-row-dark-before" src="https://github.com/user-attachments/assets/89188abc-e62e-4fb3-be05-213cdc941af0" /> | <img width="690" height="1110" alt="left-channel-row-dark-after" src="https://github.com/user-attachments/assets/50c7c739-6b0b-44dc-a523-a2d3b4e4b90d" /> |
| <img width="690" height="1110" alt="left-channel-row-dark-hover-before" src="https://github.com/user-attachments/assets/ec4ebfb1-0a68-4359-865e-18d7e12d5e64" /> | <img width="690" height="1110" alt="left-channel-row-dark-hover-after" src="https://github.com/user-attachments/assets/126efefd-2a94-4e71-8ba9-23859f15f017" /> |
| <img width="690" height="1110" alt="left-folder-row-dark-before" src="https://github.com/user-attachments/assets/86552819-9da5-4c19-967b-80b81e6ac540" /> | <img width="690" height="1110" alt="left-folder-row-dark-after" src="https://github.com/user-attachments/assets/a3c8dfa0-79a9-40c8-b064-5c14bf4a7efe" /> |
| <img width="690" height="1110" alt="left-folder-row-dark-hover-before" src="https://github.com/user-attachments/assets/018be968-8883-4154-9a66-97c2618887fe" /> | <img width="690" height="1110" alt="left-folder-row-dark-hover-after" src="https://github.com/user-attachments/assets/6a18ad4b-0ce8-4efe-82e8-4981d9f0c1b0" /> |


_Light mode:_

| Before | After |
| --- | --- |
| <img width="690" height="1110" alt="left-filter-row-light-hover-before" src="https://github.com/user-attachments/assets/ce89bb59-6360-4182-be38-155fbbe3f3bb" /> | <img width="690" height="1110" alt="left-filter-row-light-hover-after" src="https://github.com/user-attachments/assets/3b17214b-a808-47de-86af-148fc24e5e7a" /> |
| <img width="690" height="1110" alt="left-channel-row-light-before" src="https://github.com/user-attachments/assets/06070bee-2067-4bd9-96f1-7bdffc4bf2f6" /> | <img width="690" height="1110" alt="left-channel-row-light-after" src="https://github.com/user-attachments/assets/2696f363-4158-4255-89f0-251cae683dfa" /> |
| <img width="690" height="1110" alt="left-channel-row-light-hover-before" src="https://github.com/user-attachments/assets/5b9f1b71-c924-48f6-9344-0bcdb3ea1c2c" /> | <img width="690" height="1110" alt="left-channel-row-light-hover-after" src="https://github.com/user-attachments/assets/feb19a11-6545-4bcc-9bfb-715e28e4bf06" /> |
| <img width="690" height="1110" alt="left-folder-row-light-before" src="https://github.com/user-attachments/assets/88425b08-f25d-449f-b665-2dc7dac4504d" /> | <img width="690" height="1110" alt="left-folder-row-light-after" src="https://github.com/user-attachments/assets/2b3f5415-631d-4e9a-b7d7-846bc757bb4d" /> |
| <img width="690" height="1110" alt="left-folder-row-light-hover-before" src="https://github.com/user-attachments/assets/70857b47-0126-47f5-b653-1a9bdbf862a0" /> | <img width="690" height="1110" alt="left-folder-row-light-hover-after" src="https://github.com/user-attachments/assets/69a11446-ffad-4553-8490-7399c09ba1be" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>