### PR TITLE
run-dev: Revert back to localhost, not localhost.localdomain.

### DIFF
--- a/tools/run-dev
+++ b/tools/run-dev
@@ -447,7 +447,7 @@ async def serve() -> None:
         # the default/zulip subdomain.
         default_hostname = "zulip." + os.uname()[1].lower()
     else:
-        default_hostname = "localhost.localdomain"
+        default_hostname = "localhost"
 
     external_host = os.getenv("EXTERNAL_HOST", f"{default_hostname}:{proxy_port}")
     http_protocol = "https" if options.behind_https_proxy else "http"

--- a/zerver/checks.py
+++ b/zerver/checks.py
@@ -54,7 +54,7 @@ def check_external_host_setting(
 
     errors = []
     hostname = settings.EXTERNAL_HOST
-    if "." not in hostname and os.environ.get("ZULIP_TEST_SUITE") != "true":
+    if "." not in hostname and os.environ.get("ZULIP_TEST_SUITE") != "true" and settings.PRODUCTION:
         suggest = ".localdomain" if hostname == "localhost" else ".local"
         errors.append(
             checks.Error(

--- a/zerver/tests/test_checks.py
+++ b/zerver/tests/test_checks.py
@@ -35,6 +35,7 @@ class TestChecks(ZulipTestCase):
             ZULIP_ADMINISTRATOR=None,
         )
 
+    @override_settings(DEVELOPMENT=False, PRODUCTION=True)
     def test_checks_external_host_domain(self) -> None:
         message_re = r"\(zulip\.E002\) EXTERNAL_HOST \(\S+\) does not contain a domain part"
         try:


### PR DESCRIPTION
https://w3c.github.io/webappsec-secure-contexts/ gives special treatment to localhost and *.localhost that it does not give to localhost.localdomain.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
