### PR TITLE
contributor docs: Expand on claiming a mobile issue; use "help wanted"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,13 +247,21 @@ issue you're interested in.
 
 #### In other Zulip repositories
 
-There is no bot for other Zulip repositories
-([`zulip/zulip-flutter`](https://github.com/zulip/zulip-flutter/), etc.). If
-you are interested in claiming an issue in one of these repositories, simply
-post a comment on the issue thread saying that you've started work on the
-issue and would like to claim it. In your comment, describe what part of the
-code you're modifying and how you plan to approach the problem, based on
-what you learned in steps 1–4 [above](#picking-an-issue-to-work-on).
+In other Zulip repositories, including
+[`zulip/zulip-flutter`](https://github.com/zulip/zulip-flutter/),
+there is no bot.  Instead:
+* Use the steps above to find an issue you'd like to work on
+  and to get started working on it.
+* Post a comment on the issue thread saying that you've started work
+  on the issue and would like to claim it.
+* In your comment, **describe what you learned in steps 1–4
+  [above](#picking-an-issue-to-work-on)**: what part of the code
+  you're modifying and how you plan to approach the problem.
+* Once you've followed these steps, you've successfully claimed the issue.
+  Go ahead and continue work on the issue, and send a PR when ready.
+  Someone might come along and assign the issue to you for better
+  tracking, but there's no need to wait for that or for any other
+  form of permission.
 
 There is no need to @-mention the issue creator in your comment. There is
 also no need to post the same information in multiple places, for example in


### PR DESCRIPTION
#### 7e3ebc2e9 contributor docs: Use "help wanted" for mobile too

A few weeks ago I went and applied this label to a number of issues.
I think it's a helpful form of guidance for new contributors.



#### 62990213a contributor docs: Expand on claiming a mobile issue

We last revised this section in 68e96bc73, a little over a year ago.

Some new contributors do appear to be reading it, in that they gesture
toward saying how they would solve the issue... though the majority
even of those don't really say anything more specific than "I'd solve
the issue by solving the issue", and give no evidence of having
actually started on it as instructed.  So, first, revise to be more
emphatic about that part.

Second, lots of new contributors post a comment saying they want to
claim the issue (with or without following anything like the
instruction to post a plan)... but phrase it like a request for
permission, and then don't follow up, as if they were waiting for a
reply before actually proceeding.

The point of these instructions was always that the "claim" comment
is self-executing, and the contributor should proceed right ahead to
a PR -- after all, if they've followed instructions up to this point,
they've already done much of the work anyway.  Make that point
explicit.

