### PR TITLE
deactivated_org: Direct org members to contact org admins.

### DIFF
--- a/templates/zerver/deactivated.html
+++ b/templates/zerver/deactivated.html
@@ -51,6 +51,10 @@
                             {% trans %}
                             If you are an owner of this organization, you can <a href="mailto:{{ support_email }}">contact Zulip support</a> to reactivate it.
                             {% endtrans %}
+                            <br /><br />
+                            {% trans %}
+                            If you're a member of the organization and want information about why it has been deactivated, please reach out to the organization's administrators directly.
+                            {% endtrans %}
                         {% else %}
                             {% trans %}
                             If you are an owner of this organization, you can <a href="mailto:{{ support_email }}">contact this Zulip server's administrators</a> to reactivate it.


### PR DESCRIPTION
This helps clarify that normal members cannot reactivate the org by contacting us.


| before | after |
| --- | --- |
| <img width="801" height="407" alt="Screenshot from 2025-09-24 14-27-31" src="https://github.com/user-attachments/assets/f1f0d930-1a5b-485f-9d61-67a0a118b670" /> | <img width="801" height="407" alt="image" src="https://github.com/user-attachments/assets/826b7ad3-6a28-4915-9983-0a3881f6abab" /> |