### PR TITLE
settings_bots: fix sort by owner filter

### DIFF
--- a/web/src/settings_bots.ts
+++ b/web/src/settings_bots.ts
@@ -125,11 +125,21 @@ function sort_bot_email(a: BotInfo, b: BotInfo): number {
 }
 
 function sort_bot_owner(a: BotInfo, b: BotInfo): number {
-    function owner_name(bot: BotInfo): string {
-        return (bot.bot_owner_full_name || "").toLowerCase();
+    // Always show bots without owner at bottom
+    if (a.no_owner && b.no_owner) {
+        return 0;
+    }
+    if (a.no_owner) {
+        return 1;
+    }
+    if (b.no_owner) {
+        return -1;
     }
 
-    return util.compare_a_b(owner_name(a), owner_name(b));
+    return util.compare_a_b(
+        a.bot_owner_full_name.toLowerCase(),
+        b.bot_owner_full_name.toLocaleLowerCase(),
+    );
 }
 
 export function generate_botserverrc_content(


### PR DESCRIPTION
Fixes: #36570

Modified `sort_bot_owner` to place bots without an owner at the bottom when sorting by the "Owner" column. This groups bots with owners together for easier scanning.

The code first prioritizes moving any bot with "No owner" to the bottom of the list, the alphabetical name comparison is only used as the final step when both bots actually have owners to compare.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
|Sort By|Before|After|
|:-:|:-:|:-:|
|Ascending|<img width="121" height="387" alt="Screenshot 2025-11-13 at 11 56 05 AM" src="https://github.com/user-attachments/assets/c26c2c3a-9e49-46ee-908d-e1eeb5562c91" />|<img width="121" height="387" alt="Screenshot 2025-11-13 at 11 58 25 AM" src="https://github.com/user-attachments/assets/3db3e1f4-adb8-497d-9fe2-896500dcb48b" />|
|Descending|<img width="121" height="387" alt="Screenshot 2025-11-13 at 12 20 20 PM" src="https://github.com/user-attachments/assets/d0d5e85c-ecb7-48c7-8353-5204846309fa" />|<img width="121" height="387" alt="Screenshot 2025-11-13 at 11 58 30 AM" src="https://github.com/user-attachments/assets/b9406081-d197-4670-a629-91ddf65ff72f" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
