### PR TITLE
message_list_view: Fix failing test.

### DIFF
--- a/web/tests/message_list_view.test.cjs
+++ b/web/tests/message_list_view.test.cjs
@@ -367,6 +367,7 @@ test("muted_message_vars", () => {
 
 test("merge_message_groups", ({mock_template}) => {
     mock_template("message_list.hbs", false, () => "<message-list-stub>");
+    mock_template("bookend.hbs", false, () => "<bookend-stub>");
     // MessageListView has lots of DOM code, so we are going to test the message
     // group merging logic on its own.
 


### PR DESCRIPTION
It was throwing error when running test for
message_list_view without failing the entire test suite.

Introduced in PR #36280

Thanks @laurynmm for noticing.
