### PR TITLE
search: Fix narrow banner for quoted stop words.

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -92,7 +92,9 @@ function empty_search_query_banner(current_filter: Filter): NarrowBannerData {
 
     // Gather information about each query word
     for (const query_word of query_words) {
-        if (realm.stop_words.includes(query_word)) {
+        // Remove all double quotes
+        const cleaned_query_word = query_word.replaceAll(/["']/g, "");
+        if (realm.stop_words.includes(cleaned_query_word)) {
             search_string_result.has_stop_word = true;
             search_string_result.query_words.push({
                 query_word,

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -145,6 +145,8 @@ run_test("empty_narrow_html", ({mock_template}) => {
     const search_data_with_stop_word = {
         has_stop_word: true,
         query_words: [
+            {query_word: '"this"', is_stop_word: true},
+            {query_word: "'is'", is_stop_word: true},
             {query_word: "a", is_stop_word: true},
             {query_word: "search", is_stop_word: false},
         ],
@@ -156,6 +158,8 @@ run_test("empty_narrow_html", ({mock_template}) => {
     <h4 class="empty-feed-notice-title"> This is a title </h4>
         <div class="empty-feed-notice-description">
             Common words were excluded from your search: <br/>
+                <del>&quot;this&quot;</del>
+                <del>&#x27;is&#x27;</del>
                 <del>a</del>
                 <span class="search-query-word">search</span>
         </div>


### PR DESCRIPTION
Previously, searching a stop word within quotes did not trigger the expected warning: "Common words are excluded from your search." This PRcorrects the behavior so that the warning is shown consistently.

Fixes #30470.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Search | Before| After |
|--------|--------|--------|
| Without quoted search | <img width="1117" height="824" alt="image" src="https://github.com/user-attachments/assets/86a4d18d-0b54-4f8d-a4f6-a1e22649af3d" />| <img width="1123" height="822" alt="image" src="https://github.com/user-attachments/assets/ae0f2706-1e81-41d4-a63e-d6ef830e7645" />|
| With quoted search | <img width="1115" height="814" alt="image" src="https://github.com/user-attachments/assets/2a9647af-7ce6-497d-9169-8e3d06a599c3" /> | <img width="1135" height="819" alt="image" src="https://github.com/user-attachments/assets/b08278eb-85f3-46a1-8778-9818db84286c" /> | 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
