### PR TITLE
emails: Revise subject of confirm_demo_organization_email.

### DIFF
--- a/templates/zerver/emails/confirm_demo_organization_email.subject.txt
+++ b/templates/zerver/emails/confirm_demo_organization_email.subject.txt
@@ -1,1 +1,1 @@
-{{ _("Verify your new email address for your demo Zulip organization") }}
+{{ _("Verify your email address for your Zulip demo organization") }}

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -424,7 +424,7 @@ class EmailChangeTestCase(ZulipTestCase):
         email_message = mail.outbox[0]
         self.assertEqual(
             email_message.subject,
-            "Verify your new email address for your demo Zulip organization",
+            "Verify your email address for your Zulip demo organization",
         )
         body = email_message.body
         self.assertIn(


### PR DESCRIPTION
Per discussion in [#design > demo org onboarding emails](https://chat.zulip.org/#narrow/channel/101-design/topic/demo.20org.20onboarding.20emails/with/2325328), revises the subject of `confirm_demo_organization_email` to be:

> Verify your email address for your Zulip demo organization

**Screenshots and screen captures:**

*dev email in Firefox*:
<img width="1486" height="1077" alt="Screenshot From 2025-12-12 18-26-58" src="https://github.com/user-attachments/assets/b28139a5-b8e8-4a82-b658-0ea76b6777bc" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
