### PR TITLE
user_profile: Add keyboard navigation for remove buttons.

### DIFF
--- a/web/src/channel_folders_ui.ts
+++ b/web/src/channel_folders_ui.ts
@@ -222,6 +222,8 @@ function render_channel_list(streams: StreamSubscription[], folder_id: number): 
         $simplebar_container: $("#edit_channel_folder .modal__content"),
     });
 
+    $container.find(".remove-button").attr("tabindex", "0");
+
     $container.on("click", ".remove-button", (e) => {
         e.stopPropagation();
         e.preventDefault();
@@ -472,5 +474,35 @@ export function handle_editing_channel_folder(folder_id: number): void {
             render_channel_list(subs, folder_id);
             render_add_channel_folder_widget();
         },
+    });
+}
+
+export function initialize(): void {
+    $("body").on("keydown", "#edit_channel_folder .stream-row", (e) => {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+
+        const $row = $(e.currentTarget);
+        const $button = $row.find(".remove-button");
+
+        if ((e.key === "ArrowLeft" || e.key === "ArrowRight") && $button.length > 0) {
+            e.preventDefault();
+            e.stopPropagation();
+            $button.trigger("focus");
+        }
+    });
+
+    $("body").on("keydown", "#edit_channel_folder .stream-row .remove-button", (e) => {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+
+        if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+            e.preventDefault();
+            e.stopPropagation();
+            const $row = $(e.currentTarget).closest(".stream-row");
+            $row.trigger("focus");
+        }
     });
 }

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -22,6 +22,7 @@ import * as bot_data from "./bot_data.ts";
 import * as channel from "./channel.ts";
 import * as channel_folders from "./channel_folders.ts";
 import * as channel_folders_popover from "./channel_folders_popover.ts";
+import * as channel_folders_ui from "./channel_folders_ui.ts";
 import * as click_handlers from "./click_handlers.ts";
 import * as color_picker_popover from "./color_picker_popover.ts";
 import * as common from "./common.ts";
@@ -603,6 +604,7 @@ export async function initialize_everything(state_data) {
     color_picker_popover.initialize();
     add_stream_options_popover.initialize();
     channel_folders_popover.initialize();
+    channel_folders_ui.initialize();
     click_handlers.initialize();
     scheduled_messages_overlay_ui.initialize();
     compose_paste.initialize({

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -409,6 +409,8 @@ function render_user_stream_list(streams: StreamSubscription[], user: User): voi
         },
         $simplebar_container: $("#user-profile-modal .modal__body"),
     });
+
+    $container.find(".remove-button").attr("tabindex", "0");
 }
 
 function render_or_update_user_groups_tab(user: User): void {
@@ -454,6 +456,8 @@ function render_user_group_list(groups: UserGroup[], user: User): void {
         },
         $simplebar_container: $("#user-profile-modal .modal__body"),
     });
+
+    $container.find(".remove-member-button").attr("tabindex", "0");
 }
 
 function render_manage_profile_content(user: User): void {
@@ -1553,6 +1557,62 @@ export function initialize(): void {
             hide_user_profile();
         },
     );
+
+    $("body").on("keydown", "#user-profile-modal .stream-row", (e) => {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+
+        const $row = $(e.currentTarget);
+        const $button = $row.find(".remove-button");
+
+        if ((e.key === "ArrowLeft" || e.key === "ArrowRight") && $button.length > 0) {
+            e.preventDefault();
+            e.stopPropagation();
+            $button.trigger("focus");
+        }
+    });
+
+    $("body").on("keydown", "#user-profile-modal .stream-row .remove-button", (e) => {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+
+        if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+            e.preventDefault();
+            e.stopPropagation();
+            const $row = $(e.currentTarget).closest(".stream-row");
+            $row.trigger("focus");
+        }
+    });
+
+    $("body").on("keydown", "#user-profile-modal .user-profile-group-row", (e) => {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+
+        const $row = $(e.currentTarget);
+        const $button = $row.find(".remove-member-button:not(:disabled)");
+
+        if ((e.key === "ArrowLeft" || e.key === "ArrowRight") && $button.length > 0) {
+            e.preventDefault();
+            e.stopPropagation();
+            $button.trigger("focus");
+        }
+    });
+
+    $("body").on("keydown", "#user-profile-modal .remove-member-button", (e) => {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+
+        if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+            e.preventDefault();
+            e.stopPropagation();
+            const $row = $(e.currentTarget).closest(".user-profile-group-row");
+            $row.trigger("focus");
+        }
+    });
 
     bot_helper.initialize_bot_click_handlers();
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -223,24 +223,13 @@
 
 .hidden-remove-button {
     opacity: 0;
-    visibility: hidden;
-    transition:
-        opacity 0.3s ease,
-        visibility 0.3s ease;
-    pointer-events: none;
 }
 
-.hidden-remove-button:has(.button-loading-indicator) {
-    visibility: visible;
-    cursor: default;
+.hidden-remove-button-row:hover .hidden-remove-button,
+.hidden-remove-button:focus,
+.hidden-remove-button-row:focus-within .hidden-remove-button,
+.hidden-remove-button-row:focus .hidden-remove-button {
     opacity: 1;
-}
-
-.hidden-remove-button-row:hover
-    .hidden-remove-button:not(:has(.button-loading-indicator)) {
-    opacity: 1;
-    visibility: visible;
-    pointer-events: auto;
 }
 
 #stream-actions-menu-popover,


### PR DESCRIPTION
Adds keyboard navigation for remove buttons in channels and groups tables in the user profile modal.

Fixes: #36641

**How changes were tested:**

- Tested Tab/Shift-Tab navigation to remove buttons
- Tested arrow key navigation (ArrowRight/ArrowLeft) within rows
- Verified buttons appear when focused
- Tested Enter key triggers unsubscribe/remove
- Confirmed mouse hover and click still work
- Ran linters and frontend tests

**Screenshots :**
Before:
<img width="1002" height="952" alt="Screenshot from 2025-11-24 22-52-18" src="https://github.com/user-attachments/assets/cb024f0f-863f-4b13-954c-4e74741e4be6" />
<img width="1002" height="952" alt="Screenshot from 2025-11-24 22-52-43" src="https://github.com/user-attachments/assets/3c391a99-4d55-4c95-8bce-97efbd5e8ab3" />

After:
<img width="1002" height="952" alt="Screenshot from 2025-11-24 22-48-25" src="https://github.com/user-attachments/assets/48c71bd3-bea4-4184-9046-5a401819571a" />
<img width="1002" height="952" alt="Screenshot from 2025-11-24 22-48-31" src="https://github.com/user-attachments/assets/0be75d4e-f08e-4509-b0fc-0b74b06cdda6" />
<img width="1002" height="952" alt="Screenshot from 2025-11-24 22-49-14" src="https://github.com/user-attachments/assets/cbd0cda6-19b0-44a1-95d0-927b2e0dfce9" />
<img width="1002" height="952" alt="Screenshot from 2025-11-24 22-49-18" src="https://github.com/user-attachments/assets/a3f1155f-33ac-4a3d-9704-097858f9c7f5" />



**screen capture: ** 
Before:

https://github.com/user-attachments/assets/79cda75a-11de-40c7-aa01-759f2a67226c

After:


https://github.com/user-attachments/assets/aa1b4f3b-d483-4e41-9517-6dc82f3b8c84



<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
