### PR TITLE
inbox: Fix left missing list of topics for old channels.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -40,7 +40,7 @@ import * as stream_settings_api from "./stream_settings_api.ts";
 import * as stream_topic_history from "./stream_topic_history.ts";
 import * as stream_topic_history_util from "./stream_topic_history_util.ts";
 import * as sub_store from "./sub_store.ts";
-import {TopicListWidget} from "./topic_list.ts";
+import * as topic_list from "./topic_list.ts";
 import * as topic_list_data from "./topic_list_data.ts";
 import * as unread from "./unread.ts";
 import * as unread_ops from "./unread_ops.ts";
@@ -1082,7 +1082,7 @@ function hide_channel_view_loading_indicator(): void {
     loading.destroy_indicator($("#inbox-loading-indicator #loading_more_indicator"));
 }
 
-class InboxTopicListWidget extends TopicListWidget {
+class InboxTopicListWidget extends topic_list.TopicListWidget {
     override topic_list_class_name = "inbox-channel-topic-list";
     topics_widget?: list_widget.ListWidget<topic_list_data.TopicInfo>;
 
@@ -1126,6 +1126,8 @@ class InboxTopicListWidget extends TopicListWidget {
                 }
 
                 channel_view_topic_widget.build();
+                // Also, update the left sidebar topics list for this channel.
+                topic_list.update_widget_for_stream(this.my_stream_id);
             });
         } else {
             show_empty_inbox_channel_view_text(this.is_empty());

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -40,7 +40,7 @@ export function update(): void {
     }
 }
 
-function update_widget_for_stream(stream_id: number): void {
+export function update_widget_for_stream(stream_id: number): void {
     const widget = active_widgets.get(stream_id);
     if (widget === undefined) {
         blueslip.warn("User re-narrowed before topic history was returned.");


### PR DESCRIPTION
Since we have the complete list of topics of the channel when showing list of topics view for the channel, we update the channel in left sidebar as the new fetched data.

This provides a nicer experince for old channels for which we don't have any messages to extract any topic info from.

discussion: [#issues > left sidebar topics when channel links go to list of topics](https://chat.zulip.org/#narrow/channel/9-issues/topic/left.20sidebar.20topics.20when.20channel.20links.20go.20to.20list.20of.20topics/with/2288203)


| before | after |
| --- | --- |
| <img width="1280" height="1454" alt="Screenshot from 2025-10-30 16-40-37" src="https://github.com/user-attachments/assets/f117857b-f3ee-4739-99fc-82e01e3801b9" /> | <img width="1280" height="1454" alt="Screenshot from 2025-10-30 16-40-08" src="https://github.com/user-attachments/assets/7c7f7cd9-aaa6-4456-a171-68720489fe64" /> |

Reproduced by having message fetch parameters only fetch a few messages during app load so that most channels don't have any message history.
