### PR TITLE
refactor(auth): Deduplicate early parsing in start_social_signup with start_social_login

### DIFF
--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -3,7 +3,7 @@ import secrets
 from collections.abc import Callable, Mapping
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Concatenate, TypeAlias, cast
-from urllib.parse import urlencode, urljoin, urlsplit
+from zproject.settings_types import OIDCIdPConfigDict, SAMLIdPConfigDict
 
 import jwt
 import orjson


### PR DESCRIPTION
Resolves the # TODO: Deduplicate this prep logic with start_social_login. in start_social_signup.

This PR extracts the duplicated setup logic from start_social_login and start_social_signup into a new _start_social_auth helper function and then it is called by both start_social_login and start_social_signup.

Fixes #36581