### PR TITLE
Fix type annotation for html_topic_display in email notifications

### DIFF
--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -249,6 +249,11 @@ p.digest_paragraph,
     font-weight: normal;
 }
 
+/* Styling for empty topic display ("general chat"). */
+.empty-topic-display {
+    font-style: italic;
+}
+
 /* Text and link colors for missed-message emails. */
 .email-preferences {
     color: #666;


### PR DESCRIPTION
Fixed empty topic display in digest emails to show localized "general chat" instead of blank space, addressing both HTML and plain text formats with proper escaping and CSS styling.

Fixes: https://github.com/zulip/zulip/issues/36689

**Addresses feedback from #36752:**

***Feedback 1 (Plain Text Case)***: ✅ IMPLEMENTED
- **Issue**: Plain text digest emails showed an empty topic as a blank space
- **Solution**: Updated `header = f"{channel_privacy_icon}{stream.name} > {plain_topic_display}"` to use processed variable instead of raw `message.topic_name()`
- **Result**: Plain text emails now show "general > general chat" instead of "general > "

***Feedback #2 (Variable Naming)***: ✅ IMPLEMENTED  
- **Research**: Used `git grep` to analyse existing patterns as requested:
  ```bash
  git grep -n "topic.*display"     # Found topic_display_name used in 100+ files
  git grep -n "plain.*display"    # Confirmed no naming conflicts
  ```
- **Decision**: Chose `plain_topic_display` and `html_topic_display` following the established `topic_display_name` semantic pattern
- **Result**: Clear, descriptive variables that match codebase conventions

***Feedback #3 (CSS Class Usage)***: ✅ IMPLEMENTED
- **Issue**: Previous approach used direct `<i>` tags  
- **Solution**: Implemented `<span class="empty-topic-display"><i>{}</i></span>` as specifically requested
- **Code**: `Markup('<span class="empty-topic-display"><i>{}</i></span>').format(escape(localized_topic_name))`
- **Result**: Proper semantic HTML with italicized styling and correct CSS class

**How changes were tested:**

- Ran `./tools/lint --skip=gitlint zerver/lib/email_notifications.py` - all linting passes
- Verified digest email preview at `http://localhost:9991/digest/` displays correctly  
- Confirmed both HTML and plain text versions render properly
- MyPy type checking now passes without errors
- **Added test case `test_empty_topic_display_in_digest_email` to verify empty topic handling**
- All email notification tests pass: `./tools/test-backend zerver/tests/test_email_notifications.py`
- **Manual testing**: Created messages with empty topics and verified digest display

**Screenshots and screen captures:**

**Empty topic display fix:**
| Before | After |
| --- | --- |
| ![Fix_1_1_Before_Fix](https://github.com/user-attachments/assets/e4a267e9-0d4e-47db-b172-95932f0e6954) | ![Fix_1_1_After_Fix](https://github.com/user-attachments/assets/b0010a74-ac08-453b-ab08-6c0616b5d765) |

**Additional comparison:**
| Before | After |
| --- | --- |
| ![Fix_1_2_Before_Fix](https://github.com/user-attachments/assets/f1d5dfe3-ea58-4b0f-87a8-6893bdd39afb) | ![Fix_1_2_After_Fix](https://github.com/user-attachments/assets/931f7785-3025-4520-b051-e71498043d90) |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalisation.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>