### PR TITLE
bug: Disallow spaces and reserved keywords in custom languages in Code Playground settings

### DIFF
--- a/web/e2e-tests/realm-playground.test.ts
+++ b/web/e2e-tests/realm-playground.test.ts
@@ -12,9 +12,7 @@ type Playground = {
 
 async function _add_playground_and_return_status(page: Page, payload: Playground): Promise<string> {
     await page.waitForSelector(".admin-playground-form", {visible: true});
-    // Let's first ensure that the success/failure status from an earlier step has disappeared.
     const admin_playground_status_selector = "div#admin-playground-status";
-    await page.waitForSelector(admin_playground_status_selector, {hidden: true});
 
     await common.select_item_via_typeahead(
         page,
@@ -33,6 +31,9 @@ async function _add_playground_and_return_status(page: Page, payload: Playground
     await page.$eval("button#submit_playground_button", (el) => {
         el.click();
     });
+
+    // Wait for the request to complete by checking when the button is re-enabled.
+    await page.waitForSelector("button#submit_playground_button:not([disabled])");
 
     // We return the success/failure status message back to the caller.
     await page.waitForSelector(admin_playground_status_selector, {visible: true});
@@ -81,7 +82,7 @@ async function test_invalid_playground_parameters(page: Page): Promise<void> {
     payload.url_template = "https://python.example.com?code={code}";
     payload.pygments_language = "py!@%&";
     status = await _add_playground_and_return_status(page, payload);
-    assert.strictEqual(status, "Failed: Invalid characters in pygments language");
+    assert.strictEqual(status, "Failed: Invalid character in language: !");
 }
 
 async function test_successful_playground_deletion(page: Page): Promise<void> {

--- a/web/src/settings_playgrounds.ts
+++ b/web/src/settings_playgrounds.ts
@@ -146,12 +146,7 @@ function build_page(): void {
                 },
                 error(xhr) {
                     $add_playground_button.prop("disabled", false);
-                    ui_report.error(
-                        $t_html({defaultMessage: "Failed"}),
-                        xhr,
-                        $playground_status,
-                        3000,
-                    );
+                    ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $playground_status);
                 },
             });
         });

--- a/zerver/lib/markdown/fenced_code.py
+++ b/zerver/lib/markdown/fenced_code.py
@@ -94,6 +94,7 @@ from typing_extensions import override
 from zerver.lib.exceptions import MarkdownRenderingError
 from zerver.lib.markdown.priorities import PREPROCESSOR_PRIORITIES
 from zerver.lib.tex import render_tex
+from zerver.models.realm_playgrounds import PLAYGROUND_LANGUAGE_REGEX
 
 # Global vars
 FENCE_RE = re.compile(
@@ -109,7 +110,9 @@ FENCE_RE = re.compile(
         # language, like ".py" or "{javascript}"
         \{?\.?
         (?P<lang>
-            [a-zA-Z0-9_+-./#]+
+            """
+    + PLAYGROUND_LANGUAGE_REGEX
+    + r"""
         ) # "py" or "javascript"
 
         [ ]* # spaces

--- a/zerver/migrations/0001_squashed_0569.py
+++ b/zerver/migrations/0001_squashed_0569.py
@@ -3099,7 +3099,7 @@ class Migration(migrations.Migration):
                         validators=[
                             django.core.validators.RegexValidator(
                                 message="Invalid characters in pygments language",
-                                regex="^[ a-zA-Z0-9_+-./#]*$",
+                                regex="^[a-zA-Z0-9_+-./#]+$",
                             )
                         ],
                     ),

--- a/zerver/migrations/0315_realmplayground.py
+++ b/zerver/migrations/0315_realmplayground.py
@@ -33,7 +33,7 @@ class Migration(migrations.Migration):
                         validators=[
                             django.core.validators.RegexValidator(
                                 message="Invalid characters in pygments language",
-                                regex="^[ a-zA-Z0-9_+-./#]*$",
+                                regex="^[a-zA-Z0-9_+-./#]+$",
                             )
                         ],
                     ),

--- a/zerver/models/realm_playgrounds.py
+++ b/zerver/models/realm_playgrounds.py
@@ -10,6 +10,8 @@ from zerver.lib.types import RealmPlaygroundDict
 from zerver.models.linkifiers import url_template_validator
 from zerver.models.realms import Realm
 
+PLAYGROUND_LANGUAGE_REGEX = r"[a-zA-Z0-9_+-./#]+"
+
 
 class RealmPlayground(models.Model):
     """Server side storage model to store playground information needed by our
@@ -17,6 +19,8 @@ class RealmPlayground(models.Model):
     """
 
     MAX_PYGMENTS_LANGUAGE_LENGTH = 40
+
+    RESTRICTED_KEYWORDS = {"latex", "math", "quote", "spoiler"}
 
     realm = models.ForeignKey(Realm, on_delete=CASCADE)
     url_template = models.TextField(validators=[url_template_validator])
@@ -33,7 +37,8 @@ class RealmPlayground(models.Model):
         # language in the code block.
         validators=[
             RegexValidator(
-                regex=r"^[ a-zA-Z0-9_+-./#]*$", message=_("Invalid characters in pygments language")
+                regex=rf"^{PLAYGROUND_LANGUAGE_REGEX}$",
+                message=_("Invalid characters in pygments language"),
             )
         ],
     )

--- a/zerver/tests/test_realm_playgrounds.py
+++ b/zerver/tests/test_realm_playgrounds.py
@@ -60,7 +60,10 @@ class RealmPlaygroundTests(ZulipTestCase):
             "url_template": "https://template.com{code}",
         }
         resp = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
-        self.assert_json_error(resp, "Invalid characters in pygments language")
+        self.assert_json_error(
+            resp,
+            "Invalid character in language: $",
+        )
 
         payload = {
             "name": "Template with an unexpected variable",
@@ -87,6 +90,30 @@ class RealmPlaygroundTests(ZulipTestCase):
         }
         resp = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
         self.assert_json_error(resp, 'Missing the required variable "code" in the URL template')
+
+    def test_add_realm_playground_validation(self) -> None:
+        iago = self.example_user("iago")
+
+        # Test to check that spaces are rejected
+        payload = {
+            "name": "Bad Name",
+            "pygments_language": "rust lang",
+            "url_template": "https://example.com",
+        }
+        result = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
+        self.assert_json_error(
+            result,
+            "Invalid character in language:  ",
+        )
+
+        # Test to check that restricted keywords are rejected
+        payload = {
+            "name": "Bad Keyword",
+            "pygments_language": "math",
+            "url_template": "https://example.com",
+        }
+        result = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
+        self.assert_json_error(result, "Language 'math' is not allowed.")
 
     def test_create_already_existing_playground(self) -> None:
         iago = self.example_user("iago")

--- a/zerver/views/realm_playgrounds.py
+++ b/zerver/views/realm_playgrounds.py
@@ -13,6 +13,7 @@ from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import PathOnly, typed_endpoint
 from zerver.lib.validator import check_capped_string
 from zerver.models import Realm, RealmPlayground, UserProfile
+from zerver.models.realm_playgrounds import PLAYGROUND_LANGUAGE_REGEX
 
 
 def check_pygments_language(var_name: str, val: object) -> str:
@@ -21,10 +22,14 @@ def check_pygments_language(var_name: str, val: object) -> str:
     # Pygments languages. Keeping it open would allow us to hook up a "playground"
     # for custom "languages" that aren't known to Pygments. We use a similar strategy
     # even in our fenced_code Markdown processor.
-    valid_pygments_language = re.compile(r"^[ a-zA-Z0-9_+-./#]*$")
-    matched_results = valid_pygments_language.match(s)
-    if not matched_results:
-        raise JsonableError(_("Invalid characters in pygments language"))
+    if not re.match(rf"^{PLAYGROUND_LANGUAGE_REGEX}$", s):
+        for char in s:
+            if not re.match(rf"^{PLAYGROUND_LANGUAGE_REGEX}$", char):
+                raise JsonableError(
+                    _("Invalid character in language: {character}").format(character=char)
+                )
+    if s in RealmPlayground.RESTRICTED_KEYWORDS:
+        raise JsonableError(_("Language '{language}' is not allowed.").format(language=s))
     return s
 
 


### PR DESCRIPTION
This PR adds validation logic to the "Add a new code playground" form in the organization settings to prevent conflicts with Markdown syntax.

**Specifically, this change:**
* **Disallows spaces** in the language name, as these break code block parsing.
* **Disallows reserved keywords** (`latex`, `math`, `quote`, `spoiler`) that are used for other Markdown features.
* **Refactors validation** by moving logic into `check_pygments_language` and storing restricted keywords in the `RealmPlayground` model.

**Note:** Previously, this PR enforced lowercase. Per discussion on CZO, that enforcement has been removed. This PR now strictly focuses on validation (blocking invalid characters and keywords) without altering casing.

**Fixes:** #24044

**How changes were tested:**
Manually verified in the development environment:
1. Tried adding a language with spaces (e.g., `test space`); confirmed that a red error message appears.
2. Tried adding a reserved keyword (e.g., `math`); confirmed that a red error message appears ("Invalid characters...").
3. Tried adding a mixed-case language (e.g., `Rust`); confirmed that it saves successfully as `Rust` (preserving case).

**Screenshots and screen captures:**
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/be723020-f41a-4b33-8b5d-52f8112cbad9

</td>
<td>


https://github.com/user-attachments/assets/53ce2a9f-0888-4d53-b57b-643a8e534366



</td>

</tr>
<tr>
<td>

https://github.com/user-attachments/assets/552747eb-8caa-4208-85da-05eb34c82b80


</td>
<td>


https://github.com/user-attachments/assets/450e221a-e595-4015-aae9-0092af21d9d1


</td>
</tr>
<table>


https://github.com/user-attachments/assets/3984297c-1a88-45e5-9177-8969f22a0f5b



<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>