### PR TITLE
web: Show proper error messages for existing channel names

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -116,6 +116,23 @@
     color: hsl(0deg 100% 50%);
 }
 
+.stream_creation_error a,
+#change_stream_name_error a {
+    text-decoration: underline;
+}
+
+#change_stream_name {
+    margin-bottom: 0;
+}
+
+#change_stream_name_error {
+    color: hsl(0deg 100% 50%);
+}
+
+.change-stream-name-container {
+    margin-bottom: 20px;
+}
+
 /* TODO: Unify with settings.css definition */
 h3.stream_setting_subsection_title,
 h3.user_group_setting_subsection_title {

--- a/web/templates/stream_settings/change_stream_info_modal.hbs
+++ b/web/templates/stream_settings/change_stream_info_modal.hbs
@@ -1,8 +1,9 @@
-<div>
+<div class="change-stream-name-container">
     <label for="change_stream_name" class="modal-field-label">
         {{t 'Channel name' }}
     </label>
     <input type="text" id="change_stream_name" class="modal_text_input" name="stream_name" value="{{ stream_name }}" maxlength="{{ max_stream_name_length }}" />
+    <div id="change_stream_name_error"></div>
 </div>
 <div>
     <label for="change_stream_description" class="modal-field-label">

--- a/web/templates/stream_settings/channel_name_conflict_error.hbs
+++ b/web/templates/stream_settings/channel_name_conflict_error.hbs
@@ -1,0 +1,22 @@
+{{#if is_archived}}
+    {{#if can_view_channel}}
+        {{#tr}}
+            An <z-link>archived channel</z-link> with this name already exists.
+            {{#*inline "z-link"}}<a href="#channels/{{stream_id}}/general" class="stream-settings-link">{{> @partial-block}}</a>{{/inline}}
+        {{/tr}}
+    {{else}}
+        {{t "An archived channel with this name already exists." }}
+    {{/if}}
+    {{#if show_rename}}
+        <a id="archived_stream_rename" data-stream-id="{{stream_id}}">{{t "Rename it" }}</a>
+    {{/if}}
+{{else}}
+    {{#if can_view_channel}}
+        {{#tr}}
+            A <z-link>channel</z-link> with this name already exists.
+            {{#*inline "z-link"}}<a href="#channels/{{stream_id}}/general" class="stream-settings-link">{{> @partial-block}}</a>{{/inline}}
+        {{/tr}}
+    {{else}}
+        {{t "A channel with this name already exists." }}
+    {{/if}}
+{{/if}}

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -13,7 +13,6 @@
                         <input type="text" name="stream_name" id="create_stream_name" class="settings_text_input"
                           placeholder="{{t 'Channel name' }}" value="" autocomplete="off" maxlength="{{ max_stream_name_length }}" />
                         <div id="stream_name_error" class="stream_creation_error"></div>
-                        <a id="archived_stream_rename"></a>
                     </section>
                     <section id="create_stream_description_container">
                         <label for="create_stream_description" class="settings-field-label">


### PR DESCRIPTION
- This PR fixes the error messages shown when creating a channel with a name that already exists.  
For unarchived channels, the word "channel" now links to the General settings panel for that channel.  
For archived channels, "An archived channel with this name already exists." The "Archived channel" text links to the General settings panel, and the "Rename it" option is shown only if the user has permission, opening the name/description editing modal when clicked.  

- For renaming channels, the same error and styling as used for new channels has been implemented, replacing the previous banner with a more consistent error message and style.

Fixes #36076

<!-- Describe your pull request here. -->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

## Before & After Comparison

| Before | After |
| --- | --- |
| **Current error message** | **User editing channel name to match an archived channel they can view** |
| <img width="519" height="206" alt="Screenshot 2025-10-04 at 16 41 28" src="https://github.com/user-attachments/assets/fded3ec5-c41b-47f5-a8d3-84f55383406d" /> | <img width="510" height="192" alt="Screenshot 2025-10-11 at 15 24 12" src="https://github.com/user-attachments/assets/f064560d-fa75-4160-84e0-ddb7674cb853" /> |
| **Current error message** | **User editing a channel name to match an existing channel.** |
| <img width="514" height="205" alt="Screenshot 2025-10-04 at 16 42 43" src="https://github.com/user-attachments/assets/5c98f3c6-d5ae-4036-b513-61131e308d98" />| <img width="502" height="191" alt="Screenshot 2025-10-11 at 15 23 24" src="https://github.com/user-attachments/assets/9961d120-d07b-4c45-8942-80bd283b33af" /> |
| **Current error message** | **User tries to create a channel matching an archived channel they can view, have rename permission.** |
| <img width="805" height="167" alt="Screenshot 2025-10-04 at 16 40 16" src="https://github.com/user-attachments/assets/bc2694ef-5a4b-4791-b4ca-7f31a548ffd4" /> | <img width="482" height="145" alt="Screenshot 2025-10-04 at 16 10 14" src="https://github.com/user-attachments/assets/31ecdde0-c532-4de2-a836-f836f1fa3431" />|
| **Current error message** | **User tries to create a channel matching an archived channel they can view, but they don't have rename permission.** |
| <img width="506" height="140" alt="Screenshot 2025-10-04 at 16 45 32" src="https://github.com/user-attachments/assets/633dae91-7d22-4f89-abd6-ab3a77f94d56" /> | <img width="449" height="143" alt="Screenshot 2025-10-04 at 16 12 09" src="https://github.com/user-attachments/assets/6d52b056-2096-44b5-bf83-ce01ace8b0f5" /> |
| **Current error message** | **User tries to create a channel with a name that matches an existing public channel** |
|<img width="474" height="137" alt="Screenshot 2025-10-04 at 16 40 28" src="https://github.com/user-attachments/assets/04ff9308-7ee3-43a2-876c-36171dadd992" /> | <img width="478" height="141" alt="Screenshot 2025-10-04 at 16 10 27" src="https://github.com/user-attachments/assets/8e7a37a7-349f-4a50-9c9f-eba6a33b45f2" /> |



<details>
<summary>Screen Recordings</summary>

### Recording for unarchived channel


https://github.com/user-attachments/assets/f53d7c7e-2a5e-4222-abf9-a0c78830e9bd



### Recording for archived channel


https://github.com/user-attachments/assets/3b26a812-8279-4e16-9c13-6bf2600ac885


</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
