### PR TITLE
markdown: Fix linkification of URLs starting with query params

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -262,8 +262,10 @@ def get_web_link_regex() -> Pattern[str]:
                     (?:{tlds})        # TLDs
                 )
             )
-            (?:/             # A path, beginning with /
-                {nested_paren_chunk}           # zero-to-6 sets of paired parens
+            (?:
+                (?:/ {nested_paren_chunk} )      # A path, beginning with /; zero-to-6 sets of paired parens
+                |
+                (?: \? (?![)\"\s]|\Z) {nested_paren_chunk} ) # Query starting with ? (must not be trailing punctuation)
             )?)              # Path is optional
             | (?:[\w.-]+\@[\w.-]+\.[\w]+) # Email is separate, since it can't have a path
             {file_links}               # File path start with file:///, enable by setting ENABLE_FILE_LINKS=True

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -1437,6 +1437,26 @@
       "quora http://generate.quora.net/render?width=700&from=-4hours&until=now&height=400&bgcolor=black&lineMode=connected&title=arb%20hint%20status&target=alias(ans.hintland.hand.arb.enhint_rate%2C%22enhint%20rate%22)&target=alias(ans.hintland.hand.arb.unhint_rate%2C%22unhint%20rate%22)&target=alias(ans.hintland.hand.arb.size%2C%22hint%20size%22)&target=alias(scale(ans.vagabond.dingarb_cube_count%2C10000)%2C%22cube%20count%20x%2010K%22)&target=alias(scale(hnumbers.time.ding.gegevens.query.count%2C10)%2C%22ding%20gegevens%20query%20count%20x%2010%22)&fgcolor=white&uniq=0.44046106841415167",
       "<p>quora %s</p>",
       "http://generate.quora.net/render?width=700&amp;from=-4hours&amp;until=now&amp;height=400&amp;bgcolor=black&amp;lineMode=connected&amp;title=arb%20hint%20status&amp;target=alias(ans.hintland.hand.arb.enhint_rate%2C%22enhint%20rate%22)&amp;target=alias(ans.hintland.hand.arb.unhint_rate%2C%22unhint%20rate%22)&amp;target=alias(ans.hintland.hand.arb.size%2C%22hint%20size%22)&amp;target=alias(scale(ans.vagabond.dingarb_cube_count%2C10000)%2C%22cube%20count%20x%2010K%22)&amp;target=alias(scale(hnumbers.time.ding.gegevens.query.count%2C10)%2C%22ding%20gegevens%20query%20count%20x%2010%22)&amp;fgcolor=white&amp;uniq=0.44046106841415167"
+    ],
+    [
+      "Check this: https://podcasts.google.com?feed=abc",
+      "<p>Check this: %s</p>",
+      "https://podcasts.google.com?feed=abc"
+    ],
+    [
+      "Is this https://google.com?",
+      "<p>Is this %s?</p>",
+      "https://google.com"
+    ],
+    [
+      "New logic inside parens: (see https://podcasts.google.com?feed=abc)",
+      "<p>New logic inside parens: (see <a href=\"https://podcasts.google.com?feed=abc\">https://podcasts.google.com?feed=abc</a>)</p>",
+      "(see https://podcasts.google.com?feed=abc)"
+    ],
+    [
+      "New logic with trailing dot: Go to https://podcasts.google.com?feed=abc.",
+      "<p>New logic with trailing dot: Go to <a href=\"https://podcasts.google.com?feed=abc\">https://podcasts.google.com?feed=abc</a>.</p>",
+      "Go to https://podcasts.google.com?feed=abc."
     ]
   ]
 }


### PR DESCRIPTION
This PR updates the linkifier regex to correctly handle URLs where the query string (`?`) immediately follows the domain name, without a preceding slash (e.g., `https://podcasts.google.com?feed=abc`).

Previously, the regex required a path component (starting with `/`) to be present before it would match a query string. This caused valid URLs from services like Google Podcasts to render as plain text.

Fixes: #19778

**How changes were tested:**

Manually verified in the development environment with the following test cases:

1.  **The Fix:** Sent a message containing `https://podcasts.google.com?feed=abc`.
    * **Result:** The URL is now correctly linkified and clickable.
2.  **Regression Testing:** Verified that standard URLs still work as expected:
    * `https://www.google.com` (No path/query) -> Works
    * `https://github.com/zulip/zulip` (Standard path) -> Works
    * `https://www.google.com/search?q=zulip` (Path + Query) -> Works

**Screenshots and screen captures:**

Before 
<img width="913" height="130" alt="Screenshot 2025-11-25 at 9 23 57 PM" src="https://github.com/user-attachments/assets/9f1c1d99-bd22-4281-9d1d-e8d09df5e6a2" />

After
<img width="681" height="125" alt="Screenshot 2025-11-25 at 9 26 10 PM" src="https://github.com/user-attachments/assets/1500c503-bc33-4156-b45e-5c9a92626275" />

Tests to check if other url's are clickable after changes
[
<img width="684" height="177" alt="Screenshot 2025-11-25 at 9 45 48 PM" src="https://github.com/user-attachments/assets/6d5ee0ac-4d95-449e-9e32-e4a8cd5e189d" />
](url)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>