### PR TITLE
slack: Don't skip message contents in message with url previews.

### DIFF
--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1069,9 +1069,10 @@ def channel_message_to_zerver_message(
         # Leave it as is if formatted_block is an empty string, it's likely
         # one of the unhandled_types.
         if formatted_block != "":
-            # For most cases, the value of message["text"] will be just an
-            # empty string.
-            message["text"] = formatted_block
+            if original_text := message["text"]:
+                message["text"] = f"{original_text}\n{formatted_block}"
+            else:
+                message["text"] = formatted_block
 
         try:
             content, mentioned_user_ids, has_link = convert_to_zulip_markdown(


### PR DESCRIPTION
The previous code, by skipping the original `message["text"]` would discard message content when it shouldn't be discarded.

This is a bug we ran into with messages with URL previews. The actual message would be discarded, leaving only the preview, without context.

Original Slack message:

<img width="678" height="346" alt="image" src="https://github.com/user-attachments/assets/bbcdf3d0-cc44-4f6f-995d-7e0b4cf11fba" />

Imported message without the patch. The message text is missing. We just get the  URL preview:
<img width="932" height="289" alt="image" src="https://github.com/user-attachments/assets/3b646e47-3634-48da-9376-9f1a04d13c07" />


Imported message after applying this patch:

<img width="754" height="307" alt="image" src="https://github.com/user-attachments/assets/010e77b0-8ecd-439c-89c2-618c5d0fd0fa" />
