### PR TITLE
organization_profile: Render realm description for non-admins.

### DIFF
--- a/web/src/admin.ts
+++ b/web/src/admin.ts
@@ -10,6 +10,7 @@ import {$t, language_list} from "./i18n.ts";
 import * as information_density from "./information_density.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
+import {postprocess_content} from "./postprocess_content.ts";
 import {realm_user_settings_defaults} from "./realm_user_settings_defaults.ts";
 import * as settings from "./settings.ts";
 import * as settings_bots from "./settings_bots.ts";
@@ -153,6 +154,7 @@ export function build_page(): void {
         gif_rating_options: realm.gif_rating_options,
         gif_api_key_empty: realm.giphy_api_key === "" && realm.tenor_api_key === "",
         realm_description: realm.realm_description,
+        realm_description_html: postprocess_content(page_params.realm_rendered_description),
         realm_inline_image_preview: realm.realm_inline_image_preview,
         server_inline_image_preview: realm.server_inline_image_preview,
         realm_inline_url_embed_preview: realm.realm_inline_url_embed_preview,

--- a/web/src/base_page_params.ts
+++ b/web/src/base_page_params.ts
@@ -44,10 +44,7 @@ const home_params_schema = z.looseObject({
     narrow_topic: z.optional(z.string()),
     presence_history_limit_days_for_web_app: z.number(),
     promote_sponsoring_zulip: z.boolean(),
-    // `realm_rendered_description` is only sent for spectators, because
-    // it isn't displayed for logged-in users and requires markdown
-    // processor time to compute.
-    realm_rendered_description: z.optional(z.string()),
+    realm_rendered_description: z.string(),
     show_try_zulip_modal: z.boolean(),
     state_data: z.nullable(state_data_schema),
     translation_data: z.record(z.string(), z.string()),

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -147,6 +147,23 @@ h3,
     box-sizing: border-box;
 }
 
+.admin-realm-description.rendered_markdown {
+    /* 5px at 16px and 10px at 16px */
+    padding: 0.3125em 0.625em;
+    width: fit-content;
+    /* 500px at 16px */
+    max-width: 31.25em;
+    min-width: 0;
+
+    & > p:first-child {
+        padding-top: 0;
+    }
+
+    & > p:last-child {
+        margin-bottom: 0;
+    }
+}
+
 .admin-realm-welcome-message-custom-text {
     margin-bottom: 10px;
 }

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -32,11 +32,7 @@
                   is_disabled=disable_want_advertise_in_communities_directory
                   label=admin_settings_label.realm_want_advertise_in_communities_directory
                   help_link="/help/communities-directory"}}
-                <div class="input-group admin-realm">
-                    <label for="id_realm_description" class="settings-field-label">{{t "Organization description" }}</label>
-                    <textarea id="id_realm_description" name="realm_description" class="admin-realm-description setting-widget prop-element settings-textarea"
-                      maxlength="1000" data-setting-widget-type="string">{{ realm_description }}</textarea>
-                </div>
+                {{> realm_description . }}
             </div>
         </div>
 

--- a/web/templates/settings/realm_description.hbs
+++ b/web/templates/settings/realm_description.hbs
@@ -1,0 +1,14 @@
+<div class="input-group admin-realm">
+    <label for="id_realm_description" class="settings-field-label">
+        {{t "Organization description" }}
+    </label>
+    {{#if is_admin}}
+        <textarea id="id_realm_description" name="realm_description"
+          class="admin-realm-description setting-widget prop-element settings-textarea"
+          maxlength="1000" data-setting-widget-type="string">{{ realm_description_text }}</textarea>
+    {{else}}
+        <div class="admin-realm-description settings-highlight-box rendered_markdown">
+            {{rendered_markdown realm_description_html}}
+        </div>
+    {{/if}}
+</div>

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -205,10 +205,11 @@ def build_page_params_for_home_page_load(
 
     page_params["translation_data"] = get_language_translation_data(request_language)
 
+    # This is used by `admin.ts` to display realm description for non-administrator
+    # logged-in users.
+    page_params["realm_rendered_description"] = get_realm_rendered_description(realm)
+
     if user_profile is None:
-        # Get rendered version of realm description which is displayed in right
-        # sidebar for spectator.
-        page_params["realm_rendered_description"] = get_realm_rendered_description(realm)
         page_params["language_cookie_name"] = settings.LANGUAGE_COOKIE_NAME
 
     return queue_id, page_params

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -57,6 +57,7 @@ class HomeTest(ZulipTestCase):
         "page_type",
         "presence_history_limit_days_for_web_app",
         "promote_sponsoring_zulip",
+        "realm_rendered_description",
         "request_language",
         "show_try_zulip_modal",
         "state_data",
@@ -303,7 +304,7 @@ class HomeTest(ZulipTestCase):
             set(result["Cache-Control"].split(", ")), {"must-revalidate", "no-store", "no-cache"}
         )
 
-        self.assert_length(cache_mock.call_args_list, 6)
+        self.assert_length(cache_mock.call_args_list, 7)
 
         html = result.content.decode()
 
@@ -606,7 +607,7 @@ class HomeTest(ZulipTestCase):
         ):
             result = self._get_home_page()
             self.check_rendered_logged_in_app(result)
-            self.assert_length(cache_mock.call_args_list, 7)
+            self.assert_length(cache_mock.call_args_list, 8)
 
     def test_num_queries_with_streams(self) -> None:
         main_user = self.example_user("hamlet")


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #36777

Design discussion: [#design > uneditable field styling](https://chat.zulip.org/#narrow/channel/101-design/topic/uneditable.20field.20styling/with/2313232)

**Screenshots and screen captures:**
(Updated on Dec 9)

- Non admin view

  | Before | After |
  |--------|--------|
  |   <img width="1098" height="803" alt="image" src="https://github.com/user-attachments/assets/ae2ca2c1-6e25-4fea-8082-71792e5fcfc0" /> |   <img width="1054" height="901" alt="image" src="https://github.com/user-attachments/assets/e5ca4aef-602d-4689-a280-9c4aa9b9e0a6" /> | 

- Admin view
  <img width="1054" height="897" alt="image" src="https://github.com/user-attachments/assets/3ba7e23f-8404-495e-91be-a865cda7c324" />

- No realm description
  <img width="1098" height="805" alt="image" src="https://github.com/user-attachments/assets/695350b7-2c89-4782-bb0a-50276f633a0f" />

- 1000 char limit
  <img width="1098" height="801" alt="image" src="https://github.com/user-attachments/assets/568d02e7-f13c-4389-9caa-ca0f88243f79" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
