### PR TITLE
help: Add FlattenedList for flattening lists without adding Steps.

### DIFF
--- a/starlight_help/src/components/FlattenedList.astro
+++ b/starlight_help/src/components/FlattenedList.astro
@@ -1,0 +1,42 @@
+---
+import assert from "node:assert/strict";
+
+import {fromHtml} from "hast-util-from-html";
+import {toHtml} from "hast-util-to-html";
+
+const tree = fromHtml(await Astro.slots.render("default"), {fragment: true});
+
+const tree_with_removed_newlines = {
+    type: "root",
+    children: tree.children.filter((child) => {
+        if (child.type === "text" && child.value === "\n") {
+            return false;
+        }
+        return true;
+    }),
+};
+const first_element = tree_with_removed_newlines.children[0];
+assert.ok(
+    first_element?.type === "element" &&
+        ["ol", "ul"].includes(first_element.tagName),
+);
+const flattened = {
+    ...first_element,
+    children: tree_with_removed_newlines.children.flatMap((other) => {
+        if (other.type === "comment") {
+            return [];
+        }
+        assert.ok(other.type === "element");
+        // Flatten only in case of matching tagName, for the rest, we
+        // return the elements without flattening since asides, code
+        // blocks and other elements can be part of a single list item
+        // and we do not want to flatten them.
+        if (other.tagName === first_element.tagName) {
+            return other.children;
+        }
+        return [other];
+    }),
+};
+---
+
+<Fragment set:html={toHtml(flattened)} />

--- a/starlight_help/src/components/FlattenedSteps.astro
+++ b/starlight_help/src/components/FlattenedSteps.astro
@@ -1,43 +1,7 @@
 ---
-import assert from "node:assert/strict";
-
 import {Steps} from "@astrojs/starlight/components";
-import {fromHtml} from "hast-util-from-html";
-import {toHtml} from "hast-util-to-html";
 
-const tree = fromHtml(await Astro.slots.render("default"), {fragment: true});
-
-const tree_with_removed_newlines = {
-    type: "root",
-    children: tree.children.filter((child) => {
-        if (child.type === "text" && child.value === "\n") {
-            return false;
-        }
-        return true;
-    }),
-};
-const first_element = tree_with_removed_newlines.children[0];
-assert.ok(
-    first_element?.type === "element" &&
-        ["ol", "ul"].includes(first_element.tagName),
-);
-const flattened = {
-    ...first_element,
-    children: tree_with_removed_newlines.children.flatMap((other) => {
-        if (other.type === "comment") {
-            return [];
-        }
-        assert.ok(other.type === "element");
-        // Flatten only in case of matching tagName, for the rest, we
-        // return the elements without flattening since asides, code
-        // blocks and other elements can be part of a single list item
-        // and we do not want to flatten them.
-        if (other.tagName === first_element.tagName) {
-            return other.children;
-        }
-        return [other];
-    }),
-};
+import FlattenedList from "./FlattenedList.astro";
 ---
 
-<Steps><Fragment set:html={toHtml(flattened)} /></Steps>
+<Steps><FlattenedList><slot /></FlattenedList></Steps>

--- a/starlight_help/src/content/docs/moving-from-discord.mdx
+++ b/starlight_help/src/content/docs/moving-from-discord.mdx
@@ -4,9 +4,11 @@ title: Moving from Discord
 
 import {Steps, TabItem, Tabs} from "@astrojs/starlight/components";
 
+import FlattenedList from "../../components/FlattenedList.astro";
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import ZulipTip from "../../components/ZulipTip.astro";
-import CommunicationPolicies from "../include/_CommunicationPolicies.mdx";
+import CommunicationPoliciesIntro from "../include/_CommunicationPoliciesIntro.mdx";
+import CommunicationPoliciesList from "../include/_CommunicationPoliciesList.mdx";
 import ConfigureYourOrganization from "../include/_ConfigureYourOrganization.mdx";
 import CreateOrgNoImport from "../include/_CreateOrgNoImport.mdx";
 import HowToInviteUsersToJoinNoImport from "../include/_HowToInviteUsersToJoinNoImport.mdx";
@@ -69,22 +71,26 @@ think through the transition process in your own context.
 
 ## Review and update communication policies
 
-<CommunicationPolicies />
+<CommunicationPoliciesIntro />
 
-* If you've been maintaining a forum in addition to your Discord server, it's
-  common to discontinue it when moving to Zulip. Conversations in Zulip are
-  organized enough to fulfill the role of a forum, and can be
-  [configured](/help/public-access-option) for public access if desired.
-* Zulip makes it easy to find conversations and follow up, so you may be able to
-  reduce your reliance on @-mentions. [Silent
-  mentions](/help/mention-a-user-or-group#silently-mention-a-user) make it easy
-  to refer to someone without calling for their attention.
-* Because in Zulip messages are organized by topic, it’ll generally be clear
-  what you’re responding to when you send a message. Consider encouraging users
-  to simply send messages to the appropriate topic, rather than
-  [replying](/help/replying-to-messages) as in Discord.
-* If moving a community, be sure to check out Zulip's [community moderation
-  toolkit](/help/moderating-open-organizations).
+<FlattenedList>
+  <CommunicationPoliciesList />
+
+  * If you've been maintaining a forum in addition to your Discord server, it's
+    common to discontinue it when moving to Zulip. Conversations in Zulip are
+    organized enough to fulfill the role of a forum, and can be
+    [configured](/help/public-access-option) for public access if desired.
+  * Zulip makes it easy to find conversations and follow up, so you may be able to
+    reduce your reliance on @-mentions. [Silent
+    mentions](/help/mention-a-user-or-group#silently-mention-a-user) make it easy
+    to refer to someone without calling for their attention.
+  * Because in Zulip messages are organized by topic, it’ll generally be clear
+    what you’re responding to when you send a message. Consider encouraging users
+    to simply send messages to the appropriate topic, rather than
+    [replying](/help/replying-to-messages) as in Discord.
+  * If moving a community, be sure to check out Zulip's [community moderation
+    toolkit](/help/moderating-open-organizations).
+</FlattenedList>
 
 ## Prepare users for the transition
 

--- a/starlight_help/src/content/docs/moving-from-slack.mdx
+++ b/starlight_help/src/content/docs/moving-from-slack.mdx
@@ -4,9 +4,11 @@ title: Moving from Slack
 
 import {Steps, TabItem, Tabs} from "@astrojs/starlight/components";
 
+import FlattenedList from "../../components/FlattenedList.astro";
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import ZulipTip from "../../components/ZulipTip.astro";
-import CommunicationPolicies from "../include/_CommunicationPolicies.mdx";
+import CommunicationPoliciesIntro from "../include/_CommunicationPoliciesIntro.mdx";
+import CommunicationPoliciesList from "../include/_CommunicationPoliciesList.mdx";
 import ConfigureYourOrganization from "../include/_ConfigureYourOrganization.mdx";
 import HowToInviteUsersToJoinImport from "../include/_HowToInviteUsersToJoinImport.mdx";
 import HowToInviteUsersToJoinNoImport from "../include/_HowToInviteUsersToJoinNoImport.mdx";
@@ -96,13 +98,17 @@ made the decision to move to Zulip.
 
 ## Review and update communication policies
 
-<CommunicationPolicies />
+<CommunicationPoliciesIntro />
 
-* Zulip makes it easy to find conversations and follow up. To avoid disrupting
-  focus work, @-mentions in Zulip should generally be reserved for
-  time-sensitive messages. [Silent
-  mentions](/help/mention-a-user-or-group#silently-mention-a-user) make it easy
-  to refer to someone without calling for their attention.
+<FlattenedList>
+  <CommunicationPoliciesList />
+
+  * Zulip makes it easy to find conversations and follow up. To avoid disrupting
+    focus work, @-mentions in Zulip should generally be reserved for
+    time-sensitive messages. [Silent
+    mentions](/help/mention-a-user-or-group#silently-mention-a-user) make it easy
+    to refer to someone without calling for their attention.
+</FlattenedList>
 
 ## Prepare users for the transition
 

--- a/starlight_help/src/content/docs/moving-from-teams.mdx
+++ b/starlight_help/src/content/docs/moving-from-teams.mdx
@@ -4,9 +4,11 @@ title: Moving from Microsoft Teams
 
 import {Steps, TabItem, Tabs} from "@astrojs/starlight/components";
 
+import FlattenedList from "../../components/FlattenedList.astro";
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import ZulipTip from "../../components/ZulipTip.astro";
-import CommunicationPolicies from "../include/_CommunicationPolicies.mdx";
+import CommunicationPoliciesIntro from "../include/_CommunicationPoliciesIntro.mdx";
+import CommunicationPoliciesList from "../include/_CommunicationPoliciesList.mdx";
 import ConfigureYourOrganization from "../include/_ConfigureYourOrganization.mdx";
 import CreateOrgNoImport from "../include/_CreateOrgNoImport.mdx";
 import HowToInviteUsersToJoinNoImport from "../include/_HowToInviteUsersToJoinNoImport.mdx";
@@ -58,20 +60,24 @@ think through the transition process in your own context.
 
 ## Review and update communication policies
 
-<CommunicationPolicies />
+<CommunicationPoliciesIntro />
 
-* In Zulip, it's easy to have many conversations in parallel without losing
-  track of anything. Consider adjusting your communication guidelines to
-  recommend having substantive discussions in channels, with less reliance on
-  DMs.
-* Zulip allows users to fine-tune their notification settings. Make sure you're
-  happy with the [defaults](/help/configure-default-new-user-settings) for your
-  organization, and encourage users to adjust from there.
-* Zulip makes it easy to find conversations and follow up. To avoid disrupting
-  focus work, @-mentions in Zulip should generally be reserved for
-  time-sensitive messages. [Silent
-  mentions](/help/mention-a-user-or-group#silently-mention-a-user) make it easy
-  to refer to someone without calling for their attention.
+<FlattenedList>
+  <CommunicationPoliciesList />
+
+  * In Zulip, it's easy to have many conversations in parallel without losing
+    track of anything. Consider adjusting your communication guidelines to
+    recommend having substantive discussions in channels, with less reliance on
+    DMs.
+  * Zulip allows users to fine-tune their notification settings. Make sure you're
+    happy with the [defaults](/help/configure-default-new-user-settings) for your
+    organization, and encourage users to adjust from there.
+  * Zulip makes it easy to find conversations and follow up. To avoid disrupting
+    focus work, @-mentions in Zulip should generally be reserved for
+    time-sensitive messages. [Silent
+    mentions](/help/mention-a-user-or-group#silently-mention-a-user) make it easy
+    to refer to someone without calling for their attention.
+</FlattenedList>
 
 ## Prepare users for the transition
 

--- a/starlight_help/src/content/docs/moving-to-zulip.mdx
+++ b/starlight_help/src/content/docs/moving-to-zulip.mdx
@@ -7,7 +7,8 @@ import {Steps, TabItem, Tabs} from "@astrojs/starlight/components";
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import ZulipNote from "../../components/ZulipNote.astro";
 import ZulipTip from "../../components/ZulipTip.astro";
-import CommunicationPolicies from "../include/_CommunicationPolicies.mdx";
+import CommunicationPoliciesIntro from "../include/_CommunicationPoliciesIntro.mdx";
+import CommunicationPoliciesList from "../include/_CommunicationPoliciesList.mdx";
 import ConfigureYourOrganization from "../include/_ConfigureYourOrganization.mdx";
 import HowToInviteUsersToJoinImport from "../include/_HowToInviteUsersToJoinImport.mdx";
 import HowToInviteUsersToJoinNoImport from "../include/_HowToInviteUsersToJoinNoImport.mdx";
@@ -108,7 +109,9 @@ Zulip.
 
 ## Review and update communication policies
 
-<CommunicationPolicies />
+<CommunicationPoliciesIntro />
+
+<CommunicationPoliciesList />
 
 ## Prepare users for the transition
 

--- a/starlight_help/src/content/docs/saml-authentication.mdx
+++ b/starlight_help/src/content/docs/saml-authentication.mdx
@@ -4,6 +4,7 @@ title: SAML authentication
 
 import {Steps, TabItem, Tabs} from "@astrojs/starlight/components";
 
+import FlattenedList from "../../components/FlattenedList.astro";
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import ZulipTip from "../../components/ZulipTip.astro";
 import AdminOnly from "../include/_AdminOnly.mdx";
@@ -54,12 +55,16 @@ providers.
       1. Assign the appropriate accounts in the **Assignments** tab. These are the users
          that will be able to log in to your Zulip organization.
       1. <SendUsInfo />
-         * Your organization's URL
-         * The **Identity Provider metadata** provided by Okta for the application.
-           To get the data, click the **View SAML setup instructions button** in
-           the right sidebar in the **Sign on** tab.
-           Copy the IdP metadata shown at the bottom of the page.
-         <SamlLoginButton />
+
+         <FlattenedList>
+           * Your organization's URL
+           * The **Identity Provider metadata** provided by Okta for the application.
+             To get the data, click the **View SAML setup instructions button** in
+             the right sidebar in the **Sign on** tab.
+             Copy the IdP metadata shown at the bottom of the page.
+
+           <SamlLoginButton />
+         </FlattenedList>
     </FlattenedSteps>
   </TabItem>
 
@@ -86,9 +91,13 @@ providers.
          | last\_name  | Last Name  |
          | username    | Email      |
       1. <SendUsInfo />
-         * Your organization's URL
-         * The **issuer URL** from the **SSO** section. It contains required **Identity Provider** metadata.
-         <SamlLoginButton />
+
+         <FlattenedList>
+           * Your organization's URL
+           * The **issuer URL** from the **SSO** section. It contains required **Identity Provider** metadata.
+
+           <SamlLoginButton />
+         </FlattenedList>
     </FlattenedSteps>
   </TabItem>
 
@@ -120,14 +129,18 @@ providers.
          * **name**: `user.principalname`
          * **Unique User Identifier**: `user.principalname`
       1. <SendUsInfo />
-         * Your organization's URL
-         * From the **SAML Signing Certificate** section:
-           * **App Federation Metadata Url**
-           * Certificate downloaded from **Certificate (Base64)**
-         * From the **Set up** section
-           * **Login URL**
-           * **Microsoft Entra Identifier**
-         <SamlLoginButton />
+
+         <FlattenedList>
+           * Your organization's URL
+           * From the **SAML Signing Certificate** section:
+             * **App Federation Metadata Url**
+             * Certificate downloaded from **Certificate (Base64)**
+           * From the **Set up** section
+             * **Login URL**
+             * **Microsoft Entra Identifier**
+
+           <SamlLoginButton />
+         </FlattenedList>
     </FlattenedSteps>
   </TabItem>
 
@@ -161,9 +174,13 @@ providers.
            * **SAML Attribute Name**: `email`
            * **SAML Attribute Name Format**: `Basic`
       1. <SendUsInfo />
-         * Your organization's URL
-         * The URL of your Keycloak realm.
-         <SamlLoginButton />
+
+         <FlattenedList>
+           * Your organization's URL
+           * The URL of your Keycloak realm.
+
+           <SamlLoginButton />
+         </FlattenedList>
     </FlattenedSteps>
 
     <ZulipTip>
@@ -193,9 +210,13 @@ providers.
          }
          ```
       1. <SendUsInfo />
-         * Your organization's URL
-         * The **SAML Metadata URL** value mentioned above. It contains required **Identity Provider** metadata.
-         <SamlLoginButton />
+
+         <FlattenedList>
+           * Your organization's URL
+           * The **SAML Metadata URL** value mentioned above. It contains required **Identity Provider** metadata.
+
+           <SamlLoginButton />
+         </FlattenedList>
     </FlattenedSteps>
   </TabItem>
 </Tabs>

--- a/starlight_help/src/content/include/_CommunicationPoliciesIntro.mdx
+++ b/starlight_help/src/content/include/_CommunicationPoliciesIntro.mdx
@@ -1,0 +1,2 @@
+Consider updating your organization's communication policies and practices to
+take advantage of Zulip's organized conversations:

--- a/starlight_help/src/content/include/_CommunicationPoliciesList.mdx
+++ b/starlight_help/src/content/include/_CommunicationPoliciesList.mdx
@@ -1,6 +1,3 @@
-Consider updating your organization's communication policies and practices to
-take advantage of Zulip's organized conversations:
-
 * Many organizations find that with Zulip, there’s no longer a reason to use
   email for internal communications. You get the organization of an email
   [inbox](/help/inbox) together with all the features of a modern chat app,


### PR DESCRIPTION
Our motivation to add this component was to flatten unordered lists. We did not flatten unordered lists before this because starlight was not inserting space between two adjacent unordered lists even if they were two different lists. That is no longer the case after starlight PR no. 3340 (we don't link since it creates unnecessary spam on the original PR).

I did a manual check on existing unordered list includes and added FlattenedList wherever necessary.

Fixes https://chat.zulip.org/#narrow/channel/19-documentation/topic/shared.20unordered.20list.20content

**How changes were tested:**
See screenshots

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Moving to Zulip:
<img width="790" height="505" alt="moving-to-zulip" src="https://github.com/user-attachments/assets/161c82ae-fc59-44fa-b143-299b1643b995" />
Moving from Discord:
<img width="822" height="751" alt="moving-from-discord" src="https://github.com/user-attachments/assets/a61b6a45-6d87-4b3e-892d-95697531b215" />
Moving from teams:
<img width="834" height="699" alt="moving-from-teams" src="https://github.com/user-attachments/assets/41b24bf7-0958-485c-9c29-b1e415a9d45f" />
Moving from slack:
<img width="791" height="547" alt="moving-from-slack" src="https://github.com/user-attachments/assets/595397ad-8c74-454d-b103-e8c46c41a537" />
SAML authentication:
<img width="797" height="251" alt="Screenshot 2025-11-11 at 3 23 46 PM" src="https://github.com/user-attachments/assets/5153df6b-c13a-4037-8dea-0b3ce6756ee4" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
