### PR TITLE
demo-orgs: Limit random subdomain to MAX_REALM_SUBDOMAIN_LENGTH.

### DIFF
--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -1428,6 +1428,8 @@ def generate_demo_realm_subdomain() -> str:
         adjective = random.SystemRandom().choice(demo_organization_words["adjectives"])
         noun = random.SystemRandom().choice(demo_organization_words["nouns"])
         demo_subdomain = f"{adverb}-{adjective}-{noun}"
+        if len(demo_subdomain) > Realm.MAX_REALM_SUBDOMAIN_LENGTH:  # nocoverage
+            continue
         try:
             check_subdomain_available(demo_subdomain)
             break


### PR DESCRIPTION
[#automated testing > main failing @ 💬](https://chat.zulip.org/#narrow/channel/43-automated-testing/topic/main.20failing/near/2330051)

As a follow-up, we'll probably want to look at the word lists for demo organization subdomains and assess how this impacts the entropy for these subdomains.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
