### PR TITLE
submessage: Accept todo submessage with extra_data: null

### DIFF
--- a/web/src/submessage.ts
+++ b/web/src/submessage.ts
@@ -42,7 +42,7 @@ const widget_data_event_schema = z.object({
         }),
         z.object({
             widget_type: z.literal("todo"),
-            extra_data: todo_widget_extra_data_schema,
+            extra_data: z.nullable(todo_widget_extra_data_schema),
         }),
     ]),
 });


### PR DESCRIPTION
Before commit 6df3ad251a836ce9327990daa3457b07b6880f72 (#24235), `get_extra_data_from_widget_type` would initialize `extra_data` to `null` for `todo` messages.