### PR TITLE
Updated Zulip’s Taiga webhook integration so it verifies the signature of incoming webhook payloads.

### DIFF
--- a/zerver/webhooks/taiga/view.py
+++ b/zerver/webhooks/taiga/view.py
@@ -7,10 +7,9 @@ value should always be in bold; otherwise the subject of US/task
 should be in bold.
 """
 
-from typing import TypeAlias
-
 import hashlib
 import hmac
+from typing import TypeAlias
 
 from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
 
@@ -23,7 +22,6 @@ from zerver.models import UserProfile
 
 EventType: TypeAlias = dict[str, str | dict[str, str | bool | None]]
 ReturnType: TypeAlias = tuple[WildValue, WildValue]
-
 
 @webhook_view("Taiga")
 @typed_endpoint


### PR DESCRIPTION
- Updated Zulip’s Taiga webhook integration so it verifies the signature of incoming webhook payloads. 

import hashlib
import hmac
from typing import TypeAlias

from django.http import (HttpRequest, HttpResponse, HttpResponseBadRequest)

from zerver.decorator import webhook_view
from zerver.lib.response import json_success
from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
from zerver.lib.validator import WildValue, check_bool, check_none_or, check_string
from zerver.lib.webhooks.common import check_send_webhook_message
from zerver.models import UserProfile

EventType: TypeAlias = dict[str, str | dict[str, str | bool | None]]
ReturnType: TypeAlias = tuple[WildValue, WildValue]

@webhook_view("Taiga")
@typed_endpoint
def api_taiga_webhook(
    request: HttpRequest,
    user_profile: UserProfile,
    *,
    message: JsonBodyPayload[WildValue],
) -> HttpResponse:
    key = request.GET.get("api_key")
    data = request.body
    signature = request.headers.get("X-TAIGA-WEBHOOK-SIGNATURE")

    if "Content-Type" not in request.headers or "X-TAIGA-WEBHOOK-SIGNATURE" not in request.headers:
        return HttpResponseBadRequest("Missing appropriate headers.")

    if verify_signature(key, data, signature):
        parsed_events = parse_message(message)
        content = "".join(sorted(generate_content(event) + "\n" for event in parsed_events))
        topic_name = "General"
        if message["data"].get("milestone") and "name" in message["data"]["milestone"]:
            topic_name = message["data"]["milestone"]["name"].tame(check_string)
        check_send_webhook_message(request, user_profile, topic_name, content)

        return json_success(request)
    else:
        return HttpResponseBadRequest("Invalid signature.")

- Fixed Formatting (deleted empty spaces).

- Fixed Formatting (Replaced single ' ' quotes with double quotes " ").

- Fixed annotation issues in line 170.
Before:
def verify_signature(key, data, signature) 
    mac = hmac.new(key.encode("utf-8"), msg=data, digestmod=hashlib.sha1)
    return mac.hexdigest() == signature
Now:
def verify_signature(key: str, data: bytes, signature: str) -> bool:
    mac = hmac.new(key.encode("utf-8"), msg=data, digestmod=hashlib.sha1)
    return mac.hexdigest() == signature

**Screenshots and screen captures:**

<img width="840" height="808" alt="Screenshot 2025-10-14 at 10 58 30 AM" src="https://github.com/user-attachments/assets/4ca4483e-5a72-4c2f-a3d8-785b7b0a0f9b" />

<img width="644" height="69" alt="Screenshot 2025-10-14 at 10 56 38 AM" src="https://github.com/user-attachments/assets/d967b98f-456d-4afb-a40d-216063c2044f" />

- Used Zulip's integrations page to verify changes worked