### PR TITLE
help-center: Pass allowedHosts instead of default subdomain for dev.

### DIFF
--- a/tools/run-dev
+++ b/tools/run-dev
@@ -304,7 +304,7 @@ async def forward(upstream_port: int, request: web.Request) -> web.StreamRespons
 
 
 def run_help_center_dev_server(
-    external_host: str, port: int = help_center_port
+    allowed_hosts: str, port: int = help_center_port
 ) -> "subprocess.Popen[bytes]":
     env = os.environ.copy()
     env["ZULIP_WEB_APP_PROXY_PORT"] = str(proxy_port)
@@ -316,11 +316,29 @@ def run_help_center_dev_server(
             "dev",
             f"--port={port}",
             "--host",
-            f"--allowed-hosts={urlsplit(external_host).hostname}",
+            f"--allowed-hosts={allowed_hosts}",
         ],
         cwd="starlight_help",
         env=env,
     )
+
+
+def get_help_center_allowed_hosts() -> str:
+    import django
+
+    django.setup()
+    from django.conf import settings
+
+    hostnames = set()
+    # * is not a valid value for --allowed-hosts in vite.
+    # Ports are not allowed for --allowed-hosts in vite.
+    for host in settings.ALLOWED_HOSTS:
+        if host != "*":
+            hostname = urlsplit(f"//{host}").hostname
+            if hostname:
+                hostnames.add(hostname)
+
+    return ",".join(hostnames)
 
 
 @web.middleware
@@ -454,7 +472,8 @@ async def serve() -> None:
     external_host_url = f"{http_protocol}://{external_host}"
 
     if options.only_help_center:
-        children.append(run_help_center_dev_server(external_host_url, proxy_port))
+        help_center_allowed_hosts = get_help_center_allowed_hosts()
+        children.append(run_help_center_dev_server(help_center_allowed_hosts, proxy_port))
         print_listeners(external_host_url)
         return
 
@@ -464,7 +483,8 @@ async def serve() -> None:
         children.append(start_webpack_watcher())
 
     if help_center_dev_server_enabled:
-        children.append(run_help_center_dev_server(external_host_url))
+        help_center_allowed_hosts = get_help_center_allowed_hosts()
+        children.append(run_help_center_dev_server(help_center_allowed_hosts))
 
     setup_routes(options.help_center_static_build, options.help_center_dev_server)
 


### PR DESCRIPTION
When running the dev server, we need to pass a list of allowedHosts to
vite. We were passing the hostname along with the default realm prefix:
`zulip.` to the help center. We don't use the default hostname anymore
and use settings.ALLOWED_HOSTS to pass the list of allowed hosts.

Fixes https://chat.zulip.org/#narrow/channel/19-documentation/topic/help.20center.20in.20dev.20with.20new.20realms

**How changes were tested:**

Tested on local vagrant setup.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
