### PR TITLE
upgrade-zulip-from-git: Provide better error message on a bad refname.

### DIFF
--- a/scripts/lib/upgrade-zulip-from-git
+++ b/scripts/lib/upgrade-zulip-from-git
@@ -148,28 +148,34 @@ try:
         )
 
     # Generate the deployment directory via git worktree from our local repository.
-    try:
-        fullref = f"refs/tags/{refname}"
-        commit_hash = subprocess.check_output(
-            ["git", "rev-parse", "--verify", fullref],
+    try_refs = [
+        f"refs/tags/{refname}",
+        f"refs/heads/{refname}" if args.local_ref else f"refs/remotes/origin/{refname}",
+    ]
+    commit_hash: str | None = None
+    fullref: str | None = None
+    for ref in try_refs:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", ref],
             preexec_fn=su_to_zulip,
             text=True,
             stderr=subprocess.DEVNULL,
-        ).strip()
-    except subprocess.CalledProcessError as e:
-        if e.returncode == 128:
-            # Try in the origin namespace, or local heads if --local-ref
-            if args.local_ref:
-                fullref = f"refs/heads/{refname}"
-            else:
-                fullref = f"refs/remotes/origin/{refname}"
-            commit_hash = subprocess.check_output(
-                ["git", "rev-parse", "--verify", fullref],
-                preexec_fn=su_to_zulip,
-                text=True,
-                stderr=subprocess.DEVNULL,
-            ).strip()
-    refname = fullref
+            check=False,
+        )
+        if result.returncode == 0:
+            fullref = ref
+            commit_hash = result.stdout.strip()
+            break
+        elif result.returncode != 128:
+            result.check_returncode()
+    if not commit_hash or not fullref:
+        logging.error(
+            "Failed to resolve %s as a tag or %s branch name!",
+            refname,
+            "local" if args.local_ref else "remote",
+        )
+        sys.exit(1)
+
     subprocess.check_call(
         ["git", "worktree", "add", "--detach", deploy_path, refname],
         stdout=subprocess.DEVNULL,


### PR DESCRIPTION
Before:

```
# ./scripts/upgrade-zulip-from-git --remote-url https://github.com/alexmv/zulip.git moose
Traceback (most recent call last):
  File "/home/zulip/deployments/2025-10-07-19-23-54/./scripts/lib/upgrade-zulip-from-git", line 153, in <module>
    commit_hash = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'rev-parse', '--verify', 'refs/tags/moose']' returned non-zero exit status 128.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/zulip/deployments/2025-10-07-19-23-54/./scripts/lib/upgrade-zulip-from-git", line 166, in <module>
    commit_hash = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'rev-parse', '--verify', 'refs/remotes/origin/moose']' returned non-zero exit status 128.

Zulip upgrade failed (exit code 1)!

The upgrade process is designed to be idempotent, so you can retry after resolving whatever issue caused the failure (there should be a traceback above). A log of this installation is available in /var/log/zulip/upgrade.log
```

After:

```
# ./scripts/upgrade-zulip-from-git --remote-url https://github.com/alexmv/zulip.git moose
2025-10-08 01:57:36,253 upgrade-zulip-from-git: Failed to resolve moose as a tag or remote branch name!

Zulip upgrade failed (exit code 1)!

The upgrade process is designed to be idempotent, so you can retry after resolving whatever issue caused the failure (there should be a traceback above). A log of this installation is available in /var/log/zulip/upgrade.log
```

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
