### PR TITLE
message_select: Fix text selection not working for clicks.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -190,9 +190,14 @@ export function initialize(): void {
             return;
         }
 
+        if (document.getSelection()?.type === "Range") {
+            // Drags and double/triple clicks on the message
+            // (to copy message text) shouldn't trigger a reply.
+            return;
+        }
+
         if (mouse_drag.is_drag(e)) {
-            // Drags on the message (to copy message text) shouldn't trigger a reply.
-            // This also prevents triggering a reply when you click and drag through
+            // This prevents triggering a reply when you click and drag through
             // an area that doesn't contain text.
             return;
         }


### PR DESCRIPTION
This addresses the bug where double or triple clicking text in a message doesn't select text and instead
triggers the `respond_to_message` flow.

The mouse_drag.is_drag check correctly classifies
a selection triggered by multiple clicks, but that leads to this bug, so we add back the
`document.getSelection().type` check to address that.

Fixes: https://chat.zulip.org/#narrow/channel/9-issues/topic/Clicking.20to.20select.20text.20doesn't.20work.20for.20DM.20messages.2E/with/2331737.

<!-- Describe your pull request here.-->

Before: 

https://github.com/user-attachments/assets/bb83e778-7139-4f88-afd6-bed158ca353f


After:

https://github.com/user-attachments/assets/15b528a6-3392-471f-8b0d-c2d8d785b1ec

