### PR TITLE
digest: Add '#' before channel name in digest email messege headers.

### DIFF
--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -17,6 +17,7 @@ from confirmation.models import one_click_unsubscribe_link
 from zerver.context_processors import common_context
 from zerver.lib.email_notifications import (
     build_message_list,
+    get_channel_privacy_icon,
     message_content_allowed_in_missedmessage_emails,
 )
 from zerver.lib.logging_util import log_to_file
@@ -266,8 +267,12 @@ def gather_new_streams(
 
     for stream in new_streams:
         narrow_url = stream_narrow_url(realm, stream)
-        channel_link = Markup("<a href='{narrow_url}'>{stream_name}</a>").format(
-            narrow_url=narrow_url, stream_name=stream.name
+        channel_link = Markup(
+            "<a href='{narrow_url}'>{channel_privacy_icon}{stream_name}</a>"
+        ).format(
+            narrow_url=narrow_url,
+            channel_privacy_icon=get_channel_privacy_icon(stream),
+            stream_name=stream.name,
         )
         channels_html.append(channel_link)
         channels_plain.append(stream.name)

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -217,6 +217,18 @@ def add_quote_prefix_in_text(content: str) -> str:
     return "\n".join(output)
 
 
+def get_channel_privacy_icon(channel: Stream) -> str:
+    """
+    Return the relevant icon for given channel.
+    """
+    # TODO: Implement emoji icons (🔒, 🌍, etc.) here.
+    #       Emojis were approved in #design > digest email design; when working
+    #       on this, include comments to keep this logic consistent with the
+    #       web app and avoid future drift.
+
+    return "#"
+
+
 def build_message_list(
     user: UserProfile,
     messages: list[Message],
@@ -301,12 +313,14 @@ def build_message_list(
             stream=stream,
             topic_name=message.topic_name(),
         )
-        header = f"{stream.name} > {message.topic_name()}"
+        channel_privacy_icon = get_channel_privacy_icon(stream)
+        header = f"{channel_privacy_icon}{stream.name} > {message.topic_name()}"
         stream_link = stream_narrow_url(user.realm, stream)
         header_html = Markup(
-            "<a href='{stream_link}'>{stream_name}</a> &gt; <a href='{narrow_link}'>{topic_name}</a>"
+            "<a href='{stream_link}'>{channel_privacy_icon}{stream_name}</a> &gt; <a href='{narrow_link}'>{topic_name}</a>"
         ).format(
             stream_link=stream_link,
+            channel_privacy_icon=channel_privacy_icon,
             stream_name=stream.name,
             narrow_link=narrow_link,
             topic_name=message.topic_name(),

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -23,6 +23,7 @@ from zerver.lib.digest import (
     get_recently_created_streams,
     get_user_stream_map,
 )
+from zerver.lib.email_notifications import get_channel_privacy_icon
 from zerver.lib.message import get_last_message_id
 from zerver.lib.streams import create_stream_if_needed
 from zerver.lib.test_classes import ZulipTestCase
@@ -526,7 +527,7 @@ class TestDigestEmailMessages(ZulipTestCase):
             realm, recently_created_streams, can_access_public=True
         )
         self.assertEqual(stream_count, 1)
-        expected_html = f"<a href='http://zulip.testserver/#narrow/channel/{stream.id}-New-stream'>New stream</a>"
+        expected_html = f"<a href='http://zulip.testserver/#narrow/channel/{stream.id}-New-stream'>{get_channel_privacy_icon(stream)}New stream</a>"
         self.assertEqual(stream_info["html"][0], expected_html)
 
         # guests don't see our stream


### PR DESCRIPTION
Uses `get_stream_prefix` and gets the relevent prefix for a given stream, the prefix is added to both new channels and channels in email notifications.

For now the default prefix is `#`, we can then change the function to return specific prefix(emoji/icon) for a specific channel type.

Fixes #36686.

The PR #36703 is not the relevent solution, it does not add the `#` to link, bellow is the screenshots.

**Screenshots and screen captures:**
|Before|this PR| #36703 PR| 
|---|---|---|
|<img width="1710" height="982" alt="Screenshot 2025-11-21 at 4 12 16 PM" src="https://github.com/user-attachments/assets/5b1f54d4-6958-46c1-8a1a-a51cc209f27c" /> |<img width="1710" height="982" alt="Screenshot 2025-11-21 at 3 40 00 PM" src="https://github.com/user-attachments/assets/00d05381-fee9-4665-a11f-8ad8ef3ff7c0" />|<img width="1710" height="982" alt="Screenshot 2025-11-21 at 2 28 20 PM" src="https://github.com/user-attachments/assets/d69cfa2c-ed85-4bf8-ad43-8b0cb5414336" />| 


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
