### PR TITLE
tooltip: updated tooltip for creating or browsing channels

### DIFF
--- a/web/src/left_sidebar_tooltips.ts
+++ b/web/src/left_sidebar_tooltips.ts
@@ -150,7 +150,7 @@ export function initialize(): void {
                 settings_data.user_can_create_public_streams() ||
                 settings_data.user_can_create_web_public_streams();
             const tooltip_text = can_create_streams
-                ? $t({defaultMessage: "Add channels"})
+                ? $t({defaultMessage: "Browse or create channels"})
                 : $t({defaultMessage: "Browse channels"});
             instance.setContent(tooltip_text);
         },


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Left sidebar tooltip on the top of the screen previously said 'Add channels'. I found this confusing and so I thought it would be better if it instead said 'Browse or create channels' for clarity. This only applies to users with permissions to actually create channels.

Fixes: https://github.com/zulip/zulip/issues/36671

**How changes were tested:** Tested by simply saving the environment and letting webpack recompile. Issue was a simple string change and as such shouldn't need more testing than verifying that the new string actually shows up.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Hovering the left-sidebar tooltip for adding channels or browsing channels previously looked like this:
<img width="432" height="114" alt="Image" src="https://github.com/user-attachments/assets/472ffd8a-7a12-4367-86ea-9136fff804b3" />

I have changed the string to instead say:
<img width="470" height="140" alt="image" src="https://github.com/user-attachments/assets/15e8c794-e2b8-402d-b47b-87545473f20e" />

My motivation for this is that it provides much more clarity for new users who are trying to navigate Zulip. The old text "Add channels" doesn't tell userst that they can also browse channels by clicking the icon.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
