### PR TITLE
stream-list: Simplify navigate_to_stream in on_sidebar_channel_click.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -43,7 +43,6 @@ import * as ui_util from "./ui_util.ts";
 import * as unread from "./unread.ts";
 import type {FullUnreadCountsData, StreamCountInfo} from "./unread.ts";
 import {user_settings} from "./user_settings.ts";
-import * as user_topics from "./user_topics.ts";
 
 let pending_stream_list_rerender = false;
 let zoomed_in = false;
@@ -1278,15 +1277,16 @@ export function on_sidebar_channel_click(
     let topics = stream_topic_history.get_recent_topic_names(stream_id);
 
     const navigate_to_stream = (): void => {
+        // Muted topics are not included in the unzoomed topic list
+        // information.
         const topic_list_info = topic_list_data.get_list_info(
             stream_id,
             false,
             (topic_names: string[]) => topic_names,
         );
-        // This initial value handles both the
-        // top_topic_in_channel mode as well as the
-        // top_unread_topic_in_channel fallback when there are no
-        // (unmuted) unreads in the channel.
+        // This initial value handles both the top_topic_in_channel
+        // mode as well as the top_unread_topic_in_channel fallback
+        // when there are no (unmuted) unreads in the channel.
         let topic_item = topic_list_info.items[0];
 
         if (
@@ -1294,10 +1294,7 @@ export function on_sidebar_channel_click(
             web_channel_default_view_values.top_unread_topic_in_channel.code
         ) {
             for (const topic_list_item of topic_list_info.items) {
-                if (
-                    unread.topic_has_any_unread(stream_id, topic_list_item.topic_name) &&
-                    !user_topics.is_topic_muted(stream_id, topic_list_item.topic_name)
-                ) {
+                if (topic_list_item.unread > 0) {
                     topic_item = topic_list_item;
                     break;
                 }
@@ -1305,11 +1302,7 @@ export function on_sidebar_channel_click(
         }
 
         if (topic_item !== undefined) {
-            const destination_url = hash_util.by_channel_topic_permalink(
-                stream_id,
-                topic_item.topic_name,
-            );
-            browser_history.go_to_location(destination_url);
+            browser_history.go_to_location(topic_item.url);
         } else {
             show_channel_feed(stream_id, "sidebar");
             return;


### PR DESCRIPTION
The topic list data returned by `topic_list_data.get_list_info` has already filtered out muted topics, includes the unread count for the topic and has the channel topic permalink set.

So we can use that information to simplify the loop over the topic list data for the `top_unread_topic_in_channel` setting, and in the call to `browser_history.go_to_location` when we've found a `TopicList` item.

[CODE LINK](https://github.com/zulip/zulip/blob/f06f717b759d043638e0d6ea2a54dcfe0860c956/web/src/topic_list_data.ts#L125-L139)
```typescript
        const topic_info: TopicInfo = {
            stream_id,
            topic_name,
            topic_resolved_prefix,
            topic_display_name: util.get_final_topic_display_name(topic_bare_name),
            is_empty_string_topic: topic_bare_name === "",
            unread: num_unread,
            is_zero: num_unread === 0,
            is_muted: is_topic_muted,
            is_followed: is_topic_followed,
            is_unmuted_or_followed: is_topic_unmuted_or_followed,
            is_active_topic,
            url: hash_util.by_channel_topic_permalink(stream_id, topic_name),
            contains_unread_mention,
        };
```

---

**Screenshots and screen captures: NO CHANGES**

*Set to top topic*
| Before | After |
| --- | --- |
| <img width="1351" height="735" alt="Screenshot From 2025-11-26 17-06-06" src="https://github.com/user-attachments/assets/fb10a7f3-5033-4621-9f5f-6d353fe809b6" /> | <img width="1351" height="735" alt="Screenshot From 2025-11-26 17-06-21" src="https://github.com/user-attachments/assets/8f81e680-46ab-4ab9-b75f-0e34669b8cd1" />

*Set to top unread*
| Before | After |
| --- | --- |
| <img width="1351" height="735" alt="Screenshot From 2025-11-26 17-06-58" src="https://github.com/user-attachments/assets/a5e34534-c4a8-432f-bdde-2013f632ec45" /> | <img width="1351" height="735" alt="Screenshot From 2025-11-26 17-07-44" src="https://github.com/user-attachments/assets/c63c6b0c-8a6b-4293-b2a5-7c8ba1f9bbdf" />

*Set to top unread - with `✔ MOBILE` topic muted*
| Before | After |
| --- | --- |
| <img width="1351" height="735" alt="Screenshot From 2025-11-26 17-11-28" src="https://github.com/user-attachments/assets/eeffbbca-5769-487b-86ae-6da1f01b91bc" /> | <img width="1351" height="735" alt="Screenshot From 2025-11-26 17-11-38" src="https://github.com/user-attachments/assets/25624400-c1c1-4ebc-b11c-c439e29d0887" />



---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
