### PR TITLE
api-docs: Update outgoing webhooks page.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -1574,10 +1574,10 @@ deactivated groups.
 
 * [`GET /events`](/api/get-events), [`GET /messages`](/api/get-messages),
   [`GET /messages/{message_id}`](/api/get-message),
-  [`POST /zulip-outgoing-webhook`](/api/zulip-outgoing-webhooks): Removed
-  the `prev_rendered_content_version` field from the `edit_history` object
-  within message objects and the `update_message` event type as it is an
-  internal server implementation detail not used by any client.
+  [outgoing webhook payloads](/api/outgoing-webhook-payload#zulip-format):
+  Removed the `prev_rendered_content_version` field from the `edit_history`
+  object within message objects and the `update_message` event type as it
+  is an internal server implementation detail not used by any client.
 
 **Feature level 283**
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -169,3 +169,4 @@
 * [Add an FCM registration token](/api/add-fcm-token)
 * [Remove an FCM registration token](/api/remove-fcm-token)
 * [Create BigBlueButton video call](/api/create-big-blue-button-video-call)
+* [Outgoing webhook payloads](/api/outgoing-webhook-payload)

--- a/api_docs/outgoing-webhook-payload.md
+++ b/api_docs/outgoing-webhook-payload.md
@@ -1,0 +1,106 @@
+# Outgoing webhook payloads
+
+Zulip supports [outgoing webhooks](/api/outgoing-webhooks) in a clean,
+native [Zulip format](#zulip-format), as well as in a [Slack-compatible
+format](#slack-compatible-format).
+
+## Zulip format
+
+{generate_code_example|/zulip-outgoing-webhook:post|fixture}
+
+### Fields documentation
+
+{generate_return_values_table|zulip.yaml|/zulip-outgoing-webhook:post}
+
+## Slack-compatible format
+
+This webhook format is compatible with [Slack's outgoing webhook
+API](https://api.slack.com/custom-integrations/outgoing-webhooks),
+which can help with porting an existing Slack integration to work with
+Zulip, and allows immediate integration with many third-party systems
+that already support Slack outgoing webhooks.
+
+The following table details how the Zulip server translates a Zulip
+message into the Slack-compatible webhook format.
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>token</code></td>
+            <td>A string of alphanumeric characters you can use to
+            authenticate the webhook request (each bot user uses a fixed token)</td>
+        </tr>
+        <tr>
+            <td><code>team_id</code></td>
+            <td>ID of the Zulip organization prefixed by "T".</td>
+        </tr>
+        <tr>
+            <td><code>team_domain</code></td>
+            <td>Hostname of the Zulip organization</td>
+        </tr>
+        <tr>
+            <td><code>channel_id</code></td>
+            <td>Channel ID prefixed by "C"</td>
+        </tr>
+        <tr>
+            <td><code>channel_name</code></td>
+            <td>Channel name</td>
+        </tr>
+        <tr>
+            <td><code>thread_ts</code></td>
+            <td>Timestamp for when message was sent</td>
+        </tr>
+        <tr>
+            <td><code>timestamp</code></td>
+            <td>Timestamp for when message was sent</td>
+        </tr>
+        <tr>
+            <td><code>user_id</code></td>
+            <td>ID of the user who sent the message prefixed by "U"</td>
+        </tr>
+        <tr>
+            <td><code>user_name</code></td>
+            <td>Full name of sender</td>
+        </tr>
+        <tr>
+            <td><code>text</code></td>
+            <td>The content of the message (in Markdown)</td>
+        </tr>
+        <tr>
+            <td><code>trigger_word</code></td>
+            <td>Trigger method</td>
+        </tr>
+        <tr>
+            <td><code>service_id</code></td>
+            <td>ID of the bot user</td>
+        </tr>
+    </tbody>
+</table>
+
+The above data is posted as list of tuples (not JSON), here's an example:
+
+```
+[('token', 'v9fpCdldZIej2bco3uoUvGp06PowKFOf'),
+ ('team_id', 'T1512'),
+ ('team_domain', 'zulip.example.com'),
+ ('channel_id', 'C123'),
+ ('channel_name', 'integrations'),
+ ('thread_ts', 1532078950),
+ ('timestamp', 1532078950),
+ ('user_id', 'U21'),
+ ('user_name', 'Full Name'),
+ ('text', '@**test**'),
+ ('trigger_word', 'mention'),
+ ('service_id', 27)]
+```
+
+* For successful requests, if data is returned, it returns that data,
+  else it returns a blank response.
+* For failed requests, it returns the reason of failure, as returned by
+  the server, or the exception message.

--- a/api_docs/outgoing-webhooks.md
+++ b/api_docs/outgoing-webhooks.md
@@ -3,7 +3,8 @@
 Outgoing webhooks allow you to build or set up Zulip integrations
 which are notified when certain types of messages are sent in Zulip
 When one of those events is [triggered](#triggering), the Zulip server
-will send an HTTP POST payload to the webhook's configured URL.
+will send an HTTP POST [payload](/api/outgoing-webhook-payload) to the
+webhook's configured URL.
 
 Outgoing webhooks can be used to power a wide range of Zulip
 integrations. For example, the [Zulip Botserver](/api/deploying-bots#zulip-botserver)
@@ -22,8 +23,8 @@ is built on top of this API.
 1. Set **Bot type** to **Outgoing webhook**.
 
 1. Fill out the fields, with **Endpoint URL** set to the URL you'd like
-   Zulip to post to, and the outgoing webhook [format](#formats) you
-   plan on using.
+   Zulip to post to, and the outgoing webhook [format](/api/outgoing-webhook-payload)
+   you plan on using.
 
 1. Click **Add**.
 
@@ -88,110 +89,3 @@ The `content` field should contain [Zulip-flavored Markdown](/help/format-your-m
 Note that an outgoing webhook bot can use the [Zulip REST
 API](/api/rest) with its API key in case your bot needs to do
 something else, like add an emoji reaction or upload a file.
-
-## Formats
-
-Zulip supports outgoing webhooks in a clean, native
-[Zulip format](#zulip-format), as well as in a
-[Slack-compatible format](#slack-compatible-format).
-
-### Zulip format
-
-{generate_code_example|/zulip-outgoing-webhook:post|fixture}
-
-### Fields documentation
-
-{generate_return_values_table|zulip.yaml|/zulip-outgoing-webhook:post}
-
-### Slack-compatible format
-
-This webhook format is compatible with [Slack's outgoing webhook
-API](https://api.slack.com/custom-integrations/outgoing-webhooks),
-which can help with porting an existing Slack integration to work with
-Zulip, and allows immediate integration with many third-party systems
-that already support Slack outgoing webhooks.
-
-The following table details how the Zulip server translates a Zulip
-message into the Slack-compatible webhook format.
-
-<table class="table">
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><code>token</code></td>
-            <td>A string of alphanumeric characters you can use to
-            authenticate the webhook request (each bot user uses a fixed token)</td>
-        </tr>
-        <tr>
-            <td><code>team_id</code></td>
-            <td>ID of the Zulip organization prefixed by "T".</td>
-        </tr>
-        <tr>
-            <td><code>team_domain</code></td>
-            <td>Hostname of the Zulip organization</td>
-        </tr>
-        <tr>
-            <td><code>channel_id</code></td>
-            <td>Channel ID prefixed by "C"</td>
-        </tr>
-        <tr>
-            <td><code>channel_name</code></td>
-            <td>Channel name</td>
-        </tr>
-        <tr>
-            <td><code>thread_ts</code></td>
-            <td>Timestamp for when message was sent</td>
-        </tr>
-        <tr>
-            <td><code>timestamp</code></td>
-            <td>Timestamp for when message was sent</td>
-        </tr>
-        <tr>
-            <td><code>user_id</code></td>
-            <td>ID of the user who sent the message prefixed by "U"</td>
-        </tr>
-        <tr>
-            <td><code>user_name</code></td>
-            <td>Full name of sender</td>
-        </tr>
-        <tr>
-            <td><code>text</code></td>
-            <td>The content of the message (in Markdown)</td>
-        </tr>
-        <tr>
-            <td><code>trigger_word</code></td>
-            <td>Trigger method</td>
-        </tr>
-        <tr>
-            <td><code>service_id</code></td>
-            <td>ID of the bot user</td>
-        </tr>
-    </tbody>
-</table>
-
-The above data is posted as list of tuples (not JSON), here's an example:
-
-```
-[('token', 'v9fpCdldZIej2bco3uoUvGp06PowKFOf'),
- ('team_id', 'T1512'),
- ('team_domain', 'zulip.example.com'),
- ('channel_id', 'C123'),
- ('channel_name', 'integrations'),
- ('thread_ts', 1532078950),
- ('timestamp', 1532078950),
- ('user_id', 'U21'),
- ('user_name', 'Full Name'),
- ('text', '@**test**'),
- ('trigger_word', 'mention'),
- ('service_id', 27)]
-```
-
-* For successful request, if data is returned, it returns that data,
-  else it returns a blank response.
-* For failed request, it returns the reason of failure, as returned by
-  the server, or the exception message.


### PR DESCRIPTION
Fixes #36601, with an additional prep commit for moving the outgoing webhook documentation from the API documentation to the help center (see [#integrations > integration docs reorg](https://chat.zulip.org/#narrow/channel/127-integrations/topic/integration.20docs.20reorg/with/2311831)).

**Screenshots and screen captures:**

[CURRENT DOC](https://zulip.com/api/outgoing-webhooks)
<img width="774" height="1572" alt="Screenshot From 2025-12-11 15-57-08" src="https://github.com/user-attachments/assets/3a24d63c-56fe-4659-bb65-18fe10471df5" />

*New page for outgoing webhook payload information, note that this content is just basically moved from the current doc linked above.*
<img width="774" height="1582" alt="Screenshot From 2025-12-11 15-51-36" src="https://github.com/user-attachments/assets/04a5db2e-8f3d-43b7-8085-f17c0b889c40" />
*Not included in the screenshots is the majority of the Zulip format API as that content is generated from the zulip.yaml file, which is not edited as part of these changes.*
<img width="774" height="1599" alt="Screenshot From 2025-12-11 15-51-50" src="https://github.com/user-attachments/assets/0556d8a7-351c-44f4-9882-c39506f9cfeb" />


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
