### PR TITLE
typeahead: Place availability indicator on avatar in user typeaheads.

### DIFF
--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -52,17 +52,6 @@
                 outline: 0;
             }
 
-            .user-circle {
-                /* 11px at 16px/1em */
-                font-size: 0.6875em;
-                align-self: center;
-                /* TODO: A grid rewrite of typeahead rows
-                   should help to obviate these kinds of
-                   fiddly spacing hacks. */
-                margin-right: 2px;
-                margin-left: -2px;
-            }
-
             &.topic-typeahead-link {
                 gap: 5px;
             }
@@ -193,24 +182,53 @@
     }
 }
 
+.typeahead-image.zulip-icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
 /* For FontAwesome icons and zulip icons used in place of images for some users. */
 .typeahead-image {
     flex: 0 0 auto;
+    position: relative;
     height: 1.3125em; /* 21px at 16px/1em */
     width: 1.3125em; /* 21px at 16px/1em */
     border-radius: 4px;
 
-    &.no-presence-circle {
-        /* 0.6875em at 16px/1em is the width of presence circle,
-           no margin (-2px left margin + 2px right margin = 0px),
-           and 0.3571  is the gap between the presence circle and
-           image avatars. */
-        margin-left: calc(0.6875em + 0.3571em);
-        /* To properly align icons within the 21px square box
-           defined on .typeahead-image, we establish a flexbox: */
-        display: flex;
-        align-items: center;
-        justify-content: center;
+    .typeahead-image-avatar {
+        border-radius: 4px;
+        /* Override bootstrap img */
+        vertical-align: baseline;
+    }
+
+    .user-circle {
+        position: absolute;
+        /* This is smaller than the sidebar because avatars here are smaller */
+        font-size: 0.4375em; /* 7px at 16px/1em */
+        line-height: 1;
+        bottom: -0.5px;
+        right: -0.5px;
+        background-color: var(--color-background-dropdown-widget);
+        padding: 1px;
+        border-radius: 50%;
+
+        &.user-circle-offline {
+            display: none;
+        }
+    }
+
+    /* Move the background styles onto the :before element so that the 1px padding
+       outline still works. */
+    .user-circle-idle {
+        background: var(--color-background-dropdown-widget);
+    }
+
+    .user-circle-idle::before {
+        background: var(--gradient-user-circle-idle);
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+        border-radius: 50%;
     }
 }
 

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -5,16 +5,18 @@
         <span class='emoji emoji-{{ emoji_code }}'></span>
     {{/if}}
 {{else if is_person}}
-    {{#if user_circle_class}}
-    <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
-    {{/if}}
     {{#if has_image}}
-    <img class="typeahead-image" src="{{ img_src }}" />
+    <div class="typeahead-image">
+        <img class="typeahead-image-avatar" src="{{ img_src }}" />
+        {{#if user_circle_class}}
+        <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
+        {{/if}}
+    </div>
     {{else}}
-    <i class='typeahead-image zulip-icon zulip-icon-user-group no-presence-circle'></i>
+    <i class='typeahead-image zulip-icon zulip-icon-user-group'></i>
     {{/if}}
 {{else if is_user_group}}
-    <i class="typeahead-image zulip-icon zulip-icon-user-group no-presence-circle" aria-hidden="true"></i>
+    <i class="typeahead-image zulip-icon zulip-icon-user-group" aria-hidden="true"></i>
 {{/if}}
 {{#if is_stream_topic}}
 <div class="typeahead-text-container">

--- a/web/templates/user_group_display_only_pill.hbs
+++ b/web/templates/user_group_display_only_pill.hbs
@@ -1,6 +1,6 @@
 <span class="pill-container display_only_group_pill">
     <a data-user-group-id="{{group_id}}" class="view_user_group pill" tabindex="0">
-        <i class="zulip-icon zulip-icon-user-group no-presence-circle" aria-hidden="true"></i>
+        <i class="zulip-icon zulip-icon-user-group" aria-hidden="true"></i>
         <span class="pill-label {{#if strikethrough}} strikethrough {{/if}}" >
             <span class="pill-value">{{display_value}}</span>
         </span>

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1460,8 +1460,10 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 ct.get_or_set_token_for_testing("othello");
                 actual_value = options.item_html(othello_item);
                 expected_value =
-                    `    <span class="zulip-icon zulip-icon-user-circle-offline user-circle-offline user-circle"></span>\n` +
-                    `    <img class="typeahead-image" src="/avatar/${othello.user_id}" />\n` +
+                    '    <div class="typeahead-image">\n' +
+                    `        <img class="typeahead-image-avatar" src="/avatar/${othello.user_id}" />\n` +
+                    '        <span class="zulip-icon zulip-icon-user-circle-offline user-circle-offline user-circle"></span>\n' +
+                    "    </div>\n" +
                     '<div class="typeahead-text-container">\n' +
                     '    <strong class="typeahead-strong-section">Othello, the Moor of Venice</strong>    <span class="autocomplete_secondary">othello@zulip.com</span>' +
                     "</div>\n";
@@ -1473,7 +1475,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 ct.get_or_set_token_for_testing("hamletcharacters");
                 actual_value = options.item_html(hamletcharacters);
                 expected_value =
-                    '    <i class="typeahead-image zulip-icon zulip-icon-user-group no-presence-circle" aria-hidden="true"></i>\n' +
+                    '    <i class="typeahead-image zulip-icon zulip-icon-user-group" aria-hidden="true"></i>\n' +
                     '<div class="typeahead-text-container">\n' +
                     '    <strong class="typeahead-strong-section">hamletcharacters</strong>    <span class="autocomplete_secondary">Characters of Hamlet</span>' +
                     "</div>\n";


### PR DESCRIPTION
Fixes #36425.

screenshots:

screenshots:

<img width="797" height="102" alt="image" src="https://github.com/user-attachments/assets/e908c557-a017-4889-aa23-583f0741ded8" />

<img width="788" height="82" alt="image" src="https://github.com/user-attachments/assets/2a36c5b5-a535-4458-8e52-26e9ba2afc36" />

<img width="773" height="110" alt="image" src="https://github.com/user-attachments/assets/45da11bc-3c64-4b9f-80b2-19ae9d9308fe" />

<img width="786" height="101" alt="image" src="https://github.com/user-attachments/assets/1809fbd4-eb8f-464f-9723-7bc3538f3bd7" />

<img width="865" height="105" alt="image" src="https://github.com/user-attachments/assets/b604aacb-6ba9-4ca6-8421-d1c1998d8fc9" />


<img width="900" height="117" alt="image" src="https://github.com/user-attachments/assets/1e9830d6-516d-4c27-8339-b8f33fc680a9" />

<img width="828" height="124" alt="image" src="https://github.com/user-attachments/assets/3eb8e90e-d1f2-4f3e-bc77-f002dcccca82" />

<img width="870" height="136" alt="image" src="https://github.com/user-attachments/assets/f69c168d-510d-4bc3-85e1-7f00deabdb50" />
