### PR TITLE
watchdog: Improve unsuspend responsiveness using Page Lifecycle API.

### DIFF
--- a/web/src/server_events.js
+++ b/web/src/server_events.js
@@ -285,7 +285,6 @@ export function initialize(params) {
     });
 
     get_events();
-    watchdog.initialize();
 }
 
 function cleanup_event_queue() {

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -175,6 +175,7 @@ import * as user_status_ui from "./user_status_ui.ts";
 import * as user_topic_popover from "./user_topic_popover.ts";
 import * as user_topics from "./user_topics.ts";
 import * as util from "./util.ts";
+import * as watchdog from "./watchdog.ts";
 import * as widgets from "./widgets.ts";
 
 // This is where most of our initialization takes place.
@@ -616,6 +617,7 @@ export async function initialize_everything(state_data) {
         restart_get_events: server_events.restart_get_events,
     });
     server_events.initialize(state_data.server_events);
+    watchdog.initialize();
     user_status.initialize(state_data.user_status);
     compose_recipient.initialize();
     compose_pm_pill.initialize({

--- a/web/src/watchdog.ts
+++ b/web/src/watchdog.ts
@@ -85,4 +85,22 @@ export function on_unsuspend(f: () => void): void {
 
 export function initialize(): void {
     setInterval(check_for_unsuspend, CHECK_FREQUENCY_MILLISECONDS);
+
+    // The Page Lifecycle API "resume" event.
+    // This handles when the page is "resumed" from a frozen state, such as when
+    // the user switches back to a tab that Chrome has discarded/frozen to save memory.
+    // Note: This event is currently only available on Chrome.
+    // See https://developer.chrome.com/docs/web-platform/page-lifecycle-api#event-resume
+    document.addEventListener("resume", () => {
+        check_for_unsuspend();
+    });
+
+    // The BFCache "pageshow" event.
+    // This handles when the page is restored from the Back-Forward Cache (BFCache),
+    // e.g. when the user navigates back to this page.
+    window.addEventListener("pageshow", (event) => {
+        if (event.persisted) {
+            check_for_unsuspend();
+        }
+    });
 }

--- a/web/tests/watchdog.test.cjs
+++ b/web/tests/watchdog.test.cjs
@@ -22,6 +22,25 @@ set_global("setInterval", (f, interval) => {
     assert.equal(interval, 5000);
 });
 
+let resume_handler;
+let pageshow_handler;
+
+set_global("document", {
+    addEventListener(event, handler) {
+        if (event === "resume") {
+            resume_handler = handler;
+        }
+    },
+});
+
+set_global("window", {
+    addEventListener(event, handler) {
+        if (event === "pageshow") {
+            pageshow_handler = handler;
+        }
+    },
+});
+
 run_test("basics", () => {
     const watchdog = zrequire("watchdog");
     watchdog._reset_for_testing();
@@ -85,6 +104,35 @@ run_test("suspect_offline", () => {
 
     watchdog.set_suspect_offline(false);
     assert.ok(!watchdog.suspects_user_is_offline());
+});
+
+run_test("browser_events", () => {
+    const watchdog = zrequire("watchdog");
+    watchdog._reset_for_testing();
+    watchdog.initialize();
+    // Verify handlers were registered
+    assert.ok(resume_handler);
+    assert.ok(pageshow_handler);
+
+    let num_times_called_back = 0;
+    watchdog.on_unsuspend(() => {
+        num_times_called_back += 1;
+    });
+
+    // Simulate resume event (after >75s delay)
+    advance_secs(80);
+    resume_handler();
+    assert.equal(num_times_called_back, 1);
+
+    // Simulate pageshow event (persisted) (after >75s delay)
+    advance_secs(80);
+    pageshow_handler({persisted: true});
+    assert.equal(num_times_called_back, 2);
+
+    // Simulate pageshow event (not persisted)
+    advance_secs(80);
+    pageshow_handler({persisted: false});
+    assert.equal(num_times_called_back, 2);
 });
 
 run_test("reset MockDate", () => {


### PR DESCRIPTION
Fixes: [#37034](https://github.com/zulip/zulip/issues/37034)

This PR speeds up how quickly the app reconnects when you come back to a frozen tab (like after system sleep or if Chrome discarded the page). Right now, we just poll every 5 seconds, so when you wake up the computer, you might sit there for a few seconds waiting for the app to realize it's back online.

### Changes

- I added listeners for the `resume `event (Page Lifecycle API) and `pageshow `(for BFCache). This way, as soon as the tab wakes up, we trigger the `unsuspend `check immediately instead of waiting for the next timer tick.
- wrapped the listeners in checks for `document `and `window `so this doesn't break the Node.js tests.

**How changes were tested:**

- Verified manual behavior by using `chrome://discards` to freeze the tab. Confirmed that upon clicking the tab, the `check_for_unsuspend` logic triggered instantly (verified via logs before removal).
- Verified automated tests by running `web/tests/watchdog.test.cjs` to ensure no regressions.

**Screenshots and screen captures:**

<img width="2879" height="1601" alt="image" src="https://github.com/user-attachments/assets/0d2f1fa6-2197-47a9-aeef-7264d6844502" />
<img width="2879" height="870" alt="image" src="https://github.com/user-attachments/assets/e5e8a83d-3903-4caa-80cd-a142466760e7" />

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
