### PR TITLE
settings: Allow tabs and buttons in right panel to wrap.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1059,7 +1059,7 @@ h4.user_group_setting_subsection_title {
 
     .group_settings_header,
     .stream_settings_header {
-        white-space: nowrap;
+        flex-wrap: wrap;
         display: flex;
         margin-left: 18px;
 
@@ -1397,11 +1397,6 @@ h4.user_group_setting_subsection_title {
 @media (width < $lg_min) {
     .two-pane-settings-container {
         max-width: 95%;
-    }
-
-    #groups_overlay .group_settings_header,
-    #subscription_overlay .stream_settings_header {
-        flex-wrap: wrap;
     }
 }
 


### PR DESCRIPTION
Previously, the tabs and buttons in the right panel for a selected stream or group would wrap into next line only for smaller screen width. This resulted in all tabs and buttons showed in a single line with a scrollable view for larger font sizes which did not look good. This commit updates the CSS to allow wrapping to next line for larger screen width so that the buttons can move to next line on larger font size.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->https://chat.zulip.org/#narrow/channel/9-issues/topic/tabs.20don't.20fit.20in.20channel.20settings/with/2327957


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
| ------ | ------ |
|<img width="1654" height="947" alt="image" src="https://github.com/user-attachments/assets/4154612d-a443-4834-8b81-17125a5925f7" /> | <img width="1654" height="947" alt="Screenshot from 2025-12-16 12-21-46" src="https://github.com/user-attachments/assets/ea13d023-b0c5-4d66-8ced-746ffc628078" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
