### PR TITLE
stream_settings: Truncate long titles with ellipsis in add-subscribers screen.

### DIFF
--- a/web/templates/stream_settings/selected_stream_title.hbs
+++ b/web/templates/stream_settings/selected_stream_title.hbs
@@ -1,4 +1,4 @@
-<a {{#if preview_url}}class="tippy-zulip-delayed-tooltip selected-stream-title" data-tooltip-template-id="view-stream-tooltip-template" data-tippy-placement="top" href="{{preview_url}}{{/if}}">
+<a class="{{#if preview_url}}tippy-zulip-delayed-tooltip {{/if}}selected-stream-title" {{#if preview_url}}data-tooltip-template-id="view-stream-tooltip-template" data-tippy-placement="top" href="{{preview_url}}"{{/if}}>
 {{#unless preview_url}}{{t "Add subscribers to "}}{{/unless}}
 {{> stream_privacy_icon
   invite_only=sub.invite_only


### PR DESCRIPTION
Previously, long stream titles in the `Add subscribers` screen wrapped to next line.
Now, they are displayed on a single line with an ellipsis when exceeding the available width.

Fixes: #33455

**Before**
<img width="1295" height="356" alt="Screenshot 2025-11-05 at 11 20 36" src="https://github.com/user-attachments/assets/3eff2ace-51ed-4275-b7e7-0cfc9981d717" />


**After**
<img width="1352" height="367" alt="Screenshot 2025-11-05 at 11 43 48" src="https://github.com/user-attachments/assets/6a7cb3b9-3d57-4213-8f02-f25102874aa6" />


**Before**
<img width="1345" height="423" alt="Screenshot 2025-11-05 at 11 20 23" src="https://github.com/user-attachments/assets/9e05cc79-f583-4ff2-8019-bab45611bbe5" />

**After**
<img width="1306" height="357" alt="Screenshot 2025-11-05 at 11 43 38" src="https://github.com/user-attachments/assets/110ad1ef-12e2-4385-b399-819ef68a4756" />

**Before**
<img width="1350" height="380" alt="Screenshot 2025-11-05 at 11 20 48" src="https://github.com/user-attachments/assets/eb109702-8d76-4faf-b420-9710fd74c68e" />

 **After**
<img width="1367" height="380" alt="Screenshot 2025-11-05 at 11 44 07" src="https://github.com/user-attachments/assets/3ffd7703-a6a3-4cf6-80ed-008cf400141e" />


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>