### PR TITLE
reminders: Remove unused `forwarder_user_profile`.

### DIFF
--- a/zerver/actions/reminders.py
+++ b/zerver/actions/reminders.py
@@ -29,7 +29,6 @@ def schedule_reminder_for_message(
         addressee,
         get_reminder_formatted_content(message, current_user, note),
         current_user.realm,
-        forwarder_user_profile=current_user,
     )
     send_request.deliver_at = deliver_at
     send_request.reminder_target_message_id = message_id

--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -45,7 +45,6 @@ def check_schedule_message(
     deliver_at: datetime,
     realm: Realm | None = None,
     *,
-    forwarder_user_profile: UserProfile | None = None,
     read_by_sender: bool | None = None,
     skip_events: bool = False,
 ) -> int:
@@ -56,7 +55,6 @@ def check_schedule_message(
         addressee,
         message_content,
         realm=realm,
-        forwarder_user_profile=forwarder_user_profile,
     )
     send_request.deliver_at = deliver_at
 
@@ -236,7 +234,6 @@ def edit_scheduled_message(
             addressee,
             updated_content,
             realm=realm,
-            forwarder_user_profile=sender,
         )
 
     if recipient_type_name is not None or message_to is not None:

--- a/zerver/views/scheduled_messages.py
+++ b/zerver/views/scheduled_messages.py
@@ -180,7 +180,6 @@ def create_scheduled_message_backend(
         message_content,
         deliver_at,
         realm=user_profile.realm,
-        forwarder_user_profile=user_profile,
         read_by_sender=read_by_sender,
     )
     return json_success(request, data={"scheduled_message_id": scheduled_message_id})


### PR DESCRIPTION
There is no use for them since current_user has the same permissions as the forwarder_user_profile passed to `check_message`


discussion: https://github.com/zulip/zulip/pull/36586#issuecomment-3529064077