### PR TITLE
openapi: Improve description for `default_group_name` field.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 427**
+
+* [`POST /register`](/api/register-queue): `stream_creator_or_nobody`
+  value for `default_group_name` field in `server_supported_permission_settings`
+  object is renamed to `channel_creator`.
+
 **Feature level 426**
 
 * [`POST /register`](/api/register-queue): Removed the

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 426
+API_FEATURE_LEVEL = 427
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1829,7 +1829,7 @@ export function create_stream_group_setting_widget({
             setting_name,
             "stream",
         )!.default_group_name;
-        if (default_group_name === "stream_creator_or_nobody") {
+        if (default_group_name === "channel_creator") {
             set_group_setting_widget_value(pill_widget, {
                 direct_members: [current_user.user_id],
                 direct_subgroups: [],

--- a/web/tests/lib/example_settings.cjs
+++ b/web/tests/lib/example_settings.cjs
@@ -15,7 +15,7 @@ exports.server_supported_permission_settings = {
             allow_internet_group: false,
             allow_nobody_group: true,
             allow_everyone_group: false,
-            default_group_name: "stream_creator_or_nobody",
+            default_group_name: "channel_creator",
             allowed_system_groups: [],
         },
         can_remove_subscribers_group: {

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -234,7 +234,7 @@ def get_stream_permission_default_group(
     creator: UserProfile | None = None,
 ) -> UserGroup:
     setting_default_name = Stream.stream_permission_group_settings[setting_name].default_group_name
-    if setting_default_name == "stream_creator_or_nobody":
+    if setting_default_name == "channel_creator":
         if creator:
             default_group = UserGroup(
                 realm=creator.realm,

--- a/zerver/models/streams.py
+++ b/zerver/models/streams.py
@@ -171,7 +171,7 @@ class Stream(models.Model):
         "can_administer_channel_group": GroupPermissionSetting(
             allow_nobody_group=True,
             allow_everyone_group=False,
-            default_group_name="stream_creator_or_nobody",
+            default_group_name="channel_creator",
         ),
         "can_delete_any_message_group": GroupPermissionSetting(
             allow_nobody_group=True,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -27977,7 +27977,7 @@ components:
           description: |
             Name of the default system group for the setting.
 
-            For some channel settings, this can also be `stream_creator_or_nobody`.
+            For some channel settings, this can also be `channel_creator`.
             In that case:
 
             - If the channel's [`creator_id`][channel-response] is not `null`, default for the
@@ -27985,6 +27985,9 @@ components:
               the only member.
             - If the channel's [`creator_id`][channel-response] is `null`, default for the setting
               is `role:nobody` system group.
+
+            **Changes**: In Zulip 12.0 (feature level 427), renamed
+            `stream_creator_or_nobody` value to `channel_creator`.
 
             [channel-response]: /api/get-stream-by-id#response
         default_for_system_groups:

--- a/zerver/tests/test_channel_creation.py
+++ b/zerver/tests/test_channel_creation.py
@@ -706,7 +706,7 @@ class TestCreateStreams(ZulipTestCase):
         result = self.subscribe_via_post(user, subscriptions, subdomain="zulip")
         self.assert_json_success(result)
         stream = get_stream("new_stream", realm)
-        if permission_config.default_group_name == "stream_creator_or_nobody":
+        if permission_config.default_group_name == "channel_creator":
             self.assertEqual(list(getattr(stream, setting_name).direct_members.all()), [user])
             self.assertEqual(
                 list(getattr(stream, setting_name).direct_subgroups.all()),

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -694,7 +694,7 @@ def access_requested_group_permissions(
             group_settings_map[setting_name] = get_stream_permission_default_group(
                 setting_name, system_groups_name_dict, creator=user_profile
             )
-            if permission_configuration.default_group_name == "stream_creator_or_nobody":
+            if permission_configuration.default_group_name == "channel_creator":
                 # Default for some settings like "can_administer_channel_group"
                 # is anonymous group with stream creator.
                 anonymous_group_membership[group_settings_map[setting_name].id] = (


### PR DESCRIPTION
- First commit is to improve channel's `creator_id` description.
- Second commit is to explain about `stream_creator_or_nobody` value for `default_group_name`
field in `server_supported_permission_settings` object.
- Third commit is to rename `stream_creator_or_nobody` to ` channel_creator`.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->https://chat.zulip.org/#narrow/channel/378-api-design/topic/stream_creator_or_nobody/with/2259946

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="708" height="168" alt="image" src="https://github.com/user-attachments/assets/60327607-d7b6-4e40-88eb-52b9f7df3e89" />

<img width="638" height="262" alt="image" src="https://github.com/user-attachments/assets/edc9b3fb-44dd-4b03-b08d-ab55c41efb39" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
