### PR TITLE
popover: Add href for Channel settings link.

### DIFF
--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -121,12 +121,24 @@ function build_stream_popover(opts: {elt: HTMLElement; stream_id: number}): void
     const stream_unread = unread.unread_count_info_for_stream(stream_id);
     const stream_unread_count = stream_unread.unmuted_count + stream_unread.muted_count;
     const has_unread_messages = stream_unread_count > 0;
+
+    // Admin can change any stream's name & description either stream is public or
+    // private, subscribed or unsubscribed.
+    const sub = sub_store.get(stream_id);
+    assert(sub !== undefined);
+
+    const can_change_permissions =
+        stream_data.can_change_permissions_requiring_metadata_access(sub);
+    const settings_section = can_change_permissions ? "general" : "personal";
+    const stream_edit_hash = hash_util.channels_settings_edit_url(sub, settings_section);
+
     const content = render_left_sidebar_stream_actions_popover({
         stream: {
-            ...sub_store.get(stream_id),
+            ...sub,
             url: browser_history.get_full_url(stream_hash),
             list_of_topics_view_url: hash_util.by_channel_topic_list_url(stream_id),
         },
+        stream_edit_hash,
         has_unread_messages,
         show_go_to_channel_feed,
         show_go_to_list_of_topics,
@@ -168,22 +180,6 @@ function build_stream_popover(opts: {elt: HTMLElement; stream_id: number}): void
             $popper.on("click", ".stream-popover-go-to-list-of-topics", (e) => {
                 e.stopPropagation();
                 hide_stream_popover(instance);
-            });
-
-            // Stream settings
-            $popper.on("click", ".open_stream_settings", (e) => {
-                const sub = stream_popover_sub(e);
-                hide_stream_popover(instance);
-
-                // Admin can change any stream's name & description either stream is public or
-                // private, subscribed or unsubscribed.
-                const can_change_stream_permissions =
-                    stream_data.can_change_permissions_requiring_metadata_access(sub);
-                let stream_edit_hash = hash_util.channels_settings_edit_url(sub, "general");
-                if (!can_change_stream_permissions) {
-                    stream_edit_hash = hash_util.channels_settings_edit_url(sub, "personal");
-                }
-                browser_history.go_to_location(stream_edit_hash);
             });
 
             // Pin/unpin

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
@@ -49,7 +49,7 @@
         </li>
         <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>
         <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
-            <a role="menuitem" class="open_stream_settings popover-menu-link" tabindex="0">
+            <a role="menuitem" href="{{stream_edit_hash}}" class="open_stream_settings popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-gear" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Channel settings" }}</span>
             </a>


### PR DESCRIPTION
Adds href tag for channel settings link in left sidebar channel options popover to give it link behaviour.

Screen recording:-
https://github.com/user-attachments/assets/4bef9913-2909-4416-a22c-9d10783c5016



Fixes #36609

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
(variable names, readability, and consistency with the style guide).
- [x] Verified that clicking on channel settings with ctrl+click opens it in a new tab.
- [x] Commit message explains reasoning and motivation for changes.
- [x] Each commit represents a coherent, reviewable change.
- [x] Made sure that the PR follows Zulip’s coding style.

Testing:-
- [x] Verified that the PR passes all the CI build tests.
- [x] Manually tested that the link after adding href is working as expected when clicked with ctrl+click.
</details>
