### PR TITLE
starlight_help: Add ZulipTip for checking current time zone

### DIFF
--- a/starlight_help/src/content/docs/change-your-timezone.mdx
+++ b/starlight_help/src/content/docs/change-your-timezone.mdx
@@ -6,6 +6,7 @@ import {Steps, TabItem, Tabs} from "@astrojs/starlight/components";
 
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import NavigationSteps from "../../components/NavigationSteps.astro";
+import ZulipTip from "../../components/ZulipTip.astro";
 
 Zulip uses the time zone configured on your computer or mobile device for
 displaying dates and times, such as when a message was sent.


### PR DESCRIPTION
This PR adds a small ZulipTip to the "Change your time zone" documentation.

The new tip helps users quickly locate their current time zone in **Settings → Profile**, which improves clarity for new users.

**Before:** The page explained how to change the time zone but did not show where to view the current one.

**After:** A concise ZulipTip highlights exactly where to find the current time zone.

No functional changes; documentation only.


