### PR TITLE
popovers: Keep scheduling popovers open when choosing a custom time.

### DIFF
--- a/web/src/compose_send_menu_popover.ts
+++ b/web/src/compose_send_menu_popover.ts
@@ -108,12 +108,25 @@ export function open_schedule_message_menu(
                             current_time.getTime() +
                                 scheduled_messages.MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS * 1000,
                         ),
-                        onClose(selectedDates, _dateStr, instance) {
+                        appendTo: $popper[0]!,
+                        position: "above center",
+                        onOpen() {
+                            // Prevent the parent popover from closing when flatpickr opens
+                            instance.setProps({
+                                hideOnClick: false,
+                            });
+                        },
+                        onClose(selectedDates, _dateStr, flatpickr_instance) {
                             // Return to normal state.
                             $send_later_options_content.css("pointer-events", "all");
+                            // Re-enable hiding on click for the parent popover
+                            instance.setProps({hideOnClick: true});
                             const selected_date = selectedDates[0];
-                            assert(instance.config.minDate !== undefined);
-                            if (selected_date && selected_date < instance.config.minDate) {
+                            assert(flatpickr_instance.config.minDate !== undefined);
+                            if (
+                                selected_date &&
+                                selected_date < flatpickr_instance.config.minDate
+                            ) {
                                 scheduled_messages.set_minimum_scheduled_message_delay_minutes_note(
                                     true,
                                 );


### PR DESCRIPTION
In this PR, I prevented the parent popover from closing when Flatpickr opens by adding the logic inside the onOpen function, and reversed it in the onClose function.

Fixes: #35464.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Location | Before | After |
|--|--|---|
| Message Reminder | <img width="340" height="436" alt="Screenshot 2025-10-30 at 3 37 15 PM" src="https://github.com/user-attachments/assets/d74519d6-e187-4d33-998c-36a347f8c924" /> | <img width="342" height="465" alt="Screenshot 2025-10-30 at 3 36 06 PM" src="https://github.com/user-attachments/assets/7cd39481-1ca7-4da8-aae1-8c8cf30600c8" /> |
| Schedule Message | <img width="389" height="465" alt="Screenshot 2025-10-30 at 3 37 28 PM" src="https://github.com/user-attachments/assets/22551bb8-c1d0-4f11-9267-4d8669c54b7d" /> | <img width="414" height="472" alt="Screenshot 2025-10-30 at 3 35 54 PM" src="https://github.com/user-attachments/assets/cfdf8ca2-70f5-4f59-a77c-822c3319a9ee" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
