### PR TITLE
Fix extraneous fields for unknown user

### DIFF
--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -123,6 +123,8 @@ export const user_schema = z.intersection(
         is_missing_server_data: z.optional(z.boolean()),
         // used for inaccessible user objects.
         is_inaccessible_user: z.optional(z.boolean()),
+        is_unknown_user: z.optional(z.boolean()),
+        // used for unknown users
         is_system_bot: z.optional(z.literal(true)),
     }),
     z.discriminatedUnion("is_bot", [

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -650,6 +650,7 @@ export function show_user_profile(user: User, default_tab_key = "profile-tab"): 
         user_is_guest: user.is_guest,
         user_time: people.get_user_time(user.user_id),
         user_type: people.get_user_type(user.user_id),
+        is_unknown_user: Boolean(user.is_unknown_user),
     };
 
     if (user.is_bot) {

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -17,19 +17,21 @@
                 {{/if}}
             </div>
             <div class="popover-menu-user-type">
-                {{#if is_bot}}
-                    {{#if is_system_bot}}
-                        <div>{{t "System bot" }}</div>
+                {{#unless is_unknown_user}}
+                    {{#if is_bot}}
+                        {{#if is_system_bot}}
+                            <div>{{t "System bot" }}</div>
+                        {{else}}
+                            <div>{{t "Bot" }}
+                                {{~#unless (eq user_type "Member")}}
+                                    <span class="lowercase">({{user_type}})</span>
+                                {{/unless~}}
+                            </div>
+                        {{/if}}
                     {{else}}
-                        <div>{{t "Bot" }}
-                            {{~#unless (eq user_type "Member")}}
-                                <span class="lowercase">({{user_type}})</span>
-                            {{/unless~}}
-                        </div>
+                        <div>{{ user_type }}</div>
                     {{/if}}
-                {{else}}
-                    <div>{{ user_type }}</div>
-                {{/if}}
+                {{/unless}}
             </div>
         </div>
     </div>
@@ -143,16 +145,18 @@
             {{/if}}
         {{/if}}
         {{> ./user_card_popover_custom_fields profile_fields=display_profile_fields}}
-        <li role="none" class="popover-menu-list-item link-item hidden-for-spectators">
-            <a role="menuitem" class="popover-menu-link view_full_user_profile" tabindex="0">
-                <i class="popover-menu-icon zulip-icon zulip-icon-account" aria-hidden="true"></i>
-                {{#if is_me}}
-                    <span class="popover-menu-label">{{t "View your profile" }}</span>
-                {{else}}
-                    <span class="popover-menu-label">{{t "View profile" }}</span>
-                {{/if}}
-            </a>
-        </li>
+        {{#unless is_unknown_user}}
+            <li role="none" class="popover-menu-list-item link-item hidden-for-spectators">
+                <a role="menuitem" class="popover-menu-link view_full_user_profile" tabindex="0">
+                    <i class="popover-menu-icon zulip-icon zulip-icon-account" aria-hidden="true"></i>
+                    {{#if is_me}}
+                        <span class="popover-menu-label">{{t "View your profile" }}</span>
+                    {{else}}
+                        <span class="popover-menu-label">{{t "View profile" }}</span>
+                    {{/if}}
+                </a>
+            </li>
+        {{/unless}}
         {{#if can_send_private_message}}
             <li role="none" class="popover-menu-list-item link-item hidden-for-spectators">
                 <a role="menuitem" class="popover-menu-link {{ private_message_class }}" tabindex="0">

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -54,6 +54,7 @@
                                         <div class="name">{{t "User ID" }}</div>
                                         <div class="value">{{user_id}}</div>
                                     </div>
+                                    {{#unless is_unknown_user}}
                                     <div id="user-type" class="default-field">
                                         <div class="name">{{t "Role" }}</div>
                                         {{#if is_bot}}
@@ -72,6 +73,7 @@
                                         <div class="name">{{t "Joined" }}</div>
                                         <div class="value">{{date_joined}}</div>
                                     </div>
+                                    {{/unless}}
                                     {{#if user_time}}
                                     <div class="default-field">
                                         <div class="name">{{t "Local time" }}</div>

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -584,6 +584,7 @@ class APIUserDict(TypedDict):
     is_system_bot: NotRequired[bool]
     max_message_id: NotRequired[int]
     is_imported_stub: bool
+    is_unknown_user: NotRequired[bool]
 
 
 def format_user_row(
@@ -1032,6 +1033,7 @@ def get_data_for_inaccessible_user(realm: Realm, user_id: int) -> APIUserDict:
         delivery_email=None,
         avatar_url=get_avatar_for_inaccessible_user(),
         profile_data={},
+        is_unknown_user=True,
         is_imported_stub=False,
     )
     return user_dict

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -28175,6 +28175,7 @@ components:
               nullable: true
             avatar_version: {}
             is_imported_stub: {}
+            is_unknown_user: {}
             profile_data: {}
     UserBase:
       type: object
@@ -28321,6 +28322,16 @@ components:
             user's message history.
 
             **Changes**: New in Zulip 12.0 (feature level 433).
+          example: false
+        is_unknown_user:
+          type: boolean
+          description: |
+            Indicates whether this user is unknown/inaccessible to the requesting user
+            due to limited access permissions. When true, this means the user's full
+            details are not available and only basic information like a generic name
+            and avatar are provided.
+
+            **Changes**: New in Zulip 13.0 (feature level TBD).
           example: false
         profile_data:
           $ref: "#/components/schemas/profile_data"


### PR DESCRIPTION
popover: Hide member role and date joined for unknown users.

In the user popover, added logic to check the `is_unknown_user` value
and used it to conditionally hide the member role and date joined
fields for unknown users.

Fixes #36519.
BEFORE
<img width="285" height="337" alt="Screenshot 2025-11-18 at 3 02 05 AM" src="https://github.com/user-attachments/assets/dfa86634-e66f-4e25-a16c-c91eb214b1de" />
<img width="639" height="757" alt="Screenshot 2025-11-18 at 3 02 34 AM" src="https://github.com/user-attachments/assets/988048ff-0176-43d1-807e-d1008f99476b" />

AFTER
<img width="649" height="720" alt="Screenshot 2025-11-14 at 12 21 30 AM" src="https://github.com/user-attachments/assets/94f3c585-9b06-4225-92ef-af793681d705" />
<img width="232" height="337" alt="Screenshot 2025-11-14 at 12 22 25 AM" src="https://github.com/user-attachments/assets/b339cd57-8359-4183-a122-8cbc51b2087c" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
