### PR TITLE
popovers: Fix name for sidebar channel folders popover.

### DIFF
--- a/web/src/channel_folders_popover.ts
+++ b/web/src/channel_folders_popover.ts
@@ -36,7 +36,7 @@ export function initialize(): void {
             const show_channel_folders = user_settings.web_left_sidebar_show_channel_folders;
             // Assuming that the instance can be shown, track and
             // prep the instance for showing
-            popover_menus.popover_instances.show_channels_sidebar = instance;
+            popover_menus.popover_instances.show_folders_sidebar = instance;
             instance.setContent(
                 parse_html(
                     render_left_sidebar_channels_folder_setting_popover({show_channel_folders}),
@@ -48,7 +48,7 @@ export function initialize(): void {
         },
         onHidden(instance) {
             instance.destroy();
-            popover_menus.popover_instances.show_channels_sidebar = null;
+            popover_menus.popover_instances.show_folders_sidebar = null;
         },
     });
 }

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -33,7 +33,7 @@ type PopoverName =
     | "buddy_list"
     | "stream_actions_popover"
     | "color_picker_popover"
-    | "show_channels_sidebar"
+    | "show_folders_sidebar"
     | "send_later_options";
 
 export const popover_instances: Record<PopoverName, tippy.Instance | null> = {
@@ -56,7 +56,7 @@ export const popover_instances: Record<PopoverName, tippy.Instance | null> = {
     buddy_list: null,
     stream_actions_popover: null,
     color_picker_popover: null,
-    show_channels_sidebar: null,
+    show_folders_sidebar: null,
     send_later_options: null,
 };
 


### PR DESCRIPTION
The current name is very misleading.