### PR TITLE
message_list_data_cache: Use cached data for `near` / `with` narrows.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1183,6 +1183,16 @@ export class Filter {
         );
     }
 
+    // Returns the message ID named by an operator whose operand is a
+    // message ID, or undefined if the filter has no such term.
+    message_id_operand(operator: "id" | "near" | "with"): number | undefined {
+        const term = this.terms_with_operator(operator)[0];
+        if (term === undefined) {
+            return undefined;
+        }
+        return Number.parseInt(term.operand, 10);
+    }
+
     has_negated_operand(operator: string, operand: string): boolean {
         return this._terms.some(
             (term) => term.negated && term.operator === operator && term.operand === operand,
@@ -2062,8 +2072,8 @@ export class Filter {
         }
 
         if (!message) {
-            const message_id = Number.parseInt(this.terms_with_operator("with")[0]!.operand, 10);
-            message = message_store.get(message_id);
+            const with_message_id = this.message_id_operand("with")!;
+            message = message_store.get(with_message_id);
         }
 
         if (!message) {

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -786,10 +786,7 @@ export function update_messages(events: UpdateMessageEvent[]): void {
                         //
                         // If the `with` message was moved, we need to update the URL to
                         // use a message from the old topic.
-                        const message_id = Number.parseInt(
-                            current_filter.terms_with_operator("with")[0]!.operand,
-                            10,
-                        );
+                        const message_id = current_filter.message_id_operand("with")!;
                         if (event.message_ids.includes(message_id)) {
                             // At this point, we know that the `with` message was moved.
                             if (!is_old_topic_empty_locally) {

--- a/web/src/message_list_data_cache.ts
+++ b/web/src/message_list_data_cache.ts
@@ -83,16 +83,68 @@ export function clear(): void {
     latest_key = 0;
 }
 
-export function get_superset_datasets(filter: Filter): MessageListData[] {
-    const superset_datasets = [];
-    // Try to get exact match first.
-    const superset_data = get(filter);
-    if (superset_data !== undefined) {
-        // TODO: Search for additional superset datasets.
-        superset_datasets.push(superset_data);
+function get_supersets_containing_near_or_with_message(filter: Filter): MessageListData[] {
+    // A conversation view is a view of a single conversation: a
+    // channel+topic pair or a DM thread, with or without its own
+    // `near`/`with` operator. Interleaved views, like a channel feed or
+    // the combined feed, are not conversation views.
+    //
+    // For a target conversation view with a `near`/`with` operator, look
+    // for other cached conversation views that already hold that message.
+    // Restricting both the target and the candidates to conversation views
+    // via `is_conversation_view` ensures a candidate cannot have silently
+    // dropped a message the target needs:
+    //
+    //  - `excludes_muted_topics` is false for every conversation-view shape,
+    //    so muted-topic filtering never drops a candidate message.
+    //  - `excludes_muted_users` is true for channel+topic shapes (and false
+    //    for DM shapes), but channel and DM messages never share a dataset,
+    //    and the flag is identical across views of the same shape. So
+    //    whenever a candidate can actually supply the target's messages, it
+    //    has dropped only the messages the target would drop too.
+    if (!filter.is_conversation_view()) {
+        return [];
     }
 
-    return [...superset_datasets, recent_view_messages_data.recent_view_messages_data];
+    const message_id = filter.message_id_operand("with") ?? filter.message_id_operand("near");
+    if (message_id === undefined || Number.isNaN(message_id)) {
+        return [];
+    }
+
+    // Iterate most-recently-used first so the freshest cached dataset wins
+    // when several contain the message.
+    const supersets: MessageListData[] = [];
+    for (const cached_data of all().toReversed()) {
+        if (!cached_data.filter.is_conversation_view()) {
+            continue;
+        }
+        if (cached_data.get(message_id) !== undefined) {
+            supersets.push(cached_data);
+        }
+    }
+    return supersets;
+}
+
+export function get_superset_datasets(filter: Filter): MessageListData[] {
+    // The returned datasets are tried in order by the caller; the first one
+    // that contains the messages needed to locally render the target narrow
+    // wins. Earlier entries are higher-priority (more specific) candidates.
+    // A `Set` preserves insertion order, and dedupes a dataset that
+    // qualifies via more than one of the checks below.
+    const supersets = new Set<MessageListData>();
+
+    const exact_match = get(filter);
+    if (exact_match !== undefined) {
+        supersets.add(exact_match);
+    }
+
+    for (const cached_data of get_supersets_containing_near_or_with_message(filter)) {
+        supersets.add(cached_data);
+    }
+
+    supersets.add(recent_view_messages_data.recent_view_messages_data);
+
+    return [...supersets];
 }
 
 export function remove(filter: Filter): void {

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -370,12 +370,13 @@ export function try_rendering_locally_for_same_narrow(
         return false;
     }
 
+    const near_message_id = filter.message_id_operand("near");
     let target_id;
     if (opts.then_select_id !== undefined) {
         target_id = opts.then_select_id;
         target_scroll_offset = opts.then_select_offset;
-    } else if (filter.has_operator("near")) {
-        target_id = Number.parseInt(filter.terms_with_operator("near")[0]!.operand, 10);
+    } else if (near_message_id !== undefined) {
+        target_id = near_message_id;
     } else if (filter.equals(current_filter)) {
         // The caller doesn't want to force rerender and the filter is the same.
         // Also, we don't have a specific message id we want to select, so we
@@ -558,13 +559,9 @@ export let show = (raw_terms: NarrowTerm[], show_opts: ShowMessageViewOpts): voi
         const terms = filter.terms();
 
         // These two narrowing operators specify what message should be
-        // selected and should be the center of the narrow.
-        if (filter.has_operator("near")) {
-            id_info.target_id = Number.parseInt(filter.terms_with_operator("near")[0]!.operand, 10);
-        }
-        if (filter.has_operator("id")) {
-            id_info.target_id = Number.parseInt(filter.terms_with_operator("id")[0]!.operand, 10);
-        }
+        // selected and should be the center of the narrow; `id` wins
+        // if a filter somehow has both.
+        id_info.target_id = filter.message_id_operand("id") ?? filter.message_id_operand("near");
 
         if (
             // Filter has `with` operator but we don't have message locally.
@@ -577,7 +574,7 @@ export let show = (raw_terms: NarrowTerm[], show_opts: ShowMessageViewOpts): voi
             // from server first and then try to select `then_select_id` message.
             // There is no risk of this hack causing any issues since the `id_info`
             // will be reset after we fetch the `with` operator message.
-            id_info.target_id = Number.parseInt(filter.terms_with_operator("with")[0]!.operand, 10);
+            id_info.target_id = filter.message_id_operand("with")!;
         }
 
         // Narrow with near / id operator. There are two possibilities:

--- a/web/tests/message_list_data_cache.test.cjs
+++ b/web/tests/message_list_data_cache.test.cjs
@@ -1,0 +1,283 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {make_realm} = require("./lib/example_realm.cjs");
+const {make_stream} = require("./lib/example_stream.cjs");
+const {make_user} = require("./lib/example_user.cjs");
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const muted_users = zrequire("muted_users");
+const people = zrequire("people");
+const stream_data = zrequire("stream_data");
+const state_data = zrequire("state_data");
+const {initialize_user_settings} = zrequire("user_settings");
+
+state_data.set_realm(make_realm());
+const me = make_user({email: "me@example.com", user_id: 1, full_name: "Me"});
+const alice = make_user({email: "alice@example.com", user_id: 2, full_name: "Alice"});
+people.add_active_user(me, "server_events");
+people.add_active_user(alice, "server_events");
+people.initialize_current_user(me.user_id);
+state_data.set_current_user(me);
+muted_users.set_muted_users([]);
+initialize_user_settings({user_settings: {}});
+
+const foo_stream = make_stream({name: "Foo", stream_id: 100});
+stream_data.add_sub_for_tests(foo_stream);
+
+const {Filter} = zrequire("filter");
+const {MessageListData} = zrequire("../src/message_list_data");
+const message_list_data_cache = zrequire("../src/message_list_data_cache");
+const recent_view_messages_data = zrequire("../src/recent_view_messages_data");
+
+const recent = recent_view_messages_data.recent_view_messages_data;
+
+function make_channel_message(id) {
+    return {
+        id,
+        type: "stream",
+        stream_id: foo_stream.stream_id,
+        topic: "bar",
+        sender_id: me.user_id,
+        unread: false,
+    };
+}
+
+function make_dm_message(id) {
+    return {
+        id,
+        type: "private",
+        sender_id: alice.user_id,
+        display_recipient: [{id: me.user_id}, {id: alice.user_id}],
+        unread: false,
+    };
+}
+
+function make_data(filter_terms, message_ids = [], make_message = make_channel_message) {
+    const data = new MessageListData({
+        excludes_muted_topics: false,
+        excludes_muted_users: false,
+        filter: new Filter(filter_terms),
+    });
+    if (message_ids.length > 0) {
+        data.add_messages(
+            message_ids.map((id) => make_message(id)),
+            true,
+        );
+    }
+    return data;
+}
+
+function reset_cache() {
+    message_list_data_cache.clear();
+    recent.clear();
+}
+
+function test(label, f) {
+    run_test(label, () => {
+        reset_cache();
+        f();
+    });
+}
+
+const channel_topic_terms = [
+    {operator: "channel", operand: foo_stream.stream_id.toString()},
+    {operator: "topic", operand: "bar"},
+];
+const channel_topic_near_terms = (msg_id) => [
+    ...channel_topic_terms,
+    {operator: "near", operand: msg_id.toString()},
+];
+const channel_topic_with_terms = (msg_id) => [
+    ...channel_topic_terms,
+    {operator: "with", operand: msg_id.toString()},
+];
+const dm_terms = [{operator: "dm", operand: [alice.user_id]}];
+const dm_near_terms = (msg_id) => [...dm_terms, {operator: "near", operand: msg_id.toString()}];
+const dm_with_terms = (msg_id) => [...dm_terms, {operator: "with", operand: msg_id.toString()}];
+
+test("cache miss returns only recent_view_messages_data", () => {
+    const supersets = message_list_data_cache.get_superset_datasets(
+        new Filter(channel_topic_terms),
+    );
+    assert.deepEqual(supersets, [recent]);
+});
+
+test("exact match returned alongside fallback", () => {
+    const exact = make_data(channel_topic_terms);
+    message_list_data_cache.add(exact);
+    const supersets = message_list_data_cache.get_superset_datasets(
+        new Filter(channel_topic_terms),
+    );
+    assert.deepEqual(supersets, [exact, recent]);
+});
+
+test("conversation cache used to populate `near` view", () => {
+    // We have a cached `channel:foo topic:bar` view that contains message 42;
+    // target `channel:foo topic:bar near:42` should reuse it.
+    const conversation = make_data(channel_topic_terms, [40, 42, 44]);
+    message_list_data_cache.add(conversation);
+
+    const supersets = message_list_data_cache.get_superset_datasets(
+        new Filter(channel_topic_near_terms(42)),
+    );
+    assert.deepEqual(supersets, [conversation, recent]);
+});
+
+test("conversation cache used to populate `with` view", () => {
+    const conversation = make_data(channel_topic_terms, [40, 42, 44]);
+    message_list_data_cache.add(conversation);
+
+    const supersets = message_list_data_cache.get_superset_datasets(
+        new Filter(channel_topic_with_terms(42)),
+    );
+    assert.deepEqual(supersets, [conversation, recent]);
+});
+
+test("conversation cache skipped when it lacks the `near` message", () => {
+    const conversation = make_data(channel_topic_terms, [10, 11, 12]);
+    message_list_data_cache.add(conversation);
+
+    const supersets = message_list_data_cache.get_superset_datasets(
+        new Filter(channel_topic_near_terms(42)),
+    );
+    assert.deepEqual(supersets, [recent]);
+});
+
+test("two `near` views differing only in message share cached data", () => {
+    // Cached `near:42` view; target `near:99` should still consume it
+    // when the cached dataset already includes message 99.
+    const cached_near = make_data(channel_topic_near_terms(42), [40, 42, 99]);
+    message_list_data_cache.add(cached_near);
+
+    const supersets = message_list_data_cache.get_superset_datasets(
+        new Filter(channel_topic_near_terms(99)),
+    );
+    assert.deepEqual(supersets, [cached_near, recent]);
+});
+
+test("exact match for `near` view is not duplicated by helper", () => {
+    const cached_near = make_data(channel_topic_near_terms(42), [40, 42, 44]);
+    message_list_data_cache.add(cached_near);
+
+    const supersets = message_list_data_cache.get_superset_datasets(
+        new Filter(channel_topic_near_terms(42)),
+    );
+    // cached_near matches both the exact-match check and the helper's
+    // criteria; make sure it only appears once.
+    assert.deepEqual(supersets, [cached_near, recent]);
+});
+
+test("DM `near` view uses cached DM conversation", () => {
+    const dm_cached = make_data(dm_terms, [5, 7, 9], make_dm_message);
+    message_list_data_cache.add(dm_cached);
+
+    const supersets = message_list_data_cache.get_superset_datasets(new Filter(dm_near_terms(7)));
+    assert.deepEqual(supersets, [dm_cached, recent]);
+});
+
+test("DM `with` view uses cached DM conversation", () => {
+    const dm_cached = make_data(dm_terms, [5, 7, 9], make_dm_message);
+    message_list_data_cache.add(dm_cached);
+
+    const supersets = message_list_data_cache.get_superset_datasets(new Filter(dm_with_terms(7)));
+    assert.deepEqual(supersets, [dm_cached, recent]);
+});
+
+test("non-conversation cached views (e.g. is:starred) are not used as supersets", () => {
+    const starred = make_data([{operator: "is", operand: "starred"}]);
+    starred.add_messages([{...make_channel_message(42), starred: true}], true);
+    message_list_data_cache.add(starred);
+
+    const supersets = message_list_data_cache.get_superset_datasets(
+        new Filter(channel_topic_near_terms(42)),
+    );
+    // The starred view contains the message but isn't a conversation view,
+    // so muting semantics may differ — we must not use it as a superset.
+    assert.deepEqual(supersets, [recent]);
+});
+
+test("non-conversation target (e.g. a channel feed) uses no conversation cache", () => {
+    const conversation = make_data(channel_topic_terms, [40, 42, 44]);
+    message_list_data_cache.add(conversation);
+
+    // A channel feed anchored at message 42 needs every topic in the
+    // channel, so a cached single-topic dataset can't populate it.
+    const supersets = message_list_data_cache.get_superset_datasets(
+        new Filter([
+            {operator: "channel", operand: foo_stream.stream_id.toString()},
+            {operator: "near", operand: "42"},
+        ]),
+    );
+    assert.deepEqual(supersets, [recent]);
+});
+
+test("non-near/with target ignores the helper entirely", () => {
+    const cached_near = make_data(channel_topic_near_terms(42), [40, 42, 44]);
+    message_list_data_cache.add(cached_near);
+
+    // Target lacks both near and with; even though a cached conversation
+    // view exists with overlapping messages, the helper is a no-op.
+    const supersets = message_list_data_cache.get_superset_datasets(
+        new Filter(channel_topic_terms),
+    );
+    assert.deepEqual(supersets, [recent]);
+});
+
+test("recent_view_messages_data containing message is not double-listed", () => {
+    recent.add_messages([make_channel_message(42)], true);
+
+    const supersets = message_list_data_cache.get_superset_datasets(
+        new Filter(channel_topic_near_terms(42)),
+    );
+    // `recent` is empty-filter, so it's not a conversation view; the helper
+    // shouldn't include it. The fallback at the end adds it exactly once.
+    assert.deepEqual(supersets, [recent]);
+});
+
+test("multiple conversation caches are all considered", () => {
+    const conversation = make_data(channel_topic_terms, [40, 42, 44]);
+    const cached_near = make_data(channel_topic_near_terms(60), [58, 60, 62]);
+    message_list_data_cache.add(conversation);
+    message_list_data_cache.add(cached_near);
+    // Add a second message to `conversation` so it also contains 62.
+    conversation.add_messages([make_channel_message(62)], true);
+
+    const supersets = message_list_data_cache.get_superset_datasets(
+        new Filter(channel_topic_near_terms(62)),
+    );
+    // Both cached conversation datasets contain message 62, so both should
+    // be candidates. recent_view_messages_data is always last.
+    assert.equal(supersets.length, 3);
+    assert.ok(supersets.includes(conversation));
+    assert.ok(supersets.includes(cached_near));
+    assert.equal(supersets.at(-1), recent);
+});
+
+test("conversation-view muting flags keep candidate reuse safe", () => {
+    // `get_supersets_containing_near_or_with_message` trusts that a
+    // conversation-view candidate has not silently dropped a message the
+    // target needs. That relies on the muting flags below; pin them so a
+    // future filter.ts change forces this reasoning to be re-examined.
+    const cases = [
+        {terms: channel_topic_terms, excludes_muted_users: true},
+        {terms: channel_topic_near_terms(42), excludes_muted_users: true},
+        {terms: channel_topic_with_terms(42), excludes_muted_users: true},
+        {terms: dm_terms, excludes_muted_users: false},
+        {terms: dm_near_terms(7), excludes_muted_users: false},
+        {terms: dm_with_terms(7), excludes_muted_users: false},
+    ];
+    for (const {terms, excludes_muted_users} of cases) {
+        const filter = new Filter(terms);
+        assert.ok(filter.is_conversation_view());
+        // Muted-topic filtering is disabled for every conversation view, so
+        // a candidate cannot have dropped a message on that basis.
+        assert.equal(filter.excludes_muted_topics(), false);
+        // Muted-user filtering may apply, but only ever identically across
+        // views of the same shape (and channel and DM messages never share a
+        // dataset), so a candidate drops only what the target would too.
+        assert.equal(filter.excludes_muted_users(), excludes_muted_users);
+    }
+});


### PR DESCRIPTION
We check if we can render using a dataset which has the `near` or `with` message id, when rendering a narrow.

discussion: https://github.com/zulip/zulip/pull/36955#discussion_r2624697830