### PR TITLE
dropdowns: Add threshold to hide search box for short lists.

### DIFF
--- a/web/src/dropdown_widget.ts
+++ b/web/src/dropdown_widget.ts
@@ -19,6 +19,8 @@ import * as util from "./util.ts";
 
 /* Sync with max-height set in zulip.css */
 export const DEFAULT_DROPDOWN_HEIGHT = 210;
+/* Default minimum items required to show the search box. */
+export const MIN_ITEMS_TO_SHOW_SEARCH_BOX = 3;
 const noop = (): void => {
     // Empty function for default values.
 };
@@ -74,6 +76,7 @@ export type DropdownWidgetOptions = {
     // Text to show if the current value is not in `get_options()`.
     text_if_current_value_not_in_options?: string;
     hide_search_box?: boolean;
+    min_items_to_show_search_box?: number;
     // Disable the widget for spectators.
     disable_for_spectators?: boolean;
     dropdown_input_visible_selector?: string;
@@ -114,7 +117,12 @@ export class DropdownWidget {
     unique_id_type: DataType | undefined;
     $events_container: JQuery;
     text_if_current_value_not_in_options: string;
+    // Effective value used while dropdown is open.
     hide_search_box: boolean;
+    // Remember caller’s explicit request to hide search.
+    initial_hide_search_box: boolean;
+    // Only show the search box if options.length > threshold.
+    min_items_to_show_search_box: number;
     disable_for_spectators: boolean;
     dropdown_input_visible_selector: string;
     prefer_top_start_placement: boolean;
@@ -154,6 +162,11 @@ export class DropdownWidget {
         this.text_if_current_value_not_in_options =
             options.text_if_current_value_not_in_options ?? "";
         this.hide_search_box = options.hide_search_box ?? false;
+        // Preserve caller's original request to hide the search box.
+        this.initial_hide_search_box = options.hide_search_box ?? false;
+        // Use constant default if the caller didn't provide a value.
+        this.min_items_to_show_search_box =
+            options.min_items_to_show_search_box ?? MIN_ITEMS_TO_SHOW_SEARCH_BOX;
         this.disable_for_spectators = options.disable_for_spectators ?? false;
         this.dropdown_input_visible_selector =
             options.dropdown_input_visible_selector ?? this.widget_selector;
@@ -323,6 +336,12 @@ export class DropdownWidget {
                     // So, we show the dropdown even if reference is hidden on
                     // mobile.
                     $(instance.popper).find(".tippy-box").addClass("show-when-reference-hidden");
+                }
+                // Automatically hide the search box for short lists,
+                // unless the caller explicitly requested to hide it.
+                if (!this.initial_hide_search_box) {
+                    const options = this.get_options(this.current_value);
+                    this.hide_search_box = options.length <= this.min_items_to_show_search_box;
                 }
                 instance.setContent(
                     parse_html(


### PR DESCRIPTION
**Summary**


This PR updates the dropdown widget so that the search box is hidden when the list is short.
The search input now shows only when the number of options is above a configurable threshold.
This helps keep short dropdowns cleaner.
This is related to Issue #36647.

Fixes: https://github.com/zulip/zulip/issues/36647

**How I tested the changes**

Checked dropdowns with fewer items than the threshold - search box stays hidden.

Checked dropdowns with more items - search box appears normally.

Tested existing behaviors:

force_hide_search_box

spectator mode

mobile view

Ran tools/lint and fixed formatting.

Ran tools/test-js-with-node dropdown_widget and it passed.

**Screenshots**

**Before:**
<img width="1898" height="870" alt="before" src="https://github.com/user-attachments/assets/ef6c1805-c33d-46f3-9a7b-0d4fc6a5370f" />

**After:**
<img width="1919" height="860" alt="after" src="https://github.com/user-attachments/assets/f7e1ef5a-23af-49bd-8c1a-4c332578ee10" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
