### PR TITLE
compose: Ensure quoting a message selection has the same recipients.

### DIFF
--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -267,15 +267,14 @@ export function quote_message(opts: {
         compose_recipient.toggle_compose_recipient_dropdown();
     } else {
         if ($textarea.attr("id") === "compose-textarea" && !compose_state.has_message_content()) {
-            // The user has not started typing a message,
-            // but is quoting into the compose box,
-            // so we will re-open the compose box.
-            // (If you did re-open the compose box, you
-            // are prone to glitches where you select the
-            // text, plus it's a complicated codepath that
-            // can have other unintended consequences.)
+            // Whether or not the compose box is open, it's empty, so
+            // we start a new message replying to the quoted message.
             respond_to_message({
                 ...opts,
+                // Critically, we pass the message_id of the message we
+                // just quoted, to avoid incorrectly replying to an
+                // unrelated selected message in interleaved views.
+                message_id,
                 keep_composebox_empty: true,
             });
         }
@@ -383,7 +382,7 @@ function get_range_intersection_with_element(range: Range, element: Node): Range
     return intersection;
 }
 
-export function get_message_selection(selection = window.getSelection()): string {
+export let get_message_selection = (selection = window.getSelection()): string => {
     assert(selection !== null);
     let selected_message_content_raw = "";
 
@@ -426,6 +425,10 @@ export function get_message_selection(selection = window.getSelection()): string
     }
     selected_message_content_raw = selected_message_content_raw.trim();
     return selected_message_content_raw;
+};
+
+export function rewire_get_message_selection(value: typeof get_message_selection): void {
+    get_message_selection = value;
 }
 
 export function initialize(): void {

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -8,6 +8,7 @@ const {make_realm} = require("./lib/example_realm.cjs");
 const {make_stream} = require("./lib/example_stream.cjs");
 const {make_user} = require("./lib/example_user.cjs");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace.cjs");
+const {make_stub} = require("./lib/stub.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
 const $ = require("./lib/zjquery.cjs");
 
@@ -584,7 +585,6 @@ test("quote_message", ({disallow, override, override_rewire}) => {
         reply_type: "personal",
     };
     override(message_lists.current, "selected_id", () => 100);
-    override(message_lists.current, "selected_message", () => selected_message);
 
     selected_message = {
         type: "stream",
@@ -608,6 +608,50 @@ test("quote_message", ({disallow, override, override_rewire}) => {
     replaced = false;
     quote_message(opts);
     assert.ok(replaced);
+
+    // Quoting a highlighted(selected) part of a message using the ">" hotkey trigger
+    // should pass the message_id of the message whose text is highlighted in
+    // the `opts` to respond_to_message, to ensure the recipients of that message
+    // are used as the recipients when opening the composebox to quote.
+    opts = {
+        trigger: "hotkey",
+    };
+    override_rewire(compose_reply, "selection_within_message_id", () => 50);
+    override_rewire(compose_reply, "get_message_selection", () => "Hello world");
+
+    const stub = make_stub();
+    override_rewire(compose_reply, "respond_to_message", stub.f);
+
+    const highlighted_message = {
+        type: "stream",
+        stream_id: denmark_stream.stream_id,
+        topic: "test",
+        sender_full_name: "Steve Stephenson",
+        sender_id: 90,
+        raw_content: "[unselected text] Hello world [some extra text that is also not selected]",
+    };
+    expected_replacement =
+        "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/channel/92-learning/topic/Tornado):\n```quote\nHello world\n```";
+    override(message_lists.current, "get", (id) => (id === 50 ? highlighted_message : undefined));
+    quote_message(opts);
+    const {opts: opts_when_message_has_selection} = stub.get_args("opts");
+    assert.equal(opts_when_message_has_selection.trigger, "hotkey");
+    assert.equal(opts_when_message_has_selection.message_id, 50);
+    assert.ok(message_lists.current.selected_id() !== 50);
+
+    // If message text from some message is not highlighted(selected) when using the ">" hotkey
+    // to quote, then message_id passed to `respond_to_message` will be same as as the
+    // id of the message having the pointer.
+    const message_with_pointer = highlighted_message;
+    override_rewire(compose_reply, "selection_within_message_id", () => undefined);
+    override(message_lists.current, "selected_id", () => 100);
+    override(message_lists.current, "get", (id) => (id === 100 ? message_with_pointer : undefined));
+    expected_replacement =
+        "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/channel/92-learning/topic/Tornado):\n```quote\n[unselected text] Hello world [some extra text that is also not selected]\n```";
+    quote_message(opts);
+    const {opts: opts_when_message_has_no_selection} = stub.get_args("opts");
+    assert.equal(opts_when_message_has_no_selection.trigger, "hotkey");
+    assert.equal(opts_when_message_has_no_selection.message_id, 100);
 });
 
 test("focus_in_empty_compose", () => {


### PR DESCRIPTION
Using the ">" hotkey to quote some selected
part of a single message sets the recipients
to be same as the recipients of "selected" message,
which is the message having the pointer instead
of the message we are selecting text to quote from.

This confusing behavior only happens with the ">"
hotkey and doesn't when using the "select part of a
message + use message actions popover menu option
to quote" flow, which sets the recipients correctly
to be the recipients of the message containing the
selection that is being quoted regardless of
where the pointer is.

This fix is meant to set the recipients to the
recipients of the selected message being quoted,
when opening the composebox, particularly to address
this odd ">" hotkey behavior.

This is applicable only when the composebox is
closed and there is no other focused textarea
we trying to quote into.

Also, in case of selecting multiple messages,
we only quote the entire message that is
under the pointer and the recipients will be set
to this message's recipients.

Fixes: #36989.

[CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/Quoting.20can.20send.20to.20a.20different.20topic/with/2324091)

**Screenshots and screen captures:**

| Before | After |
|-----|-----|
|![hotkey-quote-before](https://github.com/user-attachments/assets/0b68b42d-926f-43d2-a240-3194e7660463) | ![hotkey-quote-after](https://github.com/user-attachments/assets/9b0458b7-7a2d-40d3-99f8-76f03fc6249c) |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
