### PR TITLE
subscriptions: Replace svg with .sub-unsub-icon in dark_theme.css.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -165,18 +165,18 @@
     .group-row {
         /* This is for coluring the plus sign SVGs in stream-list UI */
         /* public */
-        .check:not(.checked) svg {
-            fill: hsl(218deg 14% 33%);
+        .check:not(.checked) .sub-unsub-icon {
+            color: hsl(218deg 14% 33%);
         }
 
         /* private */
-        .disabled svg {
+        .disabled .sub-unsub-icon {
             opacity: 0.5;
         }
 
         /* public :hover */
-        .check:not(.checked, .disabled):hover svg {
-            fill: hsl(230deg 11% 67%);
+        .check:not(.checked, .disabled):hover .sub-unsub-icon {
+            color: hsl(230deg 11% 67%);
         }
     }
 


### PR DESCRIPTION
We missed doing so in #36047.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
| --- | --- |
| disabled plus before | Disabled plus after |
|<img width="78" height="79" alt="disasbled_icon_after" src="https://github.com/user-attachments/assets/44f0969b-2b61-4aad-919b-47fa01ba3828" /> | <img width="78" height="79" alt="disasbled_icon_before" src="https://github.com/user-attachments/assets/e4ef6ad4-0299-4f63-8a8d-2b1b1c6491f4" /> |
| Plus before | Plus After |
| <img width="78" height="79" alt="before_plus" src="https://github.com/user-attachments/assets/a09d3708-c5c0-4afb-9192-d8cadc83f119" /> |  <img width="78" height="79" alt="after_plus" src="https://github.com/user-attachments/assets/35f59d85-daf8-4723-902e-f69de2ed91b0" /> |
| hover plus before | hover plus after |
| <img width="78" height="79" alt="hover_plus-before" src="https://github.com/user-attachments/assets/868c965c-9c8a-41bf-85aa-c44e69630885" /> | <img width="78" height="79" alt="hover_plus_after" src="https://github.com/user-attachments/assets/b774271d-8dac-406d-bbf3-76e6e24f507e" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
