### PR TITLE
"Add yellow outline to organization description when empty"

### DIFF
--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -1,4 +1,4 @@
-import {add} from "date-fns";
+import { add } from "date-fns";
 import $ from "jquery";
 import assert from "minimalistic-assert";
 import * as z from "zod/mini";
@@ -10,7 +10,7 @@ import render_settings_admin_auth_methods_list from "../templates/settings/admin
 import * as audible_notifications from "./audible_notifications.ts";
 import * as blueslip from "./blueslip.ts";
 import * as channel from "./channel.ts";
-import {csrf_token} from "./csrf.ts";
+import { csrf_token } from "./csrf.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import * as group_permission_settings from "./group_permission_settings.ts";
@@ -18,7 +18,7 @@ import {
     type RealmGroupSettingNameSupportingAnonymousGroups,
     realm_group_setting_name_supporting_anonymous_groups_schema,
 } from "./group_permission_settings.ts";
-import {$t, $t_html} from "./i18n.ts";
+import { $t, $t_html } from "./i18n.ts";
 import * as information_density from "./information_density.ts";
 import * as keydown_util from "./keydown_util.ts";
 import * as loading from "./loading.ts";
@@ -26,7 +26,7 @@ import * as people from "./people.ts";
 import * as pygments_data from "./pygments_data.ts";
 import * as realm_icon from "./realm_icon.ts";
 import * as realm_logo from "./realm_logo.ts";
-import {realm_user_settings_defaults} from "./realm_user_settings_defaults.ts";
+import { realm_user_settings_defaults } from "./realm_user_settings_defaults.ts";
 import * as settings_banner from "./settings_banner.ts";
 import {
     type MessageMoveTimeLimitSetting,
@@ -41,17 +41,17 @@ import * as settings_config from "./settings_config.ts";
 import * as settings_notifications from "./settings_notifications.ts";
 import * as settings_realm_domains from "./settings_realm_domains.ts";
 import * as settings_ui from "./settings_ui.ts";
-import {current_user, realm, realm_schema} from "./state_data.ts";
-import type {Realm} from "./state_data.ts";
+import { current_user, realm, realm_schema } from "./state_data.ts";
+import type { Realm } from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_settings_data from "./stream_settings_data.ts";
-import type {StreamSubscription} from "./sub_store.ts";
+import type { StreamSubscription } from "./sub_store.ts";
 import * as timerender from "./timerender.ts";
-import {group_setting_value_schema} from "./types.ts";
-import type {HTMLSelectOneElement} from "./types.ts";
+import { group_setting_value_schema } from "./types.ts";
+import type { HTMLSelectOneElement } from "./types.ts";
 import * as ui_report from "./ui_report.ts";
 import * as user_groups from "./user_groups.ts";
-import type {UserGroup} from "./user_groups.ts";
+import type { UserGroup } from "./user_groups.ts";
 import * as util from "./util.ts";
 
 const meta = {
@@ -340,8 +340,8 @@ function set_create_web_public_stream_dropdown_visibility(): void {
     settings_components.change_element_block_display_property(
         "id_realm_can_create_web_public_channel_group",
         realm.server_web_public_streams_enabled &&
-            realm.zulip_plan_is_not_limited &&
-            realm.realm_enable_spectator_access,
+        realm.zulip_plan_is_not_limited &&
+        realm.realm_enable_spectator_access,
     );
 }
 
@@ -413,8 +413,8 @@ function update_view_welcome_bot_custom_message_button_status(
         attention: is_error ? "borderless" : "quiet",
         intent: is_error ? "danger" : "success",
         label: is_error
-            ? $t({defaultMessage: "Error sending message"})
-            : $t({defaultMessage: "View message"}),
+            ? $t({ defaultMessage: "Error sending message" })
+            : $t({ defaultMessage: "View message" }),
         id: "view_welcome_bot_custom_message",
     };
 
@@ -472,7 +472,7 @@ export function check_disable_direct_message_initiator_group_widget(): void {
 }
 
 export function populate_realm_domains_label(
-    realm_domains: {domain: string; allow_subdomains: boolean}[],
+    realm_domains: { domain: string; allow_subdomains: boolean }[],
 ): void {
     if (!meta.loaded) {
         return;
@@ -483,9 +483,9 @@ export function populate_realm_domains_label(
     );
     let domains = util.format_array_as_list(domains_list, "long", "conjunction");
     if (domains.length === 0) {
-        domains = $t({defaultMessage: "None"});
+        domains = $t({ defaultMessage: "None" });
     }
-    $("#allowed_domains_label").text($t({defaultMessage: "Allowed domains: {domains}"}, {domains}));
+    $("#allowed_domains_label").text($t({ defaultMessage: "Allowed domains: {domains}" }, { domains }));
 }
 
 export function populate_auth_methods(auth_method_to_bool_map: Record<string, boolean>): void {
@@ -665,7 +665,7 @@ export function discard_realm_property_element_changes(elem: HTMLElement): void 
                     .parse(property_value);
                 settings_components.set_input_element_value($elem, validated_property_value);
             } else {
-                blueslip.error("Element refers to unknown property", {property_name});
+                blueslip.error("Element refers to unknown property", { property_name });
             }
     }
     update_dependent_subsettings(property_name);
@@ -722,7 +722,7 @@ export function discard_stream_property_element_changes(
                     .parse(property_value);
                 settings_components.set_input_element_value($elem, validated_property_value);
             } else {
-                blueslip.error("Element refers to unknown property", {property_name});
+                blueslip.error("Element refers to unknown property", { property_name });
             }
     }
     update_dependent_subsettings(property_name);
@@ -744,7 +744,7 @@ export function discard_group_property_element_changes($elem: JQuery, group: Use
             group_setting_value_schema.parse(property_value),
         );
     } else {
-        blueslip.error("Element refers to unknown property", {property_name});
+        blueslip.error("Element refers to unknown property", { property_name });
     }
     update_dependent_subsettings(property_name);
 }
@@ -810,7 +810,7 @@ export function discard_realm_default_property_element_changes(elem: HTMLElement
                     .parse(property_value);
                 settings_components.set_input_element_value($elem, validated_property_value);
             } else {
-                blueslip.error("Element refers to unknown property", {property_name});
+                blueslip.error("Element refers to unknown property", { property_name });
             }
     }
     update_dependent_subsettings(property_name);
@@ -885,7 +885,7 @@ export function deactivate_organization(e: JQuery.Event): void {
             url: "/json/realm/deactivate",
             data,
             error(xhr) {
-                ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $("#dialog_error"));
+                ui_report.error($t_html({ defaultMessage: "Failed" }), xhr, $("#dialog_error"));
             },
         });
     }
@@ -898,20 +898,20 @@ export function deactivate_organization(e: JQuery.Event): void {
         const delete_data_value = $delete_in.val()!;
 
         if (delete_data_value === "null") {
-            return $t({defaultMessage: "Data will not be automatically deleted"});
+            return $t({ defaultMessage: "Data will not be automatically deleted" });
         }
 
         let time_in_minutes: number;
         if (delete_data_value === "custom") {
             if (!util.validate_custom_time_input(custom_deletion_time_input)) {
-                return $t({defaultMessage: "Invalid custom time"});
+                return $t({ defaultMessage: "Invalid custom time" });
             }
             time_in_minutes = util.get_custom_time_in_minutes(
                 custom_deletion_time_unit,
                 custom_deletion_time_input,
             );
             if (!is_valid_time_period(time_in_minutes)) {
-                return $t({defaultMessage: "Invalid custom time"});
+                return $t({ defaultMessage: "Invalid custom time" });
             }
         } else {
             // These options were already filtered for is_valid_time_period.
@@ -919,13 +919,13 @@ export function deactivate_organization(e: JQuery.Event): void {
         }
 
         if (time_in_minutes === 0) {
-            return $t({defaultMessage: "Data will be deleted immediately"});
+            return $t({ defaultMessage: "Data will be deleted immediately" });
         }
 
         // The below is a duplicate of timerender.get_full_datetime, with a different base string.
-        const valid_to = add(new Date(), {minutes: time_in_minutes});
+        const valid_to = add(new Date(), { minutes: time_in_minutes });
         const date = timerender.get_localized_date_or_time_for_format(valid_to, "dayofyear_year");
-        return $t({defaultMessage: "Data will be deleted after {date}"}, {date});
+        return $t({ defaultMessage: "Data will be deleted after {date}" }, { date });
     }
 
     const minimum_allowed_days = realm.server_min_deactivated_realm_deletion_days ?? 0;
@@ -964,13 +964,13 @@ export function deactivate_organization(e: JQuery.Event): void {
                 // If there's no limit at all, avoid showing 0+. It's
                 // not a marginal string for translators, since we use
                 // that string elsewhere.
-                return $t({defaultMessage: "Custom time"});
+                return $t({ defaultMessage: "Custom time" });
             }
-            return $t({defaultMessage: `Custom time ({min}+ days)`}, {min: minimum_allowed_days});
+            return $t({ defaultMessage: `Custom time ({min}+ days)` }, { min: minimum_allowed_days });
         }
         return $t(
-            {defaultMessage: `Custom time ({min}-{max} days)`},
-            {min: minimum_allowed_days, max: maximum_allowed_days},
+            { defaultMessage: `Custom time ({min}-{max} days)` },
+            { min: minimum_allowed_days, max: maximum_allowed_days },
         );
     }
 
@@ -1063,14 +1063,14 @@ export function deactivate_organization(e: JQuery.Event): void {
     });
 
     dialog_widget.launch({
-        html_heading: $t_html({defaultMessage: "Deactivate organization"}),
+        html_heading: $t_html({ defaultMessage: "Deactivate organization" }),
         help_link: "/help/deactivate-your-organization",
         html_body,
         id: "deactivate-realm-user-modal",
         on_click: do_deactivate_realm,
         close_on_submit: false,
         focus_submit_on_open: true,
-        html_submit_button: $t_html({defaultMessage: "Confirm"}),
+        html_submit_button: $t_html({ defaultMessage: "Confirm" }),
         post_render: deactivate_realm_modal_post_render,
     });
 }
@@ -1125,7 +1125,7 @@ export function save_organization_settings(
         error(xhr) {
             settings_components.change_save_button_state($save_button_container, "failed");
             $save_button.hide();
-            ui_report.error($t_html({defaultMessage: "Save failed"}), xhr, $failed_alert_elem);
+            ui_report.error($t_html({ defaultMessage: "Save failed" }), xhr, $failed_alert_elem);
         },
     });
 }
@@ -1147,7 +1147,7 @@ function set_up_dropdown_widget(
 
     let text_if_current_value_not_in_options;
     if (setting_type === "channel") {
-        text_if_current_value_not_in_options = $t({defaultMessage: "Cannot view channel"});
+        text_if_current_value_not_in_options = $t({ defaultMessage: "Cannot view channel" });
     }
 
     let unique_id_type: dropdown_widget.DataType = "number";
@@ -1170,7 +1170,7 @@ function set_up_dropdown_widget(
         },
         default_id: z.union([z.string(), z.number()]).parse(realm[setting_name]),
         unique_id_type,
-        ...(text_if_current_value_not_in_options && {text_if_current_value_not_in_options}),
+        ...(text_if_current_value_not_in_options && { text_if_current_value_not_in_options }),
         on_mount_callback(dropdown) {
             if (setting_type === "group") {
                 $(dropdown.popper).css("min-width", "300px");
@@ -1213,7 +1213,7 @@ export let init_dropdown_widgets = (): void => {
         show_disabled_icon: true,
         show_disabled_option_name: false,
         unique_id: DISABLED_STATE_ID,
-        name: $t({defaultMessage: "Disabled"}),
+        name: $t({ defaultMessage: "Disabled" }),
     };
 
     const notification_stream_options = (): dropdown_widget.Option[] => {
@@ -1295,7 +1295,7 @@ export const combined_code_language_options = (): dropdown_widget.Option[] => {
         show_disabled_icon: true,
         show_disabled_option_name: false,
         unique_id: "",
-        name: $t({defaultMessage: "No language set"}),
+        name: $t({ defaultMessage: "No language set" }),
     };
 
     return [disabled_option, ...playground_options, ...default_options];
@@ -1482,6 +1482,16 @@ export function build_page(): void {
     register_save_discard_widget_handlers($(".admin-realm-form"), "/json/realm", false);
     maybe_restore_unsaved_welcome_message_custom_text();
 
+    // Show yellow outline when organization description is empty.
+    // We use a class-based approach because :empty doesn't work for textareas.
+    function update_description_empty_state(): void {
+        const $textarea = $<HTMLTextAreaElement>("#id_realm_description");
+        const is_empty = $textarea.val()!.trim() === "";
+        $textarea.toggleClass("empty-description", is_empty);
+    }
+    update_description_empty_state();
+    $("#id_realm_description").on("input", update_description_empty_state);
+
     $(".org-permissions-form").on(
         "input change",
         ".time-limit-custom-input",
@@ -1616,7 +1626,7 @@ export function build_page(): void {
                 welcome_message_custom_text,
             },
             success(data) {
-                const {message_id} = z.object({message_id: z.number()}).parse(data);
+                const { message_id } = z.object({ message_id: z.number() }).parse(data);
                 update_view_welcome_bot_custom_message_button_status(message_id, false);
             },
             error() {
@@ -1658,7 +1668,7 @@ export function build_page(): void {
                 dialog_widget.close();
             },
             error(xhr) {
-                ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $("#dialog_error"));
+                ui_report.error($t_html({ defaultMessage: "Failed" }), xhr, $("#dialog_error"));
                 dialog_widget.hide_dialog_spinner();
             },
         });

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -64,6 +64,7 @@ h3,
 }
 
 .admin_profile_fields_table {
+
     & th.display,
     & th.required,
     td.display_in_profile_summary_cell,
@@ -87,7 +88,8 @@ h3,
 
 #change_password_modal,
 #change_email_modal {
-    width: 34.2857em; /* 480px at 14px/em */
+    width: 34.2857em;
+    /* 480px at 14px/em */
     max-width: 90vw;
 }
 
@@ -137,14 +139,17 @@ h3,
     /* We set the minimum height of textarea to be enough for two lines
     of text. Since box-sizing is set to "border-box", we also add
     2 * var(--input-vertical-padding) + 2 * var(--input-border-width). */
-    min-height: calc(
-        2em * var(--base-line-height-unitless) + 2 *
-            var(--input-vertical-padding) + 2 * var(--input-border-width)
-    );
+    min-height: calc(2em * var(--base-line-height-unitless) + 2 * var(--input-vertical-padding) + 2 * var(--input-border-width));
     width: 500px;
     max-width: 80%;
     min-width: 500px;
     box-sizing: border-box;
+}
+
+/* Show yellow outline when organization description is empty,
+   matching the compose box "approaching limit" warning style. */
+.admin-realm-description.empty-description:not(:disabled) {
+    border-color: var(--color-message-content-container-border-approaching-limit);
 }
 
 .admin-realm-welcome-message-custom-text {
@@ -165,9 +170,11 @@ h3,
 
 .play_notification_sound {
     .notification-sound-icon {
-        font-size: 1.5714em; /* 22px at 14px / em */
+        font-size: 1.5714em;
+        /* 22px at 14px / em */
         /* Visually center with chevron in select */
-        line-height: 1.8571em; /* 26px at 14px / em */
+        line-height: 1.8571em;
+        /* 26px at 14px / em */
         cursor: pointer;
     }
 }
@@ -190,7 +197,7 @@ h3,
 }
 
 #settings_content {
-    & table + .progressive-table-wrapper table tr.user_row td:first-of-type {
+    & table+.progressive-table-wrapper table tr.user_row td:first-of-type {
         width: 20%;
     }
 
@@ -199,7 +206,7 @@ h3,
     --column-count: 2;
 }
 
-#uploaded_files_table > tr > td:nth-of-type(1),
+#uploaded_files_table>tr>td:nth-of-type(1),
 #attachments-settings .upload-file-name {
     word-break: break-all;
 }
@@ -210,6 +217,7 @@ h3,
 }
 
 #linkifier-settings {
+
     #linkifier_pattern,
     #linkifier_template {
         width: calc(100% - 10em - 6em);
@@ -217,6 +225,7 @@ h3,
 }
 
 #playground-settings {
+
     #playground_pygments_language,
     #playground_name,
     #playground_url_template {
@@ -278,7 +287,8 @@ h3,
     }
 
     .loading_indicator_text {
-        font-size: 0.8571em; /* 12px at 14px/em */
+        font-size: 0.8571em;
+        /* 12px at 14px/em */
         font-weight: 400;
         vertical-align: middle;
         line-height: inherit;
@@ -316,7 +326,8 @@ h3,
         max-width: 100%;
         padding-top: 4px;
         padding-bottom: 4px;
-        height: 1.4em; /* To match height of input elements */
+        height: 1.4em;
+        /* To match height of input elements */
     }
 
     .account-settings-heading {
@@ -397,14 +408,16 @@ select.settings_select {
         display: flex;
         align-items: center;
         margin: 0;
-        margin-left: 0.5em; /* The spinner is left-justified with a slight left margin to look good. */
+        margin-left: 0.5em;
+        /* The spinner is left-justified with a slight left margin to look good. */
     }
 }
 
 .input-group {
-    margin: 0 0 1.25em; /* 20px at 16px/em */
+    margin: 0 0 1.25em;
+    /* 20px at 16px/em */
 
-    & label.checkbox + label {
+    & label.checkbox+label {
         cursor: pointer;
     }
 
@@ -418,6 +431,7 @@ select.settings_select {
 }
 
 #bot-edit-form {
+
     .api-key-details-container,
     .zuliprc-container {
         display: flex;
@@ -475,7 +489,7 @@ select.settings_select {
 }
 
 input[type="checkbox"] {
-    + .inline-block {
+    +.inline-block {
         margin-left: 10px;
     }
 
@@ -649,7 +663,8 @@ input[type="checkbox"] {
         }
 
         .toggle-advanced-configurations-icon {
-            font-size: 1.4286em; /* 20px at 14px / em */
+            font-size: 1.4286em;
+            /* 20px at 14px / em */
         }
     }
 
@@ -750,8 +765,10 @@ input[type="checkbox"] {
     }
 
     .loading_indicator_spinner {
-        width: 0.9283em; /* 13px at 14px/em */
-        height: 1.4286em; /* 20px at 14px/em */
+        width: 0.9283em;
+        /* 13px at 14px/em */
+        height: 1.4286em;
+        /* 20px at 14px/em */
         margin: 0;
     }
 
@@ -771,7 +788,8 @@ input[type="checkbox"] {
     }
 
     .settings-save-checkmark {
-        width: 0.9285em; /* 13px at 14px/em */
+        width: 0.9285em;
+        /* 13px at 14px/em */
     }
 }
 
@@ -839,6 +857,7 @@ input[type="checkbox"] {
 }
 
 #profile-settings {
+
     .custom-profile-fields-form .custom_user_field label,
     .full-name-change-container label,
     .timezone-setting-form label {
@@ -864,7 +883,7 @@ input[type="checkbox"] {
     margin-top: 5px;
     max-width: fit-content;
 
-    > .settings_url_input {
+    >.settings_url_input {
         margin-bottom: 0;
     }
 }
@@ -872,7 +891,8 @@ input[type="checkbox"] {
 .settings-profile-user-field.editable-date-field {
     display: grid;
     grid-template-areas: "datepicker close-button";
-    grid-template-columns: minmax(0, 1fr) 1.4285em; /* 20px at 14px em */
+    grid-template-columns: minmax(0, 1fr) 1.4285em;
+    /* 20px at 14px em */
     align-items: center;
     width: var(--modal-input-width);
 
@@ -967,6 +987,7 @@ input[type="checkbox"] {
     & button {
         margin-left: calc(10em + 20px) !important;
     }
+
     margin-bottom: 15px;
 
     .checkbox {
@@ -1239,7 +1260,7 @@ label.preferences-radio-choice-label {
             cursor: not-allowed;
         }
 
-        &:checked + .preferences-radio-choice-text {
+        &:checked+.preferences-radio-choice-text {
             font-weight: 600;
         }
     }
@@ -1251,7 +1272,8 @@ label.preferences-radio-choice-label {
 }
 
 .emojiset_choices {
-    width: 25em; /* 350px / 14px em */
+    width: 25em;
+    /* 350px / 14px em */
 
     .emoji {
         height: 22px;
@@ -1260,11 +1282,13 @@ label.preferences-radio-choice-label {
 }
 
 .user_list_style_values {
-    max-width: 25em; /* 350px / 14px em */
+    max-width: 25em;
+    /* 350px / 14px em */
 
     .preferences-radio-choice-label {
         display: grid;
-        grid-template-columns: 10.7143em auto; /* 150px / 14px em */
+        grid-template-columns: 10.7143em auto;
+        /* 150px / 14px em */
         justify-content: left;
         margin-right: 6px;
 
@@ -1331,7 +1355,8 @@ label.preferences-radio-choice-label {
 #settings_page {
     height: 95vh;
     width: 97vw;
-    max-width: 73.1429em; /* 1024px at 14px em */
+    max-width: 73.1429em;
+    /* 1024px at 14px em */
     margin: 2.5vh auto;
     overflow: hidden;
     border-radius: 4px;
@@ -1379,7 +1404,8 @@ label.preferences-radio-choice-label {
 
                 .ind-tab {
                     width: auto;
-                    min-width: 6.7857em; /* 95px at 14px em */
+                    min-width: 6.7857em;
+                    /* 95px at 14px em */
                 }
             }
         }
@@ -1412,11 +1438,9 @@ label.preferences-radio-choice-label {
             /* 3.5714em is 50px at 14px/1em -- the legacy height of these rows. */
             /* 2.8571em is 40px at 14px/1em */
             grid-template:
-                "starting-anchor-element row-content ending-anchor-element" 3.5714em / 2.8571em minmax(
-                    0,
+                "starting-anchor-element row-content ending-anchor-element" 3.5714em / 2.8571em minmax(0,
                     1fr
-                )
-                minmax(34px, auto);
+                ) minmax(34px, auto);
             align-items: center;
             outline: none;
             cursor: pointer;
@@ -1460,7 +1484,7 @@ label.preferences-radio-choice-label {
         }
 
         .collapse-settings-button,
-        .collapse-settings-button > #toggle_collapse_chevron {
+        .collapse-settings-button>#toggle_collapse_chevron {
             color: var(--color-text-url);
 
             &:hover {
@@ -1511,7 +1535,8 @@ label.preferences-radio-choice-label {
         .exit {
             font-weight: 600;
             position: absolute;
-            right: 0.7142em; /* 10px at 14px em */
+            right: 0.7142em;
+            /* 10px at 14px em */
             color: hsl(0deg 0% 67%);
             cursor: pointer;
         }
@@ -1616,7 +1641,8 @@ label.preferences-radio-choice-label {
 
         .datepicker {
             cursor: default;
-            padding-right: 1.4285em; /* 20px at 14px em */
+            padding-right: 1.4285em;
+            /* 20px at 14px em */
             /* full input width minus right padding and
                6px left padding from .settings_text_input
                and 1px border on each side */
@@ -1650,18 +1676,13 @@ label.preferences-radio-choice-label {
     .modal-textarea {
         /* Subtract (2 * horizontal padding) + (2 * border width) */
         box-sizing: content-box;
-        width: calc(
-            var(--modal-input-width) - 2 * var(--input-horizontal-padding) - 2 *
-                var(--input-border-width)
-        );
-        max-width: calc(
-            100% - 2 * var(--input-horizontal-padding) - 2 *
-                var(--input-border-width)
-        );
+        width: calc(var(--modal-input-width) - 2 * var(--input-horizontal-padding) - 2 * var(--input-border-width));
+        max-width: calc(100% - 2 * var(--input-horizontal-padding) - 2 * var(--input-border-width));
     }
 }
 
 #manage-profile-tab {
+
     #edit-user-form,
     #bot-edit-form {
         .name-setting {
@@ -1745,12 +1766,12 @@ label.preferences-radio-choice-label {
         }
     }
 
-    > .choice-row:first-of-type {
+    >.choice-row:first-of-type {
         margin-top: 0;
     }
 }
 
-.profile-field-choices-wrapper > .alphabetize-choices-button {
+.profile-field-choices-wrapper>.alphabetize-choices-button {
     display: block;
     margin: 12px 0 0;
 }
@@ -1928,7 +1949,8 @@ label.preferences-radio-choice-label {
             background-color: var(--color-background-modal);
             border: none;
 
-            transition: left 0.3s ease; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
+            transition: left 0.3s ease;
+            /* stylelint-disable-line plugin/no-low-performance-animation-properties */
             z-index: 10;
 
             &.show {
@@ -1944,10 +1966,7 @@ label.preferences-radio-choice-label {
             position: absolute;
             width: 100%;
             border: none;
-            height: calc(
-                100% - var(--settings-overlay-header-height) -
-                    var(--settings-overlay-subheader-height)
-            );
+            height: calc(100% - var(--settings-overlay-header-height) - var(--settings-overlay-subheader-height));
         }
     }
 }
@@ -1970,6 +1989,7 @@ label.preferences-radio-choice-label {
     #admin-user-list,
     #admin-bot-list {
         .user_row {
+
             .user_name,
             .email {
                 min-width: 8em;
@@ -1978,6 +1998,7 @@ label.preferences-radio-choice-label {
     }
 
     .admin_profile_fields_table {
+
         .profile_field_name,
         .profile_field_hint {
             min-width: 8em;
@@ -1986,10 +2007,13 @@ label.preferences-radio-choice-label {
 }
 
 @media (width < $sm_min) {
+
     #admin-user-list,
     #admin-bot-list {
+
         .user_row,
         .table-sticky-headers {
+
             .bot_type,
             .last_active {
                 display: none;
@@ -2044,6 +2068,7 @@ label.preferences-radio-choice-label {
     }
 
     .admin_profile_fields_table {
+
         .profile_field_name,
         .profile_field_hint {
             min-width: 8em;
@@ -2052,6 +2077,7 @@ label.preferences-radio-choice-label {
 }
 
 @media (width < $ml_min) {
+
     #api_key_buttons,
     #download_zuliprc {
         flex-direction: column;
@@ -2069,6 +2095,7 @@ label.preferences-radio-choice-label {
 }
 
 #edit-linkifier-form {
+
     #edit-linkifier-pattern,
     #edit-linkifier-url-template {
         width: 400px;
@@ -2165,7 +2192,7 @@ label.preferences-radio-choice-label {
             }
         }
 
-        input.search:placeholder-shown + .clear-filter {
+        input.search:placeholder-shown+.clear-filter {
             display: none;
         }
     }
@@ -2220,10 +2247,7 @@ label.preferences-radio-choice-label {
     margin-bottom: 10px;
 
     /* Subtract (2 * horizontal padding) + (2 * border width) */
-    width: calc(
-        var(--modal-input-width) - 2 * var(--input-horizontal-padding) - 2 *
-            var(--input-border-width)
-    );
+    width: calc(var(--modal-input-width) - 2 * var(--input-horizontal-padding) - 2 * var(--input-border-width));
 
     &:focus {
         border-color: hsl(206deg 80% 62% / 80%);


### PR DESCRIPTION
**Summary**
This PR adds a visual indicator (yellow outline) to the "Organization description" field in the organization profile settings when it is empty. This helps administrators quickly identify that this important field is missing information.

**Approach**
The initial attempt used the CSS `:empty` selector, but it proved unreliable for `<textarea>` elements as user input modifies the [value](cci:1://file:///home/parthdagia/projects/zulip/web/src/settings_org.ts:269:0-279:1) property, not the DOM children.

Instead, I implemented a JavaScript-based solution similar to the compose box:
1.  **[web/src/settings_org.ts](cci:7://file:///home/parthdagia/projects/zulip/web/src/settings_org.ts:0:0-0:0)**: Added an input listener that toggles a custom `.empty-description` class on the textarea when the value is effectively empty.
2.  **[web/styles/settings.css](cci:7://file:///home/parthdagia/projects/zulip/web/styles/settings.css:0:0-0:0)**: Added a rule to apply the yellow border (using the existing `approaching-limit` color variable) when the class is present.

**Fixes:** Fixes #36991

**How changes were tested:**
1.  Navigate to **Manage organization** > **Organization profile**.
2.  Clear the "Organization description" field.
3.  Verified that the yellow outline appears immediately.
4.  Type into the field.
5.  Verified that the yellow outline disappears immediately.

**Screenshots:**
<img width="1467" height="867" alt="image" src="https://github.com/user-attachments/assets/436e6678-1f65-4043-aad0-904cebc93d64" />

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

*A little change in code structure so that it looks clean and prettier *
</details>