### PR TITLE
settings: Hide deactivate organization section from non-owners.

### DIFF
--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -85,13 +85,14 @@
                   image = realm_night_logo_url }}
             </div>
         </div>
+        {{#if is_owner}}
         <h3 class="light">
             {{t "Deactivate organization" }}
             {{> ../help_link_widget link="/help/deactivate-your-organization" }}
         </h3>
         <div class="deactivate-realm-section">
             <div class="input-group">
-                <div id="deactivate_realm_button_container" class="inline-block {{#unless is_owner}}disabled_setting_tooltip{{/unless}}">
+                <div id="deactivate_realm_button_container" class="inline-block">
                     {{> ../components/action_button
                       label=(t "Deactivate organization")
                       attention="quiet"
@@ -101,5 +102,6 @@
                 </div>
             </div>
         </div>
+        {{/if}}
     </form>
 </div>


### PR DESCRIPTION
Previously, the **“Deactivate organization”** section was visible to all users in the Organization settings. The button was simply disabled for non-owners using a CSS class. This was confusing because it suggested that all users could access the feature, but were temporarily restricted.

This update improves clarity by ensuring that the entire section is displayed **only to organization owners** through a conditional check. This makes it clear that only owners have the ability to deactivate the organization.

**Fixes #36711.**

---

### **Before**

The button appeared for all users, but was disabled.

<img width="898" height="623" alt="Screenshot 2025-11-21 at 1 19 56 AM" src="https://github.com/user-attachments/assets/59bfcc53-912c-4114-b99b-55f28ff2a362" />

---

### **After (Non-owners)**

The entire section is now hidden for non-owners.

<img width="898" height="623" alt="Screenshot 2025-11-21 at 1 20 56 AM" src="https://github.com/user-attachments/assets/3c2a7e4c-4497-4008-92c7-a71944c84738" />

---

### **After (Owners)**

Owners can still see and access the *Deactivate organization* section.

<img width="898" height="623" alt="Screenshot 2025-11-21 at 1 21 18 AM" src="https://github.com/user-attachments/assets/44365ecd-dc51-49ff-a9f0-d156e096db69" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
