### PR TITLE
scheduled_messages: Force save drafts of any length when scheduling.

### DIFF
--- a/web/src/compose.ts
+++ b/web/src/compose.ts
@@ -435,6 +435,7 @@ function schedule_message_to_custom_date(): void {
         no_notify: true,
         update_count: false,
         is_sending_saving: true,
+        force_save: true,
     });
     assert(draft_id !== undefined);
 


### PR DESCRIPTION
Previously, if you wrote a two character message and attempted to schedule it, there would be an assertion error on the draft_id because we don't allow saving drafts with messages less than two characters without `force_save=true`.

[#issues > scheduling short messages @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/scheduling.20short.20messages/near/2273885)