### PR TITLE
emoji_picker: Fix `tab` not working in user status modal emoji picker.

### DIFF
--- a/web/src/emoji_picker.ts
+++ b/web/src/emoji_picker.ts
@@ -882,7 +882,8 @@ function register_click_handlers(): void {
         function (this: HTMLElement, e): void {
             e.preventDefault();
             e.stopPropagation();
-            toggle_emoji_popover(this, undefined, {placement: "bottom"});
+            const micromodal = $("#set-user-status-modal").closest(".modal__overlay")[0]!;
+            toggle_emoji_popover(this, undefined, {placement: "bottom", appendTo: micromodal});
             if (is_open()) {
                 // Because the emoji picker gets drawn on top of the user
                 // status modal, we need this hack to make clicking outside

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -695,6 +695,12 @@ ul.popover-group-menu-member-list {
     }
 }
 
+.modal__overlay #set-user-status-modal + .emoji-popover-root {
+    /* Micromodal prevents pointer events to elements outside the content.
+       We need to re-enable pointer events for the emoji popover to work. */
+    pointer-events: auto;
+}
+
 .gif-grid-in-popover {
     /* 300px of GIPHY grid + 5px is the extra gutter space
      * + 1px for outline.


### PR DESCRIPTION
Fixes: #36428

Micromodal has a feature where it prevents elements from moving focus outside it. Since, emoji picker was outside the modal, pressing tab moved focus inside the micromodal.

Fixed by moving emoji_picker inside the micromodal.
