### PR TITLE
portico: Tweak homepage section.

### DIFF
--- a/templates/corporate/hello.html
+++ b/templates/corporate/hello.html
@@ -226,17 +226,27 @@
         <div class="screen-4">
             <div class="screen-4__container">
                 <div class="screen-4__content">
-                    <img alt="" class='switch-diagram' loading="lazy" width="400" height="358"
-                      src="{{ static('images/landing-page/hello/switch-diagram.png') }}"
+                    <img alt="" class="switch-diagram mirror-image" loading="lazy" width="300"
+                      src="{{ static('images/landing-page/education/privacy.svg') }}"
                       />
                     <div class="screen-4__desc">
-                        <h2 class="screen-4__header">Switching to Zulip isn’t hard.</h2>
+                        <h2 class="screen-4__header">You own your data</h2>
                         <p>
-                            Zulip offers a convenient cloud solution, with <a href="/features/">features</a> to make your users and IT team happy. Import your data and integrations <a href="/help/import-from-slack">from Slack</a> and other products.
+                            Escape corporate vendor lock-in. You can <a
+                            href="/self-hosting/">self-host</a> Zulip’s 100% <a
+                            href="https://github.com/zulip/zulip#readme">open-source</a>
+                            software for full data sovereignty, or start
+                            with a convenient <a href="/plans">cloud
+                            solution</a> and <a
+                            href="https://zulip.readthedocs.io/en/stable/production/export-and-import.html#import-into-a-new-zulip-server">move</a>
+                            any time.
                         </p>
-                        <h3>Your data is yours!</h3>
                         <p>
-                            For ultimate control and <a href="/help/gdpr-compliance">compliance</a>, <a href="/self-hosting/">self-host</a> Zulip’s 100% <a href="https://github.com/zulip/zulip#readme">open-source</a> software, with easy <a href="https://zulip.readthedocs.io/en/stable/production/install.html">installation</a> and <a href="https://zulip.readthedocs.io/en/stable/production/upgrade.html">upgrades</a>.
+                            We make it easy to switch from <a
+                            href="/help/moving-from-slack">Slack</a>, <a
+                            href="/help/moving-from-teams">Teams</a> and <a
+                            href="/help/migrating-from-other-chat-tools">other
+                            tools</a>.
                         </p>
                     </div>
                 </div>

--- a/web/styles/portico/hello.css
+++ b/web/styles/portico/hello.css
@@ -886,6 +886,7 @@ ul {
 
         .switch-diagram {
             max-width: 220px;
+            align-self: center;
         }
 
         .screen-2__header,
@@ -1114,4 +1115,8 @@ ul {
             font-size: 18px;
         }
     }
+}
+
+.mirror-image {
+    transform: scaleX(-1);
 }


### PR DESCRIPTION
## To-do's

- Make the `mirror-image` class work here.
- Center the image at mobile widths.

@amanagr It would be great if you could take over from here.

<details><summary>Screenshots</summary>
<p>
<img width="1139" height="344" alt="Screenshot 2025-11-06 at 10 34 07" src="https://github.com/user-attachments/assets/060444f0-5197-4c6c-9125-aed62044adce" />

<img width="500" height="545" alt="Screenshot 2025-11-06 at 10 30 36" src="https://github.com/user-attachments/assets/4b866239-50fe-44be-bdb3-63d8eb52861a" />


</p>
</details> 