### PR TITLE
css: Do not use non-color values inside light-dark().

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1396,7 +1396,7 @@ input.invalid-input {
     border-color: var(--color-invalid-input-border) !important;
 
     &:focus {
-        box-shadow: var(--color-invalid-input-box-shadow);
+        box-shadow: var(--invalid-input-box-shadow);
     }
 }
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1019,9 +1019,10 @@
         hsl(3deg 57% 33%),
         hsl(3deg 73% 74%)
     );
+    --invalid-input-box-shadow: 0 0 2px var(--color-invalid-input-box-shadow);
     --color-invalid-input-box-shadow: light-dark(
-        0 0 2px hsl(3deg 57% 33%),
-        0 0 2px hsl(3deg 73% 74%)
+        hsl(3deg 57% 33%),
+        hsl(3deg 73% 74%)
     );
     --color-background-white-box: light-dark(
         hsl(0deg 0% 100%),

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -345,7 +345,7 @@
     &:has(.new_message_textarea.invalid),
     &:has(.new_message_textarea.invalid:focus) {
         border-color: var(--color-invalid-input-border);
-        box-shadow: var(--color-invalid-input-box-shadow);
+        box-shadow: var(--invalid-input-box-shadow);
     }
 }
 

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -232,7 +232,7 @@
 
     &.invalid {
         border-color: var(--color-invalid-input-border);
-        box-shadow: var(--color-invalid-input-box-shadow);
+        box-shadow: var(--invalid-input-box-shadow);
     }
 }
 


### PR DESCRIPTION
Non-color values are not permitted inside light-dark(). This commit fixes that for --color-invalid-input-box-shadow.
