### PR TITLE
demo-orgs: Fix configure email banner action button on modals.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -540,13 +540,6 @@ input.settings_text_input {
     margin-bottom: 10px;
 }
 
-#convert-demo-organization-form,
-#invite-user-form {
-    .banner-action-buttons {
-        padding: 0.085em 0;
-    }
-}
-
 .create-group-button-container {
     .upgrade-organization-banner-container {
         display: flex;

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -4,7 +4,7 @@
     <div class="alert" id="dev_env_msg"></div>
     {{/if}}
     {{#if (not user_has_email_set) }}
-    <div class="demo-organization-add-email-banner"></div>
+    <div class="demo-organization-add-email-banner banner-wrapper"></div>
     {{/if}}
     <div class="input-group">
         <div id="invite_users_option_tabs_container"></div>

--- a/web/templates/settings/convert_demo_organization_form.hbs
+++ b/web/templates/settings/convert_demo_organization_form.hbs
@@ -1,6 +1,6 @@
 <div id="convert-demo-organization-form">
     {{#unless user_has_email_set}}
-    <div class="demo-organization-add-email-banner"></div>
+    <div class="demo-organization-add-email-banner banner-wrapper"></div>
     {{/unless}}
     <p>{{t "Everyone will need to log in again at the new URL for your organization." }}</p>
     <form class="subdomain-setting">


### PR DESCRIPTION
Fixes the action button on the configure email banner that appears before a demo organization owner has added an email address on the invite user and convert demo organization modals.

**Notes**:
- Adds the banner-wrapper class so that the general CSS rules for banners are applied.
- Removes the extra padding on the button as it does not appear to be necessary any longer as the font and line height for the banner label and action buttons is now the same.

---

**Screenshots and screen captures:**

*Invite user banner*
| Before | After |
| --- | --- |
| <img width="922" height="292" alt="Screenshot From 2025-10-20 14-30-36" src="https://github.com/user-attachments/assets/013c672c-8e29-4dc6-85df-a071304bc077" /> | <img width="927" height="256" alt="Screenshot From 2025-10-20 13-42-40" src="https://github.com/user-attachments/assets/25bb1004-f85d-4094-8daa-4e0dc7dafc07" />

*Convert demo organization banner*
| Before | After |
| --- | --- |
| <img width="922" height="315" alt="Screenshot From 2025-10-20 14-30-54" src="https://github.com/user-attachments/assets/87ef3fec-7d02-453c-b2ed-612be41dc372" /> | <img width="927" height="274" alt="Screenshot From 2025-10-20 13-42-59" src="https://github.com/user-attachments/assets/01fa4b3f-c03e-4c64-8288-905c885fc6d8" />

*Mobile device set in devtools for narrow screen adjustments*
| Before | After |
| --- | --- |
| <img width="604" height="373" alt="Screenshot From 2025-10-20 14-35-44" src="https://github.com/user-attachments/assets/8654fb39-e008-458b-ac2e-5d456e6e04d5" /> | <img width="597" height="406" alt="Screenshot From 2025-10-20 13-43-24" src="https://github.com/user-attachments/assets/a7f7774d-173c-4485-8a17-7785f20e2a9a" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
