### PR TITLE
emoji: Fix Tab key navigation in status modal picker.

### DIFF
--- a/web/src/emoji_picker.ts
+++ b/web/src/emoji_picker.ts
@@ -568,6 +568,39 @@ export function navigate(event_name: string, e?: JQuery.KeyDownEvent): boolean {
 function process_keydown(e: JQuery.KeyDownEvent): void {
     const is_filter_focused = $("#emoji-popover-filter").is(":focus");
     const pressed_key = e.key;
+
+    // Handle Tab/Shift+Tab only for status emoji picker
+    if (pressed_key === "Tab" && user_status_ui.user_status_picker_open()) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const $popover = $(".emoji-picker-popover");
+        const emojis = $popover.find(".emoji-popover-emoji").toArray();
+        if (emojis.length === 0) {
+            return;
+        }
+
+        let currentIndex = -1;
+        if (document.activeElement instanceof HTMLElement) {
+            currentIndex = emojis.indexOf(document.activeElement);
+        }
+        const nextIndex = (currentIndex + (e.shiftKey ? -1 : 1) + emojis.length) % emojis.length;
+        const next_emoji = emojis[nextIndex];
+
+        if (next_emoji) {
+            next_emoji.focus();
+
+            const emoji_id = $(next_emoji).attr("data-emoji-id");
+            if (emoji_id) {
+                const coords = get_emoji_coordinates(emoji_id);
+                current_section = coords.section;
+                current_index = coords.index;
+                update_emoji_showcase($(next_emoji));
+            }
+        }
+        return;
+    }
+
     if (
         !is_filter_focused &&
         // ":" is a hotkey for toggling reactions popover.


### PR DESCRIPTION
Pressing Tab in the emoji picker of the status modal now cycles through emojis instead of moving focus to the modal controls.

Fixes: #36428

<!-- Describe your pull request here.-->
Previously, pressing Tab inside the status emoji picker moved focus outside the emoji picker. This change ensures that Tab and Shift+Tab correctly cycle focus between emojis within the picker while updating the emoji showcase.



**How changes were tested:**
Manually verified in the status modal emoji picker , pressed Tab and Shift+Tab to confirm focus cycles between emojis without leaving the emoji picker.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**After** 

https://github.com/user-attachments/assets/287c2662-c110-4022-936a-76f036a14e54

**Before**

https://github.com/user-attachments/assets/e8987caf-f0fa-4404-a3fe-6847c57facb5



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
