### PR TITLE
postprocess: Clean up and refactor embed, link, and image postprocessing.

### DIFF
--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -98,18 +98,6 @@ export function postprocess_content(html: string): string {
             );
         }
 
-        // Update older, smaller default.jpg YouTube preview images
-        // with higher-quality preview images (320px wide)
-        if (elt.parentElement?.classList.contains("youtube-video")) {
-            const img = elt.querySelector("img");
-            assert(img instanceof HTMLImageElement);
-            const img_src = img.src;
-            if (img_src.endsWith("/default.jpg")) {
-                const mq_src = img_src.replace(/\/default.jpg$/, "/mqdefault.jpg");
-                img.src = mq_src;
-            }
-        }
-
         // Add a class to the anchor tag on
         if (elt.parentElement?.classList.contains("message_embed_title")) {
             elt.classList.add("message-embed-title-link");
@@ -132,6 +120,17 @@ export function postprocess_content(html: string): string {
         if (typeof title === "string") {
             message_media_link?.setAttribute("aria-label", title);
             message_media_link?.removeAttribute("title");
+        }
+
+        // Update older, smaller default.jpg YouTube preview images
+        // with higher-quality preview images (320px wide)
+        if (message_media_wrapper.classList.contains("youtube-video")) {
+            assert(message_media_image instanceof HTMLImageElement);
+            const img_src = message_media_image.src;
+            if (img_src.endsWith("/default.jpg")) {
+                const mq_src = img_src.replace(/\/default.jpg$/, "/mqdefault.jpg");
+                message_media_image.src = mq_src;
+            }
         }
 
         // Replace the legacy .message_inline_image class, whose

--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -12,6 +12,20 @@ export function postprocess_content(html: string): string {
     const template = inertDocument.createElement("template");
     template.innerHTML = html;
 
+    for (const ol of template.content.querySelectorAll("ol")) {
+        const list_start = Number(ol.getAttribute("start") ?? 1);
+        // We don't count the first item in the list, as it
+        // will be identical to the start value
+        const list_length = ol.children.length - 1;
+        const max_list_counter = list_start + list_length;
+        // We count the characters in the longest list counter,
+        // and use that to offset the list accordingly in CSS
+        const max_list_counter_string_length = max_list_counter.toString().length;
+        ol.classList.add(`counter-length-${max_list_counter_string_length}`);
+        // We subtract 1 from list_start, as `count 0` displays 1.
+        ol.style.setProperty("counter-reset", `count ${list_start - 1}`);
+    }
+
     for (const elt of template.content.querySelectorAll("a")) {
         // Ensure that all external links have target="_blank"
         // rel="opener noreferrer".  This ensures that external links
@@ -209,20 +223,6 @@ export function postprocess_content(html: string): string {
                 ["", legacy_title].includes(elt.title) ? title : `${title}\n${elt.title}`,
             );
         }
-    }
-
-    for (const ol of template.content.querySelectorAll("ol")) {
-        const list_start = Number(ol.getAttribute("start") ?? 1);
-        // We don't count the first item in the list, as it
-        // will be identical to the start value
-        const list_length = ol.children.length - 1;
-        const max_list_counter = list_start + list_length;
-        // We count the characters in the longest list counter,
-        // and use that to offset the list accordingly in CSS
-        const max_list_counter_string_length = max_list_counter.toString().length;
-        ol.classList.add(`counter-length-${max_list_counter_string_length}`);
-        // We subtract 1 from list_start, as `count 0` displays 1.
-        ol.style.setProperty("counter-reset", `count ${list_start - 1}`);
     }
 
     for (const inline_img of template.content.querySelectorAll<HTMLImageElement>(

--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -26,6 +26,18 @@ export function postprocess_content(html: string): string {
         ol.style.setProperty("counter-reset", `count ${list_start - 1}`);
     }
 
+    // Here we're setting up better processing of message embeds;
+    // In the future, we will be able to write logic here to permit
+    // recipients to remove embeds on a per-message basis.
+    // We want to do this processing up front, so that embeds benefit
+    // from other processing below for links and images
+    for (const message_embed of template.content.querySelectorAll(".message_embed")) {
+        const message_embed_title_link = message_embed.querySelector(".message_embed_title a");
+        // Add a class to the anchor tag on embed-title links for easier
+        // reference from CSS
+        message_embed_title_link?.classList.add("message-embed-title-link");
+    }
+
     for (const elt of template.content.querySelectorAll("a")) {
         // Ensure that all external links have target="_blank"
         // rel="opener noreferrer".  This ensures that external links
@@ -96,11 +108,6 @@ export function postprocess_content(html: string): string {
                 "title",
                 ["", legacy_title].includes(elt.title) ? title : `${title}\n${elt.title}`,
             );
-        }
-
-        // Add a class to the anchor tag on
-        if (elt.parentElement?.classList.contains("message_embed_title")) {
-            elt.classList.add("message-embed-title-link");
         }
     }
 

--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -178,7 +178,8 @@ export function postprocess_content(html: string): string {
                 image_url.pathname.startsWith("/user_uploads/thumbnail/")
             ) {
                 let thumbnail_name = thumbnail.preferred_format.name;
-                if (message_media_image.dataset.animated === "true") {
+                // eslint-disable-next-line unicorn/prefer-dom-node-dataset
+                if (message_media_image.getAttribute("data-animated") === "true") {
                     if (
                         user_settings.web_animate_image_previews === "always" ||
                         // Treat on_hover as "always" on mobile web, where
@@ -208,7 +209,10 @@ export function postprocess_content(html: string): string {
         // set those values as `height` and `width` attributes on the
         // image source.
         if (message_media_image?.hasAttribute("data-original-dimensions")) {
-            const original_dimensions_attribute = message_media_image.dataset.originalDimensions;
+            // eslint-disable-next-line unicorn/prefer-dom-node-dataset
+            const original_dimensions_attribute = message_media_image.getAttribute(
+                "data-original-dimensions",
+            );
             assert(original_dimensions_attribute);
             const original_dimensions: string[] = original_dimensions_attribute.split("x");
             assert(

--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -66,6 +66,38 @@ export function postprocess_content(html: string): string {
             elt.removeAttribute("target");
         }
 
+        if (!elt.parentElement?.classList.contains("message_inline_image")) {
+            // For non-media (images, video) user uploads, the following block
+            // ensures that the title attribute always displays the filename,
+            // as a security measure.
+            let title: string;
+            let legacy_title: string;
+            if (
+                url.origin === window.location.origin &&
+                url.pathname.startsWith("/user_uploads/")
+            ) {
+                // We add the word "download" to make clear what will
+                // happen when clicking the file.  This is particularly
+                // important in the desktop app, where hovering a URL does
+                // not display the URL like it does in the web app.
+                title = legacy_title = $t(
+                    {defaultMessage: "Download {filename}"},
+                    {
+                        filename: decodeURIComponent(
+                            url.pathname.slice(url.pathname.lastIndexOf("/") + 1),
+                        ),
+                    },
+                );
+            } else {
+                title = url.toString();
+                legacy_title = href;
+            }
+            elt.setAttribute(
+                "title",
+                ["", legacy_title].includes(elt.title) ? title : `${title}\n${elt.title}`,
+            );
+        }
+
         if (elt.querySelector("img") || elt.querySelector("video")) {
             // We want a class to refer to media links
             elt.classList.add("media-anchor-element");
@@ -193,35 +225,6 @@ export function postprocess_content(html: string): string {
                     inline_image.classList.add("landscape-thumbnail");
                 }
             }
-        } else {
-            // For non-image user uploads, the following block ensures that the title
-            // attribute always displays the filename as a security measure.
-            let title: string;
-            let legacy_title: string;
-            if (
-                url.origin === window.location.origin &&
-                url.pathname.startsWith("/user_uploads/")
-            ) {
-                // We add the word "download" to make clear what will
-                // happen when clicking the file.  This is particularly
-                // important in the desktop app, where hovering a URL does
-                // not display the URL like it does in the web app.
-                title = legacy_title = $t(
-                    {defaultMessage: "Download {filename}"},
-                    {
-                        filename: decodeURIComponent(
-                            url.pathname.slice(url.pathname.lastIndexOf("/") + 1),
-                        ),
-                    },
-                );
-            } else {
-                title = url.toString();
-                legacy_title = href;
-            }
-            elt.setAttribute(
-                "title",
-                ["", legacy_title].includes(elt.title) ? title : `${title}\n${elt.title}`,
-            );
         }
     }
 

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -13,6 +13,13 @@ const {initialize_user_settings} = zrequire("user_settings");
 const user_settings = {web_font_size_px: 16};
 initialize_user_settings({user_settings});
 
+run_test("ordered_lists", () => {
+    assert.equal(
+        postprocess_content('<ol start="9"><li>Nine</li><li>Ten</li></ol>'),
+        '<ol start="9" class="counter-length-2" style="counter-reset: count 8;"><li>Nine</li><li>Ten</li></ol>',
+    );
+});
+
 // Care should be taken to present real-world cases here and
 // throughout, rather than contrived examples that serve
 // only to satisfy 100% test coverage.
@@ -79,13 +86,6 @@ run_test("postprocess_media_and_embeds", () => {
             '<div class="message_embed_description">All about us.</div>' +
             "</div>" +
             "</div>",
-    );
-});
-
-run_test("ordered_lists", () => {
-    assert.equal(
-        postprocess_content('<ol start="9"><li>Nine</li><li>Ten</li></ol>'),
-        '<ol start="9" class="counter-length-2" style="counter-reset: count 8;"><li>Nine</li><li>Ten</li></ol>',
     );
 });
 

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -81,7 +81,7 @@ run_test("postprocess_media_and_embeds", () => {
             '<a class="message_embed_image" href="https://example.com/about" style="background-image: url(&quot;https://example.com/preview.jpeg&quot;)" target="_blank" rel="noopener noreferrer" title="https://example.com/about"></a>' +
             '<div class="data-container">' +
             '<div class="message_embed_title">' +
-            '<a href="https://example.com/about" target="_blank" rel="noopener noreferrer" class="message-embed-title-link" title="https://example.com/about">About us</a>' +
+            '<a href="https://example.com/about" target="_blank" rel="noopener noreferrer" title="https://example.com/about" class="message-embed-title-link">About us</a>' +
             "</div>" +
             '<div class="message_embed_description">All about us.</div>' +
             "</div>" +

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -81,7 +81,7 @@ run_test("postprocess_media_and_embeds", () => {
             '<a class="message_embed_image" href="https://example.com/about" style="background-image: url(&quot;https://example.com/preview.jpeg&quot;)" target="_blank" rel="noopener noreferrer" title="https://example.com/about"></a>' +
             '<div class="data-container">' +
             '<div class="message_embed_title">' +
-            '<a href="https://example.com/about" target="_blank" rel="noopener noreferrer" title="https://example.com/about" class="message-embed-title-link">About us</a>' +
+            '<a href="https://example.com/about" class="message-embed-title-link" target="_blank" rel="noopener noreferrer" title="https://example.com/about">About us</a>' +
             "</div>" +
             '<div class="message_embed_description">All about us.</div>' +
             "</div>" +

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -124,12 +124,12 @@ run_test("inline_image_galleries", ({override}) => {
             '<div class="message-thumbnail-gallery">' +
             '<div class="message-media-preview-image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
-            '<img data-original-dimensions="1000x2000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" class="media-image-element portrait-thumbnail" width="1000" height="2000" style="width: 5em;" loading="lazy">' +
+            '<img data-original-dimensions="1000x2000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" class="media-image-element portrait-thumbnail" loading="lazy" width="1000" height="2000" style="width: 5em;">' +
             "</a>" +
             "</div>" +
             '<div class="message-media-preview-image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
-            '<img data-original-dimensions="2000x1000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" class="media-image-element landscape-thumbnail" width="2000" height="1000" style="width: 20em;" loading="lazy">' +
+            '<img data-original-dimensions="2000x1000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" class="media-image-element landscape-thumbnail" loading="lazy" width="2000" height="1000" style="width: 20em;">' +
             "</a>" +
             "</div>" +
             "</div>" +
@@ -137,7 +137,7 @@ run_test("inline_image_galleries", ({override}) => {
             '<div class="message-thumbnail-gallery">' +
             '<div class="message-media-preview-image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
-            '<img data-original-dimensions="1000x1000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" class="media-image-element portrait-thumbnail" width="1000" height="1000" style="width: 10em;" loading="lazy">' +
+            '<img data-original-dimensions="1000x1000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" class="media-image-element portrait-thumbnail" loading="lazy" width="1000" height="1000" style="width: 10em;">' +
             "</a>" +
             "</div>" +
             "</div>",
@@ -198,7 +198,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
         '<div class="message-thumbnail-gallery">' +
             '<div class="message-media-preview-image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element landscape-thumbnail" width="3264" height="2448" style="width: 13.333333333333334em;" loading="lazy">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element landscape-thumbnail" loading="lazy" width="3264" height="2448" style="width: 13.333333333333334em;">' +
             "</a>" +
             "</div>" +
             "</div>",
@@ -216,7 +216,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
         '<div class="message-thumbnail-gallery">' +
             '<div class="message-media-preview-image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
-            '<img data-original-dimensions="100x200" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element portrait-thumbnail" width="100" height="200" style="width: 5em;" loading="lazy">' +
+            '<img data-original-dimensions="100x200" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element portrait-thumbnail" loading="lazy" width="100" height="200" style="width: 5em;">' +
             "</a>" +
             "</div>" +
             "</div>",
@@ -234,7 +234,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
         '<div class="message-thumbnail-gallery">' +
             '<div class="message-media-preview-image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
-            '<img data-original-dimensions="1x10" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element dinky-thumbnail extreme-aspect-ratio portrait-thumbnail" width="1" height="10" style="width: 1px;" loading="lazy">' +
+            '<img data-original-dimensions="1x10" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element dinky-thumbnail extreme-aspect-ratio portrait-thumbnail" loading="lazy" width="1" height="10" style="width: 1px;">' +
             "</a>" +
             "</div>" +
             "</div>",
@@ -253,7 +253,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
         '<div class="message-thumbnail-gallery">' +
             '<div class="message-media-preview-image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200-anim.webp" data-animated="true" class="media-image-element landscape-thumbnail" width="3264" height="2448" style="width: 13.333333333333334em;" loading="lazy">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200-anim.webp" data-animated="true" class="media-image-element landscape-thumbnail" loading="lazy" width="3264" height="2448" style="width: 13.333333333333334em;">' +
             "</a>" +
             "</div>" +
             "</div>",
@@ -272,7 +272,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
         '<div class="message-thumbnail-gallery">' +
             '<div class="message-media-preview-image message_inline_animated_image_still">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" class="media-image-element landscape-thumbnail" width="3264" height="2448" style="width: 13.333333333333334em;" loading="lazy">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" class="media-image-element landscape-thumbnail" loading="lazy" width="3264" height="2448" style="width: 13.333333333333334em;">' +
             "</a>" +
             "</div>" +
             "</div>",
@@ -290,7 +290,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
         '<div class="message-thumbnail-gallery">' +
             '<div class="message-media-preview-image message_inline_animated_image_still">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" class="media-image-element landscape-thumbnail" width="3264" height="2448" style="width: 13.333333333333334em;" loading="lazy">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" class="media-image-element landscape-thumbnail" loading="lazy" width="3264" height="2448" style="width: 13.333333333333334em;">' +
             "</a>" +
             "</div>" +
             "</div>",
@@ -301,7 +301,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
     // history.
     assert.equal(
         postprocess_content(
-            '<div class="message-media-preview-image">' +
+            '<div class="message_inline_image">' +
                 '<a href="https://zulip.%20[Click%20to%20join%20video%20call](https://meeting.example.com/abcd1234)%20example.com/user_uploads/2/ab/abcd1234/image.png" target="_blank" title="image.png">' +
                 '<img src="https://zulip.%20[Click%20to%20join%20video%20call](https://meeting.example.com/abcd1234)%20example.com/user_uploads/2/ab/abcd1234/image.png">' +
                 "</a>" +


### PR DESCRIPTION
This PR represents a major reorganization and refactor of how Zulip postprocesses content. This will improve this area of the codebase significantly, and should make it trivial to postprocess forthcoming Markdown inline images without a lot of acrobatics. Among the improvements here:

1. Link processing is now detached from image processing, resulting in code that is easier to digest--and that reflects the division in link vs. image tests introduced in #36052
2. Download processing is now properly part of link processing, rather than an odd branch off of image processing.
3. Image processing (apart from image galleries, which are still handled as a separate loop) is now handled in a single loop, entirely based on what comes down from the server. Previous logic was a mix of server- and post-processed selectors and things. And we no longer have logic that repeatedly calls the same `querySelector()` or that makes lots of extra DOM-tree traversals.
4. YouTube image processing is now handled within the image loop, rather than its former odd place in link processing.
5. A new loop has been established for the `.message_embed` class, paving the way for more targeted post-processing of embeds, including the recipient-based ability to show/hide previews on a per-message basis as described in #21766.
6. Calls to `dataset` have been replaced with `getAttribute()` for easier grepping of `data-` attributes across the codebase.
7. The entire `postprocess_content.ts` file has been reordered for readability and more sensible processing.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
