### PR TITLE
filter: Separate out canonical and legacy operators.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -127,6 +127,7 @@ js_rules = RuleList(
                 "web/src/message_events_util.ts",
                 "web/src/message_helper.ts",
                 "web/src/server_message.ts",
+                "web/src/state_data.ts",
                 "web/tests/",
             },
             "exclude_pattern": "emails",

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -239,7 +239,11 @@ export function parse_narrow(hash: string[]): NarrowTerm[] | undefined {
         }
 
         const operand = decode_operand(operator, raw_operand);
-        terms.push({negated, operator, operand});
+        terms.push({
+            negated,
+            operator: operator.toLowerCase(),
+            operand,
+        });
     }
     return z.array(narrow_term_schema).parse(terms);
 }

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -23,6 +23,7 @@ import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as popup_banners from "./popup_banners.ts";
 import * as recent_view_ui from "./recent_view_ui.ts";
+import {narrow_operator_schema} from "./state_data.ts";
 import type {NarrowTerm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_list from "./stream_list.ts";
@@ -285,7 +286,10 @@ function handle_operators_supporting_id_based_api(narrow_parameter: string): str
             negated?: boolean | undefined;
         } = raw_term;
 
-        const canonical_operator = Filter.canonicalize_operator(raw_term.operator);
+        const parsed_narrow_operator = narrow_operator_schema.parse(
+            raw_term.operator.toLowerCase(),
+        );
+        const canonical_operator = Filter.canonicalize_operator(parsed_narrow_operator);
 
         if (operators_supporting_ids.has(canonical_operator)) {
             const user_ids_array = people.emails_strings_to_user_ids_array(raw_term.operand);

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -119,11 +119,14 @@ export function generate_pills_html(suggestion: Suggestion, text_query: string):
         if (user_pill_operators.has(term.operator) && term.operand !== "") {
             return search_user_pill_data_from_term(term);
         }
-        const search_pill: SearchPill = {
-            type: "generic_operator",
+        const narrow_term: NarrowTerm = {
             operator: term.operator,
             operand: term.operand,
             negated: term.negated,
+        };
+        const search_pill: SearchPill = {
+            type: "generic_operator",
+            ...narrow_term,
         };
 
         if (search_pill.operator === "topic" && search_pill.operand === "") {

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -20,31 +20,54 @@ const group_permission_setting_schema = z.object({
 });
 export type GroupPermissionSetting = z.output<typeof group_permission_setting_schema>;
 
-export const narrow_term_schema = z.object({
+export const narrow_canonical_operator_schema = z.enum([
+    "", // Used for search suggestions.
+    "channel",
+    "channels",
+    "dm",
+    "dm-including",
+    "has",
+    "id",
+    "in",
+    "is",
+    "near",
+    "search",
+    "sender",
+    "topic",
+    "with",
+]);
+export type NarrowCanonicalOperator = z.output<typeof narrow_canonical_operator_schema>;
+
+const narrow_legacy_operator_schema = z.enum([
+    "pm-with",
+    "group-pm-with",
+    "from",
+    "stream",
+    "streams",
+    "subject",
+]);
+
+export const narrow_operator_schema = z.union([
+    narrow_canonical_operator_schema,
+    narrow_legacy_operator_schema,
+]);
+export type NarrowOperator = z.output<typeof narrow_operator_schema>;
+
+export const narrow_canonical_term_schema = z.object({
     negated: z.optional(z.boolean()),
-    operator: z.enum([
-        "", // Used for search suggestions.
-        "channel",
-        "channels",
-        "dm",
-        "dm-including",
-        "from",
-        "group-pm-with",
-        "has",
-        "id",
-        "in",
-        "is",
-        "near",
-        "pm-with",
-        "search",
-        "sender",
-        "stream",
-        "streams",
-        "topic",
-        "with",
-    ]),
+    operator: narrow_canonical_operator_schema,
     operand: z.string(),
 });
+export type NarrowCanonicalTerm = z.output<typeof narrow_canonical_term_schema>;
+
+export const narrow_term_schema = z.union([
+    narrow_canonical_term_schema,
+    z.object({
+        negated: z.optional(z.boolean()),
+        operator: narrow_legacy_operator_schema,
+        operand: z.string(),
+    }),
+]);
 export type NarrowTerm = z.output<typeof narrow_term_schema>;
 
 export const custom_profile_field_schema = z.object({

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -971,17 +971,17 @@ test("redundancies", () => {
 });
 
 test("canonicalization", () => {
-    assert.equal(Filter.canonicalize_operator("Is"), "is");
-    assert.equal(Filter.canonicalize_operator("Stream"), "channel");
-    assert.equal(Filter.canonicalize_operator("Subject"), "topic");
-    assert.equal(Filter.canonicalize_operator("FROM"), "sender");
+    assert.equal(Filter.canonicalize_operator("is"), "is");
+    assert.equal(Filter.canonicalize_operator("stream"), "channel");
+    assert.equal(Filter.canonicalize_operator("subject"), "topic");
+    assert.equal(Filter.canonicalize_operator("from"), "sender");
 
     let term;
-    term = Filter.canonicalize_term({operator: "Stream", operand: "Denmark"});
+    term = Filter.canonicalize_term({operator: "stream", operand: "Denmark"});
     assert.equal(term.operator, "channel");
     assert.equal(term.operand, "Denmark");
 
-    term = Filter.canonicalize_term({operator: "Channel", operand: "Denmark"});
+    term = Filter.canonicalize_term({operator: "channel", operand: "Denmark"});
     assert.equal(term.operator, "channel");
     assert.equal(term.operand, "Denmark");
 
@@ -1607,6 +1607,10 @@ test("parse", () => {
         {operator: "is", operand: "starred"},
     ];
     _test();
+
+    string = "https://www.google.com";
+    terms = [{operator: "search", operand: "https://www.google.com"}];
+    _test();
 });
 
 test("unparse", () => {
@@ -1772,8 +1776,11 @@ test("describe", ({mock_template, override}) => {
     string = "invalid something_we_do_not_support operand for is operator";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
-    // this should be unreachable, but just in case
-    narrow = [{operator: "bogus", operand: "foo"}];
+    // All the `is` operands are handled in search_suggestions. This is just
+    // for coverage.
+    assert.equal(Filter.operator_to_prefix("is"), "messages that are");
+
+    narrow = [{operator: "with", operand: 12}];
     string = "unknown operator";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 


### PR DESCRIPTION
This will help us clearly define which operators we need to write logic for.

Especially useful when we will define different operand types for each operator.

discussion: [#frontend > filter operand type: number or string?](https://chat.zulip.org/#narrow/channel/6-frontend/topic/filter.20operand.20type.3A.20number.20or.20string.3F/with/2297037)