### PR TITLE
inbox: Correct margin declaration to avoid odd gap.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -639,19 +639,10 @@
 }
 
 .inbox-folder-components {
+    margin-bottom: 0.5em;
     border-radius: 5px;
     border: 0.5px solid hsl(0deg 0% 0% / 13%);
     overflow: hidden;
-}
-
-.inbox-folder-components
-    .inbox-folder-channel:last-child
-    .inbox-topic-container,
-#inbox-direct-messages-container {
-    .inbox-row:last-child {
-        /* 8px at 16px / 1em */
-        margin-bottom: 0.5em;
-    }
 }
 
 .inbox-folder.inbox-collapsed-state,


### PR DESCRIPTION
This avoids an odd gap at the bottom of DM and folder groups when the last channel in a folder is expanded. It also preserves a space that probably should remain between the collapsed bottom-most channel and the folder name below (compare the space around the INFORMATION folder heading in the screenshots below).

[#issues > visual gap at the bottom of folder in inbox](https://chat.zulip.org/#narrow/channel/9-issues/topic/visual.20gap.20at.20the.20bottom.20of.20folder.20in.20inbox/with/2265164)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="1800" height="1600" alt="inbox-gaps-before" src="https://github.com/user-attachments/assets/a896e7cf-fbad-44ef-942b-bfb4efec4300" /> | <img width="1800" height="1600" alt="inbox-gaps-after" src="https://github.com/user-attachments/assets/3d226c94-c42f-4917-abd6-5845f270ae60" /> |
| <img width="1800" height="1600" alt="inbox-gaps-collapsed-channel-before" src="https://github.com/user-attachments/assets/3b16d1b3-f18e-45c9-8fe1-47a7e00e4bf7" /> | <img width="1800" height="1600" alt="inbox-gaps-collapsed-channel-after" src="https://github.com/user-attachments/assets/16336074-14f4-43a8-b7dd-80cfb5dfb845" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>