### PR TITLE
fix: Move presence dot to bottom-right corner of typeahead avatars

### DIFF
--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -52,17 +52,6 @@
                 outline: 0;
             }
 
-            .user-circle {
-                /* 11px at 16px/1em */
-                font-size: 0.6875em;
-                align-self: center;
-                /* TODO: A grid rewrite of typeahead rows
-                   should help to obviate these kinds of
-                   fiddly spacing hacks. */
-                margin-right: 2px;
-                margin-left: -2px;
-            }
-
             &.topic-typeahead-link {
                 gap: 5px;
             }
@@ -193,14 +182,22 @@
     }
 }
 
-/* For FontAwesome icons and zulip icons used in place of images for some users. */
-.typeahead-image {
-    font-size: 1.3571em; /* 19px at 14px em */
+/* Container for image and presence indicator */
+.typeahead-image-container {
+    position: relative;
     display: inline-block;
     height: 1.1052em; /* 21px at 19px/1em */
     width: 1.1052em; /* 21px at 19px/1em */
-    border-radius: 4px;
+    flex-shrink: 0;
+}
 
+/* For FontAwesome icons and zulip icons used in place of images for some users. */
+.typeahead-image {
+    font-size: 1.3571em; /* 19px at 14px em */
+    display: block;
+    height: 100%;
+    width: 100%;
+    border-radius: 4px;
     text-align: center;
 
     &.zulip-icon-user-group {
@@ -217,6 +214,19 @@
         font size used to calculate presence circle width and gap. */
         margin-left: calc((0.6875 + 0.3571) * var(--base-font-size-px));
     }
+}
+
+/* Position presence dot in bottom-right corner */
+.typeahead-image-container .user-circle {
+    position: absolute;
+    font-size: 0.5em;
+    bottom: -0.5px;
+    right: -0.5px;
+    background-color: var(--color-background);
+    border: 1.5px solid var(--color-background);
+    border-radius: 50%;
+    margin: 0;
+    line-height: 1;
 }
 
 .typeahead-text-container {

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -5,14 +5,16 @@
         <span class='emoji emoji-{{ emoji_code }}'></span>
     {{/if}}
 {{else if is_person}}
-    {{#if user_circle_class}}
-    <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
-    {{/if}}
-    {{#if has_image}}
-    <img class="typeahead-image" src="{{ img_src }}" />
-    {{else}}
-    <i class='typeahead-image zulip-icon zulip-icon-user-group no-presence-circle'></i>
-    {{/if}}
+    <div class="typeahead-image-container">
+        {{#if has_image}}
+            <img class="typeahead-image" src="{{ img_src }}" />
+        {{else}}
+            <i class='typeahead-image zulip-icon zulip-icon-user-group no-presence-circle'></i>
+        {{/if}}
+        {{#if user_circle_class}}
+            <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
+        {{/if}}
+    </div>
 {{else if is_user_group}}
     <i class="typeahead-image zulip-icon zulip-icon-user-group no-presence-circle" aria-hidden="true"></i>
 {{/if}}

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1460,8 +1460,10 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 ct.get_or_set_token_for_testing("othello");
                 actual_value = options.item_html(othello_item);
                 expected_value =
-                    `    <span class="zulip-icon zulip-icon-user-circle-offline user-circle-offline user-circle"></span>\n` +
-                    `    <img class="typeahead-image" src="/avatar/${othello.user_id}" />\n` +
+                    `    <div class="typeahead-image-container">\n` +
+                    `            <img class="typeahead-image" src="/avatar/${othello.user_id}" />\n` +
+                    `            <span class="zulip-icon zulip-icon-user-circle-offline user-circle-offline user-circle"></span>\n` +
+                    `    </div>\n` +
                     '<div class="typeahead-text-container">\n' +
                     '    <strong class="typeahead-strong-section">Othello, the Moor of Venice</strong>    <span class="autocomplete_secondary">othello@zulip.com</span>' +
                     "</div>\n";


### PR DESCRIPTION
Position presence dot in bottom-right corner of typeahead avatars

Moved the availability indicator to the bottom-right corner to match the 
right sidebar. This removes the extra space that was taking up room before 
the username.

Fixes #36425

**Screenshots:**

<img width="328" height="300" alt="Screenshot 2025-11-02 at 1 28 34 PM" src="https://github.com/user-attachments/assets/c81a15ec-2c69-4e49-94a6-3c4c79e35d5f" />
<img width="328" height="300" alt="Screenshot 2025-11-02 at 1 28 50 PM" src="https://github.com/user-attachments/assets/a0e92779-ed5f-4500-a029-bca07369a5f2" />

<details>
<summary>Self-review checklist</summary>

- [x] Tested in @mentions and compose box
- [x] Works for all presence states (active/idle/offline)

</details>









