### PR TITLE
personal_recipients: Delete legacy code paths.

### DIFF
--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -7,7 +7,6 @@ from unittest import mock
 import time_machine
 from django.apps import apps
 from django.db.models import Sum
-from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 from psycopg2.sql import SQL, Literal
 from typing_extensions import override
@@ -719,7 +718,6 @@ class TestCountStats(AnalyticsTestCase):
         )
         self.assertTableState(StreamCount, [], [])
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_1_to_1_and_self_messages_sent_by_message_type_using_direct_message_group(self) -> None:
         stat = COUNT_STATS["messages_sent:message_type:day"]
         self.current_property = stat.property

--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -562,16 +562,18 @@ class TestCountStats(AnalyticsTestCase):
         bot = self.create_user(is_bot=True)
         human1 = self.create_user()
         human2 = self.create_user()
-        recipient_human1 = Recipient.objects.get(type_id=human1.id, type=Recipient.PERSONAL)
 
+        recipient_bot_and_human1 = self.get_dm_group_recipient(bot, human1)
+        recipient_human1_and_2 = self.get_dm_group_recipient(human1, human2)
+        recipient_human1 = self.get_dm_group_recipient(human1)
         recipient_stream = self.create_stream_with_recipient()[1]
         recipient_direct_message_group = self.create_direct_message_group_with_recipient()[1]
 
-        self.create_message(bot, recipient_human1)
+        self.create_message(bot, recipient_bot_and_human1)
         self.create_message(bot, recipient_stream)
         self.create_message(bot, recipient_direct_message_group)
         self.create_message(human1, recipient_human1)
-        self.create_message(human2, recipient_human1)
+        self.create_message(human2, recipient_human1_and_2)
 
         do_fill_count_stat_at_hour(stat, self.TIME_ZERO)
 
@@ -603,20 +605,23 @@ class TestCountStats(AnalyticsTestCase):
         bot = self.create_user(is_bot=True)
         human1 = self.create_user()
         human2 = self.create_user()
-        recipient_human1 = Recipient.objects.get(type_id=human1.id, type=Recipient.PERSONAL)
 
+        recipient_bot_and_human1 = self.get_dm_group_recipient(bot, human1)
+        recipient_human1_and_2 = self.get_dm_group_recipient(human1, human2)
+        recipient_human1 = self.get_dm_group_recipient(human1)
+        recipient_hourly_user_and_human1 = self.get_dm_group_recipient(self.hourly_user, human1)
         recipient_stream = self.create_stream_with_recipient()[1]
         recipient_direct_message_group = self.create_direct_message_group_with_recipient()[1]
 
         # To be included
-        self.create_message(bot, recipient_human1)
+        self.create_message(bot, recipient_bot_and_human1)
         self.create_message(bot, recipient_stream)
         self.create_message(bot, recipient_direct_message_group)
         self.create_message(human1, recipient_human1)
-        self.create_message(human2, recipient_human1)
+        self.create_message(human2, recipient_human1_and_2)
 
         # To be excluded
-        self.create_message(self.hourly_user, recipient_human1)
+        self.create_message(self.hourly_user, recipient_hourly_user_and_human1)
         self.create_message(self.hourly_user, recipient_stream)
         self.create_message(self.hourly_user, recipient_direct_message_group)
 
@@ -669,11 +674,10 @@ class TestCountStats(AnalyticsTestCase):
         self.create_message(user2, recipient_direct_message_group2)
 
         # direct messages
-        recipient_user1 = Recipient.objects.get(type_id=user1.id, type=Recipient.PERSONAL)
-        recipient_user2 = Recipient.objects.get(type_id=user2.id, type=Recipient.PERSONAL)
-        recipient_user3 = Recipient.objects.get(type_id=user3.id, type=Recipient.PERSONAL)
-        self.create_message(user1, recipient_user2)
-        self.create_message(user2, recipient_user1)
+        recipient_user1_and_2 = self.get_dm_group_recipient(user1, user2)
+        recipient_user3 = self.get_dm_group_recipient(user3)
+        self.create_message(user1, recipient_user1_and_2)
+        self.create_message(user2, recipient_user1_and_2)
         self.create_message(user3, recipient_user3)
 
         do_fill_count_stat_at_hour(stat, self.TIME_ZERO)
@@ -776,7 +780,8 @@ class TestCountStats(AnalyticsTestCase):
         self.current_property = stat.property
 
         user = self.create_user()
-        user_recipient = Recipient.objects.get(type_id=user.id, type=Recipient.PERSONAL)
+        user_recipient = self.get_dm_group_recipient(user)
+        hourly_user_and_user_recipient = self.get_dm_group_recipient(self.hourly_user, user)
         private_stream_recipient = self.create_stream_with_recipient(invite_only=True)[1]
         stream_recipient = self.create_stream_with_recipient()[1]
         direct_message_group_recipient = self.create_direct_message_group_with_recipient()[1]
@@ -790,7 +795,7 @@ class TestCountStats(AnalyticsTestCase):
         do_fill_count_stat_at_hour(stat, self.TIME_ZERO, self.default_realm)
 
         # To be excluded
-        self.create_message(self.hourly_user, user_recipient)
+        self.create_message(self.hourly_user, hourly_user_and_user_recipient)
         self.create_message(self.hourly_user, private_stream_recipient)
         self.create_message(self.hourly_user, stream_recipient)
         self.create_message(self.hourly_user, direct_message_group_recipient)
@@ -824,7 +829,7 @@ class TestCountStats(AnalyticsTestCase):
         self.current_property = stat.property
 
         user = self.create_user(id=1000)
-        user_recipient = Recipient.objects.get(type_id=user.id, type=Recipient.PERSONAL)
+        user_recipient = self.get_dm_group_recipient(user)
         stream_recipient = self.create_stream_with_recipient(id=1000)[1]
         direct_message_group_recipient = self.create_direct_message_group_with_recipient(id=1000)[1]
 
@@ -852,14 +857,15 @@ class TestCountStats(AnalyticsTestCase):
 
         user1 = self.create_user(is_bot=True)
         user2 = self.create_user()
-        recipient_user2 = Recipient.objects.get(type_id=user2.id, type=Recipient.PERSONAL)
 
+        recipient_user1_and_2 = self.get_dm_group_recipient(user1, user2)
+        recipient_user2 = self.get_dm_group_recipient(user2)
         recipient_stream = self.create_stream_with_recipient()[1]
         recipient_direct_message_group = self.create_direct_message_group_with_recipient()[1]
 
         client2 = Client.objects.create(name="client2")
 
-        self.create_message(user1, recipient_user2, sending_client=client2)
+        self.create_message(user1, recipient_user1_and_2, sending_client=client2)
         self.create_message(user1, recipient_stream)
         self.create_message(user1, recipient_direct_message_group)
         self.create_message(user2, recipient_user2, sending_client=client2)
@@ -899,19 +905,26 @@ class TestCountStats(AnalyticsTestCase):
 
         user1 = self.create_user(is_bot=True)
         user2 = self.create_user()
-        recipient_user2 = Recipient.objects.get(type_id=user2.id, type=Recipient.PERSONAL)
+
+        recipient_user1_and_2 = self.get_dm_group_recipient(user1, user2)
+        recipient_user2 = self.get_dm_group_recipient(user2)
+        recipient_hourly_user_and_user2 = self.get_dm_group_recipient(self.hourly_user, user2)
 
         client2 = Client.objects.create(name="client2")
 
         # TO be included
-        self.create_message(user1, recipient_user2, sending_client=client2)
+        self.create_message(user1, recipient_user1_and_2, sending_client=client2)
         self.create_message(user2, recipient_user2, sending_client=client2)
         self.create_message(user2, recipient_user2)
 
         # To be excluded
-        self.create_message(self.hourly_user, recipient_user2, sending_client=client2)
-        self.create_message(self.hourly_user, recipient_user2, sending_client=client2)
-        self.create_message(self.hourly_user, recipient_user2)
+        self.create_message(
+            self.hourly_user, recipient_hourly_user_and_user2, sending_client=client2
+        )
+        self.create_message(
+            self.hourly_user, recipient_hourly_user_and_user2, sending_client=client2
+        )
+        self.create_message(self.hourly_user, recipient_hourly_user_and_user2)
 
         do_fill_count_stat_at_hour(stat, self.TIME_ZERO, self.default_realm)
 
@@ -936,7 +949,8 @@ class TestCountStats(AnalyticsTestCase):
         bot = self.create_user(is_bot=True)
         human1 = self.create_user()
         human2 = self.create_user()
-        recipient_human1 = Recipient.objects.get(type_id=human1.id, type=Recipient.PERSONAL)
+        recipient_human1_and_2 = self.get_dm_group_recipient(human1, human2)
+        recipient_bot_and_human1 = self.get_dm_group_recipient(bot, human1)
 
         stream1, recipient_stream1 = self.create_stream_with_recipient()
         stream2, recipient_stream2 = self.create_stream_with_recipient()
@@ -949,8 +963,8 @@ class TestCountStats(AnalyticsTestCase):
         self.create_message(bot, recipient_stream2)
 
         # To be excluded
-        self.create_message(human2, recipient_human1)
-        self.create_message(bot, recipient_human1)
+        self.create_message(human2, recipient_human1_and_2)
+        self.create_message(bot, recipient_bot_and_human1)
         recipient_direct_message_group = self.create_direct_message_group_with_recipient()[1]
         self.create_message(human1, recipient_direct_message_group)
 
@@ -1435,7 +1449,7 @@ class TestLoggingCountStats(AnalyticsTestCase):
 
         message = Message(
             sender=hamlet,
-            recipient=self.example_user("othello").recipient,
+            recipient=self.get_dm_group_recipient(hamlet, self.example_user("othello")),
             realm_id=hamlet.realm_id,
             content="This is test content",
             rendered_content="This is test content",

--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -7,6 +7,7 @@ from unittest import mock
 import time_machine
 from django.apps import apps
 from django.db.models import Sum
+from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 from psycopg2.sql import SQL, Literal
 from typing_extensions import override
@@ -718,7 +719,8 @@ class TestCountStats(AnalyticsTestCase):
         )
         self.assertTableState(StreamCount, [], [])
 
-    def test_1_to_1_and_self_messages_sent_by_message_type_using_direct_group_message(self) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
+    def test_1_to_1_and_self_messages_sent_by_message_type_using_direct_message_group(self) -> None:
         stat = COUNT_STATS["messages_sent:message_type:day"]
         self.current_property = stat.property
 

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -7024,22 +7024,24 @@ class TestSupportBillingHelpers(StripeTestCase):
         sender = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
 
         # Organization owners get the notification bot message
-        desdemona_recipient = self.example_user("desdemona").recipient
+        bot_and_desdemona_recipient = self.get_dm_group_recipient(
+            sender, self.example_user("desdemona")
+        )
         message_to_owner = Message.objects.filter(
-            realm_id=realm.id, sender=sender.id, recipient=desdemona_recipient
+            realm_id=realm.id, sender=sender.id, recipient=bot_and_desdemona_recipient
         ).first()
         assert message_to_owner is not None
         self.assertEqual(message_to_owner.content, expected_message)
-        self.assertEqual(message_to_owner.recipient.type, Recipient.PERSONAL)
+        self.assertEqual(message_to_owner.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
         # Hamlet is in `can_manage_billing_group` so should get the notification bot message
-        hamlet_recipient = self.example_user("hamlet").recipient
+        bot_and_hamlet_recipient = self.get_dm_group_recipient(sender, self.example_user("hamlet"))
         message_to_hamlet = Message.objects.filter(
-            realm_id=realm.id, sender=sender.id, recipient=hamlet_recipient
+            realm_id=realm.id, sender=sender.id, recipient=bot_and_hamlet_recipient
         ).first()
         assert message_to_hamlet is not None
         self.assertEqual(message_to_hamlet.content, expected_message)
-        self.assertEqual(message_to_hamlet.recipient.type, Recipient.PERSONAL)
+        self.assertEqual(message_to_hamlet.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
     def test_update_realm_sponsorship_status(self) -> None:
         lear = get_realm("lear")

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -99,8 +99,8 @@ def do_delete_user(user_profile: UserProfile, *, acting_user: UserProfile | None
         # Recipient objects don't get deleted through CASCADE, so we need to handle
         # the user's personal recipient manually. This will also delete all Messages pointing
         # to this recipient (all direct messages sent to the user).
-        assert personal_recipient is not None
-        personal_recipient.delete()
+        if personal_recipient is not None:
+            personal_recipient.delete()
         replacement_user = create_user(
             force_id=user_id,
             email=Address(

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -99,8 +99,7 @@ def do_delete_user(user_profile: UserProfile, *, acting_user: UserProfile | None
         # Recipient objects don't get deleted through CASCADE, so we need to handle
         # the user's personal recipient manually. This will also delete all Messages pointing
         # to this recipient (all direct messages sent to the user).
-        if personal_recipient is not None:
-            personal_recipient.delete()
+        assert personal_recipient is None
         replacement_user = create_user(
             force_id=user_id,
             email=Address(
@@ -216,7 +215,6 @@ def do_delete_user_preserving_messages(user_profile: UserProfile) -> None:
             active=False,
             is_mirror_dummy=True,
             force_date_joined=date_joined,
-            create_personal_recipient=False,
         )
         # Uses index: zerver_message_realm_sender_recipient (prefix)
         Message.objects.filter(realm_id=realm.id, sender=user_profile).update(
@@ -238,7 +236,6 @@ def do_delete_user_preserving_messages(user_profile: UserProfile) -> None:
             active=False,
             is_mirror_dummy=True,
             force_date_joined=date_joined,
-            create_personal_recipient=False,
         )
         # We don't delete the personal recipient to preserve  personal messages!
         # Now, the personal recipient belong to replacement_user, because

--- a/zerver/data_import/mattermost.py
+++ b/zerver/data_import/mattermost.py
@@ -249,7 +249,7 @@ def convert_direct_message_group_data(
 ) -> list[ZerverFieldsT]:
     zerver_direct_message_group = []
     for direct_message_group in direct_message_group_data:
-        if len(direct_message_group["members"]) > 2:
+        if len(direct_message_group["members"]) > 2 or settings.PREFER_DIRECT_MESSAGE_GROUP:
             direct_message_group_members = frozenset(direct_message_group["members"])
             if direct_message_group_id_mapper.has(direct_message_group_members):
                 logging.info("Duplicate direct message group found in the export data. Skipping.")
@@ -612,7 +612,7 @@ def process_posts(
             # groups not channels. Direct messages and direct message groups are known
             # as direct_channels in Slack and hence the name channel_members.
             channel_members = post_dict["channel_members"]
-            if len(channel_members) > 2:
+            if len(channel_members) > 2 or settings.PREFER_DIRECT_MESSAGE_GROUP:
                 message_dict["direct_message_group_members"] = frozenset(channel_members)
             elif len(channel_members) == 2:
                 message_dict["pm_members"] = channel_members

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -920,7 +920,7 @@ def categorize_channels_and_map_with_id(
         if channel.get("prid"):
             dsc_id_to_dsc_map[channel["_id"]] = channel
         elif channel["t"] == "d":
-            if len(channel["uids"]) > 2:
+            if len(channel["uids"]) > 2 or settings.PREFER_DIRECT_MESSAGE_GROUP:
                 direct_message_group_members = frozenset(channel["uids"])
                 logging.info("Direct message group channel found. UIDs: %r", channel["uids"])
 

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime
 from email.headerregistry import Address
 
+from django.conf import settings
 from django.contrib.auth.models import UserManager
 from django.utils.timezone import now as timezone_now
 
@@ -250,7 +251,7 @@ def create_user(
         user_profile.email = get_display_email_address(user_profile)
         user_profile.save(update_fields=["email"])
 
-    if not create_personal_recipient:
+    if not create_personal_recipient or settings.PREFER_DIRECT_MESSAGE_GROUP:
         return user_profile
 
     recipient = Recipient.objects.create(type_id=user_profile.id, type=Recipient.PERSONAL)

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -38,7 +38,6 @@ from zerver.lib.message import (
     apply_unread_message_event,
     extract_unread_data_from_um_rows,
     get_raw_unread_data,
-    get_recent_conversations_recipient_id,
     get_recent_private_conversations,
     get_starred_message_ids,
     remove_message_id_from_unread_mgs,
@@ -1004,9 +1003,7 @@ def apply_event(
             if "raw_recent_private_conversations" in state:
                 # Handle maintaining the recent_private_conversations data structure.
                 conversations = state["raw_recent_private_conversations"]
-                recipient_id = get_recent_conversations_recipient_id(
-                    user_profile, event["message"]["recipient_id"], event["message"]["sender_id"]
-                )
+                recipient_id = event["message"]["recipient_id"]
 
                 if recipient_id not in conversations:
                     conversations[recipient_id] = dict(

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -1251,8 +1251,15 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
         new_user_id = get_system_bot(item["email"], internal_realm.id).id
         update_id_map(table="user_profile", old_id=item["id"], new_id=new_user_id)
         crossrealm_user_ids.add(new_user_id)
-        new_recipient_id = Recipient.objects.get(type=Recipient.PERSONAL, type_id=new_user_id).id
-        update_id_map(table="recipient", old_id=item["recipient_id"], new_id=new_recipient_id)
+        try:
+            new_recipient_id = Recipient.objects.get(
+                type=Recipient.PERSONAL, type_id=new_user_id
+            ).id
+            update_id_map(table="recipient", old_id=item["recipient_id"], new_id=new_recipient_id)
+        except Recipient.DoesNotExist:
+            # This can happen if user does not have a personal recipient,
+            # so there is nothing to do here.
+            pass
 
     # We first do a pass of updating model IDs for the cluster of
     # major models that have foreign keys into each other.

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -1399,7 +1399,9 @@ def get_recent_conversations_recipient_id(
     return recipient_id
 
 
-def get_recent_private_conversations(user_profile: UserProfile) -> dict[int, dict[str, Any]]:
+def _get_recent_conversations_via_legacy_personal_recipient(
+    user_profile_id: int, recipient_id: int
+) -> list[tuple[int, int]]:
     """This function uses some carefully optimized SQL queries, designed
     to use the UserMessage index on private_messages.  It is
     somewhat complicated by the fact that for 1:1 direct
@@ -1412,16 +1414,8 @@ def get_recent_private_conversations(user_profile: UserProfile) -> dict[int, dic
     It may be possible to write this query directly in Django, however
     it is made much easier by using CTEs, which Django does not
     natively support.
-
-    We return a dictionary structure for convenient modification
-    below; this structure is converted into its final form by
-    post_process.
-
     """
     RECENT_CONVERSATIONS_LIMIT = 1000
-
-    recipient_map = {}
-    my_recipient_id = user_profile.recipient_id
 
     query = SQL(
         """
@@ -1435,12 +1429,12 @@ def get_recent_private_conversations(user_profile: UserProfile) -> dict[int, dic
         message AS (
             SELECT message_id,
                    CASE
-                          WHEN m.recipient_id = %(my_recipient_id)s
+                          WHEN m.recipient_id = %(recipient_id)s
                           THEN m.sender_id
                           ELSE NULL
                    END AS sender_id,
                    CASE
-                          WHEN m.recipient_id <> %(my_recipient_id)s
+                          WHEN m.recipient_id <> %(recipient_id)s
                           THEN m.recipient_id
                           ELSE NULL
                    END AS outgoing_recipient_id
@@ -1466,29 +1460,64 @@ def get_recent_private_conversations(user_profile: UserProfile) -> dict[int, dic
         cursor.execute(
             query,
             {
-                "user_profile_id": user_profile.id,
+                "user_profile_id": user_profile_id,
                 "conversation_limit": RECENT_CONVERSATIONS_LIMIT,
-                "my_recipient_id": my_recipient_id,
+                "recipient_id": recipient_id,
             },
         )
-        rows = cursor.fetchall()
+        return cursor.fetchall()
 
-    # The resulting rows will be (recipient_id, max_message_id)
-    # objects for all parties we've had recent (group?) private
-    # message conversations with, including direct messages with
-    # yourself (those will generate an empty list of user_ids).
-    for recipient_id, max_message_id in rows:
-        recipient_map[recipient_id] = dict(
-            max_message_id=max_message_id,
-            user_ids=[],
+
+def _get_recent_conversations_via_direct_message_group(
+    user_profile_id: int,
+) -> list[tuple[int, int]]:
+    """
+    This functions fetches the most recent conversations given that all
+    private messages of this user are through direct message groups.
+    """
+    RECENT_CONVERSATIONS_LIMIT = 1000
+
+    recent_pm_message_ids = (
+        UserMessage.objects.filter(user_profile_id=user_profile_id)
+        .extra(where=[UserMessage.where_flag_is_present(UserMessage.flags.is_private)])  # noqa: S610
+        .order_by("-message_id")
+        .values_list("message_id", flat=True)[:RECENT_CONVERSATIONS_LIMIT]
+    )
+
+    return list(
+        Message.objects.filter(id__in=recent_pm_message_ids)
+        .values("recipient_id")
+        .annotate(max_message_id=Max("id"))
+        .values_list("recipient_id", "max_message_id")
+    )
+
+
+def get_recent_private_conversations(user_profile: UserProfile) -> dict[int, dict[str, Any]]:
+    """
+    We return a dictionary structure for convenient modification
+    below; this structure is converted into its final form by
+    post_process.
+    """
+    # Step 1: Collect recent message info
+    if user_profile.recipient_id is not None:
+        recent_conversations = _get_recent_conversations_via_legacy_personal_recipient(
+            user_profile.id, user_profile.recipient_id
         )
+    else:
+        recent_conversations = _get_recent_conversations_via_direct_message_group(user_profile.id)
+
+    recipient_map: dict[int, dict[str, Any]] = {
+        recipient_id: {"max_message_id": max_message_id, "user_ids": []}
+        for recipient_id, max_message_id in recent_conversations
+    }
 
     # Now we need to map all the recipient_id objects to lists of user IDs
-    for recipient_id, user_profile_id in (
+    subscriptions = (
         Subscription.objects.filter(recipient_id__in=recipient_map.keys())
         .exclude(user_profile_id=user_profile.id)
         .values_list("recipient_id", "user_profile_id")
-    ):
+    )
+    for recipient_id, user_profile_id in subscriptions:
         recipient_map[recipient_id]["user_ids"].append(user_profile_id)
 
     # Sort to prevent test flakes and client bugs.

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -15,7 +15,7 @@ from psycopg2.sql import SQL
 from analytics.lib.counts import COUNT_STATS
 from analytics.models import RealmCount
 from zerver.lib.cache import generic_bulk_cached_fetch, to_dict_cache_key_id
-from zerver.lib.display_recipient import get_display_recipient, get_display_recipient_by_id
+from zerver.lib.display_recipient import get_display_recipient_by_id
 from zerver.lib.exceptions import JsonableError, MissingAuthenticationError
 from zerver.lib.markdown import MessageRenderingResult
 from zerver.lib.mention import MentionData, sender_can_mention_group
@@ -1779,8 +1779,8 @@ def is_1_to_1_message(message: Message) -> bool:
 
 def is_message_to_self(message: Message) -> bool:
     if message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
-        group_members = get_display_recipient(message.recipient)
-        return len(group_members) == 1 and group_members[0]["id"] == message.sender.id
+        direct_message_group = DirectMessageGroup.objects.get(id=message.recipient.type_id)
+        return direct_message_group.group_size == 1
 
     if message.recipient.type == Recipient.PERSONAL:
         return message.recipient == message.sender.recipient

--- a/zerver/lib/message_cache.py
+++ b/zerver/lib/message_cache.py
@@ -185,7 +185,6 @@ class MessageDict:
                 skip_copy=True,
                 can_access_sender=can_access_sender,
                 realm_host=realm.host,
-                is_incoming_1_to_1=obj["recipient_id"] == user_recipient_id,
             )
 
     @staticmethod
@@ -199,7 +198,6 @@ class MessageDict:
         skip_copy: bool = False,
         can_access_sender: bool,
         realm_host: str,
-        is_incoming_1_to_1: bool,
     ) -> dict[str, Any]:
         """
         By default, we make a shallow copy of the incoming dict to avoid
@@ -244,13 +242,6 @@ class MessageDict:
             obj["content"] = obj["rendered_content"]
         else:
             obj["content_type"] = "text/x-markdown"
-
-        if is_incoming_1_to_1 and "sender_recipient_id" in obj:
-            # For an incoming 1:1 DM, the recipient’s own recipient_id is
-            # useless to the recipient themselves. Substitute the sender’s
-            # recipient_id, so the recipient can use recipient_id as documented
-            # to uniquely represent the set of 2 users in this conversation.
-            obj["recipient_id"] = obj["sender_recipient_id"]
 
         for item in obj.get("edit_history", []):
             if "prev_rendered_content_version" in item:
@@ -532,7 +523,7 @@ class MessageDict:
 
         if recipient_type == Recipient.STREAM:
             display_type = "stream"
-        elif recipient_type in (Recipient.DIRECT_MESSAGE_GROUP, Recipient.PERSONAL):
+        elif recipient_type == Recipient.DIRECT_MESSAGE_GROUP:
             assert not isinstance(display_recipient, str)
             display_type = "private"
             if len(display_recipient) == 1:

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -277,12 +277,8 @@ def send_welcome_bot_response(send_request: SendMessageRequest) -> None:
     to welcome-bot, trigger the welcome-bot reply."""
     welcome_bot = get_system_bot(settings.WELCOME_BOT, send_request.realm.id)
     human_response_lower = send_request.message.content.lower()
-    if send_request.message.recipient.type == Recipient.PERSONAL:
-        conversation_recipient_id = send_request.message.sender.recipient_id
-        assert conversation_recipient_id is not None
-    else:
-        assert send_request.message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP
-        conversation_recipient_id = send_request.message.recipient.id
+    assert send_request.message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP
+    conversation_recipient_id = send_request.message.recipient.id
     content = select_welcome_bot_response(human_response_lower)
     realm_id = send_request.realm.id
     commands = bot_commands()

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -69,7 +69,6 @@ class GenericOutgoingWebhookService(OutgoingWebhookServiceInterface):
                 get_user_profile_by_id(event["message"]["sender_id"]), self.user_profile
             ),
             realm_host=realm.host,
-            is_incoming_1_to_1=event["message"]["recipient_id"] == self.user_profile.recipient_id,
         )
 
         request_data = {

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1032,7 +1032,9 @@ def get_message_payload(
             data["channel_id"] = channel_id
 
         data["topic"] = get_topic_display_name(message.topic_name(), user_profile.default_language)
-    elif message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
+    else:
+        assert message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP
+
         data["recipient_type"] = "private" if for_legacy_clients else "direct"
         # For group DMs, we need to fetch the users for the pm_users field.
         # Note that this doesn't do a separate database query, because both
@@ -1040,8 +1042,6 @@ def get_message_payload(
         recipients = get_display_recipient(message.recipient)
         if len(recipients) > 2:
             data["pm_users"] = direct_message_group_users(message.recipient.id)
-    else:  # Recipient.PERSONAL
-        data["recipient_type"] = "private" if for_legacy_clients else "direct"
 
     return data
 
@@ -1095,8 +1095,6 @@ def get_apns_alert_subtitle(
         NotificationTriggers.STREAM_WILDCARD_MENTION,
     ):
         return _("{full_name} mentioned everyone:").format(full_name=sender_name)
-    elif message.recipient.type == Recipient.PERSONAL:
-        return ""
     elif message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
         recipients = get_display_recipient(message.recipient)
         if len(recipients) <= 2:

--- a/zerver/lib/recipient_users.py
+++ b/zerver/lib/recipient_users.py
@@ -58,19 +58,23 @@ def get_recipient_from_user_profiles(
                     type_id=direct_message_group.id,
                 )
 
-        # If no direct message group recipient exists, or if the setting
-        # is disabled, we fall back to using personal recipients.
-        del recipient_profiles_map[sender.id]
-        if len(recipient_profiles_map) == 1:
-            [recipient_user_profile] = recipient_profiles_map.values()
-        else:
-            recipient_user_profile = sender
-        return Recipient(
-            id=recipient_user_profile.recipient_id,
-            type=Recipient.PERSONAL,
-            type_id=recipient_user_profile.id,
+        # Making sure we have personal recipients for all users,
+        # otherwise, fall back to the direct message group.
+        has_personal_recipient = all(
+            user_profile.recipient_id is not None
+            for user_profile in recipient_profiles_map.values()
         )
-
+        if has_personal_recipient:
+            del recipient_profiles_map[sender.id]
+            if len(recipient_profiles_map) == 1:
+                [recipient_user_profile] = recipient_profiles_map.values()
+            else:
+                recipient_user_profile = sender
+            return Recipient(
+                id=recipient_user_profile.recipient_id,
+                type=Recipient.PERSONAL,
+                type_id=recipient_user_profile.id,
+            )
     if create:
         direct_message_group = get_or_create_direct_message_group(user_ids)
     else:

--- a/zerver/lib/recipient_users.py
+++ b/zerver/lib/recipient_users.py
@@ -1,6 +1,5 @@
 from collections.abc import Sequence
 
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext as _
 
@@ -38,30 +37,6 @@ def get_recipient_from_user_profiles(
     # Make sure the sender is included in the group direct messages.
     recipient_profiles_map[sender.id] = sender
     user_ids = list(recipient_profiles_map)
-
-    # Important note: We are transitioning 1:1 DMs and self DMs to use
-    # DirectMessageGroup as the Recipient type. If PREFER_DIRECT_MESSAGE_GROUP
-    # is enabled, we will use a DirectMessageGroup. If not enabled, we use the
-    # legacy personal recipient (if available). Once the migration completes,
-    # this code path can be removed.
-    if len(recipient_profiles_map) <= 2:
-        # Making sure we have personal recipients for all users,
-        # otherwise, fall back to the direct message group.
-        has_personal_recipient = all(
-            user_profile.recipient_id is not None
-            for user_profile in recipient_profiles_map.values()
-        )
-        if has_personal_recipient and not settings.PREFER_DIRECT_MESSAGE_GROUP:
-            del recipient_profiles_map[sender.id]
-            if len(recipient_profiles_map) == 1:
-                [recipient_user_profile] = recipient_profiles_map.values()
-            else:
-                recipient_user_profile = sender
-            return Recipient(
-                id=recipient_user_profile.recipient_id,
-                type=Recipient.PERSONAL,
-                type_id=recipient_user_profile.id,
-            )
 
     if create:
         direct_message_group = get_or_create_direct_message_group(user_ids)

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -2201,9 +2201,6 @@ class ZulipTestCase(ZulipTestCaseMixin, TestCase):
         'self.captureOnCommitCallbacks' for 'send_event_on_commit' or/and
         'queue_event_on_commit' to work.
         """
-        if not settings.PREFER_DIRECT_MESSAGE_GROUP:
-            self.create_personal_recipient(from_user, to_user)
-
         if skip_capture_on_commit_callbacks:
             message_id = super().send_personal_message(
                 from_user,
@@ -2350,21 +2347,6 @@ class ZulipTestCase(ZulipTestCaseMixin, TestCase):
         )
         assert direct_group_message.recipient is not None
         return direct_group_message.recipient
-
-    def create_personal_recipient(self, *user_profiles: UserProfile) -> None:
-        for user_profile in user_profiles:
-            if user_profile.recipient:
-                continue
-
-            recipient = Recipient.objects.create(type_id=user_profile.id, type=Recipient.PERSONAL)
-            user_profile.recipient = recipient
-            user_profile.save(update_fields=["recipient"])
-
-            Subscription.objects.create(
-                user_profile=user_profile,
-                recipient=recipient,
-                is_user_active=user_profile.is_active,
-            )
 
 
 def get_row_pks_in_all_tables() -> Iterator[tuple[str, set[int]]]:
@@ -2802,7 +2784,9 @@ class PushNotificationTestCase(BouncerTestCase):
         self.user_profile = self.example_user("hamlet")
         self.sending_client = get_client("test")
         self.sender = self.example_user("hamlet")
-        self.personal_recipient_user = self.example_user("othello")
+        self.dm_group = get_or_create_direct_message_group(
+            id_list=[self.sender.id, self.example_user("othello").id]
+        )
 
     def get_message(self, type: int, type_id: int, realm_id: int) -> Message:
         recipient, _ = Recipient.objects.get_or_create(

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -111,6 +111,7 @@ from zerver.models import (
 )
 from zerver.models.clients import get_client
 from zerver.models.realms import clear_supported_auth_backends_cache, get_realm
+from zerver.models.recipients import get_or_create_direct_message_group
 from zerver.models.streams import StreamTopicsPolicyEnum, get_realm_stream, get_stream
 from zerver.models.users import get_system_bot, get_user, get_user_by_delivery_email
 from zerver.openapi.openapi import validate_test_request, validate_test_response
@@ -2339,6 +2340,13 @@ class ZulipTestCase(ZulipTestCaseMixin, TestCase):
         return self.build_streams_subscriber_count(
             streams=Stream.objects.exclude(id__in=stream_ids)
         )
+
+    def get_dm_group_recipient(self, sender: UserProfile, *other_users: UserProfile) -> Recipient:
+        direct_group_message = get_or_create_direct_message_group(
+            id_list=[sender.id] + [user.id for user in other_users],
+        )
+        assert direct_group_message.recipient is not None
+        return direct_group_message.recipient
 
 
 def get_row_pks_in_all_tables() -> Iterator[tuple[str, set[int]]]:

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -652,7 +652,6 @@ def use_db_models(
         RealmEmoji = apps.get_model("zerver", "RealmEmoji")
         RealmFilter = apps.get_model("zerver", "RealmFilter")
         Recipient = apps.get_model("zerver", "Recipient")
-        Recipient.PERSONAL = 1
         Recipient.STREAM = 2
         Recipient.DIRECT_MESSAGE_GROUP = 3
         ScheduledEmail = apps.get_model("zerver", "ScheduledEmail")

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -743,8 +743,10 @@ def check_can_access_user(
     ).exists():
         return True
 
-    assert user_profile.recipient_id is not None
-    assert target_user.recipient_id is not None
+    if user_profile.recipient_id is None or target_user.recipient_id is None:
+        # If either user does not have a recipient_id, they rely on
+        # direct message groups for 1:1 or self DMs.
+        return False
 
     # Querying the "Message" table is expensive so we do this last.
     direct_message_query = Message.objects.filter(
@@ -795,6 +797,11 @@ def get_inaccessible_user_ids(
     possible_inaccessible_user_ids = set(target_human_user_ids) - set(common_subscription_user_ids)
     if not possible_inaccessible_user_ids:
         return set()
+
+    if not acting_user.recipient_id:
+        # If the acting user does not have a recipient_id, they only rely on
+        # direct message groups for 1:1 or self DMs.
+        return possible_inaccessible_user_ids
 
     target_user_recipient_ids = UserProfile.objects.filter(
         id__in=possible_inaccessible_user_ids
@@ -934,7 +941,9 @@ def get_users_involved_in_dms_with_target_users(
 
         direct_message_participants_dict[sender_id] = recipient_user_ids
 
-    personal_recipient_ids_for_target_users = [user.recipient_id for user in target_users]
+    personal_recipient_ids_for_target_users = [
+        user.recipient_id for user in target_users if user.recipient_id is not None
+    ]
     direct_message_senders_query = Message.objects.filter(
         realm=realm,
         recipient_id__in=personal_recipient_ids_for_target_users,

--- a/zerver/management/commands/export_search.py
+++ b/zerver/management/commands/export_search.py
@@ -12,7 +12,6 @@ from threading import Lock, Thread
 from typing import Any, NoReturn, Union
 
 import orjson
-from django.conf import settings
 from django.core.management.base import CommandError
 from django.db.models import Q
 from typing_extensions import override
@@ -215,15 +214,10 @@ This is most often used for legal compliance.
                 usermessage_joined = True
             elif len(user_profiles) == 2:
                 user_a, user_b = user_profiles
-                if settings.PREFER_DIRECT_MESSAGE_GROUP:
-                    direct_message_group = get_or_create_direct_message_group(
-                        id_list=[user_a.id, user_b.id]
-                    )
-                    limits &= Q(recipient=direct_message_group.recipient)
-                else:
-                    limits &= Q(recipient=user_a.recipient, sender=user_b) | Q(
-                        recipient=user_b.recipient, sender=user_a
-                    )
+                direct_message_group = get_or_create_direct_message_group(
+                    id_list=[user_a.id, user_b.id]
+                )
+                limits &= Q(recipient=direct_message_group.recipient)
             else:
                 direct_message_group = get_or_create_direct_message_group(
                     [user.id for user in user_profiles]

--- a/zerver/management/commands/export_search.py
+++ b/zerver/management/commands/export_search.py
@@ -21,7 +21,7 @@ from zerver.lib.management import ZulipBaseCommand
 from zerver.lib.soft_deactivation import reactivate_user_if_soft_deactivated
 from zerver.lib.upload import save_attachment_contents
 from zerver.models import AbstractUserMessage, Message, Recipient, Stream, UserProfile
-from zerver.models.recipients import get_direct_message_group, get_or_create_direct_message_group
+from zerver.models.recipients import get_or_create_direct_message_group
 from zerver.models.streams import get_stream
 from zerver.models.users import get_user_by_delivery_email
 
@@ -215,8 +215,10 @@ This is most often used for legal compliance.
                 usermessage_joined = True
             elif len(user_profiles) == 2:
                 user_a, user_b = user_profiles
-                direct_message_group = get_direct_message_group(id_list=[user_a.id, user_b.id])
-                if direct_message_group and settings.PREFER_DIRECT_MESSAGE_GROUP:
+                if settings.PREFER_DIRECT_MESSAGE_GROUP:
+                    direct_message_group = get_or_create_direct_message_group(
+                        id_list=[user_a.id, user_b.id]
+                    )
                     limits &= Q(recipient=direct_message_group.recipient)
                 else:
                     limits &= Q(recipient=user_a.recipient, sender=user_b) | Q(

--- a/zerver/management/commands/export_search.py
+++ b/zerver/management/commands/export_search.py
@@ -12,6 +12,7 @@ from threading import Lock, Thread
 from typing import Any, NoReturn, Union
 
 import orjson
+from django.conf import settings
 from django.core.management.base import CommandError
 from django.db.models import Q
 from typing_extensions import override
@@ -215,7 +216,7 @@ This is most often used for legal compliance.
             elif len(user_profiles) == 2:
                 user_a, user_b = user_profiles
                 direct_message_group = get_direct_message_group(id_list=[user_a.id, user_b.id])
-                if direct_message_group:
+                if direct_message_group and settings.PREFER_DIRECT_MESSAGE_GROUP:
                     limits &= Q(recipient=direct_message_group.recipient)
                 else:
                     limits &= Q(recipient=user_a.recipient, sender=user_b) | Q(

--- a/zerver/models/recipients.py
+++ b/zerver/models/recipients.py
@@ -188,21 +188,3 @@ def get_or_create_direct_message_group(id_list: list[int]) -> DirectMessageGroup
             ]
             Subscription.objects.bulk_create(subs_to_create)
         return direct_message_group
-
-
-def get_direct_message_group(id_list: list[int]) -> DirectMessageGroup | None:
-    """
-    Takes a list of user IDs and returns the DirectMessageGroup
-    object for the group consisting of these users if exists. If
-    the DirectMessageGroup object does not yet exist, it will
-    return None.
-    """
-
-    try:
-        direct_message_group_hash = get_direct_message_group_hash(id_list)
-        return DirectMessageGroup.objects.get(
-            huddle_hash=direct_message_group_hash,
-            group_size=len(id_list),
-        )
-    except DirectMessageGroup.DoesNotExist:
-        return None

--- a/zerver/models/recipients.py
+++ b/zerver/models/recipients.py
@@ -49,7 +49,7 @@ class Recipient(models.Model):
     PERSONAL = 1
     # The type for stream messages.
     STREAM = 2
-    # The type group direct messages.
+    # The type group direct messages for 1:1 and group dms.
     DIRECT_MESSAGE_GROUP = 3
 
     class Meta:
@@ -57,7 +57,6 @@ class Recipient(models.Model):
 
     # N.B. If we used Django's choice=... we would get this for free (kinda)
     _type_names = {
-        PERSONAL: "personal",
         STREAM: "stream",
         DIRECT_MESSAGE_GROUP: "direct_message_group",
     }

--- a/zerver/tests/fixtures/mattermost_fixtures/direct_channel/export.json
+++ b/zerver/tests/fixtures/mattermost_fixtures/direct_channel/export.json
@@ -14,6 +14,7 @@
 {"type":"direct_channel","direct_channel":{"members":["ron","harry"],"favorited_by":null,"header":""}}
 {"type":"direct_channel","direct_channel":{"members":["ron","harry", "ginny"],"favorited_by":null,"header":""}}
 {"type":"direct_channel","direct_channel":{"members":["harry","ron", "ginny"],"favorited_by":null,"header":""}}
+{"type":"direct_channel","direct_channel":{"members":["harry","voldemort"],"favorited_by":null,"header":""}}
 {"type":"direct_post","direct_post":{"channel_members":["ron","harry"],"user":"ron","message":"hey harry","create_at":1566376137676,"flagged_by":null,"reactions":null,"replies":null,"attachments":[{"path":"20210622/teams/noteam/channels/mcrm7xee5bnpzn7u9ktsd91dwy/users/knq189b88fdxbdkeeasdynia4o/o3to4ezua3bajj31mzpkn96n5e/harry-ron.jpg"}]}}
 {"type":"direct_post","direct_post":{"channel_members":["ron","harry"],"user":"harry","message":"what's up","create_at":1566376318568,"flagged_by":null,"reactions":null,"replies":null,"attachments":null}}
 {"type":"direct_post","direct_post":{"channel_members":["ron","harry","ginny"],"user":"ginny","message":"Who is going to Hogsmeade this weekend?","create_at":1566376226493,"flagged_by":null,"reactions":null,"replies":null,"attachments":null}}

--- a/zerver/tests/test_channel_fetch.py
+++ b/zerver/tests/test_channel_fetch.py
@@ -839,7 +839,7 @@ class GetSubscribersTest(ZulipTestCase):
             polonius.id,
         ]
 
-        with self.assert_database_query_count(55):
+        with self.assert_database_query_count(52):
             self.subscribe_via_post(
                 self.user_profile,
                 stream_names,

--- a/zerver/tests/test_channel_fetch.py
+++ b/zerver/tests/test_channel_fetch.py
@@ -839,7 +839,7 @@ class GetSubscribersTest(ZulipTestCase):
             polonius.id,
         ]
 
-        with self.assert_database_query_count(52):
+        with self.assert_database_query_count(55):
             self.subscribe_via_post(
                 self.user_profile,
                 stream_names,

--- a/zerver/tests/test_channel_fetch.py
+++ b/zerver/tests/test_channel_fetch.py
@@ -615,7 +615,7 @@ class GetSubscribersTest(ZulipTestCase):
         # verify that the user was sent a message informing them about the subscription
         realm = user.realm
         msg = most_recent_message(user)
-        self.assertEqual(msg.recipient.type, msg.recipient.PERSONAL)
+        self.assertEqual(msg.recipient.type, msg.recipient.DIRECT_MESSAGE_GROUP)
         self.assertEqual(msg.sender_id, self.notification_bot(realm).id)
 
         def non_ws(s: str) -> str:
@@ -839,7 +839,7 @@ class GetSubscribersTest(ZulipTestCase):
             polonius.id,
         ]
 
-        with self.assert_database_query_count(55):
+        with self.assert_database_query_count(76):
             self.subscribe_via_post(
                 self.user_profile,
                 stream_names,

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1274,7 +1274,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         incoming_valid_message["To"] = mm_address
         incoming_valid_message["Reply-to"] = self.example_email("othello")
 
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(18):
             process_message(incoming_valid_message)
 
         # confirm that Hamlet got the message

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1274,7 +1274,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         incoming_valid_message["To"] = mm_address
         incoming_valid_message["Reply-to"] = self.example_email("othello")
 
-        with self.assert_database_query_count(18):
+        with self.assert_database_query_count(17):
             process_message(incoming_valid_message)
 
         # confirm that Hamlet got the message

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1243,6 +1243,7 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
 
 
 class TestMissedMessageEmailMessages(ZulipTestCase):
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_receive_missed_personal_message_email_messages(self) -> None:
         # Build dummy messages for message notification email reply.
         # Have Hamlet send Othello a direct message. Othello will
@@ -1274,7 +1275,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         incoming_valid_message["To"] = mm_address
         incoming_valid_message["Reply-to"] = self.example_email("othello")
 
-        with self.assert_database_query_count(18):
+        with self.assert_database_query_count(17):
             process_message(incoming_valid_message)
 
         # confirm that Hamlet got the message

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1248,8 +1248,12 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         # Build dummy messages for message notification email reply.
         # Have Hamlet send Othello a direct message. Othello will
         # reply via email Hamlet will receive the message.
-        self.login("hamlet")
+        hamlet = self.example_user("hamlet")
         othello = self.example_user("othello")
+
+        self.create_personal_recipient(hamlet, othello)
+
+        self.login("hamlet")
         result = self.client_post(
             "/json/messages",
             {
@@ -1260,31 +1264,29 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         )
         self.assert_json_success(result)
 
-        user_profile = self.example_user("othello")
-        usermessage = most_recent_usermessage(user_profile)
+        usermessage = most_recent_usermessage(othello)
 
         # we don't want to send actual emails but we do need to create and store the
         # token for looking up who did reply.
-        mm_address = create_missed_message_address(user_profile, usermessage.message)
+        mm_address = create_missed_message_address(othello, usermessage.message)
 
         incoming_valid_message = EmailMessage()
         incoming_valid_message.set_content("TestMissedMessageEmailMessages body")
 
         incoming_valid_message["Subject"] = "TestMissedMessageEmailMessages subject"
-        incoming_valid_message["From"] = self.example_email("othello")
+        incoming_valid_message["From"] = othello
         incoming_valid_message["To"] = mm_address
-        incoming_valid_message["Reply-to"] = self.example_email("othello")
+        incoming_valid_message["Reply-to"] = othello
 
         with self.assert_database_query_count(17):
             process_message(incoming_valid_message)
 
         # confirm that Hamlet got the message
-        user_profile = self.example_user("hamlet")
-        message = most_recent_message(user_profile)
+        message = most_recent_message(hamlet)
 
         self.assertEqual(message.content, "TestMissedMessageEmailMessages body")
-        self.assertEqual(message.sender, self.example_user("othello"))
-        self.assertEqual(message.recipient.type_id, user_profile.id)
+        self.assertEqual(message.sender, othello)
+        self.assertEqual(message.recipient.type_id, hamlet.id)
         self.assertEqual(message.recipient.type, Recipient.PERSONAL)
 
     def test_receive_missed_group_direct_message_email_messages(self) -> None:

--- a/zerver/tests/test_embedded_bot_system.py
+++ b/zerver/tests/test_embedded_bot_system.py
@@ -34,8 +34,9 @@ class TestEmbeddedBotMessaging(ZulipTestCase):
         self.assertEqual(last_message.sender_id, self.bot_profile.id)
         display_recipient = get_display_recipient(last_message.recipient)
         assert isinstance(display_recipient, list)
-        self.assert_length(display_recipient, 1)
+        self.assert_length(display_recipient, 2)
         self.assertEqual(display_recipient[0]["email"], self.user_profile.email)
+        self.assertEqual(display_recipient[1]["email"], self.bot_profile.email)
 
     def test_stream_message_to_embedded_bot(self) -> None:
         assert self.bot_profile is not None

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -328,6 +328,7 @@ class GetEventsTest(ZulipTestCase):
         email = user_profile.email
         recipient_user_profile = self.example_user("othello")
         recipient_email = recipient_user_profile.email
+        recipient = self.get_dm_group_recipient(user_profile, recipient_user_profile)
         self.login_user(user_profile)
 
         result = self.tornado_call(
@@ -403,7 +404,7 @@ class GetEventsTest(ZulipTestCase):
         self.assertEqual(events[0]["local_message_id"], local_id)
         self.assertEqual(events[0]["message"]["display_recipient"][0]["is_mirror_dummy"], False)
         self.assertEqual(events[0]["message"]["display_recipient"][1]["is_mirror_dummy"], False)
-        self.assertEqual(events[0]["message"]["recipient_id"], recipient_user_profile.recipient_id)
+        self.assertEqual(events[0]["message"]["recipient_id"], recipient.id)
 
         last_event_id = events[0]["id"]
         local_id = "10.02"
@@ -436,7 +437,7 @@ class GetEventsTest(ZulipTestCase):
         self.assertEqual(events[0]["type"], "message")
         self.assertEqual(events[0]["message"]["sender_email"], email)
         self.assertEqual(events[0]["local_message_id"], local_id)
-        self.assertEqual(events[0]["message"]["recipient_id"], recipient_user_profile.recipient_id)
+        self.assertEqual(events[0]["message"]["recipient_id"], recipient.id)
 
         # Test that the received message in the receiver's event queue
         # exists and does not contain a local id
@@ -457,11 +458,11 @@ class GetEventsTest(ZulipTestCase):
         self.assertEqual(recipient_events[0]["message"]["sender_email"], email)
         self.assertTrue("local_message_id" not in recipient_events[0])
         # Incoming DMs show the recipient_id that outgoing DMs would.
-        self.assertEqual(recipient_events[0]["message"]["recipient_id"], user_profile.recipient_id)
+        self.assertEqual(events[0]["message"]["recipient_id"], recipient.id)
         self.assertEqual(recipient_events[1]["type"], "message")
         self.assertEqual(recipient_events[1]["message"]["sender_email"], email)
         self.assertTrue("local_message_id" not in recipient_events[1])
-        self.assertEqual(recipient_events[1]["message"]["recipient_id"], user_profile.recipient_id)
+        self.assertEqual(recipient_events[1]["message"]["recipient_id"], recipient.id)
 
     def test_get_events_narrow(self) -> None:
         user_profile = self.example_user("hamlet")

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -17,7 +17,6 @@ from unittest import mock
 import orjson
 import time_machine
 from dateutil.parser import parse as dateparser
-from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
@@ -655,8 +654,7 @@ class NormalActionsTest(BaseAction):
                     skip_capture_on_commit_callbacks=True,
                 )
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
-    def test_pm_send_message_events_using_personal_recipients(self) -> None:
+    def test_pm_send_message_events(self) -> None:
         with self.verify_action() as events:
             self.send_personal_message(
                 self.example_user("cordelia"),
@@ -706,18 +704,6 @@ class NormalActionsTest(BaseAction):
             has_new_stream_id=False,
             is_embedded_update_only=False,
         )
-
-    def test_pm_send_message_events_via_direct_message_group(self) -> None:
-        hamlet = self.example_user("hamlet")
-        cordelia = self.example_user("cordelia")
-
-        with self.verify_action():
-            self.send_group_direct_message(
-                from_user=hamlet,
-                to_users=[hamlet, cordelia],
-                content="hola",
-                skip_capture_on_commit_callbacks=True,
-            )
 
     def test_direct_message_group_send_message_events(self) -> None:
         direct_message_group = [

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -17,6 +17,7 @@ from unittest import mock
 import orjson
 import time_machine
 from dateutil.parser import parse as dateparser
+from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
@@ -654,7 +655,8 @@ class NormalActionsTest(BaseAction):
                     skip_capture_on_commit_callbacks=True,
                 )
 
-    def test_pm_send_message_events(self) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_pm_send_message_events_using_personal_recipients(self) -> None:
         with self.verify_action() as events:
             self.send_personal_message(
                 self.example_user("cordelia"),
@@ -704,6 +706,18 @@ class NormalActionsTest(BaseAction):
             has_new_stream_id=False,
             is_embedded_update_only=False,
         )
+
+    def test_pm_send_message_events_via_direct_message_group(self) -> None:
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+
+        with self.verify_action():
+            self.send_group_direct_message(
+                from_user=hamlet,
+                to_users=[hamlet, cordelia],
+                content="hola",
+                skip_capture_on_commit_callbacks=True,
+            )
 
     def test_direct_message_group_send_message_events(self) -> None:
         direct_message_group = [

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -363,7 +363,7 @@ class TestQueryCounts(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")
 
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(17):
             self.send_personal_message(
                 from_user=hamlet,
                 to_user=cordelia,

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import orjson
 import time_machine
+from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.realm_settings import do_change_realm_permission_group_setting
@@ -363,7 +364,19 @@ class TestQueryCounts(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")
 
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(24):
+            self.send_personal_message(
+                from_user=hamlet,
+                to_user=cordelia,
+                content="hello there!",
+            )
+
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_capturing_queries_using_personal_recipient(self) -> None:
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+
+        with self.assert_database_query_count(16):
             self.send_personal_message(
                 from_user=hamlet,
                 to_user=cordelia,

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import orjson
 import time_machine
-from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.realm_settings import do_change_realm_permission_group_setting
@@ -365,18 +364,6 @@ class TestQueryCounts(ZulipTestCase):
         cordelia = self.example_user("cordelia")
 
         with self.assert_database_query_count(24):
-            self.send_personal_message(
-                from_user=hamlet,
-                to_user=cordelia,
-                content="hello there!",
-            )
-
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
-    def test_capturing_queries_using_personal_recipient(self) -> None:
-        hamlet = self.example_user("hamlet")
-        cordelia = self.example_user("cordelia")
-
-        with self.assert_database_query_count(16):
             self.send_personal_message(
                 from_user=hamlet,
                 to_user=cordelia,

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -363,7 +363,7 @@ class TestQueryCounts(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")
 
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(16):
             self.send_personal_message(
                 from_user=hamlet,
                 to_user=cordelia,

--- a/zerver/tests/test_handle_push_notification.py
+++ b/zerver/tests/test_handle_push_notification.py
@@ -57,9 +57,9 @@ class HandlePushNotificationTest(PushNotificationTestCase):
         self.setup_fcm_tokens()
 
         message = self.get_message(
-            Recipient.PERSONAL,
-            type_id=self.personal_recipient_user.id,
-            realm_id=self.personal_recipient_user.realm_id,
+            Recipient.DIRECT_MESSAGE_GROUP,
+            type_id=self.dm_group.id,
+            realm_id=self.user_profile.realm_id,
         )
         UserMessage.objects.create(
             user_profile=self.user_profile,
@@ -158,9 +158,9 @@ class HandlePushNotificationTest(PushNotificationTestCase):
         realm.save()
 
         message = self.get_message(
-            Recipient.PERSONAL,
-            type_id=self.personal_recipient_user.id,
-            realm_id=self.personal_recipient_user.realm_id,
+            Recipient.DIRECT_MESSAGE_GROUP,
+            type_id=self.dm_group.id,
+            realm_id=self.user_profile.realm_id,
         )
         UserMessage.objects.create(
             user_profile=self.user_profile,
@@ -225,9 +225,9 @@ class HandlePushNotificationTest(PushNotificationTestCase):
         self.setup_fcm_tokens()
 
         message = self.get_message(
-            Recipient.PERSONAL,
-            type_id=self.personal_recipient_user.id,
-            realm_id=self.personal_recipient_user.realm_id,
+            Recipient.DIRECT_MESSAGE_GROUP,
+            type_id=self.dm_group.id,
+            realm_id=self.user_profile.realm_id,
         )
         UserMessage.objects.create(
             user_profile=self.user_profile,
@@ -328,9 +328,9 @@ class HandlePushNotificationTest(PushNotificationTestCase):
         self.setup_fcm_tokens()
 
         message = self.get_message(
-            Recipient.PERSONAL,
-            type_id=self.personal_recipient_user.id,
-            realm_id=self.personal_recipient_user.realm_id,
+            Recipient.DIRECT_MESSAGE_GROUP,
+            type_id=self.dm_group.id,
+            realm_id=self.user_profile.realm_id,
         )
         UserMessage.objects.create(
             user_profile=self.user_profile,
@@ -356,9 +356,9 @@ class HandlePushNotificationTest(PushNotificationTestCase):
 
         user_profile = self.example_user("hamlet")
         message = self.get_message(
-            Recipient.PERSONAL,
-            type_id=self.personal_recipient_user.id,
-            realm_id=self.personal_recipient_user.realm_id,
+            Recipient.DIRECT_MESSAGE_GROUP,
+            type_id=self.dm_group.id,
+            realm_id=self.user_profile.realm_id,
         )
 
         usermessage = UserMessage.objects.create(
@@ -403,9 +403,9 @@ class HandlePushNotificationTest(PushNotificationTestCase):
         """Simulates the race where message is deleted before handling push notifications"""
         user_profile = self.example_user("hamlet")
         message = self.get_message(
-            Recipient.PERSONAL,
-            type_id=self.personal_recipient_user.id,
-            realm_id=self.personal_recipient_user.realm_id,
+            Recipient.DIRECT_MESSAGE_GROUP,
+            type_id=self.dm_group.id,
+            realm_id=self.user_profile.realm_id,
         )
         UserMessage.objects.create(
             user_profile=user_profile,
@@ -438,9 +438,9 @@ class HandlePushNotificationTest(PushNotificationTestCase):
         """Simulates the race where message is missing when handling push notifications"""
         user_profile = self.example_user("hamlet")
         message = self.get_message(
-            Recipient.PERSONAL,
-            type_id=self.personal_recipient_user.id,
-            realm_id=self.personal_recipient_user.realm_id,
+            Recipient.DIRECT_MESSAGE_GROUP,
+            type_id=self.dm_group.id,
+            realm_id=self.user_profile.realm_id,
         )
         UserMessage.objects.create(
             user_profile=user_profile,
@@ -479,9 +479,9 @@ class HandlePushNotificationTest(PushNotificationTestCase):
 
         user_profile = self.user_profile
         message = self.get_message(
-            Recipient.PERSONAL,
-            type_id=self.personal_recipient_user.id,
-            realm_id=self.personal_recipient_user.realm_id,
+            Recipient.DIRECT_MESSAGE_GROUP,
+            type_id=self.dm_group.id,
+            realm_id=self.user_profile.realm_id,
         )
         UserMessage.objects.create(
             user_profile=user_profile,
@@ -550,9 +550,9 @@ class HandlePushNotificationTest(PushNotificationTestCase):
         self.setup_apns_tokens()
         self.setup_fcm_tokens()
         message = self.get_message(
-            Recipient.PERSONAL,
-            type_id=self.personal_recipient_user.id,
-            realm_id=self.personal_recipient_user.realm_id,
+            Recipient.DIRECT_MESSAGE_GROUP,
+            type_id=self.dm_group.id,
+            realm_id=self.user_profile.realm_id,
         )
         UserMessage.objects.create(
             user_profile=self.user_profile,
@@ -616,9 +616,9 @@ class HandlePushNotificationTest(PushNotificationTestCase):
 
         user_profile = self.user_profile
         message = self.get_message(
-            Recipient.PERSONAL,
-            type_id=self.personal_recipient_user.id,
-            realm_id=self.personal_recipient_user.realm_id,
+            Recipient.DIRECT_MESSAGE_GROUP,
+            type_id=self.dm_group.id,
+            realm_id=self.user_profile.realm_id,
         )
         UserMessage.objects.create(
             user_profile=user_profile,
@@ -675,9 +675,9 @@ class HandlePushNotificationTest(PushNotificationTestCase):
         self.setup_apns_tokens()
         self.setup_fcm_tokens()
         message = self.get_message(
-            Recipient.PERSONAL,
-            type_id=self.personal_recipient_user.id,
-            realm_id=self.personal_recipient_user.realm_id,
+            Recipient.DIRECT_MESSAGE_GROUP,
+            type_id=self.dm_group.id,
+            realm_id=self.user_profile.realm_id,
         )
         UserMessage.objects.create(
             user_profile=self.user_profile,
@@ -1026,10 +1026,11 @@ class HandlePushNotificationTest(PushNotificationTestCase):
         self, mock_push_notifications: mock.MagicMock, mock_info: mock.MagicMock
     ) -> None:
         user_profile = self.example_user("hamlet")
+
         message = self.get_message(
-            Recipient.PERSONAL,
-            type_id=self.personal_recipient_user.id,
-            realm_id=self.personal_recipient_user.realm_id,
+            Recipient.DIRECT_MESSAGE_GROUP,
+            type_id=self.dm_group.id,
+            realm_id=self.user_profile.realm_id,
         )
         UserMessage.objects.create(
             user_profile=user_profile,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -597,12 +597,12 @@ class HomeTest(ZulipTestCase):
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
         with (
-            self.assert_database_query_count(57),
+            self.assert_database_query_count(58),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page()
             self.check_rendered_logged_in_app(result)
-            self.assert_length(cache_mock.call_args_list, 7)
+            self.assert_length(cache_mock.call_args_list, 8)
 
     def test_num_queries_with_streams(self) -> None:
         main_user = self.example_user("hamlet")

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -952,15 +952,19 @@ class RealmImportExportTest(ExportFile):
         pm_a_msg_id = self.send_personal_message(
             self.example_user("AARON"), self.example_user("othello")
         )
+        dm_group_pm_a = DirectMessageGroup.objects.last()
         pm_b_msg_id = self.send_personal_message(
             self.example_user("cordelia"), self.example_user("iago")
         )
+        dm_group_pm_b = DirectMessageGroup.objects.last()
         pm_c_msg_id = self.send_personal_message(
             self.example_user("hamlet"), self.example_user("othello")
         )
+        dm_group_pm_c = DirectMessageGroup.objects.last()
         pm_d_msg_id = self.send_personal_message(
             self.example_user("iago"), self.example_user("hamlet")
         )
+        dm_group_pm_d = DirectMessageGroup.objects.last()
 
         # Create some non-message private data for users. We will use SavedSnippet objects as they're simple
         # to create and are private data that should not be exported for non-consenting users. There are many
@@ -1154,25 +1158,19 @@ class RealmImportExportTest(ExportFile):
             realm_id=realm.id, recipient__in=private_stream_recipients
         ).values_list("id", flat=True)
 
-        pm_recipients = Recipient.objects.filter(
-            type_id__in=consented_user_ids, type=Recipient.PERSONAL
-        )
-        pm_query = Q(recipient__in=pm_recipients) | Q(sender__in=consented_user_ids)
-        exported_pm_ids = (
-            Message.objects.filter(pm_query, realm=realm.id)
-            .values_list("id", flat=True)
-            .values_list("id", flat=True)
-        )
-
         assert (
             direct_message_group_a is not None
             and direct_message_group_b is not None
             and direct_message_group_c is not None
+            and dm_group_pm_a is not None
+            and dm_group_pm_b is not None
+            and dm_group_pm_c is not None
+            and dm_group_pm_d is not None
         )
         # Third direct message group is not exported since none of
         # the members gave consent
         direct_message_group_recipients = Recipient.objects.filter(
-            type_id__in=[direct_message_group_a.id, direct_message_group_b.id],
+            type_id__in=[direct_message_group_a.id, direct_message_group_b.id, dm_group_pm_b.id],
             type=Recipient.DIRECT_MESSAGE_GROUP,
         )
         pm_query = Q(recipient__in=direct_message_group_recipients) | Q(
@@ -1188,7 +1186,6 @@ class RealmImportExportTest(ExportFile):
             *public_stream_message_ids,
             *private_stream_message_ids,
             stream_b_second_message_id,
-            *exported_pm_ids,
             *exported_dm_group_message_ids,
         }
         self.assertEqual(self.get_set(data["zerver_message"], "id"), exported_msg_ids)
@@ -1214,9 +1211,22 @@ class RealmImportExportTest(ExportFile):
 
         exported_direct_message_group_ids = self.get_set(realm_data["zerver_huddle"], "id")
         self.assertNotIn(direct_message_group_c.id, exported_direct_message_group_ids)
+        self.assertNotIn(dm_group_pm_a.id, exported_direct_message_group_ids)
+
+        # A direct_message_group for iago is created in the populate_db.py (#L857-L866) script,
+        # when scheduling a message to self.
+        iago_dm_group = get_or_create_direct_message_group(id_list=[self.example_user("iago").id])
+
         self.assertEqual(
             exported_direct_message_group_ids,
-            {direct_message_group_a.id, direct_message_group_b.id},
+            {
+                iago_dm_group.id,
+                direct_message_group_a.id,
+                direct_message_group_b.id,
+                dm_group_pm_b.id,
+                dm_group_pm_c.id,
+                dm_group_pm_d.id,
+            },
         )
 
         # We also want to verify Subscriptions to the DirectMessageGroups were exported correctly.
@@ -2963,7 +2973,6 @@ class SingleUserExportTest(ExportFile):
         )
 
         bye_hamlet_message_id = self.send_personal_message(cordelia, hamlet, "bye hamlet")
-
         hi_myself_message_id = self.send_personal_message(cordelia, cordelia, "hi myself")
         bye_stream_message_id = self.send_stream_message(cordelia, "Denmark", "bye stream")
 

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -14,6 +14,7 @@ from django.core.exceptions import ValidationError
 from django.core.management.base import CommandError
 from django.db.models import Q, QuerySet
 from django.forms.models import model_to_dict
+from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
@@ -113,7 +114,10 @@ from zerver.models.messages import ImageAttachment
 from zerver.models.presence import PresenceSequence
 from zerver.models.realm_audit_logs import AuditLogEventType
 from zerver.models.realms import get_realm
-from zerver.models.recipients import get_direct_message_group_hash
+from zerver.models.recipients import (
+    get_direct_message_group_hash,
+    get_or_create_direct_message_group,
+)
 from zerver.models.streams import get_active_streams, get_stream
 from zerver.models.users import ExternalAuthID, get_system_bot, get_user_by_delivery_email
 
@@ -1014,6 +1018,12 @@ class RealmImportExportTest(ExportFile):
         do_deactivate_user(deactivated_non_consented_user, acting_user=None)
 
         self.assertEqual(get_consented_user_ids(realm), consented_user_ids)
+
+        # Remove the recipient of the welcome bot to test exporting bots without personal recipients.
+        internal_realm = get_realm(settings.SYSTEM_BOT_REALM)
+        welcome_bot = get_system_bot(settings.WELCOME_BOT, internal_realm.id)
+        welcome_bot.recipient = None
+        welcome_bot.save(update_fields=["recipient"])
 
         self.export_realm_and_create_auditlog(
             realm,
@@ -2984,6 +2994,55 @@ class SingleUserExportTest(ExportFile):
                 (bye_hamlet_message_id, "bye hamlet", hamlet.full_name),
                 (hi_myself_message_id, "hi myself", cordelia.full_name),
                 (bye_stream_message_id, "bye stream", "Denmark"),
+            ],
+        )
+
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
+    def test_1_to_1_message_data_using_direct_message_group(self) -> None:
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        othello = self.example_user("othello")
+        bot = self.create_test_bot("test-bot", hamlet)
+
+        get_or_create_direct_message_group([hamlet.id, cordelia.id])
+        get_or_create_direct_message_group([hamlet.id, bot.id])
+        get_or_create_direct_message_group([hamlet.id])
+
+        hi_hamlet_message_id = self.send_personal_message(othello, hamlet, "hi hamlet")
+        hi_cordelia_message_id = self.send_personal_message(hamlet, cordelia, "hi cordelia")
+        bye_hamlet_message_id = self.send_personal_message(cordelia, hamlet, "bye hamlet")
+        test_bot_message_id = self.send_personal_message(hamlet, bot, "test bot message")
+        self.send_personal_message(othello, cordelia, "an irrelevant message")
+        bye_peeps_message_id = self.send_group_direct_message(
+            othello, [cordelia, hamlet], "bye peeps"
+        )
+        self_message_id = self.send_personal_message(hamlet, hamlet, "hi myself")
+
+        output_dir = make_export_output_dir()
+        hamlet = self.example_user("hamlet")
+
+        with self.assertLogs(level="INFO"):
+            do_export_user(hamlet, output_dir)
+
+        messages = read_json("messages-000001.json")
+
+        excerpt = [
+            (rec["id"], rec["content"], rec["recipient_name"])
+            for rec in messages["zerver_message"][-6:]
+        ]
+        self.assertEqual(
+            excerpt,
+            [
+                (hi_hamlet_message_id, "hi hamlet", hamlet.full_name),
+                (hi_cordelia_message_id, "hi cordelia", cordelia.full_name),
+                (bye_hamlet_message_id, "bye hamlet", hamlet.full_name),
+                (test_bot_message_id, "test bot message", bot.full_name),
+                (
+                    bye_peeps_message_id,
+                    "bye peeps",
+                    f"{cordelia.full_name}, {hamlet.full_name}, {othello.full_name}",
+                ),
+                (self_message_id, "hi myself", hamlet.full_name),
             ],
         )
 

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -14,7 +14,6 @@ from django.core.exceptions import ValidationError
 from django.core.management.base import CommandError
 from django.db.models import Q, QuerySet
 from django.forms.models import model_to_dict
-from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
@@ -2986,16 +2985,11 @@ class SingleUserExportTest(ExportFile):
             ],
         )
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
-    def test_1_to_1_message_data_using_direct_message_group(self) -> None:
+    def test_1_to_1_message_data(self) -> None:
         hamlet = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")
         othello = self.example_user("othello")
         bot = self.create_test_bot("test-bot", hamlet)
-
-        get_or_create_direct_message_group([hamlet.id, cordelia.id])
-        get_or_create_direct_message_group([hamlet.id, bot.id])
-        get_or_create_direct_message_group([hamlet.id])
 
         hi_hamlet_message_id = self.send_personal_message(othello, hamlet, "hi hamlet")
         hi_cordelia_message_id = self.send_personal_message(hamlet, cordelia, "hi cordelia")

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -1377,10 +1377,13 @@ earl-test@zulip.com""",
         self.assert_json_success(self.invite(invitee, ["Denmark"], False))
         self.assertTrue(find_key_by_email(invitee))
         self.submit_reg_form_for_user(invitee, "password")
+        notification_bot = self.notification_bot(realm)
+        hamlet_and_notification_bot_recipient = self.get_dm_group_recipient(
+            notification_bot, user_profile
+        )
 
-        assert user_profile.recipient_id is not None
         invite_acceptance_notification_message = Message.objects.filter(
-            recipient_id=user_profile.recipient_id, realm=realm
+            recipient=hamlet_and_notification_bot_recipient, realm=realm
         ).last()
 
         self.assertIsNone(
@@ -1396,7 +1399,7 @@ earl-test@zulip.com""",
 
         new_invitee_profile = self.nonreg_user("bob")
         new_invite_acceptance_notification_message = Message.objects.filter(
-            recipient_id=user_profile.recipient_id, realm=realm
+            recipient=hamlet_and_notification_bot_recipient, realm=realm
         ).last()
 
         assert new_invite_acceptance_notification_message is not None

--- a/zerver/tests/test_mattermost_importer.py
+++ b/zerver/tests/test_mattermost_importer.py
@@ -364,6 +364,7 @@ class MatterMostImporter(ZulipTestCase):
             {malfoy_id, pansy_id},
         )
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_convert_direct_message_group_data(self) -> None:
         fixture_file_name = self.fixture_file_name(
             "export.json", "mattermost_fixtures/direct_channel"
@@ -414,7 +415,6 @@ class MatterMostImporter(ZulipTestCase):
             ["INFO:root:Duplicate direct message group found in the export data. Skipping."],
         )
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_convert_direct_message_group_data_without_personal_recipient(self) -> None:
         fixture_file_name = self.fixture_file_name(
             "export.json", "mattermost_fixtures/direct_channel"
@@ -866,6 +866,7 @@ class MatterMostImporter(ZulipTestCase):
 
         self.verify_emoji_code_foreign_keys()
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_do_convert_data_with_direct_messages(self) -> None:
         mattermost_data_dir = self.fixture_file_name("direct_channel", "mattermost_fixtures")
         output_dir = self.make_import_output_dir("mattermost")
@@ -1004,7 +1005,6 @@ class MatterMostImporter(ZulipTestCase):
         self.assertTrue(personal_messages[0].has_link)
         self.assertEqual(personal_messages[0].topic_name(), Message.DM_TOPIC)
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_do_convert_data_with_prefering_direct_messages_for_1_to_1_messages(self) -> None:
         mattermost_data_dir = self.fixture_file_name("direct_channel", "mattermost_fixtures")
         output_dir = self.make_import_output_dir("mattermost")

--- a/zerver/tests/test_mattermost_importer.py
+++ b/zerver/tests/test_mattermost_importer.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import call, patch
 
 import orjson
+from django.test import override_settings
 
 from zerver.data_import.import_util import SubscriberHandler, ZerverFieldsT
 from zerver.data_import.mattermost import (
@@ -408,6 +409,65 @@ class MatterMostImporter(ZulipTestCase):
             ),
             {1, 2, 3},
         )
+        self.assertEqual(
+            mock_log.output,
+            ["INFO:root:Duplicate direct message group found in the export data. Skipping."],
+        )
+
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
+    def test_convert_direct_message_group_data_without_personal_recipient(self) -> None:
+        fixture_file_name = self.fixture_file_name(
+            "export.json", "mattermost_fixtures/direct_channel"
+        )
+        mattermost_data = mattermost_data_file_to_dict(fixture_file_name)
+        username_to_user = create_username_to_user_mapping(mattermost_data["user"])
+        reset_mirror_dummy_users(username_to_user)
+
+        user_handler = UserHandler()
+        subscriber_handler = SubscriberHandler()
+        direct_message_group_id_mapper = IdMapper[frozenset[str]]()
+        user_id_mapper = IdMapper[str]()
+        team_name = "gryffindor"
+
+        convert_user_data(
+            user_handler=user_handler,
+            user_id_mapper=user_id_mapper,
+            user_data_map=username_to_user,
+            realm_id=3,
+            team_name=team_name,
+        )
+
+        with self.assertLogs(level="INFO") as mock_log:
+            zerver_huddle = convert_direct_message_group_data(
+                direct_message_group_data=mattermost_data["direct_channel"],
+                user_data_map=username_to_user,
+                subscriber_handler=subscriber_handler,
+                direct_message_group_id_mapper=direct_message_group_id_mapper,
+                user_id_mapper=user_id_mapper,
+                realm_id=3,
+                team_name=team_name,
+            )
+
+        self.assert_length(zerver_huddle, 3)
+
+        expected_dm_groups = [
+            (0, {2, 3}),  # direct_channel[0] should have users 2, 3
+            (1, {1, 2, 3}),  # direct_channel[1] should have users 1, 2, 3
+            (3, {3, 4}),  # direct_channel[3] should have users 3, 4
+        ]
+
+        for channel_index, expected_users in expected_dm_groups:
+            direct_message_group_members = frozenset(
+                mattermost_data["direct_channel"][channel_index]["members"]
+            )
+            self.assertTrue(direct_message_group_id_mapper.has(direct_message_group_members))
+            actual_users = subscriber_handler.get_users(
+                direct_message_group_id=direct_message_group_id_mapper.get(
+                    direct_message_group_members
+                )
+            )
+            self.assertEqual(actual_users, expected_users)
+
         self.assertEqual(
             mock_log.output,
             ["INFO:root:Duplicate direct message group found in the export data. Skipping."],
@@ -943,6 +1003,127 @@ class MatterMostImporter(ZulipTestCase):
         self.assertTrue(personal_messages[0].has_image)
         self.assertTrue(personal_messages[0].has_link)
         self.assertEqual(personal_messages[0].topic_name(), Message.DM_TOPIC)
+
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
+    def test_do_convert_data_with_prefering_direct_messages_for_1_to_1_messages(self) -> None:
+        mattermost_data_dir = self.fixture_file_name("direct_channel", "mattermost_fixtures")
+        output_dir = self.make_import_output_dir("mattermost")
+
+        with patch("builtins.print"), self.assertLogs(level="INFO"):
+            do_convert_data(
+                mattermost_data_dir=mattermost_data_dir,
+                output_dir=output_dir,
+                masking_content=False,
+            )
+
+        harry_team_output_dir = self.team_output_dir(output_dir, "gryffindor")
+        realm = self.read_file(harry_team_output_dir, "realm.json")
+
+        self.assertEqual(
+            "Organization imported from Mattermost!", realm["zerver_realm"][0]["description"]
+        )
+
+        exported_user_ids = self.get_set(realm["zerver_userprofile"], "id")
+        exported_user_full_names = self.get_set(realm["zerver_userprofile"], "full_name")
+        self.assertEqual(
+            {"Harry Potter", "Ron Weasley", "Ginny Weasley", "Tom Riddle"}, exported_user_full_names
+        )
+
+        exported_user_emails = self.get_set(realm["zerver_userprofile"], "email")
+        self.assertEqual(
+            {"harry@zulip.com", "ron@zulip.com", "ginny@zulip.com", "voldemort@zulip.com"},
+            exported_user_emails,
+        )
+
+        self.assert_length(realm["zerver_stream"], 3)
+        exported_stream_names = self.get_set(realm["zerver_stream"], "name")
+        self.assertEqual(
+            exported_stream_names,
+            {"Gryffindor common room", "Gryffindor quidditch team", "Dumbledores army"},
+        )
+        self.assertEqual(
+            self.get_set(realm["zerver_stream"], "realm"), {realm["zerver_realm"][0]["id"]}
+        )
+        self.assertEqual(self.get_set(realm["zerver_stream"], "deactivated"), {False})
+
+        self.assert_length(realm["zerver_defaultstream"], 0)
+
+        exported_recipient_ids = self.get_set(realm["zerver_recipient"], "id")
+        self.assert_length(exported_recipient_ids, 10)
+        exported_recipient_types = self.get_set(realm["zerver_recipient"], "type")
+        self.assertEqual(
+            exported_recipient_types,
+            {Recipient.PERSONAL, Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP},
+        )
+        exported_recipient_type_ids = self.get_set(realm["zerver_recipient"], "type_id")
+        self.assert_length(exported_recipient_type_ids, 4)
+
+        exported_subscription_userprofile = self.get_set(
+            realm["zerver_subscription"], "user_profile"
+        )
+        self.assert_length(exported_subscription_userprofile, 4)
+        exported_subscription_recipients = self.get_set(realm["zerver_subscription"], "recipient")
+        self.assert_length(exported_subscription_recipients, 10)
+
+        messages = self.read_file(harry_team_output_dir, "messages-000001.json")
+
+        exported_messages_id = self.get_set(messages["zerver_message"], "id")
+        self.assertIn(messages["zerver_message"][0]["sender"], exported_user_ids)
+        self.assertIn(messages["zerver_message"][0]["recipient"], exported_recipient_ids)
+        self.assertIn(messages["zerver_message"][0]["content"], "ron joined the channel.\n\n")
+
+        exported_usermessage_userprofiles = self.get_set(
+            messages["zerver_usermessage"], "user_profile"
+        )
+        self.assert_length(exported_usermessage_userprofiles, 3)
+        exported_usermessage_messages = self.get_set(messages["zerver_usermessage"], "message")
+        self.assertEqual(exported_usermessage_messages, exported_messages_id)
+
+        with self.assertLogs(level="INFO"):
+            do_import_realm(
+                import_dir=harry_team_output_dir,
+                subdomain="gryffindor",
+            )
+
+        realm = get_realm("gryffindor")
+
+        messages = Message.objects.filter(realm=realm)
+        for message in messages:
+            self.assertIsNotNone(message.rendered_content)
+        self.assert_length(messages, 24)
+
+        stream_messages = messages.filter(recipient__type=Recipient.STREAM).order_by("date_sent")
+        stream_recipients = stream_messages.values_list("recipient", flat=True)
+        self.assert_length(stream_messages, 13)
+        self.assert_length(set(stream_recipients), 2)
+
+        group_direct_messages = messages.filter(
+            recipient__type=Recipient.DIRECT_MESSAGE_GROUP
+        ).order_by("date_sent")
+        self.assert_length(group_direct_messages, 7)
+
+        direct_message_group_recipients = group_direct_messages.values_list("recipient", flat=True)
+        self.assert_length(set(direct_message_group_recipients), 3)
+
+        self.assertEqual(group_direct_messages[0].sender.email, "ron@zulip.com")
+        self.assertRegex(
+            group_direct_messages[0].content, "hey harry\n\n\\[harry-ron.jpg\\]\\(.*\\)"
+        )
+        self.assertTrue(group_direct_messages[0].has_attachment)
+        self.assertTrue(group_direct_messages[0].has_image)
+        self.assertTrue(group_direct_messages[0].has_link)
+        self.assertEqual(group_direct_messages[0].topic_name(), Message.DM_TOPIC)
+
+        self.assertEqual(group_direct_messages[1].sender.email, "ginny@zulip.com")
+        self.assertEqual(
+            group_direct_messages[1].content, "Who is going to Hogsmeade this weekend?\n\n"
+        )
+        self.assertEqual(group_direct_messages[1].topic_name(), Message.DM_TOPIC)
+
+        personal_messages = messages.filter(recipient__type=Recipient.PERSONAL).order_by(
+            "date_sent"
+        )
+        self.assert_length(personal_messages, 4)
 
     def test_do_convert_data_with_masking(self) -> None:
         mattermost_data_dir = self.fixture_file_name("", "mattermost_fixtures")

--- a/zerver/tests/test_mattermost_importer.py
+++ b/zerver/tests/test_mattermost_importer.py
@@ -1100,10 +1100,10 @@ class MatterMostImporter(ZulipTestCase):
         group_direct_messages = messages.filter(
             recipient__type=Recipient.DIRECT_MESSAGE_GROUP
         ).order_by("date_sent")
-        self.assert_length(group_direct_messages, 7)
+        self.assert_length(group_direct_messages, 11)
 
         direct_message_group_recipients = group_direct_messages.values_list("recipient", flat=True)
-        self.assert_length(set(direct_message_group_recipients), 3)
+        self.assert_length(set(direct_message_group_recipients), 7)
 
         self.assertEqual(group_direct_messages[0].sender.email, "ron@zulip.com")
         self.assertRegex(
@@ -1123,7 +1123,7 @@ class MatterMostImporter(ZulipTestCase):
         personal_messages = messages.filter(recipient__type=Recipient.PERSONAL).order_by(
             "date_sent"
         )
-        self.assert_length(personal_messages, 4)
+        self.assert_length(personal_messages, 0)
 
     def test_do_convert_data_with_masking(self) -> None:
         mattermost_data_dir = self.fixture_file_name("", "mattermost_fixtures")

--- a/zerver/tests/test_message_dict.py
+++ b/zerver/tests/test_message_dict.py
@@ -15,6 +15,7 @@ from zerver.lib.topic import TOPIC_LINKS, TOPIC_NAME
 from zerver.lib.types import DisplayRecipientT, UserDisplayRecipient
 from zerver.models import Message, Reaction, Realm, RealmFilter, Recipient, Stream, UserProfile
 from zerver.models.realms import MessageEditHistoryVisibilityPolicyEnum, get_realm
+from zerver.models.recipients import get_or_create_direct_message_group
 from zerver.models.streams import get_stream
 
 
@@ -144,7 +145,9 @@ class MessageDictTest(ZulipTestCase):
         sender = self.example_user("othello")
         receiver = self.example_user("hamlet")
         realm = get_realm("zulip")
-        pm_recipient = Recipient.objects.get(type_id=receiver.id, type=Recipient.PERSONAL)
+        pm_recipient = get_or_create_direct_message_group(
+            id_list=[sender.id, receiver.id]
+        ).recipient
         stream_name = "Çiğdem"
         stream = self.make_stream(stream_name)
         stream_recipient = Recipient.objects.get(type_id=stream.id, type=Recipient.STREAM)
@@ -176,7 +179,7 @@ class MessageDictTest(ZulipTestCase):
         num_ids = len(ids)
         self.assertTrue(num_ids >= 600)
 
-        with self.assert_database_query_count(7):
+        with self.assert_database_query_count(8):
             objs = MessageDict.ids_to_dict(ids)
             MessageDict.post_process_dicts(
                 objs,
@@ -192,11 +195,13 @@ class MessageDictTest(ZulipTestCase):
     def test_applying_markdown(self) -> None:
         sender = self.example_user("othello")
         receiver = self.example_user("hamlet")
-        recipient = Recipient.objects.get(type_id=receiver.id, type=Recipient.PERSONAL)
+        direct_message_group = get_or_create_direct_message_group(
+            id_list=[sender.id, receiver.id],
+        )
         sending_client = make_client(name="test suite")
         message = Message(
             sender=sender,
-            recipient=recipient,
+            recipient=direct_message_group.recipient,
             realm=receiver.realm,
             content="hello **world**",
             date_sent=timezone_now(),
@@ -222,11 +227,13 @@ class MessageDictTest(ZulipTestCase):
         convert_mock.return_value = None
         sender = self.example_user("othello")
         receiver = self.example_user("hamlet")
-        recipient = Recipient.objects.get(type_id=receiver.id, type=Recipient.PERSONAL)
+        direct_message_group = get_or_create_direct_message_group(
+            id_list=[sender.id, receiver.id],
+        )
         sending_client = make_client(name="test suite")
         message = Message(
             sender=sender,
-            recipient=recipient,
+            recipient=direct_message_group.recipient,
             realm=receiver.realm,
             content="hello **world**",
             date_sent=timezone_now(),
@@ -287,7 +294,7 @@ class MessageDictTest(ZulipTestCase):
     def test_reaction(self) -> None:
         sender = self.example_user("othello")
         receiver = self.example_user("hamlet")
-        recipient = Recipient.objects.get(type_id=receiver.id, type=Recipient.PERSONAL)
+        recipient = get_or_create_direct_message_group(id_list=[sender.id, receiver.id]).recipient
         sending_client = make_client(name="test suite")
         message = Message(
             sender=sender,
@@ -494,10 +501,8 @@ class MessageHydrationTest(ZulipTestCase):
         cordelia = self.example_user("cordelia")
         message_id = self.send_personal_message(hamlet, cordelia, "test")
 
-        cordelia_recipient = cordelia.recipient
         # Cause the display_recipient to get cached:
-        assert cordelia_recipient is not None
-        get_display_recipient(cordelia_recipient)
+        get_display_recipient(self.get_dm_group_recipient(hamlet, cordelia))
 
         # Change cordelia's email:
         cordelia_new_email = "new-cordelia@zulip.com"
@@ -707,7 +712,9 @@ class SewMessageAndReactionTest(ZulipTestCase):
         sender = self.example_user("othello")
         receiver = self.example_user("hamlet")
         realm = get_realm("zulip")
-        pm_recipient = Recipient.objects.get(type_id=receiver.id, type=Recipient.PERSONAL)
+        pm_recipient = get_or_create_direct_message_group(
+            id_list=[sender.id, receiver.id]
+        ).recipient
         stream_name = "Çiğdem"
         stream = self.make_stream(stream_name)
         stream_recipient = Recipient.objects.get(type_id=stream.id, type=Recipient.STREAM)

--- a/zerver/tests/test_message_dict.py
+++ b/zerver/tests/test_message_dict.py
@@ -84,7 +84,6 @@ class MessageDictTest(ZulipTestCase):
                 allow_empty_topic_name=True,
                 can_access_sender=True,
                 realm_host=get_realm("zulip").host,
-                is_incoming_1_to_1=False,
             )
             return narrow_dict
 
@@ -373,7 +372,7 @@ class MessageHydrationTest(ZulipTestCase):
         ]
 
         obj = dict(
-            recipient_type=Recipient.PERSONAL,
+            recipient_type=Recipient.DIRECT_MESSAGE_GROUP,
             recipient_type_id=None,
             sender_is_mirror_dummy=False,
             sender_email=cordelia.email,

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -212,7 +212,10 @@ class EditMessageTest(ZulipTestCase):
         response_dict = self.assert_json_success(result)
         self.assertEqual(response_dict["raw_content"], "Outgoing direct message")
         self.assertEqual(response_dict["message"]["id"], msg_id)
-        self.assertEqual(response_dict["message"]["recipient_id"], cordelia.recipient_id)
+        self.assertEqual(
+            response_dict["message"]["recipient_id"],
+            self.get_dm_group_recipient(hamlet, cordelia).id,
+        )
         self.assertEqual(response_dict["message"]["flags"], ["read"])
         self.assertEqual(response_dict["message"][TOPIC_NAME], "")
 
@@ -224,7 +227,10 @@ class EditMessageTest(ZulipTestCase):
         self.assertEqual(response_dict["raw_content"], "Incoming direct message")
         self.assertEqual(response_dict["message"]["id"], msg_id)
         # Incoming DMs show the recipient_id that outgoing DMs would.
-        self.assertEqual(response_dict["message"]["recipient_id"], cordelia.recipient_id)
+        self.assertEqual(
+            response_dict["message"]["recipient_id"],
+            self.get_dm_group_recipient(hamlet, cordelia).id,
+        )
         self.assertEqual(response_dict["message"]["flags"], [])
         self.assertEqual(response_dict["message"][TOPIC_NAME], "")
 

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -2471,6 +2471,7 @@ class GetOldMessagesTest(ZulipTestCase):
         result = self.get_and_check_messages(dict(narrow=orjson.dumps(narrow).decode()))
         self.assertNotEqual(result["messages"], [])
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_get_1_to_1_messages_with_existent_group_dm(self) -> None:
         me = self.example_user("hamlet")
         other_user = self.example_user("iago")
@@ -2495,6 +2496,7 @@ class GetOldMessagesTest(ZulipTestCase):
             self.assertIn(message["id"], message_ids)
             self.assertEqual(message["recipient_id"], direct_message_group.recipient_id)
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_get_messages_to_self_with_existent_group_dm(self) -> None:
         me = self.example_user("hamlet")
 

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -2483,7 +2483,6 @@ class GetOldMessagesTest(ZulipTestCase):
         result = self.get_and_check_messages(dict(narrow=orjson.dumps(narrow).decode()))
         self.assertNotEqual(result["messages"], [])
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_get_1_to_1_messages_with_existent_group_dm(self) -> None:
         me = self.example_user("hamlet")
         other_user = self.example_user("iago")
@@ -2508,7 +2507,6 @@ class GetOldMessagesTest(ZulipTestCase):
             self.assertIn(message["id"], message_ids)
             self.assertEqual(message["recipient_id"], direct_message_group.recipient_id)
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_get_messages_to_self_with_existent_group_dm(self) -> None:
         me = self.example_user("hamlet")
 

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -535,6 +535,18 @@ class NarrowBuilderTest(ZulipTestCase):
             "WHERE NOT ((flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s OR recipient_id IN (__[POSTCOMPILE_recipient_id_3])))",
         )
 
+    def test_add_term_using_dm_including_operator_without_personal_recipient(self) -> None:
+        # Dropping the personal recipient for Othello
+        othello = self.example_user("othello")
+        othello.recipient = None
+        othello.save()
+
+        term = NarrowParameter(operator="dm-including", operand=self.othello_email)
+        self._do_add_term_test(
+            term,
+            "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND recipient_id IN (__[POSTCOMPILE_recipient_id_1])",
+        )
+
     def test_add_term_using_id_operator_integer(self) -> None:
         term = NarrowParameter(operator="id", operand=555)
         self._do_add_term_test(term, "WHERE id = %(param_1)s")

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -350,11 +350,27 @@ class NarrowBuilderTest(ZulipTestCase):
         term = NarrowParameter(operator="sender", operand="non-existing@zulip.com")
         self.assertRaises(BadNarrowOperatorError, self._build_query, term)
 
-    def test_add_term_using_dm_operator_and_not_the_same_user_as_operand(self) -> None:
+    def test_add_term_using_dm_operator_and_not_the_same_user_as_operand_with_no_direct_message_group(
+        self,
+    ) -> None:
         term = NarrowParameter(operator="dm", operand=self.othello_email)
         self._do_add_term_test(
             term,
-            "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s)",
+            "WHERE false",
+        )
+
+    def test_add_term_using_dm_operator_and_not_the_same_user_as_operand(self) -> None:
+        # Create a direct message group between users
+        get_or_create_direct_message_group(
+            [
+                self.example_user("hamlet").id,
+                self.example_user("othello").id,
+            ]
+        )
+        term = NarrowParameter(operator="dm", operand=self.othello_email)
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id = %(recipient_id_1)s",
         )
 
     def test_negated_is_dm_with_dm_operator(self) -> None:
@@ -400,39 +416,104 @@ class NarrowBuilderTest(ZulipTestCase):
         channel_term = NarrowParameter(operator="channels", operand="public", negated=True)
         self._build_query(channel_term)
 
-    def test_add_term_using_dm_operator_not_the_same_user_as_operand_and_negated(
+    def test_add_term_using_dm_operator_not_the_same_user_as_operand_no_direct_message_group_and_negated(
         self,
     ) -> None:  # NEGATED
         term = NarrowParameter(operator="dm", operand=self.othello_email, negated=True)
         self._do_add_term_test(
             term,
-            "WHERE NOT ((flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s))",
+            "WHERE true",
         )
 
-    def test_add_term_using_dm_operator_the_same_user_as_operand(self) -> None:
+    def test_add_term_using_dm_operator_not_the_same_user_as_operand_and_negated(
+        self,
+    ) -> None:  # NEGATED
+        # Create a direct message group between users
+        get_or_create_direct_message_group(
+            [
+                self.example_user("hamlet").id,
+                self.example_user("othello").id,
+            ]
+        )
+        term = NarrowParameter(operator="dm", operand=self.othello_email, negated=True)
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id != %(recipient_id_1)s",
+        )
+
+    def test_add_term_using_dm_operator_the_same_user_as_operand_no_direct_message_group(
+        self,
+    ) -> None:
         term = NarrowParameter(operator="dm", operand=self.hamlet_email)
         self._do_add_term_test(
             term,
-            "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s",
+            "WHERE false",
         )
 
-    def test_add_term_using_dm_operator_the_same_user_as_operand_and_negated(
+    def test_add_term_using_dm_operator_the_same_user_as_operand(self) -> None:
+        # Create a direct message group with the user
+        get_or_create_direct_message_group(
+            [
+                self.example_user("hamlet").id,
+            ]
+        )
+        term = NarrowParameter(operator="dm", operand=self.hamlet_email)
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id = %(recipient_id_1)s",
+        )
+
+    def test_add_term_using_dm_operator_the_same_user_as_operand_no_direct_message_group_and_negated(
         self,
     ) -> None:  # NEGATED
         term = NarrowParameter(operator="dm", operand=self.hamlet_email, negated=True)
         self._do_add_term_test(
             term,
-            "WHERE NOT ((flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s)",
+            "WHERE true",
         )
 
-    def test_add_term_using_dm_operator_and_self_and_user_as_operand(self) -> None:
+    def test_add_term_using_dm_operator_the_same_user_as_operand_and_negated(
+        self,
+    ) -> None:  # NEGATED
+        # Create a direct message group with the user
+        get_or_create_direct_message_group(
+            [
+                self.example_user("hamlet").id,
+            ]
+        )
+        term = NarrowParameter(operator="dm", operand=self.hamlet_email, negated=True)
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id != %(recipient_id_1)s",
+        )
+
+    def test_add_term_using_dm_operator_and_self_and_user_as_operand_no_direct_message_group(
+        self,
+    ) -> None:
         myself_and_other = (
             f"{self.example_user('hamlet').email},{self.example_user('othello').email}"
         )
         term = NarrowParameter(operator="dm", operand=myself_and_other)
         self._do_add_term_test(
             term,
-            "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s)",
+            "WHERE false",
+        )
+
+    def test_add_term_using_dm_operator_and_self_and_user_as_operand(self) -> None:
+        # Make the direct message group first
+        get_or_create_direct_message_group(
+            [
+                self.example_user("hamlet").id,
+                self.example_user("othello").id,
+            ]
+        )
+        myself_and_other = (
+            f"{self.example_user('hamlet').email},{self.example_user('othello').email}"
+        )
+        term = NarrowParameter(operator="dm", operand=myself_and_other)
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id = %(recipient_id_1)s",
         )
 
     def test_add_term_using_dm_operator_more_than_one_user_as_operand_no_direct_message_group(
@@ -456,7 +537,7 @@ class NarrowBuilderTest(ZulipTestCase):
         term = NarrowParameter(operator="dm", operand=two_others)
         self._do_add_term_test(term, "WHERE recipient_id = %(recipient_id_1)s")
 
-    def test_add_term_using_dm_operator_self_and_user_as_operand_and_negated(
+    def test_add_term_using_dm_operator_self_and_user_as_operand_no_group_direct_message_and_negated(
         self,
     ) -> None:  # NEGATED
         myself_and_other = (
@@ -465,7 +546,26 @@ class NarrowBuilderTest(ZulipTestCase):
         term = NarrowParameter(operator="dm", operand=myself_and_other, negated=True)
         self._do_add_term_test(
             term,
-            "WHERE NOT ((flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s))",
+            "WHERE true",
+        )
+
+    def test_add_term_using_dm_operator_self_and_user_as_operand_and_negated(
+        self,
+    ) -> None:  # NEGATED
+        # Make the direct message group first
+        get_or_create_direct_message_group(
+            [
+                self.example_user("hamlet").id,
+                self.example_user("othello").id,
+            ]
+        )
+        myself_and_other = (
+            f"{self.example_user('hamlet').email},{self.example_user('othello').email}"
+        )
+        term = NarrowParameter(operator="dm", operand=myself_and_other, negated=True)
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id != %(recipient_id_1)s",
         )
 
     def test_add_term_using_dm_operator_more_than_one_user_as_operand_no_direct_message_group_and_negated(
@@ -508,11 +608,16 @@ class NarrowBuilderTest(ZulipTestCase):
         self._do_add_term_test(term, "WHERE (flags & %(flags_1)s) != %(param_1)s")
 
     def test_add_term_using_dm_including_operator_with_different_user_email(self) -> None:
+        # Dropping the personal recipient for Othello
+        othello = self.example_user("othello")
+        othello.recipient = None
+        othello.save()
+
         # Test without any such group direct messages existing
         term = NarrowParameter(operator="dm-including", operand=self.othello_email)
         self._do_add_term_test(
             term,
-            "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s OR recipient_id IN (__[POSTCOMPILE_recipient_id_3]))",
+            "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND recipient_id IN (__[POSTCOMPILE_recipient_id_1])",
         )
 
         # Test with at least one such group direct messages existing
@@ -523,28 +628,29 @@ class NarrowBuilderTest(ZulipTestCase):
         term = NarrowParameter(operator="dm-including", operand=self.othello_email)
         self._do_add_term_test(
             term,
-            "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s OR recipient_id IN (__[POSTCOMPILE_recipient_id_3]))",
+            "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND recipient_id IN (__[POSTCOMPILE_recipient_id_1])",
         )
 
     def test_add_term_using_dm_including_operator_with_different_user_email_and_negated(
         self,
     ) -> None:  # NEGATED
-        term = NarrowParameter(operator="dm-including", operand=self.othello_email, negated=True)
-        self._do_add_term_test(
-            term,
-            "WHERE NOT ((flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s OR recipient_id IN (__[POSTCOMPILE_recipient_id_3])))",
-        )
-
-    def test_add_term_using_dm_including_operator_without_personal_recipient(self) -> None:
         # Dropping the personal recipient for Othello
         othello = self.example_user("othello")
         othello.recipient = None
         othello.save()
 
+        term = NarrowParameter(operator="dm-including", operand=self.othello_email, negated=True)
+        self._do_add_term_test(
+            term,
+            "WHERE NOT ((flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND recipient_id IN (__[POSTCOMPILE_recipient_id_1]))",
+        )
+
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_add_term_using_dm_including_operator_with_personal_recipient(self) -> None:
         term = NarrowParameter(operator="dm-including", operand=self.othello_email)
         self._do_add_term_test(
             term,
-            "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND recipient_id IN (__[POSTCOMPILE_recipient_id_1])",
+            "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s OR recipient_id IN (__[POSTCOMPILE_recipient_id_3]))",
         )
 
     def test_add_term_using_id_operator_integer(self) -> None:
@@ -691,16 +797,37 @@ class NarrowBuilderTest(ZulipTestCase):
         self._do_add_term_test(term, "WHERE (flags & %(flags_1)s) = %(param_1)s")
 
     # Test that "pm-with" (legacy alias for "dm") works.
-    def test_add_term_using_pm_with_operator(self) -> None:
+    def test_add_term_using_pm_with_operator_no_direct_message_group(self) -> None:
         term = NarrowParameter(operator="pm-with", operand=self.hamlet_email)
         self._do_add_term_test(
             term,
-            "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s",
+            "WHERE false",
+        )
+
+    # Test that "pm-with" (legacy alias for "dm") works.
+    def test_add_term_using_pm_with_operator(self) -> None:
+        # Create a direct message group with the user
+        get_or_create_direct_message_group([self.user_profile.id])
+        term = NarrowParameter(operator="pm-with", operand=self.hamlet_email)
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id = %(recipient_id_1)s",
         )
 
     # Test that the underscore version of "pm-with" works.
     def test_add_term_using_underscore_version_of_pm_with_operator(self) -> None:
+        # Create a direct message group with the user
+        get_or_create_direct_message_group([self.user_profile.id])
         term = NarrowParameter(operator="pm_with", operand=self.hamlet_email)
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id = %(recipient_id_1)s",
+        )
+
+    # Test that "pm-with" (legacy alias for "dm") works.
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_add_term_using_pm_with_operator_and_with_personal_recipient(self) -> None:
+        term = NarrowParameter(operator="pm-with", operand=self.hamlet_email)
         self._do_add_term_test(
             term,
             "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s",
@@ -1951,8 +2078,6 @@ class GetOldMessagesTest(ZulipTestCase):
 
         scotland_channel = get_stream("Scotland", hamlet_user.realm)
         assert scotland_channel.recipient_id is not None
-        assert hamlet_user.recipient_id is not None
-        assert othello_user.recipient_id is not None
         query_ids["realm_id"] = hamlet_user.realm_id
         query_ids["scotland_recipient"] = scotland_channel.recipient_id
         query_ids["hamlet_id"] = hamlet_user.id
@@ -1960,8 +2085,14 @@ class GetOldMessagesTest(ZulipTestCase):
             tuple(sorted(get_recursive_membership_groups(hamlet_user).values_list("id", flat=True)))
         )
         query_ids["othello_id"] = othello_user.id
-        query_ids["hamlet_recipient"] = hamlet_user.recipient_id
-        query_ids["othello_recipient"] = othello_user.recipient_id
+        query_ids["hamlet_recipient"] = self.get_dm_group_recipient(hamlet_user).id
+        query_ids["hamlet_and_othello_recipient"] = self.get_dm_group_recipient(
+            hamlet_user, othello_user
+        ).id
+        assert hamlet_user.recipient is not None
+        query_ids["hamlet_personal_recipient"] = hamlet_user.recipient.id
+        assert othello_user.recipient is not None
+        query_ids["othello_personal_recipient"] = othello_user.recipient.id
         recipients = (
             get_public_streams_queryset(hamlet_user.realm)
             .values_list("recipient_id", flat=True)
@@ -2410,6 +2541,7 @@ class GetOldMessagesTest(ZulipTestCase):
         message = result["messages"][0]
         self.assertIn("gravatar.com", message["avatar_url"])
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_get_messages_with_narrow_dm(self) -> None:
         """
         A request for old messages with a narrow by direct message only returns
@@ -2830,6 +2962,7 @@ class GetOldMessagesTest(ZulipTestCase):
             """
             )
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_get_visible_messages_using_narrow_with(self) -> None:
         hamlet = self.example_user("hamlet")
         othello = self.example_user("othello")
@@ -4381,6 +4514,7 @@ class GetOldMessagesTest(ZulipTestCase):
         result = orjson.loads(payload.content)
         self.assertEqual(result["anchor"], LARGER_THAN_MAX_MESSAGE_ID)
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_use_first_unread_anchor_with_some_unread_messages(self) -> None:
         user_profile = self.example_user("hamlet")
 
@@ -4514,6 +4648,7 @@ class GetOldMessagesTest(ZulipTestCase):
             self.assertNotIn("AND message_id <=", sql)
             self.assertNotIn("AND message_id >=", sql)
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_use_first_unread_anchor_with_muted_topics(self) -> None:
         """
         Test that our logic related to `use_first_unread_anchor`
@@ -4791,11 +4926,11 @@ WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.
             {"anchor": 100, "num_before": 10, "num_after": 10}, sql
         )
 
-    def test_get_messages_with_narrow_queries(self) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_get_messages_with_narrow_queries_using_personal_recipient(self) -> None:
         query_ids = self.get_query_ids()
-        hamlet_email = self.example_user("hamlet").email
         othello_email = self.example_user("othello").email
-
+        hamlet_email = self.example_user("hamlet").email
         sql_template = """\
 SELECT anon_1.message_id, anon_1.flags \n\
 FROM (SELECT message_id, flags \n\
@@ -4804,7 +4939,7 @@ WHERE user_profile_id = {hamlet_id} AND (zerver_recipient.type != 2 OR (EXISTS (
 FROM zerver_stream \n\
 WHERE zerver_stream.recipient_id = zerver_recipient.id AND (NOT zerver_stream.invite_only OR zerver_stream.can_subscribe_group_id IN {hamlet_groups} OR zerver_stream.can_add_subscribers_group_id IN {hamlet_groups}))) OR (EXISTS (SELECT  \n\
 FROM zerver_subscription \n\
-WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND (flags & 2048) != 0 AND realm_id = {realm_id} AND (sender_id = {othello_id} AND recipient_id = {hamlet_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_recipient}) AND message_id = 0) AS anon_1 ORDER BY message_id ASC\
+WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND (flags & 2048) != 0 AND realm_id = {realm_id} AND (sender_id = {othello_id} AND recipient_id = {hamlet_personal_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_personal_recipient}) AND message_id = 0) AS anon_1 ORDER BY message_id ASC\
 """
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query(
@@ -4825,7 +4960,98 @@ WHERE user_profile_id = {hamlet_id} AND (zerver_recipient.type != 2 OR (EXISTS (
 FROM zerver_stream \n\
 WHERE zerver_stream.recipient_id = zerver_recipient.id AND (NOT zerver_stream.invite_only OR zerver_stream.can_subscribe_group_id IN {hamlet_groups} OR zerver_stream.can_add_subscribers_group_id IN {hamlet_groups}))) OR (EXISTS (SELECT  \n\
 FROM zerver_subscription \n\
-WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND (flags & 2048) != 0 AND realm_id = {realm_id} AND (sender_id = {othello_id} AND recipient_id = {hamlet_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_recipient}) AND message_id = 0) AS anon_1 ORDER BY message_id ASC\
+WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND (flags & 2048) != 0 AND realm_id = {realm_id} AND (sender_id = {othello_id} AND recipient_id = {hamlet_personal_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_personal_recipient}) AND message_id = 0) AS anon_1 ORDER BY message_id ASC\
+"""
+        sql = sql_template.format(**query_ids)
+        self.common_check_get_messages_query(
+            {
+                "anchor": 0,
+                "num_before": 1,
+                "num_after": 0,
+                "narrow": f'[["dm", "{othello_email}"]]',
+            },
+            sql,
+        )
+        sql_template = """\
+SELECT anon_1.message_id, anon_1.flags \n\
+FROM (SELECT message_id, flags \n\
+FROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id JOIN zerver_recipient ON zerver_message.recipient_id = zerver_recipient.id \n\
+WHERE user_profile_id = {hamlet_id} AND (zerver_recipient.type != 2 OR (EXISTS (SELECT  \n\
+FROM zerver_stream \n\
+WHERE zerver_stream.recipient_id = zerver_recipient.id AND (NOT zerver_stream.invite_only OR zerver_stream.can_subscribe_group_id IN {hamlet_groups} OR zerver_stream.can_add_subscribers_group_id IN {hamlet_groups}))) OR (EXISTS (SELECT  \n\
+FROM zerver_subscription \n\
+WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND (flags & 2048) != 0 AND realm_id = {realm_id} AND (sender_id = {othello_id} AND recipient_id = {hamlet_personal_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_personal_recipient}) ORDER BY message_id ASC \n\
+ LIMIT 10) AS anon_1 ORDER BY message_id ASC\
+"""
+        sql = sql_template.format(**query_ids)
+        self.common_check_get_messages_query(
+            {
+                "anchor": 0,
+                "num_before": 0,
+                "num_after": 9,
+                "narrow": f'[["dm", "{othello_email}"]]',
+            },
+            sql,
+        )
+
+        # Narrow to direct messages with yourself
+        sql_template = """\
+SELECT anon_1.message_id, anon_1.flags \n\
+FROM (SELECT message_id, flags \n\
+FROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id JOIN zerver_recipient ON zerver_message.recipient_id = zerver_recipient.id \n\
+WHERE user_profile_id = {hamlet_id} AND (zerver_recipient.type != 2 OR (EXISTS (SELECT  \n\
+FROM zerver_stream \n\
+WHERE zerver_stream.recipient_id = zerver_recipient.id AND (NOT zerver_stream.invite_only OR zerver_stream.can_subscribe_group_id IN {hamlet_groups} OR zerver_stream.can_add_subscribers_group_id IN {hamlet_groups}))) OR (EXISTS (SELECT  \n\
+FROM zerver_subscription \n\
+WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND (flags & 2048) != 0 AND realm_id = {realm_id} AND sender_id = {hamlet_id} AND recipient_id = {hamlet_personal_recipient} ORDER BY message_id ASC \n\
+ LIMIT 10) AS anon_1 ORDER BY message_id ASC\
+"""
+        sql = sql_template.format(**query_ids)
+        self.common_check_get_messages_query(
+            {
+                "anchor": 0,
+                "num_before": 0,
+                "num_after": 9,
+                "narrow": f'[["dm", "{hamlet_email}"]]',
+            },
+            sql,
+        )
+
+    def test_get_messages_with_narrow_queries_using_direct_message_group(self) -> None:
+        query_ids = self.get_query_ids()
+        hamlet_email = self.example_user("hamlet").email
+        othello_email = self.example_user("othello").email
+
+        sql_template = """\
+SELECT anon_1.message_id, anon_1.flags \n\
+FROM (SELECT message_id, flags \n\
+FROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id JOIN zerver_recipient ON zerver_message.recipient_id = zerver_recipient.id \n\
+WHERE user_profile_id = {hamlet_id} AND (zerver_recipient.type != 2 OR (EXISTS (SELECT  \n\
+FROM zerver_stream \n\
+WHERE zerver_stream.recipient_id = zerver_recipient.id AND (NOT zerver_stream.invite_only OR zerver_stream.can_subscribe_group_id IN {hamlet_groups} OR zerver_stream.can_add_subscribers_group_id IN {hamlet_groups}))) OR (EXISTS (SELECT  \n\
+FROM zerver_subscription \n\
+WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND recipient_id = {hamlet_and_othello_recipient} AND message_id = 0) AS anon_1 ORDER BY message_id ASC\
+"""
+        sql = sql_template.format(**query_ids)
+        self.common_check_get_messages_query(
+            {
+                "anchor": 0,
+                "num_before": 0,
+                "num_after": 0,
+                "narrow": f'[["dm", "{othello_email}"]]',
+            },
+            sql,
+        )
+
+        sql_template = """\
+SELECT anon_1.message_id, anon_1.flags \n\
+FROM (SELECT message_id, flags \n\
+FROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id JOIN zerver_recipient ON zerver_message.recipient_id = zerver_recipient.id \n\
+WHERE user_profile_id = {hamlet_id} AND (zerver_recipient.type != 2 OR (EXISTS (SELECT  \n\
+FROM zerver_stream \n\
+WHERE zerver_stream.recipient_id = zerver_recipient.id AND (NOT zerver_stream.invite_only OR zerver_stream.can_subscribe_group_id IN {hamlet_groups} OR zerver_stream.can_add_subscribers_group_id IN {hamlet_groups}))) OR (EXISTS (SELECT  \n\
+FROM zerver_subscription \n\
+WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND recipient_id = {hamlet_and_othello_recipient} AND message_id = 0) AS anon_1 ORDER BY message_id ASC\
 """
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query(
@@ -4846,7 +5072,7 @@ WHERE user_profile_id = {hamlet_id} AND (zerver_recipient.type != 2 OR (EXISTS (
 FROM zerver_stream \n\
 WHERE zerver_stream.recipient_id = zerver_recipient.id AND (NOT zerver_stream.invite_only OR zerver_stream.can_subscribe_group_id IN {hamlet_groups} OR zerver_stream.can_add_subscribers_group_id IN {hamlet_groups}))) OR (EXISTS (SELECT  \n\
 FROM zerver_subscription \n\
-WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND (flags & 2048) != 0 AND realm_id = {realm_id} AND (sender_id = {othello_id} AND recipient_id = {hamlet_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_recipient}) ORDER BY message_id ASC \n\
+WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND recipient_id = {hamlet_and_othello_recipient} ORDER BY message_id ASC \n\
  LIMIT 10) AS anon_1 ORDER BY message_id ASC\
 """
         sql = sql_template.format(**query_ids)
@@ -4989,7 +5215,7 @@ WHERE user_profile_id = {hamlet_id} AND (zerver_recipient.type != 2 OR (EXISTS (
 FROM zerver_stream \n\
 WHERE zerver_stream.recipient_id = zerver_recipient.id AND (NOT zerver_stream.invite_only OR zerver_stream.can_subscribe_group_id IN {hamlet_groups} OR zerver_stream.can_add_subscribers_group_id IN {hamlet_groups}))) OR (EXISTS (SELECT  \n\
 FROM zerver_subscription \n\
-WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND (flags & 2048) != 0 AND realm_id = {realm_id} AND sender_id = {hamlet_id} AND recipient_id = {hamlet_recipient} ORDER BY message_id ASC \n\
+WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.recipient_id = zerver_recipient.id AND zerver_subscription.active))) AND recipient_id = {hamlet_recipient} ORDER BY message_id ASC \n\
  LIMIT 10) AS anon_1 ORDER BY message_id ASC\
 """
         sql = sql_template.format(**query_ids)
@@ -5155,7 +5381,8 @@ WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.
             '@<span class="highlight">Othello</span>, the Moor of Venice</span>?</p>',
         )
 
-    def test_dm_recipient_id(self) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_personal_dm_recipient_id(self) -> None:
         hamlet = self.example_user("hamlet")
         othello = self.example_user("othello")
         self.login_user(hamlet)
@@ -5172,6 +5399,28 @@ WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.
         self.assertEqual(result["messages"][1]["sender_id"], othello.id)
         # Incoming DMs show the recipient_id that outgoing DMs would.
         self.assertEqual(result["messages"][1]["recipient_id"], othello.recipient_id)
+
+    def test_group_dm_recipient_id(self) -> None:
+        hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+        self.login_user(hamlet)
+
+        direct_message_group = get_or_create_direct_message_group(id_list=[hamlet.id, othello.id])
+        assert direct_message_group.recipient is not None
+        self.assertIsNotNone(direct_message_group.recipient.label())
+
+        outgoing_message_id = self.send_personal_message(hamlet, othello)
+        incoming_message_id = self.send_personal_message(othello, hamlet)
+
+        result = self.get_and_check_messages(dict(anchor="newest", num_before=2))
+        self.assert_length(result["messages"], 2)
+        self.assertEqual(result["messages"][0]["id"], outgoing_message_id)
+        self.assertEqual(result["messages"][0]["sender_id"], hamlet.id)
+        self.assertEqual(result["messages"][0]["recipient_id"], direct_message_group.recipient_id)
+        self.assertEqual(result["messages"][1]["id"], incoming_message_id)
+        self.assertEqual(result["messages"][1]["sender_id"], othello.id)
+        # Incoming DMs show the recipient_id that outgoing DMs would.
+        self.assertEqual(result["messages"][1]["recipient_id"], direct_message_group.recipient_id)
 
 
 class MessageHasKeywordsTest(ZulipTestCase):

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import orjson
 from django.db import connection
+from django.test import override_settings
 from typing_extensions import override
 
 from zerver.actions.message_flags import do_update_message_flags
@@ -1152,7 +1153,8 @@ class GetUnreadMsgsTest(ZulipTestCase):
             dict(other_user_id=cordelia.id),
         )
 
-    def test_raw_unread_personal_using_direct_group_message(self) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
+    def test_raw_unread_personal_using_direct_message_group(self) -> None:
         cordelia = self.example_user("cordelia")
         othello = self.example_user("othello")
         hamlet = self.example_user("hamlet")
@@ -1277,6 +1279,7 @@ class GetUnreadMsgsTest(ZulipTestCase):
             dict(other_user_id=hamlet.id),
         )
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_raw_unread_personal_from_self_using_direct_message_group(self) -> None:
         hamlet = self.example_user("hamlet")
 

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import orjson
 from django.db import connection
-from django.test import override_settings
 from typing_extensions import override
 
 from zerver.actions.message_flags import do_update_message_flags
@@ -1153,7 +1152,6 @@ class GetUnreadMsgsTest(ZulipTestCase):
             dict(other_user_id=cordelia.id),
         )
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_raw_unread_personal_using_direct_message_group(self) -> None:
         cordelia = self.example_user("cordelia")
         othello = self.example_user("othello")
@@ -1279,7 +1277,6 @@ class GetUnreadMsgsTest(ZulipTestCase):
             dict(other_user_id=hamlet.id),
         )
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_raw_unread_personal_from_self_using_direct_message_group(self) -> None:
         hamlet = self.example_user("hamlet")
 

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import orjson
 from django.db import connection
-from django.test import override_settings
 from typing_extensions import override
 
 from zerver.actions.message_flags import do_update_message_flags
@@ -39,7 +38,6 @@ from zerver.models import (
 )
 from zerver.models.groups import NamedUserGroup
 from zerver.models.realms import get_realm
-from zerver.models.recipients import get_or_create_direct_message_group
 from zerver.models.streams import get_stream
 
 if TYPE_CHECKING:
@@ -1128,36 +1126,12 @@ class GetUnreadMsgsTest(ZulipTestCase):
             dict(user_ids_string=direct_message_group_string),
         )
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
-    def test_raw_unread_personal_using_personal_recipients(self) -> None:
-        cordelia = self.example_user("cordelia")
-        othello = self.example_user("othello")
-        hamlet = self.example_user("hamlet")
-
-        cordelia_pm_message_ids = [self.send_personal_message(cordelia, hamlet) for i in range(3)]
-        othello_pm_message_ids = [self.send_personal_message(othello, hamlet) for i in range(3)]
-
-        raw_unread_data = get_raw_unread_data(user_profile=hamlet)
-
-        pm_dict = raw_unread_data["pm_dict"]
-
-        self.assertEqual(
-            set(pm_dict.keys()),
-            set(cordelia_pm_message_ids) | set(othello_pm_message_ids),
-        )
-
-        self.assertEqual(
-            pm_dict[cordelia_pm_message_ids[0]],
-            dict(other_user_id=cordelia.id),
-        )
-
     def test_raw_unread_personal(self) -> None:
         cordelia = self.example_user("cordelia")
         othello = self.example_user("othello")
         hamlet = self.example_user("hamlet")
 
         cordelia_pm_message_ids = [self.send_personal_message(cordelia, hamlet) for i in range(3)]
-
         othello_pm_message_ids = [self.send_personal_message(othello, hamlet) for i in range(3)]
 
         raw_unread_data = get_raw_unread_data(
@@ -1176,38 +1150,6 @@ class GetUnreadMsgsTest(ZulipTestCase):
             dict(other_user_id=cordelia.id),
         )
 
-    def test_raw_unread_personal_using_direct_message_group(self) -> None:
-        cordelia = self.example_user("cordelia")
-        othello = self.example_user("othello")
-        hamlet = self.example_user("hamlet")
-
-        # creating direct message group for 1:1 messages
-        get_or_create_direct_message_group(id_list=[cordelia.id, hamlet.id])
-        get_or_create_direct_message_group(id_list=[othello.id, hamlet.id])
-
-        cordelia_pm_message_ids = [self.send_personal_message(cordelia, hamlet) for i in range(3)]
-        othello_pm_message_ids = [self.send_personal_message(othello, hamlet) for i in range(3)]
-
-        raw_unread_data = get_raw_unread_data(
-            user_profile=hamlet,
-        )
-        pm_dict = raw_unread_data["pm_dict"]
-
-        self.assertEqual(
-            set(pm_dict.keys()),
-            set(cordelia_pm_message_ids) | set(othello_pm_message_ids),
-        )
-
-        self.assertEqual(
-            pm_dict[cordelia_pm_message_ids[0]],
-            dict(other_user_id=cordelia.id),
-        )
-        self.assertEqual(
-            pm_dict[othello_pm_message_ids[0]],
-            dict(other_user_id=othello.id),
-        )
-
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_raw_unread_personal_from_self(self) -> None:
         hamlet = self.example_user("hamlet")
 
@@ -1299,39 +1241,6 @@ class GetUnreadMsgsTest(ZulipTestCase):
 
         self.assertEqual(
             pm_dict[hamlet_msg.id],
-            dict(other_user_id=hamlet.id),
-        )
-
-    def test_raw_unread_personal_from_self_using_direct_message_group(self) -> None:
-        hamlet = self.example_user("hamlet")
-
-        # creating direct message group for self messages
-        get_or_create_direct_message_group(id_list=[hamlet.id])
-
-        # Send a message to ourself.
-        message_id = self.send_personal_message(
-            from_user=hamlet,
-            to_user=hamlet,
-            read_by_sender=False,
-        )
-
-        um = UserMessage.objects.get(
-            user_profile_id=hamlet.id,
-            message_id=message_id,
-        )
-        self.assertFalse(um.flags.read)
-
-        raw_unread_data = get_raw_unread_data(
-            user_profile=hamlet,
-        )
-        pm_dict = raw_unread_data["pm_dict"]
-
-        self.assertEqual(
-            set(pm_dict.keys()),
-            {message_id},
-        )
-        self.assertEqual(
-            pm_dict[message_id],
             dict(other_user_id=hamlet.id),
         )
 

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import orjson
 from django.db import connection
+from django.test import override_settings
 from typing_extensions import override
 
 from zerver.actions.message_flags import do_update_message_flags
@@ -1127,6 +1128,29 @@ class GetUnreadMsgsTest(ZulipTestCase):
             dict(user_ids_string=direct_message_group_string),
         )
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_raw_unread_personal_using_personal_recipients(self) -> None:
+        cordelia = self.example_user("cordelia")
+        othello = self.example_user("othello")
+        hamlet = self.example_user("hamlet")
+
+        cordelia_pm_message_ids = [self.send_personal_message(cordelia, hamlet) for i in range(3)]
+        othello_pm_message_ids = [self.send_personal_message(othello, hamlet) for i in range(3)]
+
+        raw_unread_data = get_raw_unread_data(user_profile=hamlet)
+
+        pm_dict = raw_unread_data["pm_dict"]
+
+        self.assertEqual(
+            set(pm_dict.keys()),
+            set(cordelia_pm_message_ids) | set(othello_pm_message_ids),
+        )
+
+        self.assertEqual(
+            pm_dict[cordelia_pm_message_ids[0]],
+            dict(other_user_id=cordelia.id),
+        )
+
     def test_raw_unread_personal(self) -> None:
         cordelia = self.example_user("cordelia")
         othello = self.example_user("othello")
@@ -1183,6 +1207,7 @@ class GetUnreadMsgsTest(ZulipTestCase):
             dict(other_user_id=othello.id),
         )
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_raw_unread_personal_from_self(self) -> None:
         hamlet = self.example_user("hamlet")
 

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -1297,6 +1297,7 @@ class TestMessageNotificationEmails(ZulipTestCase):
         email_subject = "Group DMs with iago and Iago"
         self._test_cases(msg_id, verify_body_include, email_subject)
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_pm_link_in_missed_message_header_using_direct_message_group(self) -> None:
         cordelia = self.example_user("cordelia")
         hamlet = self.example_user("hamlet")
@@ -1360,6 +1361,7 @@ class TestMessageNotificationEmails(ZulipTestCase):
             mail.outbox[2].alternatives[0][0],
         )
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_sender_name_in_missed_pm_using_direct_message_group(self) -> None:
         hamlet = self.example_user("hamlet")
         iago = self.example_user("iago")
@@ -1382,6 +1384,7 @@ class TestMessageNotificationEmails(ZulipTestCase):
             mail.outbox[0].alternatives[0][0],
         )
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_your_name_in_missed_pm_to_self_using_direct_message_group(self) -> None:
         hamlet = self.example_user("hamlet")
 

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -1128,10 +1128,18 @@ class TestMessageNotificationEmails(ZulipTestCase):
         self._resolved_topic_missed_stream_messages_thread_friendly()
 
     @override_settings(EMAIL_GATEWAY_PATTERN="")
-    def test_reply_warning_in_missed_personal_messages(self) -> None:
+    def test_reply_warning_in_missed_personal_messages_with_direct_message_group(self) -> None:
         self._reply_warning_in_missed_personal_messages()
 
-    def test_extra_context_in_missed_personal_messages(self) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False, EMAIL_GATEWAY_PATTERN="")
+    def test_reply_warning_in_missed_personal_messages_using_personal_recipients(self) -> None:
+        self._reply_warning_in_missed_personal_messages()
+
+    def test_extra_context_in_missed_personal_messages_with_direct_message_group(self) -> None:
+        self._extra_context_in_missed_personal_messages()
+
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_extra_context_in_missed_personal_messages_using_personal_recipients(self) -> None:
         self._extra_context_in_missed_personal_messages()
 
     def test_extra_context_in_missed_group_direct_messages_two_others(self) -> None:

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -1128,18 +1128,10 @@ class TestMessageNotificationEmails(ZulipTestCase):
         self._resolved_topic_missed_stream_messages_thread_friendly()
 
     @override_settings(EMAIL_GATEWAY_PATTERN="")
-    def test_reply_warning_in_missed_personal_messages_with_direct_message_group(self) -> None:
+    def test_reply_warning_in_missed_personal_messages(self) -> None:
         self._reply_warning_in_missed_personal_messages()
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False, EMAIL_GATEWAY_PATTERN="")
-    def test_reply_warning_in_missed_personal_messages_using_personal_recipients(self) -> None:
-        self._reply_warning_in_missed_personal_messages()
-
-    def test_extra_context_in_missed_personal_messages_with_direct_message_group(self) -> None:
-        self._extra_context_in_missed_personal_messages()
-
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
-    def test_extra_context_in_missed_personal_messages_using_personal_recipients(self) -> None:
+    def test_extra_context_in_missed_personal_messages(self) -> None:
         self._extra_context_in_missed_personal_messages()
 
     def test_extra_context_in_missed_group_direct_messages_two_others(self) -> None:

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -1297,7 +1297,6 @@ class TestMessageNotificationEmails(ZulipTestCase):
         email_subject = "Group DMs with iago and Iago"
         self._test_cases(msg_id, verify_body_include, email_subject)
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_pm_link_in_missed_message_header_using_direct_message_group(self) -> None:
         cordelia = self.example_user("cordelia")
         hamlet = self.example_user("hamlet")
@@ -1361,7 +1360,6 @@ class TestMessageNotificationEmails(ZulipTestCase):
             mail.outbox[2].alternatives[0][0],
         )
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_sender_name_in_missed_pm_using_direct_message_group(self) -> None:
         hamlet = self.example_user("hamlet")
         iago = self.example_user("iago")
@@ -1384,7 +1382,6 @@ class TestMessageNotificationEmails(ZulipTestCase):
             mail.outbox[0].alternatives[0][0],
         )
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_your_name_in_missed_pm_to_self_using_direct_message_group(self) -> None:
         hamlet = self.example_user("hamlet")
 

--- a/zerver/tests/test_message_report.py
+++ b/zerver/tests/test_message_report.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.test import override_settings
 from typing_extensions import Any, override
 
 from zerver.actions.realm_settings import do_set_realm_moderation_request_channel
@@ -187,7 +188,8 @@ class ReportMessageTest(ZulipTestCase):
         assert len(reports) == 1
         self.assertIn(expected_message_link_syntax, reports[0]["content"])
 
-    def test_dm_report(self) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_dm_report_using_personal_recipients(self) -> None:
         # Send a DM to be reported
         reported_dm_id = self.send_personal_message(
             self.reported_user,

--- a/zerver/tests/test_message_report.py
+++ b/zerver/tests/test_message_report.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.test import override_settings
 from typing_extensions import Any, override
 
 from zerver.actions.realm_settings import do_set_realm_moderation_request_channel
@@ -234,6 +235,7 @@ class ReportMessageTest(ZulipTestCase):
         result = self.report_message(ZOE, reported_dm_id, report_type, description)
         self.assert_json_error(result, msg="Invalid message(s)")
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_personal_message_report_using_direct_message_group(self) -> None:
         direct_message_group = get_or_create_direct_message_group(
             id_list=[self.hamlet.id, self.reported_user.id],

--- a/zerver/tests/test_message_report.py
+++ b/zerver/tests/test_message_report.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.test import override_settings
 from typing_extensions import Any, override
 
 from zerver.actions.realm_settings import do_set_realm_moderation_request_channel
@@ -235,7 +234,6 @@ class ReportMessageTest(ZulipTestCase):
         result = self.report_message(ZOE, reported_dm_id, report_type, description)
         self.assert_json_error(result, msg="Invalid message(s)")
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_personal_message_report_using_direct_message_group(self) -> None:
         direct_message_group = get_or_create_direct_message_group(
             id_list=[self.hamlet.id, self.reported_user.id],

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2496,6 +2496,7 @@ class PersonalMessageSendTest(ZulipTestCase):
         recipient = Recipient.objects.get(type_id=user_profile.id, type=Recipient.PERSONAL)
         self.assertEqual(most_recent_message(user_profile).recipient, recipient)
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_personal_to_self_using_direct_message_group(self) -> None:
         """
         If you send a personal to yourself using direct_message_group, only you see it.
@@ -2541,7 +2542,7 @@ class PersonalMessageSendTest(ZulipTestCase):
         self.assertEqual(message_stream_count(receiver), receiver_messages + 1)
 
         direct_message_group = get_direct_message_group([sender.id, receiver.id])
-        if direct_message_group:
+        if direct_message_group and settings.PREFER_DIRECT_MESSAGE_GROUP:
             recipient = Recipient.objects.get(
                 type_id=direct_message_group.id, type=Recipient.DIRECT_MESSAGE_GROUP
             )
@@ -2563,6 +2564,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             receiver=self.example_user("othello"),
         )
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_personal_using_direct_message_group(self) -> None:
         """
         If you send a personal using direct_message_group, only you and the recipient see it.
@@ -2618,7 +2620,7 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # Have the administrator send a message, and verify that allows the user to reply.
         self.send_personal_message(admin, user_profile)
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(16):
             self.send_personal_message(user_profile, admin)
 
         # Tests that user cannot initiate direct message thread in groups.
@@ -2654,7 +2656,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             user_group,
             acting_user=None,
         )
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(16):
             self.send_personal_message(user_profile, cordelia)
 
         # Test that query count decreases if setting is set to a system group.
@@ -2668,7 +2670,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             acting_user=None,
         )
         othello = self.example_user("othello")
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(15):
             self.send_personal_message(user_profile, othello)
 
     def test_direct_message_permission_group_setting(self) -> None:
@@ -2696,7 +2698,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             acting_user=None,
         )
         # Tests if the user is allowed to send to administrators.
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(16):
             self.send_personal_message(user_profile, admin)
         self.send_personal_message(admin, user_profile)
         # Tests if we can send messages to self irrespective of the value of the setting.
@@ -2746,7 +2748,7 @@ class PersonalMessageSendTest(ZulipTestCase):
         with self.assertRaises(DirectMessagePermissionError):
             self.send_personal_message(cordelia, polonius)
 
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(16):
             self.send_personal_message(user_profile, cordelia)
 
         # Test that query count decreases if setting is set to a system group.
@@ -2759,7 +2761,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             members_group,
             acting_user=None,
         )
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(15):
             self.send_personal_message(user_profile, cordelia)
 
         do_change_realm_permission_group_setting(

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -77,7 +77,7 @@ from zerver.models import (
 from zerver.models.constants import MAX_TOPIC_NAME_LENGTH
 from zerver.models.groups import SystemGroups
 from zerver.models.realms import RealmTopicsPolicyEnum, get_realm
-from zerver.models.recipients import get_direct_message_group, get_or_create_direct_message_group
+from zerver.models.recipients import get_or_create_direct_message_group
 from zerver.models.streams import StreamTopicsPolicyEnum, get_stream
 from zerver.models.users import get_system_bot, get_user, get_user_by_delivery_email
 from zerver.views.message_send import InvalidMirrorInputError
@@ -683,6 +683,9 @@ class MessagePOSTTest(ZulipTestCase):
         Sending a personal message to a valid user ID is successful
         for both valid strings for `type` parameter.
         """
+        hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+
         self.login("hamlet")
         recipient_type_name = ["direct", "private"]
 
@@ -692,14 +695,14 @@ class MessagePOSTTest(ZulipTestCase):
                 {
                     "type": type,
                     "content": "Test message",
-                    "to": orjson.dumps([self.example_user("othello").id]).decode(),
+                    "to": orjson.dumps([othello.id]).decode(),
                 },
             )
             self.assert_json_success(result)
 
             msg = self.get_last_message()
             self.assertEqual("Test message", msg.content)
-            self.assertEqual(msg.recipient_id, self.example_user("othello").recipient_id)
+            self.assertEqual(msg.recipient_id, self.get_dm_group_recipient(hamlet, othello).id)
 
     def test_group_personal_message_by_id(self) -> None:
         """
@@ -751,8 +754,8 @@ class MessagePOSTTest(ZulipTestCase):
         )
         self.assert_json_success(result)
         msg = self.get_last_message()
-        # Verify that we're not actually on the "recipient list"
-        self.assertNotIn("Hamlet", str(msg.recipient))
+        # Verify that we're actually on the "recipient list"
+        self.assertEqual(msg.recipient, self.get_dm_group_recipient(hamlet, othello))
 
     def test_personal_message_to_nonexistent_user(self) -> None:
         """
@@ -769,6 +772,7 @@ class MessagePOSTTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Invalid email 'nonexistent'")
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_personal_message_to_deactivated_user(self) -> None:
         """
         Sending a personal message to a deactivated user returns error JSON.
@@ -798,6 +802,7 @@ class MessagePOSTTest(ZulipTestCase):
         )
         self.assert_json_error(result, f"'{othello.email}' is no longer using Zulip.")
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_personal_message_to_inaccessible_users(self) -> None:
         othello = self.example_user("othello")
         cordelia = self.example_user("cordelia")
@@ -2498,7 +2503,8 @@ class StreamMessagesTest(ZulipTestCase):
 
 
 class PersonalMessageSendTest(ZulipTestCase):
-    def test_personal_to_self(self) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_personal_to_self_using_personal_recipient(self) -> None:
         """
         If you send a personal to yourself, only you see it.
         """
@@ -2562,12 +2568,9 @@ class PersonalMessageSendTest(ZulipTestCase):
         self.assertEqual(message_stream_count(sender), sender_messages + 1)
         self.assertEqual(message_stream_count(receiver), receiver_messages + 1)
 
-        direct_message_group = get_direct_message_group([sender.id, receiver.id])
         has_none_recipient = receiver.recipient is None or sender.recipient is None
-        if has_none_recipient:
+        if has_none_recipient or settings.PREFER_DIRECT_MESSAGE_GROUP:
             recipient = get_or_create_direct_message_group([sender.id, receiver.id]).recipient
-        elif settings.PREFER_DIRECT_MESSAGE_GROUP and direct_message_group:
-            recipient = direct_message_group.recipient
         else:
             recipient = Recipient.objects.get(type_id=receiver.id, type=Recipient.PERSONAL)
 
@@ -2576,7 +2579,8 @@ class PersonalMessageSendTest(ZulipTestCase):
         self.assertEqual(most_recent_message(sender).topic_name(), Message.DM_TOPIC)
         self.assertEqual(most_recent_message(receiver).topic_name(), Message.DM_TOPIC)
 
-    def test_personal(self) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_personal_using_personal_recipient(self) -> None:
         """
         If you send a personal, only you and the recipient see it.
         """
@@ -2621,7 +2625,59 @@ class PersonalMessageSendTest(ZulipTestCase):
         message = most_recent_message(sender)
         self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
-    def test_direct_message_initiator_group_setting(self) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_personal_message_using_personal_recipient(self) -> None:
+        user_profile = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+
+        with self.assert_database_query_count(16):
+            self.send_personal_message(user_profile, cordelia)
+
+    def test_personal_message_using_direct_message_group(self) -> None:
+        user_profile = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+
+        with self.assert_database_query_count(24):
+            self.send_personal_message(user_profile, cordelia)
+
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_direct_message_initiator_group_setting_using_personal_recipient(self) -> None:
+        """
+        Tests that direct_message_initiator_group_setting works correctly,
+        when personal recipients are used for 1:1 conversations.
+        """
+        user_profile = self.example_user("hamlet")
+        polonius = self.example_user("polonius")
+        admin = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        realm = user_profile.realm
+        administrators_system_group = NamedUserGroup.objects.get(
+            name=SystemGroups.ADMINISTRATORS, realm=realm, is_system_group=True
+        )
+        self.login_user(user_profile)
+        self.send_personal_message(user_profile, polonius)
+        do_change_realm_permission_group_setting(
+            realm,
+            "direct_message_initiator_group",
+            administrators_system_group,
+            acting_user=None,
+        )
+
+        # We can send to Polonius because we'd previously messaged him.
+        self.send_personal_message(user_profile, polonius)
+        # Tests if we can send messages to self irrespective of the value of the setting.
+        self.send_personal_message(user_profile, user_profile)
+        # We cannot send to users with whom we does not have any direct message conversation.
+        with self.assertRaises(DirectMessageInitiationError) as direct_message_initiation_error:
+            self.send_personal_message(user_profile, cordelia)
+        self.assertEqual(
+            str(direct_message_initiation_error.exception),
+            "You do not have permission to initiate direct message conversations.",
+        )
+        with self.assertRaises(DirectMessageInitiationError):
+            self.send_personal_message(user_profile, admin)
+
+    def test_direct_message_initiator_group_setting_using_direct_message_group(self) -> None:
         """
         Tests that direct_message_initiator_group_setting works correctly.
         """
@@ -2661,7 +2717,7 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # Have the administrator send a message, and verify that allows the user to reply.
         self.send_personal_message(admin, user_profile)
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(19):
             self.send_personal_message(user_profile, admin)
 
         # Tests that user cannot initiate direct message thread in groups.
@@ -2697,7 +2753,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             user_group,
             acting_user=None,
         )
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(19):
             self.send_personal_message(user_profile, cordelia)
 
         # Test that query count decreases if setting is set to a system group.
@@ -2711,7 +2767,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             acting_user=None,
         )
         othello = self.example_user("othello")
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(23):
             self.send_personal_message(user_profile, othello)
 
     def test_direct_message_permission_group_setting(self) -> None:
@@ -2739,7 +2795,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             acting_user=None,
         )
         # Tests if the user is allowed to send to administrators.
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(24):
             self.send_personal_message(user_profile, admin)
         self.send_personal_message(admin, user_profile)
         # Tests if we can send messages to self irrespective of the value of the setting.
@@ -2789,7 +2845,7 @@ class PersonalMessageSendTest(ZulipTestCase):
         with self.assertRaises(DirectMessagePermissionError):
             self.send_personal_message(cordelia, polonius)
 
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(19):
             self.send_personal_message(user_profile, cordelia)
 
         # Test that query count decreases if setting is set to a system group.
@@ -2802,7 +2858,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             members_group,
             acting_user=None,
         )
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(18):
             self.send_personal_message(user_profile, cordelia)
 
         do_change_realm_permission_group_setting(

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2447,6 +2447,28 @@ class StreamMessagesTest(ZulipTestCase):
         )
         self.assertEqual(recent_conversation["max_message_id"], message2_id)
 
+    def test_get_raw_unread_data_for_1_to_1_dms_using_group_direct_message(self) -> None:
+        sender = self.example_user("hamlet")
+        receiver = self.example_user("cordelia")
+        receiver.recipient = None
+        receiver.save()
+
+        message1_id = self.send_personal_message(sender, receiver, "test content 1")
+        message2_id = self.send_personal_message(sender, receiver, "test content 2")
+
+        msg_data = get_raw_unread_data(receiver)
+
+        self.assert_length(msg_data["pm_dict"].keys(), 2)
+        self.assert_length(msg_data["huddle_dict"].keys(), 0)
+
+        self.assertIn(message1_id, msg_data["pm_dict"].keys())
+        self.assertIn(message2_id, msg_data["pm_dict"].keys())
+
+        recent_conversations = get_recent_private_conversations(receiver)
+        [recent_conversation] = recent_conversations.values()
+        self.assertEqual(set(recent_conversation["user_ids"]), {sender.id})
+        self.assertEqual(recent_conversation["max_message_id"], message2_id)
+
     def test_stream_becomes_active_on_message_send(self) -> None:
         # Mark a stream as inactive
         stream = self.make_stream("inactive_stream")
@@ -2542,10 +2564,11 @@ class PersonalMessageSendTest(ZulipTestCase):
         self.assertEqual(message_stream_count(receiver), receiver_messages + 1)
 
         direct_message_group = get_direct_message_group([sender.id, receiver.id])
-        if direct_message_group and settings.PREFER_DIRECT_MESSAGE_GROUP:
-            recipient = Recipient.objects.get(
-                type_id=direct_message_group.id, type=Recipient.DIRECT_MESSAGE_GROUP
-            )
+        has_none_recipient = receiver.recipient is None or sender.recipient is None
+        if has_none_recipient:
+            recipient = get_or_create_direct_message_group([sender.id, receiver.id]).recipient
+        elif settings.PREFER_DIRECT_MESSAGE_GROUP and direct_message_group:
+            recipient = direct_message_group.recipient
         else:
             recipient = Recipient.objects.get(type_id=receiver.id, type=Recipient.PERSONAL)
 
@@ -2579,6 +2602,26 @@ class PersonalMessageSendTest(ZulipTestCase):
             sender=sender,
             receiver=receiver,
         )
+
+    def test_personal_when_personal_recipient_is_none(self) -> None:
+        """
+        If you send a personal using direct_message_group, only you and the recipient see it.
+        """
+        sender = self.example_user("hamlet")
+        receiver = self.example_user("othello")
+
+        # Removing the personal recipient to ensure a new direct message group is created.
+        receiver.recipient = None
+        receiver.save()
+
+        self.login("hamlet")
+        self.assert_personal(
+            sender=sender,
+            receiver=receiver,
+        )
+
+        message = most_recent_message(sender)
+        self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
     def test_direct_message_initiator_group_setting(self) -> None:
         """

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2518,7 +2518,6 @@ class PersonalMessageSendTest(ZulipTestCase):
         recipient = Recipient.objects.get(type_id=user_profile.id, type=Recipient.PERSONAL)
         self.assertEqual(most_recent_message(user_profile).recipient, recipient)
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_personal_to_self_using_direct_message_group(self) -> None:
         """
         If you send a personal to yourself using direct_message_group, only you see it.
@@ -2587,7 +2586,6 @@ class PersonalMessageSendTest(ZulipTestCase):
             receiver=self.example_user("othello"),
         )
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_personal_using_direct_message_group(self) -> None:
         """
         If you send a personal using direct_message_group, only you and the recipient see it.
@@ -2663,7 +2661,7 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # Have the administrator send a message, and verify that allows the user to reply.
         self.send_personal_message(admin, user_profile)
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(17):
             self.send_personal_message(user_profile, admin)
 
         # Tests that user cannot initiate direct message thread in groups.
@@ -2699,7 +2697,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             user_group,
             acting_user=None,
         )
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(17):
             self.send_personal_message(user_profile, cordelia)
 
         # Test that query count decreases if setting is set to a system group.
@@ -2713,7 +2711,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             acting_user=None,
         )
         othello = self.example_user("othello")
-        with self.assert_database_query_count(15):
+        with self.assert_database_query_count(16):
             self.send_personal_message(user_profile, othello)
 
     def test_direct_message_permission_group_setting(self) -> None:
@@ -2741,7 +2739,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             acting_user=None,
         )
         # Tests if the user is allowed to send to administrators.
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(17):
             self.send_personal_message(user_profile, admin)
         self.send_personal_message(admin, user_profile)
         # Tests if we can send messages to self irrespective of the value of the setting.
@@ -2791,7 +2789,7 @@ class PersonalMessageSendTest(ZulipTestCase):
         with self.assertRaises(DirectMessagePermissionError):
             self.send_personal_message(cordelia, polonius)
 
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(17):
             self.send_personal_message(user_profile, cordelia)
 
         # Test that query count decreases if setting is set to a system group.
@@ -2804,7 +2802,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             members_group,
             acting_user=None,
         )
-        with self.assert_database_query_count(15):
+        with self.assert_database_query_count(16):
             self.send_personal_message(user_profile, cordelia)
 
         do_change_realm_permission_group_setting(

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1481,6 +1481,7 @@ class TestGetAPNsPayload(PushNotificationTestCase):
         }
         self.assertDictEqual(payload, expected)
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_get_message_payload_apns_personal_message_using_direct_message_group(self) -> None:
         user_profile = self.example_user("othello")
 

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -733,6 +733,9 @@ class PushBouncerNotificationTest(BouncerTestCase):
 
     def test_send_notification_endpoint_on_free_plans(self) -> None:
         hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+        recipient = get_or_create_direct_message_group(id_list=[hamlet.id, othello.id]).recipient
+
         remote_server = self.server
         RemotePushDeviceToken.objects.create(
             kind=RemotePushDeviceToken.FCM,
@@ -744,7 +747,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
         current_time = now()
         message = Message(
             sender=hamlet,
-            recipient=self.example_user("othello").recipient,
+            recipient=recipient,
             realm_id=hamlet.realm_id,
             content="This is test content",
             rendered_content="This is test content",
@@ -773,12 +776,12 @@ class PushBouncerNotificationTest(BouncerTestCase):
                     "realm_id": hamlet.realm.id,
                     "realm_uri": hamlet.realm.url,
                     "realm_url": hamlet.realm.url,
-                    "user_id": self.example_user("othello").id,
+                    "user_id": othello.id,
                 }
             },
         }
         old_gcm_payload = {
-            "user_id": self.example_user("othello").id,
+            "user_id": othello.id,
             "event": "message",
             "alert": "New private message from King Hamlet",
             "zulip_message_id": message.id,

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1875,12 +1875,12 @@ class TestGetGCMPayload(PushNotificationTestCase):
         self._test_get_message_payload_gcm_stream_message(empty_string_topic=True)
 
     def test_get_message_payload_gcm_direct_message(self) -> None:
-        message = self.get_message(
-            Recipient.PERSONAL,
-            type_id=self.personal_recipient_user.id,
-            realm_id=self.personal_recipient_user.realm_id,
-        )
         hamlet = self.example_user("hamlet")
+        message = self.get_message(
+            Recipient.DIRECT_MESSAGE_GROUP,
+            type_id=self.dm_group.id,
+            realm_id=hamlet.realm_id,
+        )
         payload, gcm_options = get_message_payload_gcm(hamlet, message)
         self.assertDictEqual(
             payload,

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1481,7 +1481,6 @@ class TestGetAPNsPayload(PushNotificationTestCase):
         }
         self.assertDictEqual(payload, expected)
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_get_message_payload_apns_personal_message_using_direct_message_group(self) -> None:
         user_profile = self.example_user("othello")
 

--- a/zerver/tests/test_reminders.py
+++ b/zerver/tests/test_reminders.py
@@ -83,7 +83,9 @@ class RemindersTest(ZulipTestCase):
             self.get_channel_message_reminder_content(content, message_id),
         )
         # Recipient and sender are the same for reminders.
-        self.assertEqual(scheduled_message.recipient.type_id, self.example_user("hamlet").id)
+        self.assertEqual(
+            scheduled_message.recipient, self.get_dm_group_recipient(self.example_user("hamlet"))
+        )
         self.assertEqual(scheduled_message.sender, self.example_user("hamlet"))
         self.assertEqual(
             scheduled_message.scheduled_timestamp,
@@ -96,7 +98,7 @@ class RemindersTest(ZulipTestCase):
         self.assertEqual(scheduled_message.topic_name(), Message.DM_TOPIC)
 
         # Scheduling a direct message with user IDs is successful.
-        self.example_user("othello")
+        hamlet = self.example_user("hamlet")
         message_id = self.send_dm_from_hamlet_to_othello(content)
         result = self.do_schedule_reminder(message_id, scheduled_delivery_timestamp)
         self.assert_json_success(result)
@@ -104,8 +106,8 @@ class RemindersTest(ZulipTestCase):
         self.assertEqual(
             scheduled_message.content, self.get_dm_reminder_content(content, message_id)
         )
-        self.assertEqual(scheduled_message.recipient.type_id, self.example_user("hamlet").id)
-        self.assertEqual(scheduled_message.sender, self.example_user("hamlet"))
+        self.assertEqual(scheduled_message.recipient, self.get_dm_group_recipient(hamlet))
+        self.assertEqual(scheduled_message.sender, hamlet)
         self.assertEqual(
             scheduled_message.scheduled_timestamp,
             timestamp_to_datetime(scheduled_delivery_timestamp),

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -970,7 +970,7 @@ class RocketChatImporter(ZulipTestCase):
             return orjson.loads(f.read())
 
     @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
-    def test_do_convert_data(self) -> None:
+    def test_do_convert_data_using_personal_recipient(self) -> None:
         rocketchat_data_dir = self.fixture_file_name("", "rocketchat_fixtures")
         output_dir = self.make_import_output_dir("rocketchat")
 

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import orjson
+from django.test import override_settings
 
 from zerver.data_import.import_util import SubscriberHandler, ZerverFieldsT, build_recipients
 from zerver.data_import.rocketchat import (
@@ -490,6 +491,67 @@ class RocketChatImporter(ZulipTestCase):
         )
 
         self.assert_length(zerver_direct_message_group, 1)
+
+        rc_direct_message_group_id = rocketchat_data["room"][12]["_id"]
+        self.assertTrue(direct_message_group_id_mapper.has(rc_direct_message_group_id))
+
+        direct_message_group_id = direct_message_group_id_mapper.get(rc_direct_message_group_id)
+        self.assertEqual(
+            subscriber_handler.get_users(direct_message_group_id=direct_message_group_id), {3, 4, 5}
+        )
+
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
+    def test_convert_direct_message_group_data_without_personal_recipient(self) -> None:
+        fixture_dir_name = self.fixture_file_name("", "rocketchat_fixtures")
+        rocketchat_data = rocketchat_data_to_dict(fixture_dir_name)
+
+        realm_id = 3
+        domain_name = "zulip.com"
+
+        user_handler = UserHandler()
+        subscriber_handler = SubscriberHandler()
+        user_id_mapper = IdMapper[str]()
+        direct_message_group_id_mapper = IdMapper[str]()
+
+        user_id_to_user_map = map_user_id_to_user(rocketchat_data["user"])
+
+        process_users(
+            user_id_to_user_map=user_id_to_user_map,
+            realm_id=realm_id,
+            domain_name=domain_name,
+            user_handler=user_handler,
+            user_id_mapper=user_id_mapper,
+        )
+
+        direct_message_group_id_to_direct_message_group_map: dict[str, dict[str, Any]] = {}
+
+        with self.assertLogs(level="INFO"):
+            categorize_channels_and_map_with_id(
+                channel_data=rocketchat_data["room"],
+                room_id_to_room_map={},
+                team_id_to_team_map={},
+                dsc_id_to_dsc_map={},
+                direct_id_to_direct_map={},
+                direct_message_group_id_to_direct_message_group_map=direct_message_group_id_to_direct_message_group_map,
+                livechat_id_to_livechat_map={},
+            )
+
+        zerver_direct_message_group = convert_direct_message_group_data(
+            direct_message_group_id_to_direct_message_group_map=direct_message_group_id_to_direct_message_group_map,
+            direct_message_group_id_mapper=direct_message_group_id_mapper,
+            user_id_mapper=user_id_mapper,
+            subscriber_handler=subscriber_handler,
+        )
+
+        self.assert_length(zerver_direct_message_group, 2)
+
+        rc_direct_message_group_id = rocketchat_data["room"][4]["_id"]
+        self.assertTrue(direct_message_group_id_mapper.has(rc_direct_message_group_id))
+
+        direct_message_group_id = direct_message_group_id_mapper.get(rc_direct_message_group_id)
+        self.assertEqual(
+            subscriber_handler.get_users(direct_message_group_id=direct_message_group_id), {3, 4}
+        )
 
         rc_direct_message_group_id = rocketchat_data["room"][12]["_id"]
         self.assertTrue(direct_message_group_id_mapper.has(rc_direct_message_group_id))

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -197,6 +197,7 @@ class RocketChatImporter(ZulipTestCase):
         expected_error_message = f"['Invalid email format, please fix the following email(s) and try again: {bad_email1}, {bad_email2}']"
         self.assertEqual(error_message, expected_error_message)
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_categorize_channels_and_map_with_id(self) -> None:
         fixture_dir_name = self.fixture_file_name("", "rocketchat_fixtures")
         rocketchat_data = rocketchat_data_to_dict(fixture_dir_name)
@@ -443,6 +444,7 @@ class RocketChatImporter(ZulipTestCase):
         self.assert_length(subscriber_handler.get_users(stream_id=zerver_stream[6]["id"]), 0)
         self.assertTrue(zerver_stream[6]["deactivated"])
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_convert_direct_message_group_data(self) -> None:
         fixture_dir_name = self.fixture_file_name("", "rocketchat_fixtures")
         rocketchat_data = rocketchat_data_to_dict(fixture_dir_name)
@@ -500,7 +502,6 @@ class RocketChatImporter(ZulipTestCase):
             subscriber_handler.get_users(direct_message_group_id=direct_message_group_id), {3, 4, 5}
         )
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_convert_direct_message_group_data_without_personal_recipient(self) -> None:
         fixture_dir_name = self.fixture_file_name("", "rocketchat_fixtures")
         rocketchat_data = rocketchat_data_to_dict(fixture_dir_name)
@@ -606,6 +607,7 @@ class RocketChatImporter(ZulipTestCase):
         self.assertEqual(records_json[2]["realm_id"], 3)
         self.assertTrue(os.path.isfile(records_json[2]["path"]))
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_map_receiver_id_to_recipient_id(self) -> None:
         fixture_dir_name = self.fixture_file_name("", "rocketchat_fixtures")
         rocketchat_data = rocketchat_data_to_dict(fixture_dir_name)
@@ -708,6 +710,7 @@ class RocketChatImporter(ZulipTestCase):
             zerver_recipient[12]["id"],
         )
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_separate_channel_private_and_livechat_messages(self) -> None:
         fixture_dir_name = self.fixture_file_name("", "rocketchat_fixtures")
         rocketchat_data = rocketchat_data_to_dict(fixture_dir_name)
@@ -966,6 +969,7 @@ class RocketChatImporter(ZulipTestCase):
         with open(full_path, "rb") as f:
             return orjson.loads(f.read())
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_do_convert_data(self) -> None:
         rocketchat_data_dir = self.fixture_file_name("", "rocketchat_fixtures")
         output_dir = self.make_import_output_dir("rocketchat")

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -3,8 +3,6 @@ from datetime import datetime, timezone
 from typing import Any
 
 import orjson
-from django.conf import settings
-from django.test import override_settings
 
 from zerver.data_import.import_util import SubscriberHandler, ZerverFieldsT, build_recipients
 from zerver.data_import.rocketchat import (
@@ -32,7 +30,7 @@ from zerver.lib.import_realm import do_import_realm
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import Message, Reaction, Recipient, UserProfile
 from zerver.models.realms import get_realm
-from zerver.models.users import get_system_bot, get_user
+from zerver.models.users import get_user
 
 
 class RocketChatImporter(ZulipTestCase):
@@ -198,7 +196,6 @@ class RocketChatImporter(ZulipTestCase):
         expected_error_message = f"['Invalid email format, please fix the following email(s) and try again: {bad_email1}, {bad_email2}']"
         self.assertEqual(error_message, expected_error_message)
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_categorize_channels_and_map_with_id(self) -> None:
         fixture_dir_name = self.fixture_file_name("", "rocketchat_fixtures")
         rocketchat_data = rocketchat_data_to_dict(fixture_dir_name)
@@ -206,7 +203,6 @@ class RocketChatImporter(ZulipTestCase):
         room_id_to_room_map: dict[str, dict[str, Any]] = {}
         team_id_to_team_map: dict[str, dict[str, Any]] = {}
         dsc_id_to_dsc_map: dict[str, dict[str, Any]] = {}
-        direct_id_to_direct_map: dict[str, dict[str, Any]] = {}
         direct_message_group_id_to_direct_message_group_map: dict[str, dict[str, Any]] = {}
         livechat_id_to_livechat_map: dict[str, dict[str, Any]] = {}
 
@@ -216,7 +212,6 @@ class RocketChatImporter(ZulipTestCase):
                 room_id_to_room_map=room_id_to_room_map,
                 team_id_to_team_map=team_id_to_team_map,
                 dsc_id_to_dsc_map=dsc_id_to_dsc_map,
-                direct_id_to_direct_map=direct_id_to_direct_map,
                 direct_message_group_id_to_direct_message_group_map=direct_message_group_id_to_direct_message_group_map,
                 livechat_id_to_livechat_map=livechat_id_to_livechat_map,
             )
@@ -226,8 +221,7 @@ class RocketChatImporter(ZulipTestCase):
         self.assert_length(room_id_to_room_map, 6)
         self.assert_length(team_id_to_team_map, 1)
         self.assert_length(dsc_id_to_dsc_map, 5)
-        self.assert_length(direct_id_to_direct_map, 2)
-        self.assert_length(direct_message_group_id_to_direct_message_group_map, 1)
+        self.assert_length(direct_message_group_id_to_direct_message_group_map, 2)
         self.assert_length(livechat_id_to_livechat_map, 2)
 
         room_id = rocketchat_data["room"][0]["_id"]
@@ -243,8 +237,11 @@ class RocketChatImporter(ZulipTestCase):
         self.assertEqual(dsc_id_to_dsc_map[dsc_id], rocketchat_data["room"][7])
 
         direct_id = rocketchat_data["room"][4]["_id"]
-        self.assertIn(direct_id, direct_id_to_direct_map)
-        self.assertEqual(direct_id_to_direct_map[direct_id], rocketchat_data["room"][4])
+        self.assertIn(direct_id, direct_message_group_id_to_direct_message_group_map)
+        self.assertEqual(
+            direct_message_group_id_to_direct_message_group_map[direct_id],
+            rocketchat_data["room"][4],
+        )
 
         direct_message_group_id = rocketchat_data["room"][12]["_id"]
         self.assertIn(direct_message_group_id, direct_message_group_id_to_direct_message_group_map)
@@ -269,7 +266,6 @@ class RocketChatImporter(ZulipTestCase):
         room_id_to_room_map: dict[str, dict[str, Any]] = {}
         team_id_to_team_map: dict[str, dict[str, Any]] = {}
         dsc_id_to_dsc_map: dict[str, dict[str, Any]] = {}
-        direct_id_to_direct_map: dict[str, dict[str, Any]] = {}
         direct_message_group_id_to_direct_message_group_map: dict[str, dict[str, Any]] = {}
         livechat_id_to_livechat_map: dict[str, dict[str, Any]] = {}
 
@@ -279,7 +275,6 @@ class RocketChatImporter(ZulipTestCase):
                 room_id_to_room_map=room_id_to_room_map,
                 team_id_to_team_map=team_id_to_team_map,
                 dsc_id_to_dsc_map=dsc_id_to_dsc_map,
-                direct_id_to_direct_map=direct_id_to_direct_map,
                 direct_message_group_id_to_direct_message_group_map=direct_message_group_id_to_direct_message_group_map,
                 livechat_id_to_livechat_map=livechat_id_to_livechat_map,
             )
@@ -361,7 +356,6 @@ class RocketChatImporter(ZulipTestCase):
         room_id_to_room_map: dict[str, dict[str, Any]] = {}
         team_id_to_team_map: dict[str, dict[str, Any]] = {}
         dsc_id_to_dsc_map: dict[str, dict[str, Any]] = {}
-        direct_id_to_direct_map: dict[str, dict[str, Any]] = {}
         direct_message_group_id_to_direct_message_group_map: dict[str, dict[str, Any]] = {}
         livechat_id_to_livechat_map: dict[str, dict[str, Any]] = {}
 
@@ -371,7 +365,6 @@ class RocketChatImporter(ZulipTestCase):
                 room_id_to_room_map=room_id_to_room_map,
                 team_id_to_team_map=team_id_to_team_map,
                 dsc_id_to_dsc_map=dsc_id_to_dsc_map,
-                direct_id_to_direct_map=direct_id_to_direct_map,
                 direct_message_group_id_to_direct_message_group_map=direct_message_group_id_to_direct_message_group_map,
                 livechat_id_to_livechat_map=livechat_id_to_livechat_map,
             )
@@ -445,65 +438,7 @@ class RocketChatImporter(ZulipTestCase):
         self.assert_length(subscriber_handler.get_users(stream_id=zerver_stream[6]["id"]), 0)
         self.assertTrue(zerver_stream[6]["deactivated"])
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_convert_direct_message_group_data(self) -> None:
-        fixture_dir_name = self.fixture_file_name("", "rocketchat_fixtures")
-        rocketchat_data = rocketchat_data_to_dict(fixture_dir_name)
-
-        realm_id = 3
-        domain_name = "zulip.com"
-
-        user_handler = UserHandler()
-        subscriber_handler = SubscriberHandler()
-        user_id_mapper = IdMapper[str]()
-        direct_message_group_id_mapper = IdMapper[str]()
-
-        user_id_to_user_map = map_user_id_to_user(rocketchat_data["user"])
-
-        process_users(
-            user_id_to_user_map=user_id_to_user_map,
-            realm_id=realm_id,
-            domain_name=domain_name,
-            user_handler=user_handler,
-            user_id_mapper=user_id_mapper,
-        )
-
-        room_id_to_room_map: dict[str, dict[str, Any]] = {}
-        team_id_to_team_map: dict[str, dict[str, Any]] = {}
-        dsc_id_to_dsc_map: dict[str, dict[str, Any]] = {}
-        direct_id_to_direct_map: dict[str, dict[str, Any]] = {}
-        direct_message_group_id_to_direct_message_group_map: dict[str, dict[str, Any]] = {}
-        livechat_id_to_livechat_map: dict[str, dict[str, Any]] = {}
-
-        with self.assertLogs(level="INFO"):
-            categorize_channels_and_map_with_id(
-                channel_data=rocketchat_data["room"],
-                room_id_to_room_map=room_id_to_room_map,
-                team_id_to_team_map=team_id_to_team_map,
-                dsc_id_to_dsc_map=dsc_id_to_dsc_map,
-                direct_id_to_direct_map=direct_id_to_direct_map,
-                direct_message_group_id_to_direct_message_group_map=direct_message_group_id_to_direct_message_group_map,
-                livechat_id_to_livechat_map=livechat_id_to_livechat_map,
-            )
-
-        zerver_direct_message_group = convert_direct_message_group_data(
-            direct_message_group_id_to_direct_message_group_map=direct_message_group_id_to_direct_message_group_map,
-            direct_message_group_id_mapper=direct_message_group_id_mapper,
-            user_id_mapper=user_id_mapper,
-            subscriber_handler=subscriber_handler,
-        )
-
-        self.assert_length(zerver_direct_message_group, 1)
-
-        rc_direct_message_group_id = rocketchat_data["room"][12]["_id"]
-        self.assertTrue(direct_message_group_id_mapper.has(rc_direct_message_group_id))
-
-        direct_message_group_id = direct_message_group_id_mapper.get(rc_direct_message_group_id)
-        self.assertEqual(
-            subscriber_handler.get_users(direct_message_group_id=direct_message_group_id), {3, 4, 5}
-        )
-
-    def test_convert_direct_message_group_data_without_personal_recipient(self) -> None:
         fixture_dir_name = self.fixture_file_name("", "rocketchat_fixtures")
         rocketchat_data = rocketchat_data_to_dict(fixture_dir_name)
 
@@ -533,7 +468,6 @@ class RocketChatImporter(ZulipTestCase):
                 room_id_to_room_map={},
                 team_id_to_team_map={},
                 dsc_id_to_dsc_map={},
-                direct_id_to_direct_map={},
                 direct_message_group_id_to_direct_message_group_map=direct_message_group_id_to_direct_message_group_map,
                 livechat_id_to_livechat_map={},
             )
@@ -608,7 +542,6 @@ class RocketChatImporter(ZulipTestCase):
         self.assertEqual(records_json[2]["realm_id"], 3)
         self.assertTrue(os.path.isfile(records_json[2]["path"]))
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_map_receiver_id_to_recipient_id(self) -> None:
         fixture_dir_name = self.fixture_file_name("", "rocketchat_fixtures")
         rocketchat_data = rocketchat_data_to_dict(fixture_dir_name)
@@ -636,7 +569,6 @@ class RocketChatImporter(ZulipTestCase):
         room_id_to_room_map: dict[str, dict[str, Any]] = {}
         team_id_to_team_map: dict[str, dict[str, Any]] = {}
         dsc_id_to_dsc_map: dict[str, dict[str, Any]] = {}
-        direct_id_to_direct_map: dict[str, dict[str, Any]] = {}
         direct_message_group_id_to_direct_message_group_map: dict[str, dict[str, Any]] = {}
         livechat_id_to_livechat_map: dict[str, dict[str, Any]] = {}
 
@@ -646,7 +578,6 @@ class RocketChatImporter(ZulipTestCase):
                 room_id_to_room_map=room_id_to_room_map,
                 team_id_to_team_map=team_id_to_team_map,
                 dsc_id_to_dsc_map=dsc_id_to_dsc_map,
-                direct_id_to_direct_map=direct_id_to_direct_map,
                 direct_message_group_id_to_direct_message_group_map=direct_message_group_id_to_direct_message_group_map,
                 livechat_id_to_livechat_map=livechat_id_to_livechat_map,
             )
@@ -666,52 +597,42 @@ class RocketChatImporter(ZulipTestCase):
             subscriber_handler=subscriber_handler,
         )
 
-        all_users = user_handler.get_all_users()
-
         zerver_recipient = build_recipients(
-            zerver_userprofile=all_users,
             zerver_stream=zerver_stream,
             zerver_direct_message_group=zerver_direct_message_group,
         )
 
         stream_id_to_recipient_id: dict[int, int] = {}
-        user_id_to_recipient_id: dict[int, int] = {}
         direct_message_group_id_to_recipient_id: dict[int, int] = {}
 
         map_receiver_id_to_recipient_id(
             zerver_recipient=zerver_recipient,
             stream_id_to_recipient_id=stream_id_to_recipient_id,
-            user_id_to_recipient_id=user_id_to_recipient_id,
             direct_message_group_id_to_recipient_id=direct_message_group_id_to_recipient_id,
         )
 
         # 6 for streams and 6 for users.
-        self.assert_length(zerver_recipient, 13)
+        self.assert_length(zerver_recipient, 8)
         self.assert_length(stream_id_to_recipient_id, 6)
-        self.assert_length(user_id_to_recipient_id, 6)
-        self.assert_length(direct_message_group_id_to_recipient_id, 1)
+        self.assert_length(direct_message_group_id_to_recipient_id, 2)
 
         # First user recipients are built, followed by stream recipients in `build_recipients`.
         self.assertEqual(
-            user_id_to_recipient_id[zerver_recipient[0]["type_id"]], zerver_recipient[0]["id"]
+            stream_id_to_recipient_id[zerver_recipient[0]["type_id"]], zerver_recipient[0]["id"]
         )
         self.assertEqual(
-            user_id_to_recipient_id[zerver_recipient[1]["type_id"]], zerver_recipient[1]["id"]
+            stream_id_to_recipient_id[zerver_recipient[1]["type_id"]], zerver_recipient[1]["id"]
         )
 
         self.assertEqual(
-            stream_id_to_recipient_id[zerver_recipient[6]["type_id"]], zerver_recipient[6]["id"]
+            direct_message_group_id_to_recipient_id[zerver_recipient[6]["type_id"]],
+            zerver_recipient[6]["id"],
         )
         self.assertEqual(
-            stream_id_to_recipient_id[zerver_recipient[7]["type_id"]], zerver_recipient[7]["id"]
+            direct_message_group_id_to_recipient_id[zerver_recipient[7]["type_id"]],
+            zerver_recipient[7]["id"],
         )
 
-        self.assertEqual(
-            direct_message_group_id_to_recipient_id[zerver_recipient[12]["type_id"]],
-            zerver_recipient[12]["id"],
-        )
-
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_separate_channel_private_and_livechat_messages(self) -> None:
         fixture_dir_name = self.fixture_file_name("", "rocketchat_fixtures")
         rocketchat_data = rocketchat_data_to_dict(fixture_dir_name)
@@ -719,7 +640,6 @@ class RocketChatImporter(ZulipTestCase):
         room_id_to_room_map: dict[str, dict[str, Any]] = {}
         team_id_to_team_map: dict[str, dict[str, Any]] = {}
         dsc_id_to_dsc_map: dict[str, dict[str, Any]] = {}
-        direct_id_to_direct_map: dict[str, dict[str, Any]] = {}
         direct_message_group_id_to_direct_message_group_map: dict[str, dict[str, Any]] = {}
         livechat_id_to_livechat_map: dict[str, dict[str, Any]] = {}
 
@@ -729,7 +649,6 @@ class RocketChatImporter(ZulipTestCase):
                 room_id_to_room_map=room_id_to_room_map,
                 team_id_to_team_map=team_id_to_team_map,
                 dsc_id_to_dsc_map=dsc_id_to_dsc_map,
-                direct_id_to_direct_map=direct_id_to_direct_map,
                 direct_message_group_id_to_direct_message_group_map=direct_message_group_id_to_direct_message_group_map,
                 livechat_id_to_livechat_map=livechat_id_to_livechat_map,
             )
@@ -741,7 +660,6 @@ class RocketChatImporter(ZulipTestCase):
         separate_channel_private_and_livechat_messages(
             messages=rocketchat_data["message"],
             dsc_id_to_dsc_map=dsc_id_to_dsc_map,
-            direct_id_to_direct_map=direct_id_to_direct_map,
             direct_message_group_id_to_direct_message_group_map=direct_message_group_id_to_direct_message_group_map,
             livechat_id_to_livechat_map=livechat_id_to_livechat_map,
             channel_messages=channel_messages,
@@ -768,7 +686,6 @@ class RocketChatImporter(ZulipTestCase):
 
         # Message in a Discussion originating from a direct channel
         self.assertIn(rocketchat_data["message"][70], private_messages)
-        self.assertIn(rocketchat_data["message"][70]["rid"], direct_id_to_direct_map)
 
         # Add a message with no `rid`
         rocketchat_data["message"].append(
@@ -801,7 +718,6 @@ class RocketChatImporter(ZulipTestCase):
         separate_channel_private_and_livechat_messages(
             messages=rocketchat_data["message"],
             dsc_id_to_dsc_map=dsc_id_to_dsc_map,
-            direct_id_to_direct_map=direct_id_to_direct_map,
             direct_message_group_id_to_direct_message_group_map=direct_message_group_id_to_direct_message_group_map,
             livechat_id_to_livechat_map=livechat_id_to_livechat_map,
             channel_messages=channel_messages,
@@ -970,8 +886,7 @@ class RocketChatImporter(ZulipTestCase):
         with open(full_path, "rb") as f:
             return orjson.loads(f.read())
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
-    def test_do_convert_data_using_personal_recipient(self) -> None:
+    def test_do_convert_data(self) -> None:
         rocketchat_data_dir = self.fixture_file_name("", "rocketchat_fixtures")
         output_dir = self.make_import_output_dir("rocketchat")
 
@@ -990,6 +905,8 @@ class RocketChatImporter(ZulipTestCase):
             [
                 "INFO:root:Starting to process custom emoji",
                 "INFO:root:Done processing emoji",
+                "INFO:root:Direct message group channel found. UIDs: ['LdBZ7kPxtKESyHPEe', 'M2sXGqoQRJQwQoXY2']",
+                "INFO:root:Direct message group channel found. UIDs: ['LdBZ7kPxtKESyHPEe', 'NTzobKvioAAdsAJHv']",
                 "INFO:root:Direct message group channel found. UIDs: ['LdBZ7kPxtKESyHPEe', 'M2sXGqoQRJQwQoXY2', 'os6N2Xg2JkNMCSW9Z']",
                 "INFO:root:skipping direct messages discussion mention: Discussion with Hermione",
                 "INFO:root:Processed messages up to 35 / 35",
@@ -1060,16 +977,18 @@ class RocketChatImporter(ZulipTestCase):
         self.assert_length(realm["zerver_defaultstream"], 0)
 
         exported_recipient_ids = self.get_set(realm["zerver_recipient"], "id")
-        self.assert_length(exported_recipient_ids, 13)
+        self.assert_length(exported_recipient_ids, 8)
         exported_recipient_types = self.get_set(realm["zerver_recipient"], "type")
-        self.assertEqual(exported_recipient_types, {1, 2, 3})
+        self.assertEqual(
+            exported_recipient_types, {Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP}
+        )
 
         exported_subscription_userprofile = self.get_set(
             realm["zerver_subscription"], "user_profile"
         )
-        self.assert_length(exported_subscription_userprofile, 6)
+        self.assert_length(exported_subscription_userprofile, 5)
         exported_subscription_recipients = self.get_set(realm["zerver_subscription"], "recipient")
-        self.assert_length(exported_subscription_recipients, 13)
+        self.assert_length(exported_subscription_recipients, 8)
 
         messages = self.read_file(output_dir, "messages-000001.json")
 
@@ -1087,12 +1006,6 @@ class RocketChatImporter(ZulipTestCase):
         self.assert_length(exported_usermessage_userprofiles, 5)
         exported_usermessage_messages = self.get_set(messages["zerver_usermessage"], "message")
         self.assertEqual(exported_usermessage_messages, exported_messages_id)
-
-        # Creating personal recipients for bots before importing the data
-        internal_realm = get_realm(settings.SYSTEM_BOT_REALM)
-        notification_bot = get_system_bot(settings.NOTIFICATION_BOT, internal_realm.id)
-        welcome_bot = get_system_bot(settings.WELCOME_BOT, internal_realm.id)
-        self.create_personal_recipient(notification_bot, welcome_bot)
 
         with self.assertLogs(level="INFO"):
             do_import_realm(
@@ -1137,34 +1050,30 @@ class RocketChatImporter(ZulipTestCase):
         group_direct_messages = messages.filter(
             recipient__type=Recipient.DIRECT_MESSAGE_GROUP
         ).order_by("date_sent")
+
         direct_message_group_recipients = group_direct_messages.values_list("recipient", flat=True)
-        self.assert_length(group_direct_messages, 5)
-        self.assert_length(set(direct_message_group_recipients), 2)
-        self.assertEqual(group_direct_messages[0].sender.email, "hermionegranger@email.com")
-        self.assertEqual(group_direct_messages[0].content, "Hey people!")
+        self.assert_length(group_direct_messages, 14)
+        self.assert_length(set(direct_message_group_recipients), 8)
 
-        self.assertEqual(group_direct_messages[0].topic_name(), Message.DM_TOPIC)
-        self.assertEqual(group_direct_messages[2].sender.email, "harrypotter@email.com")
-        self.assertRegex(
-            group_direct_messages[2].content,
-            "This year's curriculum is out.\n\n\\[Hogwarts Curriculum.pdf\\]\\(.*\\)",
-        )
-        self.assertTrue(group_direct_messages[2].has_attachment)
-        self.assertFalse(group_direct_messages[2].has_image)
-        self.assertTrue(group_direct_messages[2].has_link)
-
-        personal_messages = messages.filter(recipient__type=Recipient.PERSONAL).order_by(
-            "date_sent"
-        )
-        personal_recipients = personal_messages.values_list("recipient", flat=True)
-        self.assert_length(personal_messages, 9)
-        self.assert_length(set(personal_recipients), 5)
-        self.assertEqual(personal_messages[0].sender.email, "harrypotter@email.com")
+        self.assertEqual(group_direct_messages[0].sender.email, "harrypotter@email.com")
         self.assertEqual(
-            personal_messages[0].content,
+            group_direct_messages[0].content,
             "Hey @**Hermione Granger** :grin:, how's everything going?",
         )
-        self.assertEqual(personal_messages[0].topic_name(), Message.DM_TOPIC)
+        self.assertEqual(group_direct_messages[0].topic_name(), Message.DM_TOPIC)
+
+        self.assertEqual(group_direct_messages[3].sender.email, "hermionegranger@email.com")
+        self.assertEqual(group_direct_messages[3].content, "Hey people!")
+        self.assertEqual(group_direct_messages[3].topic_name(), Message.DM_TOPIC)
+
+        self.assertEqual(group_direct_messages[5].sender.email, "harrypotter@email.com")
+        self.assertRegex(
+            group_direct_messages[5].content,
+            "This year's curriculum is out.\n\n\\[Hogwarts Curriculum.pdf\\]\\(.*\\)",
+        )
+        self.assertTrue(group_direct_messages[5].has_attachment)
+        self.assertFalse(group_direct_messages[5].has_image)
+        self.assertTrue(group_direct_messages[5].has_link)
 
         self.verify_emoji_code_foreign_keys()
 

--- a/zerver/tests/test_scheduled_messages.py
+++ b/zerver/tests/test_scheduled_messages.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import orjson
 import time_machine
+from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.scheduled_messages import (
@@ -209,6 +210,7 @@ class ScheduledMessageTest(ZulipTestCase):
 
         self.assert_scheduled_message_delivered(scheduled_message, recipient=sender.recipient)
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_successful_deliver_direct_scheduled_message_to_self_using_direct_message_group(
         self,
     ) -> None:

--- a/zerver/tests/test_scheduled_messages.py
+++ b/zerver/tests/test_scheduled_messages.py
@@ -7,7 +7,6 @@ from unittest import mock
 
 import orjson
 import time_machine
-from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.scheduled_messages import (
@@ -210,7 +209,6 @@ class ScheduledMessageTest(ZulipTestCase):
 
         self.assert_scheduled_message_delivered(scheduled_message, recipient=sender.recipient)
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_successful_deliver_direct_scheduled_message_to_self_using_direct_message_group(
         self,
     ) -> None:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1068,7 +1068,7 @@ class LoginTest(ZulipTestCase):
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
         with (
-            self.assert_database_query_count(97),
+            self.assert_database_query_count(96),
             self.assert_memcached_count(18),
             self.captureOnCommitCallbacks(execute=True),
         ):

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -443,7 +443,7 @@ class AddNewUserHistoryTest(ZulipTestCase):
 
         # Initial DM sent by welcome bot is also starred.
         initial_direct_user_message = UserMessage.objects.get(
-            user_profile=hamlet, message__recipient__type=Recipient.PERSONAL
+            user_profile=hamlet, message__recipient__type=Recipient.DIRECT_MESSAGE_GROUP
         )
         self.assertTrue(initial_direct_user_message.flags.starred.is_set)
 
@@ -460,7 +460,7 @@ class AddNewUserHistoryTest(ZulipTestCase):
         new_messages_count = message_stream_count(user_profile)
         self.assertEqual(new_messages_count, old_messages_count + 1)
 
-        recipient = Recipient.objects.get(type_id=user_profile.id, type=Recipient.PERSONAL)
+        recipient = self.get_dm_group_recipient(user_profile)
         message = most_recent_message(user_profile)
         self.assertEqual(message.recipient, recipient)
 
@@ -1068,7 +1068,7 @@ class LoginTest(ZulipTestCase):
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
         with (
-            self.assert_database_query_count(97),
+            self.assert_database_query_count(104),
             self.assert_memcached_count(18),
             self.captureOnCommitCallbacks(execute=True),
         ):
@@ -1772,7 +1772,7 @@ class RealmCreationTest(ZulipTestCase):
         welcome_msg = Message.objects.filter(
             realm_id=realm.id,
             sender__email="welcome-bot@zulip.com",
-            recipient__type=Recipient.PERSONAL,
+            recipient__type=Recipient.DIRECT_MESSAGE_GROUP,
         ).latest("id")
         self.assertTrue(welcome_msg.content.startswith("Hello, and welcome to Zulip!"))
 
@@ -1793,7 +1793,7 @@ class RealmCreationTest(ZulipTestCase):
         welcome_msg = Message.objects.filter(
             realm_id=realm.id,
             sender__email="welcome-bot@zulip.com",
-            recipient__type=Recipient.PERSONAL,
+            recipient__type=Recipient.DIRECT_MESSAGE_GROUP,
         ).latest("id")
         self.assertTrue(welcome_msg.content.startswith("Hello, and welcome to Zulip!"))
         self.assertNotIn("I've kicked off some conversations", welcome_msg.content)
@@ -1841,7 +1841,7 @@ class RealmCreationTest(ZulipTestCase):
         welcome_msg = Message.objects.filter(
             realm_id=get_realm(string_id).id,
             sender__email="welcome-bot@zulip.com",
-            recipient__type=Recipient.PERSONAL,
+            recipient__type=Recipient.DIRECT_MESSAGE_GROUP,
         ).latest("id")
         self.assertTrue(welcome_msg.content.startswith("Hello, and welcome to Zulip!"))
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1068,7 +1068,7 @@ class LoginTest(ZulipTestCase):
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
         with (
-            self.assert_database_query_count(96),
+            self.assert_database_query_count(97),
             self.assert_memcached_count(18),
             self.captureOnCommitCallbacks(execute=True),
         ):

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1068,7 +1068,7 @@ class LoginTest(ZulipTestCase):
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
         with (
-            self.assert_database_query_count(104),
+            self.assert_database_query_count(101),
             self.assert_memcached_count(18),
             self.captureOnCommitCallbacks(execute=True),
         ):

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -11,7 +11,6 @@ import orjson
 import responses
 from django.conf import settings
 from django.http import HttpResponse
-from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 from requests.models import PreparedRequest
 
@@ -30,7 +29,6 @@ from zerver.data_import.import_util import (
 from zerver.data_import.sequencer import NEXT_ID
 from zerver.data_import.slack import (
     SLACK_IMPORT_TOKEN_SCOPES,
-    DMMembersT,
     SlackBotEmail,
     SlackBotNotFoundError,
     SlackChannelImportedData,
@@ -872,12 +870,12 @@ class SlackImporter(ZulipTestCase):
         recipient_id = 5
         subscription_id = 7
         sub = build_subscription(recipient_id, zulip_user_id, subscription_id)
-        recipient = build_recipient(zulip_user_id, recipient_id, Recipient.PERSONAL)
+        recipient = build_recipient(zulip_user_id, recipient_id, Recipient.DIRECT_MESSAGE_GROUP)
 
         self.assertEqual(recipient["id"], sub["recipient"])
         self.assertEqual(recipient["type_id"], sub["user_profile"])
 
-        self.assertEqual(recipient["type"], Recipient.PERSONAL)
+        self.assertEqual(recipient["type"], Recipient.DIRECT_MESSAGE_GROUP)
         self.assertEqual(recipient["type_id"], 3)
 
         self.assertEqual(sub["recipient"], 5)
@@ -918,109 +916,7 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(zerver_subscription[1]["recipient"], zerver_subscription[3]["recipient"])
         self.assertEqual(zerver_subscription[1]["pin_to_top"], False)
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
-    def test_channels_to_zerver_stream_using_personal_recipient(self) -> None:
-        slack_user_id_to_zulip_user_id = {
-            "U061A1R2R": 1,
-            "U061A3E0G": 8,
-            "U061A5N1G": 7,
-            "U064KUGRJ": 5,
-        }
-        realm_id = 3
-        realm: ZerverFieldsT = {"zerver_userpresence": [], "zerver_realm": [dict()]}
-        zerver_realm = realm["zerver_realm"]
-
-        with (
-            self.assertLogs(level="INFO"),
-            mock.patch(
-                "zerver.data_import.slack.SLACK_DEFAULT_ANNOUNCEMENTS_CHANNEL_NAME", "random"
-            ),
-        ):
-            channel_import_data = channels_to_zerver_stream(
-                self.fixture_file_name("", "slack_fixtures"),
-                realm_id,
-                realm,
-                slack_user_id_to_zulip_user_id,
-            )
-
-        test_added_channels = {
-            "sharedchannel": ("C061A0HJG", 3),
-            "general": ("C061A0YJG", 1),
-            "general1": ("C061A0YJP", 2),
-            "random": ("C061A0WJG", 0),
-        }
-        test_added_mpims = {
-            "mpdm-user9--user2--user10-1": ("G9HBG2A5D", 0),
-            "mpdm-user6--user7--user4-1": ("G6H1Z0ZPS", 1),
-            "mpdm-user4--user1--user5-1": ("G6N944JPL", 2),
-        }
-        test_dm_members = {
-            "DJ47BL849": ("U061A1R2R", "U061A5N1G"),
-            "DHX1UP7EG": ("U061A5N1G", "U064KUGRJ"),
-            "DK8HSJDHS": ("U061A1R2R", "U064KUGRJ"),
-            "DRS3PSLDK": ("U064KUGRJ", "U064KUGRJ"),
-        }
-        slack_recipient_names = (
-            set(slack_user_id_to_zulip_user_id.keys())
-            | set(test_added_channels.keys())
-            | set(test_added_mpims.keys())
-        )
-
-        self.assertDictEqual(channel_import_data.added_channels, test_added_channels)
-        # zerver defaultstream already tested in helper functions.
-        # Note that the `random` stream is archived and thus should
-        # not be created as a DefaultStream.
-        self.assertEqual(realm["zerver_defaultstream"], [{"id": 0, "realm": 3, "stream": 1}])
-
-        self.assertDictEqual(channel_import_data.added_mpims, test_added_mpims)
-        self.assertDictEqual(channel_import_data.added_dms, {})
-        self.assertDictEqual(channel_import_data.dm_members, test_dm_members)
-
-        # We can't do an assertDictEqual since during the construction of personal
-        # recipients, slack_user_id_to_zulip_user_id are iterated in different order in Python 3.5 and 3.6.
-        self.assertEqual(
-            set(channel_import_data.slack_recipient_name_to_zulip_recipient_id.keys()),
-            slack_recipient_names,
-        )
-        self.assertEqual(
-            set(channel_import_data.slack_recipient_name_to_zulip_recipient_id.values()),
-            set(range(11)),
-        )
-
-        # functioning of zerver subscriptions are already tested in the helper functions
-        # This is to check the concatenation of the output lists from the helper functions
-        # subscriptions for stream
-        zerver_subscription = realm["zerver_subscription"]
-        zerver_recipient = realm["zerver_recipient"]
-        zerver_stream = realm["zerver_stream"]
-
-        self.assertEqual(self.get_set(zerver_subscription, "recipient"), set(range(11)))
-        self.assertEqual(self.get_set(zerver_subscription, "user_profile"), {1, 5, 7, 8})
-
-        self.assertEqual(
-            self.get_set(zerver_recipient, "id"), self.get_set(zerver_subscription, "recipient")
-        )
-        self.assertEqual(self.get_set(zerver_recipient, "type_id"), {0, 1, 2, 3, 5, 7, 8})
-        self.assertEqual(self.get_set(zerver_recipient, "type"), {1, 2, 3})
-
-        # stream mapping
-        self.assertEqual(zerver_stream[0]["name"], "random")
-        self.assertEqual(zerver_stream[0]["deactivated"], True)
-        self.assertEqual(zerver_stream[0]["description"], "no purpose")
-        self.assertEqual(zerver_stream[0]["invite_only"], False)
-        self.assertEqual(zerver_stream[0]["history_public_to_subscribers"], True)
-        self.assertEqual(zerver_stream[0]["realm"], realm_id)
-        self.assertEqual(zerver_stream[2]["id"], test_added_channels[zerver_stream[2]["name"]][1])
-
-        self.assertEqual(
-            zerver_realm[0]["zulip_update_announcements_stream"], zerver_stream[0]["id"]
-        )
-        self.assertEqual(zerver_realm[0]["new_stream_announcements_stream"], zerver_stream[0]["id"])
-
-        self.assertEqual(self.get_set(realm["zerver_huddle"], "id"), {0, 1, 2})
-        self.assertEqual(realm["zerver_userpresence"], [])
-
-    def test_channels_to_zerver_stream_using_direct_message_group(self) -> None:
+    def test_channels_to_zerver_stream(self) -> None:
         slack_user_id_to_zulip_user_id = {
             "U061A1R2R": 1,
             "U061A3E0G": 8,
@@ -1075,7 +971,6 @@ class SlackImporter(ZulipTestCase):
 
         self.assertDictEqual(channel_import_data.added_mpims, test_added_mpims)
         self.assertDictEqual(channel_import_data.added_dms, test_added_dms)
-        self.assertDictEqual(channel_import_data.dm_members, {})
 
         # We can't do an assertDictEqual since during the construction of personal
         # recipients, slack_user_id_to_zulip_user_id are iterated in different order in Python 3.5 and 3.6.
@@ -1127,7 +1022,7 @@ class SlackImporter(ZulipTestCase):
     )
     @mock.patch(
         "zerver.data_import.slack.channels_to_zerver_stream",
-        return_value=SlackChannelImportedData({}, {}, {}, {}, {}),
+        return_value=SlackChannelImportedData({}, {}, {}, {}),
     )
     def test_slack_workspace_to_realm(
         self, mock_channels_to_zerver_stream: mock.Mock, mock_users_to_zerver_userprofile: mock.Mock
@@ -1216,252 +1111,7 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(zerver_usermessage[3]["message"], message_id)
 
     @mock.patch("zerver.data_import.slack.build_usermessages", return_value=(2, 4))
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
-    def test_channel_message_to_zerver_message_using_personal_recipient(
-        self, mock_build_usermessage: mock.Mock
-    ) -> None:
-        user_data = [
-            {"id": "U066MTL5U", "name": "john doe", "deleted": False, "real_name": "John"},
-            {"id": "U061A5N1G", "name": "jane doe", "deleted": False, "real_name": "Jane"},
-            {
-                "id": "U061A1R2R",
-                "name": "jon",
-                "deleted": False,
-                "real_name": "Jon",
-                "profile": {"email": "jon@example.com"},
-            },
-        ]
-
-        slack_user_id_to_zulip_user_id = {"U066MTL5U": 5, "U061A5N1G": 24, "U061A1R2R": 43}
-
-        reactions = [{"name": "grinning", "users": ["U061A5N1G"], "count": 1}]
-
-        all_messages: list[dict[str, Any]] = [
-            {
-                "text": "<@U066MTL5U> has joined the channel",
-                "subtype": "channel_join",
-                "user": "U066MTL5U",
-                "ts": "1434139102.000002",
-                "channel_name": "random",
-            },
-            {
-                "text": "<@U061A5N1G>: hey!",
-                "user": "U061A1R2R",
-                "ts": "1437868294.000006",
-                "has_image": True,
-                "channel_name": "random",
-            },
-            {
-                "text": "random",
-                "user": "U061A5N1G",
-                "reactions": reactions,
-                "ts": "1439868294.000006",
-                "channel_name": "random",
-            },
-            {
-                "text": "without a user",
-                "user": None,  # this message will be ignored as it has no user
-                "ts": "1239868294.000006",
-                "channel_name": "general",
-            },
-            {
-                "text": "<http://journals.plos.org/plosone/article>",
-                "user": "U061A1R2R",
-                "ts": "1463868370.000008",
-                "channel_name": "general",
-            },
-            {
-                "text": "added bot",
-                "user": "U061A5N1G",
-                "subtype": "bot_add",
-                "ts": "1433868549.000010",
-                "channel_name": "general",
-            },
-            # This message will be ignored since it has no user and file is None.
-            # See #9217 for the situation; likely file uploads on archived channels
-            {
-                "upload": False,
-                "file": None,
-                "text": "A file was shared",
-                "channel_name": "general",
-                "type": "message",
-                "ts": "1433868549.000011",
-                "subtype": "file_share",
-            },
-            {
-                "text": "random test",
-                "user": "U061A1R2R",
-                "ts": "1433868669.000012",
-                "channel_name": "general",
-            },
-            {
-                "text": "Hello everyone",
-                "user": "U061A1R2R",
-                "type": "message",
-                "ts": "1433868669.000015",
-                "mpim_name": "mpdm-user9--user2--user10-1",
-            },
-            {
-                "text": "Who is watching the World Cup",
-                "user": "U061A5N1G",
-                "type": "message",
-                "ts": "1433868949.000015",
-                "mpim_name": "mpdm-user6--user7--user4-1",
-            },
-            {
-                "client_msg_id": "998d9229-35aa-424f-8d87-99e00df27dc9",
-                "type": "message",
-                "text": "Who is coming for camping this weekend?",
-                "user": "U061A1R2R",
-                "ts": "1553607595.000700",
-                "pm_name": "DHX1UP7EG",
-            },
-            {
-                "client_msg_id": "998d9229-35aa-424f-8d87-99e00df27dc9",
-                "type": "message",
-                "text": "<@U061A5N1G>: Are you in Kochi?",
-                "user": "U066MTL5U",
-                "ts": "1553607595.000700",
-                "pm_name": "DJ47BL849",
-            },
-            {
-                "text": "Look!",
-                "user": "U061A1R2R",
-                "ts": "1553607596.000700",
-                "has_image": True,
-                "channel_name": "random",
-                "files": [
-                    {
-                        "url_private": "https://files.slack.com/apple.png",
-                        "title": "Apple",
-                        "name": "apple.png",
-                        "mimetype": "image/png",
-                        "timestamp": 9999,
-                        "created": 8888,
-                        "size": 3000000,
-                    }
-                ],
-            },
-        ]
-
-        slack_recipient_name_to_zulip_recipient_id = {
-            "random": 2,
-            "general": 1,
-            "mpdm-user9--user2--user10-1": 5,
-            "mpdm-user6--user7--user4-1": 6,
-            "U066MTL5U": 7,
-            "U061A5N1G": 8,
-            "U061A1R2R": 8,
-        }
-        dm_members = {
-            "DJ47BL849": ("U066MTL5U", "U061A5N1G"),
-            "DHX1UP7EG": ("U061A5N1G", "U061A1R2R"),
-        }
-
-        zerver_usermessage: list[dict[str, Any]] = []
-        subscriber_map: dict[int, set[int]] = {}
-        added_channels: dict[str, tuple[str, int]] = {"random": ("c5", 1), "general": ("c6", 2)}
-
-        (
-            zerver_message,
-            zerver_usermessage,
-            attachment,
-            uploads,
-            reaction,
-        ) = channel_message_to_zerver_message(
-            1,
-            user_data,
-            slack_user_id_to_zulip_user_id,
-            slack_recipient_name_to_zulip_recipient_id,
-            all_messages,
-            [],
-            subscriber_map,
-            added_channels,
-            dm_members,
-            "domain",
-            set(),
-            convert_slack_threads=False,
-        )
-        # functioning already tested in helper function
-        self.assertEqual(zerver_usermessage, [])
-        # subtype: channel_join is filtered
-        self.assert_length(zerver_message, 10)
-
-        # Test reactions
-        self.assertEqual(reaction[0]["user_profile"], 24)
-        self.assertEqual(reaction[0]["emoji_name"], reactions[0]["name"])
-
-        # Message conversion already tested in tests.test_slack_message_conversion
-        self.assertEqual(zerver_message[0]["content"], "@**Jane**: hey!")
-        self.assertEqual(zerver_message[0]["has_link"], False)
-        self.assertEqual(zerver_message[2]["content"], "http://journals.plos.org/plosone/article")
-        self.assertEqual(zerver_message[2]["has_link"], True)
-        self.assertEqual(zerver_message[5]["has_link"], False)
-        self.assertEqual(zerver_message[7]["has_link"], False)
-
-        # Test that topic_name is set to '\x07' for direct messages and
-        # group direct messages.
-        self.assertEqual(zerver_message[6][EXPORT_TOPIC_NAME], Message.DM_TOPIC)
-        self.assertEqual(zerver_message[8][EXPORT_TOPIC_NAME], Message.DM_TOPIC)
-
-        self.assertEqual(zerver_message[3][EXPORT_TOPIC_NAME], "imported from Slack")
-        self.assertEqual(zerver_message[3]["content"], "/me added bot")
-        self.assertEqual(
-            zerver_message[4]["recipient"], slack_recipient_name_to_zulip_recipient_id["general"]
-        )
-        self.assertEqual(zerver_message[2][EXPORT_TOPIC_NAME], "imported from Slack")
-        self.assertEqual(
-            zerver_message[1]["recipient"], slack_recipient_name_to_zulip_recipient_id["random"]
-        )
-        self.assertEqual(
-            zerver_message[5]["recipient"],
-            slack_recipient_name_to_zulip_recipient_id["mpdm-user9--user2--user10-1"],
-        )
-        self.assertEqual(
-            zerver_message[6]["recipient"],
-            slack_recipient_name_to_zulip_recipient_id["mpdm-user6--user7--user4-1"],
-        )
-        self.assertEqual(
-            zerver_message[7]["recipient"], slack_recipient_name_to_zulip_recipient_id["U061A5N1G"]
-        )
-        self.assertEqual(
-            zerver_message[7]["recipient"], slack_recipient_name_to_zulip_recipient_id["U061A5N1G"]
-        )
-
-        self.assertEqual(zerver_message[3]["id"], zerver_message[0]["id"] + 3)
-        self.assertEqual(zerver_message[4]["id"], zerver_message[0]["id"] + 4)
-        self.assertEqual(zerver_message[5]["id"], zerver_message[0]["id"] + 5)
-        self.assertEqual(zerver_message[7]["id"], zerver_message[0]["id"] + 7)
-
-        self.assertIsNone(zerver_message[3]["rendered_content"])
-        self.assertEqual(zerver_message[0]["has_image"], False)
-        self.assertEqual(zerver_message[0]["date_sent"], float(all_messages[1]["ts"]))
-        self.assertEqual(zerver_message[2]["rendered_content_version"], 1)
-
-        self.assertEqual(zerver_message[0]["sender"], 43)
-        self.assertEqual(zerver_message[3]["sender"], 24)
-        self.assertEqual(zerver_message[5]["sender"], 43)
-        self.assertEqual(zerver_message[6]["sender"], 24)
-        self.assertEqual(zerver_message[7]["sender"], 43)
-        self.assertEqual(zerver_message[8]["sender"], 5)
-
-        # Test uploads
-        self.assert_length(uploads, 1)
-        self.assertEqual(uploads[0]["path"], "https://files.slack.com/apple.png")
-        self.assert_length(attachment, 1)
-        self.assertEqual(attachment[0]["file_name"], "apple.png")
-        self.assertEqual(attachment[0]["is_realm_public"], True)
-        self.assertEqual(attachment[0]["is_web_public"], False)
-        self.assertEqual(attachment[0]["content_type"], "image/png")
-
-        self.assertEqual(zerver_message[9]["has_image"], True)
-        self.assertEqual(zerver_message[9]["has_attachment"], True)
-        self.assertTrue(zerver_message[9]["content"].startswith("Look!\n[Apple](/user_uploads/"))
-
-    @mock.patch("zerver.data_import.slack.build_usermessages", return_value=(2, 4))
-    def test_channel_message_to_zerver_message_using_direct_message_group(
-        self, mock_build_usermessage: mock.Mock
-    ) -> None:
+    def test_channel_message_to_zerver_message(self, mock_build_usermessage: mock.Mock) -> None:
         user_data = [
             {"id": "U066MTL5U", "name": "john doe", "deleted": False, "real_name": "John"},
             {"id": "U061A5N1G", "name": "jane doe", "deleted": False, "real_name": "Jane"},
@@ -1616,7 +1266,6 @@ class SlackImporter(ZulipTestCase):
             [],
             subscriber_map,
             added_channels,
-            {},
             "domain",
             set(),
             convert_slack_threads=False,
@@ -1850,7 +1499,6 @@ class SlackImporter(ZulipTestCase):
             "random": 2,
             "general": 1,
         }
-        dm_members: DMMembersT = {}
 
         zerver_usermessage: list[dict[str, Any]] = []
         subscriber_map: dict[int, set[int]] = {}
@@ -1871,7 +1519,6 @@ class SlackImporter(ZulipTestCase):
             [],
             subscriber_map,
             added_channels,
-            dm_members,
             "domain",
             set(),
             convert_slack_threads=True,
@@ -2071,7 +1718,6 @@ class SlackImporter(ZulipTestCase):
             "random": 2,
             "general": 1,
         }
-        dm_members: DMMembersT = {}
 
         zerver_usermessage: list[dict[str, Any]] = []
         subscriber_map: dict[int, set[int]] = {}
@@ -2092,7 +1738,6 @@ class SlackImporter(ZulipTestCase):
             [],
             subscriber_map,
             added_channels,
-            dm_members,
             "domain",
             set(),
             convert_slack_threads=True,
@@ -2168,7 +1813,7 @@ by Pieter
             [zerver_message[:1], zerver_usermessage[:2], attachments, uploads, reactions[:1]],
             [zerver_message[1:2], zerver_usermessage[2:5], attachments, uploads, reactions[1:1]],
         ]
-        channel_data = SlackChannelImportedData(added_channels, {}, {}, {}, {})
+        channel_data = SlackChannelImportedData(added_channels, {}, {}, {})
 
         with self.assertLogs(level="INFO"):
             # Hacky: We should include a zerver_userprofile, not the empty []

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -11,6 +11,7 @@ import orjson
 import responses
 from django.conf import settings
 from django.http import HttpResponse
+from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 from requests.models import PreparedRequest
 
@@ -29,11 +30,11 @@ from zerver.data_import.import_util import (
 from zerver.data_import.sequencer import NEXT_ID
 from zerver.data_import.slack import (
     SLACK_IMPORT_TOKEN_SCOPES,
-    AddedChannelsT,
-    AddedMPIMsT,
     DMMembersT,
     SlackBotEmail,
     SlackBotNotFoundError,
+    SlackChannelImportedData,
+    SlackUsersImportedData,
     channel_message_to_zerver_message,
     channels_to_zerver_stream,
     check_token_access,
@@ -723,15 +724,12 @@ class SlackImporter(ZulipTestCase):
         mock_get_data_file.return_value = user_data
 
         with self.assertLogs(level="INFO"):
-            (
-                zerver_userprofile,
-                avatar_list,
-                slack_user_id_to_zulip_user_id,
-                customprofilefield,
-                customprofilefield_value,
-            ) = users_to_zerver_userprofile(
+            users_data = users_to_zerver_userprofile(
                 slack_data_dir, user_data, 1, timestamp, "testdomain.com"
             )
+            zerver_userprofile = users_data.zerver_userprofile
+            customprofilefield = users_data.zerver_customprofilefield
+            customprofilefield_value = users_data.zerver_customprofilefield_values
 
         # Test custom profile fields
         self.assertEqual(customprofilefield[0]["field_type"], 1)
@@ -751,8 +749,10 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(customprofilefield_value[5]["value"], "test_skype_name")
 
         # test that the primary owner should always be imported first
-        self.assertDictEqual(slack_user_id_to_zulip_user_id, test_slack_user_id_to_zulip_user_id)
-        self.assert_length(avatar_list, 9)
+        self.assertDictEqual(
+            users_data.slack_user_id_to_zulip_user_id, test_slack_user_id_to_zulip_user_id
+        )
+        self.assert_length(users_data.avatars, 9)
 
         self.assert_length(zerver_userprofile, 11)
 
@@ -925,7 +925,6 @@ class SlackImporter(ZulipTestCase):
             "U061A5N1G": 7,
             "U064KUGRJ": 5,
         }
-        zerver_userprofile = [{"id": 1}, {"id": 8}, {"id": 7}, {"id": 5}]
         realm_id = 3
         realm: ZerverFieldsT = {"zerver_userpresence": [], "zerver_realm": [dict()]}
         zerver_realm = realm["zerver_realm"]
@@ -936,18 +935,11 @@ class SlackImporter(ZulipTestCase):
                 "zerver.data_import.slack.SLACK_DEFAULT_ANNOUNCEMENTS_CHANNEL_NAME", "random"
             ),
         ):
-            (
-                realm,
-                added_channels,
-                added_mpims,
-                dm_members,
-                slack_recipient_name_to_zulip_recipient_id,
-            ) = channels_to_zerver_stream(
+            channel_import_data = channels_to_zerver_stream(
                 self.fixture_file_name("", "slack_fixtures"),
                 realm_id,
                 realm,
                 slack_user_id_to_zulip_user_id,
-                zerver_userprofile,
             )
 
         test_added_channels = {
@@ -973,21 +965,26 @@ class SlackImporter(ZulipTestCase):
             | set(test_added_mpims.keys())
         )
 
-        self.assertDictEqual(test_added_channels, added_channels)
+        self.assertDictEqual(channel_import_data.added_channels, test_added_channels)
         # zerver defaultstream already tested in helper functions.
         # Note that the `random` stream is archived and thus should
         # not be created as a DefaultStream.
         self.assertEqual(realm["zerver_defaultstream"], [{"id": 0, "realm": 3, "stream": 1}])
 
-        self.assertDictEqual(test_added_mpims, added_mpims)
-        self.assertDictEqual(test_dm_members, dm_members)
+        self.assertDictEqual(channel_import_data.added_mpims, test_added_mpims)
+        self.assertDictEqual(channel_import_data.added_dms, {})
+        self.assertDictEqual(channel_import_data.dm_members, test_dm_members)
 
         # We can't do an assertDictEqual since during the construction of personal
         # recipients, slack_user_id_to_zulip_user_id are iterated in different order in Python 3.5 and 3.6.
         self.assertEqual(
-            set(slack_recipient_name_to_zulip_recipient_id.keys()), slack_recipient_names
+            set(channel_import_data.slack_recipient_name_to_zulip_recipient_id.keys()),
+            slack_recipient_names,
         )
-        self.assertEqual(set(slack_recipient_name_to_zulip_recipient_id.values()), set(range(11)))
+        self.assertEqual(
+            set(channel_import_data.slack_recipient_name_to_zulip_recipient_id.values()),
+            set(range(11)),
+        )
 
         # functioning of zerver subscriptions are already tested in the helper functions
         # This is to check the concatenation of the output lists from the helper functions
@@ -1022,28 +1019,122 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(self.get_set(realm["zerver_huddle"], "id"), {0, 1, 2})
         self.assertEqual(realm["zerver_userpresence"], [])
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
+    def test_channels_to_zerver_stream_using_direct_message_group(self) -> None:
+        slack_user_id_to_zulip_user_id = {
+            "U061A1R2R": 1,
+            "U061A3E0G": 8,
+            "U061A5N1G": 7,
+            "U064KUGRJ": 5,
+        }
+        realm_id = 3
+        realm: ZerverFieldsT = {"zerver_userpresence": [], "zerver_realm": [dict()]}
+        zerver_realm = realm["zerver_realm"]
+
+        with (
+            self.assertLogs(level="INFO"),
+            mock.patch(
+                "zerver.data_import.slack.SLACK_DEFAULT_ANNOUNCEMENTS_CHANNEL_NAME", "random"
+            ),
+        ):
+            channel_import_data = channels_to_zerver_stream(
+                self.fixture_file_name("", "slack_fixtures"),
+                realm_id,
+                realm,
+                slack_user_id_to_zulip_user_id,
+            )
+
+        test_added_channels = {
+            "sharedchannel": ("C061A0HJG", 3),
+            "general": ("C061A0YJG", 1),
+            "general1": ("C061A0YJP", 2),
+            "random": ("C061A0WJG", 0),
+        }
+        test_added_mpims = {
+            "mpdm-user9--user2--user10-1": ("G9HBG2A5D", 0),
+            "mpdm-user6--user7--user4-1": ("G6H1Z0ZPS", 1),
+            "mpdm-user4--user1--user5-1": ("G6N944JPL", 2),
+        }
+        test_added_dms = {
+            "DJ47BL849": 3,
+            "DHX1UP7EG": 4,
+            "DK8HSJDHS": 5,
+            "DRS3PSLDK": 6,
+        }
+        slack_recipient_names = (
+            set(test_added_channels.keys())
+            | set(test_added_mpims.keys())
+            | set(test_added_dms.keys())
+        )
+
+        self.assertDictEqual(channel_import_data.added_channels, test_added_channels)
+        # zerver defaultstream already tested in helper functions.
+        # Note that the `random` stream is archived and thus should
+        # not be created as a DefaultStream.
+        self.assertEqual(realm["zerver_defaultstream"], [{"id": 0, "realm": 3, "stream": 1}])
+
+        self.assertDictEqual(channel_import_data.added_mpims, test_added_mpims)
+        self.assertDictEqual(channel_import_data.added_dms, test_added_dms)
+        self.assertDictEqual(channel_import_data.dm_members, {})
+
+        # We can't do an assertDictEqual since during the construction of personal
+        # recipients, slack_user_id_to_zulip_user_id are iterated in different order in Python 3.5 and 3.6.
+        self.assertEqual(
+            set(channel_import_data.slack_recipient_name_to_zulip_recipient_id.keys()),
+            slack_recipient_names,
+        )
+        self.assertEqual(
+            set(channel_import_data.slack_recipient_name_to_zulip_recipient_id.values()),
+            set(range(11)),
+        )
+
+        # functioning of zerver subscriptions are already tested in the helper functions
+        # This is to check the concatenation of the output lists from the helper functions
+        # subscriptions for stream
+        zerver_subscription = realm["zerver_subscription"]
+        zerver_recipient = realm["zerver_recipient"]
+        zerver_stream = realm["zerver_stream"]
+
+        self.assertEqual(self.get_set(zerver_subscription, "recipient"), set(range(11)))
+        self.assertEqual(self.get_set(zerver_subscription, "user_profile"), {1, 5, 7, 8})
+
+        self.assertEqual(
+            self.get_set(zerver_recipient, "id"), self.get_set(zerver_subscription, "recipient")
+        )
+        self.assertEqual(self.get_set(zerver_recipient, "type_id"), {0, 1, 2, 3, 4, 5, 6})
+        self.assertEqual(self.get_set(zerver_recipient, "type"), {2, 3})
+
+        # stream mapping
+        self.assertEqual(zerver_stream[0]["name"], "random")
+        self.assertEqual(zerver_stream[0]["deactivated"], True)
+        self.assertEqual(zerver_stream[0]["description"], "no purpose")
+        self.assertEqual(zerver_stream[0]["invite_only"], False)
+        self.assertEqual(zerver_stream[0]["history_public_to_subscribers"], True)
+        self.assertEqual(zerver_stream[0]["realm"], realm_id)
+        self.assertEqual(zerver_stream[2]["id"], test_added_channels[zerver_stream[2]["name"]][1])
+
+        self.assertEqual(
+            zerver_realm[0]["zulip_update_announcements_stream"], zerver_stream[0]["id"]
+        )
+        self.assertEqual(zerver_realm[0]["new_stream_announcements_stream"], zerver_stream[0]["id"])
+
+        self.assertEqual(self.get_set(realm["zerver_huddle"], "id"), {0, 1, 2, 3, 4, 5, 6})
+        self.assertEqual(realm["zerver_userpresence"], [])
+
     @mock.patch(
-        "zerver.data_import.slack.users_to_zerver_userprofile", return_value=[[], [], {}, [], []]
+        "zerver.data_import.slack.users_to_zerver_userprofile",
+        return_value=SlackUsersImportedData([], [], {}, [], []),
     )
     @mock.patch(
         "zerver.data_import.slack.channels_to_zerver_stream",
-        return_value=[{"zerver_stream": []}, {}, {}, {}, {}],
+        return_value=SlackChannelImportedData({}, {}, {}, {}, {}),
     )
     def test_slack_workspace_to_realm(
         self, mock_channels_to_zerver_stream: mock.Mock, mock_users_to_zerver_userprofile: mock.Mock
     ) -> None:
         realm_id = 1
         user_list: list[dict[str, Any]] = []
-        (
-            realm,
-            slack_user_id_to_zulip_user_id,
-            slack_recipient_name_to_zulip_recipient_id,
-            added_channels,
-            added_mpims,
-            dm_members,
-            avatar_list,
-            em,
-        ) = slack_workspace_to_realm(
+        imported_data = slack_workspace_to_realm(
             "testdomain", realm_id, user_list, "test-realm", "./random_path", {}
         )
 
@@ -1051,13 +1142,14 @@ class SlackImporter(ZulipTestCase):
             {"realm": realm_id, "allow_subdomains": False, "domain": "testdomain", "id": realm_id}
         ]
         # Functioning already tests in helper functions
-        self.assertEqual(slack_user_id_to_zulip_user_id, {})
-        self.assertEqual(added_channels, {})
-        self.assertEqual(added_mpims, {})
-        self.assertEqual(slack_recipient_name_to_zulip_recipient_id, {})
-        self.assertEqual(avatar_list, [])
+        self.assertEqual(imported_data.slack_user_id_to_zulip_user_id, {})
+        self.assertEqual(imported_data.channel_data.added_channels, {})
+        self.assertEqual(imported_data.channel_data.added_mpims, {})
+        self.assertEqual(imported_data.channel_data.added_dms, {})
+        self.assertEqual(imported_data.channel_data.slack_recipient_name_to_zulip_recipient_id, {})
+        self.assertEqual(imported_data.avatars, [])
 
-        mock_channels_to_zerver_stream.assert_called_once_with("./random_path", 1, ANY, {}, [])
+        mock_channels_to_zerver_stream.assert_called_once_with("./random_path", 1, ANY, {})
         passed_realm = mock_channels_to_zerver_stream.call_args_list[0][0][2]
         zerver_realmdomain = passed_realm["zerver_realmdomain"]
         self.assertListEqual(zerver_realmdomain, test_zerver_realmdomain)
@@ -1066,14 +1158,13 @@ class SlackImporter(ZulipTestCase):
         )
         self.assertEqual(passed_realm["zerver_userpresence"], [])
         self.assertEqual(passed_realm["import_source"], "slack")
-        self.assert_length(passed_realm.keys(), 17)
+        self.assert_length(passed_realm.keys(), 18)
 
-        self.assertEqual(realm["zerver_stream"], [])
-        self.assertEqual(realm["zerver_userprofile"], [])
-        self.assertEqual(realm["zerver_realmemoji"], [])
-        self.assertEqual(realm["zerver_customprofilefield"], [])
-        self.assertEqual(realm["zerver_customprofilefieldvalue"], [])
-        self.assert_length(realm.keys(), 5)
+        self.assertEqual(imported_data.realm["zerver_userprofile"], [])
+        self.assertEqual(imported_data.realm["zerver_realmemoji"], [])
+        self.assertEqual(imported_data.realm["zerver_customprofilefield"], [])
+        self.assertEqual(imported_data.realm["zerver_customprofilefieldvalue"], [])
+        self.assert_length(imported_data.realm.keys(), 18)
 
     def test_get_message_sending_user(self) -> None:
         message_with_file = {"subtype": "file", "type": "message", "file": {"user": "U064KUGRJ"}}
@@ -1332,6 +1423,246 @@ class SlackImporter(ZulipTestCase):
         )
         self.assertEqual(
             zerver_message[7]["recipient"], slack_recipient_name_to_zulip_recipient_id["U061A5N1G"]
+        )
+
+        self.assertEqual(zerver_message[3]["id"], zerver_message[0]["id"] + 3)
+        self.assertEqual(zerver_message[4]["id"], zerver_message[0]["id"] + 4)
+        self.assertEqual(zerver_message[5]["id"], zerver_message[0]["id"] + 5)
+        self.assertEqual(zerver_message[7]["id"], zerver_message[0]["id"] + 7)
+
+        self.assertIsNone(zerver_message[3]["rendered_content"])
+        self.assertEqual(zerver_message[0]["has_image"], False)
+        self.assertEqual(zerver_message[0]["date_sent"], float(all_messages[1]["ts"]))
+        self.assertEqual(zerver_message[2]["rendered_content_version"], 1)
+
+        self.assertEqual(zerver_message[0]["sender"], 43)
+        self.assertEqual(zerver_message[3]["sender"], 24)
+        self.assertEqual(zerver_message[5]["sender"], 43)
+        self.assertEqual(zerver_message[6]["sender"], 24)
+        self.assertEqual(zerver_message[7]["sender"], 43)
+        self.assertEqual(zerver_message[8]["sender"], 5)
+
+        # Test uploads
+        self.assert_length(uploads, 1)
+        self.assertEqual(uploads[0]["path"], "https://files.slack.com/apple.png")
+        self.assert_length(attachment, 1)
+        self.assertEqual(attachment[0]["file_name"], "apple.png")
+        self.assertEqual(attachment[0]["is_realm_public"], True)
+        self.assertEqual(attachment[0]["is_web_public"], False)
+        self.assertEqual(attachment[0]["content_type"], "image/png")
+
+        self.assertEqual(zerver_message[9]["has_image"], True)
+        self.assertEqual(zerver_message[9]["has_attachment"], True)
+        self.assertTrue(zerver_message[9]["content"].startswith("Look!\n[Apple](/user_uploads/"))
+
+    @mock.patch("zerver.data_import.slack.build_usermessages", return_value=(2, 4))
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
+    def test_channel_message_to_zerver_message_using_direct_message_group(
+        self, mock_build_usermessage: mock.Mock
+    ) -> None:
+        user_data = [
+            {"id": "U066MTL5U", "name": "john doe", "deleted": False, "real_name": "John"},
+            {"id": "U061A5N1G", "name": "jane doe", "deleted": False, "real_name": "Jane"},
+            {
+                "id": "U061A1R2R",
+                "name": "jon",
+                "deleted": False,
+                "real_name": "Jon",
+                "profile": {"email": "jon@example.com"},
+            },
+        ]
+
+        slack_user_id_to_zulip_user_id = {"U066MTL5U": 5, "U061A5N1G": 24, "U061A1R2R": 43}
+
+        reactions = [{"name": "grinning", "users": ["U061A5N1G"], "count": 1}]
+
+        all_messages: list[dict[str, Any]] = [
+            {
+                "text": "<@U066MTL5U> has joined the channel",
+                "subtype": "channel_join",
+                "user": "U066MTL5U",
+                "ts": "1434139102.000002",
+                "channel_name": "random",
+            },
+            {
+                "text": "<@U061A5N1G>: hey!",
+                "user": "U061A1R2R",
+                "ts": "1437868294.000006",
+                "has_image": True,
+                "channel_name": "random",
+            },
+            {
+                "text": "random",
+                "user": "U061A5N1G",
+                "reactions": reactions,
+                "ts": "1439868294.000006",
+                "channel_name": "random",
+            },
+            {
+                "text": "without a user",
+                "user": None,  # this message will be ignored as it has no user
+                "ts": "1239868294.000006",
+                "channel_name": "general",
+            },
+            {
+                "text": "<http://journals.plos.org/plosone/article>",
+                "user": "U061A1R2R",
+                "ts": "1463868370.000008",
+                "channel_name": "general",
+            },
+            {
+                "text": "added bot",
+                "user": "U061A5N1G",
+                "subtype": "bot_add",
+                "ts": "1433868549.000010",
+                "channel_name": "general",
+            },
+            # This message will be ignored since it has no user and file is None.
+            # See #9217 for the situation; likely file uploads on archived channels
+            {
+                "upload": False,
+                "file": None,
+                "text": "A file was shared",
+                "channel_name": "general",
+                "type": "message",
+                "ts": "1433868549.000011",
+                "subtype": "file_share",
+            },
+            {
+                "text": "random test",
+                "user": "U061A1R2R",
+                "ts": "1433868669.000012",
+                "channel_name": "general",
+            },
+            {
+                "text": "Hello everyone",
+                "user": "U061A1R2R",
+                "type": "message",
+                "ts": "1433868669.000015",
+                "mpim_name": "mpdm-user9--user2--user10-1",
+            },
+            {
+                "text": "Who is watching the World Cup",
+                "user": "U061A5N1G",
+                "type": "message",
+                "ts": "1433868949.000015",
+                "mpim_name": "mpdm-user6--user7--user4-1",
+            },
+            {
+                "client_msg_id": "998d9229-35aa-424f-8d87-99e00df27dc9",
+                "type": "message",
+                "text": "Who is coming for camping this weekend?",
+                "user": "U061A1R2R",
+                "ts": "1553607595.000700",
+                "pm_name": "DHX1UP7EG",
+            },
+            {
+                "client_msg_id": "998d9229-35aa-424f-8d87-99e00df27dc9",
+                "type": "message",
+                "text": "<@U061A5N1G>: Are you in Kochi?",
+                "user": "U066MTL5U",
+                "ts": "1553607595.000700",
+                "pm_name": "DJ47BL849",
+            },
+            {
+                "text": "Look!",
+                "user": "U061A1R2R",
+                "ts": "1553607596.000700",
+                "has_image": True,
+                "channel_name": "random",
+                "files": [
+                    {
+                        "url_private": "https://files.slack.com/apple.png",
+                        "title": "Apple",
+                        "name": "apple.png",
+                        "mimetype": "image/png",
+                        "timestamp": 9999,
+                        "created": 8888,
+                        "size": 3000000,
+                    }
+                ],
+            },
+        ]
+
+        slack_recipient_name_to_zulip_recipient_id = {
+            "random": 2,
+            "general": 1,
+            "mpdm-user9--user2--user10-1": 5,
+            "mpdm-user6--user7--user4-1": 6,
+            "DJ47BL849": 3,
+            "DHX1UP7EG": 4,
+            "DK8HSJDHS": 5,
+            "DRS3PSLDK": 6,
+        }
+
+        subscriber_map: dict[int, set[int]] = {}
+        added_channels: dict[str, tuple[str, int]] = {"random": ("c5", 1), "general": ("c6", 2)}
+        zerver_usermessage: list[dict[str, Any]] = []
+
+        (
+            zerver_message,
+            zerver_usermessage,
+            attachment,
+            uploads,
+            reaction,
+        ) = channel_message_to_zerver_message(
+            1,
+            user_data,
+            slack_user_id_to_zulip_user_id,
+            slack_recipient_name_to_zulip_recipient_id,
+            all_messages,
+            [],
+            subscriber_map,
+            added_channels,
+            {},
+            "domain",
+            set(),
+            convert_slack_threads=False,
+        )
+        # functioning already tested in helper function
+        self.assertEqual(zerver_usermessage, [])
+        # subtype: channel_join is filtered
+        self.assert_length(zerver_message, 10)
+
+        # Test reactions
+        self.assertEqual(reaction[0]["user_profile"], 24)
+        self.assertEqual(reaction[0]["emoji_name"], reactions[0]["name"])
+
+        # Message conversion already tested in tests.test_slack_message_conversion
+        self.assertEqual(zerver_message[0]["content"], "@**Jane**: hey!")
+        self.assertEqual(zerver_message[0]["has_link"], False)
+        self.assertEqual(zerver_message[2]["content"], "http://journals.plos.org/plosone/article")
+        self.assertEqual(zerver_message[2]["has_link"], True)
+        self.assertEqual(zerver_message[5]["has_link"], False)
+        self.assertEqual(zerver_message[7]["has_link"], False)
+
+        # Test that topic_name is set to '\x07' for direct messages and
+        # group direct messages.
+        self.assertEqual(zerver_message[6][EXPORT_TOPIC_NAME], Message.DM_TOPIC)
+        self.assertEqual(zerver_message[8][EXPORT_TOPIC_NAME], Message.DM_TOPIC)
+
+        self.assertEqual(zerver_message[3][EXPORT_TOPIC_NAME], "imported from Slack")
+        self.assertEqual(zerver_message[3]["content"], "/me added bot")
+        self.assertEqual(
+            zerver_message[4]["recipient"], slack_recipient_name_to_zulip_recipient_id["general"]
+        )
+        self.assertEqual(zerver_message[2][EXPORT_TOPIC_NAME], "imported from Slack")
+        self.assertEqual(
+            zerver_message[1]["recipient"], slack_recipient_name_to_zulip_recipient_id["random"]
+        )
+        self.assertEqual(
+            zerver_message[5]["recipient"],
+            slack_recipient_name_to_zulip_recipient_id["mpdm-user9--user2--user10-1"],
+        )
+        self.assertEqual(
+            zerver_message[6]["recipient"],
+            slack_recipient_name_to_zulip_recipient_id["mpdm-user6--user7--user4-1"],
+        )
+        self.assertEqual(
+            zerver_message[7]["recipient"], slack_recipient_name_to_zulip_recipient_id["DHX1UP7EG"]
+        )
+        self.assertEqual(
+            zerver_message[8]["recipient"], slack_recipient_name_to_zulip_recipient_id["DJ47BL849"]
         )
 
         self.assertEqual(zerver_message[3]["id"], zerver_message[0]["id"] + 3)
@@ -1817,15 +2148,12 @@ by Pieter
 
         def fake_get_messages_iter(
             slack_data_dir: str,
-            added_channels: AddedChannelsT,
-            added_mpims: AddedMPIMsT,
-            dm_members: DMMembersT,
+            channel_data: SlackChannelImportedData,
         ) -> Iterator[ZerverFieldsT]:
             import copy
 
             return iter(copy.deepcopy(zerver_message))
 
-        realm: dict[str, Any] = {"zerver_subscription": []}
         user_list: list[dict[str, Any]] = []
         reactions = [{"name": "grinning", "users": ["U061A5N1G"], "count": 1}]
         attachments: list[dict[str, Any]] = []
@@ -1838,6 +2166,7 @@ by Pieter
             [zerver_message[:1], zerver_usermessage[:2], attachments, uploads, reactions[:1]],
             [zerver_message[1:2], zerver_usermessage[2:5], attachments, uploads, reactions[1:1]],
         ]
+        channel_data = SlackChannelImportedData(added_channels, {}, {}, {}, {})
 
         with self.assertLogs(level="INFO"):
             # Hacky: We should include a zerver_userprofile, not the empty []
@@ -1846,11 +2175,8 @@ by Pieter
                 user_list,
                 2,
                 {},
-                {},
-                added_channels,
-                {},
-                {},
-                realm,
+                channel_data,
+                [],
                 [],
                 [],
                 "domain",

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -918,7 +918,8 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(zerver_subscription[1]["recipient"], zerver_subscription[3]["recipient"])
         self.assertEqual(zerver_subscription[1]["pin_to_top"], False)
 
-    def test_channels_to_zerver_stream(self) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_channels_to_zerver_stream_using_personal_recipient(self) -> None:
         slack_user_id_to_zulip_user_id = {
             "U061A1R2R": 1,
             "U061A3E0G": 8,
@@ -1019,7 +1020,6 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(self.get_set(realm["zerver_huddle"], "id"), {0, 1, 2})
         self.assertEqual(realm["zerver_userpresence"], [])
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_channels_to_zerver_stream_using_direct_message_group(self) -> None:
         slack_user_id_to_zulip_user_id = {
             "U061A1R2R": 1,
@@ -1216,7 +1216,10 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(zerver_usermessage[3]["message"], message_id)
 
     @mock.patch("zerver.data_import.slack.build_usermessages", return_value=(2, 4))
-    def test_channel_message_to_zerver_message(self, mock_build_usermessage: mock.Mock) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_channel_message_to_zerver_message_using_personal_recipient(
+        self, mock_build_usermessage: mock.Mock
+    ) -> None:
         user_data = [
             {"id": "U066MTL5U", "name": "john doe", "deleted": False, "real_name": "John"},
             {"id": "U061A5N1G", "name": "jane doe", "deleted": False, "real_name": "Jane"},
@@ -1456,7 +1459,6 @@ class SlackImporter(ZulipTestCase):
         self.assertTrue(zerver_message[9]["content"].startswith("Look!\n[Apple](/user_uploads/"))
 
     @mock.patch("zerver.data_import.slack.build_usermessages", return_value=(2, 4))
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_channel_message_to_zerver_message_using_direct_message_group(
         self, mock_build_usermessage: mock.Mock
     ) -> None:

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.http import HttpResponse
+from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
@@ -4878,6 +4879,7 @@ class SubscriptionAPITest(ZulipTestCase):
             expected_difference=0,
         )
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_notification_bot_dm_on_subscription(self) -> None:
         desdemona = self.example_user("desdemona")
         realm = desdemona.realm

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4888,13 +4888,22 @@ class SubscriptionAPITest(ZulipTestCase):
         test_channel = self.make_stream("test A")
         announce = realm.new_stream_announcements_stream
         assert announce is not None
+
+        cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+        iago = self.example_user("iago")
+        prospero = self.example_user("prospero")
+
+        self.create_personal_recipient(bot, desdemona, cordelia, hamlet, othello, iago, prospero)
+
         user_ids = [
             desdemona.id,
-            self.example_user("cordelia").id,
-            self.example_user("hamlet").id,
-            self.example_user("othello").id,
-            self.example_user("iago").id,
-            self.example_user("prospero").id,
+            cordelia.id,
+            hamlet.id,
+            othello.id,
+            iago.id,
+            prospero.id,
         ]
         principals_dict = dict(
             principals=orjson.dumps(user_ids).decode(), announce=orjson.dumps(True).decode()

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.test import override_settings
 from typing_extensions import override
 
 from zerver.actions.message_send import internal_send_private_message
@@ -147,7 +146,6 @@ class TutorialTests(ZulipTestCase):
             )
             self.assertEqual(most_recent_message(user).content, expected_response)
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_response_to_pm_for_help_using_direct_message_group(self) -> None:
         user = self.example_user("hamlet")
         bot = get_system_bot(settings.WELCOME_BOT, user.realm_id)
@@ -210,7 +208,6 @@ class TutorialTests(ZulipTestCase):
         )
         self.assertEqual(most_recent_message(user).content, expected_response)
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_response_to_pm_for_undefined_using_direct_message_group(self) -> None:
         user = self.example_user("hamlet")
         bot = get_system_bot(settings.WELCOME_BOT, user.realm_id)

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.test import override_settings
 from typing_extensions import override
 
 from zerver.actions.message_send import internal_send_private_message
@@ -146,6 +147,7 @@ class TutorialTests(ZulipTestCase):
             )
             self.assertEqual(most_recent_message(user).content, expected_response)
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
     def test_response_to_pm_for_help_using_direct_message_group(self) -> None:
         user = self.example_user("hamlet")
         bot = get_system_bot(settings.WELCOME_BOT, user.realm_id)
@@ -208,7 +210,8 @@ class TutorialTests(ZulipTestCase):
         )
         self.assertEqual(most_recent_message(user).content, expected_response)
 
-    def test_response_to_pm_for_undefined_using_direct_group_message(self) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=True)
+    def test_response_to_pm_for_undefined_using_direct_message_group(self) -> None:
         user = self.example_user("hamlet")
         bot = get_system_bot(settings.WELCOME_BOT, user.realm_id)
 

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.test import override_settings
 from typing_extensions import override
 
 from zerver.actions.message_send import internal_send_private_message
@@ -130,7 +131,8 @@ class TutorialTests(ZulipTestCase):
             )
             self.assertEqual(most_recent_message(user).content, expected_response)
 
-    def test_response_to_pm_for_help(self) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_response_to_pm_for_help_using_personal_recipient(self) -> None:
         user = self.example_user("hamlet")
         bot = get_system_bot(settings.WELCOME_BOT, user.realm_id)
         messages = ["help", "Help", "?"]
@@ -181,7 +183,8 @@ class TutorialTests(ZulipTestCase):
             self.assertEqual(message.content, content)
             self.assertEqual(message.sender, user)
 
-    def test_response_to_pm_for_undefined(self) -> None:
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
+    def test_response_to_pm_for_undefined_using_personal_recipient(self) -> None:
         user = self.example_user("hamlet")
         bot = get_system_bot(settings.WELCOME_BOT, user.realm_id)
         messages = ["Hello", "HAHAHA", "OKOK", "LalulaLapas"]

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.test import override_settings
 from typing_extensions import override
 
 from zerver.actions.message_send import internal_send_private_message
@@ -131,24 +130,7 @@ class TutorialTests(ZulipTestCase):
             )
             self.assertEqual(most_recent_message(user).content, expected_response)
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
-    def test_response_to_pm_for_help_using_personal_recipient(self) -> None:
-        user = self.example_user("hamlet")
-        bot = get_system_bot(settings.WELCOME_BOT, user.realm_id)
-        messages = ["help", "Help", "?"]
-        self.login_user(user)
-        for content in messages:
-            self.send_personal_message(user, bot, content)
-            expected_response = (
-                "Here are a few messages I understand: "
-                "`apps`, `profile`, `theme`, "
-                "`channels`, `topics`, `message formatting`, `keyboard shortcuts`.\n\n"
-                "Check out our [Getting started guide](/help/getting-started-with-zulip), "
-                "or browse the [help center](/help/) to learn more!"
-            )
-            self.assertEqual(most_recent_message(user).content, expected_response)
-
-    def test_response_to_pm_for_help_using_direct_message_group(self) -> None:
+    def test_response_to_pm_for_help(self) -> None:
         user = self.example_user("hamlet")
         bot = get_system_bot(settings.WELCOME_BOT, user.realm_id)
 
@@ -183,39 +165,9 @@ class TutorialTests(ZulipTestCase):
             self.assertEqual(message.content, content)
             self.assertEqual(message.sender, user)
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
-    def test_response_to_pm_for_undefined_using_personal_recipient(self) -> None:
-        user = self.example_user("hamlet")
-        bot = get_system_bot(settings.WELCOME_BOT, user.realm_id)
-        messages = ["Hello", "HAHAHA", "OKOK", "LalulaLapas"]
-        self.login_user(user)
-        # First undefined message sent.
-        self.send_personal_message(user, bot, "Hello")
-        expected_response = (
-            "You can chat with me as much as you like! To get help, try one of the following messages: "
-            "`apps`, `profile`, `theme`, `channels`, "
-            "`topics`, `message formatting`, `keyboard shortcuts`, `help`."
-        )
-        self.assertEqual(most_recent_message(user).content, expected_response)
-
-        # For future undefined messages, welcome bot won't send a reply.
-        for content in messages:
-            self.send_personal_message(user, bot, content)
-            self.assertEqual(most_recent_message(user).content, content)
-
-        # Check if Welcome bot still replies for bot commands
-        self.send_personal_message(user, bot, "apps")
-        expected_response = (
-            "You can [download](/apps/) the [mobile and desktop apps](/apps/). "
-            "Zulip also works great in a browser."
-        )
-        self.assertEqual(most_recent_message(user).content, expected_response)
-
     def test_response_to_pm_for_undefined_using_direct_message_group(self) -> None:
         user = self.example_user("hamlet")
         bot = get_system_bot(settings.WELCOME_BOT, user.realm_id)
-
-        get_or_create_direct_message_group(id_list=[user.id, bot.id])
 
         messages = ["Hello", "HAHAHA", "OKOK", "LalulaLapas"]
         self.login_user(user)

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -1,4 +1,5 @@
 import orjson
+from django.test import override_settings
 
 from zerver.actions.streams import do_deactivate_stream, do_unarchive_stream
 from zerver.lib.test_classes import ZulipTestCase
@@ -796,6 +797,7 @@ class TestSendTypingNotificationsSettings(ZulipTestCase):
         self.assertNotIn(aaron.id, event_user_ids)
         self.assertIn(iago.id, event_user_ids)
 
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_send_direct_message_edit_typing_notifications_setting(self) -> None:
         sender = self.example_user("hamlet")
         recipient_user = self.example_user("othello")

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -1,5 +1,4 @@
 import orjson
-from django.test import override_settings
 
 from zerver.actions.streams import do_deactivate_stream, do_unarchive_stream
 from zerver.lib.test_classes import ZulipTestCase
@@ -797,7 +796,6 @@ class TestSendTypingNotificationsSettings(ZulipTestCase):
         self.assertNotIn(aaron.id, event_user_ids)
         self.assertIn(iago.id, event_user_ids)
 
-    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_send_direct_message_edit_typing_notifications_setting(self) -> None:
         sender = self.example_user("hamlet")
         recipient_user = self.example_user("othello")

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1000,7 +1000,7 @@ class QueryCountTest(ZulipTestCase):
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
         with (
-            self.assert_database_query_count(88),
+            self.assert_database_query_count(86),
             self.assert_memcached_count(23),
             self.capture_send_event_calls(expected_num_events=11) as events,
         ):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1026,7 +1026,7 @@ class QueryCountTest(ZulipTestCase):
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
         with (
-            self.assert_database_query_count(86),
+            self.assert_database_query_count(88),
             self.assert_memcached_count(23),
             self.capture_send_event_calls(expected_num_events=11) as events,
         ):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -18,7 +18,10 @@ from zerver.actions.create_user import do_create_user, do_reactivate_user
 from zerver.actions.invites import do_create_multiuse_invite_link, do_invite_users
 from zerver.actions.message_send import RecipientInfoResult, get_recipient_info
 from zerver.actions.muted_users import do_mute_user
-from zerver.actions.realm_settings import do_set_realm_property
+from zerver.actions.realm_settings import (
+    do_change_realm_permission_group_setting,
+    do_set_realm_property,
+)
 from zerver.actions.user_settings import bulk_regenerate_api_keys, do_change_user_setting
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.actions.users import (
@@ -76,7 +79,7 @@ from zerver.models import (
 )
 from zerver.models.clients import get_client
 from zerver.models.custom_profile_fields import check_valid_user_ids
-from zerver.models.groups import SystemGroups
+from zerver.models.groups import NamedUserGroup, SystemGroups
 from zerver.models.prereg_users import filter_to_valid_prereg_users
 from zerver.models.realm_audit_logs import AuditLogEventType
 from zerver.models.realms import InvalidFakeEmailDomainError, get_fake_email_domain, get_realm
@@ -589,6 +592,29 @@ class PermissionTest(ZulipTestCase):
         access_user_by_id_including_cross_realm(
             self.example_user("cordelia"), self.example_user("aaron").id, for_admin=False
         )
+
+    def test_access_user_by_id_when_personal_recipient_is_none(self) -> None:
+        self.set_up_db_for_testing_user_access()
+        polonius = self.example_user("polonius")
+
+        # Removing the personal recipient to ensure a new direct message group is used for 1:1 dms.
+        polonius.recipient = None
+        polonius.save()
+
+        # Restricting the "Members" system group to not allow access to all users.
+        realm = get_realm("zulip")
+        members_system_group = NamedUserGroup.objects.get(name=SystemGroups.MEMBERS, realm=realm)
+        do_change_realm_permission_group_setting(
+            realm, "can_access_all_users_group", members_system_group, acting_user=None
+        )
+
+        aaron = self.example_user("aaron")
+        target_user = access_user_by_id(polonius, aaron.id, for_admin=False)
+        self.assertEqual(target_user, aaron)
+
+        othello = self.example_user("othello")
+        with self.assertRaises(JsonableError):
+            access_user_by_id(polonius, othello.id, for_admin=False)
 
     def check_property_for_role(self, user_profile: UserProfile, role: int) -> bool:
         if role == UserProfile.ROLE_REALM_ADMINISTRATOR:
@@ -3207,6 +3233,26 @@ class GetProfileTest(ZulipTestCase):
         inaccessible_user_ids = get_inaccessible_user_ids(
             [bot.id, hamlet.id, othello.id, shiva.id, prospero.id], polonius
         )
+        self.assertEqual(inaccessible_user_ids, {othello.id})
+
+    def test_get_inaccessible_user_ids_when_personal_recipient_is_none(self) -> None:
+        polonius = self.example_user("polonius")
+
+        # Removing the personal recipient to ensure we use direct message group.
+        polonius.recipient = None
+        polonius.save()
+
+        bot = self.example_user("default_bot")
+        hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+
+        inaccessible_user_ids = get_inaccessible_user_ids([bot.id, hamlet.id, othello.id], polonius)
+        self.assert_length(inaccessible_user_ids, 0)
+
+        self.set_up_db_for_testing_user_access()
+        polonius = self.example_user("polonius")
+
+        inaccessible_user_ids = get_inaccessible_user_ids([bot.id, hamlet.id, othello.id], polonius)
         self.assertEqual(inaccessible_user_ids, {othello.id})
 
     def test_get_users_for_spectators(self) -> None:

--- a/zerver/tests/test_zulip_update_announcements.py
+++ b/zerver/tests/test_zulip_update_announcements.py
@@ -450,13 +450,15 @@ class ZulipUpdateAnnouncementsTest(ZulipTestCase):
             self.assertEqual(
                 imported_realm.zulip_update_announcements_stream, gryffindor_common_room
             )
-            personal_message = Message.objects.filter(
-                realm=imported_realm, sender=notification_bot, recipient__type=Recipient.PERSONAL
+            bot_message = Message.objects.filter(
+                realm=imported_realm,
+                sender=notification_bot,
+                recipient__type=Recipient.DIRECT_MESSAGE_GROUP,
             ).first()
-            assert personal_message is not None
+            assert bot_message is not None
             self.assertIn(
                 "Starting tomorrow, users in your organization will receive",
-                personal_message.content,
+                bot_message.content,
             )
 
             # Two new updates added.

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -1161,7 +1161,6 @@ def process_message_event(
         client_gravatar: bool,
         allow_empty_topic_name: bool,
         can_access_sender: bool,
-        is_incoming_1_to_1: bool,
     ) -> dict[str, Any]:
         return MessageDict.finalize_payload(
             wide_dict,
@@ -1170,7 +1169,6 @@ def process_message_event(
             allow_empty_topic_name=allow_empty_topic_name,
             can_access_sender=can_access_sender,
             realm_host=realm_host,
-            is_incoming_1_to_1=is_incoming_1_to_1,
         )
 
     # Extra user-specific data to include
@@ -1253,7 +1251,6 @@ def process_message_event(
             client_gravatar=client.client_gravatar,
             allow_empty_topic_name=client.empty_topic_name,
             can_access_sender=can_access_sender,
-            is_incoming_1_to_1=wide_dict["recipient_id"] == client.user_recipient_id,
         )
 
         # Make sure mirroring bots know whether stream is invite-only

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -105,10 +105,8 @@ def send_message_edit_notification_backend(
         if not user_profile.send_private_typing_notifications:
             raise JsonableError(_("User has disabled typing notifications for direct messages"))
 
-        if recipient.type == Recipient.PERSONAL:
-            recipient_ids = [user_profile.id, recipient.type_id]
-        else:
-            recipient_ids = list(get_direct_message_group_user_ids(recipient))
+        assert recipient.type == Recipient.DIRECT_MESSAGE_GROUP
+        recipient_ids = list(get_direct_message_group_user_ids(recipient))
 
         do_send_direct_message_edit_typing_notification(
             user_profile, recipient_ids, message_id, operator

--- a/zerver/webhooks/freshstatus/tests.py
+++ b/zerver/webhooks/freshstatus/tests.py
@@ -207,4 +207,4 @@ The following scheduled maintenance has been closed: **Scheduled Maintenance Tes
 
         msg = self.get_last_message()
         self.assertEqual(msg.content, expected_message)
-        self.assertEqual(msg.recipient.type, Recipient.PERSONAL)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)

--- a/zerver/webhooks/teamcity/tests.py
+++ b/zerver/webhooks/teamcity/tests.py
@@ -44,7 +44,7 @@ class TeamCityHookTests(WebhookTestCase):
         msg = self.get_last_message()
 
         self.assertEqual(msg.content, expected_message)
-        self.assertEqual(msg.recipient.type, Recipient.PERSONAL)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
     def test_non_generic_payload_ignore_pm_notification(self) -> None:
         expected_message = MISCONFIGURED_PAYLOAD_TYPE_ERROR_MESSAGE.format(
@@ -58,4 +58,4 @@ class TeamCityHookTests(WebhookTestCase):
         msg = self.get_last_message()
 
         self.assertEqual(msg.content, expected_message)
-        self.assertEqual(msg.recipient.type, Recipient.PERSONAL)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)

--- a/zerver/webhooks/uptimerobot/tests.py
+++ b/zerver/webhooks/uptimerobot/tests.py
@@ -44,4 +44,4 @@ It was down for 44 minutes and 37 seconds.
 
         msg = self.get_last_message()
         self.assertEqual(msg.content, expected_message)
-        self.assertEqual(msg.recipient.type, Recipient.PERSONAL)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)

--- a/zerver/webhooks/zabbix/tests.py
+++ b/zerver/webhooks/zabbix/tests.py
@@ -33,4 +33,4 @@ class ZabbixHookTests(WebhookTestCase):
 
         msg = self.get_last_message()
         self.assertEqual(msg.content, expected_message)
-        self.assertEqual(msg.recipient.type, Recipient.PERSONAL)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -271,7 +271,7 @@ class Command(ZulipBaseCommand):
             "--personals",
             dest="num_personals",
             type=int,
-            default=6,
+            default=0,
             help="The number of personal pairs to create.",
         )
 
@@ -287,7 +287,7 @@ class Command(ZulipBaseCommand):
         parser.add_argument(
             "--percent-personals",
             type=float,
-            default=15,
+            default=0,
             help="The percent of messages to be personals.",
         )
 

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -747,4 +747,4 @@ MIN_PARTIAL_SUBSCRIBERS_CHANNEL_SIZE = 1000
 
 # Whether to prefer direct message group over personal recipient
 # for 1:1 or self messages.
-PREFER_DIRECT_MESSAGE_GROUP = False
+PREFER_DIRECT_MESSAGE_GROUP = True

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -744,7 +744,3 @@ SCIM_CONFIG: dict[str, SCIMConfigDict] = {}
 # Minimum number of subscribers in a channel for us to no longer
 # send full subscriber data to the client.
 MIN_PARTIAL_SUBSCRIBERS_CHANNEL_SIZE = 1000
-
-# Whether to prefer direct message group over personal recipient
-# for 1:1 or self messages.
-PREFER_DIRECT_MESSAGE_GROUP = True

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -744,3 +744,7 @@ SCIM_CONFIG: dict[str, SCIMConfigDict] = {}
 # Minimum number of subscribers in a channel for us to no longer
 # send full subscriber data to the client.
 MIN_PARTIAL_SUBSCRIBERS_CHANNEL_SIZE = 1000
+
+# Whether to prefer direct message group over personal recipient
+# for 1:1 or self messages.
+PREFER_DIRECT_MESSAGE_GROUP = False


### PR DESCRIPTION
As we completed the transition to use `DirectMessageGroups` for 1:1 and self direct messages, we can now delete all code paths where legacy `PERSONAL` recipients were used. 
We also remove the `PREFER_DIRECT_MESSAGE_GROUP` setting variable since there's no other option after this commit.

This PR should be merged after https://github.com/zulip/zulip/pull/35347

To review the changes more easily, please look at [this commit](https://github.com/zulip/zulip/pull/36107/commits/b0cf196b7c4e6215e7c8a30826e8ca2f7cabfe95).

Fixes: last part of issue https://github.com/zulip/zulip/issues/25713.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
