### PR TITLE
demo-orgs: Add lru_cache decorator to get_demo_organization_wordlists.

### DIFF
--- a/zerver/lib/demo_organizations.py
+++ b/zerver/lib/demo_organizations.py
@@ -1,4 +1,5 @@
 import os
+from functools import lru_cache
 
 import orjson
 from django.conf import settings
@@ -8,13 +9,11 @@ from zerver.lib.exceptions import JsonableError
 from zerver.models.realms import Realm
 
 
-def get_demo_organization_wordlist() -> dict[str, list[str]]:
+@lru_cache(None)
+def get_demo_organization_wordlists() -> dict[str, list[str]]:
     path = os.path.join(settings.DEPLOY_ROOT, "zerver/lib", "demo_organization_words.json")
     with open(path, "rb") as reader:
         return orjson.loads(reader.read())
-
-
-DEMO_ORGANIZATION_WORD_LIST = get_demo_organization_wordlist()
 
 
 def demo_organization_owner_email_exists(realm: Realm) -> bool:

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -67,7 +67,7 @@ from zerver.forms import (
     RegistrationForm,
     check_subdomain_available,
 )
-from zerver.lib.demo_organizations import DEMO_ORGANIZATION_WORD_LIST
+from zerver.lib.demo_organizations import get_demo_organization_wordlists
 from zerver.lib.email_validation import email_allowed_for_realm, validate_email_not_already_in_realm
 from zerver.lib.exceptions import JsonableError, RateLimitedError
 from zerver.lib.i18n import (
@@ -1418,14 +1418,15 @@ def create_realm(request: HttpRequest, confirmation_key: str | None = None) -> H
 
 
 def generate_demo_realm_subdomain() -> str:
+    demo_organization_words = get_demo_organization_wordlists()
     demo_subdomain = ""
     while True:
         # Generate a moderate-entropy string for the organization;
         # there are ~460 adverbs, ~1020 adjectives, ~2810 nouns in
         # the word list so ~= 1.32 billion possibilities.
-        adverb = random.SystemRandom().choice(DEMO_ORGANIZATION_WORD_LIST["adverbs"])
-        adjective = random.SystemRandom().choice(DEMO_ORGANIZATION_WORD_LIST["adjectives"])
-        noun = random.SystemRandom().choice(DEMO_ORGANIZATION_WORD_LIST["nouns"])
+        adverb = random.SystemRandom().choice(demo_organization_words["adverbs"])
+        adjective = random.SystemRandom().choice(demo_organization_words["adjectives"])
+        noun = random.SystemRandom().choice(demo_organization_words["nouns"])
         demo_subdomain = f"{adverb}-{adjective}-{noun}"
         try:
             check_subdomain_available(demo_subdomain)


### PR DESCRIPTION
Adds the `lru_cache` decorator with `max_size = None`, like we do with `get_language_list` in `zerver/lib/i18n.py`, to the similar function to get the dict of words for demo organization subdomains.

Follow-up to https://github.com/zulip/zulip/pull/36968#issuecomment-3643232505.

**Notes**:
- Alternatively, I considered revising `get_demo_organization_wordlists` to either get or set `DEMO_ORGANIZATION_WORD_LIST`, which would be set to `None` at the start. Since [`get_language_list`](https://github.com/zulip/zulip/blob/13cb1b8933af4a97c8a1b823516f4718e1bd8526/zerver/lib/i18n.py#L18-L24) is a very similar function, I went with mirroring that implementation.

Alternative option:
```python
DEMO_ORGANIZATION_WORD_LISTS: dict[str, list[str]] | None = None


def get_demo_organization_wordlists() -> dict[str, list[str]]:
    global DEMO_ORGANIZATION_WORD_LISTS
    if DEMO_ORGANIZATION_WORD_LISTS is not None:
        return DEMO_ORGANIZATION_WORD_LISTS

    path = os.path.join(settings.DEPLOY_ROOT, "zerver/lib", "demo_organization_words.json")
    with open(path, "rb") as reader:
        DEMO_ORGANIZATION_WORD_LISTS = orjson.loads(reader.read())
    return DEMO_ORGANIZATION_WORD_LISTS
```

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
