### PR TITLE
webhooks/sentry: Add support for error events

### DIFF
--- a/zerver/webhooks/sentry/fixtures/event_for_error_python.json
+++ b/zerver/webhooks/sentry/fixtures/event_for_error_python.json
@@ -1,0 +1,16 @@
+{
+  "action": "triggered",
+  "data": {
+    "event": {
+      "event_id": "abc123def456789",
+      "project": 5216640,
+      "platform": "python",
+      "datetime": "2024-01-15T10:30:45.123456Z",
+      "level": "error",
+      "title": "Database connection timeout",
+      "type": "error",
+      "version": "7",
+      "web_url": "https://sentry.io/organizations/example-org/issues/12345/events/abc123/"
+    }
+  }
+}

--- a/zerver/webhooks/sentry/tests.py
+++ b/zerver/webhooks/sentry/tests.py
@@ -187,6 +187,16 @@ Traceback:
 ```"""
         self.check_webhook("event_for_message_node", expected_topic_name, expected_message)
 
+    def test_event_for_error_python(self) -> None:
+        expected_topic_name = "Database connection timeout"
+        expected_message = """\
+**New error:** [Database connection timeout](https://sentry.io/organizations/example-org/issues/12345/events/abc123/)
+```quote
+**level:** error
+**timestamp:** 2024-01-15 10:30:45
+```"""
+        self.check_webhook("event_for_error_python", expected_topic_name, expected_message)
+
     def test_event_for_message_python(self) -> None:
         expected_topic_name = "A simple message-based issue."
         expected_message = """\

--- a/zerver/webhooks/sentry/view.py
+++ b/zerver/webhooks/sentry/view.py
@@ -48,7 +48,14 @@ Traceback:
 """
 )
 # Because of the \n added at the end of each context element,
-# this will actually look better in the traceback.
+
+ERROR_EVENT_TEMPLATE = """
+**New error:** [{title}]({web_link})
+```quote
+**level:** {level}
+**timestamp:** {datetime}
+```
+"""
 
 ISSUE_CREATED_MESSAGE_TEMPLATE = """
 {severity_emoji} **New issue created:** {title}
@@ -191,7 +198,9 @@ def handle_event_payload(event: dict[str, Any]) -> tuple[str, str]:
         # The event was triggered by a sentry.capture_message() call
         # (in the Python Sentry SDK) or something similar.
         body = MESSAGE_EVENT_TEMPLATE.format(**context).strip()
-
+    elif event.get("type") == "error" and "exception" not in event:
+        # Handle error events that are not exceptions
+        body = ERROR_EVENT_TEMPLATE.format(**context)
     else:
         raise UnsupportedWebhookEventTypeError("unknown-event type")
 


### PR DESCRIPTION
Adds support for Sentry error events in the Zulip webhook integration.
Previously, error events were rejected as "unsupported", causing development teams to miss critical error notifications. This PR implements detection logic, message formatting, and comprehensive tests for error events.

Fixes: #24146

## Changes
- Added ERROR_EVENT_TEMPLATE for formatting error event messages
- Modified handle_event_payload() to detect and process error events (type="error" without exception data)
- Added test case test_event_for_error_python() 
- Created fixture event_for_error_python.json
- All existing tests continue to pass (backward compatible)


## Testing
- New test "test_event_for_error_python" passes
- Full test suite "./tools/test-backend zerver.webhooks.sentry" passes
- Manually tested webhook endpoint with curl
- Verified error events now create properly formatted Zulip messages

![ResultingErrorMessage](https://github.com/user-attachments/assets/abe93084-6b62-4f2d-a325-d4c869c29f02)




**Note:** This is a college group project done by Florida International University students. Contributors: @danireyss, @deglemartinez04, @AN-235, @CJOrtega


<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
- [x] Automated tests verify logic where appropriate
- [x] End-to-end functionality tested

</details>
