### PR TITLE
giphy: Remove usage of `Y` rating.

### DIFF
--- a/web/src/giphy.ts
+++ b/web/src/giphy.ts
@@ -45,7 +45,7 @@ export function update_giphy_rating(): void {
 
 function get_rating(): Rating {
     const options = realm.giphy_rating_options;
-    for (const rating of ["pg", "g", "y", "pg-13", "r"] as const) {
+    for (const rating of ["pg", "g", "pg-13", "r"] as const) {
         if (options[rating]?.id === realm.realm_giphy_rating) {
             return rating;
         }

--- a/zerver/migrations/0763_migrate_realms_using_y_rating_to_use_a_g_rating_for_giphy.py
+++ b/zerver/migrations/0763_migrate_realms_using_y_rating_to_use_a_g_rating_for_giphy.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+
+def use_a_g_rating_instead_of_y_rating(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    # Apparently, GIPHY removed the "Y" rating at some point; so we
+    # need to consolidate/collapse our rating level configuration. We
+    # round "Y" to the nearest remaining value, "G".
+    #
+    # The previous mapping was 1->Y, 2->G, 3->PG, 4->PG-13, 5->R
+    # We now shift that to 1->G, 2->PG, 3->PG-13, 4->R
+    Realm = apps.get_model("zerver", "Realm")
+    Realm.objects.filter(giphy_rating__gte=2).update(giphy_rating=models.F("giphy_rating") - 1)
+
+
+class Migration(migrations.Migration):
+    dependencies = [("zerver", "0762_realm_owner_full_content_access")]
+    operations = [
+        migrations.RunPython(use_a_g_rating_instead_of_y_rating),
+        migrations.AlterField(
+            model_name="realm",
+            name="giphy_rating",
+            field=models.PositiveSmallIntegerField(default=1),
+        ),
+    ]

--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -669,26 +669,22 @@ class Realm(models.Model):
             "name": gettext_lazy("GIPHY integration disabled"),
             "id": 0,
         },
-        # Source: https://github.com/Giphy/giphy-js/blob/master/packages/fetch-api/README.md#shared-options
-        "y": {
-            "name": gettext_lazy("Allow GIFs rated Y (Very young audience)"),
-            "id": 1,
-        },
+        # Source: https://developers.giphy.com/docs/optional-settings/#rating
         "g": {
             "name": gettext_lazy("Allow GIFs rated G (General audience)"),
-            "id": 2,
+            "id": 1,
         },
         "pg": {
             "name": gettext_lazy("Allow GIFs rated PG (Parental guidance)"),
-            "id": 3,
+            "id": 2,
         },
         "pg-13": {
             "name": gettext_lazy("Allow GIFs rated PG-13 (Parental guidance - under 13)"),
-            "id": 4,
+            "id": 3,
         },
         "r": {
             "name": gettext_lazy("Allow GIFs rated R (Restricted)"),
-            "id": 5,
+            "id": 4,
         },
     }
 

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -2078,7 +2078,7 @@ class RealmAPITest(ZulipTestCase):
             ],
             jitsi_server_url=["https://example.jit.si"],
             giphy_rating=[
-                Realm.GIPHY_RATING_OPTIONS["y"]["id"],
+                Realm.GIPHY_RATING_OPTIONS["g"]["id"],
                 Realm.GIPHY_RATING_OPTIONS["r"]["id"],
             ],
             message_content_delete_limit_seconds=[1000, 1100, 1200],


### PR DESCRIPTION
The `Y` rating was removed by Giphy and us sending this rating to the GIPHY API ends up returning content meant for `R` rated audience, which is definitely not expected behavior.

We change the rating value from `Y` to `G` for any realms that previously used the `Y` rating.

Reference: https://developers.giphy.com/docs/optional-settings/#rating

Extracted from #36654.