### PR TITLE
fix: no special message for invalid time

### DIFF
--- a/api_docs/message-formatting.md
+++ b/api_docs/message-formatting.md
@@ -23,6 +23,14 @@ for syntax highlighting. This field is used in the
 mentions][help-global-time] to supported Markdown message formatting
 features.
 
+**Changes**: In Zulip 12.0 (feature level 437), invalid timestamp formats
+are now rendered as escaped literal text instead of a `<span>` element with `timestamp-error` class and an error message.
+
+```html
+<!-- Input: <time:2017-13-45> (invalid date) -->
+&lt;time:2017-13-45&gt;
+```
+
 ## Links to channels, topics, and messages
 
 Zulip's markup supports special readable Markdown syntax for [linking

--- a/api_docs/unmerged.d/ZF-b5e96d.md
+++ b/api_docs/unmerged.d/ZF-b5e96d.md
@@ -1,0 +1,4 @@
+* [Message formatting](/api/message-formatting#global-times): Invalid
+  timestamp formats in `<time:...>` syntax are now rendered as escaped
+  literal text (e.g., `&lt;time:invalid date&gt;`) instead of a `<span>`
+  element with class `timestamp-error` containing an error message.

--- a/version.py
+++ b/version.py
@@ -35,7 +35,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 436
+API_FEATURE_LEVEL = 437
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -590,7 +590,27 @@ function handleTimestamp(time_string: string): string {
         // there is a chance that the server would interpret it successfully
         // and if it does, the jumping from the error message to a rendered
         // timestamp doesn't look good.
-        return `<span>${escaped_time}</span>`;
+
+        // Checking if the backend could parse a timestamp
+        const backend_only_patterns = [
+            // Human-readable dates with ordinal suffixes (5th, 31st, etc.)
+            /\b\d+(st|nd|rd|th)\b/i,
+            // Dates with timezone abbreviations like IST, PST, etc.
+            /\b[A-Z]{3,4}\b/,
+        ];
+
+        const is_backend_only_timestamp = backend_only_patterns.some((pattern) =>
+            pattern.test(time_string),
+        );
+
+        if (is_backend_only_timestamp) {
+            // For timestamps that the backend can parse but frontend cannot,
+            // render just the time content in a span (frontend fallback).
+            return `<span>${escaped_time}</span>`;
+        }
+        // For all other invalid input (malformed),
+        // return escaped literal to match backend behavior.
+        return `&lt;time:${escaped_time}&gt;`;
     }
 
     // Use html5 <time> tag for valid timestamps.

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -290,6 +290,8 @@ export const update_elements = ($content: JQuery): void => {
         }
     });
 
+    // Maintains backward compatibility for legacy 'timestamp-error' spans.
+    // The server no longer generates this markup, but older records may still contain it.
     $content.find("span.timestamp-error").each(function (): void {
         const match_array = /^Invalid time format: (.*)$/.exec($(this).text());
         assert(match_array !== null);

--- a/web/tests/rendered_markdown.test.cjs
+++ b/web/tests/rendered_markdown.test.cjs
@@ -146,8 +146,8 @@ const get_content_element = () => {
     $content.set_find_results("a.stream", $array([]));
     $content.set_find_results("a.stream-topic, a.message-link", $array([]));
     $content.set_find_results("time", $array([]));
-    $content.set_find_results("span.timestamp-error", $array([]));
     $content.set_find_results(".emoji", $array([]));
+    $content.set_find_results("span.timestamp-error", $array([]));
     $content.set_find_results("div.spoiler-header", $array([]));
     $content.set_find_results("div.codehilite", $array([]));
     $content.set_find_results(".message_inline_video video", $array([]));

--- a/web/third/marked/lib/marked.cjs
+++ b/web/third/marked/lib/marked.cjs
@@ -549,7 +549,7 @@ inline.zulip = merge({}, inline.breaks, {
   stream_topic: /^#\*\*([^\*>]+)>([^\*]*)\*\*/,
   stream: /^#\*\*([^\*]+)\*\*/,
   tex: /^(\$\$([^\n_$](\\\$|[^\n$])*)\$\$(?!\$))\B/,
-  timestamp: /^<time:([^>]+)>/,
+  timestamp: /^<time:([^>]*?)>/,
   text: replace(inline.breaks.text)
     ('|', '|(\ud83c[\udd00-\udfff]|\ud83d[\udc00-\ude4f]|' +
           '\ud83d[\ude80-\udeff]|\ud83e[\udd00-\uddff]|' +
@@ -822,13 +822,6 @@ InlineLexer.prototype.output = function(src) {
     if (cap = this.rules.unicodeemoji.exec(src)) {
       src = src.substring(cap[0].length);
       out += this.unicodeEmoji(cap[1]);
-      continue;
-    }
-
-    // timestamp
-    if (cap = this.rules.timestamp.exec(src)) {
-      src = src.substring(cap[0].length);
-      out += this.timestamp(cap[1]);
       continue;
     }
 

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1224,7 +1224,7 @@ class CompiledInlineProcessor(markdown.inlinepatterns.InlineProcessor):
 
 class Timestamp(markdown.inlinepatterns.Pattern):
     @override
-    def handleMatch(self, match: Match[str]) -> Element | None:
+    def handleMatch(self, match: Match[str]) -> Element | str | None:
         time_input_string = match.group("time")
         try:
             timestamp = dateutil.parser.parse(time_input_string, tzinfos=common_timezones)
@@ -1235,12 +1235,7 @@ class Timestamp(markdown.inlinepatterns.Pattern):
                 timestamp = None
 
         if not timestamp:
-            error_element = Element("span")
-            error_element.set("class", "timestamp-error")
-            error_element.text = markdown.util.AtomicString(
-                f"Invalid time format: {time_input_string}"
-            )
-            return error_element
+            return markdown.util.AtomicString(f"<time:{time_input_string}>")
 
         # Use HTML5 <time> element for valid timestamps.
         time_element = Element("time")
@@ -1248,12 +1243,7 @@ class Timestamp(markdown.inlinepatterns.Pattern):
             try:
                 timestamp = timestamp.astimezone(timezone.utc)
             except (ValueError, OverflowError):
-                error_element = Element("span")
-                error_element.set("class", "timestamp-error")
-                error_element.text = markdown.util.AtomicString(
-                    f"Invalid time format: {time_input_string}"
-                )
-                return error_element
+                return markdown.util.AtomicString(f"<time:{time_input_string}>")
         else:
             timestamp = timestamp.replace(tzinfo=timezone.utc)
         time_element.set("datetime", timestamp.isoformat().replace("+00:00", "Z"))

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -826,9 +826,8 @@
     {
       "name": "timestamp_invalid_input",
       "input": "<time:<alert(1)>>",
-      "expected_output": "<p><span class=\"timestamp-error\">Invalid time format: &lt;alert(1)</span>&gt;</p>",
-      "marked_expected_output": "<p><span>&lt;alert(1)</span>&gt;</p>",
-      "text_content": "Invalid time format: <alert(1)>"
+      "expected_output": "<p>&lt;time:&lt;alert(1)&gt;&gt;</p>",
+      "text_content": "<time:<alert(1)>>"
     },
     {
       "name": "timestamp_timezone",
@@ -840,23 +839,20 @@
     {
       "name": "timestamp_incorrect",
       "input": "<time:**hello world**>",
-      "expected_output": "<p><span class=\"timestamp-error\">Invalid time format: **hello world**</span></p>",
-      "marked_expected_output": "<p><span>**hello world**</span></p>",
-      "text_content": "Invalid time format: **hello world**"
+      "expected_output": "<p>&lt;time:**hello world**&gt;</p>",
+      "text_content": "<time:**hello world**>"
     },
     {
       "name": "timestamp_invalid_timezone",
       "input": "<time:1969-12-31T00:00:00+32:00>",
-      "expected_output": "<p><span class=\"timestamp-error\">Invalid time format: 1969-12-31T00:00:00+32:00</span></p>",
-      "marked_expected_output": "<p><span>1969-12-31T00:00:00+32:00</span></p>",
-      "text_content": "Invalid time format: 1969-12-31T00:00:00+32:00"
+      "expected_output": "<p>&lt;time:1969-12-31T00:00:00+32:00&gt;</p>",
+      "text_content": "<time:1969-12-31T00:00:00+32:00>"
     },
     {
       "name": "timestamp_overflow",
       "input": "<time:0001-01-01T01:00:00+02:00>",
-      "expected_output": "<p><span class=\"timestamp-error\">Invalid time format: 0001-01-01T01:00:00+02:00</span></p>",
-      "marked_expected_output": "<p><span>0001-01-01T01:00:00+02:00</span></p>",
-      "text_content": "Invalid time format: 0001-01-01T01:00:00+02:00"
+      "expected_output": "<p>&lt;time:0001-01-01T01:00:00+02:00&gt;</p>",
+      "text_content": "<time:0001-01-01T01:00:00+02:00>"
     },
     {
       "name": "timestamp_unix",
@@ -867,9 +863,9 @@
     {
       "name": "timestamp_unix_overflow",
       "input": "Let's meet at <time:1234567890123>.",
-      "expected_output": "<p>Let's meet at <span class=\"timestamp-error\">Invalid time format: 1234567890123</span>.</p>",
+      "expected_output": "<p>Let's meet at &lt;time:1234567890123&gt;.</p>",
       "marked_expected_output": "<p>Let's meet at <time datetime=\"+041091-11-25T05:02:03Z\">1234567890123</time>.</p>",
-      "text_content": "Let's meet at Invalid time format: 1234567890123."
+      "text_content": "Let's meet at <time:1234567890123>."
     },
     {
       "name": "tex_inline",


### PR DESCRIPTION
This pull request fixes the issue where if user entered an invalid date inside <time> tag, then instead of showing `invalid-time-format` it will just display what the user typed.

Fixes: #36374 

### Before
<img width="834" height="80" alt="Screenshot from 2025-10-27 01-03-43" src="https://github.com/user-attachments/assets/fda2c4e5-d613-48d1-ba8c-4407af5ed38c" />


### After

<img width="1099" height="118" alt="Screenshot 2025-11-06 202929" src="https://github.com/user-attachments/assets/1a46fe89-1416-4572-906e-dbfc2365b561" />



Let me know, if anything else was expected and I will work on that as soon as I possibly can.
As this is my first contribution, please pardon my mistakes, I am really open to learning, so I will accommodate whatever needs to be changed.

<details>
<summary>Self-review checklist</summary>


- [ X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
