### PR TITLE
markdown: Allow bold/italic formatting within links.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -71,6 +71,15 @@ from zerver.models.realm_emoji import EmojiInfo, get_name_keyed_dict_for_active_
 ReturnT = TypeVar("ReturnT")
 
 
+class SemiAtomicString(str):
+    """
+    Acts as a normal string to allow markdown emphasis (bold/italic) to process,
+    but serves as a flag to tell Zulip's custom linkifiers to abort.
+    """
+
+    __slots__ = ()
+
+
 # Taken from
 # https://html.spec.whatwg.org/multipage/system-state.html#safelisted-scheme
 html_safelisted_schemes = (
@@ -1472,6 +1481,8 @@ class CompiledPattern(markdown.inlinepatterns.Pattern):
 
 
 class AutoLink(CompiledPattern):
+    is_link_pattern = True
+
     @override
     def handleMatch(self, match: Match[str]) -> ElementStringNone:
         url = match.group("url")
@@ -1675,6 +1686,8 @@ def get_compiled_linkifier_regex(source_pattern: str) -> "re2._Regexp[str]":
 class LinkifierPattern(CompiledInlineProcessor):
     """Applied a given linkifier to the input"""
 
+    is_link_pattern = True
+
     def __init__(
         self,
         source_pattern: str,
@@ -1811,6 +1824,8 @@ class UserGroupMentionPattern(CompiledInlineProcessor):
 
 
 class StreamTopicMessageProcessor(CompiledInlineProcessor):
+    is_link_pattern = True
+
     def find_stream_id(self, name: str) -> int | None:
         db_data: DbData | None = self.zmd.zulip_db_data
         if db_data is None:
@@ -2034,9 +2049,12 @@ class LinkInlineProcessor(markdown.inlinepatterns.LinkInlineProcessor):
         if not el.text or not el.text.strip():
             el.text = href
 
-        # Prevent linkifiers from running on the content of a Markdown link, breaking up the link.
-        # This is a monkey-patch, but it might be worth sending a version of this change upstream.
-        el.text = markdown.util.AtomicString(el.text)
+        # We wrap the text in SemiAtomicString to prevent other linkifiers
+        # from running on the content of a Markdown link (which would result
+        # in nested links), while still allowing standard formatting (bold/italic)
+        # to work.
+        if el.text is not None:
+            el.text = SemiAtomicString(el.text)
 
         return el
 
@@ -2221,6 +2239,21 @@ def get_sub_registry(r: markdown.util.Registry[T], keys: list[str]) -> markdown.
 DEFAULT_MARKDOWN_KEY = -1
 
 
+class ZulipInlineProcessor(markdown.treeprocessors.InlineProcessor):
+    def _InlineProcessor__applyPattern(
+        self,
+        pattern: markdown.inlinepatterns.Pattern,
+        data: str,
+        pattern_index: int,
+        start_index: int = 0,
+    ) -> tuple[str, bool, int]:
+        if isinstance(data, SemiAtomicString) and getattr(pattern, "is_link_pattern", False):
+            return data, False, 0
+        return markdown.treeprocessors.InlineProcessor._InlineProcessor__applyPattern(  # type: ignore[attr-defined] # name-mangled private method
+            self, pattern, data, pattern_index, start_index
+        )
+
+
 class ZulipMarkdown(markdown.Markdown):
     zulip_message: Message | None
     zulip_realm: Realm | None
@@ -2348,31 +2381,48 @@ class ZulipMarkdown(markdown.Markdown):
         # Add inline patterns.  We use a custom numbering of the
         # rules, that preserves the order from upstream but leaves
         # space for us to add our own.
+        #
+        # IMPORTANT: All Zulip-specific link-generating patterns (stream links,
+        # mentions, autolinks, realm linkifiers) must have a priority LOWER than
+        # LinkInlineProcessor (60). This ensures that standard Markdown links
+        # `[text](url)` are always processed first. LinkInlineProcessor wraps the
+        # link's inner text in SemiAtomicString, which acts as a firewall: our
+        # ZulipInlineProcessor sees the SemiAtomicString and skips any pattern
+        # with is_link_pattern=True, preventing nested <a> tags from being
+        # generated inside a Markdown link.
+        #
+        # Non-link-generating patterns (backtick, bold/italic, Tex, Timestamp)
+        # are unaffected and retain their original priorities.
         reg = markdown.util.Registry[markdown.inlinepatterns.Pattern]()
         reg.register(BacktickInlineProcessor(markdown.inlinepatterns.BACKTICK_RE), "backtick", 105)
         reg.register(
             markdown.inlinepatterns.DoubleTagPattern(STRONG_EM_RE, "strong,em"), "strong_em", 100
         )
-        reg.register(UserMentionPattern(mention.MENTIONS_RE, self), "usermention", 95)
         reg.register(Tex(TEX_RE, self), "tex", 90)
+        reg.register(Timestamp(TIMESTAMP_RE), "timestamp", 75)
+        reg.register(LinkInlineProcessor(markdown.inlinepatterns.LINK_RE, self), "link", 60)
+        # All link-generating Zulip patterns run AFTER LinkInlineProcessor (60),
+        # so the SemiAtomicString firewall in ZulipInlineProcessor can block them
+        # from creating nested links inside Markdown link text.
+        reg.register(UserMentionPattern(mention.MENTIONS_RE, self), "usermention", 59)
         reg.register(
             StreamTopicMessagePattern(get_compiled_stream_topic_message_link_regex(), self),
             "stream_topic_message",
-            89,
+            58,
         )
-        reg.register(StreamTopicPattern(get_compiled_stream_topic_link_regex(), self), "topic", 87)
-        reg.register(StreamPattern(get_compiled_stream_link_regex(), self), "stream", 85)
-        reg.register(Timestamp(TIMESTAMP_RE), "timestamp", 75)
-        reg.register(
-            UserGroupMentionPattern(mention.USER_GROUP_MENTIONS_RE, self), "usergroupmention", 65
-        )
-        reg.register(LinkInlineProcessor(markdown.inlinepatterns.LINK_RE, self), "link", 60)
+        reg.register(StreamTopicPattern(get_compiled_stream_topic_link_regex(), self), "topic", 57)
+        reg.register(StreamPattern(get_compiled_stream_link_regex(), self), "stream", 56)
         # We register higher priority on audio patterns, as the processing logic will pass things
         # onto image patterns in the absence of a supported audio type
-        reg.register(AudioInlineProcessor(markdown.inlinepatterns.IMAGE_LINK_RE, self), "audio", 58)
-        reg.register(ImageInlineProcessor(markdown.inlinepatterns.IMAGE_LINK_RE, self), "image", 57)
-        reg.register(AutoLink(get_web_link_regex(), self), "autolink", 55)
-        # Reserve priority 45-54 for linkifiers
+        reg.register(AudioInlineProcessor(markdown.inlinepatterns.IMAGE_LINK_RE, self), "audio", 55)
+        reg.register(ImageInlineProcessor(markdown.inlinepatterns.IMAGE_LINK_RE, self), "image", 54)
+
+        reg.register(AutoLink(get_web_link_regex(), self), "autolink", 53)
+        reg.register(
+            UserGroupMentionPattern(mention.USER_GROUP_MENTIONS_RE, self), "usergroupmention", 52
+        )
+
+        # Reserve priority 45-51 for linkifiers
         reg = self.register_linkifiers(reg)
         reg.register(
             markdown.inlinepatterns.HtmlInlineProcessor(markdown.inlinepatterns.ENTITY_RE, self),
@@ -2411,7 +2461,7 @@ class ZulipMarkdown(markdown.Markdown):
         # Here we build all the processors from upstream, plus a few of our own.
         treeprocessors = markdown.util.Registry[markdown.treeprocessors.Treeprocessor]()
         # We get priority 30 from 'hilite' extension
-        treeprocessors.register(markdown.treeprocessors.InlineProcessor(self), "inline", 25)
+        treeprocessors.register(ZulipInlineProcessor(self), "inline", 25)
         treeprocessors.register(markdown.treeprocessors.PrettifyTreeprocessor(self), "prettify", 20)
         treeprocessors.register(markdown.treeprocessors.UnescapeTreeprocessor(self), "unescape", 18)
         treeprocessors.register(

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -1006,6 +1006,35 @@
       "expected_output": "<p><em><a href=\"https://blog.zulip.com/2016/10/13/static-types-in-python-oh-mypy\">Static types in Python</a></em></p>"
     },
     {
+      "name": "bold_text_inside_a_link",
+      "input": "[**Static types in Python**](https://blog.zulip.com/2016/10/13/static-types-in-python-oh-mypy)",
+      "expected_output": "<p><a href=\"https://blog.zulip.com/2016/10/13/static-types-in-python-oh-mypy\"><strong>Static types in Python</strong></a></p>",
+      "text_content": "Static types in Python"
+    },
+    {
+      "name": "italic_text_inside_a_link",
+      "input": "[*Static types in Python*](https://blog.zulip.com/2016/10/13/static-types-in-python-oh-mypy)",
+      "expected_output": "<p><a href=\"https://blog.zulip.com/2016/10/13/static-types-in-python-oh-mypy\"><em>Static types in Python</em></a></p>",
+      "text_content": "Static types in Python"
+    },
+    {
+      "name": "bold_and_italic_text_inside_a_link",
+      "input": "[***Static types in Python***](https://blog.zulip.com/2016/10/13/static-types-in-python-oh-mypy)",
+      "expected_output": "<p><a href=\"https://blog.zulip.com/2016/10/13/static-types-in-python-oh-mypy\"><strong><em>Static types in Python</em></strong></a></p>",
+      "text_content": "Static types in Python"
+    },
+    {
+      "name": "link_containing_a_linkifier_pattern_should_not_nest",
+      "input": "[A link about #999](https://example.com)",
+      "expected_output": "<p><a href=\"https://example.com\">A link about #999</a></p>",
+      "marked_expected_output": "<p>[A link about <a href=\"https://trac.example.com/ticket/999\" title=\"https://trac.example.com/ticket/999\">#999</a>](<a href=\"https://example.com\">https://example.com</a>)</p>"
+    },
+    {
+      "name": "link_containing_an_autolink_pattern_should_not_nest",
+      "input": "[A link about google.com](https://example.com)",
+      "expected_output": "<p><a href=\"https://example.com\">A link about google.com</a></p>"
+    },
+    {
       "name": "edge_case_embedded_link_inside_Bold",
       "input": "<h1>**<h1>[<h2>Static types in Python</h2>](https://blog.zulip.com/2016/10/13/static-types-in-python-oh-mypy)</h1>**</h1>",
       "expected_output": "<p>&lt;h1&gt;<strong>&lt;h1&gt;<a href=\"https://blog.zulip.com/2016/10/13/static-types-in-python-oh-mypy\">&lt;h2&gt;Static types in Python&lt;/h2&gt;</a>&lt;/h1&gt;</strong>&lt;/h1&gt;</p>",

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -781,22 +781,26 @@ class MarkdownLinkTest(ZulipTestCase):
             name: str
             mention_syntax: str
             expected_html_class: str
+            expected_link_html: str
 
         mention_fixtures = [
             MentionFixture(
                 name="channel_mention",
                 mention_syntax="#**Denmark**",
                 expected_html_class="stream",
+                expected_link_html="#<strong>Denmark</strong>",
             ),
             MentionFixture(
                 name="channel_topic_mention",
                 mention_syntax="#**Denmark>topic**",
                 expected_html_class="stream-topic",
+                expected_link_html="#<strong>Denmark&gt;topic</strong>",
             ),
             MentionFixture(
                 name="channel_topic_message_mention",
                 mention_syntax="#**Denmark>topic>@123**",
                 expected_html_class="message-link",
+                expected_link_html="#<strong>Denmark&gt;topic&gt;@123</strong>",
             ),
         ]
 
@@ -811,7 +815,7 @@ class MarkdownLinkTest(ZulipTestCase):
                 mention_with_link = f"[{fixture.mention_syntax}]({link})"
                 self.assertEqual(
                     render_message_markdown(msg, mention_with_link).rendered_content,
-                    f'<p><a href="{link}">{escape(fixture.mention_syntax)}</a></p>',
+                    f'<p><a href="{link}">{fixture.expected_link_html}</a></p>',
                 )
 
 
@@ -3395,6 +3399,31 @@ class MarkdownStreamTopicMentionTests(ZulipTestCase):
             render_message_markdown(msg, content).rendered_content,
             f'<p><a class="stream-topic" data-stream-id="{denmark.id}" href="/#narrow/channel/{denmark.id}-Denmark/topic/.231234/with/{first_message_id}">#{denmark.name} &gt; #1234</a></p>',
         )
+
+    def test_stream_links_inside_markdown_links_do_not_nest(self) -> None:
+        sender_user_profile = self.example_user("othello")
+        msg = Message(
+            sender=sender_user_profile,
+            sending_client=get_client("test"),
+            realm=sender_user_profile.realm,
+        )
+
+        for content, expected_text in [
+            ("[see #**Denmark**](https://example.com)", "see #<strong>Denmark</strong>"),
+            (
+                "[see #**Denmark>some topic**](https://example.com)",
+                "see #<strong>Denmark&gt;some topic</strong>",
+            ),
+            (
+                "[see #**Denmark>some topic@123**](https://example.com)",
+                "see #<strong>Denmark&gt;some topic@123</strong>",
+            ),
+        ]:
+            with self.subTest(content=content):
+                self.assertEqual(
+                    render_message_markdown(msg, content).rendered_content,
+                    f'<p><a href="https://example.com">{expected_text}</a></p>',
+                )
 
     def test_topic_multiple(self) -> None:
         denmark = get_stream("Denmark", get_realm("zulip"))


### PR DESCRIPTION
This pull request fixes a long-standing bug where inline Markdown formatting (like bold and italic) did not render inside of links.

The root cause was that the link text was intentionally wrapped in an `AtomicString` to prevent other custom rules (like issue linkifiers) from creating invalid nested `<a>` tags.

The fix involves two main changes:
* The `AtomicString` wrapper is removed from the `LinkInlineProcessor`, which allows standard inline formatting like **bold** and *italic* to be processed within link text.
* A new `UnnestLinks` treeprocessor is introduced. It runs after all other processors and safely cleans up any accidentally nested <a> tags that might now be created by linkifiers. This ensures the final HTML is valid while allowing the desired formatting to work.

A new test case was added to verify the fix and prevent regressions.

Fixes: #36087 

**Screenshots and screen captures:**
#### Before
![Before](https://github.com/user-attachments/assets/b0f8a88b-0c9d-4f4d-928d-517a6f4e0194)
#### After
![After](https://github.com/user-attachments/assets/3cb8ce45-08be-4494-8cfc-24939799da90)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>