### PR TITLE
topic_list: Fix resolved topic filter persistent even when not in view.

### DIFF
--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -51,6 +51,7 @@ function update_widget_for_stream(stream_id: number): void {
 
 export function clear(): void {
     popover_menus.get_topic_menu_popover()?.hide();
+    topic_filter_pill_widget?.clear(true);
 
     for (const widget of active_widgets.values()) {
         widget.remove();
@@ -80,6 +81,10 @@ export function zoom_out(): void {
     const widget = active_widgets.get(stream_id);
     assert(widget !== undefined);
     const parent_widget = widget.get_parent();
+
+    // Reset the resolved topic filter since we moved away
+    // from the view.
+    topic_filter_pill_widget?.clear(true);
 
     rebuild_left_sidebar(parent_widget, stream_id);
 }


### PR DESCRIPTION
Going to `show more topics` and selecting a topic resolved filter pill and then navigating back to main left sidebar would result in the topic list still filtering based on the previously selected resolved filter.

This PR fixes this behaviour by clearing the topic filter status on zooming out.

<!-- Describe your pull request here.-->

Fixes: [#issues > left sidebar resolved topic filter @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/left.20sidebar.20resolved.20topic.20filter/near/2289364)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/5ddd08c8-cb03-44e2-9c7d-13ee921fe805">|<video src="https://github.com/user-attachments/assets/c5c6aa27-3264-43af-b18c-ecef6582b853">|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
