### PR TITLE
fix: Fix email generation issue in dev environment.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -3,8 +3,7 @@ import logging
 from collections.abc import Callable, Sequence
 from datetime import datetime
 from functools import wraps
-from io import BytesIO
-from typing import TYPE_CHECKING, Concatenate, TypeVar, cast, overload
+from typing import Concatenate, TypeVar, overload
 from urllib.parse import urlsplit
 
 import django_otp
@@ -14,8 +13,7 @@ from django.contrib.auth import login as django_login
 from django.contrib.auth.decorators import user_passes_test as django_user_passes_test
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.contrib.auth.views import redirect_to_login
-from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, QueryDict
-from django.http.multipartparser import MultiPartParser
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import resolve_url
 from django.template.response import SimpleTemplateResponse, TemplateResponse
 from django.utils.crypto import constant_time_compare
@@ -45,7 +43,7 @@ from zerver.lib.exceptions import (
 )
 from zerver.lib.queue import queue_json_publish_rollback_unsafe
 from zerver.lib.rate_limiter import is_local_addr, rate_limit_request_by_ip, rate_limit_user
-from zerver.lib.request import RequestNotes
+from zerver.lib.request import RequestNotes, populate_post_data
 from zerver.lib.response import json_method_not_allowed
 from zerver.lib.subdomains import get_subdomain, user_matches_subdomain
 from zerver.lib.timestamp import datetime_to_timestamp, timestamp_to_datetime
@@ -59,9 +57,6 @@ from zerver.lib.webhooks.common import (
 from zerver.models import UserProfile
 from zerver.models.clients import get_client
 from zerver.models.users import get_user_profile_by_api_key
-
-if TYPE_CHECKING:
-    from django.http.request import _ImmutableQueryDict
 
 webhook_logger = logging.getLogger("zulip.zerver.webhooks")
 webhook_unsupported_events_logger = logging.getLogger("zulip.zerver.webhooks.unsupported")
@@ -237,8 +232,12 @@ def process_client(
     `user` parameter.
     """
     request_notes = RequestNotes.get_notes(request)
+
     if client_name is None:
         client_name = request_notes.client_name
+
+    elif client_name == "internal":
+        request_notes.client_name = client_name
 
     assert client_name is not None
 
@@ -251,6 +250,7 @@ def process_client(
         client_name = "website"
 
     request_notes.client = get_client(client_name)
+
     if user is not None and user.is_authenticated:
         update_user_activity(request, user, query)
 
@@ -863,27 +863,7 @@ def process_as_post(
         # Django upstream.
 
         if not request.POST:
-            # Only take action if POST is empty.
-            if request.content_type == "multipart/form-data":
-                POST, files = MultiPartParser(
-                    request.META,
-                    BytesIO(request.body),
-                    request.upload_handlers,
-                    request.encoding,
-                ).parse()
-                # request.POST is an immutable QueryDict in most cases, while
-                # MultiPartParser.parse() returns a mutable instance of QueryDict.
-                # This can be fix when https://code.djangoproject.com/ticket/17235
-                # is resolved.
-                # django-stubs makes QueryDict of different mutabilities incompatible
-                # types. There is no way to acknowledge the django-stubs mypy plugin
-                # the change of POST's mutability, so we bypass the check with cast.
-                # See also: https://github.com/typeddjango/django-stubs/pull/925#issue-1206399444
-                POST._mutable = False
-                request.POST = cast("_ImmutableQueryDict", POST)
-                request.FILES.update(files)
-            elif request.content_type == "application/x-www-form-urlencoded":
-                request.POST = QueryDict(request.body, encoding=request.encoding)
+            request = populate_post_data(request)
 
         return view_func(request, *args, **kwargs)
 

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -35,7 +35,7 @@ from zerver.lib.email_validation import (
 from zerver.lib.exceptions import JsonableError, RateLimitedError
 from zerver.lib.i18n import get_language_list
 from zerver.lib.name_restrictions import is_reserved_subdomain
-from zerver.lib.rate_limiter import RateLimitedObject, rate_limit_request_by_ip
+from zerver.lib.rate_limiter import RateLimitedObject, rate_limit_request_by_ip, should_rate_limit
 from zerver.lib.subdomains import get_subdomain, is_root_domain_available
 from zerver.lib.users import check_full_name
 from zerver.models import PreregistrationRealm, Realm, UserProfile
@@ -509,7 +509,7 @@ class ZulipPasswordResetForm(PasswordResetForm):
             logging.info("Realm is deactivated")
             return
 
-        if settings.RATE_LIMITING:
+        if should_rate_limit(request):
             try:
                 rate_limit_password_reset_form_by_email(email)
                 rate_limit_request_by_ip(request, domain="sends_email_by_ip")

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -588,8 +588,10 @@ def client_is_exempt_from_rate_limiting(request: HttpRequest) -> bool:
 
     # Don't rate limit requests from Django that come from our own servers,
     # and don't rate-limit dev instances
-    client = RequestNotes.get_notes(request).client
-    return (client is not None and client.name.lower() == "internal") and (
+    notes = RequestNotes.get_notes(request)
+    # Parse_client in the middleware should write notes.client_name
+    assert notes.client_name is not None
+    return (notes.client_name.lower() == "internal") and (
         is_local_addr(request.META["REMOTE_ADDR"]) or settings.DEBUG_RATE_LIMITING
     )
 
@@ -598,6 +600,7 @@ def rate_limit_user(request: HttpRequest, user: UserProfile, domain: str) -> Non
     """Returns whether or not a user was rate limited. Will raise a RateLimitedError exception
     if the user has been rate limited, otherwise returns and modifies request to contain
     the rate limit information"""
+
     if not should_rate_limit(request):
         return
 

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -1,10 +1,12 @@
 from collections import defaultdict
 from collections.abc import MutableMapping
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from io import BytesIO
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from django.conf import settings
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, QueryDict
+from django.http.multipartparser import MultiPartParser
 from django.utils.translation import gettext as _
 from typing_extensions import override
 
@@ -15,6 +17,9 @@ from zerver.models import Client, Realm
 
 if settings.ZILENCER_ENABLED:
     from zilencer.models import RemoteZulipServer
+
+if TYPE_CHECKING:
+    from django.http.request import _ImmutableQueryDict
 
 
 @dataclass
@@ -98,3 +103,29 @@ class RequestVariableConversionError(JsonableError):
 
 
 arguments_map: dict[str, list[str]] = defaultdict(list)
+
+
+def populate_post_data(request: HttpRequest) -> HttpRequest:
+    # Only take action if POST is empty.
+    if request.content_type == "multipart/form-data":
+        POST, files = MultiPartParser(
+            request.META,
+            BytesIO(request.body),
+            request.upload_handlers,
+            request.encoding,
+        ).parse()
+        # request.POST is an immutable QueryDict in most cases, while
+        # MultiPartParser.parse() returns a mutable instance of QueryDict.
+        # This can be fix when https://code.djangoproject.com/ticket/17235
+        # is resolved.
+        # django-stubs makes QueryDict of different mutabilities incompatible
+        # types. There is no way to acknowledge the django-stubs mypy plugin
+        # the change of POST's mutability, so we bypass the check with cast.
+        # See also: https://github.com/typeddjango/django-stubs/pull/925#issue-1206399444
+        POST._mutable = False
+        request.POST = cast("_ImmutableQueryDict", POST)
+        request.FILES.update(files)
+    elif request.content_type == "application/x-www-form-urlencoded":
+        request.POST = QueryDict(request.body, encoding=request.encoding)
+
+    return request

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -403,7 +403,9 @@ class HostRequestMock(HttpRequest):
         RequestNotes.set_notes(
             self,
             RequestNotes(
-                client_name="",
+                client_name=meta_data["HTTP_USER_AGENT"]
+                if meta_data and "HTTP_USER_AGENT" in meta_data
+                else "",  # Mock parse_client() in middleware.py
                 log_data={},
                 tornado_handler_id=None if tornado_handler is None else tornado_handler.handler_id,
                 client=get_client(client_name) if client_name is not None else None,

--- a/zerver/lib/typed_endpoint.py
+++ b/zerver/lib/typed_endpoint.py
@@ -28,6 +28,7 @@ from zerver.lib.request import (
     RequestNotes,
     RequestVariableMissingError,
     arguments_map,
+    populate_post_data,
 )
 from zerver.lib.response import MutableJsonResponse
 
@@ -449,7 +450,9 @@ def typed_endpoint(
     expect_no_parameters: bool = False,
 ) -> Callable[Concatenate[HttpRequest, ParamT], ReturnT]:
     # Extract all the type information from the view function.
+
     endpoint_info = parse_view_func_signature(view_func)
+
     if expect_no_parameters:
         assert len(endpoint_info.parameters) == 0, UNEXPECTED_KEYWORD_ONLY_PARAMETERS.format(
             view_func_name=endpoint_info.view_func_full_name
@@ -492,6 +495,9 @@ def typed_endpoint(
             if parameter.param_name in kwargs:
                 # Skip parameters that are already supplied by the caller.
                 continue
+
+            if request.method in ["DELETE", "PATCH", "PUT"] and not request.POST:
+                request = populate_post_data(request)
 
             # Extract the value to parse from the request body if specified.
             if parameter.argument_type_is_body:

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -499,7 +499,7 @@ class RateLimitTestCase(ZulipTestCase):
         expect_rate_limit: bool,
         check_web_view: bool = False,
     ) -> None:
-        META = {"REMOTE_ADDR": remote_addr, "PATH_INFO": "test"}
+        META = {"REMOTE_ADDR": remote_addr, "PATH_INFO": "test", "HTTP_USER_AGENT": client_name}
 
         request = HostRequestMock(host="zulip.testserver", client_name=client_name, meta_data=META)
         view_func = self.ratelimited_web_view if check_web_view else self.ratelimited_json_view
@@ -1603,11 +1603,13 @@ class TestRequestNotes(ZulipTestCase):
 
 class ClientTestCase(ZulipTestCase):
     def test_process_client(self) -> None:
-        def request_user_agent(user_agent: str) -> tuple[Client, str]:
+        def request_user_agent(
+            user_agent: str, client_name: str | None = None
+        ) -> tuple[Client, str]:
             request = HttpRequest()
             request.META["HTTP_USER_AGENT"] = user_agent
             LogRequests(lambda request: HttpResponse()).process_request(request)
-            process_client(request)
+            process_client(request, client_name=client_name)
             notes = RequestNotes.get_notes(request)
             assert notes.client is not None
             assert notes.client_name is not None
@@ -1669,3 +1671,9 @@ class ClientTestCase(ZulipTestCase):
         # client_name has the full name still, though
         self.assertEqual(client_name, "very-long-name-goes-here-and-still-works")
         self.assert_length(queries, 0)
+
+        with queries_captured(keep_cache_warm=False) as queries:
+            client, internal_client = request_user_agent("ZulipThingy/2.0.0", "internal")
+        self.assertEqual(client.name, "internal")
+        self.assertEqual(internal_client, "internal")
+        self.assert_length(queries, 2)

--- a/zerver/views/development/email_log.py
+++ b/zerver/views/development/email_log.py
@@ -71,34 +71,51 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
     # Password reset emails
     # active account in realm
     result = client.post(
-        "/accounts/password/reset/", {"email": registered_email}, HTTP_HOST=realm.host
+        "/accounts/password/reset/",
+        {"email": registered_email, "client": "internal"},
+        HTTP_HOST=realm.host,
     )
+
     assert result.status_code == 302
     # deactivated user
     change_user_is_active(user, False)
     result = client.post(
-        "/accounts/password/reset/", {"email": registered_email}, HTTP_HOST=realm.host
+        "/accounts/password/reset/",
+        {"email": registered_email, "client": "internal"},
+        HTTP_HOST=realm.host,
     )
+
     assert result.status_code == 302
     change_user_is_active(user, True)
     # account on different realm
     assert other_realm is not None
     result = client.post(
-        "/accounts/password/reset/", {"email": registered_email}, HTTP_HOST=other_realm.host
+        "/accounts/password/reset/",
+        {"email": registered_email, "client": "internal"},
+        HTTP_HOST=other_realm.host,
     )
     assert result.status_code == 302
     # no account anywhere
     result = client.post(
-        "/accounts/password/reset/", {"email": unregistered_email_1}, HTTP_HOST=realm.host
+        "/accounts/password/reset/",
+        {"email": unregistered_email_1, "client": "internal"},
+        HTTP_HOST=realm.host,
     )
     assert result.status_code == 302
 
     # Confirm account email
-    result = client.post("/accounts/home/", {"email": unregistered_email_1}, HTTP_HOST=realm.host)
+    result = client.post(
+        "/accounts/home/",
+        {"email": unregistered_email_1, "client": "internal"},
+        HTTP_HOST=realm.host,
+    )
+
     assert result.status_code == 302
 
     # Find account email
-    result = client.post("/accounts/find/", {"emails": registered_email}, HTTP_HOST=realm.host)
+    result = client.post(
+        "/accounts/find/", {"emails": registered_email, "client": "internal"}, HTTP_HOST=realm.host
+    )
     assert result.status_code == 200
 
     # New login email
@@ -113,6 +130,7 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
             "invitee_emails": unregistered_email_2,
             "invite_expires_in_minutes": invite_expires_in_minutes,
             "stream_ids": orjson.dumps([stream.id]).decode(),
+            "client": "internal",
         },
         HTTP_HOST=realm.host,
     )
@@ -121,7 +139,7 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
     # Verification for new email
     result = client.patch(
         "/json/settings",
-        urlencode({"email": "hamlets-new@zulip.com"}),
+        urlencode({"email": "hamlets-new@zulip.com", "client": "internal"}),
         content_type="application/x-www-form-urlencoded",
         HTTP_HOST=realm.host,
     )
@@ -130,7 +148,7 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
     # Email change successful
     key = Confirmation.objects.filter(type=Confirmation.EMAIL_CHANGE).latest("id").confirmation_key
     user_profile = get_user_by_delivery_email(registered_email, realm)
-    result = client.post("/accounts/confirm_new_email/", {"key": key})
+    result = client.post("/accounts/confirm_new_email/", {"key": key, "client": "internal"})
     assert result.status_code == 200
 
     # Reset the email value so we can run this again

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -43,7 +43,7 @@ from zerver.lib.email_validation import (
 )
 from zerver.lib.exceptions import JsonableError, RateLimitedError, UserDeactivatedError
 from zerver.lib.i18n import get_available_language_codes
-from zerver.lib.rate_limiter import RateLimitedUser
+from zerver.lib.rate_limiter import RateLimitedUser, should_rate_limit
 from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress, send_email
 from zerver.lib.sounds import get_available_notification_sounds
@@ -414,11 +414,12 @@ def json_change_settings(
         if user_profile.delivery_email != new_email:
             validate_email_change_request(user_profile, new_email)
 
-            ratelimited, time_until_free = RateLimitedUser(
-                user_profile, domain="email_change_by_user"
-            ).rate_limit()
-            if ratelimited:
-                raise RateLimitedError(time_until_free)
+            if should_rate_limit(request):
+                ratelimited, time_until_free = RateLimitedUser(
+                    user_profile, domain="email_change_by_user"
+                ).rate_limit()
+                if ratelimited:
+                    raise RateLimitedError(time_until_free)
 
             do_start_email_change_process(user_profile, new_email)
 

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -52,7 +52,10 @@ from zerver.lib.exceptions import (
     OrganizationOwnerRequiredError,
 )
 from zerver.lib.integrations import EMBEDDED_BOTS
-from zerver.lib.rate_limiter import rate_limit_spectator_attachment_access_by_file
+from zerver.lib.rate_limiter import (
+    rate_limit_spectator_attachment_access_by_file,
+    should_rate_limit,
+)
 from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress, send_email
 from zerver.lib.streams import access_stream_by_id, access_stream_by_name, subscribed_to_stream
@@ -353,7 +356,7 @@ def avatar_by_id(
         if not realm.allow_web_public_streams_access():
             raise MissingAuthenticationError
 
-        if settings.RATE_LIMITING:
+        if should_rate_limit(request):
             unique_avatar_key = f"{realm.id}/{user_id}/{medium}"
             rate_limit_spectator_attachment_access_by_file(unique_avatar_key)
     else:


### PR DESCRIPTION

Manually generating emails in the development environment fails due to rate limiting thresholds being applied to internal requests. The development environment should not rate limit internal operations.

**Fixes issue:#27336**

**Problem**:
The rate limiting exemption logic had three issues:

- The exemption check in `client_is_exempt_from_rate_limiting()`  relied on `RequestNotes.client`, which is populated by the `process_client` decorator. In `public_json_view` decorator rate limiting occurs before `process_client` decorator, internal requests were incorrectly rate limited.

- The `process_client` decorator overwrites the `client.name` parameter when "internal" is present in the request, replacing it with "website" when `is_browser_view`, which breaks exemption detection.

- The `parse_client()` couldn't correctly parse PATCH requests because the `process_as_post` decorator only runs after views, not during middleware execution.

**PR implementation**
1. Rate Limiter Logic Update (`zerver/lib/rate_limiter.py`)

Modified `client_is_exempt_from_rate_limiting()` to use `RequestNotes.client_name` instead of `RequestNotes.client ` object.
`RequestNotes.client_name` is populated earlier in the middleware pipeline by `parse_client()`.

2. Decorator Updates (`zerver/decorator.py`)

Updated `process_client()` to set `RequestNotes.client_name` to "internal" when the `client_name` input  is internal.
This allows `RequestNotes.client.name` to maintain "website" for browser views while preserving rate limit exemption.

3. Form and View Updates

Updated `forms.py`, `user_settings.py`, and `users.py` to properly check for rate limit exemptions using `should_rate_limit()`.

4. Request Parsing Improvements (`request.py`)

Extracted the logic from process_as_post decorator into a reusable helper function.
Applied this logic in the `type_endpoint` decorator used by `parse_client()` to properly handle PATCH requests during middleware execution

5. Test Updates (`test_decorator.py`)

Updated tests indicating the client name as either "HTTP_USER_AGENT" or "client"  request parameter (matching the parsing logic in `parse_client()`)
Fixed `HostRequestMock` class  in `test_helpers.py` to properly simulate the middleware pipeline, as previous mocks only covered the `process_client()` function but not the `parse_client()` function.

**Background**
In the previous PR (https://github.com/zulip/zulip/pull/24231), the `client_is_exempt_from_rate_limiting()` function relied on the `RequestNotes.client` object as a fallback. This pull request refactors the logic to use only `RequestNotes.client_name`, ensuring that internal client status is properly preserved in the `client_name` variable.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ x] Explains differences from previous plans (e.g., issue description).
- [ x] Highlights technical choices and bugs encountered.
- [x ] Calls out remaining decisions and concerns.
- [x ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ x] Each commit is a coherent idea.
- [ x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ x] End-to-end functionality of buttons, interactions and flows.
- [ ]x Corner cases, error conditions, and easily imagined bugs.
</details>
