### PR TITLE
modals: Show merge topics warning when moving messages to "general ch…

### DIFF
--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -838,13 +838,6 @@ export async function build_move_topic_to_stream_popover(
         }
 
         assert(new_topic_name !== undefined);
-        // Don't show warning for empty topic as the user is probably
-        // about to type a new topic name. Note that if topics are
-        // mandatory, then the submit button is disabled, which returns
-        // early above.
-        if (new_topic_name === "" || new_topic_name === "(no topic)") {
-            return false;
-        }
         let stream_id: number;
         if (stream_widget_value === undefined) {
             // Set stream_id to current_stream_id since the user is not


### PR DESCRIPTION
<!-- Describe your pull request here.-->
The merge topics warning was being skipped for empty topic names, but in channels where empty topics are allowed, "" is a valid topic (general chat) that can already exist, so I have implemented the necessary checks for the same.

Fixes: #36925

**How changes were tested:**

Via manual UI checks (Screenshots attached)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="628" height="537" alt="screenshot-2025-12-06_02-15-22" src="https://github.com/user-attachments/assets/1839516a-e28c-4e62-aa79-140ff053ee31" />

<img width="617" height="446" alt="screenshot-2025-12-06_02-15-39" src="https://github.com/user-attachments/assets/4a8e4218-1e75-4125-b59a-787dabdd949e" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
