### PR TITLE
help: Note to avoid using Safari when pasting links to GitHub.

### DIFF
--- a/starlight_help/src/content/docs/link-to-a-message-or-conversation.mdx
+++ b/starlight_help/src/content/docs/link-to-a-message-or-conversation.mdx
@@ -5,6 +5,7 @@ title: Link to a message or conversation
 import {TabItem, Tabs} from "@astrojs/starlight/components";
 
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
+import ZulipNote from "../../components/ZulipNote.astro";
 import ZulipTip from "../../components/ZulipTip.astro";
 import ChannelActions from "../include/_ChannelActions.mdx";
 import ChannelLongPressMenu from "../include/_ChannelLongPressMenu.mdx";
@@ -113,6 +114,12 @@ accepts HTML formatting (e.g., your email, GitHub, docs, etc.), the link will be
 formatted as it would be in Zulip (e.g., [#channel > topic](#link-to-a-topic-within-zulip)).
 To paste the plain URL, you can paste without formatting (likely <kbd>Ctrl</kbd> +
 <kbd>Shift</kbd> + <kbd>V</kbd> in your browser).
+
+<ZulipNote>
+  Due to a Safari quirk, pasting Zulip links from Safari into GitHub
+  and some other apps may result in incorrect formatting. You can
+  paste without formatting, or use a different browser.
+</ZulipNote>
 
 ### Get a link to a specific message
 


### PR DESCRIPTION
Safari doesn't allow custom MIME types for cross domain pastes.
The other alternatives we evaluated to support this make things worse across all the browsers,
by not letting users paste links as URLs in the
browser address bar.

So we instead choose to recommend Safari users to
switch to another browser if they use Zulip and
GitHub together.

Addresses: https://chat.zulip.org/#narrow/channel/137-feedback/topic/Pasting.20links.20into.20GitHub.20using.20Safari/with/2314432

(Updated on 3rd Dec)
| Before | After |
|----|-----|
|<img width="1250" height="898" alt="image" src="https://github.com/user-attachments/assets/71360335-1d4b-4bfe-bf62-4c91fa376eea" /> |<img width="1026" height="705" alt="image" src="https://github.com/user-attachments/assets/6bd46f78-7426-470d-881b-3eaae86f9b37" />|