### PR TITLE
help-center: Document "group channels by folder in the inbox" setting.

### DIFF
--- a/starlight_help/src/content/docs/channel-folders.mdx
+++ b/starlight_help/src/content/docs/channel-folders.mdx
@@ -17,6 +17,27 @@ import MoreVerticalIcon from "~icons/zulip-icon/more-vertical";
 
 <MoveChannelToFolder />
 
+## Configure whether channels are grouped by folder in the Inbox view
+
+<Tabs>
+  <TabItem label="Via Inbox view">
+    <Steps>
+      1. Click the **ellipsis** (<MoreVerticalIcon />)
+         to the right of the **Filter** box at the top of the Inbox view.
+      1. Click **Group channels by folder** or **Don't group channels by folder**, as
+         desired.
+    </Steps>
+  </TabItem>
+
+  <TabItem label="Via personal settings">
+    <FlattenedSteps>
+      <NavigationSteps target="settings/preferences" />
+
+      1. Under **Information**, toggle **Group channels by folder in the inbox**.
+    </FlattenedSteps>
+  </TabItem>
+</Tabs>
+
 ## Configure whether channels are grouped by folder in the left sidebar
 
 <Tabs>

--- a/starlight_help/src/content/include/_ChannelFoldersIntro.mdx
+++ b/starlight_help/src/content/include/_ChannelFoldersIntro.mdx
@@ -1,8 +1,7 @@
 Organizations can sort channels into folders. For example, you can put all the
-channels associated with a team into a dedicated folder. Channels will be
-grouped into folders in the [**Inbox**](/help/inbox) view, and users can
-[decide](/help/channel-folders#configure-whether-channels-are-grouped-by-folder-in-the-left-sidebar)
-whether to group them by folder in the [left sidebar](/help/left-sidebar).
+channels associated with a team into a dedicated folder. Users can decide
+whether to group channels by folder in the [**Inbox**](/help/inbox) view and
+the [left sidebar](/help/left-sidebar).
 
 Everyone can [pin channels](/help/pin-a-channel) they personally want to pay
 close attention to. Pinned channels appear in a dedicated **pinned channels**


### PR DESCRIPTION
Documents the new user setting for organizing the display of unread conversations in the inbox by channel folder. The setting was added in #36229.

**Notes**:
- Wasn't sure about capitalization for "Inbox view", but followed what was already there in the intro text (capitalized). See CZO documentation discussion: [#documentation > capitalization of views in the help center](https://chat.zulip.org/#narrow/channel/19-documentation/topic/capitalization.20of.20views.20in.20the.20help.20center/with/2293830).

---

**Screenshots and screen captures:**

[CURRENT DOCUMENTATION](https://zulip.com/help/channel-folders)

## Shared channel folders intro text
<img width="1024" height="351" alt="Screenshot From 2025-11-07 12-58-11" src="https://github.com/user-attachments/assets/6cf3cef1-d63a-451a-9401-4476558f915e" />

## Instructions for updating the personal setting
<img width="1027" height="306" alt="Screenshot From 2025-11-06 17-56-25" src="https://github.com/user-attachments/assets/cd8557d2-a706-47aa-b723-24dc67644993" />
<img width="1027" height="306" alt="Screenshot From 2025-11-06 17-56-29" src="https://github.com/user-attachments/assets/f3244a74-6b0b-44f3-a354-f518cdb0954e" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
