### PR TITLE
direct_messages: Hide deactivated users by default.

### DIFF
--- a/web/src/pm_list_data.ts
+++ b/web/src/pm_list_data.ts
@@ -84,9 +84,19 @@ export function get_conversations(search_string = ""): DisplayObject[] {
             unread.num_unread_mentions_for_user_ids_strings(user_ids_string) > 0;
         const is_group = user_ids_string.includes(",");
         const is_active = user_ids_string === active_user_ids_string;
-        const is_deactivated = !people.is_active_user_for_popover(
-            Number.parseInt(user_ids_string, 10) || 0,
-        );
+
+        const check_if_user_deactivated = (user_id: string) => {
+            return !people.is_active_user_for_popover(Number.parseInt(user_id, 10) || 0);
+        };
+
+        let is_deactivated = check_if_user_deactivated(user_ids_string);
+
+        // A group is considered to deactivated if at least one user in the group
+        // is deactivated.
+        if (is_group) {
+            const user_ids = user_ids_string.split(",");
+            is_deactivated = user_ids.some((user_id) => check_if_user_deactivated(user_id));
+        }
 
         let user_circle_class;
         let status_emoji_info;
@@ -152,6 +162,10 @@ export function get_list_info(
         // comment in topic_list_data.ts.
         if (conversation.is_active) {
             return true;
+        }
+
+        if (conversation.is_deactivated) {
+            return false;
         }
 
         // We don't need to filter muted users here, because


### PR DESCRIPTION
Fixes #35102.

Hides deactivated users (and groups with at least one deactivated user) from the Direct Messages UI list on the left sidebar. Once "more conversations" is clicked, these conversations are shown again.

UI before clicking "more conversations":
<img width="283" height="219" alt="image (30)" src="https://github.com/user-attachments/assets/03dd484a-1664-46b2-9752-ac023d41f326" />

UI after clicking "more conversations" (users user-25, user-26, and user-27 are all deactivated users):
<img width="280" height="431" alt="image (31)" src="https://github.com/user-attachments/assets/b92ebea0-3d4b-4cf1-8db6-06437b830492" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
