### PR TITLE
search_suggestion: Greatly simplify topic filtering logic.

### DIFF
--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -735,6 +735,7 @@ test("topic_suggestions", ({override, mock_template}) => {
         `channel:5 topic:team`,
         "channel:5 topic:✔+team+work",
         `channel:5 topic:test`,
+        "channel:6 topic:REXX",
     ];
     assert.deepEqual(suggestions.strings, expected);
     override(narrow_state, "stream_id", () => "");


### PR DESCRIPTION
This fixes several code quality issues:

- Asking for the peer_data subscriptions for our own user ID isn't a good way to get our own subscriptions, we have non-async functions that get this immediately.
- We don't need to fetch subscription objects to get channel IDs.
- Way more variables/loops than were necessary.

Only the first issue was a functional one, in that it made the new code conflict with the peer_data changes in #35864 completely unnecessarily.

@apoorvapendse FYI. @evykassirer FYI as well. While the previous code was not ideal, it did not read as obviously broken, and I think the root cause is the `stream_data.get_streams_for_user` function being too easily reading as a reasonable way to get the current user's subscriptions. 