### PR TITLE
setup_docs: Emphasize creation of a new WSL instace.

### DIFF
--- a/docs/development/setup-recommended.md
+++ b/docs/development/setup-recommended.md
@@ -111,11 +111,14 @@ installation method described here. We require version 0.67.6+ of WSL 2.
 
 1. [Install WSL
    2](https://docs.microsoft.com/en-us/windows/wsl/setup/environment),
-   which includes installing an Ubuntu WSL distribution. Using an
-   existing distribution will probably work, but [a fresh
-   distribution](#rebuilding-the-development-environment) is
-   recommended if you previously installed other software in your WSL
-   environment that might conflict with the Zulip environment.
+   which includes installing an Ubuntu WSL distribution.
+
+1. **Create a new WSL instance for Zulip development**.
+   You can refer [this article](https://cloudbytes.dev/snippets/how-to-install-multiple-instances-of-ubuntu-in-wsl2)
+   for instructions on how to do so. Using an existing instance will
+   probably work, but a fresh distribution is recommended if you
+   previously installed other software like `node` in your WSL environment that
+   might conflict with the Zulip environment.
 
 1. It is required to enable `systemd` for WSL 2 to manage the database, cache and other services.
    To configure it, please follow [these instructions](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#systemd-support).


### PR DESCRIPTION
This should hopefully reduce the number of folks
who run into errors because of dependency version
conflicts while setting up their dev environment on WSL.

The earlier way this was mentioned was easy to
miss.

Fixes: https://chat.zulip.org/#narrow/channel/19-documentation/topic/Emphasize.20WSL.20fresh.20distribution.20requirement.20in.20setup.20docs/with/2310938

| Before | After |
|------|------|
|  <img width="1020" height="853" alt="image" src="https://github.com/user-attachments/assets/f5c3093b-998a-4801-b217-4d5c41cf47fb" />| <img width="1044" height="816" alt="image" src="https://github.com/user-attachments/assets/a2522a69-567a-4abd-a0d5-3a799137d535" />|
