### PR TITLE
people: Work around Safari 17 `/\p{C}/u` bug

### DIFF
--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -683,7 +683,10 @@ export function pm_perma_link(message: Message): string | undefined {
 }
 
 export function get_slug_from_full_name(full_name: string): string {
-    return internal_url.encodeHashComponent(full_name.replaceAll(/[ "%/<>`\p{C}]+/gu, "-"));
+    // We don't use \p{C} or \p{Cs} due to https://bugs.webkit.org/show_bug.cgi?id=267011
+    return internal_url.encodeHashComponent(
+        full_name.replaceAll(/[ "%/<>`\p{Cc}\p{Cf}\p{Co}\p{Cn}]+/gu, "-"),
+    );
 }
 
 export function pm_with_url(message: Message | MessageWithBooleans): string | undefined {


### PR DESCRIPTION
Safari 17 incorrectly allows individual surrogates of a surrogate pair to match `/\p{C}/u`. We don’t expect unpaired surrogates to show up in full names (PostgreSQL cannot transmit them and orjson can’t serialize or deserialize them). Since `\p{C}` is equivalent to `[\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Cn}]`, we can work around this by ignoring `Cs`.

https://bugs.webkit.org/show_bug.cgi?id=267011