### PR TITLE
digest: Show italicized "general chat" when topic name is empty in digests.

### DIFF
--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -303,13 +303,18 @@ def build_message_list(
         )
         header = f"{stream.name} > {message.topic_name()}"
         stream_link = stream_narrow_url(user.realm, stream)
+        display_topic_name = message.topic_name()
+        if display_topic_name == "":
+            display_topic_name = get_topic_display_name(display_topic_name, user.default_language)
+            display_topic_name = Markup("<i>{}</i>").format(display_topic_name)
+
         header_html = Markup(
             "<a href='{stream_link}'>{stream_name}</a> &gt; <a href='{narrow_link}'>{topic_name}</a>"
         ).format(
             stream_link=stream_link,
             stream_name=stream.name,
             narrow_link=narrow_link,
-            topic_name=message.topic_name(),
+            topic_name=display_topic_name,
         )
         return {
             "plain": header,

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -207,6 +207,42 @@ class TestDigestEmailMessages(ZulipTestCase):
         new_stream_names = kwargs["context"]["new_channels"]["plain"]
         self.assertTrue("web_public_stream" in new_stream_names)
 
+    def test_general_chat_in_digest(self) -> None:
+        othello = self.example_user("othello")
+        self.subscribe(othello, "Verona")
+
+        one_day_ago = timezone_now() - timedelta(days=1)
+        # Backdate the subscription audit log so the stream is not excluded
+        RealmAuditLog.objects.filter(
+            modified_user=othello,
+            event_type=AuditLogEventType.SUBSCRIPTION_CREATED,
+        ).update(event_time=one_day_ago)
+
+        Message.objects.all().update(date_sent=one_day_ago)
+        one_hour_ago = timezone_now() - timedelta(seconds=3600)
+
+        cutoff = time.mktime(one_hour_ago.timetuple())
+
+        # Send a message to "general chat" (empty topic)
+        self.send_stream_message(self.example_user("hamlet"), "Verona", "hello", topic_name="")
+
+        # Clear the LRU cache on the stream topics
+        get_recent_topics.cache_clear()
+
+        with (
+            mock.patch("zerver.lib.digest.enough_traffic", return_value=True),
+            mock.patch("zerver.lib.digest.send_future_email") as mock_send_future_email,
+        ):
+            bulk_handle_digest_email([othello.id], cutoff)
+
+        self.assertEqual(mock_send_future_email.call_count, 1)
+        kwargs = mock_send_future_email.call_args[1]
+
+        hot_convo = kwargs["context"]["hot_conversations"][0]
+        # Verify the header HTML contains the italicized general chat
+        header_html = hot_convo["first_few_messages"]["header"]["html"]
+        self.assertIn("<i>general chat</i>", header_html)
+
     def test_no_logging(self) -> None:
         hamlet = self.example_user("hamlet")
         startlen = len(RealmAuditLog.objects.all())


### PR DESCRIPTION
Previously, general chat messages in digest emails rendered with an empty topic field, since these messages have an empty `topic_name()`. This commit updates the digest rendering logic to detect empty topic names and replace them with the localized general chat display name, formatted in italics.

Fixes #36689.

**Screenshots and screen captures:**

|Before|After|
|---|---|
|<img width="1696" height="982" alt="Screenshot 2025-11-22 at 8 42 22 PM" src="https://github.com/user-attachments/assets/586b181d-c7b7-4843-86ed-f8e11ed2d784" />|<img width="1696" height="982" alt="Screenshot 2025-11-22 at 8 36 19 PM" src="https://github.com/user-attachments/assets/098f06bf-7d54-4c12-8e2b-e134ba2dd490" />|

<img width="608" height="40" alt="Screenshot 2025-11-22 at 8 45 30 PM" src="https://github.com/user-attachments/assets/f6e9b01e-04bc-4897-afe0-a9e27a0626d4" /> 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
