### PR TITLE
Search: Fix outer spacing in searchbox container when pills wrap.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -253,7 +253,7 @@
         /* Override style for .pill-container that isn't relevant for search. */
         border: none;
         grid-template:
-            "search-icon search-pills search-close" var(--search-box-height)
+            "search-icon search-pills search-close" var(--height-input-pill)
             ". search-pills ." auto / var(--search-left-padding) minmax(0, 1fr)
             1.75em; /* 28px at 16px em */
         align-content: center;
@@ -264,7 +264,10 @@
             background: inherit;
             gap: 0;
             /* Override padding. */
-            padding: 0;
+            padding: calc(
+                    (var(--search-box-height) - var(--height-input-pill)) / 2
+                )
+                0;
         }
 
         .pill {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Use `--height-input-pill` as the grid row height and add vertical padding `var(--search-box-height) - var(--height-input-pill)) / 2` which keeps search box height consistant over all states.

Fixes: #35426


**Screenshots and screen captures:**

Fix Screenshot on various states:
|State|Before|After|
|---|---|---|
|Unfocused Single line|<img width="1710" height="982" alt="Screenshot 2025-11-20 at 12 27 12 PM" src="https://github.com/user-attachments/assets/565b1a6d-8c5a-4023-98eb-19c370c92a18" />|<img width="1710" height="982" alt="Screenshot 2025-11-20 at 12 10 48 PM" src="https://github.com/user-attachments/assets/338e744a-862c-44cf-9142-449489959503" />|
|Unfocused Multi line|<img width="1710" height="982" alt="Screenshot 2025-11-20 at 12 27 33 PM" src="https://github.com/user-attachments/assets/7cd55c21-e054-49d7-aa18-c6dd41e99f85" />|<img width="1710" height="982" alt="Screenshot 2025-11-20 at 12 11 08 PM" src="https://github.com/user-attachments/assets/52d079f5-833d-4089-96af-ebb825432c32" />|
|Focused Single line|<img width="1710" height="982" alt="Screenshot 2025-11-20 at 1 09 11 PM" src="https://github.com/user-attachments/assets/3cb3f66b-5b71-4cee-9495-b324af394213" />|<img width="1710" height="982" alt="Screenshot 2025-11-20 at 12 11 28 PM" src="https://github.com/user-attachments/assets/c22e5a3e-bba7-418f-866a-50bc7ac378b0" />|
|Focused Multi Line|<img width="1710" height="982" alt="Screenshot 2025-11-20 at 12 27 47 PM" src="https://github.com/user-attachments/assets/582e90b7-ce45-43db-b6c0-d21b59ec1e38" />|<img width="1710" height="982" alt="Screenshot 2025-11-20 at 12 11 18 PM" src="https://github.com/user-attachments/assets/679d6e51-30a1-48e2-a8e9-de92dafff7c7" />| 







Fix Screenshot:
<img width="1710" height="982" alt="Screenshot 2025-11-20 at 12 11 18 PM" src="https://github.com/user-attachments/assets/679d6e51-30a1-48e2-a8e9-de92dafff7c7" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
