### PR TITLE
filter: Only allow specific string values as `operator`.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -16,7 +16,7 @@ import {page_params} from "./page_params.ts";
 import type {User} from "./people.ts";
 import * as people from "./people.ts";
 import type {UserPillItem} from "./search_suggestion.ts";
-import {current_user} from "./state_data.ts";
+import {current_user, narrow_term_schema} from "./state_data.ts";
 import type {NarrowTerm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as sub_store from "./sub_store.ts";
@@ -219,6 +219,8 @@ function message_matches_search_term(message: Message, operator: string, operand
         }
     }
 
+    // We will never get here since operator type validation would fail.
+    // istanbul ignore next
     return true; // unknown operators return true (effectively ignored)
 }
 
@@ -291,21 +293,30 @@ export class Filter {
         return operator;
     }
 
-    static canonicalize_term({negated = false, operator, operand}: NarrowTerm): NarrowTerm {
+    static canonicalize_term({
+        negated = false,
+        operator,
+        operand,
+    }: {
+        negated?: boolean | undefined;
+        operator: string;
+        operand: string;
+    }): NarrowTerm {
         // Make negated explicitly default to false for both clarity and
         // simplifying deepEqual checks in the tests.
         operator = Filter.canonicalize_operator(operator);
+        const narrow_term = narrow_term_schema.parse({negated, operator, operand});
 
-        switch (operator) {
+        switch (narrow_term.operator) {
             case "is":
                 // "is:private" was renamed to "is:dm"
-                if (operand === "private") {
-                    operand = "dm";
+                if (narrow_term.operand === "private") {
+                    narrow_term.operand = "dm";
                 }
                 break;
             case "has":
                 // images -> image, etc.
-                operand = operand.replace(/s$/, "");
+                narrow_term.operand = narrow_term.operand.replace(/s$/, "");
                 break;
 
             case "channel":
@@ -314,13 +325,13 @@ export class Filter {
                 break;
             case "sender":
             case "dm":
-                operand = operand.toLowerCase();
-                if (operand === "me") {
-                    operand = people.my_current_email();
+                narrow_term.operand = narrow_term.operand.toLowerCase();
+                if (narrow_term.operand === "me") {
+                    narrow_term.operand = people.my_current_email();
                 }
                 break;
             case "dm-including":
-                operand = operand.toLowerCase();
+                narrow_term.operand = narrow_term.operand.toLowerCase();
                 break;
             case "search":
                 // The mac app automatically substitutes regular quotes with curly
@@ -328,18 +339,14 @@ export class Filter {
                 // phrase search behavior, however.  So, we replace all instances of
                 // curly quotes with regular quotes when doing a search.  This is
                 // unlikely to cause any problems and is probably what the user wants.
-                operand = operand.replaceAll(/[\u201C\u201D]/g, '"');
+                narrow_term.operand = narrow_term.operand.replaceAll(/[\u201C\u201D]/g, '"');
                 break;
             default:
-                operand = operand.toLowerCase();
+                narrow_term.operand = narrow_term.operand.toLowerCase();
         }
 
         // We may want to consider allowing mixed-case operators at some point
-        return {
-            negated,
-            operator,
-            operand,
-        };
+        return narrow_term;
     }
 
     static ensure_channel_topic_terms(
@@ -388,8 +395,11 @@ export class Filter {
 
         assert(message.type === "stream");
 
-        const channel_term = {operator: "channel", operand: message.stream_id.toString()};
-        const topic_term = {operator: "topic", operand: message.topic};
+        const channel_term: NarrowTerm = {
+            operator: "channel",
+            operand: message.stream_id.toString(),
+        };
+        const topic_term: NarrowTerm = {operator: "topic", operand: message.topic};
 
         const updated_terms = [channel_term, topic_term, ...non_conversation_terms];
         return updated_terms;
@@ -422,15 +432,13 @@ export class Filter {
         const terms: NarrowTerm[] = [];
         let search_term: string[] = [];
         let negated;
-        let operator;
         let operand;
-        let term;
+        let term: NarrowTerm;
 
         function maybe_add_search_terms(): void {
             if (search_term.length > 0) {
-                operator = "search";
                 const _operand = search_term.join(" ");
-                term = {operator, operand: _operand, negated: false};
+                term = {operator: "search", operand: _operand, negated: false};
                 terms.push(term);
                 search_term = [];
             }
@@ -494,11 +502,11 @@ export class Filter {
                 // terms list. This is done so that the last active filter is correctly
                 // detected by the `get_search_result` function (in search_suggestions.ts).
                 maybe_add_search_terms();
-                term = {
+                term = narrow_term_schema.parse({
                     negated,
                     operator: Filter.canonicalize_operator(operator),
                     operand,
-                };
+                });
                 terms.push(term);
             }
         }
@@ -900,8 +908,7 @@ export class Filter {
 
             const dm_operand = dm_participants.join(",");
 
-            const dm_conversation_terms = [{operator: "dm", operand: dm_operand, negated: false}];
-            return [...dm_conversation_terms, ...filtered_terms];
+            return [{operator: "dm", operand: dm_operand, negated: false}, ...filtered_terms];
         }
 
         assert(typeof message.display_recipient === "string");
@@ -1602,12 +1609,16 @@ export class Filter {
     }
 
     _canonicalize_terms(terms_mixed_case: NarrowTerm[]): NarrowTerm[] {
-        return terms_mixed_case.map((term: NarrowTerm) => Filter.canonicalize_term(term));
+        const terms = terms_mixed_case.map((term: NarrowTerm) => Filter.canonicalize_term(term));
+        return terms;
     }
 
     adjust_with_operand_to_message(msg_id: number): void {
         const narrow_terms = this._terms.filter((term) => term.operator !== "with");
-        const adjusted_with_term = {operator: "with", operand: `${msg_id}`};
+        const adjusted_with_term: NarrowTerm = {
+            operator: "with",
+            operand: `${msg_id}`,
+        };
         const adjusted_terms = [...narrow_terms, adjusted_with_term];
         this._terms = adjusted_terms;
         this.requires_adjustment_for_moved_with_target = false;

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -1,4 +1,5 @@
 import assert from "minimalistic-assert";
+import * as z from "zod/mini";
 
 import * as internal_url from "../shared/src/internal_url.ts";
 
@@ -9,7 +10,7 @@ import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import {web_channel_default_view_values} from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
-import {realm} from "./state_data.ts";
+import {narrow_term_schema, realm} from "./state_data.ts";
 import type {NarrowTerm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_topic_history from "./stream_topic_history.ts";
@@ -198,7 +199,7 @@ export function group_edit_url(group: UserGroup, right_side_tab: string): string
 }
 
 export function search_public_streams_notice_url(terms: NarrowTerm[]): string {
-    const public_operator = {operator: "channels", operand: "public"};
+    const public_operator: NarrowTerm = {operator: "channels", operand: "public"};
     return search_terms_to_hash([public_operator, ...terms]);
 }
 
@@ -240,7 +241,7 @@ export function parse_narrow(hash: string[]): NarrowTerm[] | undefined {
         const operand = decode_operand(operator, raw_operand);
         terms.push({negated, operator, operand});
     }
-    return terms;
+    return z.array(narrow_term_schema).parse(terms);
 }
 
 export function channels_settings_edit_url(

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -820,7 +820,7 @@ export let show = (raw_terms: NarrowTerm[], show_opts: ShowMessageViewOpts): voi
                     ) {
                         // We convert the current narrow into a `near` narrow so that
                         // user doesn't accidentally mark msgs read which they haven't seen.
-                        let terms = [
+                        let terms: NarrowTerm[] = [
                             ...msg_list.data.filter.terms(),
                             {
                                 operator: "near",
@@ -1252,7 +1252,7 @@ export function render_message_list_with_selected_message(opts: {
 
 function activate_stream_for_cycle_hotkey(stream_id: number): void {
     // This is the common code for A/D hotkeys.
-    const filter_expr = [{operator: "channel", operand: stream_id.toString()}];
+    const filter_expr: NarrowTerm[] = [{operator: "channel", operand: stream_id.toString()}];
     show(filter_expr, {});
 }
 
@@ -1322,7 +1322,7 @@ export function narrow_to_next_topic(opts: {trigger: string; only_followed_topic
         return;
     }
 
-    const filter_expr = [
+    const filter_expr: NarrowTerm[] = [
         {operator: "channel", operand: next_narrow.stream_id.toString()},
         {operator: "topic", operand: next_narrow.topic},
     ];
@@ -1349,7 +1349,7 @@ export function narrow_to_next_pm_string(opts = {}): void {
     const direct_message = people.user_ids_string_to_emails_string(next_direct_message);
     assert(direct_message !== undefined);
 
-    const filter_expr = [{operator: "dm", operand: direct_message}];
+    const filter_expr: NarrowTerm[] = [{operator: "dm", operand: direct_message}];
 
     // force_close parameter is true to not auto open compose_box
     const updated_opts = {
@@ -1387,7 +1387,7 @@ export function narrow_by_topic(
         unread_ops.notify_server_message_read(original);
     }
 
-    const search_terms = [
+    const search_terms: NarrowTerm[] = [
         {operator: "channel", operand: original.stream_id.toString()},
         {operator: "topic", operand: original.topic},
     ];
@@ -1464,7 +1464,7 @@ export function to_compose_target(): void {
         }
         // If we are composing to a new topic, we narrow to the stream but
         // grey-out the message view instead of narrowing to an empty view.
-        const terms = [{operator: "channel", operand: stream_id.toString()}];
+        const terms: NarrowTerm[] = [{operator: "channel", operand: stream_id.toString()}];
         const topic = compose_state.topic();
         if (topic !== "" || stream_data.can_use_empty_topic(stream_id)) {
             terms.push({operator: "topic", operand: topic});

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -21,7 +21,7 @@ import * as util from "./util.ts";
 
 export type SearchUserPill = {
     type: "search_user";
-    operator: string;
+    operator: NarrowTerm["operator"];
     negated: boolean;
     users: {
         full_name: string;
@@ -34,14 +34,7 @@ export type SearchUserPill = {
     }[];
 };
 
-type SearchPill =
-    | {
-          type: "generic_operator";
-          operator: string;
-          operand: string;
-          negated: boolean | undefined;
-      }
-    | SearchUserPill;
+type SearchPill = ({type: "generic_operator"} & NarrowTerm) | SearchUserPill;
 
 export type SearchPillWidget = InputPillContainer<SearchPill>;
 
@@ -56,9 +49,7 @@ export function create_item_from_search_string(search_string: string): SearchPil
     }
     return {
         type: "generic_operator",
-        operator: search_term.operator,
-        operand: search_term.operand,
-        negated: search_term.negated,
+        ...search_term,
     };
 }
 
@@ -270,7 +261,11 @@ function is_sent_by_me_pill(pill: SearchUserPill): boolean {
     );
 }
 
-function search_user_pill_data(users: User[], operator: string, negated: boolean): SearchUserPill {
+function search_user_pill_data(
+    users: User[],
+    operator: NarrowTerm["operator"],
+    negated: boolean,
+): SearchUserPill {
     return {
         type: "search_user",
         operator,
@@ -290,7 +285,7 @@ function search_user_pill_data(users: User[], operator: string, negated: boolean
 function append_user_pill(
     users: User[],
     pill_widget: SearchPillWidget,
-    operator: string,
+    operator: NarrowTerm["operator"],
     negated: boolean,
 ): void {
     const pill_data = search_user_pill_data(users, operator, negated);

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -26,7 +26,7 @@ export type UserPillItem = {
 
 type TermPattern = Omit<NarrowTerm, "operand"> & Partial<Pick<NarrowTerm, "operand">>;
 
-const channel_incompatible_patterns = [
+const channel_incompatible_patterns: TermPattern[] = [
     {operator: "is", operand: "dm"},
     {operator: "channel"},
     {operator: "dm-including"},
@@ -208,7 +208,7 @@ function get_channel_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggest
         const description_html = verb + prefix + Handlebars.Utils.escapeExpression(channel_name);
         const channel = stream_data.get_sub_by_name(channel_name);
         assert(channel !== undefined);
-        const term = {
+        const term: NarrowTerm = {
             operator: "channel",
             operand: channel.stream_id.toString(),
             negated: last.negated,
@@ -310,7 +310,7 @@ function get_group_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
     const prefix = Filter.operator_to_prefix("dm", negated);
 
     return persons.map((person) => {
-        const term = {
+        const term: NarrowTerm = {
             operator: "dm",
             operand: all_but_last_part + "," + person.email,
             negated,
@@ -361,7 +361,7 @@ function get_person_suggestions(
     people_getter: () => User[],
     last: NarrowTerm,
     terms: NarrowTerm[],
-    autocomplete_operator: string,
+    autocomplete_operator: NarrowTerm["operator"],
 ): Suggestion[] {
     if ((last.operator === "is" && last.operand === "dm") || last.operator === "pm-with") {
         // Interpret "is:dm" or "pm-with:" operator as equivalent to "dm:".
@@ -551,7 +551,7 @@ function get_topic_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
     topics.sort();
 
     return topics.map((topic) => {
-        const topic_term = {operator: "topic", operand: topic, negated};
+        const topic_term: NarrowTerm = {operator: "topic", operand: topic, negated};
         const terms = [...suggest_terms, topic_term];
         return format_as_suggestion(terms);
     });
@@ -793,7 +793,7 @@ function get_operator_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugges
         last_operand = last_operand.slice(1);
     }
 
-    let choices;
+    let choices: NarrowTerm["operator"][];
 
     if (last.operator === "") {
         choices = ["channels", "channel", "streams", "stream"];
@@ -1047,7 +1047,7 @@ export function get_search_result(
     const people_getter = make_people_getter(last);
 
     function get_people(
-        flavor: string,
+        flavor: NarrowTerm["operator"],
     ): (last: NarrowTerm, base_terms: NarrowTerm[]) => Suggestion[] {
         return function (last: NarrowTerm, base_terms: NarrowTerm[]): Suggestion[] {
             return get_person_suggestions(people_getter, last, base_terms, flavor);

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -22,7 +22,29 @@ export type GroupPermissionSetting = z.output<typeof group_permission_setting_sc
 
 export const narrow_term_schema = z.object({
     negated: z.optional(z.boolean()),
-    operator: z.string(),
+    operator: z.enum([
+        "", // Used for search suggestions.
+        "channel",
+        "channels",
+        "dm",
+        "dm-including",
+        "from",
+        "group-pm-with",
+        "has",
+        "id",
+        "in",
+        "is",
+        "near",
+        "pm",
+        "pm-including",
+        "pm-with",
+        "search",
+        "sender",
+        "stream",
+        "streams",
+        "topic",
+        "with",
+    ]),
     operand: z.string(),
 });
 export type NarrowTerm = z.output<typeof narrow_term_schema>;

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -60,7 +60,9 @@ let window_focused = document.hasFocus();
 
 // Since there's a database index on is:unread, it's a fast
 // search query and thus worth including here as an optimization.),
-const all_unread_messages_narrow = [{operator: "is", operand: "unread", negated: false}];
+const all_unread_messages_narrow: NarrowTerm[] = [
+    {operator: "is", operand: "unread", negated: false},
+];
 
 export function is_window_focused(): boolean {
     return window_focused;

--- a/web/tests/activity.test.cjs
+++ b/web/tests/activity.test.cjs
@@ -115,7 +115,7 @@ const $fred_stub = $.create("fred stub");
 const rome_sub = {name: "Rome", subscribed: true, stream_id: 1001};
 function add_sub_and_set_as_current_narrow(sub) {
     stream_data.add_sub_for_tests(sub);
-    const filter_terms = [{operator: "stream", operand: sub.stream_id}];
+    const filter_terms = [{operator: "stream", operand: String(sub.stream_id)}];
     message_lists.set_current(make_message_list(filter_terms));
 }
 

--- a/web/tests/buddy_data.test.cjs
+++ b/web/tests/buddy_data.test.cjs
@@ -412,7 +412,7 @@ test("show offline channel subscribers for small channels", ({override_rewire}) 
     ]);
 
     const filter_terms = [
-        {operator: "channel", operand: sub.stream_id},
+        {operator: "channel", operand: String(sub.stream_id)},
         {operator: "topic", operand: "Foo"},
     ];
     message_lists.set_current(make_message_list(filter_terms));
@@ -437,7 +437,7 @@ test("get_conversation_participants", () => {
     peer_data.set_subscribers(rome_sub.stream_id, [selma.user_id, me.user_id]);
 
     const filter_terms = [
-        {operator: "channel", operand: rome_sub.stream_id},
+        {operator: "channel", operand: String(rome_sub.stream_id)},
         {operator: "topic", operand: "Foo"},
     ];
     message_lists.set_current(

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -630,6 +630,11 @@ test("basics", () => {
     terms = [{operator: "channel", operand: "foo", negated: false}];
     filter = new Filter(terms);
     assert.ok(filter.is_channel_view());
+
+    // Throw error on invalid operator.
+    assert.throws(() => get_predicate([["bogus", "33"]]), {
+        name: "$ZodError",
+    });
 });
 
 function assert_not_mark_read_with_has_operands(additional_terms_to_test) {
@@ -736,7 +741,9 @@ test("can_mark_messages_read", () => {
     assert_not_mark_read_with_is_operands(channel_term);
     assert_not_mark_read_when_searching(channel_term);
 
-    const channel_negated_operator = [{operator: "channel", operand: foo_stream_id, negated: true}];
+    const channel_negated_operator = [
+        {operator: "channel", operand: foo_stream_id.toString(), negated: true},
+    ];
     filter = new Filter(channel_negated_operator);
     assert.ok(!filter.can_mark_messages_read());
 
@@ -917,13 +924,13 @@ test("public_terms", ({override, override_rewire}) => {
     stream_data.clear_subscriptions();
     const some_channel_id = new_stream_id();
     let terms = [
-        {operator: "channel", operand: some_channel_id},
+        {operator: "channel", operand: some_channel_id.toString()},
         {operator: "in", operand: "all"},
         {operator: "topic", operand: "bar"},
     ];
     let filter = new Filter(terms);
     const expected_terms = [
-        {operator: "channel", operand: some_channel_id},
+        {operator: "channel", operand: some_channel_id.toString()},
         {operator: "in", operand: "all"},
         {operator: "topic", operand: "bar"},
     ];
@@ -938,7 +945,7 @@ test("public_terms", ({override, override_rewire}) => {
     assert_same_terms(filter.public_terms(), expected_terms);
     assert.ok(filter.can_bucket_by("channel"));
 
-    terms = [{operator: "channel", operand: some_channel_id}];
+    terms = [{operator: "channel", operand: some_channel_id.toString()}];
     filter = new Filter(terms);
     override(page_params, "narrow_stream", "default");
     assert_same_terms(filter.public_terms(), []);
@@ -1450,9 +1457,6 @@ test("predicate_edge_cases", () => {
     // return a function that accepts all messages.
     predicate = get_predicate([["in", "bogus"]]);
     assert.ok(!predicate({}));
-
-    predicate = get_predicate([["bogus", "33"]]);
-    assert.ok(predicate({}));
 
     predicate = get_predicate([["is", "bogus"]]);
     assert.ok(!predicate({}));

--- a/web/tests/hashchange.test.cjs
+++ b/web/tests/hashchange.test.cjs
@@ -471,7 +471,7 @@ run_test("update_hash_to_match_filter", ({override, override_rewire}) => {
     helper.assert_events([[message_viewport, "stop_auto_scrolling"]]);
     assert.equal(url_pushed, "http://zulip.zulipdev.com/#narrow/is/starred");
 
-    terms = [{operator: "-is", operand: "starred"}];
+    terms = [{operator: "is", operand: "starred", negated: true}];
 
     helper.clear_events();
     message_view.update_hash_to_match_filter(new Filter(terms));

--- a/web/tests/narrow_state.test.cjs
+++ b/web/tests/narrow_state.test.cjs
@@ -376,7 +376,7 @@ test("inbox_view_visible", () => {
     const filter = new Filter([
         {
             operator: "channel",
-            operand: 10,
+            operand: "10",
         },
     ]);
     inbox_util.set_filter(filter);

--- a/web/tests/narrow_unread.test.cjs
+++ b/web/tests/narrow_unread.test.cjs
@@ -117,7 +117,7 @@ run_test("get_unread_ids", () => {
     assert.equal(unread_ids, undefined);
     assert_unread_info({flavor: "cannot_compute"});
 
-    terms = [{operator: "bogus_operator", operand: "me@example.com"}];
+    terms = [{operator: "dm", operand: "123123"}];
     set_filter(terms);
     unread_ids = candidate_ids();
     assert.deepEqual(unread_ids, []);
@@ -270,7 +270,7 @@ run_test("defensive code", ({override_rewire}) => {
     // couldn't compute the unread message ids, but that
     // invariant is hard to future-proof.
     override_rewire(narrow_state, "_possible_unread_message_ids", () => undefined);
-    const terms = [{operator: "some-unhandled-case", operand: "whatever"}];
+    const terms = [{operator: "dm", operand: "12344"}];
     set_filter(terms);
     assert_unread_info({
         flavor: "cannot_compute",

--- a/web/tests/stream_list_sort.test.cjs
+++ b/web/tests/stream_list_sort.test.cjs
@@ -369,7 +369,7 @@ test("left_sidebar_search", ({override}) => {
 
     function setup_search_around_stream(stream) {
         message_lists.set_current(
-            make_message_list([{operator: "stream", operand: stream.stream_id}]),
+            make_message_list([{operator: "stream", operand: stream.stream_id.toString()}]),
         );
         const history = stream_topic_history.find_or_create(stream.stream_id);
         history.add_or_update("an important topic", 1);

--- a/web/tests/user_search.test.cjs
+++ b/web/tests/user_search.test.cjs
@@ -149,7 +149,9 @@ test("fetch on search", async ({override}) => {
 
     const office = {stream_id: 23, name: "office", subscribed: true};
     stream_data.add_sub_for_tests(office);
-    message_lists.set_current(make_message_list([{operator: "stream", operand: office.stream_id}]));
+    message_lists.set_current(
+        make_message_list([{operator: "stream", operand: office.stream_id.toString()}]),
+    );
     let get_call_count = 0;
     channel.get = () => {
         get_call_count += 1;
@@ -174,11 +176,11 @@ test("fetch on search", async ({override}) => {
     const living_room = {stream_id: 26, name: "living_room", subscribed: true};
     stream_data.add_sub_for_tests(living_room);
     message_lists.set_current(
-        make_message_list([{operator: "stream", operand: kitchen.stream_id}]),
+        make_message_list([{operator: "stream", operand: kitchen.stream_id.toString()}]),
     );
     set_input_val("somevalue");
     message_lists.set_current(
-        make_message_list([{operator: "stream", operand: living_room.stream_id}]),
+        make_message_list([{operator: "stream", operand: living_room.stream_id.toString()}]),
     );
     set_input_val("somevalue");
     await activity_ui.await_pending_promise_for_testing();


### PR DESCRIPTION
This will help us build for the next step where we specifiy possible operand type for each operand different from just being a string value.


discussion: https://chat.zulip.org/#narrow/channel/6-frontend/topic/filter.20operand.20type.3A.20number.20or.20string.3F/with/2261836

Next step would be to start defining `number` or other types for operators which support them in `narrow_term_schema`.