### PR TITLE
setup-recommended: Be more clear about needing to turn gRPC FUSE back on.

### DIFF
--- a/docs/development/setup-recommended.md
+++ b/docs/development/setup-recommended.md
@@ -176,7 +176,7 @@ WSL 2 can be uninstalled by following [Microsoft's documentation][uninstall-wsl]
 
 1. Install [Vagrant][vagrant-dl] (latest).
 2. Install [Docker Desktop](https://docs.docker.com/desktop/mac/install/) (latest).
-3. Open the Docker desktop app's settings panel, and choose `osxfs (legacy)` under "Choose file sharing implementation for your containers."
+3. Open the Docker desktop app's settings panel, and uncheck "Use gRPC FUSE for file sharing" to use the `osxfs (legacy)` file sharing instead.
    :::
 
 :::{tab-item} Ubuntu/Debian
@@ -329,8 +329,8 @@ other errors. The temporary fix is to open the Docker desktop app's
 settings panel, and choose `osxfs (legacy)` under "Choose file sharing
 implementation for your containers." Once Docker restarts, you should
 be able to successfully run `vagrant up --provider=docker`. Back in
-Docker, you can return to using VirtioFS for better system performance
-while developing, but you may need to revert to `osxfs (legacy)`
+Docker, you should return to using VirtioFS so that your files sync
+properly while developing, but you may need to revert to `osxfs (legacy)`
 whenever you need to re-provision.
 
 ```{include} setup/vagrant-up.md


### PR DESCRIPTION
I also updated the wording of how to toggle the setting from what Docker Desktop looks like now:

<img width="1098" height="462" alt="image" src="https://github.com/user-attachments/assets/6d51896a-6d24-4524-b054-117e5e648aab" />

Screenshots:

<img width="827" height="269" alt="image" src="https://github.com/user-attachments/assets/0f30a94b-2d9c-4f18-a540-7fee06e75eaa" />
<img width="751" height="471" alt="image" src="https://github.com/user-attachments/assets/09a21912-da38-4e1f-b81f-1317cbf44d6c" />
