### PR TITLE
drafts: Add auto-saving of drafts in compose.

### DIFF
--- a/web/src/compose.ts
+++ b/web/src/compose.ts
@@ -25,6 +25,7 @@ import * as sent_messages from "./sent_messages.ts";
 import * as server_events_state from "./server_events_state.ts";
 import {current_user} from "./state_data.ts";
 import * as transmit from "./transmit.ts";
+import * as typing from "./typing.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
 import * as zcommand from "./zcommand.ts";
@@ -150,6 +151,8 @@ export function send_message_success(
 
     echo.reify_message_id(sent_message.local_id, data.id);
     drafts.draft_model.deleteDrafts([sent_message.draft_id]);
+    // Cancel auto-save timer since the message was sent successfully
+    typing.cancel_auto_save_timer();
 
     if (sent_message.type === "stream") {
         if (data.automatic_new_visibility_policy) {
@@ -443,6 +446,8 @@ function schedule_message_to_custom_date(): void {
     const success = function (data: unknown): void {
         drafts.draft_model.deleteDrafts([draft_id]);
         clear_compose_box();
+        // Cancel auto-save timer since the scheduled message was created successfully
+        typing.cancel_auto_save_timer();
         const {scheduled_message_id} = z.object({scheduled_message_id: z.number()}).parse(data);
         const new_row_html = render_success_message_scheduled_banner({
             scheduled_message_id,

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -29,6 +29,7 @@ import * as resize from "./resize.ts";
 import * as saved_snippets_ui from "./saved_snippets_ui.ts";
 import * as spectators from "./spectators.ts";
 import * as stream_data from "./stream_data.ts";
+import * as typing from "./typing.ts";
 import * as util from "./util.ts";
 
 // Opts sent to `compose_actions.start`.
@@ -86,6 +87,8 @@ export function rewire_blur_compose_inputs(value: typeof blur_compose_inputs): v
 function hide_box(): void {
     // This is the main hook for saving drafts when closing the compose box.
     drafts.update_draft();
+    // Cancel the auto-save timer since we just saved
+    typing.cancel_auto_save_timer();
     blur_compose_inputs();
     $("#compose_recipient_box").hide();
     $("#compose-direct-recipient").hide();
@@ -366,6 +369,8 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
         (!same_recipient_as_before(opts) || opts.content !== undefined)
     ) {
         drafts.update_draft();
+        // Cancel the auto-save timer since we just saved
+        typing.cancel_auto_save_timer();
         clear_box();
     }
 

--- a/web/src/compose_send_menu_popover.ts
+++ b/web/src/compose_send_menu_popover.ts
@@ -15,6 +15,7 @@ import * as flatpickr from "./flatpickr.ts";
 import * as message_reminder from "./message_reminder.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as scheduled_messages from "./scheduled_messages.ts";
+import * as typing from "./typing.ts";
 import {parse_html} from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
@@ -266,6 +267,8 @@ export function initialize(): void {
             });
             $popper.one("click", ".compose_new_message", () => {
                 drafts.update_draft();
+                // Cancel auto-save timer since we just saved the draft
+                typing.cancel_auto_save_timer();
                 // If they want to compose a new message instead
                 // of seeing the draft, remember this and don't
                 // restore drafts in this narrow until the user

--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -37,6 +37,7 @@ import * as stream_settings_components from "./stream_settings_components.ts";
 import * as sub_store from "./sub_store.ts";
 import * as subscriber_api from "./subscriber_api.ts";
 import {get_timestamp_for_flatpickr} from "./timerender.ts";
+import * as typing from "./typing.ts";
 import * as ui_report from "./ui_report.ts";
 import * as upload from "./upload.ts";
 import * as user_topics from "./user_topics.ts";
@@ -664,6 +665,10 @@ export function initialize(): void {
         // Save drafts when the window loses focus to help
         // ensure no work is lost
         drafts.update_draft();
+        // Cancel the auto-save timer since we just saved.
+        // This prevents the timer from firing later and potentially
+        // overwriting a newer draft if the user types in another tab.
+        typing.cancel_auto_save_timer();
     });
 
     $("body").on("click", ".formatting_button", function (e) {


### PR DESCRIPTION
This pull request introduces an auto-save feature for the compose box. The content of the compose box is now automatically saved as a draft every 60 seconds when the user is typing. This is a crucial feature to prevent users from losing their work.

Fixes: #36102

**Screenshots and screen captures:**

[Screencast from 2025-10-27 11-32-19.webm](https://github.com/user-attachments/assets/2e7e4a2c-c9d9-413e-8f45-612f9f7791c5)

This screen recording shows that save is triggered only if its been `>60s` since the last save.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>