### PR TITLE
message_report: Improve message report template

### DIFF
--- a/zerver/lib/message_report.py
+++ b/zerver/lib/message_report.py
@@ -35,6 +35,7 @@ def send_message_report(
     reported_user = reported_message.sender
     reported_user_mention = silent_mention_syntax_for_user(reported_user)
     reporting_user_mention = silent_mention_syntax_for_user(reporting_user)
+    report_reason = Realm.REPORT_MESSAGE_REASONS[report_type]
 
     # Build reported message header
     if is_1_to_1_message(reported_message):
@@ -125,14 +126,14 @@ def send_message_report(
     )
     reported_message_preview_block = """
 ```quote
-**{report_type}**. {description}
+**{report_reason}**. {description}
 ```
 
 {fence} spoiler {original_message_string}
 {reported_message}
 {fence}
 """.format(
-        report_type=report_type,
+        report_reason=report_reason,
         description=description,
         original_message_string=original_message_string,
         reported_message=reported_message_content,

--- a/zerver/tests/test_message_report.py
+++ b/zerver/tests/test_message_report.py
@@ -17,7 +17,7 @@ from zerver.lib.topic_link_util import (
 from zerver.lib.url_encoding import pm_message_url
 from zerver.models import UserProfile
 from zerver.models.messages import Message
-from zerver.models.realms import get_realm
+from zerver.models.realms import Realm, get_realm
 from zerver.models.recipients import get_or_create_direct_message_group
 from zerver.models.streams import StreamTopicsPolicyEnum
 from zerver.models.users import get_system_bot
@@ -116,7 +116,7 @@ class ReportMessageTest(ZulipTestCase):
 {reported_message}
 {fence}
 """.format(
-            report_type=report_type,
+            report_type=Realm.REPORT_MESSAGE_REASONS[report_type],
             description=description,
             channel_message_link=channel_message_link,
             message_sent_to=message_sent_to,
@@ -232,7 +232,7 @@ class ReportMessageTest(ZulipTestCase):
 {reported_message}
 {fence}
 """.format(
-            report_type=report_type,
+            report_type=Realm.REPORT_MESSAGE_REASONS[report_type],
             description=description,
             direct_message_link=direct_message_link,
             message_sent_to=message_sent_to,
@@ -284,7 +284,7 @@ class ReportMessageTest(ZulipTestCase):
 {reported_message}
 {fence}
 """.format(
-            report_type=report_type,
+            report_type=Realm.REPORT_MESSAGE_REASONS[report_type],
             description=description,
             direct_message_link=direct_message_link,
             message_sent_to=message_sent_to,
@@ -331,7 +331,7 @@ class ReportMessageTest(ZulipTestCase):
 {reported_message}
 {fence}
 """.format(
-            report_type=report_type,
+            report_type=Realm.REPORT_MESSAGE_REASONS[report_type],
             description=description,
             direct_message_link=direct_message_link,
             message_sent_to=message_sent_to,
@@ -387,7 +387,7 @@ class ReportMessageTest(ZulipTestCase):
 {reported_message}
 {fence}
 """.format(
-            report_type=report_type,
+            report_type=Realm.REPORT_MESSAGE_REASONS[report_type],
             description=description,
             direct_message_link=direct_message_link,
             message_sent_to=message_sent_to,
@@ -443,7 +443,7 @@ class ReportMessageTest(ZulipTestCase):
 {reported_message}
 {fence}
 """.format(
-            report_type=report_type,
+            report_type=Realm.REPORT_MESSAGE_REASONS[report_type],
             description=description,
             direct_message_link=direct_message_link,
             message_sent_to=message_sent_to,
@@ -499,7 +499,7 @@ class ReportMessageTest(ZulipTestCase):
 {reported_message}
 {fence}
 """.format(
-            report_type=report_type,
+            report_type=Realm.REPORT_MESSAGE_REASONS[report_type],
             description=description,
             direct_message_link=direct_message_link,
             message_sent_to=message_sent_to,


### PR DESCRIPTION
This updates the template structure of message report. 
- Simplified the template as per #36492.
- Excluded the message senders name on the list of recipients in GDM report.
- Added the message recipient's name in 1-on-1 DM report.
- Switched to displaying `reason_type`'s user-facing string.

**Screenshots**
(Updated Nov 10)

- Channel message reports:

  | Before | After |
  |--------|--------|
  | <img width="1075" height="407" alt="image" src="https://github.com/user-attachments/assets/7adcab77-2b4a-4635-855e-5a39f71efac0" /> | other's message <img width="1075" height="343" alt="image" src="https://github.com/user-attachments/assets/f4b7b512-cb98-4199-8ffc-f07b02450f51" /> |
  | <img width="1075" height="317" alt="image" src="https://github.com/user-attachments/assets/4872ed25-3aba-4896-9bb2-c88619696ed2" /> | one's own message <img width="1075" height="252" alt="image" src="https://github.com/user-attachments/assets/eaa7257e-049b-4d4d-8045-72601b1c5d2d" /> |

- Group direct message reports:

  | Before | After |
  |--------|--------|
  | <img width="1075" height="379" alt="image" src="https://github.com/user-attachments/assets/ffd9c332-c92f-4766-9b6d-0941fac29b44" /> | <img width="1075" height="312" alt="image" src="https://github.com/user-attachments/assets/c47beab4-2dfc-4fbb-a7c1-9f9eab0cb693" /> |
  | other's message <img width="1075" height="317" alt="image" src="https://github.com/user-attachments/assets/cbe2bab5-c1af-4a74-9386-7b34d708bbb3" /> | one's own message <img width="1075" height="252" alt="image" src="https://github.com/user-attachments/assets/ef4ea2dd-30cd-455c-b07d-38a791f56542" /> |
  | <img width="1075" height="263" alt="image" src="https://github.com/user-attachments/assets/d9941d86-b3e1-4d0e-bc9f-b48076f61501" /> | only two other recipients <img width="1075" height="250" alt="image" src="https://github.com/user-attachments/assets/749ae2a6-663c-49c4-9496-d0d881fa607f" /> |

- 1-on-1 direct message reports:

  | Before | After |
  |--------|--------|
  | <img width="1075" height="287" alt="image" src="https://github.com/user-attachments/assets/7849089b-70da-45f3-b9cc-63811841ffd9" /> |other's dm <img width="1075" height="220" alt="image" src="https://github.com/user-attachments/assets/d5af5294-2a8f-448f-a019-b792600f82ba" /> |
  | <img width="1075" height="379" alt="image" src="https://github.com/user-attachments/assets/11d71ee5-d129-482c-9d27-1e4e615100a4" /> |one's own dm to other <img width="1075" height="312" alt="image" src="https://github.com/user-attachments/assets/d6c0249d-069d-4504-b9f0-a06203e9d560" /> | 
  | <img width="1075" height="285" alt="image" src="https://github.com/user-attachments/assets/2e3a78d2-8fff-4bec-909e-dbe92eb77f58" /> |one's own dm to self <img width="1075" height="220" alt="image" src="https://github.com/user-attachments/assets/447ba31d-dab6-431b-a16e-2f6d2d5d2c24" /> | 

- With description:

  | Before | After |
  |--------|--------|
  | <img width="1075" height="409" alt="image" src="https://github.com/user-attachments/assets/25b9ba7c-e6bf-44cf-a8b2-6adec16ba38a" /> | <img width="1075" height="342" alt="image" src="https://github.com/user-attachments/assets/10a6b500-54bc-406d-bfbe-829363813881" /> |

Fixes: #36492


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
