### PR TITLE
filter: Return operator's operand type in NarrowCanonicalTerm.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1031,8 +1031,13 @@ export class Filter {
         return safe_to_return;
     }
 
-    terms_with_operator(operator: NarrowCanonicalOperator): NarrowTerm[] {
-        return this._terms.filter((term) => !term.negated && term.operator === operator);
+    terms_with_operator<T extends NarrowCanonicalTerm["operator"]>(
+        operator: T,
+    ): Extract<NarrowCanonicalTerm, {operator: T}>[] {
+        return this._terms.filter(
+            (term): term is Extract<NarrowCanonicalTerm, {operator: T}> =>
+                !term.negated && term.operator === operator,
+        );
     }
 
     has_negated_operand(operator: string, operand: string): boolean {

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -53,11 +53,78 @@ export const narrow_operator_schema = z.union([
 ]);
 export type NarrowOperator = z.output<typeof narrow_operator_schema>;
 
-export const narrow_canonical_term_schema = z.object({
-    negated: z.optional(z.boolean()),
-    operator: narrow_canonical_operator_schema,
-    operand: z.string(),
-});
+export const narrow_canonical_term_schema = z.discriminatedUnion("operator", [
+    z.object({
+        operator: z.literal(""),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("channel"),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("channels"),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("has"),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("id"),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("in"),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("is"),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("near"),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("search"),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("topic"),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("with"),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("sender"),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("dm-including"),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("dm"),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+]);
 export type NarrowCanonicalTerm = z.output<typeof narrow_canonical_term_schema>;
 
 export const narrow_term_schema = z.union([

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -3143,6 +3143,6 @@ run_test("get_stringified_narrow_for_server_query", () => {
     const narrow = filter.get_stringified_narrow_for_server_query();
     assert.equal(
         narrow,
-        '[{"negated":false,"operator":"channel","operand":1},{"negated":false,"operator":"topic","operand":"bar"}]',
+        '[{"operator":"channel","operand":1,"negated":false},{"operator":"topic","operand":"bar","negated":false}]',
     );
 });


### PR DESCRIPTION
Extracted from #36588

This helps clarify the return type without using any assertions. Will be helpful when `NarrowCanonicalTerm` will have different `operand` types based on `operator`.

NarrowCanonicalTerm is expanded to use `discriminatedUnion` to support this which just has `string` types right now but will have different types soon based on operator.
