### PR TITLE
settings: Fix alignment of deactivate buttons in account settings.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -105,8 +105,11 @@ h3,
     cursor: not-allowed;
 }
 
-#account-settings .deactivate_realm_button {
-    margin-left: 10px;
+#account-settings .deactivate-buttons-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    flex-wrap: wrap;
 }
 
 #change_email_button,
@@ -2122,12 +2125,6 @@ label.preferences-radio-choice-label {
     #change_password_modal,
     #change_email_modal {
         width: 300px;
-    }
-}
-
-@media (width < $mm_min) {
-    .deactivate_realm_button {
-        margin-top: 20px;
     }
 }
 

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -68,7 +68,7 @@
                 {{/if}}
             </form>
 
-            <div class="input-group">
+            <div class="input-group deactivate-buttons-group">
                 <div id="deactivate_account_container" class="inline-block {{#if user_is_only_organization_owner}}disabled_setting_tooltip{{/if}}">
                     {{> ../components/action_button
                       label=(t "Deactivate account")
@@ -83,7 +83,7 @@
                       label=(t "Deactivate organization")
                       attention="quiet"
                       intent="danger"
-                      custom_classes="deactivate_realm_button inline-block"
+                      custom_classes="deactivate_realm_button"
                       }}
                 {{/if}}
             </div>


### PR DESCRIPTION
Fixes: #36104 

### Summary:

This PR fixes the misalignment of the "Deactivate account" and "Deactivate organization" buttons in the Account & Privacy settings panel. When both buttons are shown (for the sole owner of an organization), they now appear horizontally aligned and vertically centered, matching Zulip's UI consistency standards.
 
### What changed:

- Added a `#account-settings .deactivate-buttons-group` flexbox container to horizontally align the deactivate buttons
- Updated spacing and alignment to match Zulip's button group conventions (`gap: 0.5em`, `align-items: center`)
- Added `flex-wrap: wrap` to ensure proper layout responsiveness on narrow screens
- Removed unnecessary left margin from the "Deactivate organization" button for consistent appearance
- Ensured the layout works at all font sizes and screen widths

## **Screenshots and screen captures:**

### Desktop view:
| Before | After |
| --- | --- |
| <img width="1613" height="552" alt="image" src="https://github.com/user-attachments/assets/b7c66eae-85c1-4b8f-ba98-617e4834fd71" />  | <img width="1613" height="552" alt="Screenshot 2025-10-09 144442" src="https://github.com/user-attachments/assets/e3b11826-2f11-47a8-99b8-9cc5e926063f" /> |


### Narrow screen view:
| Before | After |
| --- | --- |
| <img width="294" height="178" alt="image" src="https://github.com/user-attachments/assets/d5314043-6a6f-44ec-9c43-82c42b3fc931" /> | <img width="316" height="184" alt="Screenshot 2025-10-09 144527" src="https://github.com/user-attachments/assets/25fb891d-b09c-4e4b-81d6-04ddece0b93a" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

