### PR TITLE
Support "dm" as a search alias for "Direct message"

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -284,6 +284,7 @@ function get_options_for_recipient_widget(): Option[] {
         is_direct_message: true,
         unique_id: compose_state.DIRECT_MESSAGE_ID,
         name: $t({defaultMessage: "Direct message"}),
+        aliases: [$t({defaultMessage: "DM"})],
     };
 
     if (!user_groups.is_setting_group_empty(realm.realm_direct_message_permission_group)) {

--- a/web/src/dropdown_widget.ts
+++ b/web/src/dropdown_widget.ts
@@ -39,6 +39,7 @@ export type Option = {
     delete_icon_label?: string;
     edit_icon_label?: string;
     manage_folder_icon_label?: string;
+    aliases?: string[];
 };
 
 export type DropdownWidgetOptions = {
@@ -365,7 +366,19 @@ export class DropdownWidget {
                         filter: {
                             $element: $search_input,
                             predicate(item, value) {
-                                return item.name.toLowerCase().includes(value);
+                                value = value.toLowerCase();
+
+                                if (item.name.toLowerCase().includes(value)) {
+                                    return true;
+                                }
+
+                                if (item.aliases && Array.isArray(item.aliases)) {
+                                    return item.aliases.some(
+                                        (alias) => alias.toLowerCase() === value,
+                                    );
+                                }
+
+                                return false;
                             },
                         },
                         $simplebar_container: $popper.find(".dropdown-list-wrapper"),


### PR DESCRIPTION
Fixed #36899.

This PR allows for treating "dm" case insensitive as a search

alias for the "Direct message" option in the compose channel picker.
Users often type "dm" thinking it would match direct messages, but the
picker previously didn’t recognize it. This change adds a "dm" alias to

the Direct message option and updates the dropdown filter to match

aliases in addition to the visible option name.
The main label “Direct message” remains fully translatable. “dm” is
treated as an English search keyword and is not translated.
How I tested:
Typed “dm” and “DM” in the compose channel picker and confirmed that “Direct message” is the matching option. - Verified that stream search behavior remains the same. - Dropdown works as expected: keyboard + mouse.