### PR TITLE
compose_typeahead: Use correct condition for visibility check.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -889,7 +889,7 @@ export function get_candidates(
         if (
             current_token.length === 3 &&
             !compose_ui.code_formatting_button_triggered &&
-            compose_ui.compose_textarea_typeahead === undefined
+            !compose_ui.compose_textarea_typeahead?.shown
         ) {
             return [];
         }


### PR DESCRIPTION
`compose_textarea_typeahead` is defined at initialization, so the previous check effectively skipped this `if` condition.

Fixed by checking for `shown` which is only defined when the typeahead is actually visible.

Checked that typeahead is visible when you insert code block via `ctrl + shift + c` and not when you are at the end of a complete code block.

discussion: [#issues > Pasting code/math block opens language picker typeahead.](https://chat.zulip.org/#narrow/channel/9-issues/topic/Pasting.20code.2Fmath.20block.20opens.20language.20picker.20typeahead.2E/with/2318635)
