### PR TITLE
stream_list: Fix two bugs related to is_filtering_inactives.

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -982,7 +982,7 @@ export function dispatch_normal_event(event) {
             }
             if (event.property === "demote_inactive_streams") {
                 stream_list_sort.set_filter_out_inactives();
-                stream_list.update_streams_sidebar();
+                stream_list.update_streams_sidebar(true);
             }
             if (event.property === "web_animate_image_previews") {
                 // Rerender the whole message list UI

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -17,6 +17,7 @@ import * as channel_folders from "./channel_folders.ts";
 import * as compose_actions from "./compose_actions.ts";
 import type {Filter} from "./filter.ts";
 import * as hash_util from "./hash_util.ts";
+import {$t} from "./i18n.ts";
 import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area.ts";
 import * as narrow_state from "./narrow_state.ts";
 import * as pm_list from "./pm_list.ts";
@@ -321,9 +322,7 @@ export function build_stream_list(force_rerender: boolean): void {
         assert(sidebar_row !== undefined);
         sidebar_row.update_whether_active();
         const $li = sidebar_row.get_li();
-        if (inactive_or_muted) {
-            $li.addClass("inactive-or-muted-in-channel-folder");
-        }
+        $li.toggleClass("inactive-or-muted-in-channel-folder", inactive_or_muted);
         $list.append($li);
     }
 
@@ -348,10 +347,27 @@ export function build_stream_list(force_rerender: boolean): void {
         }
         const muted_and_inactive_streams = [...section.muted_streams, ...section.inactive_streams];
         if (section.id !== "pinned-streams" && muted_and_inactive_streams.length > 0) {
+            let button_text;
+            if (section.muted_streams.length > 0 && section.inactive_streams.length > 0) {
+                button_text = $t(
+                    {defaultMessage: "{count} INACTIVE OR MUTED"},
+                    {count: muted_and_inactive_streams.length},
+                );
+            } else if (section.muted_streams.length > 0) {
+                button_text = $t(
+                    {defaultMessage: "{count} MUTED"},
+                    {count: section.muted_streams.length},
+                );
+            } else {
+                button_text = $t(
+                    {defaultMessage: "{count} INACTIVE"},
+                    {count: section.inactive_streams.length},
+                );
+            }
             $(`#stream-list-${section.id}`).append(
                 $(
                     render_show_inactive_or_muted_channels({
-                        inactive_or_muted_count: muted_and_inactive_streams.length,
+                        button_text,
                     }),
                 ),
             );

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -77,7 +77,6 @@ export function set_filter_out_inactives(): void {
     }
 }
 
-// Exported for access by unit tests.
 export function is_filtering_inactives(): boolean {
     return filter_out_inactives;
 }

--- a/web/templates/show_inactive_or_muted_channels.hbs
+++ b/web/templates/show_inactive_or_muted_channels.hbs
@@ -2,7 +2,7 @@
     <div class="show-inactive-or-muted-channels sidebar-topic-action-heading">
         <i class="zulip-icon zulip-icon-expand" aria-hidden="true"></i>
         <div class="stream-list-toggle-inactive-or-muted-channels-text">
-            {{#tr}}{inactive_or_muted_count} inactive or muted{{/tr}}
+            {{button_text}}
         </div>
         <div class="markers-and-unreads">
             <span class="unread_count quiet-count"></span>
@@ -14,7 +14,7 @@
     <div class="hide-inactive-or-muted-channels sidebar-topic-action-heading">
         <i class="zulip-icon zulip-icon-collapse" aria-hidden="true"></i>
         <div class="stream-list-toggle-inactive-or-muted-channels-text">
-            {{#tr}}{inactive_or_muted_count} inactive or muted{{/tr}}
+            {{button_text}}
         </div>
     </div>
 </div>


### PR DESCRIPTION
(1) Remove the "inactive-or-muted-in-channel-folder" classname
    when channels stop being considered inactive on rerender.
(2) The toggle button shouldn't mention inactive channels if
    we're not hiding them.

Discussed here:
https://chat.zulip.org/#narrow/channel/101-design/topic/hide.20inactive.20channel.20setting/near/2272941

Note that I did check that the counts are still being calculated correctly for both settings.
