### PR TITLE
make user pills have border

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -275,6 +275,7 @@
     .user-mention {
         color: var(--color-text-other-mention);
         background-color: var(--color-background-text-direct-mention);
+        border: 1px solid var(--color-border-pill-container);
 
         &.user-mention-me {
             color: var(--color-text-self-direct-mention);


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR adds a border to user pills in custom profile fields to make them consistent with user pills elsewhere in the app.

Fixes: https://github.com/zulip/zulip/issues/36301

The issue requested three improvements to user pills in custom profile fields:
1. ✅ Make the pill clickable (hand cursor) - Already working
2. ✅ Hover and click styling with background change - Already working

  

https://github.com/user-attachments/assets/441c0e20-7505-411a-92ca-eb488da04f58


4. **Add a border to the pill (as discussed in https://github.com/zulip/zulip/pull/36010#issuecomment-3417422585)** - Fixed in this PR
**Changes made:**
- Added `border: 1px solid var(--color-border-pill-container);` to `.user-mention` in `web/styles/rendered_markdown.css` (line 278)


Before:
<img width="491" height="233" alt="Screenshot 2025-10-23 201516" src="https://github.com/user-attachments/assets/656aa1ec-edf9-44db-a0cc-2530ad4a0f6b" />
After:
<img width="442" height="237" alt="image" src="https://github.com/user-attachments/assets/2b367878-92ac-4787-be53-351819a6b807" />
This ensures user pills in custom profile fields have the same visual appearance and border treatment as in 


<details>
<summary>Self-review checklist</summary>

- [x] I have reviewed my changes by carefully reading the diff
- [x] I have tested the changes locally in both light and dark themes
- [x] I have checked that the border appears correctly on user pills in custom profile fields
- [x] I have verified that other user pills in the app are not negatively affected
- [x] The changes follow Zulip's CSS conventions and use existing CSS variables

</details>