### PR TITLE
push_notifications: Replace `pm_users` field with `recipient_user_ids`.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,14 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 429**
+
+* Replaced the `pm_users` field with `recipient_user_ids` in
+[E2EE mobile push notifications payload](/api/mobile-notifications)
+for group direct message. Previously, `pm_users` was included only
+for group DMs; `recipient_user_ids` is present for both 1:1 and
+group DM conversations.
+
 **Feature level 428**
 
 * [`GET /events`](/api/get-events): When a user is deactivated,

--- a/api_docs/mobile-notifications.md
+++ b/api_docs/mobile-notifications.md
@@ -59,10 +59,10 @@ Sample JSON data that gets encrypted:
 {
   "content": "test content",
   "message_id": 46,
-  "pm_users": "6,10,12,15",
   "realm_name": "Zulip Dev",
   "realm_url": "http://zulip.testserver",
   "recipient_type": "direct",
+  "recipient_user_ids": [6,10,12,15],
   "sender_avatar_url": "https://secure.gravatar.com/avatar/818c212b9f8830dfef491b3f7da99a14?d=identicon&version=1",
   "sender_full_name": "aaron",
   "sender_id": 6,
@@ -72,14 +72,16 @@ Sample JSON data that gets encrypted:
 }
 ```
 
-- **Group direct messages**: The `pm_users` string field is only
-present for group direct messages, containing a sorted comma-separated
-list of all user IDs in the group direct message conversation,
-including both `user_id` and `sender_id`.
+- The `recipient_user_ids` field is a sorted array of all user IDs in
+the direct message conversation, including both `user_id` and
+`sender_id`.
 
-**Changes**: New in Zulip 11.0 (feature level 413).
+**Changes**: In Zulip 12.0 (feature level 429), replaced the
+`pm_users` field with `recipient_user_ids`. The old `pm_users` field
+was only present for group DMs, and was a string containing a
+comma-separated list of sorted user IDs.
 
-### New group direct message
+New in Zulip 11.0 (feature level 413).
 
 ### Remove notifications
 

--- a/version.py
+++ b/version.py
@@ -35,7 +35,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 428
+API_FEATURE_LEVEL = 429
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump


### PR DESCRIPTION
[#api design > E2EE - encrypted APNs payload format @ 💬](https://chat.zulip.org/#narrow/channel/378-api-design/topic/E2EE.20-.20encrypted.20APNs.20payload.20format/near/2279810)
* Rename `pm_users` to `recipient_user_ids`
* `recipient_user_ids` is present for both 1:1 and group DM conversations.
* The old `pm_users` field was a string containing a comma-separated list of sorted user IDs. `recipient_user_ids` has a more structured array format.

**Screenshots and screen captures:**

<img width="729" height="660" alt="Screenshot 2025-10-28 at 6 39 20 PM" src="https://github.com/user-attachments/assets/28b666e9-d37d-4625-bd2b-4f95abacdb88" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
