### PR TITLE
Replace autosize with custom implementation.

### DIFF
--- a/web/src/autosize.ts
+++ b/web/src/autosize.ts
@@ -1,0 +1,40 @@
+/**
+ * This module supports the CSS Grid-based autosize implementation.
+ *
+ * Instead of calculating pixel heights in JavaScript,
+ * this module simply copies the textarea's value to a `data-replicated-value`
+ * attribute on the parent container.
+ *
+ * The CSS in `compose.css` and `message_row.css` uses this attribute to populate a hidden pseudo-element
+ * that forces the grid container to grow, naturally resizing the textarea.
+ */
+
+export function watch($textarea: JQuery<HTMLTextAreaElement>): void {
+    const textarea = $textarea[0];
+    if (!textarea) {
+        return;
+    }
+
+    // Check if we have already wrapped this specific textarea
+    let $parent = $textarea.parent?.();
+
+    if (!$parent || $parent.length === 0 || !$parent.hasClass("autosize-container")) {
+        $textarea.wrap('<div class="autosize-container"></div>');
+        $parent = $textarea.parent();
+    }
+
+    // The logic: Sync value to data attribute on input so CSS can read it
+    const update = (): void => {
+        const val = $textarea.val()!;
+        $parent.attr("data-replicated-value", val);
+    };
+
+    $textarea.on("input", update);
+
+    // Initial sync
+    update();
+}
+
+export function manual_resize($textarea: JQuery<HTMLTextAreaElement>): void {
+    $textarea.trigger("input");
+}

--- a/web/src/compose.ts
+++ b/web/src/compose.ts
@@ -1,6 +1,5 @@
 /* Main compose box module for sending messages. */
 
-import autosize from "autosize";
 import $ from "jquery";
 import assert from "minimalistic-assert";
 import * as z from "zod/mini";
@@ -8,6 +7,7 @@ import * as z from "zod/mini";
 import render_success_message_scheduled_banner from "../templates/compose_banner/success_message_scheduled_banner.hbs";
 import render_wildcard_mention_not_allowed_error from "../templates/compose_banner/wildcard_mention_not_allowed_error.hbs";
 
+import * as autosize from "./autosize.ts";
 import * as channel from "./channel.ts";
 import * as compose_banner from "./compose_banner.ts";
 import * as compose_notifications from "./compose_notifications.ts";
@@ -75,12 +75,12 @@ export function clear_preview_area(): void {
     $("#compose .preview_message_area").hide();
     $("#compose .preview_content").empty();
     $("#compose .markdown_preview").show();
-    autosize.update($("textarea#compose-textarea"));
 
     // While in preview mode we disable unneeded compose_control_buttons,
     // so here we are re-enabling those compose_control_buttons
     $("#compose").removeClass("preview_mode");
     $("#compose .preview_mode_disabled .compose_control_button").attr("tabindex", 0);
+    autosize.manual_resize($("textarea#compose-textarea"));
 }
 
 export function show_preview_area(): void {

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -1,9 +1,9 @@
 /* Module primarily for opening/closing the compose box. */
 
-import autosize from "autosize";
 import $ from "jquery";
 import _ from "lodash";
 
+import * as autosize from "./autosize.ts";
 import * as blueslip from "./blueslip.ts";
 import * as compose_banner from "./compose_banner.ts";
 import * as compose_fade from "./compose_fade.ts";
@@ -176,23 +176,29 @@ export let autosize_message_content = (opts: ComposeActionsStartOpts): void => {
     if (!compose_ui.is_expanded()) {
         autosize_callback_opts = opts;
         let has_resized_once = false;
+
         $("textarea#compose-textarea")
-            .off("autosize:resized")
-            .on("autosize:resized", (e) => {
+            .off("input.autosize_check") // Use a namespace to avoid removing other input listeners
+            .on("input.autosize_check", (e) => {
+                // 1. Run the "once" logic immediately (simulating the old behavior)
                 if (!has_resized_once) {
                     has_resized_once = true;
                     maybe_scroll_up_selected_message(autosize_callback_opts);
                 }
-                const height = $(e.currentTarget).height()!;
-                const max_height = Number.parseFloat($(e.currentTarget).css("max-height"));
-                // We add 5px to account for minor differences in height detected in Chrome.
+
+                // 2. Check height logic
+                const $target = $(e.currentTarget);
+                const height = $target.height()!;
+                const max_height = Number.parseFloat($target.css("max-height"));
+
                 if (height + 5 >= max_height) {
                     $("#compose").addClass("automatically-expanded");
                 } else {
                     $("#compose").removeClass("automatically-expanded");
                 }
             });
-        autosize($("textarea#compose-textarea"));
+        // This triggers the "input" event immediately, running the code above
+        autosize.manual_resize($("textarea#compose-textarea"));
     }
 };
 

--- a/web/src/compose_paste.ts
+++ b/web/src/compose_paste.ts
@@ -771,7 +771,7 @@ export function paste_handler(
                     // and also is required for undo, see above.
                     $banner.remove();
                 });
-            }, 0);
+            }, 100);
         }
 
         // Only intervene to generate formatted links when dealing

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -1,7 +1,5 @@
 /* Compose box module responsible for manipulating the compose box
    textarea correctly. */
-
-import autosize from "autosize";
 import $ from "jquery";
 import _ from "lodash";
 import assert from "minimalistic-assert";
@@ -13,6 +11,7 @@ import {
 } from "text-field-edit";
 import * as z from "zod/mini";
 
+import * as autosize from "./autosize.ts";
 import type {Typeahead} from "./bootstrap_typeahead.ts";
 import * as bulleted_numbered_list_util from "./bulleted_numbered_list_util.ts";
 import * as channel from "./channel.ts";
@@ -113,7 +112,7 @@ export let autosize_textarea = ($textarea: JQuery<HTMLTextAreaElement>): void =>
     // Since this supports both compose and file upload, one must pass
     // in the text area to autosize.
     if (!is_expanded()) {
-        autosize.update($textarea);
+        autosize.manual_resize($textarea);
     }
 };
 
@@ -505,10 +504,6 @@ export function rewire_set_compose_box_top(value: typeof set_compose_box_top): v
 export function make_compose_box_full_size(): void {
     set_expanded_status(true);
 
-    // The autosize should be destroyed for the full size compose
-    // box else it will interfere and shrink its size accordingly.
-    autosize.destroy($("textarea#compose-textarea"));
-
     $("#compose").removeClass("compose-intermediate");
     $("#compose").removeClass("automatically-expanded");
     $("#compose").addClass("compose-fullscreen");
@@ -522,10 +517,6 @@ export function make_compose_box_full_size(): void {
 
 export function make_compose_box_intermediate_size(): void {
     set_expanded_status(true, false);
-
-    // The autosize should be destroyed for the intermediate size compose
-    // box else it will interfere and shrink its size accordingly.
-    autosize.destroy($("textarea#compose-textarea"));
 
     $("#compose").removeClass("compose-fullscreen");
     $("#compose").removeClass("automatically-expanded");
@@ -549,7 +540,7 @@ export function make_compose_box_original_size(): void {
 
     // Again initialise the compose textarea as it was destroyed
     // when compose box was made full screen
-    autosize($("textarea#compose-textarea"));
+    autosize.manual_resize($("textarea#compose-textarea"));
 
     $("textarea#compose-textarea").trigger("focus");
 }

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1,4 +1,3 @@
-import autosize from "autosize";
 import ClipboardJS from "clipboard";
 import $ from "jquery";
 import _ from "lodash";
@@ -18,6 +17,7 @@ import render_topic_edit_form from "../templates/topic_edit_form.hbs";
 
 import {detached_uploads_api_response_schema} from "./attachments.ts";
 import * as attachments_ui from "./attachments_ui.ts";
+import * as autosize from "./autosize.ts";
 import * as blueslip from "./blueslip.ts";
 import type {Typeahead} from "./bootstrap_typeahead.ts";
 import * as buttons from "./buttons.ts";
@@ -147,7 +147,7 @@ export function maybe_autosize_message_edit_box(): void {
     for (const message_id of message_ids) {
         const $edit_container = currently_editing_messages.get(message_id);
         if ($edit_container) {
-            autosize($edit_container);
+            autosize.manual_resize($edit_container);
         }
     }
     resized_edit_box_height.clear();

--- a/web/src/message_list.ts
+++ b/web/src/message_list.ts
@@ -1,8 +1,8 @@
-import autosize from "autosize";
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
 import * as activity_ui from "./activity_ui.ts";
+import * as autosize from "./autosize.ts";
 import * as blueslip from "./blueslip.ts";
 import * as compose_tooltips from "./compose_tooltips.ts";
 import * as compose_ui from "./compose_ui.ts";
@@ -531,7 +531,7 @@ export class MessageList {
         if (do_autosize) {
             // autosize will not change the height of the textarea if the `$row` is not
             // rendered in DOM yet. So, we call `autosize.update` post render.
-            autosize($row.find(".message_edit_content"));
+            autosize.watch($row.find("textarea.message_edit_content"));
         }
         compose_ui.maybe_show_scrolling_formatting_buttons(".message-edit-feature-group");
     }

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1,4 +1,3 @@
-import autosize from "autosize";
 import {isSameDay} from "date-fns";
 import $ from "jquery";
 import _ from "lodash";
@@ -13,6 +12,7 @@ import render_revealed_message_hide_button from "../templates/revealed_message_h
 import render_single_message from "../templates/single_message.hbs";
 
 import * as activity from "./activity.ts";
+import * as autosize from "./autosize.ts";
 import * as blueslip from "./blueslip.ts";
 import * as compose_fade from "./compose_fade.ts";
 import * as condense from "./condense.ts";
@@ -1285,7 +1285,7 @@ export class MessageListView {
         }
 
         // After all the messages are rendered, resize any message edit textarea if required.
-        autosize.update(this.$list.find(".message_edit_content"));
+        autosize.manual_resize(this.$list.find(".message_edit_content"));
         maybe_restore_focus_to_message_edit_form();
 
         restore_scroll_position();

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -1,7 +1,7 @@
-import autosize from "autosize";
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
+import * as autosize from "./autosize.ts";
 import * as blueslip from "./blueslip.ts";
 import * as compose_state from "./compose_state.ts";
 import * as compose_ui from "./compose_ui.ts";
@@ -70,14 +70,15 @@ export function watch_manual_resize_for_element(
     box.addEventListener("mousedown", box_handler);
 
     // If the user resizes the textarea manually, we use the
-    // callback to stop autosize from adjusting the height.
-    // It will be re-enabled when this component is next opened.
+    // callback to handle the layout update.
     const body_handler = function (): void {
         if (mousedown) {
             mousedown = false;
             if (height !== box.clientHeight) {
                 height = box.clientHeight;
-                autosize.destroy($(box)).height(height + "px");
+
+                $(box).height(height + "px"); // Explicitly set the new height
+
                 if (resize_callback) {
                     resize_callback(height);
                 }
@@ -112,17 +113,16 @@ export function reset_compose_message_max_height(bottom_whitespace_height?: numb
     );
     const compose_non_textarea_height = compose_height - compose_textarea_height;
 
-    // We ensure that the last message is not overlapped by compose box.
-    $("textarea#compose-textarea").css(
-        "max-height",
-        bottom_whitespace_height - compose_non_textarea_height,
-    );
+    $("textarea#compose-textarea")
+        .parent()
+        .css("--ghost-max-height", `${bottom_whitespace_height - compose_non_textarea_height}px`);
+
     $("#preview_message_area").css(
         "max-height",
         bottom_whitespace_height - compose_non_textarea_height,
     );
     $("#scroll-to-bottom-button-container").css("bottom", compose_height);
-    compose_ui.autosize_textarea($("#compose-textarea"));
+    autosize.manual_resize($("textarea#compose-textarea"));
 }
 
 export function resize_bottom_whitespace(): void {

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -16,6 +16,7 @@ import * as add_stream_options_popover from "./add_stream_options_popover.ts";
 import * as alert_words from "./alert_words.ts";
 import {all_messages_data} from "./all_messages_data.ts";
 import * as audible_notifications from "./audible_notifications.ts";
+import * as autosize from "./autosize.ts";
 import * as banners from "./banners.ts";
 import * as blueslip from "./blueslip.ts";
 import * as bot_data from "./bot_data.ts";
@@ -217,6 +218,7 @@ function initialize_compose_box() {
             }),
         ),
     );
+    autosize.watch($("textarea#compose-textarea"));
     $(`.enter_sends_${user_settings.enter_sends}`).show();
     common.adjust_mac_kbd_tags(".open_enter_sends_dialog kbd");
 }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -2071,3 +2071,64 @@ textarea.new_message_textarea {
         overflow: hidden !important;
     }
 }
+
+/*
+ * This implementation uses a CSS Grid trick to allow the textarea to grow
+ * automatically with content, without requiring JavaScript layout calculations.
+ *
+ * The container is a grid with one cell. Both the textarea and a hidden ::after
+ * pseudo-element (which replicates the text) occupy this same cell.
+ * The ::after element grows with the text, pushing the container height open,
+ * and the textarea fills that space.
+ *
+ * Adapted from: https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/
+ */
+
+/* Autosize Grid Setup */
+.autosize-container {
+    display: grid;
+    min-width: 0;
+    /* This ensures both the ghost and textarea share the exact same source */
+    font-family: "Source Sans 3 VF", sans-serif;
+    font-size: 1em; /* Base size */
+    line-height: var(--base-line-height-unitless, 1.2);
+}
+
+/* The Replica (Hidden) */
+.autosize-container::after {
+    content: attr(data-replicated-value) " ";
+    white-space: pre-wrap;
+    visibility: hidden;
+    overflow-wrap: anywhere;
+    box-sizing: border-box;
+    grid-area: 1 / 1 / 2 / 2;
+    font: inherit;
+    line-height: inherit;
+}
+
+.autosize-container:has(#compose-textarea)::after {
+    /* Specific Dimensions for the Main Compose Box */
+    margin-right: calc(var(--composebox-buttons-width) * -1);
+    padding: 5px var(--composebox-buttons-width) 0 5px;
+    max-height: var(--ghost-max-height, 22em);
+    overflow: hidden;
+}
+
+/* The Textarea (Visible) */
+.autosize-container > #compose-textarea {
+    resize: none;
+    overflow: hidden;
+    height: 100% !important;
+    max-height: 100%;
+    box-sizing: border-box;
+    grid-area: 1 / 1 / 2 / 2;
+    overflow-y: auto;
+
+    /* Now we can not edit textarea font styles dynamically, we can edit that of autosize-container so that those values propagates to both textarea and replica */
+    font-family: inherit !important;
+    font-size: inherit !important;
+    line-height: inherit !important;
+
+    /* Ensure padding matches the ghost exactly */
+    padding: 5px var(--composebox-buttons-width) 0 5px;
+}

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1279,3 +1279,55 @@
         }
     }
 }
+
+/*  The Replica (Hidden) */
+.autosize-container:has(.message_edit_content)::after {
+    min-height: 52px;
+    max-height: var(--max-message-edit-height);
+
+    padding: 5px 12px 0 5px; /* I have made right padding of replica to 12px because it needs to wrap first otherwise a scrollbar shows up before min height for a moment and goes away if we add 2-3 more characters, causing distracting effect */
+    line-height: var(--base-line-height-unitless);
+    font-family: "Source Sans 3 VF", sans-serif;
+    font-size: 1em;
+    scrollbar-gutter: stable;
+}
+
+.autosize-container > .message_edit_content {
+    width: 100%;
+    min-width: 206px;
+    min-height: 52px;
+    max-height: var(--max-message-edit-height);
+
+    box-sizing: border-box;
+    color: var(--color-text-default);
+    background-color: var(--background-color-textarea);
+    border-radius: 3px 3px 0 0;
+    vertical-align: middle;
+    border: none;
+    scrollbar-gutter: stable;
+
+    /* Match padding to replica */
+    padding: 5px 5px 0;
+    margin: 0;
+    box-shadow: none;
+
+    font-size: 1em;
+    line-height: var(--base-line-height-unitless);
+    font-family: "Source Sans 3 VF", sans-serif;
+
+    /* These ensure the box fills the grid cell created by the replica */
+    resize: none !important;
+    overflow: hidden !important;
+    height: 100% !important;
+    grid-area: 1 / 1 / 2 / 2; /* Stacks on top of replica */
+    overflow-y: auto !important; /* Enables scroll when full */
+}
+
+.autosize-container > .message_edit_content:focus {
+    outline: 0;
+}
+
+.autosize-container > .message_edit_content:read-only,
+.autosize-container > .message_edit_content:disabled {
+    cursor: not-allowed;
+}

--- a/web/tests/autosize.test.cjs
+++ b/web/tests/autosize.test.cjs
@@ -1,0 +1,62 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const autosize = require("../src/autosize.ts");
+
+const {run_test} = require("./lib/test.cjs");
+const $ = require("./lib/zjquery.cjs");
+
+run_test("watch sets data-replicated-value and reacts to input", () => {
+    const $textarea = $("<textarea>");
+    $textarea.wrap = (html) => {
+        const $parent = $(html);
+        $textarea.set_parent($parent);
+    };
+
+    autosize.watch($textarea);
+
+    $textarea.val("hello");
+    $textarea.trigger("input");
+
+    assert.equal($textarea.parent().attr("data-replicated-value"), "hello");
+});
+
+run_test("manual_resize triggers input event", () => {
+    let input_triggered = false;
+
+    const $textarea = $("<textarea>");
+    $textarea.on("input", () => {
+        input_triggered = true;
+    });
+
+    autosize.manual_resize($textarea);
+
+    assert.ok(input_triggered);
+});
+
+run_test("watch ignores empty jquery object", () => {
+    // This forces the 'if (!textarea) return' check to run.
+    const $empty = {
+        0: undefined,
+        length: 0,
+    };
+
+    // Should return immediately without calling .wrap() or .parent()
+    autosize.watch($empty);
+});
+
+run_test("watch uses existing parent if valid", () => {
+    const $container = $("<div>");
+    $container.addClass("autosize-container");
+
+    const $textarea = $("<textarea>");
+    $textarea.set_parent($container);
+
+    autosize.watch($textarea);
+
+    $textarea.val("existing parent");
+    $textarea.trigger("input");
+
+    assert.equal($container.attr("data-replicated-value"), "existing parent");
+});


### PR DESCRIPTION
## PR Description
It replaces the autosize library with this [implementation](https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/).

I made a new module `autosize.ts` in which the above idea was implemented and then used it by importing in the files where autosize library was being used.

Fixes #36546.
Please let me know if you notice any edge cases I might have missed.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots:**
<img width="1909" height="1069" alt="image" src="https://github.com/user-attachments/assets/76e534e3-f4e7-4df5-8a1e-ed7b2418dd22" />
<img width="1918" height="1072" alt="image" src="https://github.com/user-attachments/assets/1a78e758-98b9-4320-81bb-b76a7e9e8acc" />
<img width="1915" height="1062" alt="image" src="https://github.com/user-attachments/assets/239b1ebc-1670-4520-b50a-35500089cfc0" />
<img width="1915" height="1070" alt="image" src="https://github.com/user-attachments/assets/0959ab06-145b-4506-979a-ef9b7c3cdc72" />


**Screen Capture**

https://github.com/user-attachments/assets/e7c157ff-297b-46e9-b6ea-dfd2a3bcc79e

---


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
