### PR TITLE
setup-certbot: Puppet guarantees the certbot package.

### DIFF
--- a/scripts/setup/setup-certbot
+++ b/scripts/setup/setup-certbot
@@ -73,30 +73,6 @@ case "$method" in
         ;;
 esac
 
-# Check for a supported OS release.
-if [ -f /etc/os-release ]; then
-    os_info="$(
-        . /etc/os-release
-        printf '%s\n' "$ID" "$ID_LIKE"
-    )"
-    {
-        read -r os_id
-        read -r os_id_like || true
-    } <<<"$os_info"
-fi
-
-set -x
-
-case " $os_id $os_id_like " in
-    *' debian '*)
-        apt-get update
-        apt-get install -y certbot
-        ;;
-    *' rhel '*)
-        yum install -y certbot
-        ;;
-esac
-
 # If we aren't being run interactively, default to keeping the
 # existing certificate (rather than burning through a renewal)
 # If run interactively, certbot will prompt.


### PR DESCRIPTION
It has been installed on all hosts since 01e8f752a8c2.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
