### PR TITLE
demo-orgs: Remove setting org type in convert demo modal.

### DIFF
--- a/web/src/demo_organizations_ui.ts
+++ b/web/src/demo_organizations_ui.ts
@@ -10,12 +10,9 @@ import type {ActionButton} from "./buttons.ts";
 import * as channel from "./channel.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import {$t} from "./i18n.ts";
-import * as settings_config from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
-import * as settings_org from "./settings_org.ts";
 import type {RequestOpts} from "./settings_ui.ts";
 import {current_user, realm} from "./state_data.ts";
-import type {HTMLSelectOneElement} from "./types.ts";
 
 export function get_demo_organization_deadline_days_remaining(): number {
     const now = Date.now();
@@ -105,7 +102,6 @@ export function show_convert_demo_organization_modal(): void {
     const html_body = render_convert_demo_organization_form({
         realm_domain: domain,
         user_has_email_set: email_set,
-        realm_org_type_values: settings_org.get_org_type_dropdown_options(),
     });
 
     function demo_organization_conversion_post_render(): void {
@@ -113,37 +109,25 @@ export function show_convert_demo_organization_modal(): void {
             "#demo-organization-conversion-modal .dialog_submit_button",
         );
         $convert_submit_button.prop("disabled", true);
-        $("#add_organization_type").val(realm.realm_org_type);
 
         if (!email_set) {
-            // Disable form fields if demo organization owner email not set.
-            $("#add_organization_type").prop("disabled", true);
+            // Disable form field if demo organization owner email not set.
             $("#new_subdomain").prop("disabled", true);
             // Show banner for adding email to account.
             show_configure_email_banner();
         } else {
-            // Disable submit button if either form field blank.
+            // Disable submit button if new subdomain field blank.
             $("#convert-demo-organization-form").on("input change", () => {
                 const string_id = $<HTMLInputElement>("input#new_subdomain").val()!.trim();
-                const org_type = $<HTMLSelectOneElement>(
-                    "select:not([multiple])#add_organization_type",
-                ).val()!;
-                $convert_submit_button.prop(
-                    "disabled",
-                    string_id === "" ||
-                        Number.parseInt(org_type, 10) ===
-                            settings_config.all_org_type_values.unspecified.code,
-                );
+                $convert_submit_button.prop("disabled", string_id === "");
             });
         }
     }
 
     function submit_subdomain(): void {
         const $string_id = $("#new_subdomain");
-        const $organization_type = $("#add_organization_type");
         const data = {
             string_id: $string_id.val(),
-            org_type: $organization_type.val(),
         };
         const opts: RequestOpts = {
             success_continuation(raw_data) {

--- a/web/templates/settings/convert_demo_organization_form.hbs
+++ b/web/templates/settings/convert_demo_organization_form.hbs
@@ -5,16 +5,6 @@
     <p>{{t "Everyone will need to log in again at the new URL for your organization." }}</p>
     <form class="subdomain-setting">
         <div class="input-group">
-            <label for="organization_type" class="modal-field-label">{{t "Organization type" }}
-                {{> ../help_link_widget link="/help/organization-type" }}
-            </label>
-            <select name="organization_type" id="add_organization_type" class="modal_select bootstrap-focus-style">
-                {{#each realm_org_type_values}}
-                    <option value="{{this.code}}">{{this.description}}</option>
-                {{/each}}
-            </select>
-        </div>
-        <div class="input-group">
             <label for="string_id" class="inline-block modal-field-label">{{t "Organization URL" }}</label>
             <div id="subdomain_input_container">
                 <input id="new_subdomain" type="text" class="modal_text_input" autocomplete="off" name="string_id" placeholder="{{t 'acme' }}"/>


### PR DESCRIPTION
We require setting an organization type when creating demo orgs now, so we don't need to ask them to reset it when converting the demo to a permanent organization.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="918" height="534" alt="Screenshot From 2025-12-17 18-15-30" src="https://github.com/user-attachments/assets/5b2baf82-943d-43da-bf43-32d7819fbac6" /> | <img width="918" height="534" alt="Screenshot From 2025-12-17 18-15-48" src="https://github.com/user-attachments/assets/7a562ced-bed8-43f4-8504-e53d6ebbd1db" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
