### PR TITLE
recent topics: Highlight the filter term when selecting input after navigation.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -234,6 +234,7 @@ let filters = new Set([DEFAULT_FILTER]);
 const per_channel_filters = new Map<number, Set<string>>();
 let collapsed_containers = new Set<string>();
 
+let should_select_inbox_search = false;
 let search_keyword = "";
 let inbox_last_search_keyword = "";
 const per_channel_last_search_keyword = new Map<number, string>();
@@ -338,6 +339,9 @@ export function show(filter?: Filter): void {
     const normal_inbox_view_is_visible = inbox_util.is_visible() && !was_inbox_channel_view;
 
     inbox_util.set_filter(filter);
+    if (search_keyword !== "") {
+        should_select_inbox_search = true;
+    }
     if (inbox_util.is_channel_view()) {
         restore_channel_view_state();
         views_util.show({
@@ -1459,6 +1463,12 @@ function focus_inbox_search(): void {
     focus_current_id();
 }
 
+function select_inbox_search(): void {
+    current_focus_id = INBOX_SEARCH_ID;
+    const $search = $(`#${CSS.escape(INBOX_SEARCH_ID)}`);
+    $search.trigger("select");
+}
+
 function is_list_focused(): boolean {
     return (
         current_focus_id === undefined ||
@@ -1510,7 +1520,12 @@ export function revive_current_focus(): void {
     if (is_list_focused()) {
         set_list_focus();
     } else {
-        focus_current_id();
+        if (!should_select_inbox_search) {
+            focus_current_id();
+            return;
+        }
+        select_inbox_search();
+        should_select_inbox_search = false;
     }
 }
 

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -152,8 +152,10 @@ export function is_in_focus(): boolean {
 export function set_default_focus(): void {
     // If at any point we are confused about the currently
     // focused element, we switch focus to search.
+    const focus_action = should_select_search_text ? "select" : "focus";
     $current_focus_elem = $("#recent_view_search");
-    $current_focus_elem.trigger("focus");
+    $current_focus_elem.trigger(focus_action);
+    should_select_search_text = false;
     compose_closed_ui.set_standard_text_for_reply_button();
 }
 
@@ -1411,6 +1413,7 @@ export function update_recent_view_rendered_time(): void {
     }
 }
 
+let should_select_search_text = false;
 export function show(): void {
     assert(hide_other_views_callback !== undefined);
     hide_other_views_callback();
@@ -1435,6 +1438,10 @@ export function show(): void {
         complete_rerender,
     });
     last_scroll_offset = undefined;
+
+    if ($("#recent_view_search").val() !== "") {
+        should_select_search_text = true;
+    }
 
     if (reattach_event_handlers) {
         assert(topics_widget !== undefined);


### PR DESCRIPTION
**Summary of Changes:**
Add logic to the show function: When the filter box is not empty, set should_select_search_text to true.
Add logic in setDefaultFocus: Determine whether to perform the select or focus action based on should_select_search_text.

**Reason for correctness:**
Only pass the filter state, and leave it to other logic to decide whether to highlight the filter box.

**Focus Behavior:**
When the focus is on topic_row, switching back to "Recent conversations" will not change the focus to the search box.
When there is no focus on the screen or the focus is on the search box, switching back to "Recent conversations" will change the focus to the search box.
When the user is typing, the focus will not be changed.

<!-- Describe your pull request here.-->

**Fixes:** https://github.com/zulip/zulip/issues/17941<!-- Issue link, or clear description.-->

**How changes were tested:**
manual testing

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![gif1](https://github.com/user-attachments/assets/21e11de6-a6f5-4aea-9833-f7673aa61e5d)
![gif2](https://github.com/user-attachments/assets/fb5c3556-7750-457b-b166-4efdc285c94f)

<details>

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
