### PR TITLE
issues: Small bugs in settings/popovers.

### DIFF
--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -540,11 +540,16 @@ export function initialize(): void {
                 max_stream_name_length: realm.max_stream_name_length,
                 max_stream_description_length: realm.max_stream_description_length,
             };
+            const stream_name_with_privacy_symbol_html = render_inline_decorated_channel_name({
+                stream,
+            });
             const change_stream_info_modal = render_change_stream_info_modal(template_data);
             dialog_widget.launch({
                 html_heading: $t_html(
-                    {defaultMessage: "Edit #{channel_name}"},
-                    {channel_name: stream.name},
+                    {defaultMessage: "Edit <z-link></z-link>"},
+                    {
+                        "z-link": () => stream_name_with_privacy_symbol_html,
+                    },
                 ),
                 html_body: change_stream_info_modal,
                 id: "change_stream_info_modal",

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -449,6 +449,7 @@ function remove_subscriber({
     }
 
     function remove_user_from_private_stream(): void {
+        buttons.show_button_loading_indicator($remove_button);
         assert(sub !== undefined);
         subscriber_api.remove_user_id_from_stream(
             target_user_id,
@@ -517,6 +518,7 @@ function remove_subscriber({
         return;
     }
 
+    buttons.show_button_loading_indicator($remove_button);
     subscriber_api.remove_user_id_from_stream(
         target_user_id,
         sub,
@@ -614,7 +616,6 @@ export function initialize(): void {
             const target_user_id = Number.parseInt($list_entry.attr("data-subscriber-id")!, 10);
             const stream_id = current_stream_id;
             const $remove_button = $(this).closest(".remove-subscriber-button");
-            buttons.show_button_loading_indicator($remove_button);
             remove_subscriber({stream_id, target_user_id, $list_entry, $remove_button});
         },
     );

--- a/web/templates/popovers/schedule_message_popover.hbs
+++ b/web/templates/popovers/schedule_message_popover.hbs
@@ -12,7 +12,7 @@
         {{#if is_reminder}}
         <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="text-item popover-menu-list-item schedule-reminder-note-item">
-            <textarea class="schedule-reminder-note"  placeholder="{{t 'Note'}}" tabindex="0"
+            <textarea class="schedule-reminder-note settings_textarea"  placeholder="{{t 'Note'}}" tabindex="0"
               maxlength="{{max_reminder_note_length}}"
               ></textarea>
         </li>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR fixes some bugs found in stream settings and popovers.

Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/9-issues/topic/small.20bugs.20in.20settings.2Fpopovers.3F/with/2305069)[#issues > small bugs in settings/popovers?](https://chat.zulip.org/#narrow/channel/9-issues/topic/small.20bugs.20in.20settings.2Fpopovers.3F/with/2305069).

**How changes were tested:**
- For the first commit, changes were tested for different channels (with different privacy icons) at different font sizes.
- For the second commit, changes were tested for different font sizes and for light/dark mode.
- For the third commit, changes were tested for error as well as success response by introducing a delay and verifying the behavior of the loading indicator.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

- Channel privacy icon in the stream info modal.

| Before | After |
|--------|--------|
| <img width="755" height="422" alt="image" src="https://github.com/user-attachments/assets/a0c7e4b8-d915-41db-98d8-1abbbed44458" /> | <img width="754" height="418" alt="image" src="https://github.com/user-attachments/assets/96182b8f-752c-4b9e-9936-2ee90d22f688" /> |
| <img width="756" height="418" alt="image" src="https://github.com/user-attachments/assets/9606c1cb-e172-4dcc-b379-722a39d50c5d" /> | <img width="758" height="424" alt="image" src="https://github.com/user-attachments/assets/4d3313af-4bf0-478c-ae2d-d2f6fb86d141" /> |
| <img width="753" height="417" alt="image" src="https://github.com/user-attachments/assets/145e52ac-7354-407d-b125-7e2f3dd1d03b" /> | <img width="758" height="423" alt="image" src="https://github.com/user-attachments/assets/0c5b691d-a39a-4184-9c4e-a3f83e68d872" /> |

- Use `settings_textarea` class in the textarea element of the schedule reminder popover.

| Before | After |
|--------|--------|
| <img width="311" height="406" alt="image" src="https://github.com/user-attachments/assets/abf1d516-020c-4ce2-99d0-ea0ce3654665" /> | <img width="289" height="384" alt="image" src="https://github.com/user-attachments/assets/c175fa77-7ea2-430b-bac1-062e54c983db" /> |
| <img width="310" height="395" alt="image" src="https://github.com/user-attachments/assets/236be0a3-7923-4fd9-9abf-72b342651caf" /> | <img width="308" height="396" alt="image" src="https://github.com/user-attachments/assets/257f70c5-d7ea-45cd-94e5-14edd3cb94b9" /> | 

- Show/hide loading indicator correctly when unsubscribing a user.

| Before | After |
|--------|--------|
| ![loading indicator no hide](https://github.com/user-attachments/assets/f9f8bf07-a980-4add-8084-02c63e5c059b) | ![loading indicator hide](https://github.com/user-attachments/assets/47e0a53e-2d4a-4a32-950d-a69488b1ba98) | 





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
