### PR TITLE
message-edit: Fix keyboard navigation through formatting buttons

### DIFF
--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -51,8 +51,8 @@ export function clean_up_compose_singleton_tooltip(context: SingletonContext): v
 }
 
 export function initialize_compose_tooltips(context: SingletonContext, selector: string): void {
-    // Listen on body for the very first mouseenter on any element matching `selector`
-    $(document.body).one("mousemove", selector, (e) => {
+    // Helper function to initialize tooltip instances
+    const initialize_tooltip_instances = (): void => {
         // Clean up existing instances first
         clean_up_compose_singleton_tooltip(context);
 
@@ -81,16 +81,26 @@ export function initialize_compose_tooltips(context: SingletonContext, selector:
             },
         });
 
-        // Show the tooltip since user has hovered over the element.
-        if (e.currentTarget instanceof HTMLElement) {
-            e.currentTarget.dispatchEvent(new MouseEvent("mouseenter"));
-        }
-
         compose_button_singleton_context_map.set(context, {
             tooltip_instances,
             singleton_instance,
         });
-    });
+    };
+
+    // For message edit contexts, initialize tooltips immediately to support keyboard navigation
+    if (context.startsWith("edit_message:")) {
+        initialize_tooltip_instances();
+    } else {
+        // For the main compose box, use lazy initialization on first mousemove
+        $(document.body).one("mousemove", selector, (e) => {
+            initialize_tooltip_instances();
+
+            // Show the tooltip since user has hovered over the element.
+            if (e.currentTarget instanceof HTMLElement) {
+                e.currentTarget.dispatchEvent(new MouseEvent("mouseenter"));
+            }
+        });
+    }
 }
 
 export function initialize(): void {

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -748,8 +748,28 @@ export function process_tab_key(): boolean {
 
     const $focused_message_edit_content = $(".message_edit_content:focus");
     if ($focused_message_edit_content.length > 0) {
+        // Instead of jumping directly to Save button, let the browser naturally
+        // tab to formatting buttons first. Only intervene if no formatting buttons exist.
         $message_edit_form = $focused_message_edit_content.closest(".message_edit_form");
-        // Open message edit forms either have a save button or a close button, but not both.
+        const $formatting_buttons = $message_edit_form.find(
+            ".message-edit-feature-group .compose_control_button[tabindex='0']",
+        );
+
+        if ($formatting_buttons.length > 0) {
+            // Let browser handle Tab to go to first formatting button
+            return false;
+        }
+
+        // No formatting buttons (shouldn't happen), go to save/close button
+        $message_edit_form.find(".message_edit_save,.message_edit_close").trigger("focus");
+        return true;
+    }
+
+    // When tabbing from the last element in the formatting area (help button),
+    // move focus to the Save/Close button
+    const $focused_help_button = $(".message_edit_form .compose_help_button:focus");
+    if ($focused_help_button.length > 0) {
+        $message_edit_form = $focused_help_button.closest(".message_edit_form");
         $message_edit_form.find(".message_edit_save,.message_edit_close").trigger("focus");
         return true;
     }
@@ -786,10 +806,29 @@ export function process_shift_tab_key(): boolean {
         return true;
     }
 
-    // Shift-Tabbing from the edit message save button takes you to the content.
+    // Shift-Tabbing from the edit message save button: go to last formatting button
+    // (help button) if it exists, otherwise go to textarea
     const $focused_message_edit_save = $(".message_edit_save:focus");
     if ($focused_message_edit_save.length > 0) {
-        $focused_message_edit_save
+        const $message_edit_form = $focused_message_edit_save.closest(".message_edit_form");
+        const $help_button = $message_edit_form.find(".compose_help_button[tabindex='0']");
+
+        if ($help_button.length > 0) {
+            // Go to the last focusable element (help button) in formatting area
+            $help_button.trigger("focus");
+        } else {
+            // No formatting buttons, go directly to textarea
+            $message_edit_form.find(".message_edit_content").trigger("focus");
+        }
+        return true;
+    }
+
+    // When Shift-Tabbing from the first formatting button (preview), go back to textarea
+    const $focused_preview_button = $(
+        ".message_edit_form .markdown_preview.compose_control_button:focus",
+    );
+    if ($focused_preview_button.length > 0) {
+        $focused_preview_button
             .closest(".message_edit_form")
             .find(".message_edit_content")
             .trigger("focus");

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -581,6 +581,7 @@ function edit_message($row: JQuery, raw_content: string): void {
             giphy_enabled: giphy_state.is_giphy_enabled(),
             minutes_to_edit: Math.floor((realm.realm_message_content_edit_limit_seconds ?? 0) / 60),
             max_message_length: realm.max_message_length,
+            preview_mode_on: false,
         }),
     );
 
@@ -1758,6 +1759,7 @@ export function show_preview_area($element: JQuery): void {
 
     $row.find(".markdown_preview").hide();
     $row.find(".undo_markdown_preview").show();
+    $row.find(".undo_markdown_preview").trigger("focus");
 
     render_preview_area($row);
 }
@@ -1780,6 +1782,9 @@ export function render_preview_area($row: JQuery): void {
 
 export function clear_preview_area($element: JQuery): void {
     const $row = rows.get_closest_row($element);
+
+    // Return focus to the textarea when exiting preview mode
+    $row.find<HTMLTextAreaElement>("textarea.message_edit_content").trigger("focus");
 
     // While in preview mode we disable unneeded compose_control_buttons,
     // so here we are re-enabling those compose_control_buttons


### PR DESCRIPTION
When editing a message, Tab and Shift+Tab now properly navigate through all formatting buttons (Preview, Bold, Italic, etc.) instead of jumping directly from the textarea to the Save button.

This makes the message edit UI keyboard-accessible, matching the behavior of the main compose box.

Changes:
- Initialize tooltips immediately for message edit contexts to support keyboard users who never trigger mousemove events
- Add preview_mode_on parameter to message edit form rendering to ensure formatting buttons get tabindex=0
- Update Tab key handler to allow natural browser tabbing through formatting buttons before reaching Save button
- Update Shift+Tab handler to navigate backwards through formatting buttons from Save button to textarea
- Add handlers for first/last formatting buttons to complete the cycle

This ensures keyboard-only users can access all message editing features without requiring a mouse.

Fixes #36663.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
https://github.com/user-attachments/assets/0fc09858-376f-4520-8d92-9e97577d9026


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
