### PR TITLE
settings: Allow cropping when uploading custom emoji.

### DIFF
--- a/web/src/upload_widget.ts
+++ b/web/src/upload_widget.ts
@@ -178,9 +178,9 @@ function set_up_uppy_widget(): void {
     });
 }
 
-function open_uppy_editor(
+export function open_uppy_editor(
     file: File,
-    property_name: "realm_icon" | "realm_logo" | "user_avatar",
+    property_name: "realm_icon" | "realm_logo" | "user_avatar" | "custom_emoji",
     $file_input: JQuery<HTMLInputElement>,
     $upload_button: JQuery,
     upload_function: UploadFunction,
@@ -195,7 +195,8 @@ function open_uppy_editor(
             assert(uppy_widget !== undefined);
             uppy_widget.getPlugin<ImageEditor<Meta, Body>>("ImageEditor")!.save();
         },
-        post_render() {
+        post_render() {},
+        on_shown() {
             set_up_uppy_widget();
             assert(uppy_widget !== undefined);
 


### PR DESCRIPTION
This PR updates the "Add Custom Emoji" flow to allow users to crop images before uploading, ensuring emojis are square and properly centered.

Instead of introducing a new library, this implementation reuses the existing shared upload_widget (which uses Uppy internally). This ensures the UI is consistent with the User Avatar and Organization Logo uploaders and inherits existing features like Dark Mode support automatically.

Technical Implementation:

web/src/upload_widget.ts: Updated open_uppy_editor to use the on_shown event instead of post_render. This fixes a race condition where the cropper grid would appear "squashed" because it tried to render while the modal was still animating.

web/src/settings_emoji.ts: Modified the file input listener to intercept the upload. It now launches the Uppy modal, waits for the crop to finish, and then re-opens the "Add Custom Emoji" modal with the state (name and cropped image) fully restored.

Fixes: #36927 How changes were tested: I manually tested the end-to-end flow on a local development server:

Happy Path: Uploaded a large rectangular image, cropped it to a square, and confirmed the "Add Emoji" modal re-opened with the correct preview. Successfully uploaded and verified the emoji in the table.

Cancellation: Verified that clicking "Cancel" in the cropper returns the user to the initial state without breaking the UI.

Visuals: Verified that the cropping grid renders correctly immediately upon opening (fixed the size glitch).

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/228b75bb-521f-4ddb-92e7-368735f0c60e

<details>
<summary>Self-review checklist</summary>

- [ x ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ x ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ x ] Visual appearance of the changes.
- [ x ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ x ] End-to-end functionality of buttons, interactions and flows.
- [ x ] Corner cases, error conditions, and easily imagined bugs.
</details>
