### PR TITLE
digest_email: Fix error on including archived channel messages. 

### DIFF
--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -347,10 +347,10 @@ def get_user_stream_map(user_ids: list[int], cutoff_date: datetime) -> dict[int,
     return dct
 
 
-def get_slim_stream_id_map(realm: Realm) -> dict[int, Stream]:
+def get_slim_stream_id_map(stream_ids: set[int]) -> dict[int, Stream]:
     # "slim" because it only fetches the names of the stream objects,
     # suitable for passing into build_message_list.
-    streams = get_active_streams(realm).only("id", "name")
+    streams = Stream.objects.filter(id__in=stream_ids).only("id", "name")
     return {stream.id: stream for stream in streams}
 
 
@@ -368,11 +368,12 @@ def bulk_get_digest_context(
 
     maybe_clear_recent_topics_cache(realm.id, cutoff)
 
-    stream_id_map = get_slim_stream_id_map(realm)
     recently_created_streams = get_recently_created_streams(realm, cutoff_date)
 
     user_ids = [user.id for user in users]
     user_stream_map = get_user_stream_map(user_ids, cutoff_date)
+    stream_ids = set().union(*user_stream_map.values())
+    stream_id_map = get_slim_stream_id_map(stream_ids)
 
     for user in users:
         context = common_context(user)

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -9,6 +9,7 @@ from django.utils.timezone import now as timezone_now
 from confirmation.models import one_click_unsubscribe_link
 from zerver.actions.create_user import do_create_user
 from zerver.actions.realm_settings import do_set_realm_property
+from zerver.actions.streams import do_deactivate_stream
 from zerver.actions.users import do_deactivate_user
 from zerver.lib.digest import (
     DigestTopic,
@@ -639,6 +640,43 @@ class TestDigestEmailMessages(ZulipTestCase):
             message_id = self.send_stream_message(sender, stream, content)
             message_ids.append(message_id)
         return message_ids
+
+    def test_include_archived_channel_message(self) -> None:
+        hamlet = self.example_user("hamlet")
+        aaron = self.example_user("aaron")
+        channel = self.make_stream("new channel", realm=hamlet.realm)
+        self.subscribe(aaron, channel.name)
+        self.subscribe(hamlet, channel.name)
+
+        cutoff_date = timezone_now() - timedelta(days=5)
+        channel.date_created = cutoff_date - timedelta(days=2)
+        subscription_created_date = cutoff_date - timedelta(days=1)
+        channel.save(update_fields=["date_created"])
+        RealmAuditLog.objects.filter(
+            modified_stream_id=channel.id,
+            modified_user_id__in=[aaron.id, hamlet.id],
+            event_type=AuditLogEventType.SUBSCRIPTION_CREATED,
+        ).update(event_time=subscription_created_date)
+
+        # No 'hot_conversations'
+        with mock.patch("zerver.lib.digest.send_future_email") as mock_send_future_email:
+            bulk_handle_digest_email([aaron.id], cutoff_date.timestamp())
+        self.assertEqual(mock_send_future_email.call_count, 1)
+        kwargs = mock_send_future_email.call_args[1]
+        self.assert_length(kwargs["context"]["hot_conversations"], 0)
+
+        # Verify 'hot_conversations' includes messages from archived channel.
+        self.send_stream_message(
+            hamlet, channel.name, content="channel archived", skip_capture_on_commit_callbacks=True
+        )
+        do_deactivate_stream(channel, acting_user=None)
+
+        get_recent_topics.cache_clear()
+        with mock.patch("zerver.lib.digest.send_future_email") as mock_send_future_email:
+            bulk_handle_digest_email([aaron.id], cutoff_date.timestamp())
+        self.assertEqual(mock_send_future_email.call_count, 1)
+        kwargs = mock_send_future_email.call_args[1]
+        self.assert_length(kwargs["context"]["hot_conversations"], 2)
 
 
 class TestDigestContentInBrowser(ZulipTestCase):


### PR DESCRIPTION
PR to fix assertion error: `assert stream_id in stream_id_map` in `digest_block_header`.

**How changes were tested:**

### Manual testing
* In dev, visit `/digest`. Mark any of the channel listed there is message blocks as archived.
* Now, visit `/digest` again. assertion error is raised.

### Added a unit test as well.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
