### PR TITLE
modals: Fix styling of non-editable text inputs.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -427,6 +427,7 @@
     --opacity-left-sidebar-muted-mentions: 0.3;
     --opacity-right-sidebar-subheading: 0.65;
     --opacity-right-sidebar-subheading-hover: 0.9;
+    --opacity-readonly-modal-input: 0.7;
 
     /*
     Message box elements and values.
@@ -839,6 +840,10 @@
     --background-color-modal-selectable-icon-hover: light-dark(
         hsl(240deg 100% 50% / 7%),
         hsl(240deg 100% 75% / 20%)
+    );
+    --background-color-readonly-modal-input: light-dark(
+        hsl(240deg 7% 93%),
+        hsl(240deg 7% 17%)
     );
     --color-background-pill-container-without-placeholder: light-dark(
         hsl(0deg 0% 100%),

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -51,8 +51,8 @@
     option:disabled,
     select:disabled,
     textarea:disabled,
-    input:disabled,
-    input:not([type="radio"]):read-only,
+    input:disabled:not(.modal_text_input),
+    input:not([type="radio"], .modal_text_input):read-only,
     textarea:read-only,
     #organization-permissions .dropdown-widget-button:disabled,
     #organization-settings .dropdown-widget-button:disabled {

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -490,6 +490,11 @@
     }
 }
 
+.modal__container .modal_text_input:read-only {
+    background-color: var(--background-color-readonly-modal-input);
+    opacity: var(--opacity-readonly-modal-input);
+}
+
 #add-realm-domain-widget {
     .modal_text_input {
         width: 14.7143em; /* 206px at 14px em */


### PR DESCRIPTION
This PR updates the CSS to use the background color as per latest designs for non-editable text input in
modals along with setting the opacity to 0.7 for them.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->https://chat.zulip.org/#narrow/channel/9-issues/topic/missing.20uneditable.20field.20styling.20in.20light.20theme

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| | Light theme | Dark theme |
| ------ | ------ | ------ |
| Manage user modal | <img width="708" height="740" alt="image" src="https://github.com/user-attachments/assets/586eedb0-44b0-4f3b-8986-194a14988f95" /> | <img width="708" height="740" alt="image" src="https://github.com/user-attachments/assets/beceef96-7910-40c0-9ab1-3ef817da512b" /> |
| Todo modal | <img width="708" height="740" alt="image" src="https://github.com/user-attachments/assets/0aa7074a-2c00-4bd7-8b7b-1dc924a9bd63" /> | <img width="708" height="740" alt="image" src="https://github.com/user-attachments/assets/caaa1135-9ea9-4053-94f6-65bafbe0af9e" /> |
| Custom profile field creation | <img width="708" height="740" alt="image" src="https://github.com/user-attachments/assets/a791039f-4776-4fff-b8b4-1ee36e37ffd4" /> | <img width="708" height="740" alt="image" src="https://github.com/user-attachments/assets/8129b246-274f-4216-85e0-2b68d7a0f355" /> |
| Custom profile field editing | <img width="708" height="740" alt="image" src="https://github.com/user-attachments/assets/33f8d66e-506b-4319-8129-077f2b6b414e" /> | <img width="708" height="740" alt="image" src="https://github.com/user-attachments/assets/d2588ad8-fb26-40ad-a9af-a02fa328f6ad" /> |
| Message move modal |<img width="708" height="740" alt="image" src="https://github.com/user-attachments/assets/e74321b4-1942-47f2-a8ec-605964f4e838" /> | <img width="708" height="740" alt="image" src="https://github.com/user-attachments/assets/68bfe0c5-c224-4d84-be69-acb281de62b5" /> |
| Convert demo organization form | <img width="708" height="740" alt="image" src="https://github.com/user-attachments/assets/9e4b19b3-b321-4862-acc2-e3ce4b716d0a" /> | <img width="708" height="740" alt="image" src="https://github.com/user-attachments/assets/137e232d-939a-4c0c-9774-272a621cf83d" /> |








<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
