### PR TITLE
puppet: Fix get_django_setting_slow during first puppet run.

### DIFF
--- a/puppet/zulip/lib/puppet/functions/get_django_setting_slow.rb
+++ b/puppet/zulip/lib/puppet/functions/get_django_setting_slow.rb
@@ -9,7 +9,13 @@ require "shellwords"
 Puppet::Functions.create_function(:get_django_setting_slow) do
   def get_django_setting_slow(name)
     if File.exist?("/etc/zulip/settings.py")
-      output = `/home/zulip/deployments/current/scripts/get-django-setting #{name.shellescape} 2>&1`
+      if Dir.exist?("/home/zulip/deployments/current")
+        deploy_dir = "current"
+      else
+        # First puppet runs during install don't have a "current" yet, only a "next"
+        deploy_dir = "next"
+      end
+      output = `/home/zulip/deployments/#{deploy_dir}/scripts/get-django-setting #{name.shellescape} 2>&1`
       if $?.success?
         output.strip
       else


### PR DESCRIPTION
We will have created /home/zulip/deployments/next but not /home/zulip/deployments/current.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
