### PR TITLE
buddy_data: Only assert loaded subscribers for small channels.

### DIFF
--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -463,8 +463,12 @@ function get_filtered_user_id_list(
         // enough subscribers in the channel.
         const stream_id = narrow_state.stream_id(narrow_state.filter(), true);
         if (stream_id) {
-            const subscribers = peer_data.get_subscriber_ids_assert_loaded(stream_id);
-            if (subscribers.length <= max_channel_size_to_show_all_subscribers) {
+            const subscriber_count = peer_data.get_subscriber_count(stream_id);
+            if (subscriber_count <= max_channel_size_to_show_all_subscribers) {
+                // We can know these are all loaded because we fetch all subscribers
+                // for small channels, and max_channel_size_to_show_all_subscribers
+                // is less than MIN_PARTIAL_SUBSCRIBERS_CHANNEL_SIZE.
+                const subscribers = peer_data.get_subscriber_ids_assert_loaded(stream_id);
                 const base_user_id_set = new Set([...base_user_id_list, ...subscribers]);
                 base_user_id_list = [...base_user_id_set];
             }


### PR DESCRIPTION
Fixes this error:
https://chat.zulip.org/#narrow/channel/464-kandra-js-errors/topic/Error.3A.20Getting.20subscribers.20for.20stream.20without.20full.20subscr.2E.2E.2E/with/2328563
