### PR TITLE
popovers: Fix overly narrow topic popover for spectators.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -275,6 +275,7 @@
         line-height: 1.1;
         margin-top: 4px;
         white-space: pre-wrap;
+        min-width: 12.5em; /* 200px at 16px/1em */
     }
 }
 


### PR DESCRIPTION
The width of the popover was being defined by topic follow / mute buttons which are not visible for spectators and hence the popover shrunk.

Fixed by giving the topic name a minimum width of 200px.

No change for logged in topic popover.

discussion: [#issues > overly narrow topic menu for spectators](https://chat.zulip.org/#narrow/channel/9-issues/topic/overly.20narrow.20topic.20menu.20for.20spectators/with/2323804)

| before | after |
| --- | --- |
| <img width="368" height="171" alt="Screenshot from 2025-12-11 18-02-30" src="https://github.com/user-attachments/assets/71537c23-84b1-4ced-b239-d2f5351d1b87" /> |  <img width="368" height="171" alt="Screenshot from 2025-12-11 18-02-40" src="https://github.com/user-attachments/assets/43d08af9-715a-4dc9-bfbb-56a4c8c66e75" /> |
| <img width="412" height="467" alt="Screenshot from 2025-12-11 18-03-03" src="https://github.com/user-attachments/assets/5b471543-adf4-46bb-b195-ddc5fb295851" /> | <img width="412" height="467" alt="Screenshot from 2025-12-11 18-02-54" src="https://github.com/user-attachments/assets/f760d837-0fc4-4fc9-b9b8-b53645ed0730" /> |


