### PR TITLE
portico: Fix case studies top nav menu overflow.

### DIFF
--- a/web/styles/portico/navbar.css
+++ b/web/styles/portico/navbar.css
@@ -1,3 +1,7 @@
+:root {
+    --navbar-height: 60px;
+}
+
 details summary::-webkit-details-marker {
     /* Hide the default arrow on Safari. */
     display: none;
@@ -312,7 +316,7 @@ details summary::-webkit-details-marker {
 .top-menu-tab-input:checked ~ .top-menu-submenu {
     opacity: 1;
     visibility: visible;
-    max-height: 80vh;
+    max-height: calc(100vh - var(--navbar-height));
     overflow-y: auto;
 }
 


### PR DESCRIPTION
**Summary**
Fixes an issue where the Case Studies top navigation menu could not be fully scrolled on narrow screens, causing some items to be inaccessible.

**Fixes**
Fixes #37091

**Changes**
Constrained the Case Studies submenu height using a viewport-relative max-height
Enabled vertical scrolling to ensure all menu items remain accessible
Preserved existing layout and behavior on wider screens

**Root cause**
When the window width is narrow enough to display Case Studies items in a single column, the submenu height can exceed the viewport. Since the menu previously lacked a height constraint and vertical overflow handling, the bottom content became unreachable.

**Solution**
Applied a viewport-based height limit to the submenu and enabled overflow-y: auto, allowing users to scroll through all items without affecting the surrounding layout or interactions.

**Screenshots**

Before:
Bottom Case Studies entries are cut off and cannot be accessed

<img width="1919" height="880" alt="Screenshot 2025-12-16 184458" src="https://github.com/user-attachments/assets/264d1109-3b85-43ba-8a74-13ec9e3fb6e6" />

After:
All Case Studies entries are accessible via vertical scrolling

<img width="1919" height="881" alt="Screenshot 2025-12-18 122505" src="https://github.com/user-attachments/assets/24f4abf2-b7b5-48bc-a1c3-2584f94cdf92" />

**Testing**
Tested manually:
1. Opened the Case Studies menu on narrow window widths
2. Verified all menu items are reachable via scrolling
3. Confirmed behavior is unchanged on wider screens
4. Checked interactions with the navbar remain intact

**Self-review checklist**
- [X] Self-reviewed the changes for clarity and maintainability
- [X]  Verified visual appearance across different viewport sizes
- [X]  Confirmed no regressions in navbar behavior
- [X]  Ensured change is CSS-only and does not affect JS logic