### PR TITLE
css: Disable view type dropdown for spectators in channel topics list

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1101,8 +1101,14 @@ div.overlay .flex.overlay-content > .overlay-container,
         background-color: var(
             --color-background-disabled-dropdown-widget-button
         );
+        /* TODO: Should this be 0.5 to match the spectator block below? */
         opacity: 0.7;
     }
+}
+
+.dropdown-widget-disabled-for-spectators .dropdown-widget-button {
+    cursor: not-allowed;
+    opacity: 0.5;
 }
 
 #edit_bot_owner_widget .dropdown_widget_value {

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -640,8 +640,3 @@
         box-shadow: 0 0 5px var(--color-box-shadow-input-focus);
     }
 }
-
-.dropdown-widget-disabled-for-spectators #recent-view-filter_widget {
-    cursor: not-allowed;
-    opacity: 0.5;
-}


### PR DESCRIPTION
Spectators (logged out users) can't use the view-type dropdown in the 'list of topics' view for channels. This adds the missing CSS styling to make the dropdown appear disabled (grayed out with not-allowed cursor) for spectators, matching the behavior in recent conversations view.

**Fixes:** #36496

**How changes were tested:**
- Ran CSS linting: `./tools/lint --only=css` 
- Ran all JavaScript tests: `./tools/test-js-with-node`  
- Manual testing: Verified dropdown appears disabled for spectators in channel topics list
- Confirmed no impact on logged-in users
- Verified visual consistency with recent conversations view

**Screenshots **
=> Before:
dark theme : <img width="1608" height="239" alt="Screenshot from 2025-11-06 19-15-59" src="https://github.com/user-attachments/assets/addc541c-002b-4fb5-9440-085f99ee62e8" />
light theme : <img width="1608" height="239" alt="Screenshot from 2025-11-06 19-16-25" src="https://github.com/user-attachments/assets/fe969353-7ea2-457c-a062-a5716901638e" />
=> After:
dark theme : <img width="1758" height="328" alt="Screenshot from 2025-11-06 19-18-56" src="https://github.com/user-attachments/assets/764559ac-6bcc-45a2-a9bc-165cad074281" />
light theme : <img width="1758" height="328" alt="Screenshot from 2025-11-06 19-18-38" src="https://github.com/user-attachments/assets/446d43e3-5ad0-40b0-b027-6506962a9a07" />

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>

