### PR TITLE
inbox: Avoid extra margin from folders hidden by filters.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -639,10 +639,14 @@
 }
 
 .inbox-folder-components {
-    margin-bottom: 0.5em;
     border-radius: 5px;
     border: 0.5px solid hsl(0deg 0% 0% / 13%);
     overflow: hidden;
+
+    &:has(.inbox-row:not(.hidden_by_filters)),
+    &:has(.inbox-header:not(.hidden_by_filters)) {
+        margin-bottom: 0.5em;
+    }
 }
 
 .inbox-folder.inbox-collapsed-state,


### PR DESCRIPTION
If all channels in a folder are muted, then this margin is present in "Standard view", without there being any folder present.

Fixed by only applying margin if the folder has any header or rows that are not hidden by filters.

This is an alternative fix to #35962 which was reverted in #36123.

