### PR TITLE
Make user-type custom field pills clickable with hover style.

### DIFF
--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -15,6 +15,7 @@ import * as settings_ui from "./settings_ui.ts";
 import {current_user, realm} from "./state_data.ts";
 import * as typeahead_helper from "./typeahead_helper.ts";
 import * as ui_report from "./ui_report.ts";
+import * as user_card_popover from "./user_card_popover.ts";
 import type {UserPillWidget} from "./user_pill.ts";
 import * as user_pill from "./user_pill.ts";
 
@@ -197,6 +198,20 @@ export function initialize_custom_user_type_fields(
                 .find(".person_picker.pill-container .input");
             $input_element.trigger("focus");
         });
+
+    // Attach user card popover to user pills in custom profile fields if not already handled by global event
+    $(element_id).on('click', '.pill[data-user-id]', function (e) {
+        // Avoid double popover in case global handler already present from .person_picker
+        if (!$(this).closest('.person_picker').length) {
+            const user_id = Number.parseInt($(this).attr('data-user-id'), 10);
+            if (!isNaN(user_id)) {
+                const user = people.get_by_user_id(user_id);
+                user_card_popover.toggle_user_card_popover(this, user);
+                e.stopPropagation();
+                e.preventDefault();
+            }
+        }
+    });
 
     return user_pills;
 }

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -3,15 +3,14 @@
     gap: var(--vertical-spacing-input-pill) var(--horizontal-spacing-input-pill);
     flex-wrap: wrap;
     min-width: 0;
-
     background-color: var(--color-background-pill-container);
-
     padding: var(--outer-spacing-input-pill-container);
     border: 1px solid var(--color-border-pill-container);
     border-radius: 4px;
     align-items: center;
-
     cursor: text;
+    
+    
 
     .pill {
         display: inline-flex;
@@ -29,10 +28,12 @@
         margin: 0;
 
         color: inherit;
+        border: 1px solid var(--color-border-pill-container);
 
         border-radius: 4px;
         background-color: var(--color-background-input-pill);
         cursor: pointer;
+        transition: background 0.1s;
 
         /* Not focus-visible, because we want to support mouse+backpace to
            delete pills */
@@ -127,6 +128,7 @@
 
             &:hover {
                 background: var(--color-background-input-pill-exit-hover);
+                
 
                 .pill-close-button,
                 .pill-expand-button {
@@ -234,6 +236,51 @@
         border-color: var(--color-invalid-input-border);
         box-shadow: var(--invalid-input-box-shadow);
     }
+}
+
+
+.pill {
+    cursor: pointer !important;
+    border:1px solid var(--color-focus-outline-input-pill);
+   
+}
+
+
+.pill:not(.not-editable):hover,
+.pill:not(.not-editable):focus,
+.pill:not(.not-editable):active {
+    background: var(--color-background-input-pill-hover, #f3f0fa) !important;
+    border: none !important;
+    box-shadow: none !important;
+    outline: none !important;
+}
+
+.pill:focus,
+.pill:active,
+.pill:focus-visible,
+.pill *:focus,
+.pill *:focus-visible,
+.pill *:active {
+    outline: none !important;
+    box-shadow: none !important;
+    -webkit-box-shadow: none !important;
+    -moz-box-shadow: none !important;
+}
+
+.pill::-webkit-focus-ring,
+.pill *::-webkit-focus-ring {
+    outline: none !important;
+    box-shadow: none !important;
+}
+
+/* Nuclear option - remove ALL possible focus shadows from pills */
+.pill:focus {
+    box-shadow: none !important;
+    -webkit-box-shadow: none !important;
+    -moz-box-shadow: none !important;
+    outline: none !important;
+    -webkit-outline: none !important;
+    -moz-outline: none !important;
 }
 
 #compose-direct-recipient .pill-container {


### PR DESCRIPTION
### This PR fixes the visual and interaction behavior of user-type custom
profile fields in the user profile modal.

changes made:-

1.Ensure pills show hover background and clickable cursor.

**Before:-** 
<img width="459" height="249" alt="image" src="https://github.com/user-attachments/assets/31361d1a-b327-4037-8771-b9a5d036b212" />

**After:-**
<img width="1234" height="760" alt="image" src="https://github.com/user-attachments/assets/31946bbe-9de4-4852-b8ae-06791eb82f46" />

2.Added popover user profile card.
<img width="1099" height="699" alt="image" src="https://github.com/user-attachments/assets/bfd558fa-98d1-4c87-a29c-99ddb7a1bfb9" />

3.Added scoped CSS rules in `input_pill.css` to match standard pill styling.
4.Added a hidden `.input` element to satisfy the JS initializer for user-type fields.

Fixes: #36301