### PR TITLE
Fix: improve message-edit UI tab accessibility to match compose area

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -761,6 +761,27 @@ export function process_tab_key(): boolean {
         return true;
     }
 
+
+    const $focused_message_edit_cancel = $(".message_edit_cancel:focus");
+    if($focused_message_edit_cancel.length > 0) {
+        $message_edit_form = $focused_message_edit_cancel.closest(".message_edit_form");
+        //Tab will move the flow to the markdown_preview
+        $message_edit_form.find(".markdown_preview").trigger("focus");
+        return true;
+    }
+
+
+    const $focused_message_edit_help = $(".compose_help_button:focus");
+    if($focused_message_edit_help.length > 0) {
+        $message_edit_form = $focused_message_edit_help.closest(".message_edit_form");
+        //In message edit: Tab will move the flow to the textarea
+        if($message_edit_form.find(".message_edit_content").length > 0) {
+            $message_edit_form.find(".message_edit_content").trigger("focus");
+            return true;
+        }
+        //In new compose: let browser handle
+        return false;
+    }
     if (emoji_picker.is_open()) {
         return emoji_picker.navigate("tab");
     }
@@ -796,6 +817,18 @@ export function process_shift_tab_key(): boolean {
         return true;
     }
 
+    //Shift-Tabbing from the markdown_preview takes you back to previous element
+    if($(".markdown_preview:focus").length > 0){
+        // In message edit: go back to cancel button
+        if($(".message_edit_cancel").length > 0) {
+            $(".message_edit_cancel").trigger("focus");
+            return true;
+        }
+        // In new compose: let browser handle 
+        return false;
+    }
+
+    
     // Shift-Tabbing from emoji catalog/search results takes you back to search textbox.
     if (emoji_picker.is_open()) {
         return emoji_picker.navigate("shift_tab");


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
message edit: Make it possible to navigate to the "preview' element using the keyboard #36663

This PR adds proper keyboard navigation support to the message-edit UI.
Previously, users were unable to reach the Preview element using the keyboard alone.
This update introduces forward (Tab) and backward (Shift + Tab) navigation by adding appropriate handling to the edit-controls elements.

**How changes were tested:**

- Manually tested tab navigation in the message-edit UI.
- Verified forward navigation (Tab) reaches Save -> Cancel -> Edit controls -> Text Area.
- Verified backward navigation (Shift + Tab) works consistently.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

[Screencast from 2025-11-24 00-13-57.webm](https://github.com/user-attachments/assets/80a24303-1693-4ae4-a7ab-f09125c8f7b3)

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
