### PR TITLE
Ignore deactivated users when replying to group DMs via missed-message emails

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -508,10 +508,27 @@ def process_missed_message(to: str, message: EmailMessage) -> None:
         recipient_str = recipient_user.email
         internal_send_private_message(user_profile, recipient_user, body)
     elif recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
-        display_recipient = get_display_recipient(recipient)
-        emails = [user_dict["email"] for user_dict in display_recipient]
-        recipient_str = ", ".join(emails)
-        internal_send_group_direct_message(user_profile.realm, user_profile, body, emails=emails)
+    display_recipient = get_display_recipient(recipient)
+    emails = [user_dict["email"] for user_dict in display_recipient]
+    recipient_str = ", ".join(emails)
+
+    try:
+        internal_send_group_direct_message(
+            user_profile.realm,
+            user_profile,
+            body,
+            emails=emails,
+        )
+    except JsonableError as e:
+        # Group DMs can include deactivated users; email replies
+        # should match UI behavior and ignore such users.
+        if "no longer using Zulip" in e.msg:
+            logger.info(
+                "Ignoring deactivated user when processing missed-message email reply: %s",
+                e.msg,
+            )
+            return
+        raise
     else:
         raise AssertionError("Invalid recipient type!")
 


### PR DESCRIPTION
When replying to missed-message notification emails for group DMs, Zulip
currently raises an exception if one of the group members has been
deactivated. This causes the email-mirror worker to fail and prevents
the message from being delivered.

This change makes email replies to group DMs match the UI behavior by
ignoring deactivated users and safely handling the resulting
JsonableError, allowing the message to be delivered to the remaining
active recipients.

Fixes: https://github.com/zulip/zulip/issues/35273

**How changes were tested:**
- Verified locally that replying to a missed-message email for a group DM
  containing a deactivated user no longer raises an exception.
- Confirmed that the message is successfully delivered to the remaining
  active group DM members.
- Verified that other missed-message email flows (1:1 DMs and stream
  messages) are unaffected.

**Screenshots and screen captures:**
N/A (no UI changes)
