### PR TITLE
emoji: ensure still_url is always present for accessibility

### DIFF
--- a/zerver/models/realm_emoji.py
+++ b/zerver/models/realm_emoji.py
@@ -85,13 +85,22 @@ def get_all_custom_emoji_for_realm_uncached(realm_id: int) -> dict[str, EmojiInf
         assert realm_emoji.file_name is not None
         emoji_url = get_emoji_url(realm_emoji.file_name, realm_emoji.realm_id)
 
+        # Construct the still_url: first try with still=True
+        still_url = None
+        if realm_emoji.is_animated:
+            still_url = get_emoji_url(realm_emoji.file_name, realm_emoji.realm_id, still=True)
+
+        # Fallback: if still_url is not defined (old emojis), use source_url
+        if still_url is None:
+            still_url = emoji_url
+
         emoji_dict: EmojiInfo = dict(
             id=str(realm_emoji.id),
             name=realm_emoji.name,
             source_url=emoji_url,
             deactivated=realm_emoji.deactivated,
             author_id=author_id,
-            still_url=None,
+            still_url=still_url,
         )
 
         if realm_emoji.is_animated:


### PR DESCRIPTION
Fixes: #36339

This ensures that the `still_url` field is always present in the API response for custom emojis, even for older emojis uploaded before Zulip 5.0 that lack a dedicated still image. When `still_url` is not available (e.g. for legacy GIFs without a generated static version), we fall back to using the same URL as `source_url`. This guarantees that frontend code can always rely on the existence of `still_url` when applying accessibility preferences like `prefers-reduced-motion`.

**How changes were tested:**

- Uploaded a custom animated emoji (GIF) in a local Zulip development environment.
- Verified via `/json/realm/emoji` that both `source_url` and `still_url` are present in the API response.
- Emulated `prefers-reduced-motion: reduce` in Chrome DevTools.
- Confirmed that the frontend switches from the animated `.gif` to the static `.png` (or fallback URL) when reduce motion is active.
- Checked that non-animated emojis also include a `still_url` (identical to `source_url`), ensuring consistency.

**Screenshots and screen captures:**

_N/A — this is a backend/API change with no visual UI modification.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [**X**] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability  (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [**X**] Explains differences from previous plans (e.g., issue description).
- [**X**] Highlights technical choices and bugs encountered.
- [**X**] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [**X**] Each commit is a coherent idea.
- [**X**] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [**X**] End-to-end functionality of buttons, interactions and flows.
- [**X**] Corner cases, error conditions, and easily imagined bugs.
</details>
