### PR TITLE
help: Document reminder indicators on messages.

### DIFF
--- a/starlight_help/src/content/docs/schedule-a-reminder.mdx
+++ b/starlight_help/src/content/docs/schedule-a-reminder.mdx
@@ -6,6 +6,7 @@ import {Steps, TabItem, Tabs} from "@astrojs/starlight/components";
 
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import KeyboardTip from "../../components/KeyboardTip.astro";
+import ZulipTip from "../../components/ZulipTip.astro";
 import GoToReminders from "../include/_GoToReminders.mdx";
 import MessageActions from "../include/_MessageActions.mdx";
 
@@ -62,6 +63,10 @@ conversation at a later time.
     <FlattenedSteps>
       <GoToReminders />
     </FlattenedSteps>
+
+    <ZulipTip>
+      A note on the message will indicate that you have a reminder scheduled.
+    </ZulipTip>
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Follow-up to #36074.

Before: https://chat.zulip.org/help/schedule-a-reminder#view-reminders

After:
<img width="811" height="239" alt="Screenshot 2025-11-17 at 14 07 55" src="https://github.com/user-attachments/assets/bbfb1f31-52de-49a9-99c1-d272cf5aa898" />
