### PR TITLE
message_list_data: Rename `all_messages` function.

### DIFF
--- a/web/src/message_list.ts
+++ b/web/src/message_list.ts
@@ -624,7 +624,7 @@ export class MessageList {
     }
 
     all_messages(): Message[] {
-        return this.data.all_messages();
+        return this.data.all_messages_after_mute_filtering();
     }
 
     first_unread_message_id(): number | undefined {

--- a/web/src/message_list_data.ts
+++ b/web/src/message_list_data.ts
@@ -82,7 +82,7 @@ export class MessageListData {
         this.add_messages_callback = callback;
     }
 
-    all_messages(): Message[] {
+    all_messages_after_mute_filtering(): Message[] {
         return this._items;
     }
 

--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -35,7 +35,7 @@ export function get_count_of_messages_in_topic_sent_after_current_message(
 
 export function get_loaded_messages_in_topic(stream_id: number, topic: string): Message[] {
     return all_messages_data
-        .all_messages()
+        .all_messages_after_mute_filtering()
         .filter(
             (x) =>
                 x.type === "stream" &&
@@ -46,13 +46,13 @@ export function get_loaded_messages_in_topic(stream_id: number, topic: string): 
 
 export function get_messages_in_dm_conversations(user_ids_strings: Set<string>): Message[] {
     return all_messages_data
-        .all_messages()
+        .all_messages_after_mute_filtering()
         .filter((x) => x.type === "private" && user_ids_strings.has(x.to_user_ids));
 }
 
 export function get_max_message_id_in_stream(stream_id: number): number {
     let max_message_id = 0;
-    for (const msg of all_messages_data.all_messages()) {
+    for (const msg of all_messages_data.all_messages_after_mute_filtering()) {
         if (msg.type === "stream" && msg.stream_id === stream_id && msg.id > max_message_id) {
             max_message_id = msg.id;
         }

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1023,7 +1023,7 @@ function load_local_messages(msg_data: MessageListData, superset_data: MessageLi
     // cases when our local cache (superset_data) has at least
     // one message the user will expect to see in the new narrow.
 
-    const in_msgs = superset_data.all_messages();
+    const in_msgs = superset_data.all_messages_after_mute_filtering();
     const is_contiguous_history = true;
     msg_data.add_messages(in_msgs, is_contiguous_history);
 

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -302,7 +302,7 @@ async function get_message_placement_in_conversation(
         // we can find the adjacent messages in the current view
         // through which we can determine if the message is an
         // intermediate message or not.
-        const msg_list = message_lists.current.data.all_messages();
+        const msg_list = message_lists.current.data.all_messages_after_mute_filtering();
         let found_newer_matching_message = false;
         let found_older_matching_message = false;
         const current_dict = {

--- a/web/src/unread_ui.ts
+++ b/web/src/unread_ui.ts
@@ -118,7 +118,7 @@ export function initialize({
         // the present view as read; we need a server API to mark
         // every message matching the current search as read.
         const unread_messages = message_lists.current.data
-            .all_messages()
+            .all_messages_after_mute_filtering()
             .filter((message) => message.unread);
         notify_server_messages_read(unread_messages);
         // New messages received may be marked as read based on narrow type.

--- a/web/tests/message_list_data.test.cjs
+++ b/web/tests/message_list_data.test.cjs
@@ -25,7 +25,7 @@ function make_msgs(msg_ids) {
 }
 
 function assert_contents(mld, msg_ids) {
-    const msgs = mld.all_messages();
+    const msgs = mld.all_messages_after_mute_filtering();
     assert.deepEqual(msgs, make_msgs(msg_ids));
 }
 
@@ -120,7 +120,7 @@ run_test("basics", () => {
     mld.change_message_id(125.01, 145);
     assert_contents(mld, [120, 130, 140, 145]);
 
-    for (const msg of mld.all_messages()) {
+    for (const msg of mld.all_messages_after_mute_filtering()) {
         msg.unread = false;
     }
 

--- a/web/tests/narrow_local.test.cjs
+++ b/web/tests/narrow_local.test.cjs
@@ -50,7 +50,7 @@ function verify_fixture(fixture, override_rewire) {
             has_found_newest: () => fixture.has_found_newest,
         },
         visibly_empty: () => fixture.visibly_empty,
-        all_messages() {
+        all_messages_after_mute_filtering() {
             assert.notEqual(fixture.all_messages, undefined);
             return fixture.all_messages;
         },
@@ -74,7 +74,7 @@ function verify_fixture(fixture, override_rewire) {
 
     assert.deepEqual(id_info, fixture.expected_id_info);
 
-    const msgs = msg_data.all_messages();
+    const msgs = msg_data.all_messages_after_mute_filtering();
     const msg_ids = msgs.map((message) => message.id);
     assert.deepEqual(msg_ids, fixture.expected_msg_ids);
 }

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -1050,7 +1050,7 @@ test("test_delete_messages", ({override}) => {
 
     // messages[0] was removed.
     let reduced_msgs = messages.slice(1);
-    override(all_messages_data, "all_messages", () => reduced_msgs);
+    override(all_messages_data, "all_messages_after_mute_filtering", () => reduced_msgs);
 
     let all_topics = rt_data.get_conversations();
     assert.equal(
@@ -1081,7 +1081,7 @@ test("test_delete_messages", ({override}) => {
 });
 
 test("test_topic_edit", ({override}) => {
-    override(all_messages_data, "all_messages", () => messages);
+    override(all_messages_data, "all_messages_after_mute_filtering", () => messages);
     recent_view_util.set_visible(false);
 
     // NOTE: This test should always run in the end as it modified the messages data.


### PR DESCRIPTION
Renames `all_messages` function in `MessageListData` to `all_messages_after_mute_filtering` to make it clear that the function returns non-muted messages.

Preparatory commit extracted from #35838.