### PR TITLE
inbox: Focus on search if hotkey to open inbox is pressed.

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -28,6 +28,7 @@ import * as hash_util from "./hash_util.ts";
 import * as hashchange from "./hashchange.ts";
 import {$t} from "./i18n.ts";
 import * as inbox_ui from "./inbox_ui.ts";
+import * as inbox_util from "./inbox_util.ts";
 import * as lightbox from "./lightbox.ts";
 import * as list_util from "./list_util.ts";
 import * as message_actions_popover from "./message_actions_popover.ts";
@@ -1208,6 +1209,11 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
             browser_history.go_to_location("#recent");
             return true;
         case "open_inbox":
+            // Focus search if already in (non-channel) inbox view.
+            if (!inbox_util.is_channel_view() && !inbox_ui.is_search_focused()) {
+                inbox_ui.focus_inbox_search();
+                return true;
+            }
             browser_history.go_to_location("#inbox");
             return true;
         case "open_starred_message_view":
@@ -1242,6 +1248,12 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
                 }
             }
             if (inbox_ui.is_in_focus()) {
+                // Focus search if already in channel view.
+                if (inbox_util.is_channel_view()) {
+                    inbox_ui.focus_inbox_search();
+                    return true;
+                }
+
                 const msg = inbox_ui.get_focused_row_message();
                 if (msg?.msg_type === "stream") {
                     list_of_channel_topics_channel_id = msg.stream_id;

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1500,7 +1500,7 @@ function focus_current_id(): void {
     $(`#${CSS.escape(current_navigated_id)}`).trigger("focus");
 }
 
-function focus_inbox_search(): void {
+export function focus_inbox_search(): void {
     current_navigated_id = INBOX_SEARCH_ID;
     focus_current_id();
 }
@@ -1751,6 +1751,14 @@ function set_list_focus(input_key?: string): void {
 function focus_filters_dropdown(): void {
     current_navigated_id = INBOX_FILTERS_DROPDOWN_ID;
     $(`#${CSS.escape(INBOX_FILTERS_DROPDOWN_ID)}`).trigger("focus");
+}
+
+export function is_search_focused(): boolean {
+    const active_element = document.activeElement;
+    if (!(active_element instanceof HTMLInputElement)) {
+        return false;
+    }
+    return active_element.id === INBOX_SEARCH_ID;
 }
 
 function is_navigated_to_search(): boolean {


### PR DESCRIPTION
This implements the behaviour identical to what we have in recent conversations.

Tested that hotkeys `y` and `I` work to focus on search if the inbox rows are focused. Also, typing in search doesn't break.

discussion: [#feedback > keyboard shortcut for filter topics](https://chat.zulip.org/#narrow/channel/137-feedback/topic/keyboard.20shortcut.20for.20filter.20topics/with/2312301)