### PR TITLE
help: Better explain use cases for restricting new topics.

### DIFF
--- a/starlight_help/src/content/docs/channel-posting-policy.mdx
+++ b/starlight_help/src/content/docs/channel-posting-policy.mdx
@@ -4,12 +4,18 @@ title: Channel posting policy
 
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import NavigationSteps from "../../components/NavigationSteps.astro";
+import ZulipTip from "../../components/ZulipTip.astro";
 import SaveChanges from "../include/_SaveChanges.mdx";
 import SelectChannelViewPermissions from "../include/_SelectChannelViewPermissions.mdx";
 
 You can restrict who can send messages to a channel. For example,
 you can set up an announcement channel where only a specific
 [group](/help/user-groups) of users can send messages.
+
+<ZulipTip>
+  You can also [configure who can start new
+  topics](/help/configure-who-can-start-new-topics).
+</ZulipTip>
 
 <FlattenedSteps>
   <NavigationSteps target="relative/channel/all" />

--- a/starlight_help/src/content/docs/configure-who-can-start-new-topics.mdx
+++ b/starlight_help/src/content/docs/configure-who-can-start-new-topics.mdx
@@ -4,11 +4,23 @@ title: Configure who can start new topics
 
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import NavigationSteps from "../../components/NavigationSteps.astro";
+import ZulipTip from "../../components/ZulipTip.astro";
 import SaveChanges from "../include/_SaveChanges.mdx";
 import SelectChannelViewPermissions from "../include/_SelectChannelViewPermissions.mdx";
 
 You can restrict who can start new topics in a channel. For example, you can set
-up a channel with just a handful of topics everyone is expected to use.
+up:
+
+* A channel where only some users can post new announcements, but
+  everyone can discuss them.
+* A channel with just a handful of topics everyone is expected to use.
+* A channel for mirroring another messaging app, where each topic corresponds to
+  a channel in the other app.
+
+<ZulipTip>
+  You can also [configure who can send messages](/help/channel-posting-policy)
+  to a channel.
+</ZulipTip>
 
 <FlattenedSteps>
   <NavigationSteps target="relative/channel/all" />

--- a/starlight_help/src/content/docs/general-chat-channels.mdx
+++ b/starlight_help/src/content/docs/general-chat-channels.mdx
@@ -6,6 +6,7 @@ import {TabItem, Tabs} from "@astrojs/starlight/components";
 
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import NavigationSteps from "../../components/NavigationSteps.astro";
+import ZulipTip from "../../components/ZulipTip.astro";
 import SaveChanges from "../include/_SaveChanges.mdx";
 import SelectChannelViewPermissions from "../include/_SelectChannelViewPermissions.mdx";
 
@@ -19,6 +20,11 @@ italics, and is translated into [your language](/help/change-your-language).
 
 Users won't need to enter a topic when sending a message to a “*general chat*”
 channel.
+
+<ZulipTip>
+  You can also allow topics, but [configure who can start new
+  ones](/help/configure-who-can-start-new-topics).
+</ZulipTip>
 
 ## Configure a channel to have only the “*general chat*” topic
 
@@ -44,3 +50,4 @@ channel.
 * [Introduction to topics](/help/introduction-to-topics)
 * [“*General chat*” topic](/help/general-chat-topic)
 * [Require topics in channel messages](/help/require-topics)
+* [Configure who can start new ones](/help/configure-who-can-start-new-topics)


### PR DESCRIPTION
Also prominently cross-link new topics permission setting with related ones.

## https://chat.zulip.org/help/configure-who-can-start-new-topics
<img width="1488" height="694" alt="Screenshot 2025-12-10 at 13 44 10@2x" src="https://github.com/user-attachments/assets/0d3ddfe5-328e-441a-aa5a-e9de67c16511" />

## https://zulip.com/help/channel-posting-policy
<img width="1510" height="392" alt="Screenshot 2025-12-10 at 13 43 49@2x" src="https://github.com/user-attachments/assets/98643b91-468e-418f-ad07-70cc5effb5b6" />

## https://zulip.com/help/general-chat-channels
<img width="1498" height="686" alt="Screenshot 2025-12-10 at 13 47 46@2x" src="https://github.com/user-attachments/assets/ca849940-f0c7-432a-b11e-411f2f698ea5" />

