### PR TITLE
poll: Add markdown support for emoji and links in poll options.

### DIFF
--- a/web/src/poll_widget.ts
+++ b/web/src/poll_widget.ts
@@ -14,6 +14,7 @@ import render_widgets_poll_widget_results from "../templates/widgets/poll_widget
 import * as blueslip from "./blueslip.ts";
 import {$t} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
+import * as markdown from "./markdown.ts";
 import * as message_lists from "./message_lists.ts";
 import type {Message} from "./message_store.ts";
 import * as people from "./people.ts";
@@ -218,8 +219,23 @@ export function activate({
 
     function render_results(): void {
         const widget_data = poll_data.get_widget_data();
+        const processed_widget_data = {
+            ...widget_data,
+            options: widget_data.options.map((option) => ({
+                ...option,
+                option_html: (() => {
+                    try {
+                        return option.option && option.option.trim() !== ""
+                            ? markdown.parse_non_message(option.option)
+                            : option.option;
+                    } catch {
+                        return option.option;
+                    }
+                })(),
+            })),
+        };
 
-        const html = render_widgets_poll_widget_results(widget_data);
+        const html = render_widgets_poll_widget_results(processed_widget_data);
         $elem.find("ul.poll-widget").html(html);
 
         $elem

--- a/web/templates/widgets/poll_widget_results.hbs
+++ b/web/templates/widgets/poll_widget_results.hbs
@@ -4,7 +4,7 @@
             <button class="poll-vote {{#if current_user_vote}}current-user-vote{{/if}}" data-key="{{ key }}">
                 {{ count }}
             </button>
-            <span class="poll-option-text">{{ option }}</span>
+            <span class="poll-option-text">{{{ option_html }}}</span>
         </label>
         {{#if names}}
         <span class="poll-names">({{ names }})</span>


### PR DESCRIPTION
Enables text with hyperlinks and emojis by adding support for markdown rendering for poll options.

**Fixes: #21674  Poll options should support emoji.
Fixes: #12947  Support links in polls**
<hr>

## Screenshots and screen captures:

**Emoji Screenshots**

| Before | After |
|--------|-------|
|<img width="1919" height="1079" alt="Screenshot 2025-11-05 174259" src="https://github.com/user-attachments/assets/400fe09d-29bf-4f0b-aa0c-36d6000e935d" />|<img width="1919" height="1079" alt="Screenshot 2025-11-05 174542" src="https://github.com/user-attachments/assets/62b7d3a0-7fbd-4e2b-8134-5522ef00584e" />|

**Link Screenshots**

| Before | After |
|--------|-------|
|<img width="1919" height="1079" alt="Screenshot 2025-11-05 174419" src="https://github.com/user-attachments/assets/84ff9759-a9a1-4247-81b0-e996030200f4" />|<img width="1918" height="1079" alt="Screenshot 2025-11-05 174532" src="https://github.com/user-attachments/assets/4f3c8938-304d-44ed-861b-3ebecfb44239" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

