### PR TITLE
keyboard_navigation: Improve navigation from filter input to emoji grid and remove custom Tab/Shift+Tab behavior to follow default browser behavior

### DIFF
--- a/web/src/emoji_picker.ts
+++ b/web/src/emoji_picker.ts
@@ -508,19 +508,12 @@ export function navigate(event_name: string, e?: JQuery.KeyDownEvent): boolean {
         // Move down into emoji map.
         const filter_text = $<HTMLInputElement>("input#emoji-popover-filter").val()!;
         const is_cursor_at_end = $("#emoji-popover-filter").caret() === filter_text.length;
-        if (event_name === "down_arrow" || (is_cursor_at_end && event_name === "right_arrow")) {
-            assert($selected_emoji !== undefined);
-            $selected_emoji.trigger("focus");
-            if (current_section === 0 && current_index < 6) {
-                scroll_util.get_scroll_element($emoji_map).scrollTop(0);
-            }
-            update_emoji_showcase($selected_emoji);
-            return true;
-        }
-        if (event_name === "tab") {
-            assert($selected_emoji !== undefined);
-            $selected_emoji.trigger("focus");
-            update_emoji_showcase($selected_emoji);
+        if (
+            event_name === "tab" ||
+            event_name === "down_arrow" ||
+            (is_cursor_at_end && event_name === "right_arrow")
+        ) {
+            maybe_change_active_section(0);
             return true;
         }
         return false;
@@ -550,8 +543,7 @@ export function navigate(event_name: string, e?: JQuery.KeyDownEvent): boolean {
     switch (event_name) {
         case "tab":
         case "shift_tab":
-            change_focus_to_filter();
-            return true;
+            return false;
         case "page_up":
             maybe_change_active_section(current_section - 1);
             return true;


### PR DESCRIPTION
Fixes the navigation between filter search bar and emoji grid by focusing on the first emoji on **Down arrow/Right arrow/Tab** press and removed the custom **Tab and Shift+Tab** behavior so that they now follow the default browser behavior — moving focus to the next or previous emoji

screen recording:-
https://github.com/user-attachments/assets/34133b4a-2259-4974-ba1b-483bc70e5856

Fixes #36324