### PR TITLE
filter: Fix `has:image`  broken.

### DIFF
--- a/web/src/message_parser.ts
+++ b/web/src/message_parser.ts
@@ -17,7 +17,7 @@ export function message_has_link(message_content: string): boolean {
 }
 
 export function message_has_image(message_content: string): boolean {
-    return is_element_in_message_content(message_content, ".message-media-preview-image");
+    return is_element_in_message_content(message_content, ".message_inline_image");
 }
 
 export function message_has_attachment(message_content: string): boolean {

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1336,8 +1336,10 @@ test("predicate_basics", ({override}) => {
     assert.ok(!predicate({type: stream_message}));
 
     const img_msg = {
+        // Even though the HTML class `message_inline_image` is modified
+        // in post_process for rendered message, the raw content stays the same.
         content:
-            '<p><a href="/user_uploads/randompath/test.jpeg">test.jpeg</a></p><div class="message-media-preview-image"><a href="/user_uploads/randompath/test.jpeg" title="test.jpeg"><img src="/user_uploads/randompath/test.jpeg"></a></div>',
+            '<p><a href="/user_uploads/randompath/test.jpeg">test.jpeg</a></p><div class="message_inline_image"><a href="/user_uploads/randompath/test.jpeg" title="test.jpeg"><img src="/user_uploads/randompath/test.jpeg"></a></div>',
     };
 
     const link_msg = {
@@ -1410,17 +1412,13 @@ test("predicate_basics", ({override}) => {
     assert.ok(!has_attachment(no_has_filter_matching_msg));
 
     const has_image = get_predicate([["has", "image"]]);
-    set_find_results_for_msg_content(img_msg, ".message-media-preview-image", ["stub"]);
+    set_find_results_for_msg_content(img_msg, ".message_inline_image", ["stub"]);
     assert.ok(has_image(img_msg));
-    set_find_results_for_msg_content(non_img_attachment_msg, ".message-media-preview-image", false);
+    set_find_results_for_msg_content(non_img_attachment_msg, ".message_inline_image", false);
     assert.ok(!has_image(non_img_attachment_msg));
-    set_find_results_for_msg_content(link_msg, ".message-media-preview-image", false);
+    set_find_results_for_msg_content(link_msg, ".message_inline_image", false);
     assert.ok(!has_image(link_msg));
-    set_find_results_for_msg_content(
-        no_has_filter_matching_msg,
-        ".message-media-preview-image",
-        false,
-    );
+    set_find_results_for_msg_content(no_has_filter_matching_msg, ".message_inline_image", false);
     assert.ok(!has_image(no_has_filter_matching_msg));
 
     const has_reaction = get_predicate([["has", "reaction"]]);


### PR DESCRIPTION
`has:image` was not working since we looking for the wrong class in message content.

Bug was introduced in #36052.

discussion: [#issues > has:image doesn't work.](https://chat.zulip.org/#narrow/channel/9-issues/topic/has.3Aimage.20doesn't.20work.2E/with/2314253)