### PR TITLE
compose and feed: Improve label for DMs to yourself.

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -460,7 +460,7 @@ export function compute_placeholder_text(opts: ComposePlaceholderOptions): strin
     } else if (opts.direct_message_user_ids.length > 0) {
         const user_ids = opts.direct_message_user_ids;
         if (people.is_direct_message_conversation_with_self(user_ids)) {
-            return $t({defaultMessage: "Message yourself"});
+            return $t({defaultMessage: "Write yourself a note"});
         }
         const users = people.get_users_from_ids(user_ids);
         const recipient_parts = users.map((user) => {

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -373,8 +373,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                 if (people.is_my_user_id(recipient_user.user_id)) {
                     return {
                         title: $t({
-                            defaultMessage:
-                                "You have not sent any direct messages to yourself yet!",
+                            defaultMessage: "You haven't sent yourself any notes yet!",
                         }),
                         html: $t_html({
                             defaultMessage:

--- a/web/templates/reply_recipient_label.hbs
+++ b/web/templates/reply_recipient_label.hbs
@@ -1,6 +1,6 @@
 {{#if is_dm_with_self}}
 {{#tr}}
-    Message yourself
+    Write yourself a note
 {{/tr}}
 {{else}}
 {{#tr}}

--- a/web/tests/compose_closed_ui.test.cjs
+++ b/web/tests/compose_closed_ui.test.cjs
@@ -222,7 +222,7 @@ run_test("test_non_message_list_input", () => {
         user_ids: [current_user.user_id],
     });
     let label = $("#left_bar_compose_reply_button_big").html();
-    assert.equal(label, "Message yourself");
+    assert.equal(label, "Write yourself a note");
 
     // Invalid data for a the reply button text.
     compose_closed_ui.update_recipient_text_for_reply_button({

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -472,7 +472,7 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You have not sent any direct messages to yourself yet!",
+            "translated: You haven't sent yourself any notes yet!",
             "translated HTML: Use this space for personal notes, or to test out Zulip features.",
         ),
     );


### PR DESCRIPTION
Fixes: [#mobile-design > placeholder for messages to yourself](https://chat.zulip.org/#narrow/channel/530-mobile-design/topic/placeholder.20for.20messages.20to.20yourself/with/2265885)

<img width="997" height="321" alt="Screenshot 2025-09-26 at 09 20 50" src="https://github.com/user-attachments/assets/f27e5506-fbdf-418e-88a7-f0b1bdf14397" />
<img width="985" height="264" alt="Screenshot 2025-09-26 at 09 25 05" src="https://github.com/user-attachments/assets/d6907af6-153b-4452-9f51-d151f873992f" />
