### PR TITLE
filter_inputs: Improve filter inputs accessibility.

### DIFF
--- a/web/styles/inputs.css
+++ b/web/styles/inputs.css
@@ -75,7 +75,13 @@
 
             &:empty::before {
                 color: var(--color-text-placeholder);
-                content: attr(data-placeholder);
+                /* We add an `aria-label` attribute to the input element,
+                   since the content property is applicable only when the
+                   input is empty. In order to avoid duplicate announcements
+                   when the input is empty, we also add an empty ("") alt text
+                   to the content property in CSS, which is intended for speech
+                   output by screen-readers. */
+                content: attr(data-placeholder) / "";
             }
         }
 

--- a/web/templates/components/input_wrapper.hbs
+++ b/web/templates/components/input_wrapper.hbs
@@ -5,7 +5,7 @@
     {{> @partial-block .}}
     {{#if input_button_icon}}
         {{#if (eq input_type "filter-input") }}
-            {{> icon_button custom_classes="input-button input-close-filter-button" squared=true icon=input_button_icon intent="neutral" }}
+            {{> icon_button custom_classes="input-button input-close-filter-button" squared=true icon=input_button_icon intent="neutral" aria-label=(t "Clear filter") }}
         {{else}}
             {{> icon_button custom_classes="input-button" squared=true icon=input_button_icon intent="neutral" }}
         {{/if}}

--- a/web/templates/filter_topics.hbs
+++ b/web/templates/filter_topics.hbs
@@ -1,7 +1,7 @@
 <div class="left-sidebar-filter-input-container">
     {{#> input_wrapper input_type="filter-input" custom_classes="topic_search_section filter-topics has-input-pills" icon="search" input_button_icon="close"}}
         <div class="input-element home-page-input pill-container" id="left-sidebar-filter-topic-input">
-            <div class="input" contenteditable="true" id="topic_filter_query" data-placeholder="{{t 'Filter topics' }}"></div>
+            <div class="input" contenteditable="true" id="topic_filter_query" data-placeholder="{{t 'Filter topics' }}" aria-label="{{t 'Filter topics' }}"></div>
         </div>
     {{/input_wrapper}}
 </div>

--- a/web/templates/inbox_view/inbox_view.hbs
+++ b/web/templates/inbox_view/inbox_view.hbs
@@ -7,7 +7,7 @@
     <div class="search_group" id="inbox-filters" role="group">
         {{> ../dropdown_widget widget_name="inbox-filter"}}
         {{#> input_wrapper . input_type="filter-input" custom_classes="inbox-search-wrapper" icon="search" input_button_icon="close"}}
-            <input type="text" id="{{INBOX_SEARCH_ID}}" class="input-element" value="{{search_val}}" autocomplete="off" placeholder="{{t 'Filter' }}" />
+            <input type="text" id="{{INBOX_SEARCH_ID}}" class="input-element" value="{{search_val}}" autocomplete="off" placeholder="{{t 'Filter inbox' }}" />
         {{/input_wrapper}}
     </div>
     <div id="inbox-empty-with-search" class="inbox-empty-text empty-list-message">

--- a/web/templates/recent_view_table.hbs
+++ b/web/templates/recent_view_table.hbs
@@ -3,7 +3,7 @@
         {{> recent_view_filters .}}
     </div>
     {{#> input_wrapper . input_type="filter-input" id="recent-view-search-wrapper" icon="search" input_button_icon="close"}}
-        <input type="text" id="recent_view_search" class="input-element user-list-filter" value="{{ search_val }}" autocomplete="off" placeholder="{{t 'Filter topics' }}" />
+        <input type="text" id="recent_view_search" class="input-element user-list-filter" value="{{ search_val }}" autocomplete="off" placeholder="{{t 'Filter recent conversations' }}" />
     {{/input_wrapper}}
 </div>
 <div class="table_fix_head">


### PR DESCRIPTION
This PR changes the following:
- Commit 1: Updates the placeholder texts for filter inbox and filter recent conversations.
- Commit 2: Adds an aria-label to the clear filter button.
- Commit 3: Improves the accessibility for inputs with pills when they are non-empty.

Fixes: Part 4 of #35135.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

## **Screen reader output:**

### Clear Filter Button

| Screen Reader | Before | After |
|--------|--------|--------|
| Voiceover on MacOS | Button | Clear filter, button |
| NVDA on Windows | Button | Clear filter, button |

### Filter topics

| Screen Reader | Before | After |
|--------|--------|--------|
| Voiceover on MacOS | edit text desktop, Insertion at end of text. | Filter topics, edit text desktop, Insertion at end of text. |
| NVDA on Windows | Section multiline editable, desktop. | Filter topics section multiline editable, desktop. |

#### Filter inbox / Filter recent conversations

| Screen Reader | Before | After |
|--------|--------|--------|
| Voiceover on MacOS | Filter edit text, blank / Filter topics edit text, blank | Filter inbox edit text, blank / Filter recent conversations edit text, blank |
| NVDA on Windows | Filter edit, blank / Filter topics edit, blank | Filter inbox edit, blank / Filter recent conversations edit, blank |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
