### PR TITLE
desktop_notification: Fix error when message deleted while narrowing.

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -1473,30 +1473,8 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
             // The following code is essentially equivalent to
             // `window.location = hashutil.by_conversation_and_time_url(msg)`
             // but we use `message_view.show` to pass in the `trigger` parameter
-            switch (msg.type) {
-                case "private":
-                    message_view.show(
-                        [
-                            {operator: "dm", operand: msg.reply_to},
-                            {operator: "near", operand: String(msg.id)},
-                        ],
-                        {trigger: "hotkey"},
-                    );
-                    return true;
-                case "stream":
-                    message_view.show(
-                        [
-                            {
-                                operator: "channel",
-                                operand: msg.stream_id.toString(),
-                            },
-                            {operator: "topic", operand: msg.topic},
-                            {operator: "near", operand: String(msg.id)},
-                        ],
-                        {trigger: "hotkey"},
-                    );
-                    return true;
-            }
+            message_view.narrow_to_message_near(msg, "hotkey");
+            return true;
         }
     }
 

--- a/web/src/message_notifications.ts
+++ b/web/src/message_notifications.ts
@@ -210,7 +210,10 @@ export function process_notification(notification: {
             notification_object.addEventListener("click", () => {
                 notification_object.close();
                 if (message.type !== "test-notification") {
-                    message_view.narrow_by_topic(message.id, {trigger: "notification"});
+                    // Narrowing to message's near view helps to handle the case
+                    // where a user clicked the notification, but before narrowing
+                    // the message deletion got processed.
+                    message_view.narrow_to_message_near(message, "notification");
                 }
                 window.focus();
             });

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -39,6 +39,7 @@ import * as message_lists from "./message_lists.ts";
 import * as message_scroll_state from "./message_scroll_state.ts";
 import {raw_message_schema} from "./message_store.ts";
 import * as message_store from "./message_store.ts";
+import type {Message} from "./message_store.ts";
 import * as message_view_header from "./message_view_header.ts";
 import * as message_viewport from "./message_viewport.ts";
 import * as narrow_banner from "./narrow_banner.ts";
@@ -1533,4 +1534,33 @@ export function rerender_combined_feed(combined_feed_msg_list: MessageList): voi
         trigger: "stream / topic visibility policy change",
         force_rerender: true,
     });
+}
+
+export function narrow_to_message_near(message: Message, trigger: string): void {
+    // The following code is essentially equivalent to
+    // `window.location.href = hashutil.by_conversation_and_time_url(msg)`
+    // but we use `show` to pass in the `trigger` parameter.
+    switch (message.type) {
+        case "private":
+            show(
+                [
+                    {operator: "dm", operand: message.reply_to},
+                    {operator: "near", operand: String(message.id)},
+                ],
+                {trigger},
+            );
+            return;
+        case "stream":
+            show(
+                [
+                    {
+                        operator: "channel",
+                        operand: message.stream_id.toString(),
+                    },
+                    {operator: "topic", operand: message.topic},
+                    {operator: "near", operand: String(message.id)},
+                ],
+                {trigger},
+            );
+    }
 }


### PR DESCRIPTION
[#design > Clicking deleted desktop notifications](https://chat.zulip.org/#narrow/channel/101-design/topic/Clicking.20deleted.20desktop.20notifications/with/2283920)

Earlier:
When a user clicked the desktop notification, but before we finished processing that click, the message deletion got processed. It resulted in an error.

This commit fixes the bug by taking the user to the conversation where the now-deleted message had been prior to deletion - narrow to the message's near view.


**Screenshots and screen captures:**

Before:
<img width="1011" height="123" alt="Screenshot 2025-10-30 at 6 12 14 PM" src="https://github.com/user-attachments/assets/3b378a87-aaec-420d-98ca-30480256348d" />

After:
Verified by manually delaying the processing of click handler & deleting the message that the user gets narrowed to `/near/` view. No error.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
