### PR TITLE
ui: Restyle scroll-to-bottom button

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2135,20 +2135,37 @@ body:not(.spectator-view) {
         cursor: pointer;
 
         &:hover #scroll-to-bottom-button {
-            background: hsl(240deg 96% 68%);
+            background-color: var(
+                --color-background-info-icon-button-square-hover
+            );
+
+            & .scroll-to-bottom-icon {
+                color: var(--color-text-info-icon-button-hover);
+            }
+        }
+
+        &:active #scroll-to-bottom-button {
+            background-color: var(
+                --color-background-info-icon-button-square-active
+            );
+
+            & .scroll-to-bottom-icon {
+                color: var(--color-text-info-icon-button-square-active);
+            }
         }
 
         #scroll-to-bottom-button {
             text-align: center;
             width: 2.5em; /* 40px at 16px em */
             height: 2.5em; /* 40px at 16px em */
-            background: hsl(240deg 96% 68% / 50%);
+            background-color: var(--color-background-message-feed);
             border-radius: 50%;
             display: flex;
             align-items: center;
+            box-shadow: 0 0 4px 0 hsl(0deg 0% 0% / 10%);
 
             & .scroll-to-bottom-icon {
-                color: hsl(0deg 0% 100%);
+                color: var(--color-text-info-icon-button);
                 margin: 0 auto;
                 font-size: 1.3125em; /* 21px at 16px em */
             }

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -6,7 +6,7 @@
     <div id="scroll-to-bottom-button-container" aria-hidden="true">
         <div id="scroll-to-bottom-button-clickable-area" data-tooltip-template-id="scroll-to-bottom-button-tooltip-template">
             <div id="scroll-to-bottom-button">
-                <i class="scroll-to-bottom-icon fa fa-chevron-down"></i>
+                <i class="scroll-to-bottom-icon zulip-icon zulip-icon-chevron-down"></i>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Replace Font Awesome icon with Lucide chevron-down icon and update button styling to use info button color scheme for better visual consistency with other UI elements.

Changes:
- Change icon from Font Awesome to zulip-icon-chevron-down
- Update button colors to use info icon button variables
- Add message feed background with subtle shadow for depth
- Implement proper hover and active states using design system colors

Fixes #36640.

**How changes were tested:**
Manual testing across both light and dark themes to verify:
- Icon renders correctly with proper sizing
- Hover states provide clear visual feedback
- Active states work as expected
- Button maintains consistent positioning and sizing
- Colors align with Zulip's info button design system

**Screenshots and screen captures:**

### Dark Theme

| State | Before | After |
|-------|--------|-------|
| **Without Hover** | <img width="368" height="427" alt="Dark theme before - no hover" src="https://github.com/user-attachments/assets/72f8dce3-d5e8-4637-a2f6-0bcb3049b53f" /> | <img width="368" height="427" alt="Dark theme after - no hover" src="https://github.com/user-attachments/assets/e0522031-c3e7-420c-bec8-c53a1419941f" /> |
| **With Hover** | <img width="368" height="427" alt="Dark theme before - hover" src="https://github.com/user-attachments/assets/da8ff86e-59c4-4455-a95f-2d2853a893de" /> | <img width="368" height="427" alt="Dark theme after - hover" src="https://github.com/user-attachments/assets/0e076f62-4d8b-4efb-9446-3aedc1c2a20f" /> |

### Light Theme

| State | Before | After |
|-------|--------|-------|
| **Without Hover** | <img width="368" height="427" alt="Light theme before - no hover" src="https://github.com/user-attachments/assets/c7401371-33e8-4d46-96d3-77342850decf" /> | <img width="368" height="427" alt="Light theme after - no hover" src="https://github.com/user-attachments/assets/cf61b1b9-67ee-4104-b36a-3ecc83a7da32" /> |
| **With Hover** | <img width="368" height="427" alt="Light theme before - hover" src="https://github.com/user-attachments/assets/967e0bd4-b0da-423b-a9e4-08cbeb0de151" /> | <img width="368" height="427" alt="Light theme after - hover" src="https://github.com/user-attachments/assets/9388fc6e-ff25-4656-b17c-aa9befa16901" /> |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>