### PR TITLE
Hide unknown users and member count for limited guests

### DIFF
--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -12,6 +12,7 @@ import * as people from "./people.ts";
 import type {User} from "./people.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as rows from "./rows.ts";
+import * as settings_data from "./settings_data.ts";
 import {current_user} from "./state_data.ts";
 import * as ui_util from "./ui_util.ts";
 import * as user_group_components from "./user_group_components.ts";
@@ -125,6 +126,8 @@ export function toggle_user_group_info_popover(
                     group_members_url: hash_util.group_edit_url(group, "members"),
                     display_all_subgroups_and_members,
                     has_bots,
+                    user_can_access_all_other_users:
+                        settings_data.user_can_access_all_other_users(),
                     displayed_subgroups,
                     displayed_members,
                 };
@@ -197,11 +200,11 @@ function fetch_group_members(member_ids: number[]): PopoverGroupMember[] {
     return (
         member_ids
             .map((m: number) => people.get_user_by_id_assert_valid(m))
-            // We need to include inaccessible users here separately, since
-            // we do not include them in active_user_dict, but we want to
-            // show them in the popover as "Unknown user".
+            // Only include users that the current user is allowed to see in the popover.
+            // Inaccessible or unknown users should not appear in displayed_members.
             .filter(
-                (m: User) => people.is_active_user_for_popover(m.user_id) || m.is_inaccessible_user,
+                (m: User) =>
+                    people.is_active_user_for_popover(m.user_id) && !m.is_inaccessible_user,
             )
             .map((p: User) => ({
                 ...p,

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -12,11 +12,13 @@
             </div>
         </li>
         {{#if (or displayed_members.length displayed_subgroups.length)}}
-            <li role="none" class="popover-menu-list-item text-item italic">
-                {{#tr}}
-                {members_count, plural, =1 {1 member} other {# members}}
-                {{/tr}}
-            </li>
+            {{#if user_can_access_all_other_users}}
+                <li role="none" class="popover-menu-list-item text-item italic">
+                    {{#tr}}
+                        {members_count, plural, =1 {1 member} other {# members}}
+                    {{/tr}}
+                </li>
+            {{/if}}
         {{/if}}
         {{#if deactivated}}
             <li role="none" class="popover-menu-list-item text-item italic hidden-for-spectators">


### PR DESCRIPTION
<!-- Describe your pull request here.-->

**Summary**


This PR updates the user group info popover behavior for limited guests.

For limited guests, we should show less information on group cards.

This PR implements the following:

Do not show inaccessible/unknown users inside the group popover.
Do not show the member count (X members) when the current user is a limited guest.

Fixes: #36677

**How changes were tested:**

Tested locally on localhost:9991 using Polonius (limited guest) + Cordelia + Othello test setup.

Verified that:
Unknown/inaccessible users no longer appear in the members list for limited guests.
Member count is not shown when the viewer is a limited guest.
The UI shows only accessible members.

Ran:

./tools/test-js-with-node

./tools/lint web/src/user_group_popover.ts web/templates/popovers/user_group_info_popover.hbs

Both passed with no errors.

**Screenshots and screen captures:**


**before**

<img width="1919" height="869" alt="limiteduserbefore" src="https://github.com/user-attachments/assets/4b581120-b3c7-46d3-aecd-cdbd4c6761d0" />

**after**

<img width="1917" height="868" alt="limiteduserafter" src="https://github.com/user-attachments/assets/ec965539-e6b0-4d8e-b306-f1973c8df057" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
