### PR TITLE
mobile_web: Persist text selection on longtap.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -221,22 +221,6 @@ export function initialize(): void {
     // selection function which will open the compose box  and select the message.
     if (!util.is_mobile()) {
         $("#main_div").on("click", ".messagebox", select_message_function);
-        // on the other hand, on mobile it should be done with a long tap.
-    } else {
-        $("#main_div").on("longtap", ".messagebox", function (this: HTMLElement, e) {
-            const sel = window.getSelection();
-            // if one matches, remove the current selections.
-            // after a longtap that is valid, there should be no text selected.
-            if (sel) {
-                if (sel.removeAllRanges) {
-                    sel.removeAllRanges();
-                } else if (sel.empty) {
-                    sel.empty();
-                }
-            }
-
-            select_message_function.call(this, e);
-        });
     }
 
     $("#main_div").on("click", ".star_container", function (e) {


### PR DESCRIPTION
To test this PR locally follow these [guidelines](https://developer.chrome.com/docs/devtools/remote-debugging).

This change enables mobile web users to select text from messages which lets them do standard text selection stuff like copy, select + quote, etc.

Previously, this was not possible as long tapping
text content resulted in triggering the reply action behavior, which included removal of all selection ranges caused by longtaps.

The possible drawback is not being able long tap a message in a narrow to reply to the associated
topic/dm.
As an alternative, that can be achieved by a
short tap on the message and then tapping
the composebox.

Fixes: https://chat.zulip.org/#narrow/channel/9-issues/topic/Cannot.20select.20text.20in.20mobile.20web/with/2277387

Frontend discussion: https://chat.zulip.org/#narrow/channel/6-frontend/topic/Simulating.20text.20selection.20on.20Chrome.20DevTools.20for.20mobile.2E/with/2278441

Design discussion: https://chat.zulip.org/#narrow/channel/101-design/topic/Text.20selection.20UX.20on.20mobile.20web/with/2278584

Before 
https://github.com/user-attachments/assets/fe85d51d-ded1-449f-8d00-3c4f2e991f92

After 
https://github.com/user-attachments/assets/f2905f27-7a0b-4c96-9896-2fd4e71c1c11