### PR TITLE
feat: improved unsubscribed notice UI

### DIFF
--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1888,6 +1888,11 @@ export class MessageListView {
     ): void {
         // This is not the only place we render bookends; see also the
         // partial in message_group.hbs, which do not set is_trailing_bookend.
+
+        // Check if user can subscribe to the stream
+        const stream_sub = stream_data.get_sub_by_id(stream_id);
+        const can_subscribe = stream_sub ? stream_data.can_toggle_subscription(stream_sub) : false;
+
         const $rendered_trailing_bookend = $(
             render_bookend({
                 stream_id,
@@ -1899,6 +1904,7 @@ export class MessageListView {
                 is_trailing_bookend: true,
                 invite_only,
                 is_web_public,
+                can_subscribe,
             }),
         );
         this.$list.append($rendered_trailing_bookend);

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -24,6 +24,8 @@ import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
+import * as message_fetch from "./message_fetch.ts";
+import * as message_lists from "./message_lists.ts";
 import * as narrow_state from "./narrow_state.ts";
 import type {User} from "./people.ts";
 import * as people from "./people.ts";
@@ -523,6 +525,38 @@ export function initialize(): void {
         }
 
         stream_settings_components.sub_or_unsub(sub);
+    });
+
+    $("#main_div").on("click", ".load-updates-button", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (message_lists.current !== undefined) {
+            message_fetch.maybe_load_newer_messages({
+                msg_list: message_lists.current,
+            });
+        }
+    });
+
+    $("#main_div").on("click", ".subscribe-and-load-button", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const sub = narrow_state.stream_sub();
+
+        if (sub === undefined) {
+            return;
+        }
+
+        stream_settings_components.ajaxSubscribe(sub.name, sub.color);
+
+        setTimeout(() => {
+            if (message_lists.current !== undefined) {
+                message_fetch.maybe_load_newer_messages({
+                    msg_list: message_lists.current,
+                });
+            }
+        }, 500);
     });
 
     $("#channels_overlay_container").on(

--- a/web/styles/banners.css
+++ b/web/styles/banners.css
@@ -230,3 +230,7 @@
 
     width: 100%;
 }
+
+.not-subscribed-banner .banner-content {
+    align-items: center;
+}

--- a/web/templates/bookend.hbs
+++ b/web/templates/bookend.hbs
@@ -21,11 +21,26 @@
                     {{#*inline "channel-settings-link"}} <a class="bookend-channel-settings-link" href="#channels/{{stream_id}}/{{stream_name}}/general">{{t 'View in channel settings'}}</a>{{/inline}}
                 {{/tr}}
             {{else}}
-                {{#tr}}
-                    You are not subscribed to <z-stream-name></z-stream-name>. <subscribe-button></subscribe-button>
-                    {{#*inline "z-stream-name"}}{{> stream_privacy . }} {{stream_name}}{{/inline}}
-                    {{#*inline "subscribe-button"}} <a class="stream_sub_unsub_button">{{t 'Subscribe'}}</a>{{/inline}}
-                {{/tr}}
+                <div class="not-subscribed-banner banner banner-info">
+                    <span class="banner-content">
+                        <span class="banner-label">
+                            {{#tr}}
+                                Because you aren't subscribed to <z-stream-name></z-stream-name>, you won't see new messages, reactions, and other updates.
+                                {{#*inline "z-stream-name"}}{{> stream_privacy . }} {{stream_name}}{{/inline}}
+                            {{/tr}}
+                        </span>
+                        <span class="banner-action-buttons">
+                            <button class="load-updates-button action-button action-button-borderless-neutral" type="button">
+                                <span class="action-button-label">{{t 'Load updates'}}</span>
+                            </button>
+                            {{#if can_subscribe}}
+                                <button class="subscribe-and-load-button action-button action-button-quiet-brand" type="button">
+                                    <span class="action-button-label">{{t 'Subscribe'}}</span>
+                                </button>
+                            {{/if}}
+                        </span>
+                    </span>
+                </div>
             {{/if}}
         </span>
     {{/if}}


### PR DESCRIPTION
Fixes #35901

### Summary
This PR improves the “You are not subscribed” notice by:
- Converting it into a banner for better visibility
- Adding explanation text about missed updates
- Adding **Load updates** and **Subscribe** buttons

Other notices remain unchanged.

### Visual changes
<details>
<summary>Before vs After</summary>

| Before | After |
|--------|------|
| <img width="2007" height="663" alt="image" src="https://github.com/user-attachments/assets/3c96dac7-d136-4f9a-a16f-3c75a6e4e5f6" />| <img width="2594" height="1131" alt="Screenshot 2025-09-27 173839" src="https://github.com/user-attachments/assets/9ed935f2-ffd2-4dfe-9545-d2375425400a" /> |

</details>

### Notes
- Button label changed from “Reload” → “Load updates” for clarity.

### Code changes
I improved the unsubscribed channel notice banner in Zulip by updating its UI and button logic. The "Load updates" button now reliably fetches messages using maybe_load_newer_messages and has a low visual emphasis, while the "Subscribe" button was restyled with primary brand emphasis for better visibility. I also centered the action buttons and made the "Subscribe" button appear only when allowed. These changes make the banner clearer and more consistent for users.

### Self-review
- [x] I have tested all affected UI states.
- [x] I verified that no other notices were impacted.