### PR TITLE
unread: Don't include archived channels in unread data.

### DIFF
--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -330,8 +330,10 @@ class UnreadTopicCounter {
             // unsubscribed.  Since users may re-subscribe, we don't
             // completely throw away the data.  But we do ignore it here,
             // so that callers have a view of the **current** world.
+            // Similarly we ignore unreads for archived channels, since
+            // they don't show up in the left sidebar either.
             const sub = sub_store.get(stream_id);
-            if (!sub || !stream_data.is_subscribed(stream_id)) {
+            if (!sub || !stream_data.is_subscribed(stream_id) || sub.is_archived) {
                 continue;
             }
 

--- a/web/tests/unread.test.cjs
+++ b/web/tests/unread.test.cjs
@@ -401,6 +401,49 @@ test("home_messages", () => {
     test_notifiable_count(counts.home_unread_messages, 0);
 });
 
+test("archived_stream", () => {
+    const rome = {
+        stream_id: 401,
+        name: "Rome",
+        subscribed: true,
+        is_muted: false,
+    };
+    sub_store.add_hydrated_sub(rome.stream_id, rome);
+
+    const denmark = {
+        stream_id: 501,
+        name: "Denmark",
+        subscribed: true,
+        is_muted: false,
+    };
+    sub_store.add_hydrated_sub(denmark.stream_id, denmark);
+
+    const rome_message = {
+        id: 15,
+        type: "stream",
+        stream_id: rome.stream_id,
+        topic: "lunch",
+        unread: true,
+    };
+
+    const denmark_message = {
+        id: 16,
+        type: "stream",
+        stream_id: denmark.stream_id,
+        topic: "lunch",
+        unread: true,
+    };
+    unread.process_loaded_messages([rome_message, denmark_message]);
+
+    let counts = unread.get_counts();
+    assert.equal(counts.home_unread_messages, 2);
+
+    // Now archive rome.
+    rome.is_archived = true;
+    counts = unread.get_counts();
+    assert.equal(counts.home_unread_messages, 1);
+});
+
 test("phantom_messages", () => {
     const message = {
         id: 999,


### PR DESCRIPTION
Fixes bug reported here:
https://chat.zulip.org/#narrow/channel/9-issues/topic/untraceable.20unread/near/2303718

Tested by marking unread in a subscribed channel then archiving it, seeing the unread show up in the folder header, then applying this change and seeing the unread go away.