### PR TITLE
postgresql: Default random_page_cost to 1.1.

### DIFF
--- a/docs/production/system-configuration.md
+++ b/docs/production/system-configuration.md
@@ -236,7 +236,10 @@ setting](https://www.postgresql.org/docs/current/runtime-config-connection.html#
 #### `random_page_cost`
 
 Override PostgreSQL's [`random_page_cost`
-setting](https://www.postgresql.org/docs/current/runtime-config-query.html#GUC-RANDOM-PAGE-COST)
+setting](https://www.postgresql.org/docs/current/runtime-config-query.html#GUC-RANDOM-PAGE-COST).
+Zulip defaults this value to 1.1, which is an appropriate value for
+SSDs; if your server uses spinning disks, you should set this back to
+the upstream default of 4.0.
 
 #### `replication_primary`
 

--- a/puppet/zulip/manifests/profile/postgresql.pp
+++ b/puppet/zulip/manifests/profile/postgresql.pp
@@ -23,7 +23,7 @@ class zulip::profile::postgresql(Boolean $start = true) {
   $wal_buffers = zulipconf('postgresql', 'wal_buffers', undef)
   $min_wal_size = zulipconf('postgresql', 'min_wal_size', undef)
   $max_wal_size = zulipconf('postgresql', 'max_wal_size', undef)
-  $random_page_cost = zulipconf('postgresql', 'random_page_cost', undef)
+  $random_page_cost = zulipconf('postgresql', 'random_page_cost', '1.1')
   $effective_io_concurrency = zulipconf('postgresql', 'effective_io_concurrency', undef)
 
   $listen_addresses = zulipconf('postgresql', 'listen_addresses', undef)


### PR DESCRIPTION
The upstream PostgreSQL default is 4, which is more appropriate for spinning disks.  In general, production deploys almost always use SSDs; adjust the Zulip default value to a better value for those.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
