### PR TITLE
template-styles: Remove upgrade-tip and upgrade-or-sponsorship-tip.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -489,26 +489,6 @@ input.settings_text_input {
     line-height: 38px;
 }
 
-.upgrade-tip,
-.upgrade-or-sponsorship-tip {
-    width: fit-content;
-
-    &::before {
-        content: "\f135";
-        margin-right: 6px;
-    }
-}
-
-.upgrade-tip:hover {
-    color: hsl(0deg 0% 20%);
-    border: 1px solid hsl(49deg 20% 60%);
-    box-shadow: 0 0 4px hsl(199deg 79% 56% / 20%);
-
-    text-decoration: none;
-}
-
-.upgrade-tip,
-.upgrade-or-sponsorship-tip,
 .tip,
 .invite-stream-notice {
     position: relative;
@@ -530,8 +510,6 @@ input.settings_text_input {
     }
 }
 
-.upgrade-tip,
-.upgrade-or-sponsorship-tip,
 .tip {
     margin: 10px 0;
 }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -155,8 +155,6 @@
         box-shadow: 0 0 0 1px hsl(0deg 0% 0% / 40%);
     }
 
-    .upgrade-tip,
-    .upgrade-or-sponsorship-tip,
     .tip,
     .invite-stream-notice {
         color: inherit;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1843,10 +1843,6 @@ label.preferences-radio-choice-label {
     margin-top: 13px;
     display: block;
 
-    .upgrade-tip {
-        width: auto;
-    }
-
     .tip::before {
         content: "\f135";
         margin-right: 8px;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -582,13 +582,6 @@ h4.user_group_setting_subsection_title {
             .settings-empty-option-text {
                 color: var(--color-text-item);
             }
-
-            .upgrade-or-sponsorship-tip,
-            .upgrade-tip {
-                /* Center tip in parent container */
-                margin-left: auto;
-                margin-right: auto;
-            }
         }
     }
 


### PR DESCRIPTION
Removes the CSS rules for upgrade-or-sponsorship-tip and upgrade-tip as they no longer are in use.

**Notes**:
- The last use of upgrade-or-sponsorship-tip was removed in commit a93a015b2.
- The last use of upgrade-tip was removed in commit 021af590e.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
