### PR TITLE
 #37091 Fix scrolling issue in Case Studies submenu

### DIFF
--- a/web/styles/portico/navbar.css
+++ b/web/styles/portico/navbar.css
@@ -267,7 +267,6 @@ details summary::-webkit-details-marker {
     }
 }
 
-
 .top-menu-tab .top-menu-tab-user-label {
     max-width: 140px;
     padding-right: 28px;


### PR DESCRIPTION
fixes #37091

This PR fixes a scrolling issue in the Case Studies submenu where the bottom content was being clipped when the submenu exceeded the viewport height. The submenu did not previously have a constrained height or vertical scrolling enabled, which prevented users from accessing all items.

The fix constrains the submenu height relative to the viewport and enables vertical scrolling when needed, ensuring all content remains accessible without affecting the existing layout.
Fixes: Case Studies submenu content being clipped when exceeding viewport height.

Testing: Opened the Case Studies submenu and verified that all items are now accessible via scrolling
Tested across different viewport sizes to confirm responsive behavior
<img width="1305" height="877" alt="Screenshot 2025-12-16 223659" src="https://github.com/user-attachments/assets/0ee6fc96-12e5-44be-be61-520b04f11795" />
<img width="1298" height="890" alt="Screenshot 2025-12-16 223745" src="https://github.com/user-attachments/assets/4a26b65d-373c-4ee2-b1d7-0d6cf48b3bfb" />
