### PR TITLE
portico: Fix built-in emoji rendering in organization descriptions

### DIFF
--- a/corporate/tests/test_activity_views.py
+++ b/corporate/tests/test_activity_views.py
@@ -143,7 +143,7 @@ class ActivityTest(ZulipTestCase):
         user_profile.is_staff = True
         user_profile.save(update_fields=["is_staff"])
 
-        with self.assert_database_query_count(12):
+        with self.assert_database_query_count(11):
             result = self.client_get("/activity")
             self.assertEqual(result.status_code, 200)
 
@@ -194,28 +194,28 @@ class ActivityTest(ZulipTestCase):
             event_time=timezone_now() - timedelta(days=1),
             extra_data=extra_data,
         )
-        with self.assert_database_query_count(11):
+        with self.assert_database_query_count(10):
             result = self.client_get("/activity/remote")
             self.assertEqual(result.status_code, 200)
 
-        with self.assert_database_query_count(6):
+        with self.assert_database_query_count(5):
             result = self.client_get("/activity/integrations")
             self.assertEqual(result.status_code, 200)
 
-        with self.assert_database_query_count(8):
+        with self.assert_database_query_count(7):
             result = self.client_get("/realm_activity/zulip/")
             self.assertEqual(result.status_code, 200)
 
         iago = self.example_user("iago")
-        with self.assert_database_query_count(7):
+        with self.assert_database_query_count(6):
             result = self.client_get(f"/user_activity/{iago.id}/")
             self.assertEqual(result.status_code, 200)
 
-        with self.assert_database_query_count(9):
+        with self.assert_database_query_count(8):
             result = self.client_get(f"/activity/plan_ledger/{plan.id}/")
             self.assertEqual(result.status_code, 200)
 
-        with self.assert_database_query_count(8):
+        with self.assert_database_query_count(7):
             result = self.client_get(f"/activity/remote/logs/server/{server.uuid}/")
             self.assertEqual(result.status_code, 200)
 
@@ -377,10 +377,10 @@ class ActivityTest(ZulipTestCase):
         add_audit_log_data(realm.server, remote_realm=realm, realm_id=None)
 
         self.login("iago")
-        with self.assert_database_query_count(12):
+        with self.assert_database_query_count(11):
             result = self.client_get("/activity/remote")
             self.assertEqual(result.status_code, 200)
 
-        with self.assert_database_query_count(8):
+        with self.assert_database_query_count(7):
             result = self.client_get(f"/activity/remote/logs/server/{remote_server.uuid}/")
             self.assertEqual(result.status_code, 200)

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -175,7 +175,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
     def test_remote_support_view_queries(self) -> None:
         iago = self.example_user("iago")
         self.login_user(iago)
-        with self.assert_database_query_count(29):
+        with self.assert_database_query_count(28):
             result = self.client_get("/activity/remote/support", {"q": "zulip-3.example.com"})
             self.assertEqual(result.status_code, 200)
 
@@ -751,7 +751,7 @@ class TestSupportEndpoint(ZulipTestCase):
     def test_realm_support_view_queries(self) -> None:
         iago = self.example_user("iago")
         self.login_user(iago)
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(23):
             result = self.client_get("/activity/support", {"q": "zulip"}, subdomain="zulip")
             self.assertEqual(result.status_code, 200)
 

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -123,12 +123,15 @@ def zulip_default_context(request: HttpRequest) -> dict[str, Any]:
         realm_url = settings.ROOT_DOMAIN_URI
         realm_name = None
         realm_icon = None
-        realm_default_emojiset = UserProfile.GOOGLE_EMOJISET
     else:
         realm_url = realm.url
         realm_name = realm.name
         realm_icon = get_realm_icon_url(realm)
-        realm_default_emojiset = RealmUserDefault.objects.get(realm=realm).emojiset
+    if realm is not None and not request.user.is_authenticated:
+        realm_user_default = RealmUserDefault.objects.get(realm=realm)
+        realm_default_emojiset = realm_user_default.emojiset
+    else:
+        realm_default_emojiset = UserProfile.GOOGLE_EMOJISET
 
     skip_footer = False
     register_link_disabled = settings.REGISTER_LINK_DISABLED

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -293,7 +293,7 @@ class HomeTest(ZulipTestCase):
 
         # Verify succeeds once logged-in
         with (
-            self.assert_database_query_count(59),
+            self.assert_database_query_count(58),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page(stream="Denmark")
@@ -601,7 +601,7 @@ class HomeTest(ZulipTestCase):
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
         with (
-            self.assert_database_query_count(58),
+            self.assert_database_query_count(57),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page()
@@ -633,7 +633,7 @@ class HomeTest(ZulipTestCase):
         self._get_home_page()
 
         # Then for the second page load, measure the number of queries.
-        with self.assert_database_query_count(54):
+        with self.assert_database_query_count(53):
             result = self._get_home_page()
 
         # Do a sanity check that our new streams were in the payload.


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Uses the Realm Default Emoji Set for portico pages and google emoji is kept for fallback(non realm).
adds `realm_default_emojiset` in `zulip_default_context`, which is then synced to `default_page_params` and the emojiset is selected in `signup.js` file.


Fixes: #36394  




<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.
Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
**Screenshots and screen captures:**

|Type|Before|After|
|---|---|---|
|Google|<img width="463" height="176" alt="Screenshot 2025-11-29 at 11 53 37 PM" src="https://github.com/user-attachments/assets/0450490d-2735-4814-82da-740551c45a9b" />|<img width="463" height="176" alt="Screenshot 2025-11-29 at 11 49 33 PM" src="https://github.com/user-attachments/assets/c4441a20-8461-42f4-9fb4-a89032459c4b" />|
|twitter|<img width="463" height="176" alt="Screenshot 2025-11-29 at 11 53 37 PM" src="https://github.com/user-attachments/assets/0450490d-2735-4814-82da-740551c45a9b" />|<img width="463" height="176" alt="Screenshot 2025-11-29 at 11 52 10 PM" src="https://github.com/user-attachments/assets/ed3d52b5-6d1e-49c1-b50a-2b120d99b74d" /> |

<details>
<summary>Self-review checklist</summary>
<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->
<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->
- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.
  - _Note: No new tests added as this is initialization code. Existing emoji rendering tests cover functionality._

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:
- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
  - _Note: No UI changes, only initialization code._
- [x] Strings and tooltips.
  - _Note: No new strings added._
- [x] End-to-end functionality of buttons, interactions and flows.
  - _Verified emojis render on login page and continue working after login._
- [x] Corner cases, error conditions, and easily imagined bugs.
  - _Verified browser caching prevents duplicate loads._
</details>