### PR TITLE
realm_redirect: Show error from server instead browser default error.

### DIFF
--- a/templates/zerver/realm_redirect.html
+++ b/templates/zerver/realm_redirect.html
@@ -23,7 +23,7 @@
                             <input
                               type="text" value="{% if form.subdomain.value() %}{{ form.subdomain.value() }}{% endif %}"
                               placeholder="{{ _('your-organization') }}" autofocus id="realm_redirect_subdomain" name="subdomain"
-                              autocomplete="off" required/>
+                              autocomplete="off"/>
                             <span id="realm_redirect_external_host">.{{external_host}}</span>
                         </div>
                         <div id="errors">


### PR DESCRIPTION
We want to show "This field is required." here for consistency instead of what browser decides to show for required fields.

| before | after |
| --- | --- |
| <img width="937" height="599" alt="image" src="https://github.com/user-attachments/assets/3d00312a-607b-4ed4-a3fb-3be6ff28c981" /> | <img width="937" height="599" alt="Screenshot from 2025-11-18 15-20-29" src="https://github.com/user-attachments/assets/17eb1d26-3919-40f3-a23a-f74cbeffec41" /> |
