### PR TITLE
digest: Fix CSS inlining in developer preview.

### DIFF
--- a/templates/zerver/digest_base.html
+++ b/templates/zerver/digest_base.html
@@ -15,7 +15,7 @@
                 <h1> Zulip digest </h1>
             </div>
             <div class="digest-email-html">
-                {% include 'zerver/emails/digest.html' %}
+                {{ inlined_digest_content|safe }}
                 <img id="digest-footer" src="{{ static('images/emails/footer.png') }}"/>
             </div>
             <br />

--- a/zerver/views/digest.py
+++ b/zerver/views/digest.py
@@ -3,11 +3,12 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import render
+from django.template.loader import render_to_string
 from django.utils.timezone import now as timezone_now
 
 from zerver.decorator import zulip_login_required
 from zerver.lib.digest import DIGEST_CUTOFF, get_digest_context
+from zerver.lib.send_email import get_inliner_instance
 
 
 @zulip_login_required
@@ -18,4 +19,13 @@ def digest_page(request: HttpRequest) -> HttpResponse:
 
     context = get_digest_context(user_profile, cutoff)
     context.update(physical_address=settings.PHYSICAL_ADDRESS)
-    return render(request, "zerver/digest_base.html", context=context)
+
+    email_body_html = render_to_string("zerver/emails/digest.html", context, request=request)
+
+    inliner = get_inliner_instance()
+    inlined_body = inliner.inline(email_body_html)
+
+    context["inlined_digest_content"] = inlined_body
+    final_html = render_to_string("zerver/digest_base.html", context, request=request)
+
+    return HttpResponse(final_html)


### PR DESCRIPTION
digest: Fix CSS inlining in developer preview

Previously, the `/digest` developer tool rendered emails using standard CSS classes. This differed from production behavior, where the email system uses the `css_inline` library to convert these classes into inline styles for compatibility with email clients (like Gmail and Outlook).

This commit updates the `digest_page` view to use `zerver.lib.send_email.get_inliner_instance()`. This ensures the developer preview uses the exact same CSS inlining logic and configuration as the production email pipeline.

Fixes #36800

**How changes were tested:**

1. Navigated to `http://localhost:9991/digest/` in the development environment.
2. Verified the page renders correctly visually.
3. Used the browser's "Inspect Element" tool to verify that HTML tags (such as `<a>` and `<p>`) now contain inline `style="..."` attributes, matching the structure of actual sent emails.
<details>
<summary>Screenshots and screen captures:</summary>
Before
<img width="1920" height="1128" alt="Screenshot From 2025-12-06 15-33-16" src="https://github.com/user-attachments/assets/1a972931-e563-4b4a-91b8-456de31c4b90" />
After
<img width="1916" height="1128" alt="Screenshot From 2025-12-06 16-36-20" src="https://github.com/user-attachments/assets/db8a818b-aee7-41c2-b120-d3d20eca1ef3" />
</details>
<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>