### PR TITLE
search_user_pill: Move guest indicator and emoji info into pill value.

### DIFF
--- a/web/templates/search_user_pill.hbs
+++ b/web/templates/search_user_pill.hbs
@@ -11,11 +11,14 @@
             <span class="fa fa-ban slashed-circle-icon"></span>
             {{/if}}
             <span class="pill-label">
-                <span class="pill-value">{{ this.full_name }}</span>
-                {{~#if this.should_add_guest_user_indicator}}&nbsp;<i>({{t 'guest'}})</i>{{~/if~}}
-                {{~#if this.status_emoji_info~}}
-                    {{~> status_emoji this.status_emoji_info~}}
-                {{~/if~}}
+                <span class="pill-value">
+                    {{~this.full_name~}}
+                    {{~#if this.should_add_guest_user_indicator}}&nbsp;<i>({{t 'guest'}})</i>{{~/if~}}
+                    {{~#if this.status_emoji_info~}}
+                        {{~> status_emoji this.status_emoji_info~}}
+                    {{~/if~}}
+                </span>
+                {{~!-- squash whitespace --~}}
             </span>
             <div class="exit">
                 <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>


### PR DESCRIPTION
When we shrink the pills and add ellipses, we should be shrinking name and guest indicator and emoji info all together, otherwise they'll spill out or individually show ellipses.

Reported here:
[#issues > 🛠️ "(guest)" marker makes search typeahead pills spill out](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.9B.A0.EF.B8.8F.20.22.28guest.29.22.20marker.20makes.20search.20typeahead.20pills.20spill.20out/with/2322896)

