### PR TITLE
github: Update template for topic permalinks and HTML links.

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_discussed_on_czo.md
+++ b/.github/ISSUE_TEMPLATE/1_discussed_on_czo.md
@@ -5,6 +5,6 @@ about: Bug report, feature or improvement already discussed on chat.zulip.org.
 
 <!-- Issue description -->
 
-<!-- Link to a message in the chat.zulip.org discussion. Message links will still work even if the topic is renamed or resolved. Link back to this issue from the chat.zulip.org thread. -->
+<!-- Link to a topic or message where this issue was discussed on chat.zulip.org. Link back to this issue from the discussion thread. -->
 
-CZO thread
+CZO thread:


### PR DESCRIPTION
I kind of want a space after `CZO thread:`, but I'm not sure how to get around the linter.