### PR TITLE
docs: Remove trailing slash from canonical URL for non-root docs.

### DIFF
--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -251,6 +251,14 @@ class DocPageTest(ZulipTestCase):
         )
         self.assertEqual(result.status_code, 404)
 
+        result = self.client_get(
+            # Non-root API docs pages do not have a trailing slash.
+            "/api/changelog/",
+            follow=True,
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(result.status_code, 404)
+
     def test_dev_environment_endpoints(self) -> None:
         self._test("/devlogin/", ["Normal users"])
         self._test("/devtools/", ["Useful development URLs"])

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -77,7 +77,12 @@ def add_api_url_context(
 
 
 def add_canonical_link_context(context: dict[str, Any], request: HttpRequest) -> None:
-    context["REL_CANONICAL_LINK"] = f"https://zulip.com{request.path}"
+    if request.path in ["/api/", "/policies/", "/integrations/"]:
+        # Root doc pages have a trailing slash in the canonical URL.
+        canonical_path = request.path
+    else:
+        canonical_path = request.path.removesuffix("/")
+    context["REL_CANONICAL_LINK"] = f"https://zulip.com{canonical_path}"
 
 
 class ApiURLView(TemplateView):


### PR DESCRIPTION
The root pages for API, integrations and policies documentation have a trailing slash for the canoncial URL, but the individual articles on those pages do not have a trailing slash for the page we want to mark as canonical.

**Notes**:
- Only integrations non-root docs return a 200 response with a trailing slash.
- API and policies docs return a 404 response when there is a trailing slash. Added a test case for this to `test_docs.DocPageTest.test_api_doc_404_status_codes`.

**Screenshots and screen captures:**

*GitLab integrations article*
| Before | After |
| --- | --- |
| <img width="1141" height="474" alt="Screenshot From 2025-10-22 16-33-34" src="https://github.com/user-attachments/assets/f09b7df9-e600-4a8a-aacb-37c20b8adf31" /> | <img width="1141" height="474" alt="Screenshot From 2025-10-22 16-33-54" src="https://github.com/user-attachments/assets/739ff347-89e6-4c5a-81fb-37b4ac63928f" />

*Customer support group of integrations docs*
| Before | After |
| --- | --- |
| <img width="1141" height="474" alt="Screenshot From 2025-10-22 16-34-50" src="https://github.com/user-attachments/assets/6469f602-195d-4b9b-8500-5e892e113a16" /> | <img width="1141" height="474" alt="Screenshot From 2025-10-22 16-35-13" src="https://github.com/user-attachments/assets/61958915-156a-47f6-af73-bb18fda28106" />

*Root integrations doc* - no change
| Before | After |
| --- | --- |
| <img width="1141" height="474" alt="Screenshot From 2025-10-22 16-35-29" src="https://github.com/user-attachments/assets/17635a9c-ce83-4b68-b5e1-5b361ba0c03c" /> | <img width="1141" height="474" alt="Screenshot From 2025-10-22 16-35-46" src="https://github.com/user-attachments/assets/c980c7b9-cbb2-4336-b77d-3c10a352268a" />

*404s for API and policies articles with a trailing slash* - no change
<img width="1141" height="474" alt="Screenshot From 2025-10-22 16-36-34" src="https://github.com/user-attachments/assets/ac333e66-fe64-4e61-8c71-90ffe2cbf279" />
<img width="1141" height="474" alt="Screenshot From 2025-10-22 16-36-55" src="https://github.com/user-attachments/assets/70a6db22-cd6d-4bc6-9bf6-37611ecae80f" />


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
