### PR TITLE
left-sidebar: Fix topic filter persistence across channel switches.

### DIFF
--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -57,6 +57,7 @@ export function clear(): void {
     }
 
     active_widgets.clear();
+    topic_filter_pill_widget?.clear(true);
 }
 
 export function close(): void {
@@ -81,6 +82,7 @@ export function zoom_out(): void {
     assert(widget !== undefined);
     const parent_widget = widget.get_parent();
 
+    topic_filter_pill_widget?.clear(true);
     rebuild_left_sidebar(parent_widget, stream_id);
 }
 


### PR DESCRIPTION
Previously, when users applied a topic filter (like "is:unresolved") and then navigated to a different channel and back, the filter would remain active but the filter UI would be hidden, making it impossible to see or clear the active filter without refreshing the page.

This occurred because the topic filter pill widget state persisted globally while the topic list widgets were cleared during channel navigation, creating a disconnect between the active filter state and UI visibility.

Fix this by clearing the topic filter pill widget and search input when clearing topic list widgets during channel navigation, ensuring that topic filters are channel-specific rather than global.

<!-- Describe your pull request here.-->

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/137-feedback/topic/hiding.20resolved.20topics/near/2257860)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
