### PR TITLE
topic_list: Add "new topic" button at the bottom of zoomed topics.

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -214,7 +214,8 @@ function get_focus_area(opts: ComposeTriggeredOptions): string {
         if (
             opts.trigger === "clear topic button" ||
             opts.trigger === "compose_hotkey" ||
-            opts.trigger === "inbox_nofocus"
+            opts.trigger === "inbox_nofocus" ||
+            opts.trigger === "zoomed new topic"
         ) {
             return "input#stream_message_recipient_topic";
         }

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -28,6 +28,7 @@ import * as popovers from "./popovers.ts";
 import * as scroll_util from "./scroll_util.ts";
 import {web_channel_default_view_values} from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
+import {realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_list_sort from "./stream_list_sort.ts";
 import type {StreamListSection} from "./stream_list_sort.ts";
@@ -1356,18 +1357,30 @@ export function set_event_handlers({
         on_sidebar_channel_click(stream_id, e, show_channel_feed);
     });
 
-    $("#stream_filters").on("click", ".channel-new-topic-button", function (this: HTMLElement, e) {
-        e.stopPropagation();
-        e.preventDefault();
-        const stream_id = Number.parseInt(this.getAttribute("data-stream-id")!, 10);
-        compose_actions.start({
-            message_type: "stream",
-            stream_id,
-            topic: "",
-            trigger: "clear topic button",
-            keep_composebox_empty: true,
-        });
-    });
+    $("#stream_filters").on(
+        "click",
+        ".channel-new-topic-button, .zoomed-new-topic",
+        function (this: HTMLElement, e) {
+            e.stopPropagation();
+            e.preventDefault();
+            const stream_id = Number.parseInt(this.getAttribute("data-stream-id")!, 10);
+            let trigger = "clear topic button";
+            let topic = "";
+
+            if ($(e.target).closest(".zoomed-new-topic").length > 0) {
+                trigger = "zoomed new topic";
+                topic = $("#topic_filter_query").text().trim().slice(0, realm.max_topic_length);
+            }
+
+            compose_actions.start({
+                message_type: "stream",
+                stream_id,
+                topic,
+                trigger,
+                keep_composebox_empty: true,
+            });
+        },
+    );
 
     function toggle_pm_header_icon(): void {
         if (pm_list.is_private_messages_collapsed()) {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -711,6 +711,10 @@
         }
     }
 
+    &:has(.zoomed-new-topic):hover {
+        background: var(--color-background-sidebar-action-heading-hover);
+    }
+
     &:has(.sidebar-topic-action-heading):hover {
         background-color: var(--color-background-sidebar-action-heading-hover);
     }
@@ -1855,6 +1859,52 @@ li.active-sub-filter {
     align-self: baseline;
 }
 
+.zoomed-new-topic {
+    display: grid;
+    grid-template:
+        "starting-offset starting-anchor-element icon-content-gap row-content ending-offset"
+        var(--line-height-sidebar-row-prominent)
+        ".               .                       .                row-content ."
+        auto
+        / var(--input-icon-starting-offset) var(
+            --left-sidebar-icon-column-width
+        )
+        var(--left-sidebar-icon-content-gap)
+        minmax(0, 1fr)
+        0;
+    color: var(--color-text-sidebar-action-heading);
+
+    .topic-list-new-topic-icon {
+        grid-area: starting-anchor-element;
+        place-self: center end;
+    }
+
+    .new-topic-label {
+        grid-area: row-content;
+        margin-top: -0.06em;
+        font-size: var(--font-size-sidebar-action-heading);
+        font-weight: var(--font-weight-sidebar-action-heading);
+        font-variant: var(--font-variant-sidebar-action-heading);
+        font-feature-settings: var(
+            --font-feature-settings-sidebar-action-heading
+        );
+        text-transform: var(--text-transform-sidebar-action-heading);
+    }
+
+    &:not(:active):focus {
+        text-decoration: none;
+        border: none;
+        outline: none;
+    }
+
+    &:hover,
+    &:focus-visible {
+        border-radius: 4px;
+        text-decoration: none;
+        color: var(--color-text-sidebar-action-heading);
+    }
+}
+
 .channel-new-topic-button {
     /* display: flex; is set on visible channels and
        channel-row hovers. */
@@ -2035,7 +2085,10 @@ ul.topic-list:has(.show-more-topics)::after {
 #stream_filters
     .narrow-filter
     .topic-list
-    .bottom_left_row:has(a.sidebar-topic-action-heading:focus-visible) {
+    .bottom_left_row:has(
+        a.sidebar-topic-action-heading:focus-visible,
+        a.zoomed-new-topic:focus-visible
+    ) {
     outline: 2px solid var(--color-outline-focus);
     outline-offset: -2px;
     background-color: var(--color-background-hover-narrow-filter);
@@ -2052,6 +2105,15 @@ li.topic-list-item {
     position: relative;
     padding-right: 5px;
     margin-left: var(--left-sidebar-toggle-width-offset);
+
+    &:has(.zoomed-new-topic) {
+        /* We set a margin equal to starting-offset of filter-input to match
+           its alignment */
+        margin-left: calc(
+            var(--left-sidebar-toggle-width-offset) -
+                var(--input-icon-starting-offset)
+        );
+    }
 }
 
 .dm-box {

--- a/web/templates/topic_list_new_topic.hbs
+++ b/web/templates/topic_list_new_topic.hbs
@@ -1,0 +1,6 @@
+<li class="bottom_left_row topic-list-item">
+    <a class="zoomed-new-topic" data-stream-id="{{stream_id}}" href="">
+        <i class="topic-list-new-topic-icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
+        <span class="new-topic-label">{{~t "NEW TOPIC" ~}}</span>
+    </a>
+</li>


### PR DESCRIPTION
Adds a "new topic" button below the list of topics in the "show all topics" view in the left sidebar. The button renders when we successfully get all channel history and positioned at the bottom of the topic list.
Works like the `+` button next to the name for the channel in the left sidebar

Fixes: zulip#36573.

<!-- Describe your pull request here.-->

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

## Dark theme:

<img width="330" height="496" alt="Screenshot from 2025-11-19 14-21-19" src="https://github.com/user-attachments/assets/bd5ff630-3f09-4c8d-814a-3deea20bdcd3" />
<img width="330" height="496" alt="Screenshot from 2025-11-19 14-21-40" src="https://github.com/user-attachments/assets/134fa6e7-f67b-4466-99de-ba0da8864112" />
<img width="330" height="496" alt="Screenshot from 2025-11-19 14-22-08" src="https://github.com/user-attachments/assets/cd8a5adb-2798-4a9f-b982-f84e9f2c885d" />


## Light theme: 
<img width="330" height="496" alt="Screenshot from 2025-11-19 14-20-39" src="https://github.com/user-attachments/assets/beb54a9a-9a71-4aaf-9fc0-6fce29015093" />

## Alignment:

<img width="426" height="722" alt="Screenshot from 2025-11-19 14-19-18" src="https://github.com/user-attachments/assets/428d1137-af15-4044-a2bd-eac195b680c2" />

## Screenshare:

[Screencast from 2025-11-19 14-25-10.webm](https://github.com/user-attachments/assets/0e1e532b-1b22-4ecf-9ee1-69363a1f0171)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
