### PR TITLE
Fixed Wrong Command to add user in docker group for fedora

### DIFF
--- a/docs/development/setup-recommended.md
+++ b/docs/development/setup-recommended.md
@@ -221,7 +221,7 @@ official `docker-ce` package in their repositories. They provide the package
 docker distribution, you can follow
 [their documentation to install Docker on Fedora](https://docs.docker.com/engine/install/fedora/).
 
-```{include} setup/install-docker.md
+```{include} setup/install-docker-fedora.md
 
 ```
 

--- a/docs/development/setup/install-docker-fedora.md
+++ b/docs/development/setup/install-docker-fedora.md
@@ -1,0 +1,38 @@
+##### 2. Add yourself to the `docker` group:
+
+```console
+$ sudo usermod -aG docker $USER
+```
+
+You will need to reboot for this change to take effect. If it worked,
+you will see `docker` in your list of groups:
+
+```console
+$ groups | grep docker
+YOURUSERNAME adm cdrom sudo dip plugdev lpadmin sambashare docker
+```
+
+##### 3. Make sure the Docker daemon is running:
+
+If you had previously installed and removed an older version of
+Docker, an [Ubuntu
+bug](https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/1844894)
+may prevent Docker from being automatically enabled and started after
+installation. You can check using the following:
+
+```console
+$ systemctl status docker
+● docker.service - Docker Application Container Engine
+   Loaded: loaded (/lib/systemd/system/docker.service; enabled; vendor preset: enabled)
+   Active: active (running) since Mon 2019-07-15 23:20:46 IST; 18min ago
+```
+
+If the service is not running, you'll see `Active: inactive (dead)` on
+the second line, and will need to enable and start the Docker service
+using the following:
+
+```console
+$ sudo systemctl unmask docker
+$ sudo systemctl enable docker
+$ sudo systemctl start docker
+```


### PR DESCRIPTION
**Fix: Corrected the command to add a user to the Docker group on Fedora 43.**

**Issue**: The command shown in some docs (sudo adduser $USER docker) is Ubuntu/Debian-specific and may not work **correctly** on Fedora.

**Change**: Replaced it with the correct Fedora-compatible command:

**References / Screenshots:**
Original (wrong) command from Zulip Docs:
[https://docs.docker.com/engine/install/linux-postinstall/](url)
<img width="470" height="185" alt="image" src="https://github.com/user-attachments/assets/862ddf3b-f509-4240-87ec-afa6d932c009" />

Correct command from official Docker Docs:
[https://docs.docker.com/engine/install/linux-postinstall/](url)
<img width="621" height="148" alt="image" src="https://github.com/user-attachments/assets/71572ecf-f915-46eb-8527-9c5033e69087" />

**Notes:**
- This is a markdown/documentation fix only.
- No testing performed as this does not affect functionality. Testing can be done if required.


