### PR TITLE
markdown: Reduce paragraph-list spacing to 1/4.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -17,8 +17,8 @@
         &:has(+ ul, + ol) {
             /* When a paragraph is immediately followed
                by a list sibling, we reduce the paragraph's
-               ordinary bottom space by half. */
-            margin-bottom: calc(var(--markdown-interelement-space-px) / 2);
+               ordinary bottom space to a quarter. */
+            margin-bottom: calc(var(--markdown-interelement-space-px) / 4);
         }
     }
 


### PR DESCRIPTION
This PR is an experiment to further reduce the space between a paragraph and the list that follows it.

Discussion: [#issues > spacing above bulleted list @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/spacing.20above.20bulleted.20list/near/2239724)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Showing default, loosest, and tightest info-density line height:_

| Before | After |
| --- | --- |
| <img width="1400" height="1200" alt="normal-before" src="https://github.com/user-attachments/assets/72502530-18ed-47e0-8067-d9e9d7c75e5b" /> | <img width="1400" height="1200" alt="normal-after" src="https://github.com/user-attachments/assets/193cbba4-220c-4d3d-959b-0d099d63023b" /> |
| <img width="1400" height="1200" alt="extra-loose-before" src="https://github.com/user-attachments/assets/9ecaf74a-21b2-4bcb-8f7a-df1bb2d5f858" /> | <img width="1400" height="1200" alt="extra-loose-after" src="https://github.com/user-attachments/assets/5b4e22ea-edcf-4833-9107-fd58f05ef584" /> |
| <img width="1400" height="1200" alt="extra-tight-before" src="https://github.com/user-attachments/assets/de0b766e-0576-41a4-a874-5b9310ad1d2e" /> | <img width="1400" height="1200" alt="extra-tight-after" src="https://github.com/user-attachments/assets/56547fe1-2e63-4b07-97c1-52abebb65448" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>