### PR TITLE
portico: Remove links to the wrong docs.

### DIFF
--- a/templates/corporate/comparison_table_integrated.html
+++ b/templates/corporate/comparison_table_integrated.html
@@ -1349,11 +1349,7 @@
                 <td class="comparison-value-positive self-hosted-cell" data-title="{{ _('Supported') }}"><i class="icon icon-check"></i></td>
             </tr>
             <tr>
-                <td class="comparison-table-feature">
-                    <a href="https://zulip.readthedocs.io/en/latest/subsystems/logging.html">
-                        Detailed audit log of administrative actions
-                    </a>
-                </td>
+                <td class="comparison-table-feature">Detailed audit log of administrative actions</td>
                 <td class="comparison-value-negative cloud-cell"><i class="icon icon-x"></i></td>
                 <td class="comparison-value-negative cloud-cell"><i class="icon icon-x"></i></td>
                 <td class="comparison-value-positive cloud-cell"><i class="icon icon-check"></i></td>

--- a/templates/corporate/security.md
+++ b/templates/corporate/security.md
@@ -25,7 +25,7 @@ This page will walk you Zulip's security tools and practices:
 - Self-hosting facilitates HIPAA and FERPA compliance
 - [Message editing and deletion policies](/help/restrict-message-editing-and-deletion)
 - [Global and per-channel data retention policies](/help/message-retention-policy)
-- [Detailed audit log of administrative actions](https://zulip.readthedocs.io/en/stable/subsystems/logging.html#backend-logging)
+- Detailed audit log of administrative actions
 - [Complete data exports](/help/export-your-organization)
 - [Compliance exports](https://zulip.readthedocs.io/en/stable/production/export-and-import.html#compliance-exports)
 
@@ -191,10 +191,8 @@ security issues from being introduced in Zulip.
   [deleting](/help/restrict-message-editing-and-deletion) and
   [moving](/help/restrict-moving-messages) messages, and an audit history of
   these actions
-- Permanent long-term [audit
-  log](https://zulip.readthedocs.io/en/stable/subsystems/logging.html#backend-logging)
-  of important actions (e.g., changes to passwords, email addresses, and channel
-  subscriptions)
+- Permanent long-term audit log of important actions (e.g., changes to
+  passwords, email addresses, and channel subscriptions)
 
 ### Tightly controlled guest accounts for vendors, partners, and customers
 


### PR DESCRIPTION
These were links to a page about a different type of logging.

