### PR TITLE
lightbox: Open YouTube videos at correct timestamp.

### DIFF
--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -557,6 +557,14 @@ export function parse_media_data(media: HTMLMediaElement | HTMLImageElement): Me
     } else if (is_youtube_video) {
         type = "youtube-video";
         source = "https://www.youtube.com/embed/" + $parent.attr("data-id");
+        // YouTube URLs support a `start` parameter that can be either
+        // an integer or a string-encoded time offset like
+        // "1h20m12s". The embed API only supports the integer format,
+        // so we may need to convert the format.
+        const start_time = util.parse_youtube_start_time(url);
+        if (start_time !== undefined) {
+            source += "?start=" + start_time;
+        }
     } else if (is_vimeo_video) {
         type = "vimeo-video";
         source = "https://player.vimeo.com/video/" + $parent.attr("data-id");

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -607,3 +607,28 @@ export function unique_array_insert<T>(array: T[], new_item: T): void {
     }
     array.push(new_item);
 }
+
+export function parse_youtube_start_time(url: string): number | undefined {
+    const url_obj = new URL(url, window.location.href);
+    const params = new URLSearchParams(url_obj.search);
+    const t = params.get("t") ?? params.get("start");
+
+    if (t === null) {
+        return undefined;
+    }
+
+    // t can be in seconds (e.g. 120) or in #h#m#s format (e.g. 1h2m30s)
+    if (/^\d+$/.test(t)) {
+        return Number.parseInt(t, 10);
+    }
+
+    const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(t);
+    if (match) {
+        const h = Number.parseInt(match[1] ?? "0", 10);
+        const m = Number.parseInt(match[2] ?? "0", 10);
+        const s = Number.parseInt(match[3] ?? "0", 10);
+        return h * 3600 + m * 60 + s;
+    }
+
+    return undefined;
+}

--- a/web/tests/util.test.cjs
+++ b/web/tests/util.test.cjs
@@ -635,3 +635,25 @@ run_test("unique_array_insert", () => {
         {c: "beep", d: "boop"},
     ]);
 });
+
+run_test("parse_youtube_start_time", () => {
+    assert.equal(util.parse_youtube_start_time("https://youtu.be/VIDEO_ID?t=120"), 120);
+    assert.equal(
+        util.parse_youtube_start_time("https://www.youtube.com/watch?v=VIDEO_ID&t=150"),
+        150,
+    );
+    assert.equal(
+        util.parse_youtube_start_time("https://www.youtube.com/watch?v=VIDEO_ID"),
+        undefined,
+    );
+    assert.equal(util.parse_youtube_start_time("https://youtu.be/VIDEO_ID?t=1h"), 3600);
+    assert.equal(util.parse_youtube_start_time("https://youtu.be/VIDEO_ID?t=1h1m1s"), 3661);
+    assert.equal(util.parse_youtube_start_time("https://youtu.be/VIDEO_ID?t=1m1s"), 61);
+    assert.equal(
+        util.parse_youtube_start_time("https://www.youtube.com/watch?v=VIDEO_ID&start=100"),
+        100,
+    );
+    assert.equal(util.parse_youtube_start_time("https://youtu.be/ID?t=1m"), 60);
+    assert.equal(util.parse_youtube_start_time("https://youtu.be/ID?t=1h30m"), 5400);
+    assert.equal(util.parse_youtube_start_time("https://youtu.be/ID?t=invalid"), undefined);
+});


### PR DESCRIPTION
lightbox: Open YouTube videos at correct timestamp.

Previously, opening a YouTube link with a timestamp (e.g., `?t=1m20s` or `?start=80`) in the lightbox would play the video from the beginning because the query parameters were ignored.

This commit updates the lightbox logic to correctly parse the `t` or `start` parameter from the URL and pass it to the embedded YouTube player so the video starts at the specific time intended by the sender.

**Changes:**
* Added `parse_youtube_start_time` helper function in `web/src/util.ts`.
* Updated `web/src/lightbox.ts` to use this helper and append the `start` parameter to the embed URL.
* Added unit tests in `web/tests/util.test.cjs` to cover various timestamp formats.

Fixes: #36990

**How changes were tested:**

1. **Manual Verification:**
   - Sent messages with YouTube links containing timestamps (e.g., `t=42s`, `t=1m10s`).
   - Clicked the video preview to open the lightbox.
   - Verified that the video started playing at the correct timestamp instead of 0:00.

2. **Automated Tests:**
   - Added unit tests for `parse_youtube_start_time` covering formats like `?t=120`, `?t=2m30s`, and `?start=80`.

**Screenshots and screen captures:**


https://github.com/user-attachments/assets/842ff528-129f-46d4-9809-92e253afb9ff


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>