### PR TITLE
import: Avoid caching realm emoji before it is imported.

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -1392,9 +1392,7 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
         else:
             for setting_name in Stream.stream_permission_group_settings:
                 re_map_foreign_keys(data, "zerver_stream", setting_name, related_table="usergroup")
-        # Handle rendering of stream descriptions for import from non-Zulip
         for stream in data["zerver_stream"]:
-            stream["rendered_description"] = render_stream_description(stream["description"], realm)
             stream["name"] = stream["name"][: Stream.MAX_NAME_LENGTH]
         bulk_import_model(data, Stream)
 
@@ -1438,13 +1436,6 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
         user_profile.tos_version = UserProfile.TOS_VERSION_BEFORE_FIRST_LOGIN
     UserProfile.objects.bulk_create(user_profiles)
 
-    # UserProfiles have been loaded, so now we're ready to set .creator_id
-    # for streams based on the mapping we saved earlier.
-    streams = Stream.objects.filter(id__in=stream_id_to_creator_id.keys())
-    for stream in streams:
-        stream.creator_id = stream_id_to_creator_id[stream.id]
-    Stream.objects.bulk_update(streams, ["creator_id"])
-
     channel_folders = ChannelFolder.objects.filter(id__in=channel_folder_id_to_creator_id.keys())
     for channel_folder in channel_folders:
         channel_folder.creator_id = channel_folder_id_to_creator_id[channel_folder.id]
@@ -1483,6 +1474,17 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
             assert first_user_profile is not None
             realm_emoji.author_id = first_user_profile.id
             realm_emoji.save(update_fields=["author_id"])
+
+    channels = Stream.objects.filter(realm=realm)
+    for channel in channels:
+        # render_stream_description requires RealmEmoji in order to work correctly,
+        # so we had to ensure to import emojis first before calling it.
+        channel.rendered_description = render_stream_description(channel.description, realm)
+        # UserProfiles have been loaded, so now we're ready to set .creator_id
+        # for channels based on the mapping we saved earlier.
+        if channel.id in stream_id_to_creator_id:
+            channel.creator_id = stream_id_to_creator_id[channel.id]
+    Stream.objects.bulk_update(channels, ["rendered_description", "creator_id"])
 
     if "zerver_huddle" in data:
         update_model_ids(DirectMessageGroup, data, "huddle")


### PR DESCRIPTION
Previously, `render_stream_description` is called before realm emoji is imported. Since it calls `get_all_custom_emoji_for_realm`, an empty set of realm emoji is cached, creating a stale cache once the realm emoji is imported and emoji used in channel description won't be rendered.

It's done here because importing realm emoji requires the user profile table to be imported, which requires channel table to be imported first.

Fixes #36482.

**Screenshots and screen captures:**
- emojis in channel description is rendered properly

  | Before| After|
  |--------|--------|
  | <img width="536" height="200" alt="image" src="https://github.com/user-attachments/assets/da401d54-b6c2-4821-a052-1a57546e56d3" />| <img width="534" height="196" alt="image" src="https://github.com/user-attachments/assets/3db462ed-ab17-4b9e-b5b5-03fd4633f5d2" />|

  
- custom emoji menu doesn't display stale empty realm emoji cache:

  | Before| After|
  |--------|--------|
  | <img width="1054" height="550" alt="image" src="https://github.com/user-attachments/assets/0f8cee35-5c4b-489b-a16d-3a86942fd852" /> | <img width="1054" height="418" alt="image" src="https://github.com/user-attachments/assets/ce08e501-2d75-4a2f-baac-076bdac7ee7d" /> |
  

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
