### PR TITLE
emails: Remove demo organization text from account_registered email.

### DIFF
--- a/templates/zerver/emails/account_registered.html
+++ b/templates/zerver/emails/account_registered.html
@@ -6,20 +6,10 @@
 
 {% block content %}
 {% if realm_creation %}
-{% if is_demo_organization %}
-<p>
-    {% trans demo_organizations_help_link="https://zulip.com/help/demo-organizations" %}Congratulations, you have created a new Zulip demo organization. Note
-    that this organization will be automatically deleted in 30 days. Learn more
-    about demo organizations <a
-    href="{{ demo_organizations_help_link }}">here</a>!
-    {% endtrans %}
-</p>
-{% else %}
 <p>
     {% trans %}Congratulations, you have created a new Zulip
     organization: <b>{{ realm_name }}</b>.{% endtrans %}
 </p>
-{% endif %}
 {% else %}
 <p>{{ _('Welcome to Zulip!') }}</p>
 <p>

--- a/templates/zerver/emails/account_registered.txt
+++ b/templates/zerver/emails/account_registered.txt
@@ -1,11 +1,7 @@
 {{ _('Welcome to Zulip!') }}
 
 {% if realm_creation %}
-    {% if is_demo_organization %}
-        {% trans demo_organizations_help_link="https://zulip.com/help/demo-organizations" %}Congratulations, you have created a new demo Zulip organization. Note that this organization will be automatically deleted in 30 days. Learn more about demo organizations here: {{ demo_organizations_help_link }}!{% endtrans %}
-    {% else %}
-        {% trans %}Congratulations, you have created a new Zulip organization: {{ realm_name }}.{% endtrans %}
-    {% endif %}
+    {% trans %}Congratulations, you have created a new Zulip organization: {{ realm_name }}.{% endtrans %}
 {% else %}
 {% trans %}You've joined the Zulip organization {{ realm_name }}.{% endtrans %}
 {% endif %}

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -836,7 +836,6 @@ def send_account_registered_email(user: UserProfile, realm_creation: bool = Fals
         realm_creation=realm_creation,
         email=user.delivery_email,
         is_realm_admin=user.is_realm_admin,
-        is_demo_organization=user.realm.demo_organization_scheduled_deletion_date is not None,
     )
 
     account_registered_context["getting_organization_started_link"] = (


### PR DESCRIPTION
These emails are never sent when a demo organization is created as the organization owner does not set an email address during that process.

This was implemented in an earlier design for demo organizations when an email address was required in the creation process.

See [#design > demo org onboarding emails](https://chat.zulip.org/#narrow/channel/101-design/topic/demo.20org.20onboarding.20emails/with/2317995).

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
