### PR TITLE
presence: Add helpful in-code comments pointing to API docs.

### DIFF
--- a/web/src/presence.ts
+++ b/web/src/presence.ts
@@ -1,3 +1,5 @@
+// See https://zulip.com/api/update-presence for API documentation.
+
 import * as z from "zod/mini";
 
 import * as people from "./people.ts";

--- a/zerver/lib/presence.py
+++ b/zerver/lib/presence.py
@@ -15,6 +15,14 @@ from zerver.models import Realm, UserPresence, UserProfile
 def get_presence_dicts_for_rows(
     all_rows: Sequence[Mapping[str, Any]], slim_presence: bool
 ) -> dict[str, dict[str, Any]]:
+    # This function takes the presence data fetched from the database and
+    # turn it into an appropriate format for the API to return to clients.
+    # Used by the two endpoints that conduct realm-wide presence fetch:
+    # 1) `POST /users/me/presence`: https://zulip.com/api/update-presenc
+    # 2) `POST /register` when presence data is requested:
+    #    https://zulip.com/api/register-queue
+    # TODO: For consistency, we likely also should be using this for formatting
+    # presence data for https://zulip.com/api/get-user-presence
     if slim_presence:
         # Stringify user_id here, since it's gonna be turned
         # into a string anyway by JSON, and it keeps mypy happy.

--- a/zerver/models/presence.py
+++ b/zerver/models/presence.py
@@ -11,6 +11,13 @@ from zerver.models.users import UserProfile
 class UserPresence(models.Model):
     """A record from the last time we heard from a given user on a given client.
 
+    This is the core table for Zulip's presence API, which consists of two components:
+    1) The update-presence endpoint, which is used for clients to update their presence
+       status and fetch latest presence data the whole realm:
+       https://zulip.com/api/update-presence
+    2) The events system is used to send limited immediate updates when
+       a user comes back online: https://zulip.com/api/get-events#presence
+
     NOTE: Users can disable updates to this table (see UserProfile.presence_enabled),
     so this cannot be used to determine if a user was recently active on Zulip.
     The UserActivity table is recommended for that purpose.
@@ -29,6 +36,8 @@ class UserPresence(models.Model):
     # the row gets last_update_id equal to 1 more than the previously updated
     # row in that realm.
     # This allows us to order UserPresence rows by when they were last updated.
+    # The API side of this functionality is documented at:
+    # https://zulip.com/api/update-presence#parameter-last_update_id
     last_update_id = models.PositiveBigIntegerField(db_index=True, default=0)
 
     # The last time the user had a client connected to Zulip,

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -1287,13 +1287,14 @@ def process_presence_event(event: Mapping[str, Any], users: Iterable[int]) -> No
         # since presence events are pretty ephemeral in nature.
         logging.warning("Dropping some obsolete presence events after upgrade.")
 
+    # See https://zulip.com/api/get-events#presence for more context
+    # on these various event formats.
     slim_event = dict(
         type="presence",
         user_id=event["user_id"],
         server_timestamp=event["server_timestamp"],
         presence=event["legacy_presence"],
     )
-
     legacy_event = dict(
         type="presence",
         user_id=event["user_id"],
@@ -1301,7 +1302,6 @@ def process_presence_event(event: Mapping[str, Any], users: Iterable[int]) -> No
         server_timestamp=event["server_timestamp"],
         presence=event["legacy_presence"],
     )
-
     modern_event = dict(
         type="presence",
         presences={str(event["user_id"]): event["modern_presence"]},


### PR DESCRIPTION
Now that we have solid documentation for the presence API, we can include links pointing to it in some places in the code to improve readability / make it easier to understand the context for what's being done.

Closes #13519

