### PR TITLE
contributing: Fix lint error from recent edits for moble app repos.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,15 +249,16 @@ issue you're interested in.
 
 In other Zulip repositories, including
 [`zulip/zulip-flutter`](https://github.com/zulip/zulip-flutter/),
-there is no bot.  Instead:
-* Use the steps above to find an issue you'd like to work on
+there is no bot. Instead:
+
+- Use the steps above to find an issue you'd like to work on
   and to get started working on it.
-* Post a comment on the issue thread saying that you've started work
+- Post a comment on the issue thread saying that you've started work
   on the issue and would like to claim it.
-* In your comment, **describe what you learned in steps 1–4
+- In your comment, **describe what you learned in steps 1–4
   [above](#picking-an-issue-to-work-on)**: what part of the code
   you're modifying and how you plan to approach the problem.
-* Once you've followed these steps, you've successfully claimed the issue.
+- Once you've followed these steps, you've successfully claimed the issue.
   Go ahead and continue work on the issue, and send a PR when ready.
   Someone might come along and assign the issue to you for better
   tracking, but there's no need to wait for that or for any other


### PR DESCRIPTION
[#automated testing > lint issue on CONTRIBUTING.md](https://chat.zulip.org/#narrow/channel/43-automated-testing/topic/lint.20issue.20on.20CONTRIBUTING.2Emd/with/2324315)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
