### PR TITLE
demo-orgs: Filter demos from eligible community directory realms.

### DIFF
--- a/corporate/views/portico.py
+++ b/corporate/views/portico.py
@@ -337,6 +337,10 @@ def communities_view(request: HttpRequest) -> HttpResponse:
             # Filter out realms who haven't changed their description from the default.
             description="",
         )
+        .exclude(
+            # Filter out demo organizations.
+            demo_organization_scheduled_deletion_date__isnull=False,
+        )
         .order_by("name")
     )
     for realm in want_to_be_advertised_realms:

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -1,6 +1,7 @@
 import os
 import re
 from collections.abc import Sequence
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 from unittest import mock, skipUnless
 from urllib.parse import urlsplit
@@ -377,6 +378,15 @@ class DocPageTest(ZulipTestCase):
         realm.save()
         self._test(
             "/communities/", ["Open communities directory", "Zulip Dev", 'data-category="research"']
+        )
+
+        # Demo organizations are not shown.
+        demo_deletion_date = timezone_now() + timedelta(days=15)
+        realm.demo_organization_scheduled_deletion_date = demo_deletion_date
+        realm.save()
+        result = self.client_get("/communities/")
+        self.assert_not_in_success_response(
+            ["Zulip Dev", "Some description", 'data-category="research"'], result
         )
 
     def test_integration_doc_endpoints(self) -> None:


### PR DESCRIPTION
When demo organizations are in production, we'll want to make sure that they are not listed in the community directory until they are converted to permanent organizations.

**Notes**:
- In the help center article for the [communities directory](https://zulip.com/help/communities-directory), we already note that checking the setting on a Zulip organization does not guarantee that the organization will be listed, so I don't think we need to document anything here.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
