### PR TITLE
templates: Remove unnecessary "margin" class from register template.

### DIFF
--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -169,9 +169,9 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
             {% if default_stream_groups %}
             <hr />
             <div class="default-stream-groups">
-                <p class="margin">{{ _('What are you interested in?') }}</p>
+                <p>{{ _('What are you interested in?') }}</p>
                 {% for default_stream_group in default_stream_groups %}
-                <div class="input-group margin">
+                <div class="input-group">
                     <label for="id_default_stream_group__{{ default_stream_group.id }}"
                       class="inline-block checkbox">
                         <input class="inline-block" type="checkbox"
@@ -218,7 +218,7 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
             </div>
             {% endif %}
 
-            <div class="input-group margin terms-of-service">
+            <div class="input-group terms-of-service">
                 {% if terms_of_service %}
                 <div class="input-group">
                     {#

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -898,10 +898,6 @@ input.new-organization-button {
 }
 
 .input-group {
-    &.margin {
-        margin: 10px 0;
-    }
-
     .progress {
         margin: 0;
         margin-top: 5px;


### PR DESCRIPTION
Removes the instances of the "margin" class from `register.html` and the portico CSS rule. Doing so does not result in any visible changes in the only place it was being applied the terms of service checkbox on the page.

**Notes**:
- Prior to these changes, `git grep '\.margin' web/styles/` returned only one rule with this class name.
- Would have renamed the class/rule, but as it's not doing anything on the page, it seemed better to just remove them.
  - The div for the terms still has a bottom margin of 10px applied through another CSS rule.
  - The 10px top margin was overlapping with the bottom margin of the div or fieldset element above the terms div. See screenshots below.
- As `default_stream_groups` is always false, that section of the template is not rendered on the page.

<details>
<summary>git grep for "margin" in templates directory after changes</summary>

```
$ git grep margin templates/
templates/corporate/case-studies/end-point-case-study.md:painful to use, you marginalize remote staff,” as conversations move from chat
templates/corporate/development-community.html:        <div class="bottom-register-buttons extra_margin_before_footer">
templates/corporate/for/communities.html:    <div class="bottom-register-buttons extra_margin_before_footer">
templates/corporate/for/open-source.html:    <div class="bottom-register-buttons extra_margin_before_footer">
templates/corporate/for/research.html:        <div class="bottom-register-buttons extra_margin_before_footer">
templates/corporate/partners.html:            <div class="bottom-register-buttons extra_margin_before_footer">
templates/zerver/app/index.html:    margin: auto;
templates/zerver/emails/email.css:    margin: 0;
templates/zerver/emails/email.css:    margin: 0 auto !important;
templates/zerver/emails/email.css:    margin: 20px auto 0;
templates/zerver/emails/email.css:    margin-top: 20px;
templates/zerver/emails/email.css:    margin-top: 25px;
templates/zerver/emails/email.css:    margin-bottom: 5px;
templates/zerver/emails/email.css:    margin: 10px 0;
templates/zerver/emails/email.css:    margin-left: 15px;
templates/zerver/emails/email.css:    margin: 20px auto;
templates/zerver/emails/email.css:    margin-bottom: 4px;
templates/zerver/emails/email.css:    margin-left: 1px;
templates/zerver/emails/email.css:    margin-right: 2px;
templates/zerver/emails/email.css:    margin: 0 0 20px;
templates/zerver/emails/email.css:        margin-bottom: 10px !important;
templates/zerver/footer.html:                <li class="extra_margin"><a href="/apps/">{{ _("Desktop & mobile apps") }}</a></li>
templates/zerver/footer.html:                <li class="extra_margin"><a href="/for/communities/">{{ _("Communities") }}</a></li>
templates/zerver/footer.html:                <li class="extra_margin"><a href="https://status.zulip.com/">{{ _("Zulip Cloud status") }}</a></li>
```
</details>

---

**Screenshots and screen captures:**

*New organization registration*
| Before | After |
| --- | --- |
| <img width="636" height="447" alt="Screenshot From 2025-10-08 14-48-20" src="https://github.com/user-attachments/assets/9704df2a-c54b-4cbc-ad07-250989b9e6fc" /> | <img width="636" height="447" alt="Screenshot From 2025-10-08 14-48-59" src="https://github.com/user-attachments/assets/9acd11ef-eba4-4aa4-9291-c4d74f1dd816" />

*New user registration*
| Before | After |
| --- | --- |
| <img width="636" height="486" alt="Screenshot From 2025-10-08 15-01-01" src="https://github.com/user-attachments/assets/c166da92-3f92-4855-b43e-0e44cd773a90" /> | <img width="636" height="486" alt="Screenshot From 2025-10-08 15-01-59" src="https://github.com/user-attachments/assets/0a3053c6-e75f-4538-97ad-4ce1874ce3ee" />


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
