### PR TITLE
[wip] slack_importer: Parallelize Slack data import avatar processing.

### DIFF
--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -19,12 +19,9 @@ from django.forms.models import model_to_dict
 from django.utils.timezone import now as timezone_now
 
 from zerver.data_import.sequencer import NEXT_ID
-from zerver.lib.avatar_hash import user_avatar_base_path_from_ids
 from zerver.lib.markdown import get_markdown_link_for_url
 from zerver.lib.message import normalize_body_for_import
-from zerver.lib.mime_types import INLINE_MIME_TYPES, bare_content_type, guess_extension
-from zerver.lib.parallel import run_parallel
-from zerver.lib.partial import partial
+from zerver.lib.mime_types import INLINE_MIME_TYPES, bare_content_type, guess_extension, guess_type
 from zerver.lib.stream_color import STREAM_ASSIGNMENT_COLORS as STREAM_COLORS
 from zerver.lib.thumbnail import THUMBNAIL_ACCEPT_IMAGE_TYPES, BadImageError
 from zerver.lib.upload import sanitize_name
@@ -83,6 +80,7 @@ class UploadFileRequest:
     kwargs: dict[str, Any]
 
 
+@dataclass
 class AvatarRecordData:
     avatar_version: int
     content_type: str | None
@@ -92,6 +90,11 @@ class AvatarRecordData:
     s3_path: str
     size: int | None
     user_profile_id: int
+
+
+@dataclass
+class AvatarFileRequest(UploadFileRequest):
+    base_avatar_path: str
 
 
 class SubscriberHandler:
@@ -593,80 +596,45 @@ def build_attachment(
     zerver_attachment.append(attachment_dict)
 
 
-def get_avatar(avatar_dir: str, size_url_suffix: str, avatar_upload_item: list[str]) -> None:
-    avatar_url = avatar_upload_item[0]
-
-    image_path = os.path.join(avatar_dir, avatar_upload_item[1])
-    original_image_path = os.path.join(avatar_dir, avatar_upload_item[2])
-
-    if avatar_url.startswith("https://ca.slack-edge.com/"):
-        # Adjust the avatar size for a typical Slack user.
-        avatar_url += size_url_suffix
-
-    response = request_file_stream(avatar_url)
-    with open(image_path, "wb") as image_file:
-        shutil.copyfileobj(response.raw, image_file)
-    shutil.copy(image_path, original_image_path)
-
-
-def process_avatars(
-    avatar_list: list[AvatarRecordData],
-    avatar_dir: str,
-    realm_id: int,
-    processes: int,
-    size_url_suffix: str = "",
-) -> list[AvatarRecordData]:
-    """
-    This function gets the avatar of the user and saves it in the
-    user's avatar directory with both the extensions '.png' and '.original'
-    Required parameters:
-
-    1. avatar_list: List of avatars to be mapped in avatars records.json file
-    2. avatar_dir: Folder where the downloaded avatars are saved
-    3. realm_id: Realm ID.
-
-    We use this for Slack conversions, where avatars need to be
-    downloaded.
-    """
-
-    logging.info("######### GETTING AVATARS #########\n")
-    logging.info("DOWNLOADING AVATARS .......\n")
-    avatar_original_list = []
-    avatar_upload_list = []
-    for avatar in avatar_list:
-        avatar_hash = user_avatar_base_path_from_ids(
-            avatar.user_profile_id, avatar.avatar_version, realm_id
-        )
-        avatar_url = avatar.path
-        avatar_original = copy.deepcopy(avatar)
-
-        image_path = f"{avatar_hash}.png"
-        original_image_path = f"{avatar_hash}.original"
-
-        avatar_upload_list.append([avatar_url, image_path, original_image_path])
-        # We don't add the size field here in avatar's records.json,
-        # since the metadata is not needed on the import end, and we
-        # don't have it until we've downloaded the files anyway.
-        avatar.path = image_path
-        avatar.s3_path = image_path
-        avatar.content_type = "image/png"
-
-        avatar_original.path = original_image_path
-        avatar_original.s3_path = original_image_path
-        avatar_original.content_type = "image/png"
-        avatar_original_list.append(avatar_original)
-
-    # Run downloads in parallel
-    run_parallel(
-        partial(get_avatar, avatar_dir, size_url_suffix),
-        avatar_upload_list,
-        processes=processes,
-        catch=True,
-        report=lambda count: logging.info("Finished %s items", count),
+def download_and_export_avatar_file(
+    output_dir: str,
+    avatar_records: list[AvatarRecordData],
+    /,
+    incomplete_avatar_record: AvatarRecordData,
+    avatar_file_request: AvatarFileRequest,
+) -> None:
+    response = request_file_stream(
+        avatar_file_request.request_url,
+        avatar_file_request.params,
+        avatar_file_request.headers,
+        **avatar_file_request.kwargs,
     )
+    content_type = response.headers.get("Content-Type")
+    if content_type is None:
+        content_type = guess_type(avatar_file_request.request_url)[0]
+    if content_type not in THUMBNAIL_ACCEPT_IMAGE_TYPES:
+        raise BadImageError("Invalid image format")
 
-    logging.info("######### GETTING AVATARS FINISHED #########\n")
-    return avatar_list + avatar_original_list
+    file_extension = guess_extension(content_type, strict=False)
+    relative_image_path = f"{avatar_file_request.base_avatar_path}.{file_extension}"
+    relative_original_image_path = f"{avatar_file_request.base_avatar_path}.original"
+
+    full_image_path = os.path.join(output_dir, "avatars", relative_image_path)
+    full_original_image_path = os.path.join(output_dir, "avatars", relative_original_image_path)
+
+    with open(full_image_path, "wb") as image_file:
+        shutil.copyfileobj(response.raw, image_file)
+    shutil.copy(full_image_path, full_original_image_path)
+
+    incomplete_avatar_record.content_type = content_type
+    original_avatar_record = copy.deepcopy(incomplete_avatar_record)
+    original_avatar_record.path = full_original_image_path
+    original_avatar_record.s3_path = full_original_image_path
+    avatar_record = incomplete_avatar_record
+    avatar_record.path = full_image_path
+    avatar_record.s3_path = full_image_path
+
+    avatar_records += [avatar_record, original_avatar_record]
 
 
 def request_file_stream(

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -1234,17 +1234,7 @@ class SlackImporter(ZulipTestCase):
     ) -> None:
         realm_id = 1
         user_list: list[dict[str, Any]] = []
-        (
-            realm,
-            slack_user_id_to_zulip_user_id,
-            slack_recipient_name_to_zulip_recipient_id,
-            added_channels,
-            added_mpims,
-            added_dms,
-            _dm_members,
-            avatar_list,
-            _em,
-        ) = slack_workspace_to_realm(
+        converted_realm_result = slack_workspace_to_realm(
             "testdomain", realm_id, user_list, "test-realm", "./random_path", {}
         )
 
@@ -1252,12 +1242,12 @@ class SlackImporter(ZulipTestCase):
             {"realm": realm_id, "allow_subdomains": False, "domain": "testdomain", "id": realm_id}
         ]
         # Functioning already tests in helper functions
-        self.assertEqual(slack_user_id_to_zulip_user_id, {})
-        self.assertEqual(added_channels, {})
-        self.assertEqual(added_mpims, {})
-        self.assertEqual(added_dms, {})
-        self.assertEqual(slack_recipient_name_to_zulip_recipient_id, {})
-        self.assertEqual(avatar_list, [])
+        self.assertEqual(converted_realm_result.slack_user_id_to_zulip_user_id, {})
+        self.assertEqual(converted_realm_result.added_channels, {})
+        self.assertEqual(converted_realm_result.added_mpims, {})
+        self.assertEqual(converted_realm_result.added_dms, {})
+        self.assertEqual(converted_realm_result.slack_recipient_name_to_zulip_recipient_id, {})
+        self.assertEqual(converted_realm_result.avatar_list, [])
 
         mock_channels_to_zerver_stream.assert_called_once_with("./random_path", 1, ANY, {}, [])
         passed_realm = mock_channels_to_zerver_stream.call_args_list[0][0][2]
@@ -1270,6 +1260,7 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(passed_realm["import_source"], "slack")
         self.assert_length(passed_realm.keys(), 17)
 
+        realm = converted_realm_result.realm
         self.assertEqual(realm["zerver_stream"], [])
         self.assertEqual(realm["zerver_userprofile"], [])
         self.assertEqual(realm["zerver_realmemoji"], [])

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -2236,7 +2236,6 @@ by Pieter
     @responses.activate
     @mock.patch("zerver.data_import.slack.build_attachment", return_value=[])
     @mock.patch("zerver.data_import.slack.build_avatar_url", return_value=("", ""))
-    @mock.patch("zerver.data_import.slack.build_avatar")
     @mock.patch("zerver.data_import.slack.get_slack_api_data")
     @mock.patch("zerver.data_import.slack.check_slack_token_access")
     def test_slack_import_to_existing_database(
@@ -2244,7 +2243,6 @@ by Pieter
         mock_check_slack_token_access: mock.Mock,
         mock_get_slack_api_data: mock.Mock,
         mock_build_avatar_url: mock.Mock,
-        mock_build_avatar: mock.Mock,
         mock_attachment: mock.Mock,
     ) -> None:
         test_slack_dir = os.path.join(
@@ -2460,7 +2458,6 @@ by Pieter
     @mock.patch("zerver.data_import.slack.requests.get")
     @mock.patch("zerver.data_import.slack.build_attachment", return_value=[])
     @mock.patch("zerver.data_import.slack.build_avatar_url", return_value=("", ""))
-    @mock.patch("zerver.data_import.slack.build_avatar")
     @mock.patch("zerver.data_import.slack.get_slack_api_data")
     @mock.patch("zerver.data_import.slack.check_slack_token_access")
     def test_slack_import_unicode_filenames(
@@ -2468,7 +2465,6 @@ by Pieter
         mock_check_slack_token_access: mock.Mock,
         mock_get_slack_api_data: mock.Mock,
         mock_build_avatar_url: mock.Mock,
-        mock_build_avatar: mock.Mock,
         mock_attachment: mock.Mock,
         mock_requests_get: mock.Mock,
     ) -> None:


### PR DESCRIPTION
Stacked on top of #36335.
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
