### PR TITLE
digest: Inline CSS for developer preview.

### DIFF
--- a/zerver/views/digest.py
+++ b/zerver/views/digest.py
@@ -1,21 +1,23 @@
-import time
-from datetime import timedelta
-
-from django.conf import settings
+import css_inline
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import render
-from django.utils.timezone import now as timezone_now
+from django.template.loader import render_to_string
 
 from zerver.decorator import zulip_login_required
 from zerver.lib.digest import DIGEST_CUTOFF, get_digest_context
+from zerver.models import UserProfile
 
 
 @zulip_login_required
 def digest_page(request: HttpRequest) -> HttpResponse:
-    user_profile = request.user
-    assert user_profile.is_authenticated
-    cutoff = time.mktime((timezone_now() - timedelta(days=DIGEST_CUTOFF)).timetuple())
+    user = request.user
+    assert isinstance(user, UserProfile)
 
-    context = get_digest_context(user_profile, cutoff)
-    context.update(physical_address=settings.PHYSICAL_ADDRESS)
-    return render(request, "zerver/digest_base.html", context=context)
+    cutoff = DIGEST_CUTOFF
+
+    context = get_digest_context(user, cutoff)
+
+    raw_html = render_to_string("zerver/emails/digest.html", context, request=request)
+
+    inlined_html = css_inline.inline(raw_html)
+
+    return HttpResponse(inlined_html)


### PR DESCRIPTION
Fixes #36800.

I noticed `sarafarajnasardi` was assigned to this recently. However, I had already implemented and verified the fix locally before seeing the assignment, so I am submitting my patch for review to avoid wasted effort.

**Changes:**
* Imported `css_inline` in `zerver/views/digest.py`.
* Updated `digest_page` to render the template to a string and apply `css_inline.inline()`.
* **Verification:** Verified locally that the `/digest` endpoint now renders HTML with inline `style="..."` attributes.

**Screenshots:**
<img width="1332" height="634" alt="Screenshot (4176)" src="https://github.com/user-attachments/assets/90abe1d1-6b64-4096-81e3-263d40ad1a7a" />
