### PR TITLE
search: Remove outline for focused pills in the typeahead.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -424,9 +424,18 @@
                     1fr
                 );
 
+            /* We don't show a border for focused pills
+               in the search typeahead */
             &:focus {
-                /* Keep the border the same color, there's no user interaction for users in the typeahead menu */
+                /* Regular pills use box-shadow. */
+                box-shadow: none;
+
+                /* User pills use border */
                 border-color: var(--color-background-input-pill);
+
+                .pill-image-border {
+                    border-color: var(--color-border-input-pill-image);
+                }
             }
 
             .exit {


### PR DESCRIPTION
Reported here:
https://chat.zulip.org/#narrow/channel/9-issues/topic/extraneous.20box.20when.20clicking.20on.20search.20pill.20in.20typeahead/near/2268435
