### PR TITLE
settings: Hide “Deactivate organization” section for non-owners.

### DIFF
--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -75,16 +75,17 @@ export function maybe_disable_widgets(): void {
         .prop("disabled", true);
 
     if (current_user.is_admin) {
-        $(".deactivate_realm_button").prop("disabled", true);
-        $("#deactivate_realm_button_container").addClass("disabled_setting_tooltip");
+        $(".deactivate-realm-section").hide();
         $("#org-message-retention").find("input, select").prop("disabled", true);
         $("#org-join-settings").find("input, select, button").prop("disabled", true);
         $("#id_realm_invite_required_label").parent().addClass("control-label-disabled");
         return;
     }
 
+    $(".deactivate-realm-section").hide();
+
     $(".organization-box [data-name='organization-profile']")
-        .find("input, textarea, .deactivate_realm_button, select")
+        .find("input, textarea, select")
         .prop("disabled", true);
 
     $(".organization-box [data-name='organization-profile']").find(".image_upload_button").hide();

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -421,17 +421,6 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: "#deactivate_realm_button_container.disabled_setting_tooltip",
-        content: $t({
-            defaultMessage: "Only organization owners may deactivate an organization.",
-        }),
-        appendTo: () => document.body,
-        onHidden(instance) {
-            instance.destroy();
-        },
-    });
-
-    tippy.delegate("body", {
         target: ".settings-radio-input-parent.default_stream_private_tooltip",
         content: $t({
             defaultMessage: "Default channels for new users cannot be made private.",

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -85,13 +85,13 @@
                   image = realm_night_logo_url }}
             </div>
         </div>
-        <h3 class="light">
-            {{t "Deactivate organization" }}
-            {{> ../help_link_widget link="/help/deactivate-your-organization" }}
-        </h3>
         <div class="deactivate-realm-section">
+            <h3 class="light">
+                {{t "Deactivate organization" }}
+                {{> ../help_link_widget link="/help/deactivate-your-organization" }}
+            </h3>
             <div class="input-group">
-                <div id="deactivate_realm_button_container" class="inline-block {{#unless is_owner}}disabled_setting_tooltip{{/unless}}">
+                <div id="deactivate_realm_button_container" class="inline-block">
                     {{> ../components/action_button
                       label=(t "Deactivate organization")
                       attention="quiet"


### PR DESCRIPTION
This commit moves the “Deactivate organization” text and its helper icon into the deactivate-realm-section container. This refactor does not alter the existing UI behavior. Then, in settings_org.maybe_disable_widgets, we hide the entire section for non-owner users, ensuring correct permissions handling.

Fixes #36711.

This PR updates the logic inside settings_org.maybe_disable_widgets, which is the correct live-update path. The #36717 PR modified UI directly, which broke live-updates. My approach keeps the behavior consistent with Zulip’s patterns and avoids that issue.

**Screenshots and screen captures:**
|User|Before|After|
|---|---|---|
|Owner| <img width="1710" height="982" alt="Screenshot 2025-11-21 at 10 34 53 PM" src="https://github.com/user-attachments/assets/fe725784-595a-493a-839e-0f511269a515" />|<img width="1710" height="982" alt="Screenshot 2025-11-21 at 10 09 51 PM" src="https://github.com/user-attachments/assets/7d34480b-6cd7-4673-a43d-aced02dad79f" />|
|Non-Owner|<img width="1710" height="982" alt="Screenshot 2025-11-21 at 9 57 07 PM" src="https://github.com/user-attachments/assets/f5bec25e-a824-44a3-afb7-5bf2be121fe6" />|<img width="1710" height="982" alt="Screenshot 2025-11-21 at 10 38 20 PM" src="https://github.com/user-attachments/assets/edee5376-0308-47ea-941e-d2d198e77208" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
