### PR TITLE
giphy: Show larger previews with 2 columns and 300px width

### DIFF
--- a/web/src/giphy.ts
+++ b/web/src/giphy.ts
@@ -63,6 +63,16 @@ async function renderGIPHYGrid(targetEl: HTMLElement): Promise<{remove: () => vo
 
     giphy_fetch ??= new GiphyFetch(realm.giphy_api_key);
 
+    const GRID_COLUMNS = 2;
+    const GRID_GUTTER = 6;
+    const MAX_GIF_WIDTH = 300;
+
+    function computeGridWidth(): number {
+        const desired = GRID_COLUMNS * MAX_GIF_WIDTH + (GRID_COLUMNS - 1) * GRID_GUTTER;
+        const viewportCap = Math.floor(window.innerWidth * 0.97);
+        return Math.min(desired, viewportCap);
+    }
+
     async function fetchGifs(offset: number): Promise<GifsResult> {
         assert(giphy_fetch !== undefined);
         const config = {
@@ -83,10 +93,10 @@ async function renderGIPHYGrid(targetEl: HTMLElement): Promise<{remove: () => vo
         // for detailed documentation.
         renderGrid(
             {
-                width: 300,
+                width: computeGridWidth(),
                 fetchGifs,
-                columns: 3,
-                gutter: 6,
+                columns: GRID_COLUMNS,
+                gutter: GRID_GUTTER,
                 noLink: true,
                 // Hide the creator attribution that appears over a
                 // GIF; nice in principle but too distracting.
@@ -116,6 +126,9 @@ async function renderGIPHYGrid(targetEl: HTMLElement): Promise<{remove: () => vo
     // content appearing while the user is typing.
     const resizeRender = _.throttle(render, 300);
     window.addEventListener("resize", resizeRender, false);
+    const $container = $(targetEl).closest("#giphy_grid_in_popover");
+    const containerWidth = computeGridWidth() + 6;
+    $container.css("width", `${containerWidth}px`);
     const remove = render();
     return {
         remove() {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -769,10 +769,8 @@ ul.popover-group-menu-member-list {
 }
 
 #giphy_grid_in_popover {
-    /* 300px of GIPHY grid + 5px is the extra gutter space
-     * + 1px for outline.
-     * between gif columns. */
-    width: 306px;
+    width: auto;
+    max-width: 97vw;
     border: 0;
     padding: 0;
 


### PR DESCRIPTION


This PR implements larger GIF previews in the GIF picker as requested.
Changes Made:
- Changed GIF grid from 3 columns to 2 columns
- Increased maximum GIF width from 120px to 300px
- Made popover width dynamic to accommodate larger previews
- Grid automatically adjusts on window resize
- Works well on both desktop and mobile web sizes

Technical Details:
- Updated `renderGIPHYGrid` function in `web/src/giphy.ts` to use 2 columns and compute dynamic width
- Modified `giphy_grid_in_popover` CSS in `web/styles/popovers.css` to support dynamic width
- Uses Giphy's grid API with `columns: 2` and computed `width` parameter
- Width calculation ensures popover stays within viewport constraints (97vw max)

Testing:
- Tested on desktop browsers
- Tested on mobile web sizes
- Verified grid resizes correctly on window resize
- Confirmed popover stays within viewport boundaries


