### PR TITLE
push_notifications: Fix error in sending notification.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1370,14 +1370,15 @@ def send_push_notifications_legacy(
     # While sending push notifications for new messages to older clients
     # (which don't support E2EE), if `require_e2ee_push_notifications`
     # realm setting is set to `true`, we redact the content.
-    if gcm_payload.get("event") != "remove" and user_profile.realm.require_e2ee_push_notifications:
+    if user_profile.realm.require_e2ee_push_notifications:
         # Make deep copies so redaction doesn't affect the original dicts
-        apns_payload = copy.deepcopy(apns_payload)
-        gcm_payload = copy.deepcopy(gcm_payload)
-
         placeholder_content = _("New message")
-        apns_payload["alert"]["body"] = placeholder_content
-        gcm_payload["content"] = placeholder_content
+        if gcm_payload and gcm_payload.get("event") != "remove":
+            gcm_payload = copy.deepcopy(gcm_payload)
+            gcm_payload["content"] = placeholder_content
+        if apns_payload and apns_payload["custom"]["zulip"].get("event") != "remove":
+            apns_payload = copy.deepcopy(apns_payload)
+            apns_payload["alert"]["body"] = placeholder_content
 
     if uses_notification_bouncer():
         send_notifications_to_bouncer(


### PR DESCRIPTION
While sending push notifications for a user in realm with `require_e2ee_push_notifications=true` and no iOS device registered, it resulted in an error.

Also, while sending notif to revoke in realm with `require_e2ee_push_notifications=true` and no android device registered, it resulted in an error.

This PR fixes the bug.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
