### PR TITLE
hotkey: Specify reactions toggle to message controls.

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -1378,7 +1378,9 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
         // ':': open reactions to message
         case "toggle_reactions_popover": {
             const $row = message_lists.current.selected_row();
-            const $emoji_icon = $row.find(".emoji-message-control-button-container");
+            const $emoji_icon = $row.find(
+                ".message_controls .emoji-message-control-button-container",
+            );
             let emoji_picker_reference;
             if (
                 $emoji_icon?.length !== 0 &&

--- a/web/tests/hotkey.test.cjs
+++ b/web/tests/hotkey.test.cjs
@@ -107,7 +107,7 @@ message_lists.current = {
     selected_row() {
         const $row = $.create("selected-row-stub");
         $row.set_find_results(".message-actions-menu-button", ["<menu-button-stub>"]);
-        $row.set_find_results(".emoji-message-control-button-container", {
+        $row.set_find_results(".message_controls .emoji-message-control-button-container", {
             closest: () => ({css: () => "none"}),
         });
         return $row;


### PR DESCRIPTION
Sometimes this selector was catching a second `emoji-message-control-button-container` from an emoji reaction, which was only caught once we started using `util.the`. This change avoids catching that irrelevant element.

Fixes [#kandra js errors > hotkey emoji assertion issue @ 💬](https://chat.zulip.org/#narrow/channel/464-kandra-js-errors/topic/hotkey.20emoji.20assertion.20issue/near/2274759)