### PR TITLE
templates: For 11.x backport, add rel-canonical link to documentation pages.

### DIFF
--- a/templates/zerver/meta_tags.html
+++ b/templates/zerver/meta_tags.html
@@ -1,4 +1,7 @@
 <!-- Google / search engine tags -->
+{% if REL_CANONICAL_LINK %}
+<link rel="canonical" href="{{ REL_CANONICAL_LINK }}" />
+{% endif %}
 {% if allow_search_engine_indexing %}
     {% if PAGE_DESCRIPTION %}
     <meta name="description" content="{{ PAGE_DESCRIPTION }}" />

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -75,6 +75,10 @@ def add_api_url_context(
     context["html_settings_links"] = html_settings_links
 
 
+def add_canonical_link_context(context: dict[str, Any], request: HttpRequest) -> None:
+    context["REL_CANONICAL_LINK"] = f"https://zulip.com{request.path}"
+
+
 class ApiURLView(TemplateView):
     @override
     def get_context_data(self, **kwargs: Any) -> dict[str, str]:
@@ -209,6 +213,7 @@ class MarkdownDirectoryView(ApiURLView):
             sidebar_article = self.get_path("include/sidebar_index")
             sidebar_index = sidebar_article.article_path
             title_base = "Zulip help center"
+            add_canonical_link_context(context, self.request)
         elif self.policies_view:
             context["page_is_policy_center"] = True
             context["doc_root"] = "/policies/"
@@ -219,6 +224,9 @@ class MarkdownDirectoryView(ApiURLView):
             else:
                 sidebar_index = None
             title_base = "Zulip terms and policies"
+            # We don't add a rel-canonical link to self-hosted server policies docs.
+            if settings.CORPORATE_ENABLED:
+                add_canonical_link_context(context, self.request)
         elif self.api_doc_view:
             context["page_is_api_center"] = True
             context["doc_root"] = "/api/"
@@ -226,6 +234,7 @@ class MarkdownDirectoryView(ApiURLView):
             sidebar_article = self.get_path("sidebar_index")
             sidebar_index = sidebar_article.article_path
             title_base = "Zulip API documentation"
+            add_canonical_link_context(context, self.request)
         else:
             raise AssertionError("Invalid documentation view type")
 
@@ -383,6 +392,7 @@ class IntegrationView(ApiURLView):
         context: dict[str, Any] = super().get_context_data(**kwargs)
         add_integrations_context(context)
         add_integrations_open_graph_context(context, self.request)
+        add_canonical_link_context(context, self.request)
         add_google_analytics_context(context)
         return context
 


### PR DESCRIPTION
Updates `templates/zerver/meta_tags.html` to add a rel-canonical link if `REL_CANONICAL_LINK` is in the template context dict.

**Notes**:
- These are basically the same changes as in #36146 (merged commit in `main` is 6fb19fdd2dd8538d9c52d0afa4f36b435897aa97), but includes adding the rel-canonical link to the help center docs prior to the starlight/astro migration.
- Adds `REL_CANONICAL_LINK` to the documentation context for the help center, API and integrations documentation pages in all cases.
- For policies documentation pages, adds `REL_CANONICAL_LINK` to the context only when `settings.CORPORATE_ENABLED` is true, so that self-hosted servers' policies documentation do not have a rel-canonical link set.

---

**Main help center page**:
<img width="1101" height="483" alt="Screenshot From 2025-10-06 12-52-36" src="https://github.com/user-attachments/assets/bc642d39-8b6d-4213-b3cf-7f34680f692e" />

**Specific article in help center**:
<img width="1101" height="483" alt="Screenshot From 2025-10-06 12-53-03" src="https://github.com/user-attachments/assets/c09c17e4-1237-4e65-8984-f5586df39193" />

**Policies page with corporate enabled**:
<img width="1101" height="483" alt="Screenshot From 2025-10-06 12-53-20" src="https://github.com/user-attachments/assets/12c8a0ec-fec3-4aea-9ba5-67f15bdfbe38" />

**Integrations article**:
<img width="1101" height="483" alt="Screenshot From 2025-10-06 12-53-40" src="https://github.com/user-attachments/assets/399b169e-278d-4d03-87d3-45e5068893c6" />

**API changelog**:
<img width="1101" height="483" alt="Screenshot From 2025-10-06 12-53-56" src="https://github.com/user-attachments/assets/8e1cddda-6fd8-4362-8503-bf44c9272bd1" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
