### PR TITLE
message view: Show DM avatars with presence and user card in navbar.

### DIFF
--- a/web/e2e-tests/stream_create.test.ts
+++ b/web/e2e-tests/stream_create.test.ts
@@ -96,7 +96,7 @@ async function create_stream(page: Page): Promise<void> {
     // We redirect to the channel message view.
     await page.waitForSelector("#subscription_overlay", {hidden: true});
     await page.waitForSelector(
-        `xpath///*[${common.has_class_x("message-header-navbar-title")} and text()="Puppeteer"]`,
+        `xpath///*[${common.has_class_x("decorated-channel-name")} and text()="Puppeteer"]`,
     );
 
     await page.waitForSelector(".message-header-stream-settings-button");

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -188,6 +188,18 @@ export function toggle_user_card_popover(element: HTMLElement, user: User): void
     );
 }
 
+function toggle_user_card_popover_for_navbar(element: HTMLElement, user: User): void {
+    show_user_card_popover(
+        user,
+        $(element),
+        false,
+        false,
+        "compose_private_message",
+        "user_card",
+        "bottom",
+    );
+}
+
 function toggle_user_card_popover_for_bot_owner(element: HTMLElement, user: User): void {
     show_user_card_popover(
         user,
@@ -726,6 +738,17 @@ function register_click_handlers(): void {
             }
         }
         toggle_user_card_popover_for_message(this, user, message.sender_id, true);
+    });
+
+    $("body").on("click", ".navbar-dm-avatar-container", function (this: HTMLElement, e) {
+        const user_id = Number.parseInt(this.getAttribute("data-user-id") ?? "", 10);
+        if (Number.isNaN(user_id)) {
+            return;
+        }
+        const user = people.get_by_user_id(user_id);
+        toggle_user_card_popover_for_navbar(this, user);
+        e.stopPropagation();
+        e.preventDefault();
     });
 
     // Note: Message feeds and drafts have their own direct event listeners

--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -54,6 +54,12 @@
             /* Align all icons to center. */
             align-self: center;
         }
+
+        /* When containing DM avatars, center the navbar_title within
+           #message_view_header instead of using baseline alignment. */
+        &:has(.navbar-dm-avatar-container) {
+            align-self: center;
+        }
     }
 
     .message-header-navbar-title {
@@ -67,6 +73,17 @@
 
         .channel-privacy-type-icon {
             width: auto;
+        }
+
+        /* When containing DM avatars, become a flex container so
+           child align-self works, and center within the navbar. */
+        &:has(.navbar-dm-avatar-container) {
+            display: flex;
+            align-items: center;
+            align-self: center;
+            /* Reset line-height inherited from #message_view_header
+               which would otherwise create extra vertical space. */
+            line-height: normal;
         }
     }
 
@@ -168,5 +185,58 @@
     to {
         max-height: var(--header-height);
         padding-bottom: 0;
+    }
+}
+
+/* Navbar DM avatar styles */
+.navbar-dm-avatar-container {
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    margin: 0 6px 0 5px;
+    align-self: center;
+
+    .navbar-dm-avatar-wrapper {
+        position: relative;
+        width: 32px;
+        height: 32px;
+        flex-shrink: 0;
+    }
+
+    .navbar-dm-avatar {
+        width: 32px;
+        height: 32px;
+        border-radius: 4px;
+        object-fit: cover;
+        display: block;
+
+        &.guest-avatar {
+            border: 1px solid var(--color-border-subtle);
+        }
+
+        &.deactivated {
+            opacity: 0.5;
+        }
+    }
+
+    .navbar-dm-avatar-presence {
+        position: absolute;
+        right: -1px;
+        bottom: -1px;
+        font-size: 12px;
+        line-height: 1;
+        background-color: var(--color-background-navbar);
+        border: solid 1px var(--color-background-navbar);
+        border-radius: 50%;
+
+        &.deactivated-user-icon {
+            font-size: 10px;
+            background-color: var(--color-background-navbar);
+            padding: 1px;
+        }
+    }
+
+    &:hover {
+        opacity: 0.9;
     }
 }

--- a/web/templates/navbar_dm_avatar.hbs
+++ b/web/templates/navbar_dm_avatar.hbs
@@ -1,0 +1,15 @@
+<div class="navbar-dm-avatar-container" data-user-id="{{user_id}}">
+    <div class="navbar-dm-avatar-wrapper">
+        <img class="navbar-dm-avatar{{#if is_guest}} guest-avatar{{/if}}{{#if is_deactivated}} deactivated{{/if}}"
+          src="{{avatar_url}}"
+          alt=""
+          loading="lazy"/>
+        {{#if (and (not is_bot) (not is_deactivated))}}
+        <span class="navbar-dm-avatar-presence zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle hidden-for-spectators" data-presence-indicator-user-id="{{user_id}}"></span>
+        {{/if}}
+        {{#if is_deactivated}}
+        <span class="navbar-dm-avatar-presence conversation-partners-icon fa fa-ban deactivated-user-icon"></span>
+        {{/if}}
+    </div>
+</div>
+


### PR DESCRIPTION
For DM conversations, replace the text title in the message view navbar with participant avatars, including presence dots in the bottom-right corner (using the existing presence indicator system). Clicking an avatar opens the user card popover, making it easier to access user details directly from the DM view header.
 - *1-on-1 DMs*: Show the other participant's avatar with a presence indicator
 - *Group DMs*: Show up to 3 participant avatars with their respective presence indicators
The DM icon in the navbar is suppressed for these DM views, so the avatars become the primary visual cue, while names remain visible in the message header bar below.

Fixes #37078.

# Changes
- The design thread suggests:
  - Using **avatars** in the DM navbar, since names are still visible in the message header bar.
  - Adding **presence** on those avatars.
  - Making the avatars **clickable** to open the user card.
  - Possibly dropping the DM icon.
- This PR:
  - Implements avatars + presence + user-card click for **1-on-1 DMs**.
  - Shows up to 3 avatars for group DMs.
  - Drops the DM icon in those cases (configurable by changing `zulip_icon: undefined` → `"user"` if we decide to keep it).
  - Leaves group DM navbars and the DM message header strip unchanged.

- Additional Info:
  - **Message view header dependency cleanup**
  - Replaced `inbox_util` checks in `message_view_header.ts` with equivalent logic
    based on the current `filter` and `recent_view_util`:
    - Inbox view is now detected via `filter === undefined && !recent_view_util.is_visible()`.
    - Channel view inside Inbox uses `filter.is_channel_view()`.
  - This avoids an import cycle involving `inbox_util` / `views_util` / `message_view_header`,
    without changing the user-facing behaviour of the Inbox or channel headers.

**How changes were tested:**

Manual testing in development:

1. **1-on-1 DM view**
   - Open a DM with another user.
   - Confirm that the top navbar:
     - Shows the other user’s avatar (no “You and …” text in the navbar).
     - Shows a presence dot in the bottom-right of the avatar that matches the user’s availability.
   - Click the avatar and confirm that the **user card popover** opens correctly.

2. **Self-DM**
   - Open DMs with yourself.
   - Confirm the navbar shows your own avatar and presence appropriately.

3. **Group DM view**
   - Open a group DM with multiple participants.
   - Confirm the navbar shows up to 3 participant avatars with presence indicators.
   - Click each avatar and confirm the user card popover opens for the correct user.

4. **Non-DM views**
   - Open:
     - Inbox
     - Recent conversations
     - Channel views
   - Confirm their navbars are unchanged.

5. **Presence updates**
   - Change the other user’s status (or simulate presence changes) and verify the presence dot updates in the navbar, consistent with the right sidebar.

**Screenshots and screen captures:**
### 1-on-1 DM navbar (before)   
<img width="521" height="120" alt="image" src="https://github.com/user-attachments/assets/d984b83f-c958-418c-b511-4f5e35abd8e1" />

  ### 1-on-1 DM navbar (after)
<img width="1017" height="513" alt="image" src="https://github.com/user-attachments/assets/153edd86-74db-4dc2-86a7-a6c023698273" />

### Group DM navbar (after)
<img width="1006" height="543" alt="image" src="https://github.com/user-attachments/assets/20014194-6571-4722-830e-b6fccd984c03" />


### Different Font size:
Font - 20
<img width="293" height="164" alt="image" src="https://github.com/user-attachments/assets/6a5ea214-5526-446d-bd49-557038cc27de" />

Font - 18
<img width="198" height="139" alt="image" src="https://github.com/user-attachments/assets/dde7adff-34ba-4fe5-b891-d900c0947a55" />


### Mobile web view:
<img width="494" height="516" alt="image" src="https://github.com/user-attachments/assets/dab0de16-6e54-4e26-aac4-c6d24a6e4243" />

<details>
<summary>Self-review checklist</summary>
- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
