### PR TITLE
tests: Add set_user_role helper method to ZulipTestCase.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -85,7 +85,7 @@ from zerver.actions.create_user import (
     do_reactivate_user,
 )
 from zerver.actions.realm_settings import do_deactivate_realm, do_reactivate_realm
-from zerver.actions.users import change_user_is_active, do_change_user_role, do_deactivate_user
+from zerver.actions.users import change_user_is_active, do_deactivate_user
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.remote_server import send_server_data_to_push_bouncer
 from zerver.lib.test_classes import ZulipTestCase
@@ -444,8 +444,8 @@ class StripeTestCase(ZulipTestCase):
         # Add hamlet in `can_manage_billing_group` for testing.
         hamlet = self.example_user("hamlet")
         iago = self.example_user("iago")
-        do_change_user_role(hamlet, UserProfile.ROLE_REALM_OWNER, acting_user=None)
-        do_change_user_role(iago, UserProfile.ROLE_REALM_OWNER, acting_user=None)
+        self.set_user_role(hamlet, UserProfile.ROLE_REALM_OWNER)
+        self.set_user_role(iago, UserProfile.ROLE_REALM_OWNER)
 
         self.billing_session: (
             RealmBillingSession | RemoteRealmBillingSession | RemoteServerBillingSession
@@ -6163,9 +6163,9 @@ class LicenseLedgerTest(StripeTestCase):
             acting_user=None,
         )
         # Change guest user role to member
-        do_change_user_role(guest, UserProfile.ROLE_MEMBER, acting_user=None)
+        self.set_user_role(guest, UserProfile.ROLE_MEMBER)
         # Change again to moderator, no LicenseLedger created
-        do_change_user_role(guest, UserProfile.ROLE_MODERATOR, acting_user=None)
+        self.set_user_role(guest, UserProfile.ROLE_MODERATOR)
         ledger_entries = list(
             LicenseLedger.objects.values_list(
                 "is_renewal", "licenses", "licenses_at_next_renewal"
@@ -6663,7 +6663,7 @@ class InvoiceTest(StripeTestCase):
             )
 
         with time_machine.travel(self.now + timedelta(days=10), tick=False):
-            do_change_user_role(user, UserProfile.ROLE_MEMBER, acting_user=None)
+            self.set_user_role(user, UserProfile.ROLE_MEMBER)
 
         billing_session = RealmBillingSession(realm=realm)
         billing_session.invoice_plan(plan, self.next_month)

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -49,6 +49,7 @@ from corporate.models.plans import CustomerPlan
 from zerver.actions.message_send import check_send_message, check_send_stream_message
 from zerver.actions.realm_settings import do_change_realm_permission_group_setting
 from zerver.actions.streams import bulk_add_subscriptions, bulk_remove_subscriptions
+from zerver.actions.users import do_change_user_role
 from zerver.decorator import do_two_factor_login
 from zerver.lib.cache import bounce_key_prefix_for_testing
 from zerver.lib.email_notifications import MissedMessageData, handle_missedmessage_emails
@@ -2366,6 +2367,19 @@ class ZulipTestCase(ZulipTestCaseMixin, TestCase):
         return self.build_streams_subscriber_count(
             streams=Stream.objects.exclude(id__in=stream_ids)
         )
+
+    def set_user_role(self, user: UserProfile, role: int) -> None:
+        """
+        Test helper for switching a user to a given role. Hardcodes
+        acting_user=None, which means the change is treated as
+        though it was done by a management command, not another
+        user.
+
+        Tests using this should consider using users who have the
+        appropriate initial role; this is usually more readable and
+        a bit faster.
+        """
+        do_change_user_role(user, role, acting_user=None)
 
 
 def get_row_pks_in_all_tables() -> Iterator[tuple[str, set[int]]]:

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -1501,7 +1501,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         # Test for not allowing a non-owner user to make assign a bot an owner role
         desdemona = self.example_user("desdemona")
-        do_change_user_role(desdemona, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(desdemona, UserProfile.ROLE_REALM_ADMINISTRATOR)
 
         req = dict(role=UserProfile.ROLE_REALM_OWNER)
 

--- a/zerver/tests/test_channel_creation.py
+++ b/zerver/tests/test_channel_creation.py
@@ -7,7 +7,6 @@ from zerver.actions.realm_settings import (
     do_set_realm_property,
 )
 from zerver.actions.user_groups import check_add_user_group
-from zerver.actions.users import do_change_user_role
 from zerver.lib.default_streams import get_default_stream_ids_for_realm
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import UnreadStreamInfo, aggregate_unread_data, get_raw_unread_data
@@ -247,7 +246,7 @@ class TestCreateStreams(ZulipTestCase):
         )
         self.assert_json_error(result, "Insufficient permission")
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
         result = self.subscribe_via_post(
             user_profile, subscriptions, {"is_default_stream": "true"}, subdomain="zulip"
         )

--- a/zerver/tests/test_channel_permissions.py
+++ b/zerver/tests/test_channel_permissions.py
@@ -14,7 +14,6 @@ from zerver.actions.streams import (
     do_deactivate_stream,
 )
 from zerver.actions.user_groups import add_subgroups_to_user_group, check_add_user_group
-from zerver.actions.users import do_change_user_role
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import get_subscription
 from zerver.lib.types import UserGroupMembersData
@@ -50,7 +49,7 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         # User should be allowed to add subscribers when creating the
         # channel even if they don't have realm wide permission to
         # add other subscribers to a channel.
-        do_change_user_role(self.test_user, UserProfile.ROLE_MODERATOR, acting_user=None)
+        self.set_user_role(self.test_user, UserProfile.ROLE_MODERATOR)
         result = self.subscribe_via_post(
             self.test_user,
             ["stream1"],
@@ -88,7 +87,7 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         # Admins have a special permission to administer every channel
         # they have access to. This also grants them access to add
         # subscribers.
-        do_change_user_role(self.test_user, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(self.test_user, UserProfile.ROLE_REALM_ADMINISTRATOR)
         self.subscribe_via_post(
             self.test_user, ["stream1"], {"principals": orjson.dumps([invitee_user_id]).decode()}
         )
@@ -100,7 +99,7 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
             realm, "can_add_subscribers_group", moderators_group, acting_user=None
         )
 
-        do_change_user_role(self.test_user, UserProfile.ROLE_MEMBER, acting_user=None)
+        self.set_user_role(self.test_user, UserProfile.ROLE_MEMBER)
         # Make sure that we are checking the permission with a full member,
         # as full member is the user just below moderator in the role hierarchy.
         self.assertFalse(self.test_user.is_provisional_member)
@@ -117,7 +116,7 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Insufficient permission")
 
-        do_change_user_role(self.test_user, UserProfile.ROLE_MODERATOR, acting_user=None)
+        self.set_user_role(self.test_user, UserProfile.ROLE_MODERATOR)
         self.subscribe_via_post(
             self.test_user, ["stream2"], {"principals": orjson.dumps([invitee_user_id]).decode()}
         )
@@ -129,7 +128,7 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         do_change_realm_permission_group_setting(
             realm, "can_add_subscribers_group", members_group, acting_user=None
         )
-        do_change_user_role(self.test_user, UserProfile.ROLE_GUEST, acting_user=None)
+        self.set_user_role(self.test_user, UserProfile.ROLE_GUEST)
         result = self.subscribe_via_post(
             self.test_user,
             ["stream2"],
@@ -138,7 +137,7 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Not allowed for guest users")
 
-        do_change_user_role(self.test_user, UserProfile.ROLE_MEMBER, acting_user=None)
+        self.set_user_role(self.test_user, UserProfile.ROLE_MEMBER)
         self.subscribe_via_post(
             self.test_user,
             ["stream2"],
@@ -164,11 +163,11 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
 
         # Moderators, Admins and owners are always full members.
         self.assertTrue(user_profile.is_provisional_member)
-        do_change_user_role(self.test_user, UserProfile.ROLE_MODERATOR, acting_user=None)
+        self.set_user_role(self.test_user, UserProfile.ROLE_MODERATOR)
         self.assertFalse(self.test_user.is_provisional_member)
-        do_change_user_role(self.test_user, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(self.test_user, UserProfile.ROLE_REALM_ADMINISTRATOR)
         self.assertFalse(self.test_user.is_provisional_member)
-        do_change_user_role(self.test_user, UserProfile.ROLE_REALM_OWNER, acting_user=None)
+        self.set_user_role(self.test_user, UserProfile.ROLE_REALM_OWNER)
         self.assertFalse(self.test_user.is_provisional_member)
 
         do_set_realm_property(realm, "waiting_period_threshold", 0, acting_user=None)
@@ -240,13 +239,13 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         # Admins have a special permission to administer every channel
         # they have access to. This also grants them access to add
         # subscribers.
-        do_change_user_role(self.test_user, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(self.test_user, UserProfile.ROLE_REALM_ADMINISTRATOR)
         result = self.subscribe_via_post(
             self.test_user, ["stream1"], {"principals": orjson.dumps([invitee_user_id]).decode()}
         )
         self.assert_json_success(result)
 
-        do_change_user_role(self.test_user, UserProfile.ROLE_MEMBER, acting_user=None)
+        self.set_user_role(self.test_user, UserProfile.ROLE_MEMBER)
         # Make sure that we are checking the permission with a full member,
         # as full member is the user just below moderator in the role hierarchy.
         self.assertFalse(self.test_user.is_provisional_member)
@@ -270,7 +269,7 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Insufficient permission")
 
-        do_change_user_role(self.test_user, UserProfile.ROLE_MODERATOR, acting_user=None)
+        self.set_user_role(self.test_user, UserProfile.ROLE_MODERATOR)
         self.subscribe_via_post(
             self.test_user, ["stream2"], {"principals": orjson.dumps([invitee_user_id]).decode()}
         )
@@ -282,7 +281,7 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         do_change_stream_group_based_setting(
             stream2, "can_add_subscribers_group", members_group, acting_user=user_profile
         )
-        do_change_user_role(self.test_user, UserProfile.ROLE_GUEST, acting_user=None)
+        self.set_user_role(self.test_user, UserProfile.ROLE_GUEST)
         result = self.subscribe_via_post(
             self.test_user,
             ["stream2"],
@@ -291,7 +290,7 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Not allowed for guest users")
 
-        do_change_user_role(self.test_user, UserProfile.ROLE_MEMBER, acting_user=None)
+        self.set_user_role(self.test_user, UserProfile.ROLE_MEMBER)
         self.subscribe_via_post(
             self.test_user,
             ["stream2"],
@@ -749,7 +748,7 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Must be an organization owner")
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_OWNER, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_OWNER)
         result = self.client_patch(
             f"/json/streams/{stream.id}", {"message_retention_days": orjson.dumps(2).decode()}
         )

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -22,7 +22,7 @@ from django.utils.timezone import now as timezone_now
 
 from zerver.actions.realm_settings import do_deactivate_realm
 from zerver.actions.streams import do_change_stream_group_based_setting, do_deactivate_stream
-from zerver.actions.users import do_change_user_role, do_deactivate_user
+from zerver.actions.users import do_deactivate_user
 from zerver.lib.email_mirror import (
     RateLimitedRealmMirror,
     create_missed_message_address,
@@ -698,7 +698,7 @@ class TestChannelEmailMessagesPermissions(ZulipTestCase):
         realm = get_realm("zulip")
         channel = get_stream("Denmark", realm)
 
-        do_change_user_role(hamlet, UserProfile.ROLE_MODERATOR, acting_user=None)
+        self.set_user_role(hamlet, UserProfile.ROLE_MODERATOR)
         moderators_group = NamedUserGroup.objects.get(
             name=SystemGroups.MODERATORS, realm_for_sharding=realm, is_system_group=True
         )
@@ -753,7 +753,7 @@ class TestChannelEmailMessagesPermissions(ZulipTestCase):
         )
 
         # Sender is a bot owned by the current user + has the post permission.
-        do_change_user_role(bot, UserProfile.ROLE_MODERATOR, acting_user=None)
+        self.set_user_role(bot, UserProfile.ROLE_MODERATOR)
         incoming_valid_message = self.create_incoming_valid_message(channel_email_address)
 
         with self.assertLogs(logger_name, level="INFO") as m:
@@ -770,7 +770,7 @@ class TestChannelEmailMessagesPermissions(ZulipTestCase):
         realm = get_realm("zulip")
         channel = get_stream("Denmark", realm)
 
-        do_change_user_role(hamlet, UserProfile.ROLE_MODERATOR, acting_user=None)
+        self.set_user_role(hamlet, UserProfile.ROLE_MODERATOR)
         admins_group = NamedUserGroup.objects.get(
             name=SystemGroups.ADMINISTRATORS, realm_for_sharding=realm, is_system_group=True
         )
@@ -825,7 +825,7 @@ class TestChannelEmailMessagesPermissions(ZulipTestCase):
         )
 
         # Sender is a bot owned by the current user + has the post permission.
-        do_change_user_role(bot, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(bot, UserProfile.ROLE_REALM_ADMINISTRATOR)
         incoming_valid_message = self.create_incoming_valid_message(channel_email_address)
 
         with self.assertLogs(logger_name, level="INFO") as m:

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -17,7 +17,6 @@ from zerver.actions.message_send import check_send_message
 from zerver.actions.presence import do_update_user_presence
 from zerver.actions.streams import do_change_stream_folder
 from zerver.actions.user_settings import do_change_user_setting
-from zerver.actions.users import do_change_user_role
 from zerver.lib.event_schema import check_web_reload_client_event
 from zerver.lib.events import fetch_initial_state_data, post_process_state
 from zerver.lib.exceptions import AccessDeniedError
@@ -661,7 +660,7 @@ class FetchInitialStateDataTest(ZulipTestCase):
     # Admin users have access to all bots in the realm_bots field
     def test_realm_bots_admin(self) -> None:
         user_profile = self.example_user("hamlet")
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
         self.assertTrue(user_profile.is_realm_admin)
         result = fetch_initial_state_data(user_profile, realm=user_profile.realm)
         self.assertGreater(len(result["realm_bots"]), 2)

--- a/zerver/tests/test_realm_domains.py
+++ b/zerver/tests/test_realm_domains.py
@@ -6,7 +6,6 @@ from typing_extensions import override
 from zerver.actions.create_realm import do_create_realm
 from zerver.actions.realm_domains import do_change_realm_domain, do_remove_realm_domain
 from zerver.actions.realm_settings import do_set_realm_property
-from zerver.actions.users import do_change_user_role
 from zerver.lib.domains import validate_domain
 from zerver.lib.email_validation import email_allowed_for_realm
 from zerver.lib.test_classes import ZulipTestCase
@@ -69,7 +68,7 @@ class RealmDomainTest(ZulipTestCase):
         mit_user_profile = self.mit_user("sipbtest")
         self.login_user(mit_user_profile)
 
-        do_change_user_role(mit_user_profile, UserProfile.ROLE_REALM_OWNER, acting_user=None)
+        self.set_user_role(mit_user_profile, UserProfile.ROLE_REALM_OWNER)
 
         result = self.client_post(
             "/json/realm/domains", info=data, HTTP_HOST=mit_user_profile.realm.host

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -8,7 +8,6 @@ from zerver.actions.realm_settings import (
     do_set_realm_property,
 )
 from zerver.actions.user_groups import check_add_user_group
-from zerver.actions.users import do_change_user_role
 from zerver.lib.emoji import get_emoji_file_name
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.test_classes import ZulipTestCase
@@ -185,7 +184,7 @@ class RealmEmojiTest(ZulipTestCase):
         realm = othello.realm
         self.login_user(othello)
 
-        do_change_user_role(othello, UserProfile.ROLE_MODERATOR, acting_user=None)
+        self.set_user_role(othello, UserProfile.ROLE_MODERATOR)
         administrators_system_group = NamedUserGroup.objects.get(
             name=SystemGroups.ADMINISTRATORS, realm_for_sharding=realm, is_system_group=True
         )
@@ -200,7 +199,7 @@ class RealmEmojiTest(ZulipTestCase):
             result = self.client_post("/json/realm/emoji/my_emoji_1", info=emoji_data)
         self.assert_json_error(result, "Insufficient permission")
 
-        do_change_user_role(othello, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(othello, UserProfile.ROLE_REALM_ADMINISTRATOR)
         with get_test_image_file("img.png") as fp1:
             emoji_data = {"f1": fp1}
             result = self.client_post("/json/realm/emoji/my_emoji_1", info=emoji_data)
@@ -215,13 +214,13 @@ class RealmEmojiTest(ZulipTestCase):
             moderators_system_group,
             acting_user=None,
         )
-        do_change_user_role(othello, UserProfile.ROLE_MEMBER, acting_user=None)
+        self.set_user_role(othello, UserProfile.ROLE_MEMBER)
         with get_test_image_file("img.png") as fp1:
             emoji_data = {"f1": fp1}
             result = self.client_post("/json/realm/emoji/my_emoji_2", info=emoji_data)
         self.assert_json_error(result, "Insufficient permission")
 
-        do_change_user_role(othello, UserProfile.ROLE_MODERATOR, acting_user=None)
+        self.set_user_role(othello, UserProfile.ROLE_MODERATOR)
         with get_test_image_file("img.png") as fp1:
             emoji_data = {"f1": fp1}
             result = self.client_post("/json/realm/emoji/my_emoji_2", info=emoji_data)
@@ -237,7 +236,7 @@ class RealmEmojiTest(ZulipTestCase):
             acting_user=None,
         )
         do_set_realm_property(othello.realm, "waiting_period_threshold", 100000, acting_user=None)
-        do_change_user_role(othello, UserProfile.ROLE_MEMBER, acting_user=None)
+        self.set_user_role(othello, UserProfile.ROLE_MEMBER)
 
         with get_test_image_file("img.png") as fp1:
             emoji_data = {"f1": fp1}
@@ -259,13 +258,13 @@ class RealmEmojiTest(ZulipTestCase):
             members_system_group,
             acting_user=None,
         )
-        do_change_user_role(othello, UserProfile.ROLE_GUEST, acting_user=None)
+        self.set_user_role(othello, UserProfile.ROLE_GUEST)
         with get_test_image_file("img.png") as fp1:
             emoji_data = {"f1": fp1}
             result = self.client_post("/json/realm/emoji/my_emoji_4", info=emoji_data)
         self.assert_json_error(result, "Not allowed for guest users")
 
-        do_change_user_role(othello, UserProfile.ROLE_MEMBER, acting_user=None)
+        self.set_user_role(othello, UserProfile.ROLE_MEMBER)
         with get_test_image_file("img.png") as fp1:
             emoji_data = {"f1": fp1}
             result = self.client_post("/json/realm/emoji/my_emoji_4", info=emoji_data)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -29,7 +29,7 @@ from zerver.actions.realm_settings import (
     do_set_realm_property,
     do_set_realm_user_default_setting,
 )
-from zerver.actions.users import change_user_is_active, do_change_user_role, do_deactivate_user
+from zerver.actions.users import change_user_is_active, do_deactivate_user
 from zerver.decorator import do_two_factor_login
 from zerver.forms import HomepageForm
 from zerver.lib.default_streams import get_slim_realm_default_streams
@@ -3607,11 +3607,11 @@ class DeactivateUserTest(ZulipTestCase):
         user = self.example_user("desdemona")
         self.assertTrue(user.is_active)
         self.assertTrue(user.is_realm_owner)
-        do_change_user_role(user_2, UserProfile.ROLE_REALM_OWNER, acting_user=None)
+        self.set_user_role(user_2, UserProfile.ROLE_REALM_OWNER)
         self.assertTrue(user_2.is_realm_owner)
         result = self.client_delete("/json/users/me")
         self.assert_json_success(result)
-        do_change_user_role(user, UserProfile.ROLE_REALM_OWNER, acting_user=None)
+        self.set_user_role(user, UserProfile.ROLE_REALM_OWNER)
 
     def test_do_not_deactivate_final_user(self) -> None:
         realm = get_realm("zulip")

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -35,7 +35,7 @@ from zerver.actions.streams import (
     do_unarchive_stream,
 )
 from zerver.actions.user_groups import bulk_add_members_to_user_groups, check_add_user_group
-from zerver.actions.users import do_change_user_role, do_deactivate_user
+from zerver.actions.users import do_deactivate_user
 from zerver.lib.attachments import (
     validate_attachment_request,
     validate_attachment_request_for_spectator_access,
@@ -231,7 +231,7 @@ class StreamAdminTest(ZulipTestCase):
         self.make_stream("private_stream_1", invite_only=True)
         self.make_stream("private_stream_2", invite_only=True)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
         params = {
             "is_private": orjson.dumps(False).decode(),
         }
@@ -241,7 +241,7 @@ class StreamAdminTest(ZulipTestCase):
 
         stream = self.subscribe(user_profile, "private_stream_1")
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
         params = {
             "is_private": orjson.dumps(False).decode(),
         }
@@ -298,7 +298,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertTrue(private_stream.invite_only)
 
         stream = self.subscribe(user_profile, "private_stream_3", invite_only=True)
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_OWNER, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_OWNER)
         nobody_group = NamedUserGroup.objects.get(
             name=SystemGroups.NOBODY, realm_for_sharding=realm, is_system_group=True
         )
@@ -332,7 +332,7 @@ class StreamAdminTest(ZulipTestCase):
         self.make_stream("public_stream_1", realm=realm)
         self.make_stream("public_stream_2")
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
         params = {
             "is_private": orjson.dumps(True).decode(),
         }
@@ -387,7 +387,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertFalse(default_stream.invite_only)
 
         stream = self.subscribe(user_profile, "public_stream_3")
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_OWNER, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_OWNER)
         nobody_group = NamedUserGroup.objects.get(
             name=SystemGroups.NOBODY, realm_for_sharding=realm, is_system_group=True
         )
@@ -487,7 +487,7 @@ class StreamAdminTest(ZulipTestCase):
         realm = user_profile.realm
         self.make_stream("public_history_stream", realm=realm)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
         params = {
             "is_private": orjson.dumps(True).decode(),
             "history_public_to_subscribers": orjson.dumps(True).decode(),
@@ -600,7 +600,7 @@ class StreamAdminTest(ZulipTestCase):
             owners_group,
             acting_user=None,
         )
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
         result = self.client_patch(f"/json/streams/{stream_id}", params)
         self.assert_json_error(result, "Insufficient permission")
 
@@ -613,7 +613,7 @@ class StreamAdminTest(ZulipTestCase):
             nobody_group,
             acting_user=None,
         )
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_OWNER, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_OWNER)
         result = self.client_patch(f"/json/streams/{stream_id}", params)
         self.assert_json_error(result, "Insufficient permission")
 
@@ -623,7 +623,7 @@ class StreamAdminTest(ZulipTestCase):
             owners_group,
             acting_user=None,
         )
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_OWNER, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_OWNER)
         with self.settings(WEB_PUBLIC_STREAMS_ENABLED=False):
             result = self.client_patch(f"/json/streams/{stream_id}", params)
         self.assert_json_error(result, "Web-public channels are not enabled.")
@@ -1194,7 +1194,7 @@ class StreamAdminTest(ZulipTestCase):
         realm = user_profile.realm
         self.make_stream("public_stream", realm=realm)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
         params = {
             "is_private": orjson.dumps(False).decode(),
             "history_public_to_subscribers": orjson.dumps(False).decode(),
@@ -1261,7 +1261,7 @@ class StreamAdminTest(ZulipTestCase):
         self.login_user(user_profile)
         stream = self.make_stream("new_stream_1")
         self.subscribe(user_profile, stream.name)
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
 
         # Subscribe Cordelia to verify that the archive notification is marked as read for all subscribers.
         cordelia = self.example_user("cordelia")
@@ -1537,7 +1537,7 @@ class StreamAdminTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
         self.make_stream("new_stream")
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
 
         result = self.client_delete("/json/streams/999999999")
         self.assert_json_error(result, "Invalid channel ID")
@@ -1546,7 +1546,7 @@ class StreamAdminTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
 
         self.make_stream("private_stream", invite_only=True)
         self.subscribe(user_profile, "private_stream")
@@ -1593,7 +1593,7 @@ class StreamAdminTest(ZulipTestCase):
         realm = user_profile.realm
         stream = self.subscribe(user_profile, "stream_name")
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
         result = self.client_patch(f"/json/streams/{stream.id}", {"new_name": "stream_name1"})
         self.assert_json_success(result)
 
@@ -1781,7 +1781,7 @@ class StreamAdminTest(ZulipTestCase):
         self.make_stream("stream_name1")
 
         stream = self.subscribe(user_profile, "stream_name1")
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
         result = self.client_patch(f"/json/streams/{stream.id}", {"new_name": "stream_name2"})
         self.assert_json_success(result)
 
@@ -2024,7 +2024,7 @@ class StreamAdminTest(ZulipTestCase):
             '<p>See <a href="https://zulip.com/team/">https://zulip.com/team/</a></p>',
         )
 
-        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_MEMBER)
         result = self.client_patch(
             f"/json/streams/{stream_id}", {"description": "Test description"}
         )
@@ -2686,7 +2686,7 @@ class StreamAdminTest(ZulipTestCase):
         if subscribed:
             self.subscribe(user_profile, stream_name)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
 
         return stream
 
@@ -2803,7 +2803,7 @@ class StreamAdminTest(ZulipTestCase):
 
         # Even becoming a realm admin doesn't help us for an out-of-realm
         # stream.
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
         result = self.client_delete("/json/streams/" + str(stream.id))
         self.assert_json_error(result, "Invalid channel ID")
 
@@ -3456,7 +3456,7 @@ class SubscriptionAPITest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
         stream = self.subscribe(user_profile, "stream_name1")
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        self.set_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
         # Check for empty name
         result = self.client_patch(f"/json/streams/{stream.id}", {"new_name": ""})
         self.assert_json_error(result, "Channel name can't be empty.")


### PR DESCRIPTION
This adds a helper method that wraps `do_change_user_role` for use in tests. This is a preparatory commit for PR #36208.

In PR #36208, a variable `notify` is added to `do_change_user_role`. This PR will make it easy to update all the tests with `notify=False`.

Updates all existing test files to use the new helper method instead of calling `do_change_user_role` directly.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
