### PR TITLE
views_util: Fix hotkeys not working when views filter is in focus.

### DIFF
--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -156,7 +156,7 @@ export function is_in_focus(): boolean {
         !sidebar_ui.any_sidebar_expanded_as_overlay() &&
         !overlays.any_active() &&
         !modals.any_active_or_animating() &&
-        !$(".input-element").is(":focus") &&
+        !$(".input-element:not(#recent_view_search):not(#inbox-search)").is(":focus") &&
         !$("#search_query").is(":focus") &&
         !$(".navbar-item").is(":focus")
     );


### PR DESCRIPTION
When focus for recent view / inbox is in focus, hotkeys were not working since #36035 didn't account for inputs inside the view.

Fixed by removing recent view and inbox filter elements from `.input-element` selector.

Tested that hotkeys now work for recent view, inbox and channels topics list as expected.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/Recent.20via.20keyboard.20navigation.20from.20filter.20widget