### PR TITLE
emoji_picker: Improve algorithm for frequently used emojis.

### DIFF
--- a/web/src/emoji_frequency.ts
+++ b/web/src/emoji_frequency.ts
@@ -15,8 +15,10 @@ export type ReactionUsage = {
     current_user_reacted_message_ids: Set<number>;
 };
 
-const MAX_FREQUENTLY_USED_EMOJIS = 12;
+const EMOJI_PICKER_ROW_LENGTH = 6;
+const MAX_FREQUENTLY_USED_EMOJIS = 5 * EMOJI_PICKER_ROW_LENGTH;
 const CURRENT_USER_REACTION_WEIGHT = 5;
+const POPULAR_EMOJIS_BONUS_WEIGHT = 12;
 export const reaction_data = new Map<string, ReactionUsage>();
 
 export function update_frequently_used_emojis_list(): void {
@@ -25,12 +27,8 @@ export function update_frequently_used_emojis_list(): void {
     );
 
     const top_frequently_used_emojis = [];
-    let popular_emojis = typeahead.get_popular_emojis();
     for (const emoji of frequently_used_emojis) {
-        if (
-            top_frequently_used_emojis.length + popular_emojis.length ===
-            MAX_FREQUENTLY_USED_EMOJIS
-        ) {
+        if (top_frequently_used_emojis.length === MAX_FREQUENTLY_USED_EMOJIS || emoji.score < 10) {
             break;
         }
         assert(emoji !== undefined);
@@ -38,15 +36,16 @@ export function update_frequently_used_emojis_list(): void {
             emoji_type: emoji.emoji_type,
             emoji_code: emoji.emoji_code,
         });
-        popular_emojis = popular_emojis.filter(
-            (popular_emoji) => popular_emoji.emoji_code !== emoji.emoji_code,
-        );
     }
 
-    const final_frequently_used_emoji_list = [...top_frequently_used_emojis, ...popular_emojis];
-    typeahead.set_frequently_used_emojis(
-        final_frequently_used_emoji_list.slice(0, MAX_FREQUENTLY_USED_EMOJIS),
+    const num_frequently_used_emojis =
+        Math.floor(top_frequently_used_emojis.length / EMOJI_PICKER_ROW_LENGTH) *
+        EMOJI_PICKER_ROW_LENGTH;
+    const final_frequently_used_emoji_list = top_frequently_used_emojis.slice(
+        0,
+        num_frequently_used_emojis,
     );
+    typeahead.set_frequently_used_emojis(final_frequently_used_emoji_list);
     emoji_picker.rebuild_catalog();
 }
 
@@ -148,6 +147,22 @@ export function update_emoji_frequency_on_messages_deletion(message_ids: number[
 export function initialize_frequently_used_emojis(): void {
     const message_data = all_messages_data.all_messages_data;
     const messages = message_data.all_messages_after_mute_filtering();
+
+    for (const {emoji_code, emoji_type} of typeahead.get_popular_emojis()) {
+        const emoji_id = [emoji_type, emoji_code].join(",");
+        if (!reaction_data.has(emoji_id)) {
+            reaction_data.set(emoji_id, {
+                score: POPULAR_EMOJIS_BONUS_WEIGHT,
+                emoji_code,
+                emoji_type,
+                message_ids: new Set(),
+                current_user_reacted_message_ids: new Set(),
+            });
+        }
+        const reaction = reaction_data.get(emoji_id);
+        assert(reaction !== undefined);
+        reaction.score += POPULAR_EMOJIS_BONUS_WEIGHT;
+    }
 
     for (let i = messages.length - 1; i >= 0; i -= 1) {
         const message = messages[i];

--- a/web/src/emoji_picker.ts
+++ b/web/src/emoji_picker.ts
@@ -329,7 +329,9 @@ export function rebuild_catalog(): void {
         }
     }
 
-    catalog.set("Frequently used", frequently_used);
+    if (frequently_used.length > 0) {
+        catalog.set("Frequently used", frequently_used);
+    }
 
     const categories = EMOJI_CATEGORIES.filter((category) => catalog.has(category.name));
     complete_emoji_catalog = categories.map((category) => ({

--- a/web/tests/emoji_picker.test.cjs
+++ b/web/tests/emoji_picker.test.cjs
@@ -71,7 +71,8 @@ run_test("initialize", () => {
         score,
     });
 
-    const popular_emojis = typeahead.popular_emojis.map((emoji_code) => make_emoji(emoji_code, 10));
+    // Note: The 18 here no longer matches POPULAR_EMOJIS_BONUS_WEIGHT
+    const popular_emojis = typeahead.popular_emojis.map((emoji_code) => make_emoji(emoji_code, 18));
     const non_popular_emoji_codes = [
         "1f3df", // stadium
         "1f4b0", // money bag
@@ -83,7 +84,7 @@ run_test("initialize", () => {
     ];
     const non_popular_emojis_usage = [];
     for (const [i, non_popular_emoji_code] of non_popular_emoji_codes.entries()) {
-        non_popular_emojis_usage.push(make_emoji(non_popular_emoji_code, i));
+        non_popular_emojis_usage.push(make_emoji(non_popular_emoji_code, i + 10));
     }
     for (const emoji of [...popular_emojis, ...non_popular_emojis_usage]) {
         emoji_frequency.reaction_data.set(emoji.emoji_code, emoji);


### PR DESCRIPTION
This PR is a follow-up to #35838 that aims to improve the algorithm for finding emojis for the frequently used emoji section in the emoji picker. Following changes are made to the algorithm:
- Popular emojis are given a bonus weight of 18.
- Complete rows of emojis are shown such that the last emoji in each row has a score of at least 10 with a maximum of 5 rows.

Custom emoji bonus weight part of #37134 is not implemented in this PR.

Fixes part of #37134.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details><summary>Screenshots</summary>
<p>

<img width="371" height="531" alt="image" src="https://github.com/user-attachments/assets/7cc38dff-c5f9-4cc9-8ed3-04a2b8202f99" />

</p>
</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
