### PR TITLE
backup: Handle PORT being numeric now.

### DIFF
--- a/zerver/management/commands/backup.py
+++ b/zerver/management/commands/backup.py
@@ -82,10 +82,10 @@ class Command(ZulipBaseCommand):
                     "--dbname=" + settings.DATABASES["default"]["NAME"],
                     "--no-password",
                 ]
-                if settings.DATABASES["default"]["HOST"] != "":
+                if settings.DATABASES["default"].get("HOST"):
                     pg_dump_command += ["--host=" + settings.DATABASES["default"]["HOST"]]
-                if settings.DATABASES["default"]["PORT"] != "":
-                    pg_dump_command += ["--port=" + settings.DATABASES["default"]["PORT"]]
+                if settings.DATABASES["default"].get("PORT"):
+                    pg_dump_command += ["--port=" + str(settings.DATABASES["default"]["PORT"])]
 
                 os.environ["PGPASSWORD"] = settings.DATABASES["default"]["PASSWORD"]
 


### PR DESCRIPTION
f1ec8163ef0d broke `./manage.py backup` due to the port no longer being a string.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
