### PR TITLE
stream_popover: Add href to channel settings link in popover.

### DIFF
--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -121,12 +121,24 @@ function build_stream_popover(opts: {elt: HTMLElement; stream_id: number}): void
     const stream_unread = unread.unread_count_info_for_stream(stream_id);
     const stream_unread_count = stream_unread.unmuted_count + stream_unread.muted_count;
     const has_unread_messages = stream_unread_count > 0;
+
+    // Admin can change any stream's name & description either stream is public or
+    // private, subscribed or unsubscribed.
+    const sub = sub_store.get(stream_id);
+    assert(sub !== undefined);
+    const can_change_stream_permissions =
+        stream_data.can_change_permissions_requiring_metadata_access(sub);
+    let stream_edit_hash = hash_util.channels_settings_edit_url(sub, "general");
+    if (!can_change_stream_permissions) {
+        stream_edit_hash = hash_util.channels_settings_edit_url(sub, "personal");
+    }
     const content = render_left_sidebar_stream_actions_popover({
         stream: {
             ...sub_store.get(stream_id),
             url: browser_history.get_full_url(stream_hash),
             list_of_topics_view_url: hash_util.by_channel_topic_list_url(stream_id),
         },
+        stream_edit_hash,
         has_unread_messages,
         show_go_to_channel_feed,
         show_go_to_list_of_topics,
@@ -168,22 +180,6 @@ function build_stream_popover(opts: {elt: HTMLElement; stream_id: number}): void
             $popper.on("click", ".stream-popover-go-to-list-of-topics", (e) => {
                 e.stopPropagation();
                 hide_stream_popover(instance);
-            });
-
-            // Stream settings
-            $popper.on("click", ".open_stream_settings", (e) => {
-                const sub = stream_popover_sub(e);
-                hide_stream_popover(instance);
-
-                // Admin can change any stream's name & description either stream is public or
-                // private, subscribed or unsubscribed.
-                const can_change_stream_permissions =
-                    stream_data.can_change_permissions_requiring_metadata_access(sub);
-                let stream_edit_hash = hash_util.channels_settings_edit_url(sub, "general");
-                if (!can_change_stream_permissions) {
-                    stream_edit_hash = hash_util.channels_settings_edit_url(sub, "personal");
-                }
-                browser_history.go_to_location(stream_edit_hash);
             });
 
             // Pin/unpin

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
@@ -49,7 +49,7 @@
         </li>
         <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>
         <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
-            <a role="menuitem" class="open_stream_settings popover-menu-link" tabindex="0">
+            <a href="{{stream_edit_hash}}" role="menuitem" class="open_stream_settings popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-gear" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Channel settings" }}</span>
             </a>


### PR DESCRIPTION
Clicking 'Channel settings' in the left sidebar channel popover now supports Ctrl+Click to open in a new tab. The link now has an href attribute, enabling standard browser link behaviors like middle-click, right-click menu, and URL preview on hover.

Fixes: #36609


**How changes were tested:**
Manually tested in development environment:
- Regular click navigates to channel settings
- Ctrl+Click opens settings in new tab
- Right-click shows "Open in new tab" option
- Hover displays URL in browser status bar

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


 Before | After |
| --- | --- |
| **Hover to URL** | **Hover to URL after** |
| <img width="571" height="483" alt="Screenshot 2025-11-15 at 21 13 15" src="https://github.com/user-attachments/assets/cdf6d506-ee83-48e2-9ff5-f63d29bfc8fd" /> | <img width="783" height="488" alt="Screenshot 2025-11-15 at 21 17 15" src="https://github.com/user-attachments/assets/8302aa93-f65d-4719-b0c5-237f71e5ea06" />
| **Right Click Menu Before** | **Right Click Menu  after** |
| <img width="1033" height="583" alt="Screenshot 2025-11-15 at 21 14 05" src="https://github.com/user-attachments/assets/6155d487-5e13-4210-aa9a-b26291d3f72d" /> | <img width="787" height="506" alt="Screenshot 2025-11-15 at 21 17 21" src="https://github.com/user-attachments/assets/a7aad328-65b9-486d-b330-d4d25e390902" />

**Ctrl+click Behaviour Recording** 

https://github.com/user-attachments/assets/94a5543c-21dd-4bf7-944b-f414b642069c


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
