### PR TITLE
Add new integration category "Calling" for video and audio call integrations.

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -46,6 +46,7 @@ META_CATEGORY: dict[str, StrPromise] = {
 
 CATEGORIES: dict[str, StrPromise] = {
     **META_CATEGORY,
+    "video-calling": gettext_lazy("Video calling"),
     "continuous-integration": gettext_lazy("Continuous integration"),
     "customer-support": gettext_lazy("Customer support"),
     "deployment": gettext_lazy("Deployment"),
@@ -615,7 +616,7 @@ WEBHOOK_INTEGRATIONS: list[WebhookIntegration] = [
 INTEGRATIONS: dict[str, Integration] = {
     "asana": Integration("asana", ["project-management"]),
     "big-blue-button": Integration(
-        "big-blue-button", ["communication"], display_name="BigBlueButton"
+        "big-blue-button", ["video-calling", "communication"], display_name="BigBlueButton"
     ),
     "capistrano": Integration("capistrano", ["deployment"], display_name="Capistrano"),
     "discourse": Integration("discourse", ["communication"]),
@@ -630,13 +631,13 @@ INTEGRATIONS: dict[str, Integration] = {
     ),
     "hubot": Integration("hubot", ["meta-integration", "bots"]),
     "jenkins": Integration("jenkins", ["continuous-integration"]),
-    "jitsi": Integration("jitsi", ["communication"], display_name="Jitsi Meet"),
+    "jitsi": Integration("jitsi", ["video-calling", "communication"], display_name="Jitsi Meet"),
     "mastodon": Integration("mastodon", ["communication"]),
     "notion": Integration("notion", ["productivity"]),
     "onyx": Integration("onyx", ["productivity"], logo="images/integrations/logos/onyx.png"),
     "puppet": Integration("puppet", ["deployment"]),
     "redmine": Integration("redmine", ["project-management"]),
-    "zoom": Integration("zoom", ["communication"]),
+    "zoom": Integration("zoom", ["video-calling", "communication"]),
 }
 
 PYTHON_API_INTEGRATIONS: list[PythonAPIIntegration] = [


### PR DESCRIPTION
**Motivation**: Each of these "calling" integrations' docs link to all the other "calling" integrations. With the addition of the new video call integration "Constructor Groups", the list keeps getting larger. With the new category, all the 4 links can be replaced with a single link to the category of integrations.

- I've added the "Calling" category in addition to the "Communication" category that these integrations were tagged under. So, "Calling" serves as a sub-category inside "Communication", but this relationship is not visible in the UI.
- The category name "Calling" was suggested in CZO. Is "Video and audio call integrations" suitable for the link text?
- Technically, we can use the category button (image attached) shown below the integration logo. But, I've added the link to the "Related documentation" section of each doc to suggest the link more explicitly.
<img width="234" height="426" alt="image" src="https://github.com/user-attachments/assets/d817247c-b5d5-499e-991d-c26526ad377a" />

<details>
<summary><h3>Screenshots</h3></summary>

<img width="1222" height="786" alt="image" src="https://github.com/user-attachments/assets/2124024b-f996-4b63-882a-45de992ac065" />

[BigBlueButton](https://zulip.com/integrations/doc/bigbluebutton)
<img width="445" height="201" alt="image" src="https://github.com/user-attachments/assets/2c2e9b7b-cd3c-4564-8d1b-7ca334e4c5ae" />

[Jitsi Meet](https://zulip.com/integrations/doc/jitsi)
<img width="445" height="201" alt="image" src="https://github.com/user-attachments/assets/28f2a794-165e-48f4-9e39-049156516760" />

[Zoom](https://zulip.com/integrations/doc/zoom)
<img width="445" height="201" alt="image" src="https://github.com/user-attachments/assets/4500934a-5340-4a68-8a01-af3100f9a1c1" />

[Start a call](https://zulip.com/help/start-a-call)
<img width="445" height="201" alt="image" src="https://github.com/user-attachments/assets/d2037a66-d24f-4846-83f4-58a4aced775a" />

[Configure call provider](https://zulip.com//help/configure-call-provider)
<img width="445" height="201" alt="image" src="https://github.com/user-attachments/assets/b9da71d5-d346-42b2-935a-16b9691060e4" />


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
