### PR TITLE
direct_message_group: Add assertion to ensure unique user IDs.

### DIFF
--- a/zerver/models/recipients.py
+++ b/zerver/models/recipients.py
@@ -153,6 +153,7 @@ def get_or_create_direct_message_group(id_list: list[int]) -> DirectMessageGroup
     """
     from zerver.models import Subscription, UserProfile
 
+    assert len(id_list) == len(set(id_list))
     direct_message_group_hash = get_direct_message_group_hash(id_list)
     with transaction.atomic(savepoint=False):
         (direct_message_group, created) = DirectMessageGroup.objects.get_or_create(


### PR DESCRIPTION
Addresses: https://github.com/zulip/zulip/pull/35769#discussion_r2561092919

This is an extra check to ensure that duplicate users aren’t passed to the `get_or_create_direct_message_group` function. However, the function is primarily used [here](https://github.com/mreza-kiani/zulip/blob/f2caebe35338f7aaef99eae36f3c9b847b631bcb/zerver/lib/recipient_users.py#L78-L86), where `user_ids` is taken from dictionary keys, so we know they’re already unique.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
