### PR TITLE
Add repository name support to Github integration push messages.

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -658,6 +658,11 @@ WEBHOOK_INTEGRATIONS: list[WebhookIntegration] = [
         url_options=[
             WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES),
             WebhookUrlOption.build_preset_config(PresetUrlOption.IGNORE_PRIVATE_REPOSITORIES),
+            WebhookUrlOption(
+                name="include_repository_name",
+                label="Include repository name in the notifications",
+                validator=check_bool,
+            ),
         ],
     ),
     WebhookIntegration(

--- a/zerver/lib/webhooks/git.py
+++ b/zerver/lib/webhooks/git.py
@@ -17,6 +17,9 @@ PUSH_PUSHED_TEXT_WITH_URL = "[{push_type}]({compare_url}) {number_of_commits} {c
 PUSH_PUSHED_TEXT_WITHOUT_URL = "{push_type} {number_of_commits} {commit_or_commits}"
 
 PUSH_COMMITS_BASE = "{user_name} {pushed_text} to branch {branch_name}."
+PUSH_COMMITS_BASE_WITH_REPOSITORY_NAME = (
+    "{user_name} {pushed_text} to branch {branch_name} of [{repository_name}]({repository_url})."
+)
 PUSH_COMMITS_MESSAGE_TEMPLATE_WITH_COMMITTERS = """{base_message} {committers_details}.
 
 {commits_data}
@@ -93,6 +96,8 @@ def get_push_commits_event_message(
     is_truncated: bool = False,
     deleted: bool = False,
     force_push: bool | None = False,
+    repository_name: str | None = None,
+    repository_url: str | None = None,
 ) -> str:
     if not commits_data and deleted:
         return PUSH_DELETE_BRANCH_MESSAGE_TEMPLATE.format(
@@ -127,11 +132,17 @@ def get_push_commits_event_message(
         commit_or_commits=COMMIT_OR_COMMITS.format("s" if len(commits_data) > 1 else ""),
     )
 
-    base_message_template = PUSH_COMMITS_BASE
+    base_message_template = (
+        PUSH_COMMITS_BASE_WITH_REPOSITORY_NAME
+        if repository_name and repository_url
+        else PUSH_COMMITS_BASE
+    )
     base_message = base_message_template.format(
         user_name=user_name,
         pushed_text=pushed_text_message,
         branch_name=branch_name,
+        repository_name=repository_name,
+        repository_url=repository_url,
     )
 
     committers_items: list[tuple[str, int]] = get_all_committers(commits_data)

--- a/zerver/webhooks/github/doc.md
+++ b/zerver/webhooks/github/doc.md
@@ -8,8 +8,9 @@ Get GitHub notifications in Zulip!
 
 1. Decide where to send {{ integration_display_name }} notifications, and
    [generate the integration URL](/help/generate-integration-url). You'll be
-   able to configure which branches you'll receive notifications from, and
-   whether to exclude notifications from private repositories.
+   able to configure which branches you'll receive notifications from,
+   whether to exclude notifications from private repositories, and whether
+   to include the repository name in the notifications.
 
 1. On your repository's web page, go to **Settings**. Select **Webhooks**,
    and click **Add webhook**. GitHub may prompt you for your password.

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -118,6 +118,17 @@ class GitHubWebhookTest(WebhookTestCase):
         expected_message = f"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 50 commits to branch changes.\n\n{commit_info * COMMITS_LIMIT}[and 30 more commit(s)]"
         self.check_webhook("push__50_commits", TOPIC_BRANCH, expected_message)
 
+    def test_push_1_commit_with_repository_name(self) -> None:
+        self.url = self.build_webhook_url(include_repository_name="true")
+        expected_message = "baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 1 commit to branch changes of [baxterthehacker/public-repo](https://github.com/baxterthehacker/public-repo).\n\n* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"
+        self.check_webhook("push__1_commit", TOPIC_BRANCH, expected_message)
+
+    def test_push_multiple_committers_with_repository_name(self) -> None:
+        self.url = self.build_webhook_url(include_repository_name="true")
+        commits_info = "* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
+        expected_message = f"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 6 commits to branch changes of [baxterthehacker/public-repo](https://github.com/baxterthehacker/public-repo). Commits by Tomasz (3), Ben (2) and baxterthehacker (1).\n\n{commits_info * 5}* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"""
+        self.check_webhook("push__multiple_committers", TOPIC_BRANCH, expected_message)
+
     def test_commit_comment_msg(self) -> None:
         expected_message = "baxterthehacker [commented](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b#commitcomment-11056394) on [9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b):\n~~~ quote\nThis is a really good change! :+1:\n~~~"
         self.check_webhook("commit_comment", TOPIC_REPO, expected_message)

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -62,10 +62,12 @@ class Helper:
         request: HttpRequest,
         payload: WildValue,
         include_title: bool,
+        include_repository_name: bool,
     ) -> None:
         self.request = request
         self.payload = payload
         self.include_title = include_title
+        self.include_repository_name = include_repository_name
 
     def log_unsupported(self, event: str) -> None:
         summary = f"The '{event}' event isn't currently supported by the GitHub webhook; ignoring"
@@ -315,6 +317,10 @@ def get_push_commits_body(helper: Helper) -> str:
         commits_data,
         deleted=payload["deleted"].tame(check_bool),
         force_push=payload["forced"].tame(check_bool),
+        repository_name=get_repository_full_name(payload)
+        if helper.include_repository_name
+        else None,
+        repository_url=get_repository_url(payload) if helper.include_repository_name else None,
     )
 
 
@@ -820,6 +826,10 @@ def get_repository_full_name(payload: WildValue) -> str:
     return payload["repository"]["full_name"].tame(check_string)
 
 
+def get_repository_url(payload: WildValue) -> str:
+    return payload["repository"]["html_url"].tame(check_string)
+
+
 def get_organization_name(payload: WildValue) -> str:
     return payload["organization"]["login"].tame(check_string)
 
@@ -1011,6 +1021,7 @@ def api_github_webhook(
     branches: str | None = None,
     user_specified_topic: OptionalUserSpecifiedTopicStr = None,
     ignore_private_repositories: Json[bool] = False,
+    include_repository_name: Json[bool] = False,
 ) -> HttpResponse:
     """
     GitHub sends the event as an HTTP header.  We have our
@@ -1054,6 +1065,7 @@ def api_github_webhook(
         request=request,
         payload=payload,
         include_title=user_specified_topic is not None,
+        include_repository_name=include_repository_name,
     )
     body = body_function(helper)
 


### PR DESCRIPTION
This PR adds a feature that allows users to opt in to including repository names in Github integration push messages.

Fixes #34525.

Relevant CZO topic: [#integrations > Repo name in GitHub webhook #34525](https://chat.zulip.org/#narrow/channel/127-integrations/topic/Repo.20name.20in.20GitHub.20webhook.20.2334525/with/2165365)

**Screenshots and screen captures:**

<details>
  <summary>Generate Integration URL modal</summary>
  <table>
    <thead>
      <tr>
        <th>Include repository name option</th>
        <th>Include repository name URL</th>
      </tr>
    </thead>
    <tbody>
      <tr>
        <td><img width="622" height="658" alt="Screenshot 2025-11-16 at 12 31 35 AM" src="https://github.com/user-attachments/assets/0c2819d0-a021-4b7e-84bb-40135c076de9" /></td>
        <td><img width="618" height="655" alt="Screenshot 2025-11-16 at 12 31 41 AM" src="https://github.com/user-attachments/assets/369266d3-3a96-4903-845a-4e53b1d05cf1" /></td>
      </tr>
    </tbody>
  </table>
</details>

- Sample message with repository name
<img width="678" height="76" alt="Screenshot 2025-11-16 at 12 35 35 AM" src="https://github.com/user-attachments/assets/96dcb8a1-fd4c-494d-b626-de05da91d2a8" />

- The original message with the repo URL
<img width="756" height="158" alt="Screenshot 2025-11-16 at 12 35 57 AM" src="https://github.com/user-attachments/assets/e958ecfc-f936-4089-9ae8-db2bc0138e82" />

- [GitHub integration documentation](https://zulip.com/integrations/github)

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="732" height="81" alt="Screenshot 2025-12-07 at 2 00 34 PM" src="https://github.com/user-attachments/assets/3e8de158-5fbb-4bc7-8c93-b58b1e11a4bb" /></td>
    <td><img width="758" height="80" alt="Screenshot 2025-12-07 at 2 00 09 PM" src="https://github.com/user-attachments/assets/a6edcff5-d526-4bec-9e26-870355d5c1f4" /></td>
  </tr>
</table>

---


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
