### PR TITLE
left_sidebar: Fix content peeking through under sticky topics header.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -129,6 +129,8 @@
     .zoom-in {
         #topics_header {
             background-color: var(--color-background);
+            /* Ensure full background coverage in dark theme */
+            box-shadow: 0 1px 0 0 var(--color-background);
         }
     }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -2128,7 +2128,7 @@ li.topic-list-item {
     display: grid;
     position: sticky;
     top: 0;
-    z-index: 2;
+    z-index: 3;
     grid-template-columns:
         [topics-content-area-start] var(--left-sidebar-toggle-width-offset)
         0 0 minmax(0, 1fr) 0
@@ -2140,6 +2140,8 @@ li.topic-list-item {
     padding-top: var(--left-sidebar-sections-vertical-gutter);
     color: hsl(0deg 0% 43%);
     background-color: var(--color-background);
+    /* Ensure full background coverage to prevent content peeking through */
+    box-shadow: 0 1px 0 0 var(--color-background);
     /* With quiet unreads, we want the BACK TO CHANNELS
        and unread count to share a common baseline. */
     line-height: var(--line-height-sidebar-row);


### PR DESCRIPTION
Fixes issue where text content was showing through/peeking under the sticky topics header in the left sidebar, especially on external monitors and certain zoom levels. This affected the 'Back to channels' button area and other content in the topics header section.

Changes:
- Increased z-index from 2 to 3 for better stacking context
- Added box-shadow for complete background coverage
- Applied same fix to dark theme for consistency

Fixes #35159.

Fixes: #35159

**Screenshots and screen captures:**

<details>
<summary>Left sidebar with expanded channel view</summary>

![
<img width="531" height="442" alt="image" src="https://github.com/user-attachments/assets/e1549d6d-a6b0-476e-b95c-f25223eebee4" />

](
<img width="1837" height="999" alt="Screenshot from 2025-10-26 01-40-41" src="https://github.com/user-attachments/assets/f461e506-ad60-4edf-86ea-525d6695a11c" />
)

</details>

**Note:** The visual difference is subtle as this fix addresses edge cases that may be more visible on certain screen configurations, zoom levels, or during scrolling interactions. The fix improves z-index stacking and background coverage to prevent content peeking through.

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate. (Not applicable for CSS-only changes)
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
