### PR TITLE
compose: Skip adding backticks when pasting in inline code span.

### DIFF
--- a/web/src/compose_paste.ts
+++ b/web/src/compose_paste.ts
@@ -535,13 +535,9 @@ export function paste_handler_converter(
             const language = get_code_block_language(node, className);
             // We convert single line code inside a code block which does not have language metadata
             // to inline markdown code, and the code for this is taken from upstream's `code` rule.
-            if (!code.includes("\n") && language === "") {
-                // If the cursor is just after a backtick, then we don't add extra backticks.
-                if (
-                    $textarea &&
-                    $textarea.caret() !== 0 &&
-                    $textarea.val()?.at($textarea.caret() - 1) === "`"
-                ) {
+            if (!code.includes("\n")) {
+                // If the cursor is inside an inline code span, then we don't add extra backticks.
+                if ($textarea && compose_ui.cursor_inside_inline_code_span($textarea)) {
                     return content;
                 }
                 if (!code) {

--- a/web/tests/compose_paste.test.cjs
+++ b/web/tests/compose_paste.test.cjs
@@ -149,18 +149,99 @@ run_test("paste_handler_converter", () => {
         '<meta http-equiv="content-type" content="text/html; charset=utf-8"><pre><code>single line</code></pre>';
     assert.equal(
         compose_paste.paste_handler_converter(input, {
-            caret: () => 6,
-            val: () => "e.g. `",
+            val() {
+                return "e.g. `";
+            },
+            0: {
+                selectionStart: 6,
+                value: "e.g. `",
+            },
+            length: 1,
         }),
         "single line",
     );
 
-    // Yes code formatting if the given text area has a backtick but not at the cursor position
+    // No code formatting if the given text area has a backtick at the cursor position
     input =
         '<meta http-equiv="content-type" content="text/html; charset=utf-8"><pre><code>single line</code></pre>';
     assert.equal(
         compose_paste.paste_handler_converter(input, {
-            caret: () => 0,
+            val() {
+                return "`e.g. ` ```hi`` ``";
+            },
+            0: {
+                selectionStart: 19,
+                value: "`e.g. ` ```hi`` ``",
+            },
+            length: 1,
+        }),
+        "single line",
+    );
+
+    // No code formatting if the given text area has a opening backtick before the cursor position
+    input =
+        '<meta http-equiv="content-type" content="text/html; charset=utf-8"><pre><code>single line</code></pre>';
+    assert.equal(
+        compose_paste.paste_handler_converter(input, {
+            val() {
+                return "e.g. ` ";
+            },
+            0: {
+                selectionStart: 7,
+                value: "e.g. ` ",
+            },
+            length: 1,
+        }),
+        "single line",
+    );
+
+    // Yes code formatting if the given text area does not have a backtick at the cursor position.
+    input =
+        '<meta http-equiv="content-type" content="text/html; charset=utf-8"><pre><code>single line</code></pre>';
+    assert.equal(
+        compose_paste.paste_handler_converter(input, {
+            val() {
+                return "";
+            },
+            0: {
+                selectionStart: 0,
+                value: "",
+            },
+            length: 1,
+        }),
+        "`single line`",
+    );
+
+    // Yes code formatting if the given text area closes the code block before the cursor position
+    input =
+        '<meta http-equiv="content-type" content="text/html; charset=utf-8"><pre><code>single line</code></pre>';
+    assert.equal(
+        compose_paste.paste_handler_converter(input, {
+            val() {
+                return "` e.g. ` ";
+            },
+            0: {
+                selectionStart: 9,
+                value: "` e.g. ` ",
+            },
+            length: 1,
+        }),
+        "`single line`",
+    );
+
+    // Yes code formatting if the given text area closes the code block before the cursor position
+    input =
+        '<meta http-equiv="content-type" content="text/html; charset=utf-8"><pre><code>single line</code></pre>';
+    assert.equal(
+        compose_paste.paste_handler_converter(input, {
+            val() {
+                return "``` e.g. ``` ``hi`` ";
+            },
+            0: {
+                selectionStart: 20,
+                value: "``` e.g. ``` ``hi`` ",
+            },
+            length: 1,
         }),
         "`single line`",
     );


### PR DESCRIPTION
(This carries forward the work in #35524 by addressing the recent [review comments](https://github.com/zulip/zulip/pull/35524#discussion_r2525098325) by @timabbott)

Thanks to @NewtonLC, @jjustinn53 and @amcdowell226 for their contributions towards this!


Add cursor_inside_inline_span() to detect an unfinished inline code span by tracking unmatched runs of backticks. The Turndown fencedCodeBlock rule now calls this helper and inserts the raw code when the cursor is already inside a span instead of wrapping it in a second pair of backticks.

Fixes: #34313


https://github.com/user-attachments/assets/37553e6a-5a89-45f9-bfc4-396e29e4dbfe


