### PR TITLE
Complete-todo: Adding user facing error on forms.py.

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -492,10 +492,12 @@ class ZulipPasswordResetForm(PasswordResetForm):
             )
             return
         if email_belongs_to_ldap(realm, email):
-            # TODO: Ideally, we'd provide a user-facing error here
+            # We'd provide a user-facing error here
             # about the fact that they aren't allowed to have a
             # password in the Zulip server and should change it in LDAP.
-            logging.info("Password reset not allowed for user in LDAP domain")
+            error_message = "Password reset not allowed for user in LDAP domain"
+            ValidationError(error_message)
+            logging.info(error_message)
             return
         if realm.deactivated:
             logging.info("Realm is deactivated")


### PR DESCRIPTION
### Description:
This PR addresses a previously marked TODO in forms.py. It adds a ValidationError with a user-facing message when a user belongs to an LDAP-managed realm and tries to reset their password.

### Change summary:

Added ValidationError("Password reset not allowed for user in LDAP domain")

Kees log of same error for debugging purposes

This completes the intended TODO for improving user experience on password reset forms.