### PR TITLE
help-beta: Update help center links to use main app link styling.

### DIFF
--- a/starlight_help/src/styles/main.css
+++ b/starlight_help/src/styles/main.css
@@ -22,10 +22,33 @@
     --color-user-circle-deactivated: hsl(0deg 0% 50%);
     /* stylelint-enable color-no-hex */
 
-    /* NOTE: These colors are also used in zulip web app for banner
-       colors. Do grep for these variables when changing them and
-       confirm on CZO on whether the colors there need to change as
-       well. */
+    /* =========================================================
+     * APP VARIABLES
+     * NOTE: These variables are shared with the Zulip web app.
+     * Before making any changes here, please confirm on CZO
+     * if the same changes need to be carried over.
+     * ========================================================= */
+
+    /* Link colors */
+    --color-text-link: light-dark(hsl(210deg 94% 42%), hsl(200deg 100% 50%));
+    --color-text-link-decoration: light-dark(
+        color-mix(in oklch, hsl(210deg 94% 42%) 20%, transparent),
+        color-mix(in oklch, hsl(200deg 100% 50%) 20%, transparent)
+    );
+    --color-text-link-hover: light-dark(
+        hsl(212deg 100% 50%),
+        hsl(200deg 100% 60%)
+    );
+    --color-text-link-decoration-hover: light-dark(
+        color-mix(in oklch, hsl(212deg 100% 50%) 70%, transparent),
+        color-mix(in oklch, hsl(200deg 100% 60%) 70%, transparent)
+    );
+    --color-text-link-active: light-dark(
+        hsl(212deg 100% 30%),
+        hsl(200deg 100% 50%)
+    );
+
+    /* Banner colors */
     /* Banners - Neutral Variant */
     --color-text-neutral-banner: light-dark(
         hsl(229deg 12% 25%),
@@ -65,6 +88,10 @@
         hsl(204deg 58% 92%),
         hsl(204deg 100% 12%)
     );
+
+    /* =========================================================
+     * END APP VARIABLES
+     * ========================================================= */
 
     /* Keyboard shortcuts */
     --color-keyboard-shortcuts: light-dark(
@@ -220,6 +247,27 @@
             box-shadow: none;
             border: none;
             vertical-align: text-top;
+        }
+    }
+
+    a:not(:where(.not-content *)) {
+        /* The :not(:where(.not-content *)) is required to avoid
+           applying these styles to links in certain components
+           which use the .not-content class.
+           Reference: https://starlight.astro.build/components/using-components/#compatibility-with-starlights-styles */
+        color: var(--color-text-link);
+        text-decoration-color: var(--color-text-link-decoration);
+        text-decoration-style: solid;
+        text-underline-offset: 2px;
+
+        &:hover {
+            color: var(--color-text-link-hover);
+            text-decoration-color: var(--color-text-link-decoration-hover);
+        }
+
+        &:active {
+            color: var(--color-text-link-active);
+            text-decoration-color: currentcolor;
         }
     }
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1531,6 +1531,9 @@
     );
 
     /* Link colors */
+    /* NOTE: These variables are shared with the Starlight help center.
+       Before making any changes here, please confirm on CZO if the
+       same changes need to be carried over. */
     --color-text-link: light-dark(hsl(210deg 94% 42%), hsl(200deg 100% 50%));
     --color-text-link-decoration: light-dark(
         color-mix(in oklch, hsl(210deg 94% 42%) 20%, transparent),


### PR DESCRIPTION
This PR also applies an additional text-underline-offset as discussed in https://github.com/zulip/zulip/issues/24877; this is yet to be implemented in the main app styles as of the time of this commit.

Fixes: #35124

Previous PR: #35251

**How changes were tested:**
- Visually, navigating through the Starlight help-beta docs.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| State/Theme | Before | After |
|--------|--------|--------|
| Normal/Light | <img width="803" height="260" alt="Screenshot 2025-11-27 at 6 33 31 PM" src="https://github.com/user-attachments/assets/aca52c66-8499-4d99-b316-379ae4c7b025" /> | <img width="803" height="260" alt="Screenshot 2025-11-27 at 6 31 24 PM" src="https://github.com/user-attachments/assets/aaabf78c-1586-4223-a89f-a8dbf2f476b9" /> |
| Hover/Light | <img width="803" height="260" alt="Screenshot 2025-11-27 at 6 33 34 PM" src="https://github.com/user-attachments/assets/38cc0ffc-79ca-4188-8c25-2a3e90f6f4aa" /> | <img width="803" height="260" alt="Screenshot 2025-11-27 at 6 30 23 PM" src="https://github.com/user-attachments/assets/60b1e247-d6b8-4953-934f-7cb7b2bff556" /> |
| Active/Light | <img width="803" height="260" alt="Screenshot 2025-11-27 at 6 33 41 PM" src="https://github.com/user-attachments/assets/4a875f7a-d4b0-467c-8848-e83ff1a906b3" /> | <img width="803" height="260" alt="Screenshot 2025-11-27 at 6 30 46 PM" src="https://github.com/user-attachments/assets/ef0ea75f-1543-47b6-92d7-4a856a643ca7" /> |
| Normal/Dark | <img width="803" height="260" alt="Screenshot 2025-11-27 at 6 33 50 PM" src="https://github.com/user-attachments/assets/d78fd018-b6b4-460b-9dea-c587215af64e" /> | <img width="803" height="260" alt="Screenshot 2025-11-27 at 6 31 42 PM" src="https://github.com/user-attachments/assets/c22bd208-d520-4bcf-bd83-27fe5a9f4956" /> |
| Hover/Dark | <img width="803" height="260" alt="Screenshot 2025-11-27 at 6 33 53 PM" src="https://github.com/user-attachments/assets/f011d9db-4d45-46f4-b752-85b6c02a1b9b" /> | <img width="803" height="260" alt="Screenshot 2025-11-27 at 6 31 45 PM" src="https://github.com/user-attachments/assets/382c759e-ef81-4b3f-aa94-e458b1d703d6" /> | 
| Active/Dark | <img width="803" height="260" alt="Screenshot 2025-11-27 at 6 33 58 PM" src="https://github.com/user-attachments/assets/1c4ea281-fa2a-4a34-a68b-cca7f2881cca" /> | <img width="803" height="260" alt="Screenshot 2025-11-27 at 6 31 49 PM" src="https://github.com/user-attachments/assets/9b8c4ff4-b8e7-46f7-ad35-56b2f8f23823" /> | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
