### PR TITLE
message_list_view: Fix missing bookend when prepending messages.

### DIFF
--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -983,6 +983,11 @@ export class MessageListView {
                 update_group_date(second_group, curr_msg_container.msg, prev_msg_container?.msg);
                 // We could add an action to update the date row, but for now rerender the group.
                 message_actions.rerender_groups.push(second_group);
+            } else if (second_group.bookend_top) {
+                // We know there was no bookend_top before since we
+                // are adding messages to the top.
+                const rendered_bookend_html = render_bookend(second_group);
+                this.$list.prepend($(rendered_bookend_html));
             }
             message_actions.prepend_groups = new_message_groups;
             this._message_groups = [...new_message_groups, ...this._message_groups];


### PR DESCRIPTION
The logic for inserting bookend when prepending messages was missing.

Fixed by inserting the bookend at the correct position.

Reproducer:

Modify `message_fetch` parameters to only fetch
one message per fetch to ensure that each message is prepended.

Subscribe to a channel and send a message.

Reload.

Bookend is absent before the latest message without this commit.

discussion: [#issues > surprising topic header](https://chat.zulip.org/#narrow/channel/9-issues/topic/surprising.20topic.20header/with/2277344)

| before | after |
| --- | --- |
| <img width="863" height="458" alt="Screenshot from 2025-10-14 20-56-39" src="https://github.com/user-attachments/assets/d9d40996-4da4-4f86-87da-d0c7ce26f18d" /> | <img width="863" height="458" alt="Screenshot from 2025-10-14 20-55-56" src="https://github.com/user-attachments/assets/2ccccc1b-812c-4327-bd87-fa6ad855a8ca" /> |
