### PR TITLE
emails: Render stream-specific colors in digest email headers

### DIFF
--- a/templates/zerver/emails/digest.html
+++ b/templates/zerver/emails/digest.html
@@ -7,7 +7,7 @@
         <div class='messages'>
             {% with recipient_block=convo.first_few_messages %}
                 <div class='hot_convo_recipient_block'>
-                    <div class='hot_convo_recipient_header'>{{ recipient_block.header.html|safe }}</div>
+                    <div class='hot_convo_recipient_header' {% if recipient_block.header.recipient_bar_color %}style='background-color: {{ recipient_block.header.recipient_bar_color }};'{% endif %}>{{ recipient_block.header.html|safe }}</div>
                     <div class='hot_convo_message_content'>
                         {% for sender_block in recipient_block.senders %}
                             {% for message_block in sender_block.content %}

--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -223,15 +223,25 @@ p.digest_paragraph,
 }
 
 .hot_convo_recipient_block {
-    border: 1px solid #000;
+    border: 1px solid hsl(0deg 0% 0% / 20%);
+    border-radius: 7px 7px 0 0;
     margin-bottom: 4px;
+    overflow: hidden;
 }
 
 .hot_convo_recipient_header {
-    background-color: #9ec9ff;
-    border-bottom: 1px solid #000;
-    font-weight: bold;
-    padding: 2px;
+    background-color: #9ec9ff; /* Fallback color if inline style not applied */
+    border-bottom: 1px solid hsl(0deg 0% 0% / 20%);
+    font-weight: 600;
+    font-size: 1.0714em;
+    line-height: 1.2;
+    padding: 5px 6px;
+    color: hsl(0deg 0% 20%);
+}
+
+.hot_convo_recipient_header a {
+    color: hsl(0deg 0% 20%);
+    text-decoration: none;
 }
 
 .hot_convo_message_content {


### PR DESCRIPTION
This PR updates the Weekly Digest emails to render the actual stream color for conversation header-bars, replacing the static blue background that was previously used for all headers background.

As discussed with @timabbott  we are not using the full color-mixing algorithm used in the web app because the web app mixes colors based on the user's theme (Light vs. Dark mode) to ensure contrast. In an email context, we cannot statically detect the recipient's theme.

Workaround: To avoid headers being too dark or intense, I implemented a simplified solution using the raw stream color with reduced **opacity (30%)**. This mimics the "mixed" look and ensures the text remains black and readable on most backgrounds.

Documentation: A comment explaining this constraint has been added to the code.

Future Work: A follow-up issue can created to investigate if a more complex theme-aware solution is possible.

Fixes #36685

**How changes were tested:**
1. Visual Inspection: Generated sample digest emails in the development environment.
2. Color Variety: Verified the rendering for streams with a wide range of colors (including dark, bright, and light hues) to ensure that the `30% opacity` logic maintains sufficient contrast for the black header text.
3. HTML Validation: Inspected the generated HTML source to confirm that the **background-color** is correctly applied as an `rgba()` value in the inline styles.

**Screenshots and screen captures:**

## Before
<img width="740" height="823" alt="Screenshot from 2025-11-26 01-53-17" src="https://github.com/user-attachments/assets/1c2336ae-af1d-49f8-8425-b2895ba3bcf7" />

## After
<img width="696" height="774" alt="Screenshot from 2025-11-27 00-07-59" src="https://github.com/user-attachments/assets/af22bd1d-bc7c-4055-a7e0-4f6997dfb7b8" />


<details>
<summary>Self-review checklist</summary>

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
