### PR TITLE
search: Align suggestion left padding with search bar icon space.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -198,6 +198,12 @@
     --search-pill-label-min-width: 2.5em; /* 35px at 14px/em */
 
     /*
+    This is the space for the searchbar's search icon, and the left padding
+    for the search suggestions so they match up with searchbar content.
+    */
+    --search-left-padding: 35px;
+
+    /*
     Since #navbar_alerts_wrapper can take variable height depending upon
     window width / language, we sync its height in navbar_alerts.js
     */

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -224,7 +224,7 @@
         border: none;
         grid-template:
             "search-icon search-pills search-close" var(--search-box-height)
-            ". search-pills ." auto / auto minmax(0, 1fr)
+            ". search-pills ." auto / var(--search-left-padding) minmax(0, 1fr)
             1.75em; /* 28px at 16px em */
         align-content: center;
         cursor: pointer;
@@ -232,8 +232,7 @@
         /* Override styles for .pill-container that aren't relevant for search. */
         &.pill-container {
             background: inherit;
-            /* Maintain only a column gap. */
-            gap: 0 0.3125em; /* 5px at 16px em */
+            gap: 0;
             /* Override padding. */
             padding: 0;
         }
@@ -382,7 +381,7 @@
     }
 
     .typeahead-menu .simplebar-content > li > a {
-        padding: 3px 40px;
+        padding: 3px var(--search-left-padding);
         /* Override white-space: nowrap from zulip.css */
         white-space: normal;
 


### PR DESCRIPTION
before:

<img width="499" height="301" alt="image" src="https://github.com/user-attachments/assets/35e9650b-f6b5-4afe-8921-92ab081498ea" />


after:

<img width="507" height="309" alt="image" src="https://github.com/user-attachments/assets/af28e5eb-0457-44b4-b263-af48c824ddf6" />


Reported on CZO: [#issues > search pills misaligned @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/search.20pills.20misaligned/near/2253402)