### PR TITLE
user_profile: Handle and update widgets only when the tab is open

### DIFF
--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -127,14 +127,12 @@
                                 </div>
                             </div>
                         </div>
-                        {{#if show_user_subscribe_widget}}
-                            <div class="stream-list-bottom-section">
-                                <div class="header-section">
-                                    <h3 class="stream-tab-element-header">{{t 'Subscribe {full_name} to channels'}}</h3>
-                                </div>
-                                {{> user_profile_subscribe_widget}}
+                        <div class="stream-list-bottom-section">
+                            <div class="header-section">
+                                <h3 class="stream-tab-element-header">{{t 'Subscribe {full_name} to channels'}}</h3>
                             </div>
-                        {{/if}}
+                            {{> user_profile_subscribe_widget}}
+                        </div>
                     </div>
 
                     <div class="tabcontent" id="user-profile-groups-tab">


### PR DESCRIPTION
Fixes issue described here: [#frontend > user profile modal: user_unsub_streams.length &gt; 0 @ 💬](https://chat.zulip.org/#narrow/channel/6-frontend/topic/user.20profile.20modal.3A.20user_unsub_streams.2Elength.20.3E.200/near/2320692)

More details in commit messages.

I tested with an admin account, regular account without group access, and Coredlia (who can manage the hamlet group).