### PR TITLE
user-pills: Improve user pill styling and open popover on pill click

### DIFF
--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -470,11 +470,7 @@ export function update_user_custom_profile_fields(user: User): void {
 
     const profile_data = {profile_fields};
     $custom_profile_field.html(render_user_custom_profile_fields(profile_data));
-    custom_profile_fields_ui.initialize_custom_user_type_fields(
-        "#user-profile-modal #content",
-        user.user_id,
-        false,
-    );
+    custom_profile_fields_ui.initialize_profile_user_type_pills(user.user_id);
 }
 
 export function hide_user_profile(): void {
@@ -500,11 +496,7 @@ function initialize_user_type_fields(user: User): void {
     // Avoid duplicate pill fields, by removing existing ones.
     $("#user-profile-modal .pill").remove();
     if (!user.is_bot) {
-        custom_profile_fields_ui.initialize_custom_user_type_fields(
-            "#user-profile-modal #content",
-            user.user_id,
-            false,
-        );
+        custom_profile_fields_ui.initialize_profile_user_type_pills(user.user_id);
     } else {
         initialize_bot_owner("#user-profile-modal #content", user.user_id);
     }

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -337,6 +337,7 @@
 
 /* These pill are similar to .not-editable, but are meant to show
    profile cards when clicked. */
+.user-type-custom-field-pill-container > .display_only_pill,
 .panel_user_list > .pill-container,
 .creator_details > .display_only_pill {
     gap: 2px;
@@ -349,6 +350,13 @@
 
     &:hover {
         color: inherit;
+    }
+
+    /* `settings.css` applies a :focus-within box-shadow to `.custom_user_field .pill-container`
+    and `.bot_owner_user_field .pill-container`.That effect conflicts with the unified pill
+    styling (no shadow), so we override it here. */
+    &:focus-within {
+        box-shadow: none;
     }
 
     > .pill {
@@ -366,6 +374,30 @@
                 padding: 5px;
                 max-width: 165px;
             }
+        }
+    }
+}
+
+#user-profile-modal {
+    .user-type-custom-field-pill-container {
+        display: inline-flex;
+        gap: var(--vertical-spacing-input-pill)
+            var(--horizontal-spacing-input-pill);
+        max-width: 100%;
+        flex-wrap: wrap;
+
+        /* We override the `.pill-container` style defined in
+         `settings.css` to ensure it expands to full width, preventing
+        names in the pill from being cut off in the user profile modal. */
+        .pill-container {
+            max-width: 100%;
+        }
+
+        /* We're overriding the `.pill-value` style defined
+        in `settings.css` to ensure that names inside the pill
+        render fully and aren't cut off in the user profile modal. */
+        .pill-value {
+            max-width: 100%;
         }
     }
 }

--- a/web/templates/user_custom_profile_fields.hbs
+++ b/web/templates/user_custom_profile_fields.hbs
@@ -20,9 +20,7 @@
                 {{this.value}}
             </a>
         {{else if this.is_user_field}}
-            <div class="pill-container not-editable" data-field-id="{{this.id}}">
-                <div class="input" contenteditable="false" style="display: none;"></div>
-            </div>
+            <div class="user-type-custom-field-pill-container" data-field-id="{{this.id}}"></div>
         {{else}}
             {{#if this.rendered_value}}
             <span class="value rendered_markdown {{#if ../for_user_card_popover}}tippy-zulip-tooltip{{/if}}" data-tippy-content="{{this.name}}">{{rendered_markdown this.rendered_value}}</span>


### PR DESCRIPTION
Updates the user pill styling in the profile modal for visual consistency and open a popover on pill click.


**Light theme:-**
| Before| After |
| ------------- | ------------- |
| <img width="250" height="158" alt="502786347-c10bb3ec-7f25-444d-ae4b-1800fd1045a5" src="https://github.com/user-attachments/assets/08834a1e-7f28-48e5-90b2-454f7bee7c13" />  | <img width="250" height="46" alt="user-pill" src="https://github.com/user-attachments/assets/6f0e4eb4-14f2-4ef0-b355-11715d341cdf" />


**Dark theme:-**
| Before| After |
| ------------- | ------------- |
| <img width="215" height="104" alt="dark before" src="https://github.com/user-attachments/assets/3fb0c97b-970c-46da-b284-9443bcc93086" /> | <img width="404" height="137" alt="dark theme" src="https://github.com/user-attachments/assets/662c0418-6d35-4e12-9f8b-7cbdeef3717e" />

**popover:-**
| <img width="250" height="347" alt="popover" src="https://github.com/user-attachments/assets/fe6e6769-51ed-4fe8-8977-bb0eb1e0ee8b" /> | <img width="250" height="361" alt="dark theme 2" src="https://github.com/user-attachments/assets/12c47cf5-52bd-46f7-b43e-58a5544e3ad7" />

**proof of other pills weren't affected:-**
<img width="300" height="125" alt="Screenshot 2025-11-05 070350" src="https://github.com/user-attachments/assets/9ebee51d-f7f7-4d20-93d3-fd3ffb987c3b" />
<img width="300" height="310" alt="Screenshot (10)" src="https://github.com/user-attachments/assets/bd715968-6640-4ff1-9612-e2e8c84636d7" />
<img width="300" height="166" alt="compose proof dark theme" src="https://github.com/user-attachments/assets/5239d495-a67c-49fd-9b0e-ee0aec75ba69" />
<img width="300" height="326" alt="compose on click dark theme" src="https://github.com/user-attachments/assets/4580a612-17a0-4e2f-a40c-b0d4afa794ef" />


Fixes #36301

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
(variable names, readability, and consistency with the style guide).
- [x] Confirmed other pills are not affected by the changes.
- [x] Commit message explains reasoning and motivation for changes.
- [x] Each commit represents a coherent, reviewable change.
- [x] Made sure that the PR follows Zulip’s coding style.

Testing:-
- [x] Verified that the PR passes all the CI build tests.
- [x] Manually tested that the user pills follow the styling consistency and popover is working as requested in the issue.
</details>