### PR TITLE
integration_docs: Update links for Tenor and GIPHY.

### DIFF
--- a/templates/zerver/integrations/giphy.md
+++ b/templates/zerver/integrations/giphy.md
@@ -11,4 +11,4 @@ GIPHY is enabled by default in Zulip Cloud. Follow
 * [Using GIFs in Zulip][help-center-gifs]
 
 [help-center-gifs]: /help/animated-gifs
-[configure-giphy]: https://zulip.readthedocs.io/en/latest/production/gif-picker-integrations.html
+[configure-giphy]: https://zulip.readthedocs.io/en/latest/production/gif-picker-integrations.html#giphy

--- a/templates/zerver/integrations/tenor.md
+++ b/templates/zerver/integrations/tenor.md
@@ -10,4 +10,4 @@ Follow [these instructions][configure-tenor] to configure Tenor on a
 * [Using GIFs in Zulip][help-center-gifs]
 
 [help-center-gifs]: /help/animated-gifs
-[configure-tenor]: https://zulip.readthedocs.io/en/latest/production/gif-picker-integrations.html
+[configure-tenor]: https://zulip.readthedocs.io/en/latest/production/gif-picker-integrations.html#tenor


### PR DESCRIPTION
A follow-up point from #36654.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
