### PR TITLE
emoji: Fix aliases for dotted_six_pointed_star.

### DIFF
--- a/tools/setup/emoji/custom_emoji_names.py
+++ b/tools/setup/emoji/custom_emoji_names.py
@@ -1292,9 +1292,11 @@ CUSTOM_EMOJI_NAME_MAPS: dict[str, dict[str, Any]] = {
     "262a": {"canonical_name": "star_and_crescent", "aliases": ["islam"]},
     "1f549": {"canonical_name": "om", "aliases": ["hinduism"]},
     "2638": {"canonical_name": "wheel_of_dharma", "aliases": ["buddhism"]},
-    "2721": {"canonical_name": "star_of_david", "aliases": ["judaism"]},
-    # can't find any explanation of this at all. Is an alternate star of david?
-    # '1f52f': {'canonical_name': 'X', 'aliases': ['six_pointed_star']},
+    "2721": {"canonical_name": "star_of_david", "aliases": ["judaism", "jewish"]},
+    "1f52f": {
+        "canonical_name": "dotted_six_pointed_star",
+        "aliases": ["six_pointed"],
+    },  # Hindu Shatkona, not a Star of David
     "1f54e": {"canonical_name": "menorah", "aliases": []},
     "262f": {"canonical_name": "yin_yang", "aliases": []},
     "2626": {"canonical_name": "orthodox_cross", "aliases": []},

--- a/tools/setup/emoji/emoji_names.py
+++ b/tools/setup/emoji/emoji_names.py
@@ -1119,7 +1119,7 @@ EMOJI_NAME_MAPS: dict[str, dict[str, Any]] = {
     "1f52c": {"canonical_name": "science", "aliases": ["microscope"]},
     "1f52d": {"canonical_name": "telescope", "aliases": []},
     "1f52e": {"canonical_name": "crystal_ball", "aliases": ["oracle", "future", "fortune_telling"]},
-    "1f52f": {"canonical_name": "dotted_six_pointed_star", "aliases": ["jewish", "six_pointed"]},
+    "1f52f": {"canonical_name": "dotted_six_pointed_star", "aliases": ["six_pointed"]},
     "1f530": {"canonical_name": "beginner", "aliases": []},
     "1f531": {"canonical_name": "trident", "aliases": []},
     "1f532": {"canonical_name": "white_and_black_square", "aliases": []},
@@ -2191,7 +2191,7 @@ EMOJI_NAME_MAPS: dict[str, dict[str, Any]] = {
     },
     "1fae5": {
         "canonical_name": "dotted_line_face",
-        "aliases": ["depressed", "introvert", "invisible", "line"],
+        "aliases": ["depressed", "dotted", "introvert", "invisible", "line"],
     },
     "1fae6": {
         "canonical_name": "biting_lip",
@@ -2371,7 +2371,7 @@ EMOJI_NAME_MAPS: dict[str, dict[str, Any]] = {
     "2714": {"canonical_name": "check_mark", "aliases": []},
     "2716": {"canonical_name": "multiplication", "aliases": ["multiply"]},
     "271d": {"canonical_name": "cross", "aliases": ["christianity"]},
-    "2721": {"canonical_name": "star_of_david", "aliases": ["judaism"]},
+    "2721": {"canonical_name": "star_of_david", "aliases": ["judaism", "jewish"]},
     "2728": {"canonical_name": "sparkles", "aliases": ["glamour"]},
     "2733": {"canonical_name": "eight_spoked_asterisk", "aliases": []},
     "2734": {"canonical_name": "eight_pointed_star", "aliases": []},


### PR DESCRIPTION
CLDR 46 added this alias, which is not accurate; remove it.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
