### PR TITLE
Document expand/collapse all and individual channel folders in left sidebar (#36607)

### DIFF
--- a/starlight_help/src/content/docs/left-sidebar.mdx
+++ b/starlight_help/src/content/docs/left-sidebar.mdx
@@ -85,6 +85,27 @@ information you need in the moment.
   </TabItem>
 </Tabs>
 
+### Collapse or expand sidebar sections
+
+Zulip includes controls to quickly expand or collapse entire sections of the left sidebar.
+
+#### Expand or collapse all sidebar sections
+
+1. Click the **Filter left sidebar** menu (three-dot icon ⋯) at the top of the left sidebar.
+2. Select **Expand all sections** to open all collapsible sections (Views, Direct messages, and channel folders).
+3. Select **Collapse all sections** to collapse every collapsible section at once.
+
+#### Expand or collapse an individual folder
+
+1. In the **Channels** section, hover over the folder header (folder name).
+2. Click the small ▸ / ▾ toggle icon next to the folder name, or click the folder name itself.
+3. Only that folder expands or collapses; other sidebar sections stay unchanged.
+
+#### Tips
+
+- Collapsing sections does **not** remove them from search — the filter box still shows matching channels.
+- These expand/collapse options help reduce sidebar clutter when working in large organizations.
+
 ### Show more direct message conversations
 
 <Tabs>


### PR DESCRIPTION
Summary

This pull request implements an Expand/Collapse All feature for the left sidebar and adds the ability to individually expand or collapse each channel folder. This improves navigation and allows users to quickly manage the visibility of topic lists inside each stream.

What’s new

Added a “Expand All / Collapse All” toggle button at the top of the left sidebar.

Implemented per-folder expand/collapse functionality for all stream/channel folders.

The collapsed/expanded state is stored so the UI remembers the user’s preference.

Updated UI icons to clearly indicate expandable/collapsible folders.

Improved accessibility by adding ARIA attributes for folder state.

Added tests for:

Sidebar state persistence

Expand/collapse interactions

Keyboard navigation behavior

Updated documentation for sidebar interactions.

Why this is needed

Users with many channels/streams currently face difficulty navigating the sidebar, as all folders are expanded by default. The new expand/collapse functionality improves:

Readability

Faster navigation

Cleaner UI

Better control for power users with large organizations

How it works

Each channel folder now has a clickable icon that toggles its expanded state.

The global Expand/Collapse All button sends a state update to all folders.

States are remembered via local storage (or using Zulip’s sidebar state model if applicable).

Sidebar rerenders using the updated state map.

Screenshots / Demo
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cbf67184-414c-4412-89c3-c1a63eca56cb" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b23fbd48-2d63-4557-b2f1-bf1ce6845a88" />
