### PR TITLE
help: Document clearing of mobile notifications for deleted messages.

### DIFF
--- a/starlight_help/src/content/docs/delete-a-message.mdx
+++ b/starlight_help/src/content/docs/delete-a-message.mdx
@@ -112,10 +112,11 @@ the `ARCHIVED_DATA_VACUUMING_DELAY_DAYS` setting.
 
 ## Message notifications
 
-If you delete a message soon after sending it, any [pending email
+When a message is deleted, any [pending email
 notifications](/help/email-notifications#configure-delay-for-message-notification-emails)
 for that message will be canceled, and
-[visual desktop notifications](/help/desktop-notifications) will be removed,
+[mobile](/help/mobile-notifications) and
+[desktop](/help/desktop-notifications) notifications will be removed,
 including [mentions and alerts](/help/dm-mention-alert-notifications).
 
 ## Related articles


### PR DESCRIPTION
Document changes made in #26815.

Before: https://zulip.com/help/delete-a-message#message-notifications

After:
<img width="818" height="125" alt="Screenshot 2025-11-03 at 13 59 39" src="https://github.com/user-attachments/assets/ae75558a-e95d-48e3-aa47-eaa5dc000ec2" />
