### PR TITLE
templates: Add rel-canonical link to documentation pages.

### DIFF
--- a/templates/zerver/meta_tags.html
+++ b/templates/zerver/meta_tags.html
@@ -1,4 +1,7 @@
 <!-- Google / search engine tags -->
+{% if REL_CANONICAL_LINK %}
+<link rel="canonical" href="{{ REL_CANONICAL_LINK }}" />
+{% endif %}
 {% if allow_search_engine_indexing %}
     {% if PAGE_DESCRIPTION %}
     <meta name="description" content="{{ PAGE_DESCRIPTION }}" />

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -76,6 +76,10 @@ def add_api_url_context(
     context["html_settings_links"] = html_settings_links
 
 
+def add_canonical_link_context(context: dict[str, Any], request: HttpRequest) -> None:
+    context["REL_CANONICAL_LINK"] = f"https://zulip.com{request.path}"
+
+
 class ApiURLView(TemplateView):
     @override
     def get_context_data(self, **kwargs: Any) -> dict[str, str]:
@@ -200,6 +204,9 @@ class MarkdownDirectoryView(ApiURLView):
             else:
                 sidebar_index = None
             title_base = "Zulip terms and policies"
+            # We don't add a rel-canonical link to self-hosted server policies docs.
+            if settings.CORPORATE_ENABLED:
+                add_canonical_link_context(context, self.request)
         elif self.api_doc_view:
             context["page_is_api_center"] = True
             context["doc_root"] = "/api/"
@@ -207,6 +214,7 @@ class MarkdownDirectoryView(ApiURLView):
             sidebar_article = self.get_path("sidebar_index")
             sidebar_index = sidebar_article.article_path
             title_base = "Zulip API documentation"
+            add_canonical_link_context(context, self.request)
         else:
             raise AssertionError("Invalid documentation view type")
 
@@ -364,6 +372,7 @@ class IntegrationView(ApiURLView):
         context: dict[str, Any] = super().get_context_data(**kwargs)
         add_integrations_context(context)
         add_integrations_open_graph_context(context, self.request)
+        add_canonical_link_context(context, self.request)
         add_google_analytics_context(context)
         return context
 


### PR DESCRIPTION
Updates `templates/zerver/meta_tags.html` to add a rel-canonical link if `REL_CANONICAL_LINK` is in the template context dict.

**Notes**:
- This is a similar implementation to #36059, which adds the rel-canonical link to the help center docs.
- Adds `REL_CANONICAL_LINK` to the documentation context for the API and integrations documentation pages, both for self-hosted and Zulip Cloud organizations. The link will be self-referencing for the main https://zulip.com/ docs pages.
- The integrations doc pages don't update the page's head/meta data if a user navigates around the site, e.g., if you go to the main integrations page and then click on a category or integration, then page title and open graph data don't update for the updated request path. So, the rel-canonical link for integration docs will only be correctly set when the page loads.
- For policies documentation pages, adds `REL_CANONICAL_LINK` to the context only when `settings.CORPORATE_ENABLED` is true, so that self-hosted servers' policies documentation do not have a rel-canonical link set.

Relevant CZO discussion: [#documentation > rel=canonical](https://chat.zulip.org/#narrow/channel/19-documentation/topic/rel.3Dcanonical/with/2261040)

Part of #35110.

---

**Devtools screenshots:**

_GitLab integration doc_
<img width="1185" height="486" alt="Screenshot From 2025-09-29 21-13-51" src="https://github.com/user-attachments/assets/e89c36be-d6a4-4924-b725-3be868ac54b0" />

_API "Get messages" endpoint_
<img width="1216" height="486" alt="Screenshot From 2025-09-29 21-16-01" src="https://github.com/user-attachments/assets/230dec52-6cbc-4341-82bd-e39e6fc46d8c" />

_API changelog_
<img width="1216" height="486" alt="Screenshot From 2025-09-29 21-16-22" src="https://github.com/user-attachments/assets/486db3cb-7a7f-46d8-af6e-cc8d19e4ba4e" />

_Home API docs page_
<img width="1216" height="486" alt="Screenshot From 2025-09-29 21-20-07" src="https://github.com/user-attachments/assets/b96aac06-f9ca-4606-969b-55488ff2d0f7" />

_Policies doc with corporate enabled_
<img width="1216" height="486" alt="Screenshot From 2025-09-29 21-16-49" src="https://github.com/user-attachments/assets/7e6b63ba-40a8-41c8-be77-4c92b781fb27" />


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
