### PR TITLE
push_notification: Fix invalid `data` argument to `firebase_messaging.Message`.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1447,6 +1447,9 @@ APNsPriority: TypeAlias = Literal[10, 5, 1]
 
 @dataclass
 class PushRequestBasePayload:
+    # FCM expects in this type must always be strings. Non-string
+    # fields must be converted into strings in the FCM code path
+    # within send_e2ee_push_notifications.
     push_account_id: int
     encrypted_data: str
 

--- a/zilencer/lib/push_notifications.py
+++ b/zilencer/lib/push_notifications.py
@@ -196,9 +196,14 @@ def send_e2ee_push_notifications(
             apns_remote_push_devices.append(remote_push_device)
         else:
             assert isinstance(push_request, FCMPushRequest)
+            fcm_payload = dict(
+                # FCM only allows string values, so we stringify push_account_id.
+                push_account_id=str(push_request.payload.push_account_id),
+                encrypted_data=push_request.payload.encrypted_data,
+            )
             fcm_requests.append(
                 firebase_messaging.Message(
-                    data=asdict(push_request.payload),
+                    data=fcm_payload,
                     token=remote_push_device.token,
                     android=firebase_messaging.AndroidConfig(priority=push_request.fcm_priority),
                 )


### PR DESCRIPTION
Earlier, we were passing invalid `data` argument to `firebase_messaging.Message` which would result in an error while
sending E2EE push notification for android devices.

The API requires all keys and values in the `data` dictionary to be strings. One of the value was an integer.

This PR fixes the bug by converting the values to str if they are not.

---

Noticed this while trying to log a sample JSON for documentation: [#api design > E2EE - encrypted APNs payload format @ 💬](https://chat.zulip.org/#narrow/channel/378-api-design/topic/E2EE.20-.20encrypted.20APNs.20payload.20format/near/2289046)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
