### PR TITLE
push_notification: Skip clearing notif for users without push devices.

### DIFF
--- a/zerver/models/push_notifications.py
+++ b/zerver/models/push_notifications.py
@@ -131,7 +131,8 @@ class PushDevice(AbstractPushDevice):
         ]
         indexes = [
             models.Index(
-                # Used in 'send_push_notifications' and `send_e2ee_test_push_notification_api`.
+                # Used in 'send_push_notifications', `send_e2ee_test_push_notification_api`,
+                # 'get_recipient_info', and 'do_clear_mobile_push_notifications_for_ids'.
                 fields=["user", "bouncer_device_id"],
                 condition=Q(bouncer_device_id__isnull=False),
                 name="zerver_pushdevice_user_bouncer_device_id_idx",

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -9,6 +9,7 @@ from typing_extensions import override
 from zerver.actions.message_flags import do_update_message_flags
 from zerver.actions.streams import do_change_stream_group_based_setting, do_change_stream_permission
 from zerver.actions.user_groups import check_add_user_group
+from zerver.actions.user_settings import do_change_user_setting
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.lib.fix_unreads import fix, fix_unsubscribed
 from zerver.lib.message import (
@@ -30,6 +31,7 @@ from zerver.lib.test_helpers import get_subscription
 from zerver.lib.user_message import DEFAULT_HISTORICAL_FLAGS, create_historical_user_messages
 from zerver.models import (
     Message,
+    PushDevice,
     Recipient,
     Stream,
     Subscription,
@@ -951,6 +953,54 @@ class PushNotificationMarkReadFlowsTest(ZulipTestCase):
         self.assertEqual(self.get_mobile_push_notification_ids(user_profile), [])
         mock_push_notifications.assert_called()
         mock_send_push_notifications.assert_called()
+
+    @mock.patch("zerver.lib.push_notifications.send_push_notifications")
+    @mock.patch("zerver.lib.push_notifications.push_notifications_configured", return_value=True)
+    def test_skip_clear_notification_for_user_without_push_device(
+        self,
+        mock_push_notifications: mock.MagicMock,
+        mock_send_push_notifications: mock.MagicMock,
+    ) -> None:
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        self.login_user(cordelia)
+        self.register_push_device(cordelia.id)
+        do_change_user_setting(cordelia, "enable_stream_push_notifications", True, acting_user=None)
+
+        # Initially, no active push notifications.
+        self.assertEqual(self.get_mobile_push_notification_ids(cordelia), [])
+
+        verona = self.subscribe(cordelia, "Verona")
+        message_ids = [self.send_stream_message(hamlet, "Verona", str(i)) for i in range(10)]
+
+        # Verify push notifications sent to `cordelia` for `message_ids`
+        self.assertEqual(
+            self.get_mobile_push_notification_ids(cordelia),
+            message_ids,
+        )
+
+        # Device unregistered. Verify that no event to revoke notifications gets
+        # enqueued to `missedmessage_mobile_notifications` and `active_mobile_push_notification`
+        # flag is unset.
+        PushDevice.objects.all().delete()
+        with (
+            mock.patch(
+                "zerver.actions.message_flags.queue_event_on_commit"
+            ) as mock_queue_event_on_commit,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            result = self.client_post(
+                "/json/mark_stream_as_read",
+                {
+                    "stream_id": str(verona.id),
+                },
+            )
+        self.assert_json_success(result)
+        mock_queue_event_on_commit.assert_not_called()
+        self.assertEqual(
+            self.get_mobile_push_notification_ids(cordelia),
+            [],
+        )
 
 
 class MarkAllAsReadEndpointTest(ZulipTestCase):

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2503,6 +2503,7 @@ class TestClearOnRead(ZulipTestCase):
             user_profile_id=hamlet.id,
             message_id__in=message_ids,
         ).update(flags=F("flags").bitor(UserMessage.flags.active_mobile_push_notification))
+        self.register_push_device(hamlet.id)
 
         with mock_queue_publish("zerver.actions.message_flags.queue_event_on_commit") as m:
             assert stream.recipient_id is not None


### PR DESCRIPTION
First commit: https://github.com/zulip/zulip/pull/36121#issuecomment-3444264235

This PR adds check to skip enqueuing events with type="remove" if no push device is registered for the user.

21dedfe40a02cc64a52c1568c22c72eadbcd5cb2 made improvements to skip enqueuing events to send push notif if no push device is registered - it helped to lower the number of events enqueued to *clear* notifs as well because we have overall less number of usermessages with `active_mobile_push_notification` flag set.

But there's still a couple of cases where events to clear can be enqueued when no push device is registered for a user:
* After 21dedfe40a02cc64a52c1568c22c72eadbcd5cb2:
  * event to send push notif is enqueued when push device was present
  * push device unregistered
  * event to clear (type="remove") can be enqueued as usermessages
    with active_mobile_push_notification flag set is present.
* event to send push notif enqueued prior to 21dedfe40a02cc64a52c1568c22c72eadbcd5cb2 results in usermessages with 'active_mobile_push_notification' flag set - so events to clear them can be enqueued post upgrade.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
