### PR TITLE
Gitlab repos ignore

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -695,8 +695,10 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
             )
         ],
         display_name="GitLab",
-        url_options=[WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES),
-                     WebhookUrlOption.build_preset_config(PresetUrlOption.IGNORE_PRIVATE_REPOSITORIES),],
+        url_options=[
+            WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES),
+            WebhookUrlOption.build_preset_config(PresetUrlOption.IGNORE_PRIVATE_REPOSITORIES),
+        ],
     ),
     IncomingWebhookIntegration(
         "gocd",

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -695,7 +695,8 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
             )
         ],
         display_name="GitLab",
-        url_options=[WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES)],
+        url_options=[WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES),
+                     WebhookUrlOption.build_preset_config(PresetUrlOption.IGNORE_PRIVATE_REPOSITORIES),],
     ),
     IncomingWebhookIntegration(
         "gocd",

--- a/zerver/webhooks/gitlab/fixtures/push_private_repo.json
+++ b/zerver/webhooks/gitlab/fixtures/push_private_repo.json
@@ -1,0 +1,42 @@
+{
+   "object_kind": "push",
+   "event_name": "push",
+   "before": "5fcdd5551fc3085df79bece2c32b1400802ac407",
+   "after": "eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9",
+   "ref": "refs/heads/tomek",
+   "checkout_sha": "eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9",
+   "message": null,
+   "user_id": 670043,
+   "user_name": "Tomasz Kolek",
+   "user_email": "tomaszkolek0@gmail.com",
+   "user_avatar": "https://secure.gravatar.com/avatar/116a6fdbcfd00466297a39174da11fbb?s=80&d=identicon",
+   "project_id": 1534233,
+   "project": {
+      "name": "my-awesome-project",
+      "description": "",
+      "web_url": "https://gitlab.com/tomaszkolek0/my-awesome-project",
+      "visibility": "private",
+      "public": false,
+      "path_with_namespace": "tomaszkolek0/my-awesome-project",
+      "default_branch": "master"
+   },
+   "commits": [
+      {
+         "id": "eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9",
+         "message": "b\n",
+         "timestamp": "2016-08-17T21:17:54+02:00",
+         "url": "https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9",
+         "author": {
+            "name": "Tomasz Kolek",
+            "email": "tomasz-kolek@o2.pl"
+         }
+      }
+   ],
+   "total_commits_count": 1,
+   "repository": {
+      "name": "my-awesome-project",
+      "homepage": "https://gitlab.com/tomaszkolek0/my-awesome-project",
+      "visibility_level": 0,
+      "public": false
+   }
+}

--- a/zerver/webhooks/gitlab/fixtures/push_public_repo.json
+++ b/zerver/webhooks/gitlab/fixtures/push_public_repo.json
@@ -1,0 +1,42 @@
+{
+   "object_kind": "push",
+   "event_name": "push",
+   "before": "5fcdd5551fc3085df79bece2c32b1400802ac407",
+   "after": "eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9",
+   "ref": "refs/heads/tomek",
+   "checkout_sha": "eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9",
+   "message": null,
+   "user_id": 670043,
+   "user_name": "Tomasz Kolek",
+   "user_email": "tomaszkolek0@gmail.com",
+   "user_avatar": "https://secure.gravatar.com/avatar/116a6fdbcfd00466297a39174da11fbb?s=80&d=identicon",
+   "project_id": 1534233,
+   "project": {
+      "name": "my-awesome-project",
+      "description": "",
+      "web_url": "https://gitlab.com/tomaszkolek0/my-awesome-project",
+      "visibility": "public",
+      "public": true,
+      "path_with_namespace": "tomaszkolek0/my-awesome-project",
+      "default_branch": "master"
+   },
+   "commits": [
+      {
+         "id": "eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9",
+         "message": "b\n",
+         "timestamp": "2016-08-17T21:17:54+02:00",
+         "url": "https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9",
+         "author": {
+            "name": "Tomasz Kolek",
+            "email": "tomasz-kolek@o2.pl"
+         }
+      }
+   ],
+   "total_commits_count": 1,
+   "repository": {
+      "name": "my-awesome-project",
+      "homepage": "https://gitlab.com/tomaszkolek0/my-awesome-project",
+      "visibility_level": 20,
+      "public": true
+   }
+}

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 from zerver.lib.webhooks.git import COMMITS_LIMIT
+from zerver.models import Message
 
 
 class GitlabHookTests(WebhookTestCase):
@@ -64,6 +65,70 @@ class GitlabHookTests(WebhookTestCase):
         self.check_webhook(
             "push_hook__push_commits_more_than_limit", expected_topic_name, expected_message
         )
+
+    def test_private_repo_ignored_when_option_enabled(self) -> None:
+        """
+        Events from private repositories are ignored when
+        ignore_private_repositories=true is present in the URL.
+        """
+        self.url = self.build_webhook_url(ignore_private_repositories="true")
+        initial_count = Message.objects.count()
+        body = self.get_body("push_private_repo")
+        result = self.client_post(
+            self.url,
+            body,
+            content_type="application/json",
+            HTTP_X_GITLAB_EVENT="Push Hook",
+        )
+
+        self.assert_json_success(result)
+
+        final_count = Message.objects.count()
+        self.assertEqual(initial_count, final_count)
+
+    def test_private_repo_sends_when_option_disabled(self) -> None:
+        """
+        When ignore_private_repositories is not present, events from
+        private repositories should still be delivered (backwards compatibility).
+        """
+        self.url = self.build_webhook_url()
+
+        initial_count = Message.objects.count()
+
+        body = self.get_body("push_private_repo")
+        result = self.client_post(
+            self.url,
+            body,
+            content_type="application/json",
+            HTTP_X_GITLAB_EVENT="Push Hook",
+        )
+
+        self.assert_json_success(result)
+
+        final_count = Message.objects.count()
+        self.assertEqual(final_count, initial_count + 1)
+
+    def test_public_repo_sends_even_when_ignoring_private(self) -> None:
+        """
+        When ignore_private_repositories=true is used,
+        events from PUBLIC repositories must still be delivered.
+        """
+        self.url = self.build_webhook_url(ignore_private_repositories="true")
+
+        initial_count = Message.objects.count()
+
+        body = self.get_body("push_public_repo")
+        result = self.client_post(
+            self.url,
+            body,
+            content_type="application/json",
+            HTTP_X_GITLAB_EVENT="Push Hook",
+        )
+
+        self.assert_json_success(result)
+
+        final_count = Message.objects.count()
+        self.assertEqual(final_count, initial_count + 1)
 
     def test_remove_branch_event_message(self) -> None:
         expected_topic_name = "my-awesome-project / tomek"

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -10,7 +10,7 @@ from zerver.lib.exceptions import UnsupportedWebhookEventTypeError
 from zerver.lib.partial import partial
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
-from zerver.lib.validator import WildValue, check_int, check_none_or, check_string, check_bool
+from zerver.lib.validator import WildValue, check_bool, check_int, check_none_or, check_string
 from zerver.lib.webhooks.common import (
     OptionalUserSpecifiedTopicStr,
     check_send_webhook_message,
@@ -580,51 +580,41 @@ def api_gitlab_webhook(
     use_merge_request_title: Json[bool] = True,
     user_specified_topic: OptionalUserSpecifiedTopicStr = None,
 ) -> HttpResponse:
-    ignore_private_repos = request.GET.get("ignore_private_repositories") == "true"
+    ignore_private_repos = request.GET.get("ignore_private_repositories", "false") == "true"
 
     if ignore_private_repos:
         project = payload.get("project", {})
         repository = payload.get("repository", {})
 
-        # Project-level visibility
         project_visibility_node = project.get("visibility")
         if isinstance(project_visibility_node, WildValue):
             project_visibility = project_visibility_node.tame(check_string)
-        else:
-            project_visibility = project_visibility_node
+        else:  # nocoverage
+            project_visibility = project_visibility_node  # type: ignore[unreachable] # unreachable due to WildValue guard
 
         project_public_flag_node = project.get("public")
         if isinstance(project_public_flag_node, WildValue):
             project_public_flag = project_public_flag_node.tame(check_bool)
-        else:
-            project_public_flag = project_public_flag_node
+        else:  # nocoverage
+            project_public_flag = bool(project_public_flag_node)  # type: ignore[unreachable] # unreachable due to WildValue guard
 
-        project_is_private = (
-            project_visibility == "private"
-            or project_public_flag is False
-        )
+        project_is_private = project_visibility == "private" or project_public_flag is False
 
-        # Repository-level visibility
         repo_visibility_level_node = repository.get("visibility_level")
         if isinstance(repo_visibility_level_node, WildValue):
             repo_visibility_level = repo_visibility_level_node.tame(check_int)
-        else:
-            repo_visibility_level = repo_visibility_level_node
+        else:  # nocoverage
+            repo_visibility_level = repo_visibility_level_node  # type: ignore[unreachable] # unreachable due to WildValue guard
 
         repo_public_flag_node = repository.get("public")
         if isinstance(repo_public_flag_node, WildValue):
             repo_public_flag = repo_public_flag_node.tame(check_bool)
-        else:
-            repo_public_flag = repo_public_flag_node
+        else:  # nocoverage
+            repo_public_flag = bool(repo_public_flag_node)  # type: ignore[unreachable] # unreachable due to WildValue guard
 
-        repo_is_private = (
-            repo_visibility_level == 0
-            or repo_public_flag is False
-        )
+        repo_is_private = repo_visibility_level == 0 or repo_public_flag is False
 
-        is_private_repo = project_is_private or repo_is_private
-
-        if is_private_repo:
+        if project_is_private or repo_is_private:
             return json_success(request)
 
     event = get_event(request, payload, branches)
@@ -640,11 +630,18 @@ def api_gitlab_webhook(
             body = f"{project_url} {body}"
 
         topic_name = get_topic_based_on_event(event, payload, use_merge_request_title)
+
         check_send_webhook_message(
-            request, user_profile, topic_name, body, event, no_previews=skip_previews(event)
+            request,
+            user_profile,
+            topic_name,
+            body,
+            event,
+            no_previews=skip_previews(event),
         )
 
     return json_success(request)
+
 
 def get_body_based_on_event(event: str) -> EventFunction:
     return EVENT_FUNCTION_MAPPER[event]


### PR DESCRIPTION
This PR adds support for filtering out GitLab webhook events originating
from private repositories. The new `ignore_private_repositories=true`
URL option mirrors the behavior recently added to the GitHub integration.

When this option is enabled, events from private repositories are ignored;
otherwise, Zulip continues to process them as before.

Fixes: #31766

**How changes were tested:**

- Added a new test: `test_private_repo_sends_when_option_disabled`
  to validate backward compatibility and ensure that events from private
  repositories are still delivered when the option is *not* enabled.
- Added `test_private_repo_ignored_when_option_enabled` to verify
  that private repo events are skipped when the filter is active.
- Added `test_public_repo_sends_even_when_ignoring_private` to ensure that
  events from public repositories continue to be delivered when
  `ignore_private_repositories=true` is used, preserving expected behavior.
- Added 2 fixtures where needed to reflect repository visibility.
- Ran the full GitLab webhook test suite (`94 tests`), ensuring no regressions.

**Screenshots and screen captures:**
<img width="579" height="570" alt="image" src="https://github.com/user-attachments/assets/957b5e59-bebe-4851-8b2c-aa9b5c5557a8" />


<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed changes for clarity and maintainability.
- [x] Explained deviations from the issue’s original plan.
- [x] Highlighted technical decisions and bugs encountered during implementation.
- [x] Added automated tests validating the new logic.
- [x] Each commit is a coherent idea and includes a descriptive message.
- [x] Verified end-to-end webhook behavior using test fixtures.

</details>

