### PR TITLE
email_mirror_server: Fix the logfile path which is checked.

### DIFF
--- a/zerver/lib/email_mirror_server.py
+++ b/zerver/lib/email_mirror_server.py
@@ -177,7 +177,7 @@ class PermissionDroppingUnthreadedController(UnthreadedController):  # nocoverag
             # We may have a logfile owned by root, from before we
             # fixed it to be owned by zulip; chown it if it exists, so
             # we don't fail below.
-            if os.path.exists(settings.EMAIL_LOG_PATH):
+            if os.path.exists(settings.EMAIL_MIRROR_LOG_PATH):
                 os.chown(settings.EMAIL_MIRROR_LOG_PATH, self.user_id, self.group_id)
 
             logger.info("Dropping privileges to uid %d / gid %d", self.user_id, self.group_id)


### PR DESCRIPTION
(cherry picked from commit 17fd249a628ef5f83eb3983a4359b0c55ab5b04b)

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
