### PR TITLE
composebox_typeahead: Change topic typeahead to always open upwards.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1630,6 +1630,7 @@ export function initialize({
         type: "input",
     };
     stream_message_topic_typeahead = new Typeahead(stream_message_typeahead_input, {
+        dropup: true,
         source(): string[] {
             return topics_seen_for(compose_state.stream_id());
         },


### PR DESCRIPTION
Currently, in topic recipient input in compose box, if the topic typeahead ahead is small enough then the typeahead is placed below the input field. And when the typeahead list has more entries then it would would be placed above the input field. This typeahead shifts places whenever user types in the input.

We fix the typeahead for topic recipients to always opened upwards.

**Note:** why it may even seem like longer typeahead list are placed below.
When initially typeahead renders and is small enough to fit below and any subsequent keypresses populates the typeahead(server fetch or increased topic matches), the same instance is just populated which is positioned below.

<!-- Describe your pull request here.-->

Fixes: [#design > pm compose should open typeahead @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/pm.20compose.20should.20open.20typeahead/near/1972589)

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
|Before|After|
|-|-|
|<img width="423" height="135" alt="Screenshot from 2025-12-16 02-01-15" src="https://github.com/user-attachments/assets/9d4e6098-9f6c-41d4-a5f5-85ee1e27c5aa" />|<img width="423" height="135" alt="Screenshot from 2025-12-16 02-00-57" src="https://github.com/user-attachments/assets/c528ee65-b692-446c-bdb8-bac14da21b78" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
