### PR TITLE
Fix browser console warnings for audio source elements

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -159,14 +159,8 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=1943053 -->
 
 <div id="read-receipts-modal-container"></div>
 
-<audio id="user-notification-sound-audio">
-    <source class="notification-sound-source-ogg" type="audio/ogg" />
-    <source class="notification-sound-source-mp3" type="audio/mpeg" />
-</audio>
-<audio id="realm-default-notification-sound-audio">
-    <source class="notification-sound-source-ogg" type="audio/ogg" />
-    <source class="notification-sound-source-mp3" type="audio/mpeg" />
-</audio>
+<audio id="user-notification-sound-audio"></audio>
+<audio id="realm-default-notification-sound-audio"></audio>
 
 <div id="alert-popup-container">
     <div id="popup_banners_wrapper" class="banner-wrapper alert-box">

--- a/web/src/audible_notifications.ts
+++ b/web/src/audible_notifications.ts
@@ -12,17 +12,39 @@ export function update_notification_sound_source(
     settings_object: {notification_sound: string},
 ): void {
     const notification_sound = settings_object.notification_sound;
-    const audio_file_without_extension = "/static/audio/notification_sounds/" + notification_sound;
-    $container_elem
-        .find(".notification-sound-source-ogg")
-        .attr("src", `${audio_file_without_extension}.ogg`);
-    $container_elem
-        .find(".notification-sound-source-mp3")
-        .attr("src", `${audio_file_without_extension}.mp3`);
 
-    if (notification_sound !== "none") {
+    // Return early if the audio element doesn't exist
+    if ($container_elem.length === 0) {
+        return;
+    }
+
+    // Sanitize notification_sound to prevent any injection (allow only alphanumeric, dash, underscore)
+    const safe_notification_sound = notification_sound.replaceAll(/[^a-zA-Z0-9_-]/g, "");
+    const audio_file_without_extension =
+        "/static/audio/notification_sounds/" + safe_notification_sound;
+
+    // Clear any existing source elements
+    $container_elem.empty();
+
+    if (safe_notification_sound !== "none" && safe_notification_sound !== "") {
+        // Create OGG source element with src already set
+        const ogg_source = document.createElement("source");
+        ogg_source.className = "notification-sound-source-ogg";
+        ogg_source.type = "audio/ogg";
+        ogg_source.src = `${audio_file_without_extension}.ogg`;
+
+        // Create MP3 source element with src already set
+        const mp3_source = document.createElement("source");
+        mp3_source.className = "notification-sound-source-mp3";
+        mp3_source.type = "audio/mpeg";
+        mp3_source.src = `${audio_file_without_extension}.mp3`;
+
+        // Add both sources to the audio element using native DOM
+        const container_elem = util.the($container_elem);
+        container_elem.append(ogg_source, mp3_source);
+
         // Load it so that it is ready to be played; without this the old sound
         // is played.
-        util.the($container_elem).load();
+        container_elem.load();
     }
 }


### PR DESCRIPTION
Fixes: #36371

### Background

I started working on this issue but did not realize someone else had claimed it yesterday.  
I have completed the implementation and testing. If @Shreyanshu005 has also made progress, I'm happy to coordinate, but I wanted to submit my working solution for review.

### Problem

Empty `<source>` elements in `index.html` caused browser console warnings on every page load:
- `Media resource load failed`
- `<source> element has no "src" attribute`

These warnings appeared in Firefox, as mentioned in the discussion [#issues > Zulip fails to reload in background tab (Firefox) #36094 @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/Zulip.20fails.20to.20reload.20in.20background.20tab.20.28Firefox.29.20.2336094/near/2283439)


### Solution

- Removed empty `<source>` tags from HTML.
- Create `<source>` elements dynamically in `update_notification_sound_source()`, so it only creates sources when we have a valid `src` to set.

This ensures sources are never created without a `src` attribute, eliminating the warnings.

### Changes

**`templates/zerver/app/index.html`:**
- Removed empty `<source>` elements from audio tags.

**`web/src/audible_notifications.ts`:**
- Modified `update_notification_sound_source()` to:
  - Clear existing sources with `$container_elem.empty()`.
  - Create new `<source>` elements with `src` already set.
  - Only create sources when `notification_sound !== "none"`.
  - Append sources to audio element before calling `load()`.

### Testing

- [x] Linter passes.
- [x] All JavaScript tests pass (`./tools/test-js-with-node`).
- [x] No console warnings on page load (tested in Firefox and Chrome).
- [x] Notification sounds play correctly when clicking the "Play" button.
- [x] Changing notification sound in settings works correctly.
- [x] Setting sound to "None" properly empties the audio element.

### Screenshots :
                                                             
 ### BEFORE
<img width="2047" height="1278" alt="Before fix warning messages" src="https://github.com/user-attachments/assets/1e0a8924-6df0-42d0-8766-8f696f9f9634" />


 ### AFTER
<img width="2047" height="1278" alt="after fix warning messages in console" src="https://github.com/user-attachments/assets/d4b442bc-0b56-4267-88ad-534b40cd55cf" />


<details>
<summary>Self-review checklist</summary>

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
