### PR TITLE
api-docs: Update "Delete a message" endpoint permissions.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10077,12 +10077,39 @@ paths:
       description: |
         Permanently delete a message.
 
-        This API corresponds to the
-        [delete a message completely][delete-completely] feature documented in
-        the Zulip help center.
+        This API corresponds to the [delete a message completely][delete-completely]
+        feature documented in the Zulip help center.
+
+        A user must be able to access the content of a message in order to delete it.
+        See [channel permissions](/help/channel-permissions) for more information
+        about content access for channel messages. For direct messages, the user
+        must have received or sent the direct message to have content access.
+
+        See [restricting message deletion](/help/restrict-message-editing-and-deletion)
+        for documentation on when users are allowed to delete messages.
+
+        The relevant realm settings in the API that are related to the above linked
+        documentation on when users are allowed to delete messages are:
+
+        - `realm_can_delete_any_message_group`
+        - `realm_can_delete_own_message_group`
+        - `realm_can_set_delete_message_policy_group`
+        - `realm_message_content_delete_limit_seconds`
+
+        The relevant per-channel permission settings in the API that are related to the
+        above linked documentation on when users are allowed to delete messages in a
+        specific channel are:
+
+        - `can_delete_any_message_group`
+        - `can_delete_own_message_group`
+
+        More details about these realm and channel settings can be found in the
+        [`POST /register`](/api/register-queue) response.
+
+        **Changes**: Prior to Zulip 10.0 (feature level 281), only organization
+        administrators had permission to permanently delete a message.
 
         [delete-completely]: /help/delete-a-message#delete-a-message-completely
-      x-requires-administrator: true
       parameters:
         - $ref: "#/components/parameters/MessageId"
       responses:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18990,6 +18990,12 @@ paths:
                               A [group-setting value](/api/group-setting-values) defining the set of
                               users who have permission to delete any message in the organization.
 
+                              Note that a user must also be able to access the content of a message
+                              in order to delete it. See [channel permissions](/help/channel-permissions)
+                              for information about content access for channel messages. For direct
+                              messages, the user must have received or sent the direct message to
+                              have content access.
+
                               **Changes**: New in Zulip 10.0 (feature level 281). Previously, this
                               permission was limited to administrators only and was uneditable.
                           - $ref: "#/components/schemas/GroupSettingValue"


### PR DESCRIPTION
Prior to feature level 281, the only users who had permissions to permanently delete any message in the organization were organization administrators.

Currently, various realm and channel permission settings, which use the user group model, determine if a user is able to permanently delete a specific message.

Updates the main description of the endpoint to note these settings and removes the note that the endpoint is limited to organization administrators.

**Notes**:
- Used the "Edit a message" endpoint main description as a template for these updates.
- Not sure if we want to include **Changes** notes for the realm and channel user-group settings. Currently, I only added a note for the 281 feature level when the `realm_can_delete_any_message_group` was added.
- Also updates the description of `realm_can_delete_any_message_group` in the register response to note that content access to a message is also needed to permanently delete it via the API.

Relevant CZO discussion: [#api documentation > delete-message](https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/delete-message/with/2264101)

---

**Screenshots and screen captures:**

[CURRENT DELETE MESSAGE DOC](https://zulip.com/api/delete-message)
<img width="1117" height="1090" alt="Screenshot From 2025-09-29 16-57-41" src="https://github.com/user-attachments/assets/c0e79415-505a-457a-917c-affd688e00d9" />

[CURRENT REGISTER RESPONSE DOC](https://zulip.com/api/register-queue): *search page for realm_can_delete_any_message_group*
<img width="1117" height="705" alt="Screenshot From 2025-09-29 17-11-25" src="https://github.com/user-attachments/assets/241c916d-0d85-4fcd-8f3a-201d6992d8c8" />


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
