### PR TITLE
Improve clarity for newcomers in how-we-communicate documentation

### DIFF
--- a/docs/contributing/how-we-communicate.md
+++ b/docs/contributing/how-we-communicate.md
@@ -1,8 +1,8 @@
 # How we communicate
 
-The primary communication forum for the Zulip community is the Zulip server
-hosted at [chat.zulip.org](https://chat.zulip.org/). If you are not familiar
-with it, start by reading the [Zulip development community
+The primary communication forum for the Zulip community is the Zulip server hosted at [chat.zulip.org](https://chat.zulip.org/).  
+If you're new here, this is the best place to ask questions and interact with the community.
+If you are not familiar with it, start by reading the [Zulip development community
 guide](https://zulip.com/development-community/). The guidelines here also apply
 to how we communicate on GitHub issues and pull requests, but other pages in
 this section go into greater detail about expectations that are specific to pull


### PR DESCRIPTION
This PR improves the clarity of the introduction in `how-we-communicate.md`.

I added a short sentence explaining that newcomers can use chat.zulip.org to ask questions and interact with the community.

This makes the documentation more welcoming and easier to understand.
