### PR TITLE
typeahead: Auto-open topic typeahead when creation is disallowed.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -259,6 +259,9 @@ export class Typeahead<ItemType extends string | object> {
     // Used to determine whether the typeahead should be shown,
     // when the user clicks anywhere on the input element.
     showOnClick: boolean;
+    // Used to determine whether the typeahead should be shown,
+    // when the input element gains focus.
+    showOnFocus: () => boolean;
     // Used for custom situations where we want to hide the typeahead
     // after selecting an option, instead of the default call to lookup().
     hideAfterSelect: () => boolean;
@@ -306,6 +309,7 @@ export class Typeahead<ItemType extends string | object> {
         this.shouldHighlightFirstResult = options.shouldHighlightFirstResult ?? (() => true);
         this.updateElementContent = options.updateElementContent ?? true;
         this.showOnClick = options.showOnClick ?? true;
+        this.showOnFocus = options.showOnFocus ?? (() => false);
         this.hideAfterSelect = options.hideAfterSelect ?? (() => true);
         this.hideOnEmptyAfterBackspace = options.hideOnEmptyAfterBackspace ?? false;
         this.getCustomItemClassname = options.getCustomItemClassname;
@@ -674,6 +678,7 @@ export class Typeahead<ItemType extends string | object> {
             .on("keypress", this.keypress.bind(this))
             .on("keyup", this.keyup.bind(this))
             .on("click", this.element_click.bind(this))
+            .on("focus", this.element_focus.bind(this))
             .on("keydown", this.keydown.bind(this))
             .on("typeahead.refreshPosition", this.refreshPosition.bind(this));
 
@@ -694,7 +699,7 @@ export class Typeahead<ItemType extends string | object> {
     unlisten(): void {
         this.hide();
         this.$container.remove();
-        const events = ["blur", "keydown", "keyup", "keypress", "click"];
+        const events = ["blur", "keydown", "keyup", "keypress", "click", "focus"];
         for (const event of events) {
             $(this.input_element.$element).off(event);
         }
@@ -897,6 +902,16 @@ export class Typeahead<ItemType extends string | object> {
         this.lookup(false);
     }
 
+    element_focus(): void {
+        // The focus event also fires when we programmatically refocus the
+        // input (e.g. from blur()), so bail if the menu is already shown to
+        // avoid a redundant lookup.
+        if (this.shown || !this.showOnFocus()) {
+            return;
+        }
+        this.lookup(false);
+    }
+
     click(e: JQuery.ClickEvent): void {
         e.stopPropagation();
         e.preventDefault();
@@ -971,6 +986,7 @@ type TypeaheadOptions<ItemType> = {
     shouldHighlightFirstResult?: () => boolean;
     updateElementContent?: boolean;
     showOnClick?: boolean;
+    showOnFocus?: () => boolean;
     hideAfterSelect?: () => boolean;
     getCustomItemClassname?: (item: ItemType) => string;
 };

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -243,7 +243,7 @@ export class Typeahead<ItemType extends string | object> {
     // Used to clear tooltip instances attached to typeahead container.
     clear_typeahead_tooltip: (() => void) | undefined;
     closeInputFieldOnHide: (() => void) | undefined;
-    helpOnEmptyStrings: boolean;
+    helpOnEmptyStrings: () => boolean;
     tabIsEnter: boolean;
     stopAdvance: boolean;
     advanceKeys: string[];
@@ -302,7 +302,7 @@ export class Typeahead<ItemType extends string | object> {
         this.advanceKeys = options.advanceKeys ?? [];
         this.closeInputFieldOnHide = options.closeInputFieldOnHide;
         this.tabIsEnter = options.tabIsEnter ?? true;
-        this.helpOnEmptyStrings = options.helpOnEmptyStrings ?? false;
+        this.helpOnEmptyStrings = options.helpOnEmptyStrings ?? (() => false);
         this.non_tippy_parent_element = options.non_tippy_parent_element;
         this.values = new WeakMap();
         this.requireHighlight = options.requireHighlight ?? true;
@@ -546,7 +546,7 @@ export class Typeahead<ItemType extends string | object> {
         // The force_lookup parameter allows specific code paths to override
         // the helpOnEmptyStrings configured for the typeahead element.
         if (
-            (!this.helpOnEmptyStrings || hideOnEmpty) &&
+            (!this.helpOnEmptyStrings() || hideOnEmpty) &&
             (!this.query || this.query.length < MIN_LENGTH) &&
             !force_lookup
         ) {
@@ -964,7 +964,7 @@ type TypeaheadOptions<ItemType> = {
     closeInputFieldOnHide?: () => void;
     dropup?: boolean;
     footer_html?: (matching_items: ItemType[]) => string | false;
-    helpOnEmptyStrings?: boolean;
+    helpOnEmptyStrings?: () => boolean;
     hideOnEmptyAfterBackspace?: boolean;
     matcher?: (query: string) => (item: ItemType) => boolean;
     on_escape?: () => void;

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1581,6 +1581,7 @@ export function initialize_topic_edit_typeahead(
     stream_name: string,
     dropup: boolean,
 ): Typeahead<string> {
+    const stream_id = stream_data.get_stream_id(stream_name);
     const bootstrap_typeahead_input: TypeaheadInputElement = {
         $element: form_field,
         type: "input",
@@ -1601,7 +1602,6 @@ export function initialize_topic_edit_typeahead(
             return get_topic_matcher(query);
         },
         sorter(items: string[], query: string): string[] {
-            const stream_id = stream_data.get_stream_id(stream_name);
             const sorted = typeahead_helper.sorter(query, items, (x) =>
                 util.get_final_topic_display_name(x),
             );
@@ -1616,7 +1616,6 @@ export function initialize_topic_edit_typeahead(
             return sorted;
         },
         source(): string[] {
-            const stream_id = stream_data.get_stream_id(stream_name);
             return topics_seen_for(stream_id);
         },
         items: max_num_items,

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1576,6 +1576,35 @@ function compose_trigger_selection(event: JQuery.KeyDownEvent): boolean {
     return false;
 }
 
+// Used to hide the auto-opened topic typeahead once the input already
+// names an existing topic and no other topic still matches the query,
+// since there is then nothing left to suggest. We never suppress an
+// empty query (the typeahead should still list the existing topics)
+// nor when there are non-topic suggestions such as people to show.
+export function should_suppress_topic_typeahead(
+    query: string,
+    items: (string | UserPillData)[],
+): boolean {
+    if (!query) {
+        return false;
+    }
+    if (items.some((item) => typeof item !== "string")) {
+        return false;
+    }
+    const topics = items.filter((item): item is string => typeof item === "string");
+    const normalize = (topic: string): string =>
+        util.get_final_topic_display_name(topic).trim().toLowerCase();
+    const normalized_query = normalize(query);
+    if (!topics.some((topic) => normalize(topic) === normalized_query)) {
+        return false;
+    }
+    // Suppress only if every topic is either the one the user already
+    // typed, or wouldn't be displayed for this query anyway; otherwise
+    // the user may be typing toward another suggestion.
+    const matcher = get_topic_matcher(query);
+    return topics.every((topic) => normalize(topic) === normalized_query || !matcher(topic));
+}
+
 export function initialize_topic_edit_typeahead(
     form_field: JQuery<HTMLInputElement>,
     stream_name: string,
@@ -1588,6 +1617,8 @@ export function initialize_topic_edit_typeahead(
     };
     return new Typeahead(bootstrap_typeahead_input, {
         dropup,
+        helpOnEmptyStrings: () => !stream_data.is_topic_creation_enabled(stream_id),
+        showOnFocus: () => !stream_data.is_topic_creation_enabled(stream_id),
         item_html(_query: string): (item: string) => string {
             return function (item: string): string {
                 const is_empty_string_topic = item === "";
@@ -1615,8 +1646,12 @@ export function initialize_topic_edit_typeahead(
             }
             return sorted;
         },
-        source(): string[] {
-            return topics_seen_for(stream_id);
+        source(query: string): string[] {
+            const topics = topics_seen_for(stream_id);
+            if (should_suppress_topic_typeahead(query, topics)) {
+                return [];
+            }
+            return topics;
         },
         items: max_num_items,
         getCustomItemClassname() {
@@ -1764,13 +1799,19 @@ export function initialize({
     };
     stream_message_topic_typeahead = new Typeahead(stream_message_typeahead_input, {
         dropup: true,
+        helpOnEmptyStrings: () => !stream_data.is_topic_creation_enabled(compose_state.stream_id()),
+        showOnFocus: () => !stream_data.is_topic_creation_enabled(compose_state.stream_id()),
         source(query: string): (UserPillData | string)[] {
             let people_candidates: UserPillData[] = [];
             if (query && query.length > 3) {
                 people_candidates = get_person_suggestion_for_topic_typeahead(query);
             }
             const topics = topics_seen_for(compose_state.stream_id());
-            return [...people_candidates, ...topics];
+            const candidates = [...people_candidates, ...topics];
+            if (should_suppress_topic_typeahead(query, candidates)) {
+                return [];
+            }
+            return candidates;
         },
         items: max_num_items,
         item_html(_query: string): (item: string | UserPillData) => string {

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -410,7 +410,7 @@ export function initialize_custom_pronouns_type_fields(element_id: string): void
                 type: "input" as const,
             };
             new Typeahead(bootstrap_typeahead_input, {
-                helpOnEmptyStrings: true,
+                helpOnEmptyStrings: () => true,
                 source() {
                     return commonly_used_pronouns;
                 },

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -96,11 +96,10 @@ export function set_up_stream(
         $element: $input,
         type: "contenteditable",
     };
-    opts.help_on_empty_strings ??= false;
     opts.hide_on_empty_after_backspace ??= false;
     new Typeahead(bootstrap_typeahead_input, {
         dropup: true,
-        helpOnEmptyStrings: opts.help_on_empty_strings,
+        helpOnEmptyStrings: () => opts.help_on_empty_strings ?? false,
         hideOnEmptyAfterBackspace: opts.hide_on_empty_after_backspace,
         source(_query: string): StreamPillData[] {
             return stream_pill.typeahead_source(pills, opts.invite_streams);
@@ -174,7 +173,7 @@ export function set_up_user_group(
             $input.trigger("focus");
         },
         stopAdvance: true,
-        helpOnEmptyStrings: true,
+        helpOnEmptyStrings: () => true,
         hideOnEmptyAfterBackspace: true,
     });
 }
@@ -263,7 +262,7 @@ export function set_up_group_setting_typeahead(
             $input.trigger("focus");
         },
         stopAdvance: true,
-        helpOnEmptyStrings: true,
+        helpOnEmptyStrings: () => true,
         hideOnEmptyAfterBackspace: true,
     });
 }
@@ -298,7 +297,7 @@ export function set_up_combined(
     };
     new Typeahead(bootstrap_typeahead_input, {
         dropup: true,
-        helpOnEmptyStrings: true,
+        helpOnEmptyStrings: () => true,
         hideOnEmptyAfterBackspace: true,
         source(query: string): TypeaheadItem[] {
             let source: TypeaheadItem[] = [];

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -212,7 +212,7 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
         },
         non_tippy_parent_element: "#searchbox_form",
         items: search_suggestion.max_num_of_search_results,
-        helpOnEmptyStrings: true,
+        helpOnEmptyStrings: () => true,
         stopAdvance: true,
         requireHighlight: false,
         item_html(query: string): (item: string) => string {

--- a/web/src/settings_playgrounds.ts
+++ b/web/src/settings_playgrounds.ts
@@ -164,7 +164,7 @@ function build_page(): void {
             language_labels = realm_playground.get_pygments_typeahead_list_for_settings(query);
             return [...language_labels.keys()];
         },
-        helpOnEmptyStrings: true,
+        helpOnEmptyStrings: () => true,
         item_html(_query: string): (item: string) => string {
             return (item: string) => render_typeahead_item({primary: language_labels.get(item)});
         },

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -962,6 +962,15 @@ export function rewire_can_create_new_topics_in_stream(
     can_create_new_topics_in_stream = value;
 }
 
+// Returns true when no channel is selected, so callers can pass the
+// compose state's channel id directly.
+export function is_topic_creation_enabled(stream_id: number | undefined): boolean {
+    if (stream_id === undefined) {
+        return true;
+    }
+    return can_create_new_topics_in_stream(stream_id);
+}
+
 export function user_can_move_messages_out_of_channel(stream: StreamSubscription): boolean {
     if (page_params.is_spectator) {
         return false;

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -842,6 +842,99 @@ test("topics_seen_for", ({override}) => {
     assert.deepEqual(ct.topics_seen_for(""), []);
 });
 
+test("should_suppress_topic_typeahead", () => {
+    // An empty query is never suppressed, even when the empty topic (which
+    // renders as a non-empty display name) is among the items.
+    assert.ok(!ct.should_suppress_topic_typeahead("", ["", "design"]));
+
+    // An exact match against an existing topic suppresses the typeahead,
+    // normalizing case and surrounding whitespace.
+    assert.ok(ct.should_suppress_topic_typeahead("design", ["design", "other"]));
+    assert.ok(ct.should_suppress_topic_typeahead("  DESIGN ", ["Design"]));
+
+    // An exact match is not suppressed while another topic still matches
+    // the query, since the user may be typing toward it.
+    assert.ok(!ct.should_suppress_topic_typeahead("design", ["design", "designs"]));
+    assert.ok(!ct.should_suppress_topic_typeahead("design", ["design", "my design doc"]));
+
+    // Another topic keeps the typeahead open only if the typeahead would
+    // actually display it: a multi-word query must match other topics at
+    // a word boundary, not as a mid-word substring ("design office"
+    // contains "sign off" but is not a suggestion for it).
+    assert.ok(!ct.should_suppress_topic_typeahead("sign off", ["sign off", "sign offsite"]));
+    assert.ok(ct.should_suppress_topic_typeahead("sign off", ["sign off", "design office"]));
+
+    // A query that names no existing topic is not suppressed.
+    assert.ok(!ct.should_suppress_topic_typeahead("new topic", ["design"]));
+
+    // People suggestions keep the typeahead open even on an exact match.
+    assert.ok(!ct.should_suppress_topic_typeahead("design", ["design", cordelia_item]));
+});
+
+test("topic typeahead auto-opens when topic creation is disabled", ({
+    override,
+    override_rewire,
+}) => {
+    let topic_edit_config;
+    override(bootstrap_typeahead, "Typeahead", (_input_element, config) => {
+        topic_edit_config = config;
+    });
+
+    let topic_creation_allowed = true;
+    override_rewire(stream_data, "can_create_new_topics_in_stream", () => topic_creation_allowed);
+
+    ct.initialize_topic_edit_typeahead($.create("fake-topic-edit-input"), "Denmark", false);
+
+    // The same typeahead instance reflects the channel's live permission,
+    // so it auto-opens on focus (showOnFocus) and shows for an empty query
+    // (helpOnEmptyStrings) exactly when topic creation is disabled.
+    topic_creation_allowed = false;
+    assert.ok(topic_edit_config.showOnFocus());
+    assert.ok(topic_edit_config.helpOnEmptyStrings());
+
+    topic_creation_allowed = true;
+    assert.ok(!topic_edit_config.showOnFocus());
+    assert.ok(!topic_edit_config.helpOnEmptyStrings());
+
+    // With no channel resolved, topic creation is treated as allowed, so
+    // the typeahead does not auto-open.
+    ct.initialize_topic_edit_typeahead($.create("fake-missing-stream-input"), "Nonexistent", false);
+    topic_creation_allowed = false;
+    assert.ok(!topic_edit_config.showOnFocus());
+    assert.ok(!topic_edit_config.helpOnEmptyStrings());
+});
+
+test("topic typeahead source suppresses an exact-match topic", ({override}) => {
+    let topic_edit_config;
+    override(bootstrap_typeahead, "Typeahead", (_input_element, config) => {
+        topic_edit_config = config;
+    });
+    override(stream_topic_history_util, "get_server_history", noop);
+    // Higher message_ids are more recent, so "design" sorts before
+    // "design docs" in the source's output.
+    for (const [message_id, topic_name] of [
+        [2, "design"],
+        [1, "design docs"],
+    ]) {
+        stream_topic_history.add_message({
+            stream_id: netherland_stream.stream_id,
+            message_id,
+            topic_name,
+        });
+    }
+
+    ct.initialize_topic_edit_typeahead($.create("fake-source-input"), "The Netherlands", false);
+
+    // "design docs" still has "design" as a substring, so an exact match on
+    // "design" keeps the existing topics listed.
+    assert.deepEqual(topic_edit_config.source("design"), ["design", "design docs"]);
+    // Matching the longest topic exactly leaves nothing to suggest, so the
+    // source returns no items and the typeahead stays hidden.
+    assert.deepEqual(topic_edit_config.source("design docs"), []);
+    // A query that names no existing topic lists the topics as usual.
+    assert.deepEqual(topic_edit_config.source("new"), ["design", "design docs"]);
+});
+
 test("content_typeahead_selected", ({override}) => {
     const input_element = {
         $element: {},

--- a/web/tests/pill_typeahead.test.cjs
+++ b/web/tests/pill_typeahead.test.cjs
@@ -283,6 +283,7 @@ run_test("set_up_stream", ({mock_template, override, override_rewire}) => {
         assert.equal(typeof config.matcher, "function");
         assert.equal(typeof config.sorter, "function");
         assert.equal(typeof config.updater, "function");
+        assert.equal(config.helpOnEmptyStrings(), false);
 
         // test queries
         const stream_query = "#denmark";
@@ -376,6 +377,7 @@ run_test("set_up_user_group", ({mock_template, override, override_rewire}) => {
         assert.equal(typeof config.matcher, "function");
         assert.equal(typeof config.sorter, "function");
         assert.equal(typeof config.updater, "function");
+        assert.equal(config.helpOnEmptyStrings(), true);
 
         const group_query = "testers";
 
@@ -476,6 +478,7 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
         assert.equal(typeof config.matcher, "function");
         assert.equal(typeof config.sorter, "function");
         assert.equal(typeof config.updater, "function");
+        assert.equal(config.helpOnEmptyStrings(), true);
 
         // test queries
         const stream_query = "#Denmark";
@@ -786,6 +789,7 @@ run_test("set_up_group_setting_typeahead", ({mock_template, override, override_r
         assert.equal(typeof config.matcher, "function");
         assert.equal(typeof config.sorter, "function");
         assert.equal(typeof config.updater, "function");
+        assert.equal(config.helpOnEmptyStrings(), true);
 
         // test queries
         const person_query = "me";

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -82,7 +82,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
         opts = opts_;
         assert.equal(input_element.$element[0], $search_query_box[0]);
         assert.equal(opts.items, 999);
-        assert.equal(opts.helpOnEmptyStrings, true);
+        assert.equal(opts.helpOnEmptyStrings(), true);
         assert.equal(opts.matcher("")(), true);
 
         search_typeahead = {

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -1561,6 +1561,16 @@ test("can_create_topics_in_stream", ({override}) => {
     page_params.is_spectator = false;
     sub.is_archived = true;
     assert.equal(stream_data.can_create_new_topics_in_stream(sub.stream_id), false);
+
+    // is_topic_creation_enabled tracks can_create_new_topics_in_stream,
+    // and treats "no channel selected" (undefined) as enabled.
+    sub.is_archived = false;
+    sub.can_create_topic_group = admins_group.id;
+    override(current_user, "user_id", admin_user_id);
+    assert.equal(stream_data.is_topic_creation_enabled(sub.stream_id), true);
+    override(current_user, "user_id", moderator_user_id);
+    assert.equal(stream_data.is_topic_creation_enabled(sub.stream_id), false);
+    assert.equal(stream_data.is_topic_creation_enabled(undefined), true);
 });
 
 test("can_move_messages_out_of_channel", ({override}) => {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #36970 

In this PR, I made the necessary changes so that the topic typeaheads open immediately if the user does not has can_create_new_topics_in_stream permission. 

### Changes

- Added an additional optional parameter in initialize_topic_edit_typeahead. When set to true, it makes the helpOnEmptyStrings true which makes the menu to open immediately. 
- Updated the topic typeahead behavior in the compose box, move message modal, and inline topic edit such that it will automatically open the list of available topics when the user lacks the permission to create new ones.
- Additionally added input focus handlers as without it, the topic typeahead was coming up when we removed the topic but when we un-focused and re-focused on the input area, it didn't appear, so i added these input handlers on focus.
- Added a suppress hook to hide the topic typeahead for certain queries, which is used to hide the typeahead when the input already contains an existing topic. 

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

- Ran the `./tools/test-all` .
- Manually tested the behavior of the topic typeaheads for each case(user has permission to create a new topic and when it lacks the permission).

**Screenshots and screen captures:**

| Before | After |
| :---: | :---: |
| <img width="3196" height="1936" alt="image" src="https://github.com/user-attachments/assets/d6278c2c-dab8-4690-b392-3986cd096e6e" /> | <img width="3196" height="1936" alt="image" src="https://github.com/user-attachments/assets/e13d18f1-f909-47f4-8fa7-c0e66be88df9" /> |
| <img width="3196" height="1936" alt="image" src="https://github.com/user-attachments/assets/c5d65a11-514b-4ed3-9f69-ba25dee9820e" /> | <img width="3196" height="1936" alt="image" src="https://github.com/user-attachments/assets/d78272fb-035a-40c7-980d-4ea7021ff6f9" /> |
|<img width="3196" height="1936" alt="image" src="https://github.com/user-attachments/assets/31939e80-39b2-47c6-8e95-cb3a7abb6b6e" />| <img width="3196" height="1936" alt="image" src="https://github.com/user-attachments/assets/162d3e89-e37e-4444-a697-111a190b2ea5" /> |

Video ->

https://github.com/user-attachments/assets/f71c1763-e253-468a-80f7-ec9ff1d1622a


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
