### PR TITLE
message_edit_history: Apply highlight colors to links.

### DIFF
--- a/web/styles/message_edit_history.css
+++ b/web/styles/message_edit_history.css
@@ -83,4 +83,26 @@
             );
         }
     }
+
+    /* Show `Link:` text of media beside it
+       to clarify click area for opening media
+       in new tab vs in lightbox. */
+    .highlight_text_inserted:has(.media-anchor-element .media-image-element),
+    .highlight_text_deleted:has(.media-anchor-element .media-image-element) {
+        > .media-anchor-element {
+            display: flex;
+            overflow-wrap: anywhere;
+
+            > .media-image-element {
+                flex-grow: 1;
+                flex-shrink: 0;
+            }
+        }
+
+        @media (width < $sm_min) {
+            > .media-anchor-element {
+                flex-direction: column;
+            }
+        }
+    }
 }


### PR DESCRIPTION
discussion: [#issues > message edit history colors and media width](https://chat.zulip.org/#narrow/channel/9-issues/topic/message.20edit.20history.20colors.20and.20media.20width/with/2286331)

This avoids added or deleted links from looking werid due to changed background color.

| before | after |
| --- | --- |
| <img width="1327" height="1427" alt="image" src="https://github.com/user-attachments/assets/af35f342-59de-4938-b0d5-bc7697f23643" /> | <img width="1058" height="1152" alt="image" src="https://github.com/user-attachments/assets/ff097aee-03a1-4092-b651-8e7b5a07dec1" /> |
|   <img width="1058" height="1152" alt="image" src="https://github.com/user-attachments/assets/77a8b640-993c-4d54-aa02-6c676268ffb9" />  | <img width="1058" height="1152" alt="image" src="https://github.com/user-attachments/assets/c9fdbb5e-a8a4-4f40-877d-ac9a5a420387" /> |



2nd commit:

| before | after |
| --- | --- |
| <img width="1058" height="1152" alt="image" src="https://github.com/user-attachments/assets/ff097aee-03a1-4092-b651-8e7b5a07dec1" /> | <img width="802" height="1321" alt="Screenshot from 2025-10-29 12-44-17" src="https://github.com/user-attachments/assets/04153eac-daf2-4968-8281-9ee9626e30b0" /> |


