### PR TITLE
inbox: Fix collapsed note missing user only has unread DMs.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1352,14 +1352,16 @@ function should_show_all_folders_collapsed_note(): boolean {
         // Some DM content is visible.
         return false;
     }
+    // Defined just for code reading clarity.
+    const has_visible_but_collapsed_dm_folder = has_visible_dm_folder;
 
     const visible_folders = [...channel_folders_dict.values()].filter(
         (folder) => folder.is_header_visible,
     );
     if (visible_folders.length === 0) {
-        // Nothing at all is visible; the empty inbox message takes
-        // precedence.
-        return false;
+        // Nothing at all is visible; unless there is a visible but collapsed
+        // DM folder, we show the empty inbox message.
+        return has_visible_but_collapsed_dm_folder;
     }
 
     // At least one uncollapsed row is visible in some folder.


### PR DESCRIPTION
When there are only unread DMs and it is collapsed, the all rows collapsed not is not shown.

This occurred since we didn't check for that.

| before | after |
| --- | --- |
| <img width="895" height="165" alt="image" src="https://github.com/user-attachments/assets/4eeb6bdf-2ab7-4461-8495-5dbe21a06cb6" /> | <img width="895" height="165" alt="image" src="https://github.com/user-attachments/assets/2b578b4b-12b1-4058-bff5-53641eb179da" /> |


discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/missing.20.22all.20unread.20conversations.20are.20hidden.22.20notice