### PR TITLE
compose: Show "Topic" placeholder when user can't start topics.

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -395,6 +395,7 @@ export function update_topic_displayed_text(topic_name = "", has_topic_focus = f
     const recipient_widget_hidden =
         $(".compose_select_recipient-dropdown-list-container").length === 0;
     const $topic_not_mandatory_placeholder = $("#topic-not-mandatory-placeholder");
+    const stream_id = compose_state.stream_id();
 
     // reset
     $input.prop("disabled", false);
@@ -404,7 +405,7 @@ export function update_topic_displayed_text(topic_name = "", has_topic_focus = f
     $topic_not_mandatory_placeholder.hide();
     $("#compose-channel-recipient").removeClass("disabled");
 
-    if (!stream_data.can_use_empty_topic(compose_state.stream_id())) {
+    if (!stream_data.can_use_empty_topic(stream_id)) {
         $input.attr("placeholder", $t({defaultMessage: "Topic"}));
         // When topics are mandatory, no additional adjustments are needed.
         // Also, if the recipient in the compose box is not selected, the
@@ -412,9 +413,15 @@ export function update_topic_displayed_text(topic_name = "", has_topic_focus = f
         return;
     }
 
+    assert(stream_id !== undefined);
+    if (!stream_data.should_display_empty_string_topic(stream_id)) {
+        $input.attr("placeholder", $t({defaultMessage: "Topic"}));
+        return;
+    }
+
     // If `topics_policy` is set to `empty_topic_only`, disable the topic input
     // and empty the input box.
-    if (stream_data.is_empty_topic_only_channel(compose_state.stream_id())) {
+    if (stream_data.is_empty_topic_only_channel(stream_id)) {
         compose_state.topic("");
         $input.prop("disabled", true);
         $input.addClass("empty-topic-only");

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -441,7 +441,8 @@ export function compute_placeholder_text(opts: ComposePlaceholderOptions): strin
             topic_display_name = opts.topic;
         } else if (
             stream_data.can_use_empty_topic(opts.stream_id) &&
-            !$("input#stream_message_recipient_topic").is(":focus")
+            !$("input#stream_message_recipient_topic").is(":focus") &&
+            stream_data.should_display_empty_string_topic(opts.stream_id!)
         ) {
             topic_display_name = util.get_final_topic_display_name(opts.topic);
         }

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -14,6 +14,7 @@ import * as settings_config from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
 import type {CurrentUser, GroupSettingValue, StateData} from "./state_data.ts";
 import {current_user, realm} from "./state_data.ts";
+import * as stream_topic_history from "./stream_topic_history.ts";
 import type {APIStream, StreamPermissionGroupSetting, StreamTopicsPolicy} from "./stream_types.ts";
 import * as sub_store from "./sub_store.ts";
 import type {
@@ -1232,6 +1233,17 @@ export function is_empty_topic_only_channel(stream_id: number | undefined): bool
     }
     return (
         topics_policy === settings_config.get_stream_topics_policy_values().empty_topic_only.code
+    );
+}
+
+// Returns whether the empty string topic ("general chat") should be displayed
+// as an option for the user in the given stream. This is true when the user can
+// create new topics, it's an empty_topic_only channel, or general chat already exists.
+export function should_display_empty_string_topic(stream_id: number): boolean {
+    return (
+        can_create_new_topics_in_stream(stream_id) ||
+        is_empty_topic_only_channel(stream_id) ||
+        stream_topic_history.stream_has_empty_string_topic(stream_id)
     );
 }
 

--- a/web/src/stream_topic_history.ts
+++ b/web/src/stream_topic_history.ts
@@ -33,6 +33,17 @@ export function stream_has_topics(stream_id: number): boolean {
     return history.has_topics();
 }
 
+export function stream_has_empty_string_topic(stream_id: number): boolean {
+    if (!stream_dict.has(stream_id)) {
+        return false;
+    }
+
+    const history = stream_dict.get(stream_id);
+    assert(history !== undefined);
+
+    return history.topics.has("");
+}
+
 export function stream_has_locally_available_named_topics(stream_id: number): boolean {
     if (!stream_dict.has(stream_id)) {
         return false;

--- a/web/tests/stream_topic_history.test.cjs
+++ b/web/tests/stream_topic_history.test.cjs
@@ -294,6 +294,29 @@ test("test_stream_has_topics", () => {
     assert.equal(stream_topic_history.stream_has_locally_available_named_topics(stream_id), true);
 });
 
+test("test_stream_has_empty_string_topic", () => {
+    const stream_id = 90;
+
+    assert.equal(stream_topic_history.stream_has_empty_string_topic(stream_id), false);
+
+    stream_topic_history.find_or_create(stream_id);
+    assert.equal(stream_topic_history.stream_has_empty_string_topic(stream_id), false);
+
+    stream_topic_history.add_message({
+        stream_id,
+        message_id: 900,
+        topic_name: "some topic",
+    });
+    assert.equal(stream_topic_history.stream_has_empty_string_topic(stream_id), false);
+
+    stream_topic_history.add_message({
+        stream_id,
+        message_id: 901,
+        topic_name: "",
+    });
+    assert.equal(stream_topic_history.stream_has_empty_string_topic(stream_id), true);
+});
+
 test("test_stream_has_resolved_topics", () => {
     const stream_id = 89;
 


### PR DESCRIPTION
When a user cannot start new topics in a channel that allows general chat but doesn't have an existing general chat topic, show "Topic" as the placeholder instead of the general chat display name. This matches the behaviour in channels where general chat is disabled.

Fixes: #37104 

## Changes
- Added `stream_has_empty_topic()` helper to check if a stream has an existing general chat topic
- Updated `update_topic_displayed_text()` to show "Topic" placeholder when user cannot create topics and no general chat exists

## Screenshots
**Before:** Topic placeholder shows "general chat" even when user can't start topics and no general chat exists  
<img width="1174" height="739" alt="image" src="https://github.com/user-attachments/assets/d0108d93-7e08-4335-9096-0cc2c114a74e" />

**After:** Topic placeholder shows "Topic" in this scenario
<img width="1178" height="737" alt="image" src="https://github.com/user-attachments/assets/844ba5b9-80fc-4a5c-98d3-ef71629f9f59" />

## Testing

Tested manually:
1. Created channel with general chat allowed but restricted "Who can start new topics"
2. Verified non-admin user sees "Topic" placeholder when no general chat exists
3. Verified placeholder changes to general chat display name after general chat topic is created

<details>
<summary>Self-review checklist</summary>
- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
</details>
