### PR TITLE
message_store: Edit message content in a helper function.

### DIFF
--- a/web/src/alert_words.ts
+++ b/web/src/alert_words.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 
 import type {Message} from "./message_store.ts";
+import * as message_store from "./message_store.ts";
 import * as people from "./people.ts";
 import type {StateData} from "./state_data.ts";
 
@@ -56,7 +57,7 @@ export function process_message(message: Message): void {
         const after_punctuation = "(?=\\s)|$|<|[\\)\\\"\\?!:.,';\\]!]";
 
         const regex = new RegExp(`(${before_punctuation})(${clean})(${after_punctuation})`, "ig");
-        message.content = message.content.replace(
+        const updated_content = message.content.replace(
             regex,
             (
                 match: string,
@@ -81,6 +82,7 @@ export function process_message(message: Message): void {
                 return before + "<span class='alert-word'>" + word + "</span>" + after;
             },
         );
+        message_store.update_message_content(message, updated_content);
     }
 }
 

--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -162,7 +162,7 @@ function resend_message(
         send_message: typeof transmit.send_message;
     },
 ): void {
-    message.content = message.raw_content!;
+    message_store.update_message_content(message, message.raw_content!);
     if (show_retry_spinner($row)) {
         // retry already in in progress
         return;
@@ -401,7 +401,7 @@ export function edit_locally(message: Message, request: LocalEditRequest): Messa
             // the saved content and flags rather than rendering; this
             // is important in case
             // markdown.contains_backend_only_syntax(message) is true.
-            message.content = request.content;
+            message_store.update_message_content(message, request.content);
             message.mentioned = request.mentioned ?? false;
             message.mentioned_me_directly = request.mentioned_me_directly ?? false;
             message.alerted = request.alerted ?? false;
@@ -411,7 +411,7 @@ export function edit_locally(message: Message, request: LocalEditRequest): Messa
             // properties of how the user has interacted with the
             // message, and not its rendering.
             const {content, flags, is_me_message} = markdown.render(message.raw_content);
-            message.content = content;
+            message_store.update_message_content(message, content);
             message.flags = flags;
             message.is_me_message = is_me_message;
             if (request.starred !== undefined) {
@@ -548,7 +548,7 @@ export function process_from_server(messages: ServerMessage[]): ServerMessage[] 
         }
 
         if (client_message.content !== message.content) {
-            client_message.content = message.content;
+            message_store.update_message_content(client_message, message.content);
             sent_messages.mark_disparity(local_id);
         }
         sent_messages.report_event_received(local_id);

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -447,7 +447,7 @@ export function update_messages(events: UpdateMessageEvent[]): void {
             message_store.update_booleans(anchor_message, event.flags);
 
             if (event.rendered_content !== undefined) {
-                anchor_message.content = event.rendered_content;
+                message_store.update_message_content(anchor_message, event.rendered_content);
             }
 
             if (event.is_me_message !== undefined) {

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -396,6 +396,10 @@ export function reify_message_id({old_id, new_id}: {old_id: number; new_id: numb
     }
 }
 
+export function update_message_content(message: Message, new_content: string): void {
+    message.content = new_content;
+}
+
 export function remove(message_ids: number[]): void {
     for (const message_id of message_ids) {
         stored_messages.delete(message_id);

--- a/web/tests/echo.test.cjs
+++ b/web/tests/echo.test.cjs
@@ -34,6 +34,10 @@ const message_store = mock_esm("../src/message_store", {
 
     update_booleans() {},
 
+    update_message_content(message, new_content) {
+        message.content = new_content;
+    },
+
     convert_raw_message_to_message_with_booleans() {},
 });
 


### PR DESCRIPTION
In #36293, this will be where we ensure the saved topic links are up to date.

I updated every relevant instance of `.content` but would appreciate a careful second pair of eyes to double check this helper is called everywhere it should be.