### PR TITLE
Add space between dropdown items and edge of dropdown container.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2314,6 +2314,7 @@ body:not(.spectator-view) {
             text-decoration: none;
             background-color: var(--background-color-active-dropdown-item);
             outline: none;
+            border-radius: 4px;
 
             .dropdown-list-delete,
             .dropdown-list-edit {
@@ -2325,11 +2326,13 @@ body:not(.spectator-view) {
 
 .dropdown-list-container .list-item {
     color: var(--color-dropdown-item);
+    margin: 0 4px;
 
     &:focus,
     &.current_selection {
         background-color: var(--background-color-active-dropdown-item);
         outline: none;
+        border-radius: 4px;
     }
 }
 


### PR DESCRIPTION
Earlier, dropdown item elements would occupy entire width of the dropdown container and focus highlight and hover highlight would also occupy the same.

This commit shrinks the dropdown items to match that of the search container and hover/focus highlight reflects that.

Fixes: https://github.com/zulip/zulip/pull/35850#issuecomment-3429841453

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|Before|After|
|-|-|
|<img width="530" height="569" alt="Screenshot from 2025-10-25 02-47-11" src="https://github.com/user-attachments/assets/6720b324-357f-4210-88f2-73dffac032dd" />|<img width="522" height="569" alt="Screenshot from 2025-10-25 02-40-11" src="https://github.com/user-attachments/assets/136832da-84e8-4937-bd7d-14af8caecf9e" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
