### PR TITLE
portico: Add Zulip Cloud landing page to top nav.

### DIFF
--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -25,6 +25,7 @@
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/why-zulip/">Why Zulip</a></li>
                             <li class="top-menu-submenu-list-item"><a href="{{ 'https://chat.zulip.org' if not development_environment}}/?show_try_zulip_modal">Try Zulip</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/help/moving-to-zulip">Moving to Zulip</a></li>
+                            <li class="top-menu-submenu-list-item"><a href="https://zulip.com/zulip-cloud/">Zulip Cloud</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/self-hosting/">Self-hosting</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/security/">Security</a></li>
                         </ul>


### PR DESCRIPTION
It's already in the footer.

<img width="712" height="301" alt="Screenshot 2025-12-09 at 14 49 24" src="https://github.com/user-attachments/assets/59dbb0d6-63dd-42c9-9642-bd754cfdc699" />
