### PR TITLE
stream_list: Fix `n` key ignoring muted channels.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1591,7 +1591,7 @@ export function get_sorted_channel_ids_for_next_unread_navigation(): {
     // Get sorted section ids.
     const sections = stream_list_sort.get_current_sections().map((section) => ({
         id: section.id,
-        channels: section.streams,
+        channels: [...section.streams, ...section.muted_streams, ...section.inactive_streams],
         is_collapsed: collapsed_sections.has(section.id),
     }));
 


### PR DESCRIPTION
We were not checking `muted/inactive` channels for unread topics as `topic_generator` was not fed those channels.

discussion: [#issues > unread in muted channel, unmuted topic, n key not working](https://chat.zulip.org/#narrow/channel/9-issues/topic/unread.20in.20muted.20channel.2C.20unmuted.20topic.2C.20n.20key.20not.20working/with/2328600)