### PR TITLE
feat(portico): Improve Altcha verification visual feedback

### DIFF
--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -385,12 +385,31 @@ $(() => {
                 return fetch(url, {...init, credentials: "include"});
             },
         });
+
         const $submit = $(altcha).closest("form").find("button[type=submit]");
         $submit.prop("disabled", true);
+
+        const $text_container = $(altcha).find(".altcha-text-container");
+        const $loader = $text_container.find(".altcha-loader");
+        const $confirmation = $text_container.find(".altcha-confirmation");
+
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         altcha.addEventListener("statechange", ((ev: AltchaStateChangeEvent) => {
-            if (ev.detail.state === "verified") {
+            $loader.hide();
+            $confirmation.hide();
+
+            if (ev.detail.state === "verifying" || ev.detail.state === "solving") {
+                // Show a loader when verification is in progress.
+                $loader.show();
+                $submit.prop("disabled", true);
+            } else if (ev.detail.state === "verified") {
+                // Show the verification confirmation message for a few seconds.
+                $confirmation.show();
                 $submit.prop("disabled", false);
+
+                setTimeout(() => {
+                    $confirmation.fadeOut(400);
+                }, 3000); // 3 seconds
             }
         }) as EventListener);
     }

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -342,6 +342,12 @@ class AltchaWidget(forms.TextInput):
         attrs: dict[str, Any] | None = None,
         renderer: BaseRenderer | None = None,
     ) -> SafeString:
+        altcha_strings = orjson.dumps(
+            {
+                "verified": _("Verified that you're a human user!"),
+                "verifying": _("Verifying that you're not a bot…"),
+            }
+        ).decode()
         return format_html(
             (
                 "<altcha-widget"
@@ -349,21 +355,19 @@ class AltchaWidget(forms.TextInput):
                 '  challengeurl="/json/antispam_challenge"'
                 "  hidelogo"
                 "  hidefooter"
-                '  floating="bottom"'
                 "  refetchonexpire"
                 '  style="{}"'
                 '  strings="{}"'
                 ">"
+                '<div class="altcha-text-container">'
+                    '<div class="altcha-loader loading-indicator-spinner"></div>'
+                    '<div class="altcha-confirmation">{}</div>'
+                "</div>"
             ),
             "--altcha-max-width: 300px;",
-            orjson.dumps(
-                {
-                    "verified": _("Verified that you're a human user!"),
-                    "verifying": _("Verifying that you're not a bot…"),
-                }
-            ).decode(),
+            altcha_strings,
+            _("Verified that you're a human user!"),
         )
-
 
 class CaptchaRealmCreationForm(RealmCreationForm):
     captcha = forms.CharField(required=True, widget=AltchaWidget)


### PR DESCRIPTION
feat(portico): Improve Altcha verification visual feedback

This commit implements a custom loader and a fading confirmation message for the Altcha widget to replace the default subtle checkbox behavior.

We implemented:
* Updated HTML structure in `zerver/forms.py` to include the new container, loader, and confirmation elements.
* Added the state change logic in `web/src/portico/signup.ts` to control the visibility of the loader and the confirmation text, and to temporarily disable the Submit button during verification.

**Status on Styling:**
I was unable to locate the correct `.scss` file (looked for `portico.scss` and `portico_signin.scss`) to apply the necessary styling, specifically to hide the duplicate default Altcha UI (`.altcha-main`) and style the new elements. The current implementation shows duplicate 'Verified' messages.
Could a maintainer please point me to the correct SCSS file for the portico sign-up forms so I can complete the styling?

Fixes: #36086