### PR TITLE
recent_view: Fix incompletely updated UI after topic edits.

### DIFF
--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -814,11 +814,17 @@ export function process_topic_edit(
     recent_view_data.conversations.delete(recent_view_util.get_topic_key(old_stream_id, old_topic));
 
     const old_topic_msgs = message_util.get_loaded_messages_in_topic(old_stream_id, old_topic);
-    process_messages(old_topic_msgs);
 
     new_stream_id = new_stream_id || old_stream_id;
     const new_topic_msgs = message_util.get_loaded_messages_in_topic(new_stream_id, new_topic);
-    process_messages(new_topic_msgs);
+
+    for (const msg of [...old_topic_msgs, ...new_topic_msgs]) {
+        recent_view_data.process_message(msg);
+    }
+
+    // It is best to re-render the complete UI instead of
+    // handling all edge cases that can arise due to topic edit.
+    complete_rerender();
 }
 
 export function topic_in_search_results(


### PR DESCRIPTION
If the new message for topic edit arrives before the topic update event, the recent view ui ends up in a broken state due to the way we process these events.

Best way to avoid this bug and similar race bugs of this kind is just to do a complete rerender.

discussion: [#issues > recent conversations not updating in separate tab](https://chat.zulip.org/#narrow/channel/9-issues/topic/recent.20conversations.20not.20updating.20in.20separate.20tab/with/2293692)

| before | after |
| --- | --- |
| <img width="1203" height="474" alt="Screenshot from 2025-11-07 12-48-43" src="https://github.com/user-attachments/assets/556bc9c9-b83b-414f-b403-3806ff37c41d" /> | <img width="1203" height="474" alt="image" src="https://github.com/user-attachments/assets/ce1bc532-5f0a-4303-b088-2780656c3fa6" /> |

Reproduced by applying this diff to make sure we process the new message from resolving the topic first before the topice edit event:

```diff
diff --git a/web/src/server_events.js b/web/src/server_events.js
index 65f2b4ca55..1dc971720d 100644
--- a/web/src/server_events.js
+++ b/web/src/server_events.js
@@ -135,7 +135,9 @@ function get_events_success(events) {
 
     if (update_message_events.length > 0) {
         try {
-            message_events.update_messages(update_message_events);
+            setTimeout(() => {
+                message_events.update_messages(update_message_events);
+            }, 1000);
         } catch (error) {
             blueslip.error("Failed to update messages", undefined, error);
         }
```

and opening a topic in new tab marking it as resolved. The resolved topic only has a message from bot while the old topic doesn't change.
