### PR TITLE
docs: Fix stale links for how to rebase a PR.

### DIFF
--- a/docs/git/overview.md
+++ b/docs/git/overview.md
@@ -57,7 +57,7 @@ Git workflow, or if you'd like a Git refresher.
 
 [github-help-draft-pr]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
 [gitbook-rebase]: https://git-scm.com/book/en/v2/Git-Branching-Rebasing
-[github-rebase-pr]: https://github.com/openedx/edx-platform/wiki/How-to-Rebase-a-Pull-Request
+[github-rebase-pr]: https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request
 [github-zulip]: https://github.com/zulip/
 [github-zulip-zulip]: https://github.com/zulip/zulip/
 [continuous-integration]: ../testing/continuous-integration.md

--- a/docs/git/pull-requests.md
+++ b/docs/git/pull-requests.md
@@ -152,7 +152,7 @@ follow-up comment in which you: a) ask for any clarifications you need, b)
 explain to the reviewer how you solved any problems they mentioned, and c) ask
 for another review.
 
-[edx-howto-rebase-pr]: https://github.com/openedx/edx-platform/wiki/How-to-Rebase-a-Pull-Request
+[edx-howto-rebase-pr]: https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request
 [github-help-about-pr]: https://help.github.com/en/articles/about-pull-requests
 [github-help-create-pr-fork]: https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
 [github-help-draft-pr]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests


### PR DESCRIPTION
@qi-lan32 and I noticed that the link “How to Rebase a Pull Request” from the [Create a pull request doc](https://zulip.readthedocs.io/en/latest/git/pull-requests.html#update-a-pull-request) and the “read this excellent guide” link in the [Quick start](https://zulip.readthedocs.io/en/latest/git/overview.html) guide are currently stale due to the resource being taken down. We would like to suggest changing the links to this [DigitalOcean tutorial on rebasing a PR](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request).
 Pros:

- Covers interactive rebasing:
  - How to squash and reword commits
  - How to update a pull request after rebasing
- Includes recovery guidance using `git reflog`

Cons:

- Lacks visual aids/diagrams that explain Git history

If you would prefer to keep the original tutorial instead, we would be happy to update this PR to use the [archive link of the original resource](https://web.archive.org/web/20240204225038/https://github.com/openedx/edx-platform/wiki/How-to-Rebase-a-Pull-Request).

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.

- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
