### PR TITLE
contributor docs: Rename section and update references.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ This page will guide you through the following steps:
 1. [Getting started](#getting-started)
 1. [Finding an issue to work on](#finding-an-issue-to-work-on)
 1. [Getting help](#getting-help) as you work on your first pull request
-1. Learning [what makes a great Zulip contributor](#what-makes-a-great-zulip-contributor)
+1. Learning [best practices](#best-practices)
 1. [Submitting a pull request](#submitting-a-pull-request)
 1. [Going beyond the first issue](#beyond-the-first-issue)
 
@@ -304,7 +304,7 @@ Well-posed questions will generally get a response within 1-2 business days.
 There is no need to @-mention anyone when you ask a question, as maintainers
 keep a close eye on all the ongoing discussions.
 
-## What makes a great Zulip contributor?
+## Best practices
 
 As you're working on your first code contribution, here are some best practices
 to keep in mind.

--- a/docs/contributing/asking-great-questions.md
+++ b/docs/contributing/asking-great-questions.md
@@ -43,9 +43,6 @@ When your question is answered, follow through on the advice you receive, and (w
 appropriate) summarize the resolution of your problem so that others can learn
 from your experience.
 
-You can find additional helpful tips in our guide to [what makes a great Zulip
-contributor](contributing.md#what-makes-a-great-zulip-contributor).
-
 ## Follow the community guidelines
 
 As always, be sure to follow the [Zulip community

--- a/docs/outreach/apply.md
+++ b/docs/outreach/apply.md
@@ -104,8 +104,8 @@ As you are getting started on your first pull request:
   review. Catching mistakes yourself will help your PRs be merged faster, and
   folks will appreciate the quality and professionalism of your work.
 
-Our documentation on [what makes a great Zulip
-contributor](../contributing/contributing.md#what-makes-a-great-zulip-contributor)
+Our documentation on [how to be a successful
+contributor](../contributing/contributing.md#how-to-be-a-successful-contributor)
 offers some additional advice.
 
 ## Putting together your application


### PR DESCRIPTION
Also remove unnecessary reference from questions doc.

/apply may need a more detailed refresh pass, but I want to leave that for when we're closer to GSoC application season.


<img width="1458" height="326" alt="Screenshot 2025-10-27 at 15 03 43@2x" src="https://github.com/user-attachments/assets/5ba48d8f-16a7-44b4-816f-755faaa00fd9" />
<img width="1320" height="78" alt="Screenshot 2025-10-27 at 15 04 17@2x" src="https://github.com/user-attachments/assets/c9d3e826-f65d-4e22-9425-ece38b0f141d" />
