### PR TITLE
message_store: Remove extra properties when reifying a local message.

### DIFF
--- a/web/tests/message_store.test.cjs
+++ b/web/tests/message_store.test.cjs
@@ -275,10 +275,10 @@ test("errors", ({disallow_rewire}) => {
 });
 
 test("reify_message_id", () => {
-    const message = {type: "private", id: 500};
+    const message = {type: "private", id: 500, topic: "", queue_id: 5, draft_id: 6};
 
     message_store.update_message_cache({
-        type: "server_message",
+        type: "local_message",
         message,
     });
     assert.equal(message_store.get_cached_message(500).message, message);
@@ -286,6 +286,11 @@ test("reify_message_id", () => {
     message_store.reify_message_id({old_id: 500, new_id: 501});
     assert.equal(message_store.get_cached_message(500), undefined);
     assert.equal(message_store.get_cached_message(501).message, message);
+    assert.deepEqual(message_store.get_cached_message(501).message, {
+        type: "private",
+        id: 501,
+        locally_echoed: false,
+    });
 });
 
 test("update_booleans", () => {


### PR DESCRIPTION
Prep for #36293. Also discussed here: [#frontend > turning local message into server message](https://chat.zulip.org/#narrow/channel/6-frontend/topic/turning.20local.20message.20into.20server.20message/with/2288542)