### PR TITLE
users: Consistently fill is_inaccessible_user, hide them in buddy list.

### DIFF
--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -488,7 +488,9 @@ export function get_conversation_participants_callback(): () => Set<number> {
 export function get_filtered_and_sorted_user_ids(user_filter_text: string): number[] {
     let user_ids;
     const conversation_participants = get_conversation_participants_callback()();
+
     user_ids = get_filtered_user_id_list(user_filter_text, conversation_participants);
+    user_ids = user_ids.filter((user_id) => !people.get_by_user_id(user_id).is_inaccessible_user);
     user_ids = maybe_shrink_list(user_ids, user_filter_text, conversation_participants);
     return sort_users(user_ids, conversation_participants);
 }

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1218,7 +1218,7 @@ export function get_bot_ids(): number[] {
 export let get_active_human_count = (): number => {
     let count = 0;
     for (const person of active_user_dict.values()) {
-        if (!person.is_bot) {
+        if (!person.is_bot && !person.is_inaccessible_user) {
             count += 1;
         }
     }
@@ -1669,6 +1669,7 @@ export function remove_inaccessible_user(user_id: number): void {
     // Create unknown user object for the inaccessible user.
     const email = "user" + user_id + "@" + realm.realm_bot_domain;
     const unknown_user = make_user(user_id, email, INACCESSIBLE_USER_NAME);
+    unknown_user.is_inaccessible_user = true;
     _add_user(unknown_user);
 }
 
@@ -1734,6 +1735,7 @@ export function make_user(user_id: number, email: string, full_name: string): Us
 export function add_inaccessible_user(user_id: number): User {
     const email = "user" + user_id + "@" + realm.realm_bot_domain;
     const unknown_user = make_user(user_id, email, INACCESSIBLE_USER_NAME);
+    unknown_user.is_inaccessible_user = true;
     _add_user(unknown_user);
     return unknown_user;
 }

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -122,7 +122,7 @@ export const user_schema = z.intersection(
         // used for fake user objects.
         is_missing_server_data: z.optional(z.boolean()),
         // used for inaccessible user objects.
-        is_inaccessible_user: z.optional(z.boolean()),
+        is_inaccessible_user: z.boolean(),
         is_system_bot: z.optional(z.literal(true)),
     }),
     z.discriminatedUnion("is_bot", [

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -583,6 +583,7 @@ class APIUserDict(TypedDict):
     profile_data: NotRequired[dict[str, Any] | None]
     is_system_bot: NotRequired[bool]
     max_message_id: NotRequired[int]
+    is_inaccessible_user: bool
 
 
 def format_user_row(
@@ -627,6 +628,7 @@ def format_user_row(
         if acting_user is None
         else row["date_joined"].isoformat(timespec="minutes"),
         delivery_email=delivery_email,
+        is_inaccessible_user=False,
     )
 
     if acting_user is None:
@@ -1029,6 +1031,7 @@ def get_data_for_inaccessible_user(realm: Realm, user_id: int) -> APIUserDict:
         delivery_email=None,
         avatar_url=get_avatar_for_inaccessible_user(),
         profile_data={},
+        is_inaccessible_user=True,
     )
     return user_dict
 


### PR DESCRIPTION
Fixes issue discussed here: [#issues > Guest can see other guests with title 'Unknown user' @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/Guest.20can.20see.20other.20guests.20with.20title.20'Unknown.20user'/near/2294118)

`is_inaccessible_user` wasn't storing this information consistently, so this PR populates it and then filters inaccessible users out of the buddy list using that field.