### PR TITLE
test_slack_importer: Add more test for message attributes.

### DIFF
--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -1382,9 +1382,17 @@ class SlackImporter(ZulipTestCase):
 
         # Message conversion already tested in tests.test_slack_message_conversion
         self.assertEqual(zerver_message[0]["content"], "@**Jane**: hey!")
+        self.assertEqual(zerver_message[0]["has_attachment"], False)
+        self.assertEqual(zerver_message[0]["has_image"], False)
         self.assertEqual(zerver_message[0]["has_link"], False)
+
+        # Messages containing links should only have the has_link attribute set
+        # to true.
         self.assertEqual(zerver_message[2]["content"], "http://journals.plos.org/plosone/article")
+        self.assertEqual(zerver_message[2]["has_attachment"], False)
+        self.assertEqual(zerver_message[2]["has_image"], False)
         self.assertEqual(zerver_message[2]["has_link"], True)
+
         self.assertEqual(zerver_message[5]["has_link"], False)
         self.assertEqual(zerver_message[7]["has_link"], False)
 
@@ -1443,8 +1451,11 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(attachment[0]["is_web_public"], False)
         self.assertEqual(attachment[0]["content_type"], "image/png")
 
-        self.assertEqual(zerver_message[9]["has_image"], True)
+        # Messages with images should have the has_attachment, has_image,
+        # and has_link attributes set to true.
         self.assertEqual(zerver_message[9]["has_attachment"], True)
+        self.assertEqual(zerver_message[9]["has_image"], True)
+        self.assertEqual(zerver_message[9]["has_link"], True)
         self.assertTrue(zerver_message[9]["content"].startswith("Look!\n[Apple](/user_uploads/"))
 
     def test_channel_message_to_zerver_message_with_threads(self) -> None:


### PR DESCRIPTION
Existing tests aren't clearly checking whether a message has correct `has_*` attributes or not.

Fixes #10386.



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
