### PR TITLE
upload: Use normpath when comparing to LOCAL_UPLOADS_DIR.

### DIFF
--- a/zerver/lib/upload/local.py
+++ b/zerver/lib/upload/local.py
@@ -27,7 +27,8 @@ def assert_is_local_storage_path(type: Literal["avatars", "files"], full_path: s
     defense in depth.
     """
     assert settings.LOCAL_UPLOADS_DIR is not None
-    type_path = os.path.join(settings.LOCAL_UPLOADS_DIR, type)
+    type_path = os.path.normpath(os.path.join(settings.LOCAL_UPLOADS_DIR, type))
+    full_path = os.path.normpath(full_path)
     assert os.path.commonpath([type_path, full_path]) == type_path
 
 


### PR DESCRIPTION
This prevents a development-mode-only directory traversal attack, where the Django development server could be made to respond to requests for `/user_avatars/../../../../../../etc/passwd`.

The production server is not affected by this vulnerability, as nginx's configuration sets `PATH_INFO` to `$document_uri`, which is normalized[^1] -- that is, by the time uwsgi and Django see it, the path has been percent-decoded once, and all `../` path components have been applied[^2].

Close this by explicitly normalizing the paths before comparing; the `LOCAL_UPLOADS_DIR` side is unlikely to require normalization as well, but is also normalized for consistency.  The failure here is left as an assertion failure, and not a JsonableError, because it only affects the development server.

[^1]: https://nginx.org/en/docs/http/ngx_http_core_module.html#var_uri
[^2]: https://nginx.org/en/docs/http/ngx_http_core_module.html#location

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
