### PR TITLE
message edit: Make it possible to navigate to the "preview' element using the keyboard

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -762,19 +762,18 @@ export function process_tab_key(): boolean {
     }
 
     const $focused_message_edit_cancel = $(".message_edit_cancel:focus");
-    if($focused_message_edit_cancel.length > 0) {
+    if ($focused_message_edit_cancel.length > 0) {
         $message_edit_form = $focused_message_edit_cancel.closest(".message_edit_form");
         // Tab will move the flow to the markdown_preview
         $message_edit_form.find(".markdown_preview").trigger("focus");
         return true;
     }
 
-
     const $focused_message_edit_help = $(".compose_help_button:focus");
-    if($focused_message_edit_help.length > 0) {
+    if ($focused_message_edit_help.length > 0) {
         $message_edit_form = $focused_message_edit_help.closest(".message_edit_form");
         // In message edit: Tab will move the flow to the textarea
-        if($message_edit_form.find(".message_edit_content").length > 0) {
+        if ($message_edit_form.find(".message_edit_content").length > 0) {
             $message_edit_form.find(".message_edit_content").trigger("focus");
             return true;
         }
@@ -818,13 +817,13 @@ export function process_shift_tab_key(): boolean {
     }
 
     // Shift-Tabbing from the markdown_preview takes you back to previous element
-    if($(".markdown_preview:focus").length > 0){
+    if ($(".markdown_preview:focus").length > 0) {
         // In message edit: go back to cancel button
-        if($(".message_edit_cancel").length > 0) {
+        if ($(".message_edit_cancel").length > 0) {
             $(".message_edit_cancel").trigger("focus");
             return true;
         }
-        // In new compose: let browser handle 
+        // In new compose: let browser handle
         return false;
     }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: zulip/zulip/issues/36663

**How changes were tested:**
I performed manual testing on Chrome and Firefox using the following steps:

1. Open message → Edit message.
2. Press Tab repeatedly and confirm focus moves in this order:
   - Text area → Save → Cancel → Editor Controls.
3. Press Shift + Tab to verify backward navigation.
4. Confirmed behavior still matches compose box tab order.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screen captures:**

<details>
<summary>Tab behaviour before</summary>

https://github.com/user-attachments/assets/3cf6e051-a19e-4c65-b8a1-ff88966386e1

</details>

<details>
<summary>Tab behaviour after</summary>


https://github.com/user-attachments/assets/5211932d-7b95-42cb-ba21-e4ace3d625c0



</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
