### PR TITLE
webhooks/papertrail: Use the datetime value with the timezone info.

### DIFF
--- a/zerver/webhooks/papertrail/tests.py
+++ b/zerver/webhooks/papertrail/tests.py
@@ -15,11 +15,11 @@ class PapertrailHookTests(WebhookTestCase):
         expected_message = """
 [Search for "Important stuff"](https://papertrailapp.com/searches/42) found **2** matches:
 
-<time:May 18 20:30:02> - abc - cron OR server1:
+<time:2011-05-18T20:30:02-07:00> - abc - cron OR server1:
 ``` quote
 message body
 ```
-<time:May 18 20:30:02> - server1 - cron OR server1:
+<time:2011-05-18T20:30:02-07:00> - server1 - cron OR server1:
 ``` quote
 A short event
 ```
@@ -37,19 +37,19 @@ A short event
         expected_message = """
 [Search for "Important stuff"](https://papertrailapp.com/searches/42) found **5** matches:
 
-<time:May 18 20:30:02> - abc - cron OR server1:
+<time:2011-05-18T20:30:02-07:00> - abc - cron OR server1:
 ``` quote
 message body 1
 ```
-<time:May 18 20:30:02> - abc - cron OR server1:
+<time:2011-05-18T20:30:02-07:00> - abc - cron OR server1:
 ``` quote
 message body 2
 ```
-<time:May 18 20:30:02> - abc - cron OR server1:
+<time:2011-05-18T20:30:02-07:00> - abc - cron OR server1:
 ``` quote
 message body 3
 ```
-<time:May 18 20:30:02> - abc - cron OR server1:
+<time:2011-05-18T20:30:02-07:00> - abc - cron OR server1:
 ``` quote
 message body 4
 ```

--- a/zerver/webhooks/papertrail/view.py
+++ b/zerver/webhooks/papertrail/view.py
@@ -39,7 +39,7 @@ def api_papertrail_webhook(
 
     for i, event in enumerate(payload["events"]):
         event_text = SEARCH_TEMPLATE.format(
-            timestamp=event["display_received_at"].tame(check_string),
+            timestamp=event["received_at"].tame(check_string),
             source=event["source_name"].tame(check_string),
             query=payload["saved_search"]["query"].tame(check_string),
             message=event["message"].tame(check_string),


### PR DESCRIPTION
**Reason for making this a draft**: [#integrations > Time elements in integrations @ 💬](https://chat.zulip.org/#narrow/channel/127-integrations/topic/Time.20elements.20in.20integrations/near/2304420)

Inspiration: [#integrations > Time elements in integrations @ 💬](https://chat.zulip.org/#narrow/channel/127-integrations/topic/Time.20elements.20in.20integrations/near/2304397)

Papertrail sends two datetime fields: one with timezone info and one without.
We're switching to the former for global time display.

In Papertrail, we have the following fields in the fixture:
```
"received_at": "2011-05-18T20:30:02-07:00",
"display_received_at": "May 18 20:30:02",
```
We're currently using `display_received_at`, instead of `received_at` in the message template.
This PR switches to using `received_at`, since we've started using `<time:>` format for all datetime values.



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
