### PR TITLE
muted_users: Introduce a "Hide" button for revealed messages.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -167,6 +167,11 @@ export function initialize(): void {
             return true;
         }
 
+        // Hide button for a revealed message sent by a muted user.
+        if ($target.closest(".rehide-muted-user-message").length > 0) {
+            return true;
+        }
+
         return false;
     }
 
@@ -263,6 +268,20 @@ export function initialize(): void {
         message_lists.current.view.reveal_hidden_message(message_id);
         e.stopPropagation();
         e.preventDefault();
+    });
+
+    $("#main_div").on("click", ".rehide-muted-user-message", (e) => {
+        const message_id = Number($(e.currentTarget).attr("data-message-id"));
+        assert(message_lists.current !== undefined);
+        const $row = message_lists.current.get_row(message_id);
+        const message = message_lists.current.get(rows.id($row));
+        assert(message !== undefined);
+        const message_container = message_lists.current.view.message_containers.get(message.id);
+        assert(message_container !== undefined);
+        assert(!message_container.is_hidden);
+        message_lists.current.view.hide_revealed_message(message_id);
+        e.preventDefault();
+        e.stopPropagation();
     });
 
     $("#main_div").on("click", "a.stream", function (this: HTMLAnchorElement, e) {

--- a/web/src/message_actions_popover.ts
+++ b/web/src/message_actions_popover.ts
@@ -199,24 +199,6 @@ export function initialize({
                 popover_menus.hide_current_popover_if_visible(instance);
             });
 
-            $popper.one("click", ".rehide_muted_user_message", (e) => {
-                const message_id = Number($(e.currentTarget).attr("data-message-id"));
-                assert(message_lists.current !== undefined);
-                const $row = message_lists.current.get_row(message_id);
-                const message = message_lists.current.get(rows.id($row));
-                assert(message !== undefined);
-                const message_container = message_lists.current.view.message_containers.get(
-                    message.id,
-                );
-                assert(message_container !== undefined);
-                if ($row && !message_container.is_hidden) {
-                    message_lists.current.view.hide_revealed_message(message_id);
-                }
-                e.preventDefault();
-                e.stopPropagation();
-                popover_menus.hide_current_popover_if_visible(instance);
-            });
-
             $popper.one("click", ".view_read_receipts", (e) => {
                 const message_id = Number($(e.currentTarget).attr("data-message-id"));
                 read_receipts.show_user_list(message_id);

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -9,6 +9,7 @@ import render_login_to_view_image_button from "../templates/login_to_view_image_
 import render_message_group from "../templates/message_group.hbs";
 import render_message_list from "../templates/message_list.hbs";
 import render_recipient_row from "../templates/recipient_row.hbs";
+import render_revealed_message_hide_button from "../templates/revealed_message_hide_button.hbs";
 import render_single_message from "../templates/single_message.hbs";
 
 import * as activity from "./activity.ts";
@@ -45,6 +46,7 @@ import * as timerender from "./timerender.ts";
 import type {TopicLink} from "./types.ts";
 import * as typing_data from "./typing_data.ts";
 import * as typing_events from "./typing_events.ts";
+import * as ui_util from "./ui_util.ts";
 import * as user_topics from "./user_topics.ts";
 import type {AllVisibilityPolicies} from "./user_topics.ts";
 import * as util from "./util.ts";
@@ -1705,6 +1707,29 @@ export class MessageListView {
             message_content_edited: false,
             is_revealed: true,
         });
+
+        const rendered_markdown = this._rows.get(message_id)!.find(".rendered_markdown")[0];
+        assert(rendered_markdown !== undefined);
+
+        // Me messages do not have a child element in `.rendered_markdown`,
+        // so we append the "Hide" button to the `.rendered_markdown` element.
+        const last_ele = rendered_markdown?.lastElementChild ?? rendered_markdown;
+        assert(last_ele instanceof Element);
+
+        // If the last element in the message row contains text, we add the hide button
+        // inline to the same element.
+        const should_display_inline = last_ele.nodeName === "P" || last_ele.nodeName === "SPAN";
+        const hide_button_fragment = ui_util.parse_html(
+            render_revealed_message_hide_button({
+                message_id,
+                is_inline_hide_button: should_display_inline,
+            }),
+        );
+        if (should_display_inline) {
+            last_ele.append(hide_button_fragment);
+        } else {
+            rendered_markdown.append(hide_button_fragment);
+        }
     }
 
     hide_revealed_message(message_id: number): void {

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -10,7 +10,6 @@ import {$t} from "./i18n.ts";
 import * as message_delete from "./message_delete.ts";
 import * as message_edit from "./message_edit.ts";
 import * as message_lists from "./message_lists.ts";
-import * as muted_users from "./muted_users.ts";
 import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
@@ -36,7 +35,6 @@ type ActionPopoverContext = {
     editability_menu_item: string | undefined;
     move_message_menu_item: string | undefined;
     view_source_menu_item: string | undefined;
-    should_display_hide_option: boolean;
     should_display_mark_as_unread: boolean;
     should_display_remind_me_option: boolean;
     should_display_collapse: boolean;
@@ -149,12 +147,7 @@ export function get_actions_popover_content_context(message_id: number): ActionP
     assert(message_lists.current !== undefined);
     const message = message_lists.current.get(message_id);
     assert(message !== undefined);
-    const message_container = message_lists.current.view.message_containers.get(message.id)!;
     const not_spectator = !page_params.is_spectator;
-    const should_display_hide_option =
-        muted_users.is_user_muted(message.sender_id) &&
-        !message_container.is_hidden &&
-        not_spectator;
     const is_content_editable = message_edit.is_content_editable(message);
     const can_move_message = message_edit.can_move_message(message);
 
@@ -256,7 +249,6 @@ export function get_actions_popover_content_context(message_id: number): ActionP
         should_display_collapse,
         should_display_uncollapse,
         should_display_add_reaction_option,
-        should_display_hide_option,
         conversation_time_url,
         should_display_delete_option,
         should_display_read_receipts_option,

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -251,6 +251,26 @@
         }
     }
 
+    /* Leading whitespaces are collapsed if they are at the start of a line.
+    This lets us conditionally add a space to the left of `.inline-hide-button`,
+    only when there is some preceding text on the same line before the button.
+    */
+    .inline-hide-button-space-wrapper {
+        margin-right: 0.2em;
+    }
+
+    .rehide-muted-user-message {
+        &.inline-hide-button {
+            display: inline-flex;
+        }
+
+        &.block-hide-button {
+            display: flex;
+            margin-bottom: var(--markdown-interelement-space-px);
+        }
+        align-items: center;
+    }
+
     .message_reactions {
         grid-area: reactions;
         display: flex;

--- a/web/templates/popovers/message_actions_popover.hbs
+++ b/web/templates/popovers/message_actions_popover.hbs
@@ -67,7 +67,7 @@
         </li>
         {{/if}}
         {{!-- Group 4 --}}
-        {{#if (or should_display_mark_as_unread should_display_remind_me_option should_display_hide_option should_display_collapse should_display_uncollapse)}}
+        {{#if (or should_display_mark_as_unread should_display_remind_me_option should_display_collapse should_display_uncollapse)}}
         <li role="separator" class="popover-menu-separator"></li>
         {{/if}}
         {{#if should_display_mark_as_unread}}
@@ -84,14 +84,6 @@
             <a role="menuitem" data-message-id="{{message_id}}" class="message-reminder popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-alarm-clock" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Remind me about this" }}</span>
-            </a>
-        </li>
-        {{/if}}
-        {{#if should_display_hide_option}}
-        <li role="none" class="link-item popover-menu-list-item">
-            <a role="menuitem" data-message-id="{{message_id}}" class="rehide_muted_user_message popover-menu-link" tabindex="0">
-                <i class="popover-menu-icon zulip-icon zulip-icon-hide" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Hide muted message again" }}</span>
             </a>
         </li>
         {{/if}}

--- a/web/templates/revealed_message_hide_button.hbs
+++ b/web/templates/revealed_message_hide_button.hbs
@@ -1,0 +1,7 @@
+{{#if is_inline_hide_button}}
+    <span class="inline-hide-button-space-wrapper"> </span>
+{{/if}}
+<button data-message-id="{{message_id}}" class="action-button rehide-muted-user-message {{#if is_inline_hide_button}}inline-hide-button{{else}}block-hide-button{{/if}}" tabindex="0" aria-label="{{t 'Hide message from muted user' }}">
+    <i class="zulip-icon zulip-icon-hide"></i>
+    <span class="action-button-label">{{t 'Hide'}}</span>
+</button>

--- a/web/tests/i18n.test.cjs
+++ b/web/tests/i18n.test.cjs
@@ -65,7 +65,6 @@ run_test("t_tag", ({mock_template}) => {
         message_id: "99",
         should_display_quote_message: true,
         editability_menu_item: true,
-        should_display_hide_option: true,
         conversation_time_url:
             "http://zulip.zulipdev.com/#narrow/channel/101-devel/topic/testing/near/99",
     };

--- a/web/tests/popover_menus_data.test.cjs
+++ b/web/tests/popover_menus_data.test.cjs
@@ -225,7 +225,6 @@ test("my_message_all_actions", ({override}) => {
     assert.equal(response.should_display_collapse, true);
     assert.equal(response.should_display_uncollapse, false);
     assert.equal(response.should_display_add_reaction_option, true);
-    assert.equal(response.should_display_hide_option, false);
     assert.equal(response.conversation_time_url, "conversation_and_time_url");
     assert.equal(response.should_display_delete_option, true);
     assert.equal(response.should_display_read_receipts_option, true);


### PR DESCRIPTION
We get rid of the message action popover menu
item and instead switch to a "Hide" button
to hide a revealed message sent by a muted user.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
[#design > Hide button on revealing messages sent by muted users.](https://chat.zulip.org/#narrow/channel/101-design/topic/Hide.20button.20on.20revealing.20messages.20sent.20by.20muted.20users.2E/with/2319195)

First follow-up item of #34794.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


<details>
<summary>Screenshots</summary>
<img width="1156" height="109" alt="image" src="https://github.com/user-attachments/assets/dbfa2a0d-add1-49a9-9142-1e0a26d9157a" />
<img width="1038" height="766" alt="image" src="https://github.com/user-attachments/assets/24ef04a0-91db-4108-8780-ddce72155898" />
<img width="1031" height="320" alt="image" src="https://github.com/user-attachments/assets/32ba4c1e-de10-407a-a140-d4597440d28e" />
<img width="1049" height="236" alt="image" src="https://github.com/user-attachments/assets/5b7168c3-018e-4013-bd04-975e7d60bd9e" />
<img width="1026" height="206" alt="image" src="https://github.com/user-attachments/assets/f62cf6ea-88ac-4e4c-bbc8-f3147d29ba4b" />

(The third message here is a math block)
<img width="1027" height="592" alt="image" src="https://github.com/user-attachments/assets/dd59958f-2a2c-4388-a464-a683c400b9d4" />
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
