### PR TITLE
slack-import: Customize file upload strings.

### DIFF
--- a/templates/zerver/slack_import.html
+++ b/templates/zerver/slack_import.html
@@ -68,6 +68,7 @@
                         {% trans %}
                         Follow <a href="https://zulip.com/help/import-from-slack#export-your-slack-data" target="_blank" rel="noopener noreferrer">these instructions</a> to obtain your Slack message history export.
                         {% endtrans %}
+                        {% include "zerver/slack_import_file_upload_instruction.html" %}
                     </div>
                     <button class="slack-import-upload-file full-width">{{ _('Start upload') }}</button>
                 </div>

--- a/templates/zerver/slack_import_file_upload_instruction.html
+++ b/templates/zerver/slack_import_file_upload_instruction.html
@@ -1,0 +1,11 @@
+<p class="slack-import-file-upload-instruction">
+    {% if corporate_enabled %}
+    {% trans %}
+    Maximum size: {{max_file_size}} MiB. For larger exports, follow the <a href="/help/import-from-slack#import-your-data-into-zulip" rel="noopener noreferrer" target="_blank">process</a> for imports via support.
+    {% endtrans %}
+    {% else %}
+    {% trans %}
+    Maximum size: {{max_file_size}} MiB. For larger exports, follow the <a href="/help/import-from-slack#import-your-data-into-zulip" rel="noopener noreferrer" target="_blank">process</a> for self-hosted imports.
+    {% endtrans %}
+    {% endif %}
+</p>

--- a/web/src/portico/slack-import.ts
+++ b/web/src/portico/slack-import.ts
@@ -9,6 +9,9 @@ import {$t} from "../i18n.ts";
 
 $(() => {
     if ($("#slack-import-dashboard").length > 0) {
+        const max_file_upload_size_mib = Number(
+            $("#slack-import-dashboard").attr("data-max-file-size"),
+        );
         const key = $<HTMLInputElement>("#auth_key_for_file_upload").val();
         const uppy = new Uppy({
             autoProceed: true,
@@ -16,6 +19,7 @@ $(() => {
                 maxNumberOfFiles: 1,
                 minNumberOfFiles: 1,
                 allowedFileTypes: [".zip", "application/zip"],
+                maxFileSize: max_file_upload_size_mib * 1024 * 1024,
             },
             meta: {
                 key,
@@ -24,6 +28,10 @@ $(() => {
                 strings: {
                     youCanOnlyUploadFileTypes: $t({
                         defaultMessage: "Upload your Slack export zip file.",
+                    }),
+                    exceedsSize: $t({
+                        defaultMessage:
+                            "Uploaded file exceeds maximum size for self-serve imports.",
                     }),
                 },
                 // Copied from
@@ -40,6 +48,8 @@ $(() => {
         });
         uppy.use(Dashboard, {
             target: "#slack-import-dashboard",
+            // This will be replace by an HTML note after being mounted.
+            note: "...",
         });
         uppy.use(Tus, {
             endpoint: "/api/v1/tus/",
@@ -60,6 +70,14 @@ $(() => {
             $("#slack-import-uploaded-file-name").text(file.name);
             $("#slack-import-file-upload-error").text("");
             $("#realm-creation-form-slack-import .register-button").prop("disabled", false);
+        });
+        uppy.on("dashboard:modal-open", () => {
+            // Replace the note with the actual content after the dashboard is mounted.
+            $(".uppy-Dashboard-note").text(
+                $t({
+                    defaultMessage: "Upload your Slack export zip file.",
+                }),
+            );
         });
 
         $(".slack-import-upload-file").on("click", (e) => {

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -1675,3 +1675,13 @@ button#register_auth_button_gitlab {
 #new-realm-creation #altcha-submit-button-container {
     margin-bottom: 30px;
 }
+
+#slack-import-dashboard .uppy-Dashboard-note {
+    font-size: 1rem;
+    font-weight: 450;
+    color: inherit;
+}
+
+.slack-import-file-upload-instruction {
+    margin-top: 1rem;
+}


### PR DESCRIPTION



<img width="660" height="876" alt="Screenshot from 2025-12-05 13-49-23" src="https://github.com/user-attachments/assets/ed318bd5-f707-42da-89bf-16921f0fedbf" />

<details><summary>File size exceeds set limit:</summary>
<p>


<img width="1000" height="696" alt="Screenshot from 2025-12-05 13-49-32" src="https://github.com/user-attachments/assets/1c5f0abb-b334-4b29-9f76-3faea2dd2c41" />

</p>
</details> 
<details><summary>File uploaded type is not zip:</summary>
<p>



<img width="1000" height="696" alt="Screenshot from 2025-12-05 13-49-42" src="https://github.com/user-attachments/assets/3c01cc4f-5938-4b5e-a940-43f610840b04" />

</p>
</details> 

