### PR TITLE
Fix: handle large channel IDs as strings in narrow_banner.ts

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -306,7 +306,21 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
             // fallthrough to default case if no match is found
             break;
         case "channel": {
-            const stream_sub = stream_data.get_sub_by_id_string(first_operand);
+            // Ensure first_operand is a string
+            const channel_id_str = first_operand;
+
+            // Quick validation: must be only digits
+            if (!/^\d+$/.test(channel_id_str)) {
+                return {
+                    title: $t({
+                        defaultMessage:
+                            "This channel doesn't exist, or you are not allowed to view it.",
+                    }),
+                };
+            }
+
+            const stream_sub = stream_data.get_sub_by_id_string(channel_id_str);
+
             if (!stream_sub?.subscribed) {
                 // You are narrowed to a channel that either does not exist,
                 // is private, or a channel you're not currently subscribed to.
@@ -337,6 +351,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                     }),
                 };
             }
+
             assert(message_lists.current !== undefined);
             if (message_lists.current.visibly_empty() && !message_lists.current.empty()) {
                 // The current message list appears empty, but there are
@@ -346,6 +361,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
             // else fallthrough to default case
             break;
         }
+
         case "search": {
             // You are narrowed to empty search results.
             return empty_search_query_banner(current_filter);


### PR DESCRIPTION
Fixes #35036

Note: The web app was ran and tested on Firefox browser as far as this PR is concerned.

Problem: When navigated to an absurdly high channel ID which does not exist (via the address bar), a flickery-looking loading animation plays endlessly before eventually crashing with a rate-limit error.

[issue_1.webm](https://github.com/user-attachments/assets/e3ad27db-f573-4ee8-9761-7aa42f09caf4)

When tried to reproduce locally on the development server, the message said "There are no messages here." instead of endlessly loading. However the correct message should have been "This channel doesn't exist, or you are not allowed to view it."


[issue_2.webm](https://github.com/user-attachments/assets/d5f053bb-34f2-4d4f-b524-73b8e5463e9e)


I'm not sure about why the difference is the way it is between dev server and the real deal, but the fact that the wrong message is displayed in the dev server must have something to do with why it loads endlessly in production.

Fix: The fix standardizes channel ID handling by using string typing, preventing overflow and rendering inconsistencies in the narrow banner.


[issue_3.webm](https://github.com/user-attachments/assets/45f1b884-1301-467a-944a-7ba83329f0fc)


Testing done
         Manually tested navigation to:
                   Valid channels (regular and private), works as before.
                   Non-existent small IDs,  shows channel doesn’t exist.
                   Absurdly large IDs, now shows the correct channel doesn’t exist message instead of the wrong message.

Tested on Firefox.