### PR TITLE
modal: Allow channel name field to expand when needed

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -482,6 +482,15 @@
     }
 }
 
+#change_stream_info_modal {
+    #change_stream_name {
+        /* Allow channel name field to expand while maintaining minimum width */
+        min-width: calc(var(--modal-input-width) - 14px);
+        width: auto;
+        max-width: 100%;
+    }
+}
+
 .edit_profile_field_choices_container,
 #profile_field_choices {
     .modal_text_input {


### PR DESCRIPTION
This change allows the channel name input field in the change stream info modal to expand beyond its minimum width when needed for longer channel names while maintaining the existing minimum width.

The field now uses min-width instead of a fixed width, with width: auto
and max-width: 100% to allow proper expansion within the modal container.

Fixes #33454.

### **Before & After Screenshots**

**Before**
<img width="831" height="171" alt="Before - channel name field fixed width" src="https://github.com/user-attachments/assets/b780a9c1-761e-4ffb-9157-bed70d7473ba" />

**After**
<img width="831" height="176" alt="After - channel name field expanded properly" src="https://github.com/user-attachments/assets/69a49436-fc54-49ef-9603-967ddfe64341" />

