### PR TITLE
compose: Automatically save drafts while typing

### DIFF
--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -57,6 +57,14 @@ function setup_compose_actions_hooks(): void {
     compose_actions.register_compose_cancel_hook(compose_call.abort_video_callbacks);
 }
 
+const throttled_update_draft = _.throttle(
+    () => {
+        drafts.update_draft({no_notify: true});
+    },
+    60000,
+    {leading: false, trailing: true},
+);
+
 export function initialize(): void {
     // Register hooks for compose_actions.
     setup_compose_actions_hooks();
@@ -109,6 +117,9 @@ export function initialize(): void {
         if (compose_state.get_is_content_unedited_restored_draft()) {
             compose_state.set_is_content_unedited_restored_draft(false);
         }
+
+        // We occasionally update the saved draft while the user is typing to minimize data loss risk.
+        throttled_update_draft();
     });
 
     $("#compose form").on("submit", (e) => {

--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -444,10 +444,12 @@ export let update_draft = (opts: UpdateDraftOptions = {}): string | undefined =>
 
     if (draft === undefined) {
         // The user cleared the compose box, which means
-        // there is nothing to save here but delete the
-        // draft if exists.
+        // there is nothing to save here. Delete any existing draft
+        // and reset the draft id so the next attempt will create
+        // a fresh draft.
         if (draft_id) {
             draft_model.deleteDrafts([draft_id]);
+            compose_draft_id = undefined;
         }
         return undefined;
     }


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #36102
Fixes: [#36762](https://github.com/zulip/zulip/issues/36762)

This PR improves the compose box reliability by adding an auto-save mechanism that ensures drafts are saved automatically while the user is typing. This helps prevent message loss in scenarios such as bad network connections, accidental tab closures, or power loss.

## Implementation

Added throttled auto-save for compose drafts that triggers at most once every 60 seconds while the user is actively composing. The implementation uses Lodash's `throttle` function with `leading: false` and `trailing: true` to ensure the draft is saved after the user pauses typing.

**Key changes:**

1. **New `throttled_update_draft` function** (`web/src/compose.ts`):
   - Wraps `drafts.update_draft()` with a 60-second throttle
   - Configured with `leading: false` (don't save immediately on first input)
   - Configured with `trailing: true` (save once after typing pauses)

2. **Auto-save trigger** (`web/src/compose.ts`):
   - Called `throttled_update_draft()` in the compose textarea input event handler
   - Ensures drafts are created/updated automatically while typing

3. **Fix for draft recreation** (`web/src/drafts.ts`):
   - When a draft is cleared (content completely deleted), reset `compose_draft_id` to `undefined`
   - This forces creation of a new draft if the user starts typing again
   - Fixes existing bug where drafts weren't created after clearing content, switching tabs, and returning

## Testing

Manually tested the following scenarios:

- ✅ Start typing a message → verify draft is created after 60 seconds (for messages > 2 characters)
- ✅ Continue editing → verify draft updates at most once per 60 seconds
- ✅ Clear message completely and start typing again → verify new draft is created
- ✅ Clear message, switch to another browser tab, return and start typing → verify new draft is created (this previously failed)
- ✅ Type, wait for auto-save, then send message → verify draft is cleaned up properly

## Demo

<details>
<summary>Auto-save demonstration</summary>

https://github.com/user-attachments/assets/6ea78055-d37e-4579-8ba4-3398dc62001d

**Note:** The video shows a 5-second demo for brevity. In production, the auto-save interval is 60 seconds.

</details>

## Discussion

CZO thread: [#issues > 📂 save drafts more?](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20save.20drafts.20more.3F/near/2262154)

Related PR that introduced the original draft clear bug: #35444

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>