### PR TITLE
user_profile: Fix when hide_user_profile is called.

### DIFF
--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -1457,8 +1457,8 @@ export function initialize(): void {
      * but we do want to close the modal when you click them. */
 
     $("body").on("click", "#user-profile-modal #name .user-profile-profile-settings-button", () => {
-        browser_history.go_to_location("#settings/profile");
         hide_user_profile();
+        browser_history.go_to_location("#settings/profile");
     });
 
     $("body").on(


### PR DESCRIPTION
When clicking on `.user-profile-profile-settings-button` in user profile, it should first hide user profile and then navigate to the settings page.

<!-- Describe your pull request here.-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
