### PR TITLE
compose: Fix mobile keyboard overlap and disable autofill in filter/topic inputs.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -97,6 +97,7 @@ function hide_box(): void {
     // the compose box is reopened
     $("#compose-recipient").addClass("low-attention-recipient-row");
     $("#compose").removeClass("compose-box-open");
+    compose_ui.cleanup_mobile_keyboard_handling();
 }
 
 function show_compose_box(opts: ComposeActionsOpts): void {
@@ -238,6 +239,7 @@ export let complete_starting_tasks = (opts: ComposeActionsOpts): void => {
     }
     compose_ui.maybe_show_scrolling_formatting_buttons("#message-formatting-controls-container");
     compose_validate.validate_and_update_send_button_status();
+    compose_ui.initialize_mobile_keyboard_handling();
 };
 
 export function rewire_complete_starting_tasks(value: typeof complete_starting_tasks): void {

--- a/web/src/compose_mobile_keyboard_handler.ts
+++ b/web/src/compose_mobile_keyboard_handler.ts
@@ -1,0 +1,147 @@
+// Mobile keyboard handler for positioning compose box above on-screen keyboard
+// Uses visualViewport API to detect keyboard height and adjust compose position
+
+let keyboard_offset = 0;
+let resize_observer: ResizeObserver | null = null;
+
+// Callbacks registered by other modules to react to keyboard offset changes
+const offset_change_callbacks: ((offset: number) => void)[] = [];
+
+function update_compose_position(): void {
+    const compose_element = document.querySelector<HTMLElement>("#compose");
+    if (!compose_element) {
+        return;
+    }
+
+    compose_element.style.setProperty("--keyboard-offset", `${keyboard_offset}px`);
+}
+
+function notify_offset_change(): void {
+    for (const callback of offset_change_callbacks) {
+        callback(keyboard_offset);
+    }
+}
+
+function calculate_keyboard_offset(): number {
+    if (!window.visualViewport) {
+        return 0;
+    }
+
+    const viewport_height = window.visualViewport.height;
+    const viewport_offset_top = window.visualViewport.offsetTop;
+    // Use clientHeight (Layout Height) instead of innerHeight (Visible Height)
+    // to ensure consistency with visualViewport properties which are relative to layout
+    const window_height = document.documentElement.clientHeight;
+
+    // Keyboard height = window height - (viewport height + viewport offset)
+    // We subtract viewport_offset_top to prevent the compose box from scrolling with the chat.
+    // This pins the compose box to the bottom of the visible area (visual viewport).
+    const offset = Math.max(0, window_height - (viewport_height + viewport_offset_top));
+
+    // Only consider keyboard present if offset is significant (> 100px)
+    // This helps filter out address bar changes and other small viewport adjustments
+    return offset > 100 ? offset : 0;
+}
+
+function calculate_and_update_offset(): void {
+    const new_keyboard_offset = calculate_keyboard_offset();
+
+    if (new_keyboard_offset !== keyboard_offset) {
+        keyboard_offset = new_keyboard_offset;
+        update_compose_position();
+        notify_offset_change();
+    }
+}
+
+function handle_resize(): void {
+    calculate_and_update_offset();
+}
+
+function handle_scroll(): void {
+    if (window.visualViewport) {
+        calculate_and_update_offset();
+    }
+}
+
+function handle_focus(): void {
+    // When an input is focused, keyboard may appear
+    // Poll for changes over the next 1 second to catch keyboard animation
+    let poll_count = 0;
+    const poll = (): void => {
+        calculate_and_update_offset();
+        poll_count += 1;
+        if (poll_count < 10) {
+            setTimeout(poll, 100);
+        }
+    };
+    poll();
+}
+
+// Public API: Get the current keyboard offset
+export function get_keyboard_offset(): number {
+    return keyboard_offset;
+}
+
+// Public API: Register a callback for when keyboard offset changes
+export function on_offset_change(callback: (offset: number) => void): void {
+    offset_change_callbacks.push(callback);
+}
+
+// Public API: Unregister a callback
+export function off_offset_change(callback: (offset: number) => void): void {
+    const index = offset_change_callbacks.indexOf(callback);
+    if (index !== -1) {
+        offset_change_callbacks.splice(index, 1);
+    }
+}
+
+export function initialize_mobile_keyboard_handler(): void {
+    // Listen for visualViewport changes
+    if (window.visualViewport) {
+        window.visualViewport.addEventListener("resize", handle_resize);
+        // Listen to scroll to update position when chat scrolls (prevents compose from moving with chat)
+        window.visualViewport.addEventListener("scroll", handle_scroll);
+    }
+
+    // Also listen for window resize as fallback
+    window.addEventListener("resize", handle_resize);
+
+    // Listen for focus events on inputs within compose
+    document.addEventListener("focusin", (event: FocusEvent) => {
+        const target = event.target;
+        if (target instanceof HTMLElement) {
+            const compose = document.querySelector("#compose");
+            if (compose?.contains(target)) {
+                handle_focus();
+            }
+        }
+    });
+
+    // Use ResizeObserver on body as another fallback
+    if (typeof ResizeObserver !== "undefined") {
+        resize_observer = new ResizeObserver(() => {
+            calculate_and_update_offset();
+        });
+        resize_observer.observe(document.body);
+    }
+
+    // Initial calculation
+    calculate_and_update_offset();
+}
+
+export function cleanup_mobile_keyboard_handler(): void {
+    if (window.visualViewport) {
+        window.visualViewport.removeEventListener("resize", handle_resize);
+        window.visualViewport.removeEventListener("scroll", handle_scroll);
+    }
+
+    window.removeEventListener("resize", handle_resize);
+
+    if (resize_observer) {
+        resize_observer.disconnect();
+        resize_observer = null;
+    }
+
+    keyboard_offset = 0;
+    update_compose_position();
+}

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -17,6 +17,7 @@ import type {Typeahead} from "./bootstrap_typeahead.ts";
 import * as bulleted_numbered_list_util from "./bulleted_numbered_list_util.ts";
 import * as channel from "./channel.ts";
 import * as common from "./common.ts";
+import * as compose_mobile_keyboard_handler from "./compose_mobile_keyboard_handler.ts";
 import * as compose_state from "./compose_state.ts";
 import type {TypeaheadSuggestion} from "./composebox_typeahead.ts";
 import {$t, $t_html} from "./i18n.ts";
@@ -1430,4 +1431,24 @@ export function render_and_show_preview(
             },
         });
     }
+}
+
+export let initialize_mobile_keyboard_handling = (): void => {
+    compose_mobile_keyboard_handler.initialize_mobile_keyboard_handler();
+};
+
+export function rewire_initialize_mobile_keyboard_handling(
+    value: typeof initialize_mobile_keyboard_handling,
+): void {
+    initialize_mobile_keyboard_handling = value;
+}
+
+export let cleanup_mobile_keyboard_handling = (): void => {
+    compose_mobile_keyboard_handler.cleanup_mobile_keyboard_handler();
+};
+
+export function rewire_cleanup_mobile_keyboard_handling(
+    value: typeof cleanup_mobile_keyboard_handling,
+): void {
+    cleanup_mobile_keyboard_handling = value;
 }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -637,7 +637,7 @@
 
 #compose {
     position: fixed;
-    bottom: 0;
+    bottom: var(--keyboard-offset, 0);
     left: 0;
     z-index: 4;
 }

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -63,7 +63,7 @@
                                 <a role="button" class="conversation-arrow zulip-icon zulip-icon-chevron-right"></a>
                             </div>
                             <div id="compose-channel-recipient">
-                                <input type="text" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
+                                <input type="search" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
                                 <span id="topic-not-mandatory-placeholder" class="placeholder">
                                     {{> topic_not_mandatory_placeholder_text empty_string_topic_display_name=empty_string_topic_display_name}}
                                 </span>

--- a/web/templates/dropdown_list_container.hbs
+++ b/web/templates/dropdown_list_container.hbs
@@ -1,6 +1,6 @@
 <div class="dropdown-list-container {{widget_name}}-dropdown-list-container">
     <div class="dropdown-list-search popover-filter-input-wrapper">
-        <input class="dropdown-list-search-input popover-filter-input filter_text_input{{#if hide_search_box}} hide{{/if}}" type="text" placeholder="{{t 'Filter' }}" autofocus/>
+        <input class="dropdown-list-search-input popover-filter-input filter_text_input{{#if hide_search_box}} hide{{/if}}" type="search" placeholder="{{t 'Filter' }}" autofocus/>
     </div>
     <div class="dropdown-list-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <ul class="dropdown-list"></ul>

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -54,6 +54,8 @@ const compose_ui = mock_esm("../src/compose_ui", {
     is_expanded: () => false,
     set_focus: noop,
     compute_placeholder_text: noop,
+    initialize_mobile_keyboard_handling: noop,
+    cleanup_mobile_keyboard_handling: noop,
 });
 const hash_util = mock_esm("../src/hash_util");
 const narrow_state = mock_esm("../src/narrow_state", {

--- a/web/tests/compose_mobile_keyboard_handler.test.cjs
+++ b/web/tests/compose_mobile_keyboard_handler.test.cjs
@@ -1,0 +1,319 @@
+"use strict";
+
+const {set_global, zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const handler = zrequire("compose_mobile_keyboard_handler");
+
+function make_mock_window() {
+    return {
+        innerHeight: 800,
+        visualViewport: {
+            height: 600,
+            offsetTop: 0,
+            addEventListener() {},
+            removeEventListener() {},
+        },
+        addEventListener() {},
+        removeEventListener() {},
+    };
+}
+
+function make_mock_document(compose_element) {
+    return {
+        querySelector(sel) {
+            if (sel === "#compose") {
+                return compose_element;
+            }
+            /* istanbul ignore next */
+            return null;
+        },
+        documentElement: {
+            clientHeight: 800,
+        },
+        addEventListener() {},
+        removeEventListener() {},
+    };
+}
+
+set_global(
+    "ResizeObserver",
+    class ResizeObserver {
+        observe() {}
+        disconnect() {}
+    },
+);
+
+set_global("navigator", {
+    userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X)",
+});
+
+run_test("initialize and cleanup", () => {
+    const compose_element = {
+        style: {
+            setProperty() {},
+        },
+    };
+
+    set_global("document", make_mock_document(compose_element));
+    set_global("window", make_mock_window());
+
+    handler.initialize_mobile_keyboard_handler();
+    handler.cleanup_mobile_keyboard_handler();
+});
+
+run_test("no visualViewport", () => {
+    const mock_window = make_mock_window();
+    mock_window.visualViewport = undefined;
+    set_global("window", mock_window);
+
+    set_global("document", make_mock_document(null));
+
+    handler.initialize_mobile_keyboard_handler();
+    handler.cleanup_mobile_keyboard_handler();
+});
+
+run_test("missing compose element", () => {
+    let resize_handler;
+
+    const mock_window = make_mock_window();
+    mock_window.visualViewport.addEventListener = (_event, fn) => {
+        resize_handler = fn;
+    };
+    set_global("window", mock_window);
+
+    set_global("document", make_mock_document(undefined));
+
+    handler.initialize_mobile_keyboard_handler();
+
+    if (resize_handler) {
+        resize_handler();
+    }
+});
+
+run_test("viewport change triggers update", () => {
+    let resize_handler;
+
+    const compose_element = {
+        style: {
+            setProperty() {},
+        },
+    };
+
+    const mock_window = make_mock_window();
+    // Simulate keyboard open (visualViewport shrinks)
+    mock_window.visualViewport.height = 400;
+    mock_window.visualViewport.offsetTop = 0; // iOS behavior initially
+    mock_window.visualViewport.addEventListener = (_event, fn) => {
+        resize_handler = fn;
+    };
+    set_global("window", mock_window);
+
+    set_global("document", make_mock_document(compose_element));
+
+    handler.initialize_mobile_keyboard_handler();
+
+    if (resize_handler) {
+        resize_handler();
+    }
+
+    // offset = 800 - 400 = 400
+    // > 100, so offset is 400
+});
+
+run_test("handle_viewport_change with undefined viewport", () => {
+    let resize_handler;
+
+    const mock_window = make_mock_window();
+    mock_window.visualViewport.addEventListener = (_event, fn) => {
+        resize_handler = fn;
+    };
+    set_global("window", mock_window);
+
+    set_global("document", make_mock_document(null));
+
+    handler.initialize_mobile_keyboard_handler();
+
+    // Set visualViewport to undefined and call handler to hit null check
+    set_global("window", {
+        ...mock_window,
+        visualViewport: undefined,
+    });
+
+    if (resize_handler) {
+        resize_handler();
+    }
+});
+
+run_test("callbacks", () => {
+    const compose_element = {
+        style: {
+            setProperty() {},
+        },
+    };
+
+    const mock_window = make_mock_window();
+    let resize_handler;
+    mock_window.visualViewport.addEventListener = (_event, fn) => {
+        resize_handler = fn;
+    };
+    set_global("window", mock_window);
+    set_global("document", make_mock_document(compose_element));
+
+    handler.initialize_mobile_keyboard_handler();
+
+    let callback_offset = -1;
+    const callback = (offset) => {
+        callback_offset = offset;
+    };
+
+    // Register callback
+    handler.on_offset_change(callback);
+
+    // Trigger update
+    mock_window.visualViewport.height = 400; // Offset 400
+    if (resize_handler) {
+        resize_handler();
+    }
+
+    /* istanbul ignore next */
+    if (callback_offset !== 400) {
+        throw new Error("Callback not called with correct offset");
+    }
+
+    /* istanbul ignore next */
+    if (handler.get_keyboard_offset() !== 400) {
+        throw new Error("get_keyboard_offset returned incorrect value");
+    }
+
+    // Unregister callback
+    handler.off_offset_change(callback);
+    callback_offset = -1;
+
+    // Trigger another update with different height
+    mock_window.visualViewport.height = 300;
+    if (resize_handler) {
+        resize_handler();
+    }
+
+    /* istanbul ignore next */
+    if (callback_offset !== -1) {
+        throw new Error("Callback called after unregister");
+    }
+
+    // Test unregistering unknown callback
+    handler.off_offset_change(() => {});
+});
+
+run_test("scroll event", () => {
+    const mock_window = make_mock_window();
+    let scroll_handler;
+    mock_window.visualViewport.addEventListener = (event, fn) => {
+        if (event === "scroll") {
+            scroll_handler = fn;
+        }
+    };
+    set_global("window", mock_window);
+    set_global("document", make_mock_document(null));
+
+    handler.initialize_mobile_keyboard_handler();
+
+    if (scroll_handler) {
+        scroll_handler();
+    }
+});
+
+run_test("focus event", () => {
+    const mock_window = make_mock_window();
+    set_global("window", mock_window);
+
+    // No properties needed since getElement/contains are not reached
+    const compose_element = {};
+    const mock_document = make_mock_document(compose_element);
+    let focus_handler;
+    mock_document.addEventListener = (event, fn) => {
+        if (event === "focusin") {
+            focus_handler = fn;
+        }
+    };
+    set_global("document", mock_document);
+
+    handler.initialize_mobile_keyboard_handler();
+
+    if (focus_handler) {
+        focus_handler({target: {}}); // Invalid target not HTMLElement
+    }
+});
+
+run_test("focus event propagation", () => {
+    class MockHTMLElement {}
+    set_global("HTMLElement", MockHTMLElement);
+
+    const compose_element = new MockHTMLElement();
+    compose_element.contains = () => true;
+    compose_element.style = {setProperty() {}};
+
+    const mock_document = make_mock_document(compose_element);
+    let focus_handler;
+    mock_document.addEventListener = (event, fn) => {
+        if (event === "focusin") {
+            focus_handler = fn;
+        }
+    };
+    // Need querySelector to return compose_element
+    mock_document.querySelector = () => compose_element;
+
+    set_global("document", mock_document);
+    set_global("window", make_mock_window());
+
+    // Mock setTimeout
+    set_global("setTimeout", (fn) => fn());
+
+    handler.initialize_mobile_keyboard_handler();
+
+    if (focus_handler) {
+        const target = new MockHTMLElement();
+        focus_handler({target});
+    }
+});
+
+run_test("window resize fallback", () => {
+    const mock_window = make_mock_window();
+    let resize_handler;
+    mock_window.addEventListener = (event, fn) => {
+        if (event === "resize") {
+            resize_handler = fn;
+        }
+    };
+    set_global("window", mock_window);
+    set_global("document", make_mock_document(null));
+
+    handler.initialize_mobile_keyboard_handler();
+
+    if (resize_handler) {
+        resize_handler();
+    }
+});
+
+run_test("ResizeObserver fallback", () => {
+    let observe_cb;
+    set_global(
+        "ResizeObserver",
+        class ResizeObserver {
+            constructor(cb) {
+                observe_cb = cb;
+            }
+            observe() {}
+            disconnect() {}
+        },
+    );
+
+    set_global("window", make_mock_window());
+    set_global("document", make_mock_document(null));
+
+    handler.initialize_mobile_keyboard_handler();
+
+    if (observe_cb) {
+        observe_cb();
+    }
+});


### PR DESCRIPTION
## What does this PR do?

This PR fixes the mobile keyboard overlap issue where the compose box gets hidden behind the on-screen keyboard when users tap to type on mobile devices.

## Why a JavaScript solution?

CSS-only solutions were evaluated but found insufficient:

- **`dvh` units**: Work for initial layout but do not update dynamically when the keyboard opens/closes on iOS Safari.
- **`env(keyboard-inset-bottom)`**: Limited browser support; does not work reliably across iOS and Android.
- **`interactive-widget=resizes-content` meta tag**: Works on some Android browsers but causes issues on iOS and lacks universal support.

The `visualViewport` API provides the only reliable cross-platform method to detect keyboard height and adjust positioning dynamically.

## Why these specific changes?

The core problem was that on mobile browsers, the compose box (which uses `position: fixed; bottom: 0`) doesn't automatically stay above the keyboard. Different browsers handle this differently:

- **Android Chrome**: Generally resizes the viewport when keyboard opens, so the JavaScript solution using `visualViewport` API worked with minimal tweaking.
- **iOS Safari**: This was much trickier. iOS Safari sometimes resizes the viewport, but other times it just *scrolls* the page instead. This inconsistent behavior meant the compose box would sometimes be above the keyboard and sometimes behind it. We had to use `document.documentElement.clientHeight` instead of `window.innerHeight` to get consistent calculations, and carefully subtract `viewport.offsetTop` to prevent the compose box from scrolling with the chat.

So this wasn't a single issue — it was multiple behaviors across platforms that all needed to be handled:
1. Keyboard detection using `visualViewport` API
2. Handling iOS's scroll-vs-resize inconsistency
3. Keeping compose pinned to visual viewport bottom on scroll
4. Preventing browser autofill popups on channel/topic inputs

## Screenshots

### Android

| Before | | After |
|:------:|:---:|:-----:|
| <img width="200" src="https://github.com/user-attachments/assets/042382b8-c958-4444-a504-10dfc54ddd35" /> <img width="200" src="https://github.com/user-attachments/assets/81da723b-0bb1-4b67-883f-2681c722391c" /> | ➔ | <img width="200" src="https://github.com/user-attachments/assets/0ddeb741-479a-4a2a-a1d0-b98fa6ad9ad1" /> |

### iOS (Tested on Xcode Simulator - iPhone 17 Pro Max)

| Before | | After |
|:------:|:---:|:-----:|
| <img width="200" src="https://github.com/user-attachments/assets/d7e30777-c7b4-4989-ad9c-5a59ad83afbb" /> <img width="200" src="https://github.com/user-attachments/assets/ac108f9e-9e1c-48c8-ab67-17ca5377db82" /> | ➔ | <img width="200" src="https://github.com/user-attachments/assets/ffa8300a-d9fd-4954-82a7-0a032e4621bd" /> |

### iPad (Tested on Xcode Simulator - iPad Pro 11-inch M5)

| After |
|:-----:|
| <img width="500" src="https://github.com/user-attachments/assets/90d96882-3b6e-4b1e-8883-1894081759fb" /> |

<details>
<summary><strong>Self-review checklist</strong></summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability  
  (variable names, code reuse, readability, etc.)
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
- [x] Communicated decisions, questions, and potential concerns.

### Design & implementation notes
- [x] Explained differences from previous plans (e.g., issue description).
- [x] Highlighted technical choices and bugs encountered.
- [x] Called out remaining decisions and concerns.

### Testing
- [x] Automated tests verify logic where appropriate.

### Commit discipline
- [x] Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

### Manual review completed
- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions, and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>

---

Fixes #36676