### PR TITLE
webhooks: Return message ID from check_send_webhook_message.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -2485,7 +2485,7 @@ class WebhookTestCase(ZulipTestCase):
             if all_event_types is None:
                 return  # nocoverage
 
-            def side_effect(*args: Any, **kwargs: Any) -> None:
+            def side_effect(*args: Any, **kwargs: Any) -> int | None:
                 complete_event_type = (
                     kwargs.get("complete_event_type")
                     if len(args) < 5
@@ -2505,7 +2505,7 @@ self-documenting the supported event types for this integration.
 You can fix this by adding "{complete_event_type}" to ALL_EVENT_TYPES for this webhook.
 """.strip()
                     )
-                check_send_webhook_message(*args, **kwargs)
+                return check_send_webhook_message(*args, **kwargs)
 
             self.patch = mock.patch(
                 f"zerver.webhooks.{self.WEBHOOK_DIR_NAME}.view.check_send_webhook_message",

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -150,7 +150,7 @@ def check_send_webhook_message(
     exclude_events: Json[list[str]] | None = None,
     unquote_url_parameters: bool = False,
     no_previews: bool = False,
-) -> None:
+) -> int | None:
     if complete_event_type is not None and (
         # Here, we implement Zulip's generic support for filtering
         # events sent by the third-party service.
@@ -171,13 +171,13 @@ def check_send_webhook_message(
             and any(fnmatch.fnmatch(complete_event_type, pattern) for pattern in exclude_events)
         )
     ):
-        return
+        return None
 
     client = RequestNotes.get_notes(request).client
     assert client is not None
     if stream is None:
         assert user_profile.bot_owner is not None
-        check_send_private_message(
+        return check_send_private_message(
             user_profile, client, user_profile.bot_owner, body, no_previews=no_previews
         )
     else:
@@ -195,11 +195,11 @@ def check_send_webhook_message(
 
         try:
             if stream.isdecimal():
-                check_send_stream_message_by_id(
+                return check_send_stream_message_by_id(
                     user_profile, client, int(stream), topic, body, no_previews=no_previews
                 )
             else:
-                check_send_stream_message(
+                return check_send_stream_message(
                     user_profile, client, stream, topic, body, no_previews=no_previews
                 )
         except StreamDoesNotExistError:
@@ -207,7 +207,7 @@ def check_send_webhook_message(
             # notifying that the webhook bot just tried to send a message to a
             # non-existent stream, so we don't need to re-raise it since it
             # clutters up webhook-errors.log
-            pass
+            return None
 
 
 def standardize_headers(input_headers: None | dict[str, Any]) -> dict[str, str]:


### PR DESCRIPTION
Allow webhook integrations to do follow-up actions on the message they just sent such as auto-resolving topics.

<!-- Describe your pull request here.-->

`check_send_webhook_message()` now returns message ID. This allows webhook integrations to perform actions on the messages they just created. The intended use is for #34075 to auto resolve topics through `check_update_message`.

Previously, `check_send_webhook_message()` returned `None`. It now returns `int | None`. This returns the id when a message is successfully sent, and `None` when no message is sent. 

The next step would be to implement a helper to use the message id to update the message and auto resolve the topic. 

Fixes: part of #34075.

**How changes were tested:**

Test case `test_check_send_webhook_message_returns_id(self)` in `zerver/tests/test_webhooks_common.py` that verifies message Id is returned and message was created. 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

N/a

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
