### PR TITLE
topic_list: Add is:followed filter to left sidebar.

### DIFF
--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -184,6 +184,10 @@ IGNORED_PHRASES = [
     r"resolved",
     # Used in pills for unresolved topics.
     r"unresolved",
+    # Used in pills for followed topics.
+    r"followed",
+    # Used in pills for unfollowed topics.
+    r"unfollowed",
     # This is a reference to a setting/secret and should be lowercase.
     r"zulip_org_id",
     # These are custom time unit options for modal dropdowns

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -170,7 +170,11 @@ export function sort_groups(
         // term, or a muted topic matches the current topic, we include
         // the channel in the list of matches.
         const topics = topic_list_data.get_filtered_topic_names(current_channel_id, (topic_names) =>
-            topic_list_data.filter_topics_by_search_term(topic_names, search_term),
+            topic_list_data.filter_topics_by_search_term(
+                current_channel_id,
+                topic_names,
+                search_term,
+            ),
         );
         if (
             topics.some(

--- a/web/src/topic_filter_pill.ts
+++ b/web/src/topic_filter_pill.ts
@@ -8,6 +8,7 @@ export type TopicFilterPill = {
     type: "topic_filter";
     label: string;
     syntax: string;
+    match_prefix_required?: string;
 };
 
 export type TopicFilterPillWidget = InputPillContainer<TopicFilterPill>;
@@ -22,6 +23,17 @@ export const filter_options: TopicFilterPill[] = [
         type: "topic_filter",
         label: $t({defaultMessage: "resolved"}),
         syntax: "is:resolved",
+    },
+    {
+        type: "topic_filter",
+        label: $t({defaultMessage: "followed"}),
+        syntax: "is:followed",
+    },
+    {
+        type: "topic_filter",
+        label: $t({defaultMessage: "unfollowed"}),
+        syntax: "-is:followed",
+        match_prefix_required: "-is",
     },
 ];
 

--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -155,6 +155,7 @@ type TopicListInfo = {
 };
 
 export function filter_topics_by_search_term(
+    stream_id: number,
     topic_names: string[],
     search_term: string,
     topics_state = "",
@@ -172,10 +173,23 @@ export function filter_topics_by_search_term(
         word_separator_regex,
     );
 
-    if (topics_state === "is:resolved") {
-        topic_names = topic_names.filter((name) => resolved_topic.is_resolved(name));
-    } else if (topics_state === "-is:resolved") {
-        topic_names = topic_names.filter((name) => !resolved_topic.is_resolved(name));
+    switch (topics_state) {
+        case "is:resolved":
+            topic_names = topic_names.filter((name) => resolved_topic.is_resolved(name));
+            break;
+        case "-is:resolved":
+            topic_names = topic_names.filter((name) => !resolved_topic.is_resolved(name));
+            break;
+        case "is:followed":
+            topic_names = topic_names.filter((name) =>
+                user_topics.is_topic_followed(stream_id, name),
+            );
+            break;
+        case "-is:followed":
+            topic_names = topic_names.filter(
+                (name) => !user_topics.is_topic_followed(stream_id, name),
+            );
+            break;
     }
 
     return topic_names;


### PR DESCRIPTION
Add support for filtering topics by `is:followed`. The negative filter `-is:followed` is also supported as a first-class option but is hidden from the default typeahead suggestions to avoid clutter, appearing only when the user types `-`. Refactor `filter_topics_by_search_term` to require `stream_id` to check topic state, and update all callers and tests to pass the correct ID.

**Changes:**
- Added `is:followed` and `-is:followed` to `filter_options` in `web/src/topic_filter_pill.ts`.
- Updated `web/src/topic_list.ts` to filter the typeahead suggestions:
- Hide options that are already selected.
- Hide `-is:followed` unless the user explicitly starts typing`-`.
- Refactored `filter_topics_by_search_term` to use `stream_id` for accurate topic state lookups.
- Removed the check for `stream_has_locally_available_resolved_topics` so the filter input remains visible for these new filters.

Fixes part of #36878.

**How changes were tested:**

- Manually verified that `is:followed` appears as the 3rd option in the left sidebar filter typeahead.
- Manually verified that selecting `is:followed` correctly filters the topic list to show only followed topics.
- Manually verified that typing `-is:followed` (which is hidden from the dropdown initially) correctly appears when typing -, creates an "unfollowed" pill, and hides followed topics.
- Verified that the `is:resolved` filter option remains available in the dropdown even after selecting `is:followed`.
- Updated existing unit tests in `web/tests/topic_list_data.test.cjs` to match the new function signature.
- Added a new test case `filter_topics_is_followed` to verify the filtering logic programmatically.
- Ran `./tools/test-js-with-node` to confirm all tests pass.

**Screenshots:**
1. Shows `followed` option in typeahead Confirms that `is:followed` appears as the third suggestion when typing `is:` in the filter box.
<img width="250" height="350" alt="Screenshot 2025-12-06 at 9 43 49 PM" src="https://github.com/user-attachments/assets/adfb24f3-5b4e-4eb7-8fba-925ca25f99f5" />

2. Filtering by followed topics Shows that selecting the `followed` option creates a pill and correctly filters the topic list to show only topics the user follows.
<img width="250" height="350" alt="Screenshot 2025-12-06 at 9 45 03 PM" src="https://github.com/user-attachments/assets/18a722c1-bce7-49d4-915c-6246945cd2d8" />

3. When we type `-is:` it's showing `unfollowed` in the typeahead.
<img width="250" height="350" alt="image" src="https://github.com/user-attachments/assets/12c6d14c-9052-41fc-995b-8a03433cf130" />


4.Filtering by unfollowed topics Shows that the `unfollowed` pill is created and the list is correctly filtered to hide followed topics.
<img width="250" height="350" alt="image" src="https://github.com/user-attachments/assets/bd53a22e-cc18-46bd-955e-257a4d261a63" />

5. `is:resolved` filter option remains available in the dropdown even after selecting `is:followed`
<img width="324" height="239" alt="Screenshot 2025-12-11 at 8 40 30 AM" src="https://github.com/user-attachments/assets/f79829af-b2a0-440b-91da-62ef05638dd3" />




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
