### PR TITLE
settings: add link to channel general settings on name-conflict durin…

### DIFF
--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -151,7 +151,6 @@ export function open_edit_panel_empty(): void {
 export function update_stream_name(sub: StreamSubscription, new_name: string): void {
     const $edit_container = stream_settings_containers.get_edit_container(sub);
     $edit_container.find(".sub-stream-name").text(new_name);
-
     const active_data = stream_settings_components.get_active_data();
     if (active_data.id === sub.stream_id) {
         stream_settings_components.set_right_panel_title(sub);

--- a/web/templates/stream_name_error.hbs
+++ b/web/templates/stream_name_error.hbs
@@ -1,0 +1,21 @@
+<div class="stream-name-error">
+    {{!-- Error message --}}
+    {{#if message_html}}
+        {{{message_html}}}
+    {{else if message_text}}
+        <span class="error-text">{{message_text}}</span>
+    {{/if}}
+
+    {{!-- Optional "rename archived channel" link --}}
+    {{#if show_rename_archived}}
+        <a
+          id="archived_stream_rename"
+          class="rename-archived-link"
+          role="button"
+          tabindex="0"
+          data-stream-id="{{stream_id}}"
+          >
+            {{rename_label}}
+        </a>
+    {{/if}}
+</div>


### PR DESCRIPTION
…g creation.


<!-- Describe your pull request here.-->

Updated create_stream.ts so that when a User (with rights) tries to create a new channel with the same name as an existing channel, the word "channel" in the displayed error now links to the affected channels general settings page.

In the same issue there were suggestions to update the error message for archived channels as well, but I figure that actually deserves its own issue. 

Fixes: #36076

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.



Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="1199" height="364" alt="channel_link_image" src="https://github.com/user-attachments/assets/0721a1c1-c8ef-4365-855f-1b2c041d2e56" />

Trying to create a new channel that has the same name as a already existing archived channel, but without permission to rename it:
<img width="442" height="345" alt="rename_wo_permission" src="https://github.com/user-attachments/assets/b6f6288d-2752-4ca2-b4d3-21325b25852b" />

Trying to rename an archived channel but WITH permission:
<img width="526" height="239" alt="rename_archived_w_perm" src="https://github.com/user-attachments/assets/8f630ab1-3905-4950-a120-05639a288877" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
