### PR TITLE
compose: Simplify DM recipient placeholder.

### DIFF
--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -73,7 +73,7 @@
                             </div>
                             <div id="compose-direct-recipient" data-before="{{t 'You and' }}">
                                 <div class="pill-container">
-                                    <div class="input" contenteditable="true" id="private_message_recipient" data-no-recipients-text="{{t 'Add one or more users' }}" data-some-recipients-text="{{t 'Add another user…' }}"></div>
+                                    <div class="input" contenteditable="true" id="private_message_recipient" data-no-recipients-text="{{t 'Add users' }}" ></div>
                                     <button type="button" id="compose-new-direct-recipient-button" class="compose-new-recipient-button tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Add recipient' }}" tabindex="-1">
                                         <i class="zulip-icon zulip-icon-square-plus"></i>
                                     </button>


### PR DESCRIPTION
After #35154, it's clear that recipients can be added, if it wasn't obvious already.

**Question**: When would one see the `Add another user…` on the line I edited? I didn't see how to make it show up in the UI.

<img width="797" height="113" alt="Screenshot 2025-11-17 at 14 21 09" src="https://github.com/user-attachments/assets/5d1cc689-20e2-4605-bdd6-b66ee17fa831" />
