### PR TITLE
help: Update inactive and muted docs to match UI.

### DIFF
--- a/starlight_help/src/content/docs/manage-inactive-channels.mdx
+++ b/starlight_help/src/content/docs/manage-inactive-channels.mdx
@@ -13,31 +13,21 @@ hides channels with no recent messages if you're subscribed to 20+ channels. You
 can [configure](#configure-hiding-inactive-channels) Zulip to show or hide
 inactive channels regardless of how many you're subscribed to.
 
-It's easy to [reveal](#reveal-inactive-channels) or [find]() hidden inactive
-channels if you need to access them.
+It's easy to [reveal](#reveal-or-hide-inactive-channels) or
+[find](#find-inactive-channels) hidden inactive channels if you need to access
+them.
 
-## Reveal inactive channels
-
-<Tabs>
-  <TabItem label="Desktop/Web">
-    <Steps>
-      1. In the left sidebar, scroll to the bottom of the list of channels in the
-         [folder](/help/channel-folders) you're viewing.
-      1. Click **inactive channels** to reveal inactive channels. If you don't see
-         this button, there are no inactive channels, or they are already revealed.
-    </Steps>
-  </TabItem>
-</Tabs>
-
-## Hide inactive channels
+## Reveal or hide inactive channels
 
 <Tabs>
   <TabItem label="Desktop/Web">
     <Steps>
       1. In the left sidebar, scroll to the bottom of the list of channels in the
          [folder](/help/channel-folders) you're viewing.
-      1. Click **hide inactive channels**. If you don't see this button, there are no
-         inactive channels, or they are already hidden.
+      1. Click **inactive or muted** or **inactive** to toggle whether inactive
+         channels are hidden. If you don't see this button, there are no
+         inactive channels, or inactive channels are
+         [configured](#configure-hiding-inactive-channels) to always be shown.
     </Steps>
   </TabItem>
 </Tabs>

--- a/starlight_help/src/content/docs/mute-a-channel.mdx
+++ b/starlight_help/src/content/docs/mute-a-channel.mdx
@@ -2,7 +2,7 @@
 title: Mute or unmute a channel
 ---
 
-import {TabItem, Tabs} from "@astrojs/starlight/components";
+import {Steps, TabItem, Tabs} from "@astrojs/starlight/components";
 
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import NavigationSteps from "../../components/NavigationSteps.astro";
@@ -69,6 +69,20 @@ import SelectChannelViewPersonal from "../include/_SelectChannelViewPersonal.mdx
 
       1. Under **Notification settings**, toggle **Mute channel**.
     </FlattenedSteps>
+  </TabItem>
+</Tabs>
+
+## Reveal or hide muted channels
+
+<Tabs>
+  <TabItem label="Desktop/Web">
+    <Steps>
+      1. In the left sidebar, scroll to the bottom of the list of channels in the
+         [folder](/help/channel-folders) you're viewing.
+      1. Click **inactive or muted** or **muted** to toggle whether muted
+         channels are hidden. If you don't see this button, there are no muted
+         channels.
+    </Steps>
   </TabItem>
 </Tabs>
 

--- a/starlight_help/src/content/include/_MuteUnmuteIntro.mdx
+++ b/starlight_help/src/content/include/_MuteUnmuteIntro.mdx
@@ -17,8 +17,9 @@ Muting has the following effects:
 * Unread messages in muted topics do not contribute to channel unread counts.
 * Muted topics and channels are grayed out in the left sidebar of the desktop/web
   app, and in the mobile app.
-* In the desktop/web app, muted topics are sorted to the bottom of their channel,
-  and muted channels are sorted to the bottom of their channel section.
+* In the desktop/web app, muted topics are sorted to the bottom of their
+  channel, and muted channels appear in a collapsible section at the bottom of
+  their channel folder in the left sidebar.
 
 You can search muted messages using the `is:muted` [search
 filter](/help/search-for-messages#search-by-message-status), or exclude them


### PR DESCRIPTION
CZO discussion: [#design > hide inactive channel setting](https://chat.zulip.org/#narrow/channel/101-design/topic/hide.20inactive.20channel.20setting/with/2286048)

This is written taking into account that headings might be customized for whether we're just hiding muted channels, inactive ones, or both.

---

Current: https://zulip.com/help/mute-a-channel

<details>
<summary>
Updated muted channels instructions
</summary>
<img width="1264" height="246" alt="Screenshot 2025-10-27 at 10 21 39@2x" src="https://github.com/user-attachments/assets/30ef877a-5758-42ad-9511-e1f09acd7650" />
...
<img width="1414" height="368" alt="Screenshot 2025-10-27 at 10 22 16@2x" src="https://github.com/user-attachments/assets/083b139b-e635-4779-8aed-99ff287a4c86" />

</details>

---

Current: https://zulip.com/help/manage-inactive-channels
<details>
<summary>
Updated inactive channels instructions
</summary>
<img width="1380" height="402" alt="Screenshot 2025-10-27 at 14 52 40@2x" src="https://github.com/user-attachments/assets/071ca648-5e86-429c-b667-8ca1c49c5018" />

</details>