### PR TITLE
navbar: Add user avatars with availability dots for DM conversations.

### DIFF
--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -979,4 +979,14 @@ function register_click_handlers(): void {
 export function initialize(): void {
     register_click_handlers();
     clipboard_enable(".copy_mention_syntax");
+
+    // listen for custom event from DM navbar avatars
+    // this avoids circular import with message_view_header
+    $(document).on(
+        "dm-navbar-avatar-click",
+        (_e, data: {element: HTMLElement; user_id: number}) => {
+            const user = people.get_by_user_id(data.user_id);
+            toggle_user_card_popover(data.element, user);
+        },
+    );
 }

--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -70,6 +70,32 @@
         }
     }
 
+    .dm-navbar-avatars {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        margin-left: 4px;
+    }
+
+    .dm-navbar-avatar {
+        position: relative;
+        cursor: pointer;
+
+        .dm-navbar-avatar-image {
+            width: 25px;
+            height: 25px;
+            border-radius: 50%;
+            object-fit: cover;
+        }
+
+        .user-circle {
+            position: absolute;
+            bottom: -2px;
+            right: -2px;
+            font-size: 10px;
+        }
+    }
+
     .message-header-archived {
         color: var(--color-text-message-header-archived);
         cursor: default;

--- a/web/templates/navbar_icon_and_title.hbs
+++ b/web/templates/navbar_icon_and_title.hbs
@@ -3,6 +3,16 @@
 {{else if icon}}
 <i class="navbar-icon fa fa-{{icon}}" aria-hidden="true"></i>
 {{/if}}
+{{#if dm_users}}
+<div class="dm-navbar-avatars">
+    {{#each dm_users}}
+        <div class="dm-navbar-avatar" data-user-id="{{user_id}}">
+            <img class="dm-navbar-avatar-image" src="{{avatar_url}}" />
+            <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
+        </div>
+    {{/each}}
+</div>
+{{else}}
 {{#if title}}
 <span class="message-header-navbar-title">{{title}}</span>
 {{/if}}
@@ -10,9 +20,10 @@
 <span class="message-header-navbar-title">{{{title_html}}}</span>
 {{/if}}
 {{#if stream}}
-    {{#if stream.is_archived}}
-    <span class="message-header-archived">
-        <i class="archived-indicator">({{t 'archived' }})</i>
-    </span>
-    {{/if}}
+{{#if stream.is_archived}}
+<span class="message-header-archived">
+    <i class="archived-indicator">({{t 'archived' }})</i>
+</span>
+{{/if}}
+{{/if}}
 {{/if}}


### PR DESCRIPTION
Replace text-based names with clickable avatar images in the DM navbar.
Each avatar displays the user's presence status via a colored availability
dot. Clicking an avatar opens the user card popover.

Fixes: #37078

**How changes were tested:**
- Opened a 1-on-1 DM conversation, single avatar displayed
- Opened a group DM conversation, multiple avatars displayed  
- Clicked an avatar, user card popover opens correctly
- Verified availability dots show correct status (green for active, empty for offline)


**Screenshots and screen records**

Before: 

(1-on-1 DM)
<img width="839" height="312" alt="Screenshot 2025-12-16 at 4 22 57 PM" src="https://github.com/user-attachments/assets/2da93269-766a-4b19-8d99-eb800dafc034" />

(group DM)
<img width="839" height="298" alt="Screenshot 2025-12-16 at 4 26 27 PM" src="https://github.com/user-attachments/assets/0b2f6d84-1ca4-414b-9aba-9c75401239ef" />




After:

(both 1-on-1 DM and group DM)

https://github.com/user-attachments/assets/f073dc76-4980-457e-a207-4d4479420f93

**Self-review checklist:**
- [x] I have tested this change on a Zulip development environment.
- [x] I have included screenshots/recordings of the changes (for UI changes).
- [ ] I have written/updated automated tests for the new behavior.
- [ ] I have documented any new/modified endpoints in [api_docs/changelog.md](cci:7://file:///Users/pranavray/zulip/api_docs/changelog.md:0:0-0:0).
- [ ] I have documented any new/modified CSS classes in `web/styles/README.md`.

