### PR TITLE
settings: Add warning icon for overridden emojis.

### DIFF
--- a/web/src/settings_emoji.ts
+++ b/web/src/settings_emoji.ts
@@ -125,6 +125,7 @@ export function populate_emoji(): void {
                     source_url: item.source_url,
                     author,
                     can_delete_emoji: can_delete_emoji(item),
+                    is_overriding_default: is_default_emoji(item.name),
                 },
             });
         },

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -979,6 +979,16 @@ input[type="checkbox"] {
     vertical-align: middle;
 }
 
+.emoji-override-warning {
+    vertical-align: middle;
+    margin-left: 3px;
+    opacity: 0.7;
+
+    &:hover {
+        opacity: 1;
+    }
+}
+
 .add-new-linkifier-box,
 .add-new-playground-box {
     & button {

--- a/web/templates/settings/admin_emoji_list.hbs
+++ b/web/templates/settings/admin_emoji_list.hbs
@@ -2,6 +2,9 @@
 <tr class="emoji_row" id="emoji_{{name}}" data-emoji-name="{{name}}">
     <td>
         <span class="emoji_name">{{display_name}}</span>
+        {{#if is_overriding_default}}
+            <i class="zulip-icon zulip-icon-exclamation-circle tippy-zulip-tooltip emoji-override-warning" data-tippy-content="{{t 'This custom emoji overrides a default emoji with the same name.' }}"></i>
+        {{/if}}
     </td>
     <td>
         <span class="emoji_image">


### PR DESCRIPTION
This PR adds a visual warning in the custom emoji settings when a new emoji overrides a standard Unicode emoji.
Previously, while administrators received a confirmation warning when creating a conflicting emoji, there was no persistent indication in the settings list that a custom emoji was shadowing a default one.
I have updated the emoji settings list to display a warning icon (`zulip-icon-exclamation-circle`) next to the emoji name if it overrides a built-in emoji. Hovering over this icon displays a tooltip explaining the override status.

Fixes #24120.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

**How changes were tested:**
I manually verified these changes in the development environment:
- Logged in as an administrator (Iago).
- Navigated to **Organization settings** > **Custom emoji**.
- Added a new emoji named `smile` (which conflicts with the default `:smile:`).
- Confirmed the "Override built-in emoji?" modal appeared.
- Verified that the new emoji row in the settings table now displays an exclamation circle icon next to the name.
- Hovered over the icon to verify the tooltip text: "This custom emoji overrides a default emoji with the same name."


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

 Before
<img width="863" height="130" alt="Screenshot 2025-12-15 at 7 01 25 PM" src="https://github.com/user-attachments/assets/3fde0166-0a18-4aa0-a041-b498b99e590e" />

After
1. Light Mode - Normal (Icon looks grayish/muted).
<img width="866" height="194" alt="Screenshot 2025-12-20 at 8 05 24 AM" src="https://github.com/user-attachments/assets/d49f7832-3cea-4b15-83f4-6e9e8a7c2dba" />



2. Light Mode - Hover (icon turns solid black while hovering it).
<img width="871" height="204" alt="Screenshot 2025-12-20 at 8 05 32 AM" src="https://github.com/user-attachments/assets/f68d28d9-18a1-410c-8fad-25b30921950a" />



3. Dark Mode - Normal ( icon looks muted white).
<img width="860" height="220" alt="Screenshot 2025-12-20 at 8 04 15 AM" src="https://github.com/user-attachments/assets/57c3538b-d2bb-490c-8321-089efb849f1a" />



4. Dark Mode - Hover (icon turns to solid white after hovering).
<img width="877" height="221" alt="Screenshot 2025-12-20 at 8 04 54 AM" src="https://github.com/user-attachments/assets/cbc36db3-1ef6-4d0c-8216-e77f56bdcfc0" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
