### PR TITLE
Fix DM list suddenly appears in left sidebar even if filtered out by search.

### DIFF
--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -91,7 +91,8 @@ function set_dom_to(new_dom: vdom.Tag<PMNode>): void {
     prior_dom = new_dom;
 }
 
-export function update_private_messages(is_left_sidebar_search_active = false): void {
+export function update_private_messages(): void {
+    const is_left_sidebar_search_active = ui_util.get_left_sidebar_search_term() !== "";
     const is_dm_section_expanded = is_left_sidebar_search_active || !private_messages_collapsed;
     $("#toggle-direct-messages-section-icon").toggleClass(
         "rotate-icon-down",

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -604,7 +604,7 @@ function actually_update_left_sidebar_for_search(): void {
     }
 
     // Update left sidebar DM list.
-    pm_list.update_private_messages(is_left_sidebar_search_active);
+    pm_list.update_private_messages();
 
     // Update left sidebar channel list.
     stream_list.update_streams_sidebar();


### PR DESCRIPTION
discussion: [#issues > left sidebar search - direct messages header appears](https://chat.zulip.org/#narrow/channel/9-issues/topic/left.20sidebar.20search.20-.20direct.20messages.20header.20appears/with/2312441)