### PR TITLE
css: Fix time-output example alignment in "?" help menu

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -1046,3 +1046,11 @@
         padding-left: 0.3em;
     }
 }
+
+/* This is required to align the time-example output in the "?" menu. */
+#markdown-instructions p:has(time) {
+    display: flex;
+    align-items: center;
+    margin: calc(var(--markdown-interelement-space-px) / 2) 0;
+    padding: calc(var(--message-box-link-focus-ring-block-padding) / 2) 0;
+}


### PR DESCRIPTION
<!-- Describe your pull request here. -->
Fix alignment of the time output example in the "?" help menu.

**Before:**
<img width="1002" height="117" alt="Screenshot showing misaligned time example" src="https://github.com/user-attachments/assets/3b9cf208-b8af-4dcf-b9a3-3e8bdb842b6d" />

**After:**
<img width="979" height="128" alt="screenshot-2025-11-10_21-02-49" src="https://github.com/user-attachments/assets/e2591366-def2-4be1-9db9-c9e322fda9c9" />

Adjusted the CSS margins to align the time example correctly while maintaining consistent row height.

---

**Fixes:** [#30781](https://github.com/zulip/zulip/issues/30781)

---

### How changes were tested
- Verified visual alignment manually in both **dense** and **normal** display modes.
- Confirmed row height and spacing remain consistent.

---

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed for clarity and maintainability.
- [x] Verified that visual appearance is correct in both dense and normal modes.
- [ ] Verified responsiveness and accessibility.
- [x] Verified that commit messages are clear and focused.
- [x] Confirmed that the fix addresses the issue described in #30781.

</details>
