### PR TITLE
Open source contribution

### DIFF
--- a/web/templates/buddy_list_tooltip_content.hbs
+++ b/web/templates/buddy_list_tooltip_content.hbs
@@ -2,13 +2,20 @@
     <div>
         {{first_line}}
         {{#if show_you}}
-        <span class="my_user_status">{{t "(you)" }}</span>
+            <span class="my_user_status">{{t "(you)"}}</span>
         {{/if}}
     </div>
+
     {{#if second_line}}
-        <div class="tooltip-inner-content {{#if is_deactivated}}italic{{/if}}" >{{second_line}}</div>
+        <div class="tooltip-inner-content {{#if is_deactivated}}italic{{/if}}">
+            {{second_line}}
+        </div>
     {{/if}}
-    {{#if third_line}}
-        <div class="tooltip-inner-content {{#if is_deactivated}}italic{{/if}}">{{third_line}}</div>
+
+    {{#if (and third_line show_status_in_tooltip)}}
+        <div class="tooltip-inner-content {{#if is_deactivated}}italic{{/if}}">
+            {{third_line}}
+        </div>
     {{/if}}
 </div>
+


### PR DESCRIPTION
Fixes: #35238

Summary
- Adjusted tooltip logic so that status text only appears when:
  * The app is in Compact mode (sidebar hides status), or
  * The status text is too long and truncated in the sidebar.
- This prevents redundant display of the same status text in the right-sidebar tooltip.

Testing
- Verified locally using ./tools/webpack and ./tools/run-dev
- Compact mode: tooltip shows full status, sidebar hides it.
- Normal mode with short status: tooltip does not repeat the status.
- Long status: sidebar truncates, tooltip shows full version.

Notes
- This contribution is part of an academic assignment (student: Jesse Bloom).
