### PR TITLE
#35092 Improve visibility of message link emoji

### DIFF
--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -171,17 +171,16 @@
     }
 }
 
-
 /* Improve visibility of message link emoji (issue #35092) */
 .message-link-emoji {
-    opacity: 0.9;
-    filter: contrast(1.2);
+  opacity: 0.9;
+  filter: contrast(1.2);
 }
 
 body.light-theme .message-link-emoji {
-    filter: brightness(0.7);
+  filter: brightness(0.7);
 }
 
 body.dark-theme .message-link-emoji {
-    filter: brightness(1.3);
+  filter: brightness(1.3);
 }


### PR DESCRIPTION
message-links: Improve emoji visibility in light mode. (#35092)

Adjusted CSS to enhance the visibility of the message link emoji across themes.
The emoji now maintains sufficient contrast in light mode and remains balanced
in dark mode. This change improves readability and visual consistency for
message link previews.

Fixes: #35092

