### PR TITLE
typeahead: introduce gridded rows for typeahead items

### DIFF
--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -21,10 +21,10 @@
         overflow-wrap: anywhere;
 
         & > a {
-            display: flex;
-            align-items: center;
+            display: block;
+            /* align-items: center; */
             padding: 0.2142em 0.7142em; /* 3px 10px at 14px em */
-            gap: 0.3571em; /* 5px at 14px em */
+            /* gap: 0.3571em; 5px at 14px em */
             font-weight: normal;
             /* We want to keep this `max-width` less than 320px. */
             max-width: 292px;
@@ -52,9 +52,6 @@
                 outline: 0;
             }
 
-            &.topic-typeahead-link {
-                gap: 5px;
-            }
 
             &.topic-edit-typeahead {
                 display: flex;
@@ -67,14 +64,12 @@
                 }
             }
 
-            .typeahead-text-container {
-                display: flex;
-                align-self: center;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-                gap: 3px;
-                align-items: baseline;
+            .typeahead-row {
+                display: grid;
+                grid-template-columns: auto 1fr;
+                align-items: center;
+                column-gap: 0.3571em; /* same as existing gap (5px at 14px em) */
+                width: 100%;
             }
 
             .compose-stream-name {
@@ -198,8 +193,6 @@
 
     .typeahead-image-avatar {
         border-radius: 4px;
-        /* Override bootstrap img */
-        vertical-align: baseline;
     }
 
     .user-circle {
@@ -233,6 +226,8 @@
 }
 
 .typeahead-text-container {
+    min-width: 0;
+
     i.zulip-icon-bot {
         align-self: center;
     }

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -1,3 +1,4 @@
+<div class="typeahead-row">
 {{#if is_emoji}}
     {{#if has_image}}
         <img class="emoji" src="{{ img_src }}" />
@@ -18,6 +19,7 @@
 {{else if is_user_group}}
     <i class="typeahead-image zulip-icon zulip-icon-user-group" aria-hidden="true"></i>
 {{/if}}
+
 {{#if is_stream_topic}}
 <div class="typeahead-text-container">
     <span role="button" class="zulip-icon zulip-icon-corner-down-right stream-to-topic-arrow"></span>
@@ -31,7 +33,7 @@
     <strong class="typeahead-strong-section{{#if is_empty_string_topic}} empty-topic-display{{/if}}{{#if is_default_language}} default-language-display{{/if}}">
         {{~#if stream~}}
             {{~> inline_decorated_channel_name stream=stream ~}}
-            {{~else~}}
+        {{~else~}}
             {{~ primary ~}}
         {{~/if~}}
     </strong>
@@ -40,19 +42,22 @@
     {{/if}}
     {{~#if should_add_guest_user_indicator}}
         <i>({{t 'guest'}})</i>
-    {{~/if}}
+    {{/if}}
     {{~#if has_status}}
-    {{> status_emoji status_emoji_info}}
-    {{~/if}}
+        {{> status_emoji status_emoji_info}}
+    {{/if}}
     {{~#if has_pronouns}}
         <span class="pronouns">{{pronouns}}{{#if (or has_secondary_html has_secondary)}},{{/if}}</span>
-    {{~/if}}
+    {{/if}}
     {{~#if has_secondary_html}}
-    <span class="autocomplete_secondary rendered_markdown single-line-rendered-markdown">{{rendered_markdown secondary_html}}</span>
+        <span class="autocomplete_secondary rendered_markdown single-line-rendered-markdown">
+            {{rendered_markdown secondary_html}}
+        </span>
     {{~else if has_secondary}}
-    <span class="autocomplete_secondary">
-        {{~ secondary ~}}
-    </span>
-    {{~/if}}
+        <span class="autocomplete_secondary">
+            {{~ secondary ~}}
+        </span>
+    {{/if}}
 </div>
 {{/if}}
+</div>

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1225,23 +1225,32 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 options.query = "Kro";
                 actual_value = options.item_html("kronor");
                 expected_value =
+                    '<div class="typeahead-row">\n' +
+                    '\n' +
                     '<div class="typeahead-text-container">\n' +
-                    '    <strong class="typeahead-strong-section">kronor</strong></div>\n';
+                    '    <strong class="typeahead-strong-section">kronor</strong></div>\n' +
+                    '</div>';
                 assert.equal(actual_value, expected_value);
 
                 // Highlighted content should be escaped.
                 options.query = "<";
                 actual_value = options.item_html("<&>");
                 expected_value =
+                    '<div class="typeahead-row">\n' +
+                    '\n' +
                     '<div class="typeahead-text-container">\n' +
-                    '    <strong class="typeahead-strong-section">&lt;&amp;&gt;</strong></div>\n';
+                    '    <strong class="typeahead-strong-section">&lt;&amp;&gt;</strong></div>\n' +
+                    '</div>';
                 assert.equal(actual_value, expected_value);
 
                 options.query = "even m";
                 actual_value = options.item_html("even more ice");
                 expected_value =
+                    '<div class="typeahead-row">\n' +
+                    '\n' +
                     '<div class="typeahead-text-container">\n' +
-                    '    <strong class="typeahead-strong-section">even more ice</strong></div>\n';
+                    '    <strong class="typeahead-strong-section">even more ice</strong></div>\n' +
+                    '</div>';
                 assert.equal(actual_value, expected_value);
 
                 // options.sorter()


### PR DESCRIPTION
This PR refactors the layout of compose typeahead items to use a modern grid-based row structure.

A new `.typeahead-row` container is introduced to represent a single typeahead row, and CSS Grid is used to align the avatar/icon and text content consistently. This removes the need for fragile alignment techniques like `vertical-align` and spacing hacks, making the layout easier to reason about and maintain.

The clickable `<a>` element is made layout-neutral, delegating layout responsibility entirely to the row container.

Fixes: https://github.com/zulip/zulip/issues/37030

---

*Testing**

- Manually tested on the Zulip development server.
- Verified typeahead behavior in the compose box for:
  - User mentions (`@`)
  - User groups
  - Stream and topic typeahead
  - Emoji typeahead
- Confirmed that avatars/icons and text are vertically centered and aligned correctly.
- Checked long names and secondary text to ensure truncation and overflow behavior remains correct.
- Tested both light and dark themes.

---

**Screenshots and screen captures:**

<img width="1920" height="861" alt="Screenshot (103)" src="https://github.com/user-attachments/assets/0163fa00-8f3d-40f5-b09e-60baeaf867e9" />

_I think no visual design changes are intended in this PR. The UI appearance remains intentionally very close to the existing behavior; the changes are primarily architectural and layout-related._

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
