### PR TITLE
navbar_alerts: Add upload file storage space warning banner.

### DIFF
--- a/api_docs/unmerged.d/ZF-80f780.md
+++ b/api_docs/unmerged.d/ZF-80f780.md
@@ -1,0 +1,3 @@
+* [`POST /register`](/api/register-queue): Added `realm_upload_quota_used_bytes`
+  field to the response, which contains the total number of bytes currently
+  used for uploaded files in an organization.

--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -67,6 +67,22 @@ export function percentage_used_space(uploads_size: number): string | null {
     return ((100 * uploads_size) / mib_to_bytes(realm.realm_upload_quota_mib)).toFixed(1);
 }
 
+export function get_realm_used_upload_quota_percentage(): number | null {
+    if (realm.realm_upload_quota_mib === null) {
+        return null;
+    }
+
+    return (100 * realm.realm_upload_quota_used_bytes) / mib_to_bytes(realm.realm_upload_quota_mib);
+}
+
+export function get_realm_upload_quota_size(): string | null {
+    if (realm.realm_upload_quota_mib === null) {
+        return null;
+    }
+
+    return bytes_to_size(mib_to_bytes(realm.realm_upload_quota_mib), true);
+}
+
 function set_upload_space_stats(): void {
     if (realm.realm_upload_quota_mib === null) {
         return;

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -4,6 +4,7 @@ import assert from "minimalistic-assert";
 
 import render_navbar_banners_testing_popover from "../templates/popovers/navbar_banners_testing_popover.hbs";
 
+import * as attachments_ui from "./attachments_ui.ts";
 import * as banners from "./banners.ts";
 import type {AlertBanner} from "./banners.ts";
 import {is_browser_unsupported_old_version} from "./browser_support.ts";
@@ -20,6 +21,7 @@ import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as popover_menus from "./popover_menus.ts";
 import {recent_view_messages_data} from "./recent_view_messages_data.ts";
+import * as settings_config from "./settings_config.ts";
 import {current_user, realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as timerender from "./timerender.ts";
@@ -128,6 +130,12 @@ export function set_last_upgrade_nag_dismissal_time(ls: LocalStorage): void {
     }
 }
 
+export function set_upload_quota_limit_banner_dismissal_time(ls: LocalStorage): void {
+    if (localstorage.supported()) {
+        ls.set("upload_quota_limit_banner_dismissal_time", Date.now());
+    }
+}
+
 export function should_show_organization_profile_incomplete_banner(timestamp: number): boolean {
     if (!current_user.is_admin) {
         return false;
@@ -171,6 +179,48 @@ export function toggle_organization_profile_incomplete_banner(): void {
         // this is meant to be a one-time task for administrators.
         open_navbar_banner_and_resize(ORGANIZATION_PROFILE_INCOMPLETE_BANNER);
     }
+}
+
+export function should_show_upload_quota_limit_banner(ls: LocalStorage): boolean {
+    if (page_params.is_spectator) {
+        return false;
+    }
+
+    const used_upload_quota_percentage = attachments_ui.get_realm_used_upload_quota_percentage();
+    if (used_upload_quota_percentage === null) {
+        // get_realm_used_upload_quota_percentage returns null
+        // when there is no limit set for the upload quota, and
+        // thus there is no need to show the banner in that case.
+        return false;
+    }
+
+    // We show the banner when the used upload quota percentage
+    // exceeds 90% for admins, and 95% for non-admins, to give
+    // admins a head start to take the required action without
+    // nudging the non-admins with the warning banner.
+    const threshold = current_user.is_admin ? 90 : 95;
+    if (used_upload_quota_percentage < threshold) {
+        return false;
+    }
+
+    if (
+        !localstorage.supported() ||
+        ls.get("upload_quota_limit_banner_dismissal_time") === undefined
+    ) {
+        return true;
+    }
+
+    const upload_quota_limit_banner_dismissal_time = ls.get(
+        "upload_quota_limit_banner_dismissal_time",
+    );
+    assert(typeof upload_quota_limit_banner_dismissal_time === "number");
+    const upload_quota_banner_min_date = addDays(
+        new Date(upload_quota_limit_banner_dismissal_time),
+        7,
+    ).getTime();
+    // Show the banner only if it has been more than
+    // a week since the user last dismissed the banner.
+    return Date.now() > upload_quota_banner_min_date;
 }
 
 export function should_offer_to_update_timezone(): boolean {
@@ -522,6 +572,59 @@ export function check_and_show_muted_messages_banner(): void {
     }
 }
 
+const upload_file_quota_warning_banner = (): AlertBanner => {
+    const used_upload_quota_percentage = Math.floor(
+        attachments_ui.get_realm_used_upload_quota_percentage()!,
+    );
+    const upload_quota_size = attachments_ui.get_realm_upload_quota_size();
+
+    let label = $t(
+        {
+            defaultMessage:
+                "Your organization is using {used_upload_quota_percentage}% of the {upload_quota_size} file storage quota.",
+        },
+        {
+            used_upload_quota_percentage,
+            upload_quota_size,
+        },
+    );
+    let buttons: ActionButton[] = [];
+    if (realm.realm_plan_type === settings_config.realm_plan_types.limited.code) {
+        // Show the "Upgrade for more storage" text for Zulip Cloud Free users.
+        label = $t(
+            {
+                defaultMessage:
+                    "Your organization is using {used_upload_quota_percentage}% of the {upload_quota_size} file storage quota. Upgrade for more storage.",
+            },
+            {
+                used_upload_quota_percentage,
+                upload_quota_size,
+            },
+        );
+    }
+    if (
+        current_user.is_admin &&
+        realm.realm_plan_type === settings_config.realm_plan_types.limited.code
+    ) {
+        // Show the "Upgrade" button for admins in Zulip Cloud Free organizations.
+        buttons = [
+            {
+                variant: "subtle",
+                label: $t({defaultMessage: "Upgrade"}),
+                custom_classes: "upgrade-upload-quota",
+            },
+        ];
+    }
+    return {
+        process: "upload-quota-warning",
+        intent: "warning",
+        label,
+        buttons,
+        close_button: true,
+        custom_classes: "navbar-alert-banner upgrade-quota-banner",
+    };
+};
+
 export function initialize(): void {
     const ls = localstorage();
     const browser_time_zone = timerender.browser_time_zone();
@@ -550,6 +653,8 @@ export function initialize(): void {
         should_show_organization_profile_incomplete_banner(realm.realm_date_created)
     ) {
         open_navbar_banner_and_resize(ORGANIZATION_PROFILE_INCOMPLETE_BANNER);
+    } else if (should_show_upload_quota_limit_banner(ls)) {
+        open_navbar_banner_and_resize(upload_file_quota_warning_banner());
     } else {
         maybe_toggle_empty_required_profile_fields_banner();
     }
@@ -683,6 +788,20 @@ export function initialize(): void {
             set_last_upgrade_nag_dismissal_time(ls);
         },
     );
+
+    $("#navbar_alerts_wrapper").on(
+        "click",
+        ".upgrade-quota-banner .banner-close-button",
+        function (this: HTMLElement) {
+            const $banner = $(this).closest(".banner");
+            close_navbar_banner_and_resize($banner);
+            set_upload_quota_limit_banner_dismissal_time(ls);
+        },
+    );
+
+    $("#navbar_alerts_wrapper").on("click", ".upgrade-upload-quota", () => {
+        window.open("/upgrade", "_blank", "noopener,noreferrer");
+    });
 
     $("#navbar_alerts_wrapper").on(
         "click",

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -118,6 +118,7 @@ export function dispatch_normal_event(event) {
 
         case "attachment":
             attachments_ui.update_attachments(event);
+            realm.realm_upload_quota_used_bytes = event.upload_space_used;
             break;
 
         case "channel_folder":

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -584,6 +584,7 @@ export const realm_schema = z.object({
     realm_signup_announcements_stream_id: z.number(),
     realm_topics_policy: z.enum(["allow_empty_topic", "disable_empty_topic"]),
     realm_upload_quota_mib: z.nullable(z.number()),
+    realm_upload_quota_used_bytes: z.number(),
     realm_url: z.string(),
     realm_video_chat_provider: z.number(),
     realm_waiting_period_threshold: z.number(),

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -288,9 +288,11 @@ run_test("attachments", ({override}) => {
     const stub = make_stub();
     // attachments_ui is hard to test deeply
     override(attachments_ui, "update_attachments", stub.f);
+    override(realm, "realm_upload_quota_used_bytes", 0);
     dispatch(event);
     assert.equal(stub.num_calls, 1);
     assert_same(stub.get_args("event").event, event);
+    assert_same(realm.realm_upload_quota_used_bytes, event.upload_space_used);
 });
 
 run_test("user groups", ({override}) => {

--- a/web/tests/lib/example_realm.cjs
+++ b/web/tests/lib/example_realm.cjs
@@ -122,6 +122,7 @@ exports.make_realm = (opts = {}) => {
         realm_signup_announcements_stream_id: 0,
         realm_topics_policy: "allow_empty_topic",
         realm_upload_quota_mib: null,
+        realm_upload_quota_used_bytes: 0,
         realm_url: "",
         realm_video_chat_provider: 0,
         realm_waiting_period_threshold: 0,

--- a/web/tests/navbar_alerts.test.cjs
+++ b/web/tests/navbar_alerts.test.cjs
@@ -153,3 +153,60 @@ test("should_show_server_upgrade_banner", ({override}) => {
     override(Date, "now", () => addDays(start_time, 8).getTime()); // Thursday 1/9/2024 10:00:00 AM (UTC+0)
     assert.equal(navbar_alerts.should_show_server_upgrade_banner(ls), true);
 });
+
+test("should_show_upload_quota_limit_banner", ({override}) => {
+    const ls = localstorage();
+
+    // Show upload quota limit banner when following conditions are suitable:
+    // - The user is not a spectator.
+    // - The upload quota limit is defined for the realm.
+    // - For admins, the used upload quota percentage is >= 90%.
+    // - For non-admins, the used upload quota percentage is >= 95%.
+    // - The user has not dismissed the banner in the last 7 days.
+    override(page_params, "is_spectator", false);
+    override(realm, "realm_upload_quota_mib", 5120); // 5 GiB
+    override(current_user, "is_admin", true);
+    override(realm, "realm_upload_quota_used_bytes", 1024 * 1024 * 4608); // 4.5 GiB (90% of 5 GiB)
+    assert.equal(navbar_alerts.should_show_upload_quota_limit_banner(ls), true);
+
+    // Don't show banner if user is a spectator.
+    override(page_params, "is_spectator", true);
+    assert.equal(navbar_alerts.should_show_upload_quota_limit_banner(ls), false);
+    override(page_params, "is_spectator", false);
+
+    // Don't show banner if upload quota limit is not defined for the realm.
+    override(realm, "realm_upload_quota_mib", null);
+    assert.equal(navbar_alerts.should_show_upload_quota_limit_banner(ls), false);
+    override(realm, "realm_upload_quota_mib", 5120); // 5 GiB
+
+    // For admins, show the banner if the used upload quota percentage is >= 90%.
+    override(current_user, "is_admin", true);
+    override(realm, "realm_upload_quota_used_bytes", 1024 * 1024 * 4352); // 4.25 GiB (85% of 5 GiB)
+    assert.equal(navbar_alerts.should_show_upload_quota_limit_banner(ls), false);
+    override(realm, "realm_upload_quota_used_bytes", 1024 * 1024 * 4608); // 4.5 GiB (90% of 5 GiB)
+    assert.equal(navbar_alerts.should_show_upload_quota_limit_banner(ls), true);
+
+    // For non-admins, show the banner if the used upload quota percentage is >= 95%.
+    override(current_user, "is_admin", false);
+    override(realm, "realm_upload_quota_used_bytes", 1024 * 1024 * 4608); // 4.5 GiB (90% of 5 GiB)
+    assert.equal(navbar_alerts.should_show_upload_quota_limit_banner(ls), false);
+    override(realm, "realm_upload_quota_used_bytes", 1024 * 1024 * 4864); // 4.75 GiB (95% of 5 GiB)
+    assert.equal(navbar_alerts.should_show_upload_quota_limit_banner(ls), true);
+
+    // Set the initial date, which will be stored in localstorage as upload_quota_limit_banner_dismissal_time.
+    const start_time = new Date("2024-01-01T10:00:00.000Z"); // Wednesday 1/1/2024 10:00:00 AM (UTC+0)
+    override(Date, "now", () => start_time.getTime());
+    ls.set("upload_quota_limit_banner_dismissal_time", undefined);
+    assert.equal(navbar_alerts.should_show_upload_quota_limit_banner(ls), true);
+    navbar_alerts.set_upload_quota_limit_banner_dismissal_time(ls);
+
+    // Don't show the banner if the date is within 7 days (one week) of the dismissal time,
+    // even if the used upload quota percentage is above the threshold.
+    override(Date, "now", () => addDays(start_time, 7).getTime()); // Wednesday 1/8/2024 10:00:00 AM (UTC+0)
+    assert.equal(navbar_alerts.should_show_upload_quota_limit_banner(ls), false);
+
+    // Show the banner if the date is more than 7 days (one week) from the dismissal time
+    // and the used upload quota percentage is above the threshold.
+    override(Date, "now", () => addDays(start_time, 8).getTime()); // Thursday 1/9/2024 10:00:00 AM (UTC+0)
+    assert.equal(navbar_alerts.should_show_upload_quota_limit_banner(ls), true);
+});

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -275,6 +275,9 @@ def fetch_initial_state_data(
     if want("alert_words"):
         state["alert_words"] = [] if user_profile is None else user_alert_words(user_profile)
 
+    if want("attachment"):
+        state["realm_upload_quota_used_bytes"] = realm.currently_used_upload_space_bytes()
+
     if want("custom_profile_fields"):
         if user_profile is None:
             # Spectators can't access full user profiles or
@@ -1808,9 +1811,10 @@ def apply_event(
         # Typing message edit notification events are transient and thus ignored
         pass
     elif event["type"] == "attachment":
-        # Attachment events are just for updating the "uploads" UI;
-        # they are not sent directly.
-        pass
+        # Attachment events are primarily for updating the "uploads" UI;
+        # they are not sent directly, but we track upload quota usage.
+        if "realm_upload_quota_used_bytes" in state:
+            state["realm_upload_quota_used_bytes"] = event["upload_space_used"]
     elif event["type"] == "update_message_flags":
         # We don't return messages in `/register`, so most flags we
         # can ignore, but we do need to update the unread_msgs data if

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -20760,6 +20760,18 @@ paths:
 
                           New in Zulip 5.0 (feature level 72). Previously,
                           this was called `realm_upload_quota`.
+                      realm_upload_quota_used_bytes:
+                        type: integer
+                        description: |
+                          Present if `attachment` is present in `fetch_event_types`.
+
+                          The total number of bytes currently used for uploaded files in
+                          an organization.
+
+                          Clients can use this in combination with `realm_upload_quota_mib`
+                          to display usage information to users.
+
+                          **Changes**: New in Zulip 12.0 (feature level ZF-80f780).
                       realm_org_type:
                         type: integer
                         description: |

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -226,7 +226,7 @@ class EventsEndpointTest(ZulipTestCase):
                 status_code=401,
             )
 
-        with self.assert_database_query_count(15):
+        with self.assert_database_query_count(17):
             result = self.client_post("/json/register")
             result_dict = self.assert_json_success(result)
             self.assertEqual(result_dict["queue_id"], None)
@@ -1280,13 +1280,14 @@ class FetchQueriesTest(ZulipTestCase):
         self.login_user(user)
 
         with (
-            self.assert_database_query_count(49),
+            self.assert_database_query_count(51),
             mock.patch("zerver.lib.events.always_want") as want_mock,
         ):
             fetch_initial_state_data(user, realm=user.realm)
 
         expected_counts = dict(
             alert_words=1,
+            attachment=2,
             channel_folders=1,
             custom_profile_fields=1,
             default_streams=1,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -4197,7 +4197,7 @@ class NormalActionsTest(BaseAction):
             base = "/user_uploads/"
             self.assertEqual(base, url[: len(base)])
 
-        with self.verify_action(num_events=1, state_change_expected=False) as events:
+        with self.verify_action(num_events=1, state_change_expected=True) as events:
             do_upload()
 
         check_attachment_add("events[0]", events[0])
@@ -4224,7 +4224,7 @@ class NormalActionsTest(BaseAction):
         self.assertEqual(events[0]["upload_space_used"], 6)
 
         # Now remove the attachment
-        with self.verify_action(num_events=1, state_change_expected=False) as events:
+        with self.verify_action(num_events=1, state_change_expected=True) as events:
             self.client_delete(f"/json/attachments/{entry.id}")
 
         check_attachment_remove("events[0]", events[0])

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -226,6 +226,7 @@ class HomeTest(ZulipTestCase):
         "realm_signup_announcements_stream_id",
         "realm_topics_policy",
         "realm_upload_quota_mib",
+        "realm_upload_quota_used_bytes",
         "realm_uri",
         "realm_url",
         "realm_user_groups",
@@ -304,7 +305,7 @@ class HomeTest(ZulipTestCase):
 
         # Verify succeeds once logged-in
         with (
-            self.assert_database_query_count(59),
+            self.assert_database_query_count(61),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page(stream="Denmark")
@@ -313,7 +314,7 @@ class HomeTest(ZulipTestCase):
             set(result["Cache-Control"].split(", ")), {"must-revalidate", "no-store", "no-cache"}
         )
 
-        self.assert_length(cache_mock.call_args_list, 7)
+        self.assert_length(cache_mock.call_args_list, 8)
 
         html = result.content.decode()
 
@@ -609,12 +610,12 @@ class HomeTest(ZulipTestCase):
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
         with (
-            self.assert_database_query_count(59),
+            self.assert_database_query_count(61),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page()
             self.check_rendered_logged_in_app(result)
-            self.assert_length(cache_mock.call_args_list, 9)
+            self.assert_length(cache_mock.call_args_list, 10)
 
     def test_num_queries_with_streams(self) -> None:
         main_user = self.example_user("hamlet")
@@ -641,7 +642,7 @@ class HomeTest(ZulipTestCase):
         self._get_home_page()
 
         # Then for the second page load, measure the number of queries.
-        with self.assert_database_query_count(54):
+        with self.assert_database_query_count(56):
             result = self._get_home_page()
 
         # Do a sanity check that our new streams were in the payload.


### PR DESCRIPTION
This PR adds a navbar banner to warn users when their organization is approaching its file upload storage quota. The threshold for showing this banner is when the usage reaches 90% and 95% for admins and non-admins respectively.

For organizations on Cloud Free, the banner also includes a message about upgrading for more storage.

For admins of Cloud Free organizations, the banner also includes a link to the "/upgrade" page.

Fixes: #34441.

Follow-up PR for completion candidate #34516.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Description | Banner |
|--------|--------|
| Normal User in Cloud Free | <img width="1596" height="140" alt="Screenshot 2025-09-20 at 12 16 03 AM" src="https://github.com/user-attachments/assets/dbb29d96-2092-4e50-9fd9-4102a297805c" /> |
| Normal User not in Cloud Free | <img width="1596" height="140" alt="Screenshot 2025-09-20 at 12 36 49 AM" src="https://github.com/user-attachments/assets/240331a7-2037-4516-b49f-60133410f280" /> |
| Admin in Cloud Free | <img width="1596" height="140" alt="Screenshot 2025-09-20 at 12 14 34 AM" src="https://github.com/user-attachments/assets/a286858a-9b4a-4d31-b55e-1d75854f8c39" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
