### PR TITLE
portico: Adjust logo padding to prevent clipping.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -270,7 +270,8 @@ p.n-margin {
 .top-messages-logo {
     /* Since padding under message header is not transparent
        we need to position it below the padding. */
-    padding-top: var(--header-padding-bottom);
+    padding-top: 7px;
+    padding-left: 1px;
 }
 
 /* See https://web.dev/animations-guide/#triggers before adding any funny animation properties here. */


### PR DESCRIPTION
<!-- Describe your pull request here.-->

portico: Adjust logo padding to prevent visual clipping.

The Zulip logo was experiencing visual clipping on certain screen
sizes. This commit adjusts the top and left padding values (7px and
1px respectively) to ensure the logo displays properly without any
clipped edges.

Fixes: #36039

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Before:
<img width="571" height="376" alt="image" src="https://github.com/user-attachments/assets/f0310e6b-fadf-4fe9-b57c-ef3033980e49" />

After:
<img width="587" height="359" alt="image" src="https://github.com/user-attachments/assets/81ea8d20-f1ac-498a-b539-1dacfaed46de" />


Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
