### PR TITLE
ui: Replace 'Scroll down' link with button in sent messages.

### DIFF
--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -60,7 +60,7 @@ export function notify_above_composebox(
     above_composebox_narrow_url: string | null,
     link_msg_id: number,
     message_recipient: MessageRecipient | null,
-    link_text: string | null,
+    action_button_text: string | null,
 ): void {
     const $notification = $(
         render_message_sent_banner({
@@ -69,7 +69,7 @@ export function notify_above_composebox(
             above_composebox_narrow_url,
             link_msg_id,
             message_recipient,
-            link_text,
+            action_button_text,
         }),
     );
     // We pass in include_unmute_banner as false because we don't want to
@@ -224,8 +224,7 @@ function should_show_narrow_to_recipient_banner(message: Message): boolean {
 }
 
 function show_scroll_to_view_banner(link_msg_id: number): void {
-    const banner_text = $t({defaultMessage: "Sent!"});
-    const link_text = $t({defaultMessage: "Scroll down to view your message."});
+    const banner_text = $t({defaultMessage: "Sent! Scroll down to view your message."});
     notify_above_composebox(
         banner_text,
         compose_banner.CLASSNAMES.sent_scroll_to_view,
@@ -233,7 +232,7 @@ function show_scroll_to_view_banner(link_msg_id: number): void {
         null,
         link_msg_id,
         null,
-        link_text,
+        $t({defaultMessage: "Scroll down"}),
     );
     compose_banner.set_scroll_to_message_banner_message_id(link_msg_id);
 }
@@ -445,17 +444,13 @@ export function initialize(opts: {
             e.preventDefault();
         },
     );
-    $("#compose_banners").on(
-        "click",
-        ".sent_scroll_to_view .above_compose_banner_action_link",
-        (e) => {
-            assert(message_lists.current !== undefined);
-            const message_id = Number($(e.currentTarget).attr("data-message-id"));
-            message_lists.current.select_id(message_id);
-            on_click_scroll_to_selected();
-            compose_banner.clear_message_sent_banners(false);
-            e.stopPropagation();
-            e.preventDefault();
-        },
-    );
+    $("#compose_banners").on("click", ".sent_scroll_to_view .action-button", (e) => {
+        assert(message_lists.current !== undefined);
+        const message_id = Number($(e.currentTarget).attr("data-message-id"));
+        message_lists.current.select_id(message_id);
+        on_click_scroll_to_selected();
+        compose_banner.clear_message_sent_banners(false);
+        e.stopPropagation();
+        e.preventDefault();
+    });
 }

--- a/web/templates/compose_banner/message_sent_banner.hbs
+++ b/web/templates/compose_banner/message_sent_banner.hbs
@@ -1,22 +1,25 @@
 <div class="above_compose_banner main-view-banner success {{classname}}">
     <p class="banner_content">
         {{banner_text}}
+        {{#if message_recipient}}
         <a class="above_compose_banner_action_link" {{#if above_composebox_narrow_url}}href="{{above_composebox_narrow_url}}"{{/if}} data-message-id="{{link_msg_id}}">
-            {{#if message_recipient}}
-                {{#with message_recipient}}
-                {{#if (eq message_type "channel")}}
-                    {{#tr}}
-                        Go to #{channel_name} &gt; <z-topic-display-name></z-topic-display-name>
-                        {{#*inline "z-topic-display-name"}}<span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{topic_display_name}}</span>{{/inline}}
-                    {{/tr}}
-                {{else}}
-                    {{t 'Go to {recipient_text}' }}
-                {{/if}}
-                {{/with}}
+            {{#with message_recipient}}
+            {{#if (eq message_type "channel")}}
+                {{#tr}}
+                    Go to #{channel_name} &gt; <z-topic-display-name></z-topic-display-name>
+                    {{#*inline "z-topic-display-name"}}<span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{topic_display_name}}</span>{{/inline}}
+                {{/tr}}
             {{else}}
-                {{link_text}}
+                {{t 'Go to {recipient_text}' }}
             {{/if}}
+            {{/with}}
         </a>
+        {{/if}}
     </p>
+    {{#if action_button_text}}
+        <button class="action-button action-button-quiet-success" data-message-id="{{link_msg_id}}">
+            <span class="action-button-label">{{ action_button_text }}</span>
+        </button>
+    {{/if}}
     <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button"></a>
 </div>


### PR DESCRIPTION
## compose banners: Replace 'Scroll down' link with button in sent message banner

Currently, when a message is sent, the banner shows "Sent! Scroll down to view your message." where "Scroll down to view your message" is a clickable link. This is inconsistent with our current banner styles which use buttons for actions.

Fixes: #34633

## Changes made:
- Replaced the "Scroll down to view your message" link with a separate button
- "Sent! Scroll down to view your message." text now displays as plain text (no longer a link)
- Added "Scroll down" button with proper styling
- Button click functionality maintains same scroll behavior as original link

## Screenshots and screen captures

**Dark Mode Before and After Images**

| Before | After |
|--------|-------|
|<img width="1919" height="1079" alt="Screenshot 2025-10-27 200314" src="https://github.com/user-attachments/assets/8cf92223-7dc4-4bb8-b157-9f68fd4197fa" />|<img width="1919" height="1079" alt="Screenshot 2025-10-27 200153" src="https://github.com/user-attachments/assets/0c66448f-d0fb-4923-a99e-684d9e270ae2" />|

**Light Mode Before and After Images**

| Before | After |
|--------|-------|
|<img width="1919" height="1079" alt="Screenshot 2025-10-27 200355" src="https://github.com/user-attachments/assets/7e1f4a91-fe00-4db0-bc4e-6129cd771ffb" />|<img width="1919" height="1079" alt="Screenshot 2025-10-27 200100" src="https://github.com/user-attachments/assets/f31317cf-6482-43dc-be90-7943d3628236" />|

**Dark Theme Before and After Video proof**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/3692ffd0-5a45-4b55-ae59-893bf6da4002" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/ce6be1d1-c9d3-4e80-b400-6df3680194f0" width="400" controls></video> |

**Light Theme Before and After Video proof**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/81763109-bcfc-42de-a91b-861d63736d44" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/bca07fdb-c4da-4c27-b6f9-e513cd6c3fbc" width="400" controls></video> |


## Technical details:
- Modified `static/templates/compose_banner/message_sent_banner.hbs` template
- Updated event handlers in `src/compose_notifications.ts`
- Added CSS styles in `static/styles/zulip.css`

- [✅] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [✅] Explains differences from previous plans (e.g., issue description).
- [✅] Highlights technical choices and bugs encountered.
- [✅] Calls out remaining decisions and concerns.
- [✅] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [✅] Each commit is a coherent idea.
- [✅] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [✅] Visual appearance of the changes.
- [✅] Responsiveness and internationalization.
- [✅] Strings and tooltips.
- [✅] End-to-end functionality of buttons, interactions and flows.
- [✅] Corner cases, error conditions, and easily imagined bugs.

