### PR TITLE
scheduled_messages: Fix compute_send_times type safety

### DIFF
--- a/web/src/scheduled_messages.ts
+++ b/web/src/scheduled_messages.ts
@@ -33,8 +33,6 @@ export function get_all_scheduled_messages(): ScheduledMessage[] {
 }
 
 function compute_send_times(now = new Date()): Record<TimeKey, number> {
-    const send_times: Record<string, number> = {};
-
     const today = new Date(now);
     const tomorrow = new Date(new Date(now).setDate(now.getDate() + 1));
     // Find the next Monday by subtracting the current day (0-6) from 8
@@ -42,18 +40,18 @@ function compute_send_times(now = new Date()): Record<TimeKey, number> {
 
     // Since setHours returns a timestamp, it's safe to mutate the
     // original date objects here.
-    //
-    // today at 9am
-    send_times.today_nine_am = today.setHours(9, 0, 0, 0);
-    // today at 4pm
-    send_times.today_four_pm = today.setHours(16, 0, 0, 0);
-    // tomorrow at 9am
-    send_times.tomorrow_nine_am = tomorrow.setHours(9, 0, 0, 0);
-    // tomorrow at 4pm
-    send_times.tomorrow_four_pm = tomorrow.setHours(16, 0, 0, 0);
-    // next Monday at 9am
-    send_times.monday_nine_am = monday.setHours(9, 0, 0, 0);
-    return send_times;
+    return {
+        // today at 9am
+        today_nine_am: today.setHours(9, 0, 0, 0),
+        // today at 4pm
+        today_four_pm: today.setHours(16, 0, 0, 0),
+        // tomorrow at 9am
+        tomorrow_nine_am: tomorrow.setHours(9, 0, 0, 0),
+        // tomorrow at 4pm
+        tomorrow_four_pm: tomorrow.setHours(16, 0, 0, 0),
+        // next Monday at 9am
+        monday_nine_am: monday.setHours(9, 0, 0, 0),
+    };
 }
 
 export function add_scheduled_messages(scheduled_messages: ScheduledMessage[]): void {


### PR DESCRIPTION
TypeScript neglects to forbid the unsound coercion from `Record<string, number>` to `Record<TimeKey, number>`, so inconsistencies in these property names would not have been caught.

- microsoft/TypeScript#62796
