### PR TITLE
Expand PagerDuty V3 webhook events to include new types

### DIFF
--- a/zerver/webhooks/pagerduty/view.py
+++ b/zerver/webhooks/pagerduty/view.py
@@ -31,11 +31,30 @@ PAGER_DUTY_EVENT_NAMES_V2 = {
 }
 
 PAGER_DUTY_EVENT_NAMES_V3 = {
-    "incident.triggered": "triggered",
-    "incident.acknowledged": "acknowledged",
-    "incident.unacknowledged": "unacknowledged",
-    "incident.resolved": "resolved",
-    "incident.reassigned": "reassigned",
+"incident.acknowledged",
+"incident.annotated", 
+"incident.conference_bridge.updated",
+"incident.custom_field_values.updated",
+"incident.delegated",
+"incident.escalated",
+"incident.incident_type.changed",
+"incident.priority_updated",
+"incident.reassigned",
+"incident.reopened",
+"incident.resolved",
+"incident.responder.added",
+"incident.responder.replied",
+"incident.service_updated",
+"incident.status_update_published",
+"incident.triggered",
+"incident.unacknowledged",
+"incident.workflow.started",
+"incident.workflow.completed",
+ 
+"service.created",
+"service.custom_field_values.updated",
+"service.deleted",
+"service.updated"
 }
 
 ALL_EVENT_TYPES = [


### PR DESCRIPTION
Expanding the event types supported by zulip for Pagerduty v3 webhook. V3 Incident Types 
- incident.annotated
- incident.conference_bridge.updated
- incident.custom_field_values.updated
- incident.delegated
- incident.escalated
- incident.incident_type.changed
- incident.priority_updated
- incident.reopened
- incident.responder.added
- incident.responder.replied
- incident.service_updated
- incident.status_update_published
- incident.workflow.started
- incident.workflow.completed

V3 Service Events
- service.created
- service.updated
- service.deleted
- service.custom_field_values.updated

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
