### PR TITLE
[6.x] pgroonga: Remove now-unnecessary 'GRANT USAGE' statement.

### DIFF
--- a/puppet/zulip/manifests/postgresql_base.pp
+++ b/puppet/zulip/manifests/postgresql_base.pp
@@ -89,20 +89,10 @@ class zulip::postgresql_base {
     }
 
     $dbname = zulipconf('postgresql', 'database_name', 'zulip')
-    $dbuser = zulipconf('postgresql', 'database_user', 'zulip')
-    file { $pgroonga_setup_sql_path:
-      ensure  => file,
-      require => Package["${postgresql}-pgdg-pgroonga"],
-      owner   => 'postgres',
-      group   => 'postgres',
-      mode    => '0640',
-      content => template('zulip/postgresql/pgroonga_setup.sql.template.erb'),
-    }
-
     exec{'create_pgroonga_extension':
-      require => File[$pgroonga_setup_sql_path],
+      require => Package["${postgresql}-pgdg-pgroonga"],
       # lint:ignore:140chars
-      command => "bash -c 'cat ${pgroonga_setup_sql_path} | su postgres -c \"psql -v ON_ERROR_STOP=1 ${dbname}\" && touch ${pgroonga_setup_sql_path}.applied'",
+      command => "bash -c 'echo \"CREATE EXTENSION PGROONGA\" | su postgres -c \"psql -v ON_ERROR_STOP=1 ${dbname}\" && touch ${pgroonga_setup_sql_path}.applied'",
       # lint:endignore
       creates => "${pgroonga_setup_sql_path}.applied",
     }

--- a/puppet/zulip/templates/postgresql/pgroonga_setup.sql.template.erb
+++ b/puppet/zulip/templates/postgresql/pgroonga_setup.sql.template.erb
@@ -1,2 +1,0 @@
-CREATE EXTENSION PGROONGA;
-GRANT USAGE ON SCHEMA pgroonga TO <%= @dbuser %>;

--- a/scripts/setup/create-pgroonga.sql
+++ b/scripts/setup/create-pgroonga.sql
@@ -1,3 +1,2 @@
 \connect zulip
 CREATE EXTENSION pgroonga;
-GRANT USAGE ON SCHEMA pgroonga TO zulip;

--- a/tools/setup/postgresql-init-dev-db
+++ b/tools/setup/postgresql-init-dev-db
@@ -108,7 +108,6 @@ EOF
 
 "${ROOT_POSTGRES[@]}" -v ON_ERROR_STOP=1 -e "$DBNAME_BASE" <<EOF
 CREATE EXTENSION pgroonga;
-GRANT USAGE ON SCHEMA pgroonga TO $USERNAME;
 EOF
 
 psql -v ON_ERROR_STOP=1 -e -h localhost postgres "$USERNAME" <<EOF


### PR DESCRIPTION
Backport to 6.x:

- part of #26097

in an effort to fix python-zulip-api CI:

- zulip/python-zulip-api#878