### PR TITLE
[11.x] puppet: Use memory limits from cgroup, if set.

### DIFF
--- a/puppet/zulip/lib/facter/container_memory_limit.rb
+++ b/puppet/zulip/lib/facter/container_memory_limit.rb
@@ -1,0 +1,25 @@
+Facter.add(:container_memory_limit_mb) do
+  confine kernel: 'Linux'
+
+  setcode do
+    begin
+      memory_limit_mb = nil
+
+      # Check for cgroup v2
+      if File.exist?('/sys/fs/cgroup/memory.max')
+        val = File.read('/sys/fs/cgroup/memory.max').strip
+        memory_limit_mb = val.to_i / 1024 / 1024 unless val == 'max'
+
+      # Fallback to cgroup v1
+      elsif File.exist?('/sys/fs/cgroup/memory/memory.limit_in_bytes')
+        val = File.read('/sys/fs/cgroup/memory/memory.limit_in_bytes').strip.to_i
+        memory_limit_mb = val / 1024 / 1024 if val < 9223372036854771712
+      end
+
+      memory_limit_mb
+    rescue => e
+      Facter.debug("container_memory_limit_mb error: #{e}")
+      nil
+    end
+  end
+end

--- a/puppet/zulip/manifests/common.pp
+++ b/puppet/zulip/manifests/common.pp
@@ -39,8 +39,11 @@ class zulip::common {
   }
   $supervisor_conf_dir = "${supervisor_system_conf_dir}/zulip"
 
-  $total_memory_bytes = $facts['memory']['system']['total_bytes']
-  $total_memory_mb = $total_memory_bytes / 1024 / 1024
+  if $facts['container_memory_limit_mb'] {
+    $total_memory_mb = Integer($facts['container_memory_limit_mb'])
+  } else {
+    $total_memory_mb = Integer($facts['memory']['system']['total_bytes'] / 1024 / 1024)
+  }
 
   $goarch = $facts['os']['architecture'] ? {
     'amd64'   => 'amd64',


### PR DESCRIPTION
Backport:
 - #35844