### PR TITLE
Document expand/collapse all and individual channel folders in left sidebar (#36607)

### DIFF
--- a/starlight_help/src/content/docs/left-sidebar.mdx
+++ b/starlight_help/src/content/docs/left-sidebar.mdx
@@ -91,8 +91,8 @@ information you need in the moment.
   <TabItem label="Desktop/Web">
     <Steps>
       1. In the **Channels** section of the left sidebar, click the three-dot menu at the top right of the section.
-      2. Select **Expand all folders** to show all channels in their folders.
-      3. Select **Collapse all folders** to hide channels under their folder headings.
+      1. Select **Expand all folders** to show all channels in their folders.
+      1. Select **Collapse all folders** to hide channels under their folder headings.
     </Steps>
   </TabItem>
 </Tabs>


### PR DESCRIPTION
This pull request updates the `starlight_help/src/content/docs/left-sidebar.mdx` file to document the new expand/collapse all folders and per-folder sidebar toggles for channels.

- Added sections for:
    - Expanding/collapsing all channel folders via the three-dot menu in the channels section
    - Expanding/collapsing individual folders with the triangle icon
- Steps and UI instructions match recently merged feature in PR #35982.
- Fixes #36607 

Note: I could not claim the issue via zulipbot since it is missing the "help wanted" label, but I am submitting the documentation update as a first-time contributor.
