### PR TITLE
micro optimisations in auth.py

### DIFF
--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -362,22 +362,21 @@ def register_remote_user(request: HttpRequest, result: ExternalAuthResult) -> Ht
     kwargs: dict[str, Any] = dict(result.data_dict)
     # maybe_send_to_registration doesn't take these arguments, so delete them.
 
-    # These are the kwargs taken by maybe_send_to_registration. Remove anything
-    # else from the dict.
-    kwargs_to_pass = [
-        "email",
-        "full_name",
-        "role",
-        "group_memberships_sync_map",
-        "mobile_flow_otp",
-        "desktop_flow_otp",
-        "is_signup",
-        "multiuse_object_key",
-        "full_name_validated",
-        "params_to_store_in_authenticated_session",
-    ]
-    for key in dict(kwargs):
-        if key not in kwargs_to_pass:
+    for key in result.data_dict.keys():
+        if key not in {
+            # These are the kwargs taken by maybe_send_to_registration. Remove anything
+            # else from the dict.
+            "email",
+            "full_name",
+            "role",
+            "group_memberships_sync_map",
+            "mobile_flow_otp",
+            "desktop_flow_otp",
+            "is_signup",
+            "multiuse_object_key",
+            "full_name_validated",
+            "params_to_store_in_authenticated_session",
+        }:
             kwargs.pop(key, None)
 
     return maybe_send_to_registration(request, **kwargs)


### PR DESCRIPTION
do not make another copy of dict, allow python interpreter to make keys constant literal

wip. will fill description later

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.--> 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
