### PR TITLE
Compose: Match "dm" with "Direct message" in channel picker

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -284,7 +284,7 @@ function get_options_for_recipient_widget(): Option[] {
         is_direct_message: true,
         unique_id: compose_state.DIRECT_MESSAGE_ID,
         name: $t({defaultMessage: "Direct message"}),
-        
+
         aliases: [$t({defaultMessage: "dm"})],
     };
 

--- a/web/src/dropdown_widget.ts
+++ b/web/src/dropdown_widget.ts
@@ -366,20 +366,20 @@ export class DropdownWidget {
                         },
                         filter: {
                             $element: $search_input,
-                            
+
                             predicate(item, value) {
                                 const search = value.toLowerCase();
-                            
+
                                 if (item.name.toLowerCase().includes(search)) {
                                     return true;
                                 }
-                            
+
                                 if (item.aliases !== undefined) {
                                     return item.aliases.some((alias) =>
                                         alias.toLowerCase().includes(search),
                                     );
                                 }
-                            
+
                                 return false;
                             },
                         },


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR improves the compose channel picker search behavior by allowing the
abbreviation "dm" (case-insensitive) to match the Direct message option.
Previously, typing dm did not suggest “Direct message”, even though it is a
common and intuitive shorthand. The change adds a searchable alias for the
Direct message option and updates the dropdown filtering logic to match both
the visible option name and any configured aliases.

The "dm" alias is wrapped in Zulip’s translation helper so it is included in
the translation catalog.

Fixes: <!-- Issue link, or clear description.-->
Fixes #36899

**How changes were tested:**

1.Manually tested in the Zulip development environment.
2.Opened the compose box and typed dm and DM in the channel picker.
3.Verified that the Direct message option appears correctly.
4.Confirmed that existing channel picker behavior remains unchanged for other inputs.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
