### PR TITLE
help: Update mobile instructions for browse and subscribe to channels.

### DIFF
--- a/starlight_help/src/content/docs/introduction-to-channels.mdx
+++ b/starlight_help/src/content/docs/introduction-to-channels.mdx
@@ -8,6 +8,7 @@ import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import NavigationSteps from "../../components/NavigationSteps.astro";
 import ZulipTip from "../../components/ZulipTip.astro";
 import ChannelsIntro from "../include/_ChannelsIntro.mdx";
+import MobileChannels from "../include/_MobileChannels.mdx";
 
 import BarChartIcon from "~icons/fa/bar-chart";
 import SortAlphaAscIcon from "~icons/fa/sort-alpha-asc";
@@ -45,15 +46,14 @@ subscribe to [private](/help/channel-permissions#private-channels) channels.
   </TabItem>
 
   <TabItem label="Mobile">
-    Access this feature by following the web app instructions in your mobile
-    device browser. You can also follow a link to an unsubscribed channel in
-    a Zulip message, press and hold the channel name until the long-press menu
-    appears, and tap **Subscribe**.
+    <FlattenedSteps>
+      <MobileChannels />
 
-    Implementation of a list of channels to subscribe to in the mobile app is
-    tracked [on GitHub](https://github.com/zulip/zulip-flutter/issues/188).
-    If you're interested in this feature, please react to the issue's
-    description with 👍.
+      1. Scroll to the bottom of the list of subscribed channels.
+      1. Tap **All Channels**.
+      1. Scroll through the list of channels.
+      1. Use the toggle to the right of the channel name to subscribe to it.
+    </FlattenedSteps>
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Update the mobile instructions for the new all channels view that allows users to browse and subscribe to channels on the mobile app.

Flutter issue: https://github.com/zulip/zulip-flutter/issues/188
Flutter PR: https://github.com/zulip/zulip-flutter/pull/1849
CZO discussion: [#mobile-team > release management](https://chat.zulip.org/#narrow/channel/243-mobile-team/topic/release.20management/with/2266436)

---

**Screenshots and screen captures:**

[CURRENT CZO DOCUMENTATION](https://chat.zulip.org/help/introduction-to-channels)
<img width="1029" height="496" alt="Screenshot From 2025-09-30 11-54-22" src="https://github.com/user-attachments/assets/69854a1f-0fe3-4b82-b29f-7d4fbc74b3a9" />
<details>
<summary>Desktop/Web instructions for comparison</summary>

<img width="1029" height="688" alt="Screenshot From 2025-09-30 11-54-31" src="https://github.com/user-attachments/assets/16056953-f967-4306-950e-973f19ca7bd6" />
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
