### PR TITLE
api-docs: Revise descriptions for user channel folder display settings.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -26,7 +26,9 @@ format used by the Zulip server that they are interacting with.
   [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults):
   Added new `web_inbox_show_channel_folders` display setting,
   controlling whether any [channel folders](/help/channel-folders)
-  configured by the organization are displayed in the Inbox view.
+  configured by the organization are used to organize how conversations
+  with unread messages are displayed in the web/desktop application's
+  Inbox view.
 
 **Feature level 430**
 
@@ -166,7 +168,8 @@ No changes; API feature level used for the Zulip 11.0 release.
   [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults):
   Added new `web_left_sidebar_show_channel_folders` display setting,
   controlling whether any [channel folders](/help/channel-folders)
-  configured by the organization are displayed in the left sidebar.
+  configured by the organization are used to organize how channels
+  are displayed in the web/desktop application's left sidebar.
 
 **Feature level 410**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14203,16 +14203,18 @@ paths:
                 web_inbox_show_channel_folders:
                   type: boolean
                   description: |
-                    Determines whether the web/desktop application's Inbox view displays
-                    any channel folders configured by the organization.
+                    Determines whether [channel folders](/help/channel-folders)
+                    are used to organize how conversations with unread messages
+                    are displayed in the web/desktop application's Inbox view.
 
                     **Changes**: New in Zulip 12.0 (feature level 431).
                   example: true
                 web_left_sidebar_show_channel_folders:
                   type: boolean
                   description: |
-                    Determines whether the web/desktop application's left sidebar displays
-                    any channel folders configured by the organization.
+                    Determines whether [channel folders](/help/channel-folders)
+                    are used to organize how channels are displayed in the
+                    web/desktop application's left sidebar.
 
                     **Changes**: New in Zulip 11.0 (feature level 411).
                   example: true
@@ -17882,15 +17884,17 @@ paths:
                           web_inbox_show_channel_folders:
                             type: boolean
                             description: |
-                              Determines whether the web/desktop application's Inbox view displays
-                              any channel folders configured by the organization.
+                              Determines whether [channel folders](/help/channel-folders)
+                              are used to organize how conversations with unread messages
+                              are displayed in the web/desktop application's Inbox view.
 
                               **Changes**: New in Zulip 12.0 (feature level 431).
                           web_left_sidebar_show_channel_folders:
                             type: boolean
                             description: |
-                              Determines whether the web/desktop application's left sidebar displays
-                              any channel folders configured by the organization.
+                              Determines whether [channel folders](/help/channel-folders)
+                              are used to organize how channels are displayed in the
+                              web/desktop application's left sidebar.
 
                               **Changes**: New in Zulip 11.0 (feature level 411).
                           web_left_sidebar_unreads_count_summary:
@@ -20802,15 +20806,17 @@ paths:
                           web_inbox_show_channel_folders:
                             type: boolean
                             description: |
-                              Determines whether the web/desktop application's Inbox view displays
-                              any channel folders configured by the organization.
+                              Determines whether [channel folders](/help/channel-folders)
+                              are used to organize how conversations with unread messages
+                              are displayed in the web/desktop application's Inbox view.
 
                               **Changes**: New in Zulip 12.0 (feature level 431).
                           web_left_sidebar_show_channel_folders:
                             type: boolean
                             description: |
-                              Determines whether the web/desktop application's left sidebar displays
-                              any channel folders configured by the organization.
+                              Determines whether [channel folders](/help/channel-folders)
+                              are used to organize how channels are displayed in the
+                              web/desktop application's left sidebar.
 
                               **Changes**: New in Zulip 11.0 (feature level 411).
                           web_left_sidebar_unreads_count_summary:
@@ -22090,15 +22096,17 @@ paths:
                 web_inbox_show_channel_folders:
                   type: boolean
                   description: |
-                    Determines whether the web/desktop application's Inbox view displays
-                    any channel folders configured by the organization.
+                    Determines whether [channel folders](/help/channel-folders)
+                    are used to organize how conversations with unread messages
+                    are displayed in the web/desktop application's Inbox view.
 
                     **Changes**: New in Zulip 12.0 (feature level 431).
                 web_left_sidebar_show_channel_folders:
                   type: boolean
                   description: |
-                    Determines whether the web/desktop application's left sidebar displays
-                    any channel folders configured by the organization.
+                    Determines whether [channel folders](/help/channel-folders)
+                    are used to organize how channels are displayed in the
+                    web/desktop application's left sidebar.
 
                     **Changes**: New in Zulip 11.0 (feature level 411).
                   example: true


### PR DESCRIPTION
Revises the descriptions for `web_left_sidebar_show_channel_folders` and `web_inbox_show_channel_folders`, as well as the API changelog entries for when those two settings were introduced (feature levels 411 and 431).

*Noted as a follow-up task in this comment: https://github.com/zulip/zulip/pull/36229#discussion_r2496526588.*

**Screenshots and screen captures:**

## Updated API changelog entries for feature levels 431 and 411
[CURRENT DOC](https://zulip.com/api/changelog)
<img width="1065" height="267" alt="Screenshot From 2025-11-06 18-07-17" src="https://github.com/user-attachments/assets/c8b64304-424b-4aa2-b326-e344352847c7" />
<img width="1065" height="217" alt="Screenshot From 2025-11-06 18-07-32" src="https://github.com/user-attachments/assets/1caa8228-a5f4-4720-8d3c-642531507cbf" />

## Update settings parameters
[CURRENT DOC](https://zulip.com/api/update-settings#parameter-web_left_sidebar_show_channel_folders)
<img width="1065" height="544" alt="Screenshot From 2025-11-06 18-08-07" src="https://github.com/user-attachments/assets/e6fdf1be-0d53-415e-922e-90a009eb2e7d" />

## Register response fields
[CURRENT DOC](https://zulip.com/api/register-queue) - find on page "web_left"
<img width="1065" height="334" alt="Screenshot From 2025-11-06 18-08-31" src="https://github.com/user-attachments/assets/14580f03-888a-41ca-8eb7-803b246504e2" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
