### PR TITLE
hash_util: Correct nonexistent page_params.is_guest

### DIFF
--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -5,11 +5,10 @@ import * as blueslip from "./blueslip.ts";
 import * as channel_folders from "./channel_folders.ts";
 import * as internal_url from "./internal_url.ts";
 import type {Message} from "./message_store.ts";
-import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import {web_channel_default_view_values} from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
-import {narrow_term_schema, realm} from "./state_data.ts";
+import {current_user, narrow_term_schema, realm} from "./state_data.ts";
 import type {NarrowTerm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_topic_history from "./stream_topic_history.ts";
@@ -309,7 +308,7 @@ export function validate_channels_settings_hash(hash: string): string {
         //    not be in sub_store).
         //
         // In both cases we redirect the user to 'subscribed' tab.
-        if (sub === undefined || (page_params.is_guest && !stream_data.is_subscribed(stream_id))) {
+        if (sub === undefined || (current_user.is_guest && !stream_data.is_subscribed(stream_id))) {
             return channels_settings_section_url();
         }
 


### PR DESCRIPTION
Introduced by commit eea5ee8923dfc0f751a4fbd50f293dfe5a55029e (#28764, cc @sahil839).