### PR TITLE
Custom emoji upload corping feature

### DIFF
--- a/provision_output.log
+++ b/provision_output.log
@@ -1,0 +1,1 @@
++ sudo -- sh -c 'echo "$1" > "$2"' - bcf4c867-da6f-4bbf-970d-080b3c60390e /home/ak/.zulip-dev-uuid

--- a/web/src/upload_widget.ts
+++ b/web/src/upload_widget.ts
@@ -180,7 +180,7 @@ function set_up_uppy_widget(): void {
 
 function open_uppy_editor(
     file: File,
-    property_name: "realm_icon" | "realm_logo" | "user_avatar",
+    property_name: "realm_icon" | "realm_logo" | "user_avatar" | "custom_emoji",
     $file_input: JQuery<HTMLInputElement>,
     $upload_button: JQuery,
     upload_function: UploadFunction,
@@ -204,6 +204,7 @@ function open_uppy_editor(
                     cropperOptions: {...cropper_opts, aspectRatio: 8},
                 });
             } else {
+                // For user_avatar, realm_icon, and custom_emoji use 1:1 aspect ratio
                 uppy_widget.getPlugin("ImageEditor")!.setOptions({
                     cropperOptions: {...cropper_opts, aspectRatio: 1},
                 });
@@ -248,7 +249,7 @@ export function build_direct_upload_widget(
     $upload_button: JQuery,
     upload_function: UploadFunction,
     max_file_upload_size: number,
-    property_name: "realm_icon" | "realm_logo" | "user_avatar",
+    property_name: "realm_icon" | "realm_logo" | "user_avatar" | "custom_emoji",
 ): void {
     // default value of max uploaded file size
     function accept(): void {

--- a/web/tests/settings_emoji.test.cjs
+++ b/web/tests/settings_emoji.test.cjs
@@ -10,21 +10,23 @@ const upload_widget = mock_esm("../src/upload_widget");
 const settings_emoji = zrequire("settings_emoji");
 
 run_test("add_custom_emoji_post_render", () => {
-    let build_widget_stub = false;
-    upload_widget.build_widget = (
+    let build_direct_upload_widget_stub = false;
+    upload_widget.build_direct_upload_widget = (
         get_file_input,
-        file_name_field,
         input_error,
-        clear_button,
         upload_button,
+        upload_function,
+        max_file_size,
+        property_name,
     ) => {
         assert.deepEqual(get_file_input(), $("#emoji_file_input"));
-        assert.deepEqual(file_name_field, $("#emoji-file-name"));
         assert.deepEqual(input_error, $("#emoji_file_input_error"));
-        assert.deepEqual(clear_button, $("#emoji_image_clear_button"));
         assert.deepEqual(upload_button, $("#emoji_upload_button"));
-        build_widget_stub = true;
+        assert.equal(typeof upload_function, "function");
+        assert.equal(max_file_size, 5);
+        assert.equal(property_name, "custom_emoji");
+        build_direct_upload_widget_stub = true;
     };
     settings_emoji.add_custom_emoji_post_render();
-    assert.ok(build_widget_stub);
+    assert.ok(build_direct_upload_widget_stub);
 });


### PR DESCRIPTION
Fixes #36927

This adds image cropping functionality to the custom emoji upload flow,
similar to what already exists for avatar uploads.

Changes:
- Updated `upload_widget.ts` to support "custom_emoji" as a property type
- Modified `settings_emoji.ts` to use the direct upload widget with cropping
- After cropping, the emoji modal reopens with the cropped image preview

Users can now crop their emoji images to a 1:1 aspect ratio before uploading.

https://github.com/user-attachments/assets/8da0fbaf-3545-49fd-80bf-76de47472947

