### PR TITLE
markdown: Support inline images using the `![alt text](url)` syntax.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 467**
+
+* [Message formatting](/api/message-formatting): The new Markdown
+  image syntax now only supports/permits uploaded images, not
+  third-party image URLs.
+
 **Feature level 466**
 
 * [`POST /register`](/api/register-queue): Added `realm_uuid`
@@ -247,6 +253,9 @@ element to plain escaped text.
   backwards-compatibility users in the format intended for clients
   using `POST /register` without the `user_list_incomplete` client
   capability.
+* [Message formatting](/api/message-formatting): Added support for
+  Markdown image syntax, in addition to the previous link-derived
+  image previews; these can be inserted into any block-level element.
 
 **Feature level 436**
 

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 466
+API_FEATURE_LEVEL = 467
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -548,7 +548,6 @@ html_formatter = HTMLFormatter(
 
 def process_inline_images_to_thumbnails(
     image_tag: Tag | None,
-    image_src: str,
     path_id: str,
     image_data: MarkdownImageMetadata | None,
     to_delete: set[str] | None,
@@ -652,7 +651,6 @@ def process_traditional_inline_images_to_thumbnails(
 
     return process_inline_images_to_thumbnails(
         image_tag,
-        image_link["href"],
         path_id,
         image_data,
         to_delete,
@@ -702,7 +700,7 @@ def rewrite_thumbnailed_images(
         image_data = images.get(path_id)
 
         image_changed, remaining_thumbnails_to_add = process_inline_images_to_thumbnails(
-            inline_image, image_src, path_id, image_data, to_delete
+            inline_image, path_id, image_data, to_delete
         )
 
         changed |= image_changed

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -4,7 +4,6 @@ import re
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import cast
 
 import pyvips
 from bs4 import BeautifulSoup
@@ -556,8 +555,9 @@ def process_inline_images_to_thumbnails(
 ) -> tuple[bool, str | None]:
     if placeholder_image_tag is None:
         assert image_link is not None
-        full_res_image_tag = cast(Tag | None, image_link.find("img", src=image_link["href"]))
-        if full_res_image_tag and image_data is not None:
+        full_res_image_tag = image_link.find("img", src=image_link["href"])
+        assert full_res_image_tag is None or isinstance(full_res_image_tag, Tag)
+        if full_res_image_tag is not None and image_data is not None:
             # The <img> element has the same src as the link,
             # which means this is an older, non-thumbnailed
             # version.  Let's replace the image with a spinner,

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -830,29 +830,6 @@ class MarkdownEmbedsTest(ZulipTestCase):
             f"""<p><a href="http://www.youtube.com/watch_videos?video_ids=nOJgD4fcZhI,i96UO8-GFvw">http://www.youtube.com/watch_videos?video_ids=nOJgD4fcZhI,i96UO8-GFvw</a></p>\n<div class="youtube-video message_inline_image"><a data-id="nOJgD4fcZhI" href="http://www.youtube.com/watch_videos?video_ids=nOJgD4fcZhI,i96UO8-GFvw"><img src="{get_camo_url("https://i.ytimg.com/vi/nOJgD4fcZhI/mqdefault.jpg")}"></a></div>""",
         )
 
-    def test_inline_image(self) -> None:
-        image_url = "https://www.google.com/images/srpr/logo4w.png"
-        msg = f"The Google logo looks like this: ![Google logo]({image_url}) and..."
-        converted = markdown_convert_wrapper(msg)
-        self.assertEqual(
-            converted,
-            f"""<p>The Google logo looks like this: <img alt="Google logo" data-original-src="{image_url}" src="{get_camo_url(image_url)}"> and...</p>""",
-        )
-
-        msg = '![foo](/url "the title")'
-        converted = markdown_convert_wrapper(msg)
-        self.assertEqual(
-            converted,
-            '<p><img alt="foo" data-original-src="/url" src="/url" title="the title"></p>',
-        )
-
-        msg = "![](/url)"
-        converted = markdown_convert_wrapper(msg)
-        self.assertEqual(
-            converted,
-            '<p><img alt="" data-original-src="/url" src="/url"></p>',
-        )
-
     def test_inline_image_preview(self) -> None:
         url = "http://cdn.wallpapersafari.com/13/6/16eVjx.jpeg"
         camo_url = get_camo_url(url)


### PR DESCRIPTION
This PR enables native Markdown support for inline images.

The following work remains here:

- [x] Address outstanding comments from the original PR, #34732
- [x] Move the commit for inserting the `![]()` syntax to the end of the commit list, so that the bulk of the logic here can be easily deployed to CZO for testing
- [x] Revise postprocess and message-list-hover logic to handle animated inline images
- [x] Add inline-images postprocess tests to cover animate-on-hover behavior
- [x] Double-check comments in `markdown/__init.py__` to make sure they don't reference functions on the frontend that have since been renamed
- [x] Modify Turndown to correctly handle quote + reply behavior on messages that include the inline-image syntax
- [x] Document the changes here, currently presented in a standalone PR: #36278
- [x] Add screenshots showing inline, some legacy images + replies, quote & replies
- [ ] Correct for non-image files (uploaded and remote) presented in the `![]()` syntax, and present them as links to the files in question: [CZO discussion](https://chat.zulip.org/#narrow/channel/3-backend/topic/inline-image.20corner.20cases/near/2278074)
- [ ] Possibly set the `has_image` flag on `self.zmd.zulip_message` in the `InlineImageProcessor` class, parallel to that action in `InlineInterestingLinkProcessor`: [CZO discussion](https://chat.zulip.org/#narrow/channel/3-backend/topic/inline-image.20corner.20cases/near/2278211)
- [x] Look at [deduplicating](https://github.com/zulip/zulip/pull/34732#discussion_r2395016995) the `zulip_specific_src_changes` function > unsure about this; might be a follow-up and something I open a discussion about in `#backend`
- [ ] The Changes section of the documentation commit must be updated with the correct Zulip version and feature levels when the changes from this PR are ready to ship.

<!-- Describe your pull request here.-->

Fixes: #28912

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Showing the original image presentation, the whole-message reply, and quote + reply:_

| Legacy images | Inline images | Tiny inline images | Me-message images | Inline gallery images|
| --- | --- | --- | --- |  --- |
| <img width="1400" height="2200" alt="legacy-image-replies" src="https://github.com/user-attachments/assets/e3ed06cf-27d1-4d1f-86e7-5de3813bae7d" /> | <img width="1400" height="2200" alt="inline-image-replies" src="https://github.com/user-attachments/assets/61182015-18a6-4b4a-b373-a2760bdf3d97" /> | <img width="1400" height="2200" alt="inline-tiny-image-replies" src="https://github.com/user-attachments/assets/be2a252b-7e2d-4115-b73b-41b1fc1e92f0" /> | <img width="1400" height="2200" alt="inline-me-message-image-replies" src="https://github.com/user-attachments/assets/410d978d-17e5-4c7f-9b1d-14b5656a7f2f" /> | <img width="1400" height="2200" alt="inline-gallery-image-replies" src="https://github.com/user-attachments/assets/df8995a9-41fe-4e22-b471-e5542544f9be" /> |

_Showing the expected behavior of loading spinners while inline images are thumbnailed:_

![inline-images-loading](https://github.com/user-attachments/assets/cb9f1f43-0d55-42b4-b047-b86640375d46)







<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
