### PR TITLE
people: Handle inaccessible users not present in user fetch.

### DIFF
--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -2041,3 +2041,14 @@ run_test("fetch_users corner case", async ({override, override_rewire}) => {
     assert.equal(user2.full_name, "Alice");
     assert.equal(user3.full_name, "Third user");
 });
+
+run_test("fetch inaccessible user", async ({override, override_rewire}) => {
+    initialize();
+    override_rewire(people, "fetch_users_from_ids_internal", noop);
+    people.add_valid_user_id(1);
+
+    override(settings_data, "user_can_access_all_other_users", () => false);
+    const [inaccessible_user] = await people.get_or_fetch_users_from_ids([1]);
+    assert.equal(inaccessible_user.user_id, 1);
+    assert.equal(inaccessible_user.is_inaccessible_user, true);
+});


### PR DESCRIPTION
Since it is possible that the user doesn't have access to all the users, we add the users not present in fetch as inaccessible users.

discussion: [#issues > Guest can see other guests with title 'Unknown user'](https://chat.zulip.org/#narrow/channel/9-issues/topic/Guest.20can.20see.20other.20guests.20with.20title.20'Unknown.20user'/with/2311889)