### PR TITLE
error pages: Fix missing request_language param.

### DIFF
--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -36,6 +36,11 @@ from zproject.config import get_config
 DEFAULT_PAGE_PARAMS: Mapping[str, Any] = {
     "page_type": "default",
     "development_environment": settings.DEVELOPMENT,
+    # This language is used to initialize i18n.ts to do translations
+    # in the user's language. Callers are expected to replace this
+    # with the user's detected language using get_language wherever
+    # possible.
+    "request_language": "en",
 }
 
 

--- a/zproject/jinja2/__init__.py
+++ b/zproject/jinja2/__init__.py
@@ -25,6 +25,11 @@ def environment(**options: Any) -> Environment:
         # default_page_params is provided here for responses where
         # zulip_default_context is not run, including the 404.html and
         # 500.html error pages.
+        #
+        # Note that we can't use detect the user's language using
+        # get_language here, since this is only run once during
+        # process initialization. This is functionally OK, in that
+        # these error pages are translated on the server.
         default_page_params=DEFAULT_PAGE_PARAMS,
         static=staticfiles_storage.url,
         url=reverse,


### PR DESCRIPTION
- Fixes unhandled default params for error pages like 404, 500, etc.
- Previously, the page params when `zulip_default_context` doesn't run (in 404, 500, etc.) was not synced in frontend.
- Added the "fallback" Zod schema for such cases.
- Made appropriate changes to places affected by the accurate base_page_params until no lint errors were observed.

Fixes: #35032 

**How changes were tested:**

- No ZodError occured when issue steps were reproduced.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate. [Not applicable]

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization. [Not applicable]
- [ ] Strings and tooltips. [Not applicable]
- [ ] End-to-end functionality of buttons, interactions and flows. [Not applicable]
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
