### PR TITLE
feat: Add superscript to scroll-to-bottom-button.

### DIFF
--- a/web/src/compose.ts
+++ b/web/src/compose.ts
@@ -19,12 +19,14 @@ import * as echo from "./echo.ts";
 import type {PostMessageAPIData} from "./echo.ts";
 import * as message_events from "./message_events.ts";
 import type {LocalMessage} from "./message_helper.ts";
+import * as narrow_state from "./narrow_state.ts";
 import * as onboarding_steps from "./onboarding_steps.ts";
 import * as scheduled_messages from "./scheduled_messages.ts";
 import * as sent_messages from "./sent_messages.ts";
 import * as server_events_state from "./server_events_state.ts";
 import {current_user} from "./state_data.ts";
 import * as transmit from "./transmit.ts";
+import * as unread from "./unread.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
 import * as zcommand from "./zcommand.ts";
@@ -481,4 +483,13 @@ function schedule_message_to_custom_date(): void {
 
 export function is_topic_input_focused(): boolean {
     return $("#stream_message_recipient_topic").is(":focus");
+}
+
+export function update_compose_unread(): void {
+    const topic = narrow_state.topic();
+    const stream_id = narrow_state.stream_id();
+    const unreadVal: number =
+        stream_id && topic ? unread.num_unread_for_topic(stream_id, topic) : 0;
+
+    $("#new-message-count").text(unreadVal);
 }

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -400,6 +400,7 @@ function initialize_unread_ui() {
         pm_list.update_dom_with_unread_counts(counts),
     );
     unread_ui.register_update_unread_counts_hook(() => topic_list.update());
+    unread_ui.register_update_unread_counts_hook(() => compose.update_compose_unread());
     unread_ui.register_update_unread_counts_hook((counts) =>
         narrow_title.update_unread_counts(counts),
     );

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -966,6 +966,14 @@
         hsl(0deg 0% 100%),
         hsl(0deg 0% 100% / 7%)
     );
+    --color-unread-superscript-background: light-dark(
+        hsl(184deg 52% 63% / 100%),
+        hsl(183deg 52% 26% / 100%)
+    );
+    --color-unread-superscript-text: light-dark(
+        hsl(240deg 30% 40%),
+        hsl(0deg 0% 100%)
+    );
     --color-outline-tab-picker-tab-option: light-dark(
         hsl(0deg 0% 0% / 30%),
         hsl(0deg 0% 100% / 12%)

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -186,6 +186,23 @@
             opacity: 1;
         }
     }
+
+    #scroll-to-bottom-button {
+        position: relative;
+    }
+
+    .badge-counter {
+        position: absolute;
+        top: -6px;
+        right: -6px;
+        background: var(--color-unread-superscript-background);
+        color: var(--color-unread-superscript-text);
+        border-radius: 50%;
+        padding: 3px 6px;
+        font-size: 10px;
+        font-weight: bold;
+        line-height: 1;
+    }
 }
 
 .message_comp {

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -7,6 +7,7 @@
         <div id="scroll-to-bottom-button-clickable-area" data-tooltip-template-id="scroll-to-bottom-button-tooltip-template">
             <div id="scroll-to-bottom-button">
                 <i class="scroll-to-bottom-icon fa fa-chevron-down"></i>
+                <span class="badge-counter" id="new-message-count"></span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This feature enhances the scroll-to-bottom button by displaying the number of new, unread messages as a small subscript. 
For example, if User A sends 5 new messages while User B is reading earlier messages, the button will show “5” as a subscript. 
This improves message visibility and ensures users are aware of unread messages without losing their current reading position.

This feature is inspired from existing WhatsApp feature

Solves #36310 

<img width="1918" height="977" alt="Image" src="https://github.com/user-attachments/assets/ec0f1b09-b8d1-485f-a5d8-cfff7c329202" />

<img width="349" height="252" alt="Image" src="https://github.com/user-attachments/assets/4b15fb35-9b35-405a-abd1-78d402774a62" />