### PR TITLE
Put subscribe dividers inside message group

### DIFF
--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -79,6 +79,7 @@ export type MessageContainer = {
     timestr: string;
     topic_url?: string;
     want_date_divider: boolean;
+    want_subscription_status_divider: boolean;
 };
 
 export type MessageGroup = {
@@ -184,20 +185,21 @@ function clear_group_date(group: MessageGroup): void {
     group.date_unchanged = false;
 }
 
-function clear_message_date_divider(message_container: MessageContainer): void {
-    // see update_message_date_divider for how
+function clear_message_divider(message_container: MessageContainer): void {
+    // see update_message_divider for how
     // these get set
     message_container.want_date_divider = false;
+    message_container.want_subscription_status_divider = false;
     message_container.date_divider_html = undefined;
 }
 
-function update_message_date_divider(opts: {
+function update_message_divider(opts: {
     prev_msg_container: MessageContainer | undefined;
     curr_msg_container: MessageContainer;
 }): void {
     Object.assign(
         opts.curr_msg_container,
-        get_message_date_divider_data({
+        get_message_divider_data({
             prev_message: opts.prev_msg_container?.msg,
             curr_message: opts.curr_msg_container.msg,
             display_year: !same_year(opts.curr_msg_container.msg, opts.prev_msg_container?.msg),
@@ -205,21 +207,28 @@ function update_message_date_divider(opts: {
     );
 }
 
-function get_message_date_divider_data(opts: {
+function get_message_divider_data(opts: {
     prev_message: Message | undefined;
     curr_message: Message;
     display_year: boolean;
 }): {
     want_date_divider: boolean;
+    want_subscription_status_divider: boolean;
     date_divider_html: string | undefined;
 } {
     const prev_message = opts.prev_message;
     const curr_message = opts.curr_message;
     const display_year = opts.display_year;
+    let want_subscription_status_divider = false;
+
+    if (prev_message) {
+        want_subscription_status_divider = prev_message?.historical !== curr_message.historical;
+    }
 
     if (!prev_message || same_day(curr_message, prev_message)) {
         return {
             want_date_divider: false,
+            want_subscription_status_divider,
             date_divider_html: undefined,
         };
     }
@@ -227,6 +236,7 @@ function get_message_date_divider_data(opts: {
 
     return {
         want_date_divider: true,
+        want_subscription_status_divider,
         date_divider_html: timerender.render_date(curr_time, display_year).outerHTML,
     };
 }
@@ -788,21 +798,22 @@ export class MessageListView {
             let include_sender;
             let want_date_divider;
             let date_divider_html;
+            let want_subscription_status_divider = false;
             const year_changed = !same_year(message, prev_message_container?.msg);
 
             if (
                 prev_message_container &&
                 util.same_recipient(prev_message_container.msg, message) &&
-                this.collapse_messages &&
-                prev_message_container.msg.historical === message.historical
+                this.collapse_messages
             ) {
-                const date_divider_data = get_message_date_divider_data({
+                const divider_data = get_message_divider_data({
                     prev_message: prev_message_container.msg,
                     curr_message: message,
                     display_year: year_changed,
                 });
-                want_date_divider = date_divider_data.want_date_divider;
-                date_divider_html = date_divider_data.date_divider_html;
+                want_date_divider = divider_data.want_date_divider;
+                want_subscription_status_divider = divider_data.want_subscription_status_divider;
+                date_divider_html = divider_data.date_divider_html;
             } else {
                 finish_group();
                 start_group(prev_message_container?.msg, message);
@@ -824,6 +835,7 @@ export class MessageListView {
                 prev_message_container &&
                 !prev_message_container.status_message &&
                 same_day(prev_message_container.msg, message) &&
+                prev_message_container.msg.historical === message.historical &&
                 prev_message_container.msg.sender_id === message.sender_id
             ) {
                 include_sender = false;
@@ -840,6 +852,7 @@ export class MessageListView {
                 ...(topic_url && {topic_url}),
                 ...(pm_with_url && {pm_with_url}),
                 want_date_divider,
+                want_subscription_status_divider,
                 date_divider_html,
                 year_changed,
                 ...calculated_variables,
@@ -876,16 +889,13 @@ export class MessageListView {
         assert(first_msg_container !== undefined);
 
         // Join two groups into one.
-        if (
-            this.collapse_messages &&
-            same_recipient(last_msg_container, first_msg_container) &&
-            last_msg_container!.msg.historical === first_msg_container.msg.historical
-        ) {
+        if (this.collapse_messages && same_recipient(last_msg_container, first_msg_container)) {
             if (
                 !last_msg_container!.status_message &&
                 !first_msg_container.msg.is_me_message &&
                 same_day(last_msg_container?.msg, first_msg_container.msg) &&
-                same_sender(last_msg_container, first_msg_container)
+                same_sender(last_msg_container, first_msg_container) &&
+                first_msg_container.msg.historical === last_msg_container?.msg.historical
             ) {
                 first_msg_container.include_sender = false;
             }
@@ -946,12 +956,12 @@ export class MessageListView {
 
         const was_joined = this.join_message_groups(first_group, second_group);
         if (was_joined) {
-            update_message_date_divider({
+            update_message_divider({
                 prev_msg_container,
                 curr_msg_container,
             });
         } else {
-            clear_message_date_divider(curr_msg_container);
+            clear_message_divider(curr_msg_container);
         }
 
         if (where === "top") {
@@ -1074,8 +1084,20 @@ export class MessageListView {
         const msg_reactions = reactions.get_message_reactions(message_container.msg);
         message_container.msg.message_reactions = msg_reactions;
         message_container.msg.reminders = message_reminder.get_reminders(message_container.msg.id);
+        let invite_only;
+        let is_web_public;
+        let is_archived;
+        if (message_container.msg.is_stream) {
+            const stream_id = message_container.msg.stream_id;
+            invite_only = stream_data.is_invite_only_by_stream_id(stream_id);
+            is_web_public = stream_data.is_web_public(stream_id);
+            is_archived = stream_data.is_stream_archived_by_id(stream_id);
+        }
         const msg_to_render = {
             ...message_container,
+            invite_only,
+            is_web_public,
+            is_archived,
             message_list_id: this.list.id,
         };
         return render_single_message(msg_to_render);

--- a/web/src/message_report.ts
+++ b/web/src/message_report.ts
@@ -21,6 +21,7 @@ import * as people from "./people.ts";
 import {update_elements} from "./rendered_markdown.ts";
 import * as rows from "./rows.ts";
 import {realm} from "./state_data.ts";
+import * as stream_data from "./stream_data.ts";
 import {process_submessages} from "./submessage.ts";
 import * as ui_report from "./ui_report.ts";
 import {toggle_user_card_popover_for_message} from "./user_card_popover.ts";
@@ -82,6 +83,7 @@ function get_message_container_for_preview(message: Message): MessageContainer {
         status_message: "",
         timestr: get_timestr(message),
         want_date_divider: false,
+        want_subscription_status_divider: false,
     };
     const unused_variables = {
         date_divider_html: undefined,
@@ -119,6 +121,15 @@ function post_process_message_preview($row: JQuery): void {
 }
 
 export function show_message_report_modal(message: Message): void {
+    let invite_only;
+    let is_web_public;
+    let is_archived;
+    if (message.is_stream) {
+        const stream_id = message.stream_id;
+        invite_only = stream_data.is_invite_only_by_stream_id(stream_id);
+        is_web_public = stream_data.is_web_public(stream_id);
+        is_archived = stream_data.is_stream_archived_by_id(stream_id);
+    }
     const message_preview_body_args = get_message_container_for_preview(message);
     const html_body = render_report_message_modal({
         recipient_row_data: get_message_group_for_message_preview(message),
@@ -126,6 +137,9 @@ export function show_message_report_modal(message: Message): void {
             ...message_preview_body_args,
             message_list_id: "",
         },
+        invite_only,
+        is_web_public,
+        is_archived,
     });
     let report_type_dropdown_widget: dropdown_widget.DropdownWidget;
     let $message_report_description: JQuery<HTMLTextAreaElement>;

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -12,7 +12,7 @@
        `auto`. */
     grid-template: auto auto / 2px minmax(0, 1fr);
     grid-template-areas:
-        "date_unread_marker    date_row  "
+        "message_divider_unread_marker message_feed_divider_content"
         "message_unread_marker messagebox";
 
     border-left: 1px solid var(--color-message-list-border);
@@ -743,8 +743,8 @@
         transition: opacity 0.3s ease-out;
     }
 
-    &.date_unread_marker {
-        grid-area: date_unread_marker;
+    &.message_divider_unread_marker {
+        grid-area: message_divider_unread_marker;
 
         .unread-marker-fill {
             border-radius: 0 !important;
@@ -1139,7 +1139,7 @@
     /* See https://stackoverflow.com/questions/2717480/css-selector-for-first-element-with-class/8539107#8539107
        for details on how this works */
     .message_row.unread {
-        .date_unread_marker {
+        .message_divider_unread_marker {
             display: none;
         }
     }
@@ -1147,31 +1147,70 @@
     /* Select all but the first .message_row.unread,
        and remove the properties set from the previous rule. */
     .message_row.unread ~ .message_row.unread {
-        .date_unread_marker {
+        .message_divider_unread_marker {
             display: block;
         }
     }
 }
 
-.date_row {
-    grid-area: date_row;
+.message_feed_divider {
+    display: grid;
+    grid-area: message_feed_divider_content;
+    grid-template: auto / minmax(20px, 1fr) auto minmax(max-content, 1fr);
+    grid-template-areas: "left_divider_content middle_divider_content right_divider_content";
+    align-items: center;
+    padding: 8px 0;
 
-    & .timerender-content {
-        display: block;
-        overflow: hidden;
-        text-transform: uppercase;
-        font-size: calc(12em / 14);
-        font-style: normal;
-        font-weight: 600;
-        line-height: 17px; /* identical to box height, or 131% */
-        text-align: right;
+    &::before {
+        grid-area: left_divider_content;
+        content: " ";
+        height: 0;
+        border-bottom: 1px solid var(--color-border-message-group-spacer-line);
+    }
+
+    &:has(.timerender-content)::after {
+        display: none;
+    }
+
+    &:not(:has(.timerender-content))::after {
+        grid-area: right_divider_content;
+        min-width: 20px;
+        content: " ";
+        height: 0;
+        width: calc(100% - 2px);
+        border-bottom: 1px solid var(--color-border-message-group-spacer-line);
+    }
+
+    .stream-status {
+        grid-area: middle_divider_content;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        /* Same as timerender-content at 16px */
+        letter-spacing: 0.5486px;
+        padding: 0 0.25em;
+
+        & i {
+            font-size: 0.7143em; /* 10px at 14px / em */
+            /* TODO: Don't use relative positioning here. */
+            position: relative;
+            margin-left: 0.2em; /* 2px at 10px / em */
+        }
+    }
+
+    .timerender-content {
+        grid-area: right_divider_content;
+        display: flex;
+        align-items: center;
+        justify-content: end;
         letter-spacing: 0.04em;
-        color: var(--color-date);
         /* Right padding matches time in message row and date in recipient row. */
-        padding: 8px 6px 8px 4px;
+        padding-right: 6px;
 
         &::before {
+            min-width: 20px;
             width: 100%;
+            right: 0.25em;
+            margin-left: -50%;
         }
 
         &::after {
@@ -1180,6 +1219,27 @@
             /* Align date with message time and recipient bar date. */
             margin-right: -1px;
         }
+
+        &::before,
+        &::after {
+            position: relative;
+            content: " ";
+            height: 0;
+            border-bottom: 1px solid
+                var(--color-border-message-group-spacer-line);
+        }
+    }
+
+    .stream-status,
+    .timerender-content {
+        overflow: hidden;
+        text-transform: uppercase;
+        font-size: calc(12em / 14);
+        font-style: normal;
+        font-weight: 600;
+        line-height: 17px; /* identical to box height, or 131% */
+        text-align: right;
+        color: var(--color-date);
     }
 }
 
@@ -1216,7 +1276,18 @@
 
     &::before,
     &::after {
+        display: inline-block;
+        position: relative;
+        content: " ";
+        vertical-align: middle;
+        height: 0;
+        border-bottom: 1px solid var(--color-border-message-group-spacer-line);
         width: 50%;
+    }
+
+    &::before {
+        right: 0.25em;
+        margin-left: -50%;
     }
 
     &::after {
@@ -1232,24 +1303,6 @@
 
 .trailing_bookend .bookend-channel-settings-link {
     display: inline;
-}
-
-.bookend-label::before,
-.bookend-label::after,
-.date_row .timerender-content::before,
-.date_row .timerender-content::after {
-    display: inline-block;
-    position: relative;
-    content: " ";
-    vertical-align: middle;
-    height: 0;
-    border-bottom: 1px solid var(--color-border-message-group-spacer-line);
-}
-
-.bookend-label::before,
-.date_row .timerender-content::before {
-    right: 0.25em;
-    margin-left: -50%;
 }
 
 #report-message-preview-container {

--- a/web/templates/message_group.hbs
+++ b/web/templates/message_group.hbs
@@ -8,7 +8,7 @@
     <div class="recipient_row" id="{{message_group_id}}">
         {{> recipient_row . use_match_properties=../use_match_properties}}
         {{#each message_containers}}
-            {{> single_message . use_match_properties=../../use_match_properties message_list_id=../../message_list_id is_archived=../is_archived}}
+            {{> single_message . use_match_properties=../../use_match_properties message_list_id=../../message_list_id is_archived=../is_archived invite_only=../invite_only is_web_public=../is_web_public}}
         {{/each}}
     </div>
 {{/each}}

--- a/web/templates/single_message.hbs
+++ b/web/templates/single_message.hbs
@@ -1,10 +1,27 @@
 <div id="message-row-{{message_list_id}}-{{msg/id}}" data-message-id="{{msg/id}}"
   class="message_row{{#unless msg/is_stream}} private-message{{/unless}}{{#if include_sender}} messagebox-includes-sender{{/if}}{{#if mention_classname}} {{mention_classname}}{{/if}}{{#if msg.unread}} unread{{/if}} {{#if msg.locally_echoed}}locally-echoed{{/if}} selectable_row {{#if is_hidden}}muted-message-sender{{/if}}"
   role="listitem">
-    {{#if want_date_divider}}
-    <div class="unread_marker date_unread_marker"><div class="unread-marker-fill"></div></div>
-    <div class="date_row no-select">
-        {{{date_divider_html}}}
+    {{#if (or want_subscription_status_divider want_date_divider)}}
+    <div class="unread_marker message_divider_unread_marker"><div class="unread-marker-fill"></div></div>
+    <div class="message_feed_divider no-select">
+        {{#if want_subscription_status_divider}}
+        <span class="stream-status">
+            {{#if msg/historical }}
+                {{#tr}}
+                    You unsubscribed from <z-stream-name></z-stream-name>.
+                    {{#*inline "z-stream-name"}}{{> stream_privacy . }} {{msg/display_recipient}}{{/inline}}
+                {{/tr}}
+            {{else}}
+                {{#tr}}
+                    You subscribed to <z-stream-name></z-stream-name>.
+                    {{#*inline "z-stream-name"}}{{> stream_privacy . }} {{msg/display_recipient}}{{/inline}}
+                {{/tr}}
+            {{/if}}
+        </span>
+        {{/if}}
+        {{#if want_date_divider}}
+            {{{date_divider_html}}}
+        {{/if}}
     </div>
     {{/if}}
     <div class="unread_marker message_unread_marker"><div class="unread-marker-fill"></div></div>


### PR DESCRIPTION
Currently two consecutive messages are split into two message groups if the user subscribed/unsubscribed between them even if the recipient is same(both message are in same topic).

We move such bookend divider which have same recipient above and below it into the message group itself and prevent it from making two separate message groups. We still show bookend in between two message groups if the message recipient is different.

We use `want_subscription_status_divider` in message containers to denote if we want subscription divider above the message. Obviously this means `want_subscription_status_divider` of top most message in a message group is `false`.

For narrow space, date content has more preference to fit its content than subscription status(subscription text ellipsis).

Fixes: zulip#36905.

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|Before|After|
|-|-|
|<img width="920" height="300" alt="Screenshot from 2025-12-15 22-10-31" src="https://github.com/user-attachments/assets/c7a10e04-4355-4d15-921f-d11b864570c7" />|<img width="935" height="146" alt="Screenshot from 2025-12-15 21-44-47" src="https://github.com/user-attachments/assets/9c5e91c1-a019-4057-b850-183882b72c06" />|
||<img width="929" height="276" alt="image" src="https://github.com/user-attachments/assets/f36b4131-e6bc-42f0-bc85-a718addf101d" />|

|Narrow window|
|-|
|Only subscription status|
|<img width="496" height="48" alt="image" src="https://github.com/user-attachments/assets/37f4aa26-c63d-4dbf-8ebb-09eba769bf77" />|
|Only date|
|<img width="557" height="56" alt="Screenshot from 2025-12-15 22-02-00" src="https://github.com/user-attachments/assets/1b89967a-6339-45ab-b37c-79c9ace0fd55" />|
|Both between same message|
|<img width="496" height="48" alt="image" src="https://github.com/user-attachments/assets/cdbe117b-d11f-4f16-b4e4-3665f2288c95" />|

|Long divider content|
|-|
|<img width="486" height="39" alt="image" src="https://github.com/user-attachments/assets/df69fb5e-f64d-4731-9d80-c4dcea793181" />|
|<img width="497" height="39" alt="image" src="https://github.com/user-attachments/assets/605b1d95-dfb8-43c7-9238-21483f4412ea" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
