### PR TITLE
fix(email_mirror): swallow errors for deactivated users in group DM email replies

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -8,6 +8,7 @@ from re import Match
 from django.conf import settings
 from django.utils.translation import gettext as _
 from typing_extensions import override
+from zerver.lib.exceptions import JsonableError
 
 from zerver.actions.message_send import (
     check_send_message,
@@ -511,7 +512,16 @@ def process_missed_message(to: str, message: EmailMessage) -> None:
         display_recipient = get_display_recipient(recipient)
         emails = [user_dict["email"] for user_dict in display_recipient]
         recipient_str = ", ".join(emails)
-        internal_send_group_direct_message(user_profile.realm, user_profile, body, emails=emails)
+        try:
+            internal_send_group_direct_message(user_profile.realm, user_profile, body, emails=emails)
+        except JsonableError as e:
+            if "is no longer using Zulip" in str(e):
+                logger.warning(
+                    "Swallowed email-mirror group DM send error for missed message reply: %s",
+                    e,
+                )
+                return
+            raise
     else:
         raise AssertionError("Invalid recipient type!")
 

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -8,7 +8,6 @@ from re import Match
 from django.conf import settings
 from django.utils.translation import gettext as _
 from typing_extensions import override
-from zerver.lib.exceptions import JsonableError
 
 from zerver.actions.message_send import (
     check_send_message,

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1374,7 +1374,6 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         cordelia = self.example_user("cordelia")
         iago = self.example_user("iago")
         desdemona = self.example_user("desdemona")  # Will be deactivated
-    
         result = self.client_post("/json/messages", {
             "type": "private",
             "content": "original group DM message",
@@ -1399,12 +1398,12 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         incoming_valid_message["Reply-To"] = cordelia_profile.delivery_email
     
         # Assert the error is swallowed (no crash, warning logged)
-        with self.assertLogs(__name__, level="WARNING") as warn_log:
-            with self.assert_database_query_count(22):  # Matches existing test
-                process_message(incoming_valid_message)
+        with self.assertLogs(__name__, level="WARNING") as warn_log, \
+             self.assert_database_query_count(22):  # Matches existing test
+            process_message(incoming_valid_message)
     
         # Verify warning was logged for deactivated user
-        self.assertEqual(len(warn_log.output), 1)
+        self.assert_length(len(warn_log.output), 1)
         self.assertIn("Swallowed email-mirror group DM send error", warn_log.output[0])
         self.assertIn("is no longer using Zulip", warn_log.output[0])
     

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1369,41 +1369,42 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
     def test_missed_group_dm_reply_with_deactivated_user(self) -> None:
-        # Create group DM with 4 users
         self.login("hamlet")
         cordelia = self.example_user("cordelia")
         iago = self.example_user("iago")
-        desdemona = self.example_user("desdemona")  # Will be deactivated
+        desdemona = self.example_user("desdemona")
+
         result = self.client_post("/json/messages", {
             "type": "private",
             "content": "original group DM message",
             "to": orjson.dumps([cordelia.id, iago.id, desdemona.id]).decode(),
         })
         self.assert_json_success(result)
-        # Cordelia gets a missed message email
+
         cordelia_profile = self.example_user("cordelia")
         user_message = most_recent_usermessage(cordelia_profile)
         mm_address = create_missed_message_address(cordelia_profile, user_message.message)
-        # Deactivate Desdemona
+
         do_deactivate_user(desdemona, acting_user=None)
-        # Simulate Cordelia replying via missed message email
+
         incoming_valid_message = self.EmailMessage()
         incoming_valid_message.set_content("TestMissedGroupDirectMessageEmailMessages body")
         incoming_valid_message["Subject"] = "TestMissedGroupDirectMessageEmailMessages subject"
         incoming_valid_message["From"] = cordelia_profile.delivery_email
         incoming_valid_message["To"] = str(mm_address)
         incoming_valid_message["Reply-To"] = cordelia_profile.delivery_email
-        # Assert the error is swallowed (no crash, warning logged)
+
         with self.assertLogs(__name__, level="WARNING") as warn_log, \
-             self.assert_database_query_count(22):  # Matches existing test
+             self.assert_database_query_count(22):
             process_message(incoming_valid_message)
-        # Verify warning was logged for deactivated user
+
         self.assert_length(warn_log.output, 1)
         self.assertIn("Swallowed email-mirror group DM send error", warn_log.output[0])
         self.assertIn("is no longer using Zulip", warn_log.output[0])
-        # Verify no new message was created (error was swallowed)
+
         iago_profile = self.example_user("iago")
-        self.assertEqual(most_recent_message(iago_profile).content, "TestMissedGroupDirectMessageEmailMessages body")
+        self.assertEqual(most_recent_message(iago_profile).content, "original group DM message")
+
 
     def test_receive_missed_stream_message_email_messages(self) -> None:
         # build dummy messages for message notification email reply


### PR DESCRIPTION
When replying via missed-message emails to a group DM that includes a deactivated user,
the server raised an exception and crashed the email mirror worker.

This commit catches the JsonableError for "no longer using Zulip" users in
process_missed_message, logs a warning, and swallows the error to prevent failure.

Also adds a test to verify this behavior for group DMs with deactivated users.