### PR TITLE
hash_util: Revert support for incorrectly cased operator in URL.

### DIFF
--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -59,7 +59,6 @@ export function encode_stream_id(stream_id: number): string {
 }
 
 export function decode_operand(operator: string, operand: string): string {
-    operator = operator.toLowerCase();
     if (
         operator === "group-pm-with" ||
         operator === "dm-including" ||
@@ -241,7 +240,7 @@ export function parse_narrow(hash: string[]): NarrowTerm[] | undefined {
         const operand = decode_operand(operator, raw_operand);
         terms.push({
             negated,
-            operator: operator.toLowerCase(),
+            operator,
             operand,
         });
     }

--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -578,7 +578,6 @@ function hashchanged(
         browser_history.state.changing_hash = false;
         return undefined;
     }
-
     // We are changing to a "main screen" view.
     overlays.close_for_hash_change();
     sidebar_ui.hide_all();

--- a/web/tests/hashchange.test.cjs
+++ b/web/tests/hashchange.test.cjs
@@ -3,7 +3,7 @@
 const assert = require("node:assert/strict");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
 const $ = require("./lib/zjquery.cjs");
 const {page_params} = require("./lib/zpage_params.cjs");
@@ -477,4 +477,32 @@ run_test("update_hash_to_match_filter", ({override, override_rewire}) => {
     message_view.update_hash_to_match_filter(new Filter(terms));
     helper.assert_events([[message_viewport, "stop_auto_scrolling"]]);
     assert.equal(url_pushed, "http://zulip.zulipdev.com/#narrow/-is/starred");
+});
+
+run_test("fail_incorrectly_cased_URL", ({override, override_rewire}) => {
+    browser_history.clear_for_testing();
+    override(popovers, "hide_all", noop);
+    const helper = test_helper({override, override_rewire, change_tab: false});
+
+    // We can receive URLs which contain operators that
+    // are not cased correctly. We don't have to handle them
+    // since this is not a good reason to increase the types
+    // of URLs that are valid on a Zulip realm.
+    window.location.hash = "#narrow/chAnnel/4-Denmark/topic/PLOTS/with/99";
+    helper.clear_events();
+    $window_stub.trigger("hashchange");
+    helper.assert_events([
+        [overlays, "close_for_hash_change"],
+        [message_viewport, "stop_auto_scrolling"],
+        [ui_report, "error"],
+    ]);
+
+    window.location.hash = "#narrow/channel/4-Denmark/tOPic/PLOTS/with/99";
+    helper.clear_events();
+    $window_stub.trigger("hashchange");
+    helper.assert_events([
+        [overlays, "close_for_hash_change"],
+        [message_viewport, "stop_auto_scrolling"],
+        [ui_report, "error"],
+    ]);
 });


### PR DESCRIPTION
This commit aims to revert the behaviour of supporting incorrectly cased operators in URLs introduced in #36554.


Verified that searching with incorrectly cased operators in navbar search still works as expected.

discussion: [#frontend > filter operand type: number or string?](https://chat.zulip.org/#narrow/channel/6-frontend/topic/filter.20operand.20type.3A.20number.20or.20string.3F/with/2298704)