### PR TITLE
portico: Add National University of Córdoba case study.

### DIFF
--- a/corporate/urls.py
+++ b/corporate/urls.py
@@ -195,6 +195,11 @@ landing_page_urls = [
         {"template_name": "corporate/case-studies/tum-case-study.html"},
     ),
     path(
+        "case-studies/university-of-cordoba/",
+        landing_view,
+        {"template_name": "corporate/case-studies/university-of-cordoba-case-study.html"},
+    ),
+    path(
         "case-studies/ucsd/",
         landing_view,
         {"template_name": "corporate/case-studies/ucsd-case-study.html"},

--- a/templates/corporate/case-studies/tum-case-study.md
+++ b/templates/corporate/case-studies/tum-case-study.md
@@ -78,7 +78,8 @@ contribute a few patches of my own,” Robert says.
 ---
 
 Learn more about [Zulip for Education](/for/education/), and how
-Zulip is being used at the [University of California San Diego](/case-studies/ucsd/).
+Zulip is being used at the [University of California San
+Diego](/case-studies/ucsd/) and the [National University of Córdoba](/case-studies/university-of-cordoba/).
 You can also check out our guides on using Zulip for [conferences](/for/events/)
 and [research](/for/research/)!
 

--- a/templates/corporate/case-studies/ucsd-case-study.md
+++ b/templates/corporate/case-studies/ucsd-case-study.md
@@ -90,6 +90,7 @@ events, conferences of interest, etc.”
 ---
 
 Learn more about [Zulip for Education](/for/education/), and how
-Zulip is being used at the [Technical University of Munich](/case-studies/tum/).
+Zulip is being used at the [Technical University of Munich](/case-studies/tum/)
+and the [National University of Córdoba](/case-studies/university-of-cordoba/).
 You can also check out our guides on using Zulip for [conferences](/for/events/)
 and [research](/for/research/)!

--- a/templates/corporate/case-studies/university-of-cordoba-case-study.html
+++ b/templates/corporate/case-studies/university-of-cordoba-case-study.html
@@ -1,0 +1,38 @@
+{% extends "zerver/portico.html" %}
+{% set entrypoint = "marketing-page" %}
+
+{% set PAGE_TITLE = "Case study: National University of Córdoba FAMAF | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "Learn how Zulip connects faculty with students at the
+National University of Córdoba, crossing the generational divide." %}
+
+{% block customhead %}
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+{% endblock %}
+
+{% block portico_content %}
+
+{% include 'zerver/landing_nav.html' %}
+
+<div class="portico-landing why-page solutions-page case-study-page">
+    <div class="hero bg-education">
+        <div class="bg-dimmer"></div>
+        <div class="content">
+            <h1 class="center">Case study: National University of Córdoba</h1>
+            <p>Faculty of Mathematics, Astronomy, Physics and Computing
+            (FAMAF)<p>
+        </div>
+        <div class="hero-text">
+            Learn more about <a href="/for/education/">Zulip for Education</a>.
+        </div>
+    </div>
+    <div class="main">
+        <div class="padded-content">
+            <div class="inner-content markdown">
+                {{ render_markdown_path('corporate/case-studies/university-of-cordoba-case-study.md') }}
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/templates/corporate/case-studies/university-of-cordoba-case-study.md
+++ b/templates/corporate/case-studies/university-of-cordoba-case-study.md
@@ -1,0 +1,78 @@
+Founded in 1613, the National University of Córdoba is the second largest
+university in Argentina, with tuition-free enrollment for all. The university’s
+Faculty of Mathematics, Astronomy, Physics and Computing (FAMAF) teaches classes
+to over 5000 undergraduates from all over the country.
+
+“Zulip is a key piece of how we run classes in our department,” says Nicolás
+Wolovick, a professor at FAMAF and director of the computer science career
+track. “If we didn’t have Zulip, I really don’t know how we’d manage it.”
+
+## Sponsored hosting for a modern team chat app
+
+For a while, FAMAF used Moodle’s course management software to communicate with
+students, but “it was a pain,” Nicolás recalls. The department tried moving to
+Slack. However, without a software budget, the message history limit on Slack’s
+free plan was a major frustration.
+
+In search of an alternative, a faculty member reached out to request a sponsored
+Zulip Cloud Standard plan. With the request approved the very next day, the
+department moved over to Zulip starting starting in Fall 2020.
+
+Looking back, being pushed off Slack by its search history limit ended up being
+for the best: “I think Zulip is a great tool, much better than Slack,” says
+Miguel Pagano, professor at FAMAF.
+
+> “I think Zulip is a great tool, much better than Slack.”
+>
+> — Miguel Pagano, professor at FAMAF of the National University of Córdoba
+
+## Zulip becomes a knowledge base
+
+Zulip has become part of the core flow of how faculty at FAMAF run their
+classes. Instructors create channels for the classes they teach each semester.
+For lab classes, instructors make private channels for communication with each
+project group. “I use pinned channels to focus on the two subjects I’m teaching
+right now,” Nicolás notes.
+
+Discussions from prior semesters are available for easy reference, so
+instructors can simply point students to past conversations for answers to their
+questions. “Zulip acts as a knowledge database of what we did in each subject,”
+Nicolás explains. “The search is perfect.”
+
+> “We can find messages from five years ago — it’s very convenient.”
+>
+> — Miguel Pagano, professor at FAMAF of the National University of Córdoba
+
+## A cross-generational app for instructors and students
+
+Many members of the faculty prefer familiar tools, and sometimes find the UI of
+apps like Discord overwhelming. So it matters that Zulip has a clean interface,
+with channels and conversations inside channels clearly presented. There are
+also some friendly touches: “I love using Markdown for message formatting, and
+that you can copy-paste formatted text, and it translates accurately,” Nicolás
+notes.
+
+> “The UI is spartan, simple, clear — I like that. It reminds me of what Google
+> used to be.”
+>
+> — Nicolás Wolovick, professor at FAMAF of the National University of Córdoba
+
+And while students hardly use email, Nicolás and other faculty appreciate being
+able to send messages to Zulip by replying to email notifications.
+
+At the same time, Zulip offers fun features for the students. “We have a whole
+subculture of custom emoji,” Nicolás says. “Students love to use them to
+customize the space and express themselves.”
+
+Still, the overall vibe is professional, and moderation has never been an issue.
+“I’ve never had to ban anyone or even delete a message,” Nicolás says. Students
+keep their Zulip account after graduation, which provides a way for faculty and
+alumni to stay connected.
+
+---
+
+Learn more about [Zulip for Education](/for/education/), and how Zulip is being
+used at the [Technical University of Munich](/case-studies/tum/) and the
+[University of California San Diego](/case-studies/ucsd/). You can also check
+out our guides on using Zulip for [conferences](/for/events/) and
+[research](/for/research/)!

--- a/templates/corporate/for/use-cases.md
+++ b/templates/corporate/for/use-cases.md
@@ -22,6 +22,7 @@
 
 * [Technical University of Munich](/case-studies/tum/)
 * [University of California San Diego](/case-studies/ucsd/)
+* [National University of Córdoba](/case-studies/university-of-cordoba/)
 * [Lean theorem prover community](/case-studies/lean/)
 
 ### Open source and communities

--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -98,6 +98,7 @@
                         <ul class="top-menu-submenu-list">
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/tum/">Organized chat for 1000s of students at TUM</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/ucsd/">Communication hub across 6 continents at UCSD</a></li>
+                            <li class="top-menu-submenu-list-item"><a href="/case-studies/university-of-cordoba/">Connecting across generations at the National University of Córdoba</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/lean/">Research collaboration at scale in the Lean mathematical community</a></li>
                         </ul>
                     </div>
@@ -265,6 +266,7 @@
                 <ul class="top-menu-submenu-list">
                     <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/tum/">Organized chat for 1000s of students at TUM</a></li>
                     <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/ucsd/">Communication hub across 6 continents at UCSD</a></li>
+                    <li class="top-menu-submenu-list-item"><a href="/case-studies/university-of-cordoba/">Connecting across generations at the National University of Córdoba</a></li>
                     <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/lean/">Research collaboration at scale in the Lean mathematical community</a></li>
                 </ul>
                 <span class="top-menu-mobile-submenu-section">OPEN SOURCE and COMMUNITIES</span>

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -332,6 +332,7 @@ class DocPageTest(ZulipTestCase):
         # case-studies
         self._test("/case-studies/tum/", ["Technical University of Munich"])
         self._test("/case-studies/ucsd/", ["UCSD"])
+        self._test("/case-studies/university-of-cordoba/", ["University of Córdoba"])
         self._test("/case-studies/rust/", ["Rust programming language"])
         self._test("/case-studies/recurse-center/", ["Recurse Center"])
         self._test("/case-studies/lean/", ["Lean theorem prover"])


### PR DESCRIPTION
Notes:
- I'll update the quotes on /for/education as a separate pass. I think it's too much to add this one to the hero area on that page.
- Added to landing nav as a relative link for now, so that tests pass.

<details><summary>Screenshots</summary>
<p>

## Menu
<img width="1636" height="488" alt="Screenshot 2025-12-16 at 16 19 47@2x" src="https://github.com/user-attachments/assets/cc9dacc2-810a-4867-ae26-7681e576f872" />

## Page
<img width="2484" height="526" alt="Screenshot 2025-12-16 at 16 16 04@2x" src="https://github.com/user-attachments/assets/fe32c0e0-ecac-4d9d-98b5-89d3b01c85fe" />
<img width="1478" height="1268" alt="Screenshot 2025-12-16 at 16 16 15@2x" src="https://github.com/user-attachments/assets/6e155fa6-a016-416f-b323-72e336573bd6" />
<img width="1456" height="762" alt="Screenshot 2025-12-16 at 16 16 36@2x" src="https://github.com/user-attachments/assets/681a5b89-d09c-4153-80bb-6f8b928c748d" />
<img width="1504" height="1412" alt="Screenshot 2025-12-16 at 16 18 31@2x" src="https://github.com/user-attachments/assets/e49a019e-3203-4a60-8889-3e051074184b" />

## Narrow window
<img width="782" height="1120" alt="Screenshot 2025-12-16 at 16 24 35@2x" src="https://github.com/user-attachments/assets/608954ec-e9a6-4cfb-a552-2f8b18cff3f9" />

</p>
</details> 