### PR TITLE
overlay: Make sure all overlays have the same box shadow in dark mode. 

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1118,6 +1118,12 @@ input.settings_text_input {
     }
 }
 
+div.overlay .flex.overlay-content > .overlay-container,
+#settings_page,
+.informational-overlays .overlay-content {
+    box-shadow: var(--box-shadow-overlay);
+}
+
 .delete-selected-drafts-button-container {
     display: flex;
 }

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -404,6 +404,9 @@
     */
     --message-area-max-width: 57.4125em;
 
+    /* Box shadow for overlays across the web app */
+    --box-shadow-overlay: none;
+
     /* Shared sidebar typography and effects values. */
     --font-weight-sidebar-heading: 600;
     --font-weight-sidebar-action-heading: 370;
@@ -3008,6 +3011,9 @@
        don't apply negative margin that would otherwise pull
        the unread marker to the left. */
     --unread-marker-left: 0;
+
+    /* Box shadow for overlays across the web app */
+    --box-shadow-overlay: 0 0 30px hsl(212deg 32% 7%);
 
     /* Colors used across the app */
     --color-recipient-bar-controls-spinner: hsl(0deg 0% 100%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -107,12 +107,6 @@
         border-color: hsl(0deg 0% 0% / 90%);
     }
 
-    & div.overlay .flex.overlay-content > .overlay-container,
-    #settings_page,
-    .informational-overlays .overlay-content {
-        box-shadow: 0 0 30px hsl(212deg 32% 7%);
-    }
-
     .popover hr,
     hr {
         opacity: 0.2;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -113,14 +113,6 @@
         box-shadow: 0 0 30px hsl(212deg 32% 7%);
     }
 
-    #draft_overlay,
-    #scheduled_messages_overlay_container,
-    #message-edit-history-overlay-container {
-        .flex.overlay-content > .overlay-container {
-            box-shadow: 0 0 30px hsl(213deg 31% 0%);
-        }
-    }
-
     .popover hr,
     hr {
         opacity: 0.2;


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Screenshots have been included for visual changes, rest remains unchanged in the refactor, and the changes might be clear enough to not need screenshots.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Name                 | Before                                                                                                                                               | After                                                                                                                                                |
|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
| edit_history_overlay | <img width="1150" height="762" alt="edit_history_overlay_before" src="https://github.com/user-attachments/assets/46a29cc0-a67c-489d-a2d7-424021cea1e6" /> | <img width="1150" height="762" alt="edit_history_overlay_after" src="https://github.com/user-attachments/assets/1a8a8dde-bfd1-4ee1-b620-dc3addce8d0e" /> |
| reminders_overlay    | <img width="1150" height="762" alt="reminders_overlay_before" src="https://github.com/user-attachments/assets/66c5e1e7-8cc9-4ff5-93cf-979a42941203" /> | <img width="1150" height="762" alt="reminders_overlay_after" src="https://github.com/user-attachments/assets/28bc4761-7681-4da2-b3c2-26e8e6172ba3" /> |
| drafts_overlay       | <img width="1150" height="762" alt="drafts_overlay_before" src="https://github.com/user-attachments/assets/4341eda5-7f1b-4b68-8d2a-b27eab0318d8" /> | <img width="1150" height="762" alt="drafts_overlay_after" src="https://github.com/user-attachments/assets/673d8642-cd9a-4ce4-85a8-fb551fac1c9f" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
