### PR TITLE
inputs: Correct Flatpickr hovers, and whittle down `input` selector stack.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -713,16 +713,8 @@ i.zulip-icon:focus-visible,
 input:not(.input-element) {
     &[type="text"],
     &[type="password"],
-    &[type="datetime"],
-    &[type="datetime-local"],
-    &[type="date"],
-    &[type="month"],
-    &[type="time"],
-    &[type="week"],
     &[type="email"],
     &[type="url"],
-    &[type="search"],
-    &[type="tel"],
     &[type="color"] {
         font-size: inherit;
         height: 1.4em;


### PR DESCRIPTION
This PR fixes a broken hover-effect on Flatpickr times in light mode.

It also cleans up some similar but unused `[type=""]` styles in CSS, with a few more remaining that could probably be cleaned up quickly as part of a follow-up (`type="text"` notwithstanding).

There are a few follow-ups to this work that we should pursue shortly:

- [ ] For some reason, the hovered area extends to the right of the hour/minute areas in light mode. I've not yet been able to figure out what's happening to cause that issue in light mode, but not dark mode
- [ ] We have lines in `zulip.css` to hide the up/down arrows adjacent the year input at the top of Flatpickr. Those rules do not apply correctly in dark theme, but it's probably worth discussing whether we should be tinkering with that kind of thing at all...or submitting an upstream patch to improve their appearance generally. A bigger discussion is whether we should be hanging custom changes like that off of `.flatpickr-calendar` in `zulip.css` to begin with
- [ ] We should clean up the remaining input selectors in `zulip.css`; all but the `text` type should be pretty quick work, perhaps for @sayamsamal 

[#issues > calendar hover weirdness](https://chat.zulip.org/#narrow/channel/9-issues/topic/calendar.20hover.20weirdness/with/2286821)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_The removed CSS selectors cause an apparent shift of the month and year in light mode; that's owing to styles that should not have been applied to Flatpickr, so the "after" shift is actually correct. You can verify this by noting that there is no such shift in the dark theme screenshots, which overrode the things that would otherwise have been inherited from_ `zulip.css`:

| Before | After |
| --- | --- |
| <img width="750" height="900" alt="flatpickr-hover-light-before" src="https://github.com/user-attachments/assets/2859eb55-81a6-48d2-81c1-6ffa2640ae4d" /> | <img width="750" height="900" alt="flatpickr-hover-light-after" src="https://github.com/user-attachments/assets/d08adbd5-6533-4ca0-8a2d-c00acedd37d9" /> |
| <img width="750" height="900" alt="flatpickr-hover-dark-before" src="https://github.com/user-attachments/assets/f99158ca-5815-421b-9774-1e0300f91df6" /> | <img width="750" height="900" alt="flatpickr-hover-dark-after" src="https://github.com/user-attachments/assets/df8c40cc-bd03-4b29-b496-2f8288dc8aaf" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

