### PR TITLE
#37091 Fix Case Studies navbar overflow and scrolling issue

### DIFF
--- a/web/styles/portico/navbar.css
+++ b/web/styles/portico/navbar.css
@@ -259,11 +259,14 @@ details summary::-webkit-details-marker {
 #case-studies-submenu {
     flex-wrap: wrap;
     width: 1000px;
+    max-height: 80vh;
+    overflow-y: auto;
 
     @media (width <= 1100px) {
         width: 600px;
     }
 }
+
 
 .top-menu-tab .top-menu-tab-user-label {
     max-width: 140px;


### PR DESCRIPTION
This PR fixes a scrolling issue in the Case Studies submenu where the bottom content was being clipped when the submenu exceeded the viewport height. The submenu did not previously have a constrained height or vertical scrolling enabled, which prevented users from accessing all items.

The fix constrains the submenu height relative to the viewport and enables vertical scrolling when needed, ensuring all content remains accessible without affecting the existing layout.

Fixes: Case Studies submenu content being clipped when exceeding viewport height.

Testing: 
<img width="1305" height="877" alt="Screenshot 2025-12-16 223659" src="https://github.com/user-attachments/assets/4d1fa0b4-f63b-4eb3-935c-164b395310cc" />
Opened the Case Studies submenu and verified that all items are now accessible via scrolling

Tested across different viewport sizes to confirm responsive behavior
<img width="1298" height="890" alt="Screenshot 2025-12-16 223745" src="https://github.com/user-attachments/assets/51d56cd5-07e8-4e7b-ac04-9238c143a903" />
