### PR TITLE
drafts: Add placeholder text for drafts with no channel selected.

### DIFF
--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -646,13 +646,20 @@ export function format_draft(draft: LocalStorageDraftWithId): FormattedDraft | u
         let draft_topic_display_name = draft.topic;
         let is_empty_string_topic = false;
 
-        // If the channel is not known (recipient was not specified while the creation of the
-        // draft) and the topic is empty, the draft_topic_display_name will always be empty string
-        // and the draft title will appear as "# >". We don't use the term "general chat" until
-        // the channel is known.
-        if (sub && draft.topic === "" && stream_data.can_use_empty_topic(draft.stream_id)) {
-            draft_topic_display_name = util.get_final_topic_display_name("");
+        if (draft.topic === "") {
             is_empty_string_topic = true;
+            if (sub && stream_data.can_use_empty_topic(draft.stream_id)) {
+                // If the channel is known and it allows empty topic, we display
+                // the realm_empty_topic_display_name.
+                draft_topic_display_name = util.get_final_topic_display_name("");
+            } else {
+                // If the channel is not known (channel field was empty during the
+                // creation of the draft) or it doesn't allow empty topics, we display
+                // "No topic entered". We can't use realm_empty_topic_display_name
+                // for empty topics in unknown channels, since we are unaware of the
+                // channel's configuration.
+                draft_topic_display_name = $t({defaultMessage: "No topic entered"});
+            }
         }
 
         return {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2460,7 +2460,8 @@ body:not(.spectator-view) {
 
 .default-language-display,
 .empty-topic-display,
-.empty-topic-placeholder-display::placeholder {
+.empty-topic-placeholder-display::placeholder,
+.drafts-unknown-msg-header-field {
     font-style: italic;
 }
 

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -10,7 +10,7 @@
                     {{#if stream_name}}
                         {{stream_name}}
                     {{else}}
-                        &nbsp;
+                        <span class="drafts-unknown-msg-header-field">{{t "No channel selected" }}</span>
                     {{/if}}
                 </div>
                 <span class="stream_topic_separator"><i class="zulip-icon zulip-icon-chevron-right"></i></span>

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -34,7 +34,7 @@
                     {{#if has_recipient_data}}
                     <span class="private_message_header_name">{{t "You and {recipients}" }}</span>
                     {{else}}
-                    <em>{{t "No DM recipients" }}</em>
+                    <span class="drafts-unknown-msg-header-field">{{t "No DM recipients" }}</span>
                     {{/if}}
                     {{/if}}
                 </div>

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -633,8 +633,8 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
     assert.deepEqual(draft_model.get(), data);
 
     override(realm, "realm_topics_policy", "disable_empty_topic");
-    expected[5].topic_display_name = "";
-    expected[5].is_empty_string_topic = false;
+    expected[5].topic_display_name = "translated: No topic entered";
+    expected[5].is_empty_string_topic = true;
     assert.deepEqual(draft_model.get(), data);
 
     const stub_render_now = timerender.render_now;


### PR DESCRIPTION
This PR handles the empty channel placeholder for drafts saved without a channel selected. When these drafts also do not have a topic, we display "No topic selected" in tandem with "No channel selected", since we are unable to access the channel configuration to determine if we should display **realm_empty_topic_display_name**.

Follow-up PR for #34455.

CZO Discussion: [#design > header bar when recipient isn't fully specified @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/header.20bar.20when.20recipient.20isn't.20fully.20specified/near/2127548)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| <img width="1798" height="1340" alt="Screenshot 2025-09-24 at 3 22 05 PM" src="https://github.com/user-attachments/assets/861fef81-85d8-4648-8833-91337b8a7ede" /> | <img width="1798" height="1340" alt="Screenshot 2025-09-30 at 4 04 52 AM" src="https://github.com/user-attachments/assets/070fa358-9b3b-4fd1-99bc-d91346c4e1d8" /> | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
