### PR TITLE
setup-upgrade-postgresql: Add missing `--file` flag to execute SQL in a file

### DIFF
--- a/scripts/setup/upgrade-postgresql
+++ b/scripts/setup/upgrade-postgresql
@@ -108,7 +108,7 @@ su postgres -c "/usr/lib/postgresql/$UPGRADE_TO/bin/vacuumdb --all --analyze-onl
 
 # Update extensions
 if [ -n "$SCRIPTS_PATH" ] && [ -f "$SCRIPTS_PATH/update_extensions.sql" ]; then
-    su postgres -c "psql $SCRIPTS_PATH/update_extensions.sql"
+    su postgres -c "psql --file $SCRIPTS_PATH/update_extensions.sql"
     rm "$SCRIPTS_PATH/update_extensions.sql"
 fi
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: GH-36350

If we enable PGroonga, `scripts/setup/upgrade-postgresql` failed to update extensions:

```console
$ /home/zulip/deployments/current/scripts/setup/upgrade-postgresql
...
+ '[' -f /var/log/postgresql/pg_upgradecluster-16-17-main.QMPV/update_extensions.sql ']'
+ su postgres -c 'psql /var/log/postgresql/pg_upgradecluster-16-17-main.QMPV/update_extensions.sql'
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  database "/var/log/postgresql/pg_upgradecluster-16-17-main.QMPV/update_ex" does not exist
$
```

https://github.com/zulip/zulip/blob/6262c81375137ad4a59fe54e5e280e911bc63063/scripts/setup/upgrade-postgresql#L111

uses `psql ${SQL_PATH}` but it means that `psql` connects to `${SQL_PATH}`.

We need to use `psql --file ${SQL_PATH}` instead. It means that `psql` connects to the default database and executes SQL in `${SQL_PATH`.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
