### PR TITLE
compose: Remove stale "recipient not subscribed" banners.

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -9,7 +9,9 @@ import render_unknown_zoom_user_error from "../templates/compose_banner/unknown_
 import {$t} from "./i18n.ts";
 import * as scroll_util from "./scroll_util.ts";
 import * as stream_data from "./stream_data.ts";
+import * as markdown_config from "./markdown_config.ts";
 import type {StreamSubscription} from "./sub_store.ts";
+import type {MarkdownHelpers} from "./markdown.ts";
 
 export let scroll_to_message_banner_message_id: number | null = null;
 export function set_scroll_to_message_banner_message_id(val: number | null): void {
@@ -307,4 +309,117 @@ export function show_convert_pasted_text_to_file_banner(cb: () => void): JQuery 
     $new_row.on("click", ".main-view-banner-action-button", cb);
     append_compose_banner_to_banner_list($new_row, $("#compose_banners"));
     return $new_row;
+}
+
+// Syncs "users not subscribed" banners with actual mentions present
+// in the compose textarea. If a mention was removed, remove its banner.
+export function remove_banners_of_not_mentioned_users(
+    message_text: string,
+    $banner_container: JQuery,
+): void {
+    const $existing_banners = $banner_container.find(
+        `.${CSS.escape(CLASSNAMES.recipient_not_subscribed)}`,
+    );
+
+    if ($existing_banners.length === 0) {
+        return;
+    }
+
+    const invites = [...$existing_banners].map((row) => {
+        const $row = $(row);
+        return {
+            user_id: Number($row.attr("data-user-id")),
+            name: $row.attr("data-name"),
+        };
+    });
+
+    const helper_config = markdown_config.get_helpers();
+    const mentions = extract_mentions_from_text(message_text, helper_config);
+
+    const invites_to_remove = invites.filter(
+        (invite) =>
+            !mentions.some((mention) =>
+                mention.user_id !== null
+                    ? mention.user_id === invite.user_id
+                    : mention.full_name === invite.name,
+            ),
+    );
+
+    for (const invite of invites_to_remove) {
+        if (invite.user_id) {
+            $banner_container
+                .find(
+                    `.${CSS.escape(CLASSNAMES.recipient_not_subscribed)}[data-user-id="${invite.user_id}"]`,
+                )
+                .remove();
+        } else {
+            $banner_container
+                .find(
+                    `.${CSS.escape(CLASSNAMES.recipient_not_subscribed)}[data-name="${invite.name}"]`,
+                )
+                .remove();
+        }
+    }
+}
+
+// Extract user mentions from raw compose textarea text.
+// Matches Zulip mention syntax: @**Full Name|123** or @_**Name**.
+export function extract_mentions_from_text(
+    text: string,
+    helper_config: MarkdownHelpers,
+) {
+    const results = [];
+
+    // Matches @_?**mention**
+    const MENTION_REGEX = /@_?\*\*([^*]+)\*\*/g;
+
+    let match: RegExpExecArray | null;
+
+    while ((match = MENTION_REGEX.exec(text)) !== null) {
+        const mention = match[1]!.trim();
+
+        let full_name;
+        let user_id;
+
+        // EXACT same regex as parse_with_options
+        const id_regex = /^(.+)?\|(\d+)$/;
+        const id_match = id_regex.exec(mention);
+
+        if (id_match) {
+            full_name = id_match[1];
+            user_id = Number.parseInt(id_match[2]!, 10);
+
+            if (full_name === undefined) {
+                // @**|id** syntax
+                if (!helper_config.is_valid_user_id(user_id)) {
+                    continue;
+                }
+                full_name = helper_config.get_actual_name_from_user_id(user_id);
+            } else {
+                // @**name|id** syntax
+                if (
+                    !helper_config.is_valid_full_name_and_user_id(
+                        full_name,
+                        user_id,
+                    )
+                ) {
+                    continue;
+                }
+            }
+        } else {
+            // @**name** syntax
+            full_name = mention;
+            user_id = helper_config.get_user_id_from_name(full_name);
+        }
+
+        if (user_id === undefined) {
+            continue;
+        }
+
+        full_name = helper_config.get_actual_name_from_user_id(user_id);
+
+        results.push({ full_name, user_id });
+    }
+
+    return results;
 }

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -17,6 +17,7 @@ import type {Typeahead} from "./bootstrap_typeahead.ts";
 import * as bulleted_numbered_list_util from "./bulleted_numbered_list_util.ts";
 import * as channel from "./channel.ts";
 import * as common from "./common.ts";
+import * as compose_banner from "./compose_banner.ts";
 import * as compose_state from "./compose_state.ts";
 import type {TypeaheadSuggestion} from "./composebox_typeahead.ts";
 import {$t, $t_html} from "./i18n.ts";
@@ -622,6 +623,13 @@ export function handle_keyup(
     }
     // Set the rtl class if the text has an rtl direction, remove it otherwise
     rtl.set_rtl_class_for_textarea($textarea);
+
+    const message_text = $textarea.val() ?? "";
+    const $banner_container = compose_banner.get_compose_banner_container($textarea);
+
+    // Sync banners with current mentions
+    // If a mention was removed, its corresponding banner will be removed too.
+    compose_banner.remove_banners_of_not_mentioned_users(message_text, $banner_container);
 }
 
 export function cursor_inside_code_block($textarea: JQuery<HTMLTextAreaElement>): boolean {

--- a/web/templates/compose_banner/compose_banner.hbs
+++ b/web/templates/compose_banner/compose_banner.hbs
@@ -2,6 +2,7 @@
   class="main-view-banner {{banner_type}} {{classname}}"
   {{#if user_id}}data-user-id="{{user_id}}"{{/if}}
   {{#if stream_id}}data-stream-id="{{stream_id}}"{{/if}}
+  {{#if name}}data-name="{{name}}"{{/if}}
   {{#if (or topic_name is_empty_string_topic)}}data-topic-name="{{topic_name}}"{{/if}}>
     <div class="main-view-banner-elements-wrapper">
         {{#if banner_text}}

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -30,6 +30,7 @@ const message_lists = zrequire("message_lists");
 const text_field_edit = mock_esm("text-field-edit");
 const {set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
+const compose_banner = zrequire("compose_banner");
 
 const realm = make_realm({realm_topics_policy: "allow_empty_topic"});
 set_realm(realm);
@@ -1258,6 +1259,20 @@ run_test("markdown_shortcuts", ({override_rewire}) => {
 run_test("right-to-left", () => {
     const $textarea = $("textarea#compose-textarea");
 
+    const $stub = $.create("message_edit_form_stub");
+    $textarea.closest = (selector) => {
+        assert.equal(selector, ".message_edit_form");
+        $stub.length = 0;
+        return $stub;
+    };
+
+    const $banner_container = $.create("banner-container");
+    $stub.set_find_results(".edit_form_banners", $banner_container);
+    $banner_container.set_find_results(
+        `.${compose_banner.CLASSNAMES.recipient_not_subscribed}`,
+        [],
+    );
+
     const event = {
         key: "A",
     };
@@ -1265,7 +1280,7 @@ run_test("right-to-left", () => {
     assert.equal($textarea.hasClass("rtl"), false);
 
     $textarea.val("```quote\nمرحبا");
-    compose_ui.handle_keyup(event, $("textarea#compose-textarea"));
+    compose_ui.handle_keyup(event, $textarea);
 
     assert.equal($textarea.hasClass("rtl"), true);
 
@@ -1273,6 +1288,58 @@ run_test("right-to-left", () => {
     compose_ui.handle_keyup(event, $textarea);
 
     assert.equal($textarea.hasClass("rtl"), false);
+});
+
+run_test("remove-banners", () => {
+    const $banner_container = $.create("banner-container");
+
+    const $banner1 = $.create("banner1");
+    $banner1.attr("data-user-id", 1);
+    $banner1.attr("data-name", "Iago");
+    $banner1.remove = () => {
+        $banner1.attr("removed", true);
+    };
+    const $banner2 = $.create("banner2");
+    $banner2.attr("data-user-id", 2);
+    $banner2.attr("data-name", "Desdemona");
+    $banner2.remove = () => {
+        $banner2.attr("removed", true);
+    };
+
+    $banner_container.set_find_results(
+        `.${CSS.escape(compose_banner.CLASSNAMES.recipient_not_subscribed)}`,
+        [$banner1, $banner2],
+    );
+
+    $banner_container.set_find_results(
+        `.${CSS.escape(compose_banner.CLASSNAMES.recipient_not_subscribed)}[data-user-id="1"]`,
+        $banner1,
+    );
+    $banner_container.set_find_results(
+        `.${CSS.escape(compose_banner.CLASSNAMES.recipient_not_subscribed)}[data-user-id="2"]`,
+        $banner2,
+    );
+
+    $banner_container.set_find_results(
+        `.${CSS.escape(compose_banner.CLASSNAMES.recipient_not_subscribed)}[data-name="Iago"]`,
+        $banner1,
+    );
+    $banner_container.set_find_results(
+        `.${CSS.escape(compose_banner.CLASSNAMES.recipient_not_subscribed)}[data-name="Desdemona"]`,
+        $banner2,
+    );
+
+    const message_text = "";
+
+    compose_banner.remove_banners_of_not_mentioned_users(message_text, $banner_container);
+
+    let $existing_banners = $banner_container.find(
+        `.${CSS.escape(compose_banner.CLASSNAMES.recipient_not_subscribed)}`,
+    );
+
+    $existing_banners = $existing_banners.filter((banner) => !banner.attr("removed"));
+
+    assert.equal($existing_banners.length, 0);
 });
 
 const get_focus_area = compose_ui._get_focus_area;


### PR DESCRIPTION
Previously, a “recipient not subscribed” banner stayed visible even after its corresponding @mention was removed from the compose text. This caused the UI to become stale. This commit updates the compose logic to re-evaluate mentions on each keyup event and remove any banners whose associated mentions no longer exist.

Fixes [#2007](https://github.com/zulip/zulip/issues/2007)

How changes were tested

1.Added an unsubscribed @mention and confirmed the banner appears.
2.Removed the mention and verified the banner now disappears immediately.
3.Tested with multiple mentions—banners update correctly when each mention is removed.
4.Checked edge cases like partially deleting a mention; banners still update accurately.
5.Ran frontend tests (test-js-with-node and Puppeteer) and confirmed they pass.

This approach ensures the banner state always reflects the current compose text by re-evaluating mentions on every update, preventing stale UI.

https://github.com/user-attachments/assets/f8ef3f1b-93cd-4a06-908a-5d96e8e12e8a


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
