### PR TITLE
puppet: Add missing close paren.

### DIFF
--- a/puppet/zulip/lib/facter/zulip_version.rb
+++ b/puppet/zulip/lib/facter/zulip_version.rb
@@ -1,7 +1,7 @@
 Facter.add(:zulip_version) do
   setcode do
     Dir.chdir("/home/zulip/deployments/current") do
-      output = `python3 -c 'import version; print(version.ZULIP_VERSION_WITHOUT_COMMIT' 2>&1`
+      output = `python3 -c 'import version; print(version.ZULIP_VERSION_WITHOUT_COMMIT)' 2>&1`
       if not $?.success?
         Facter.debug("zulip_version error: #{output}")
         nil


### PR DESCRIPTION
This must have gotten eaten in some last-minute change.

Ref #36298.