### PR TITLE
audit-logs: Add was_demo_organization to REALM_SUBDOMAIN_CHANGED.

### DIFF
--- a/zerver/actions/create_realm.py
+++ b/zerver/actions/create_realm.py
@@ -59,6 +59,7 @@ def do_change_realm_subdomain(
     """
     old_subdomain = realm.subdomain
     old_url = realm.url
+    was_demo_organization = realm.demo_organization_scheduled_deletion_date is not None
     # If the realm had been a demo organization scheduled for
     # deleting, clear that state.
     realm.demo_organization_scheduled_deletion_date = None
@@ -75,6 +76,7 @@ def do_change_realm_subdomain(
             extra_data={
                 RealmAuditLog.OLD_VALUE: old_subdomain,
                 RealmAuditLog.NEW_VALUE: new_subdomain,
+                "was_demo_organization": was_demo_organization,
             },
         )
 

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -319,6 +319,18 @@ class RealmTest(ZulipTestCase):
         self.assertIsNone(realm.demo_organization_scheduled_deletion_date)
         self.assertEqual(realm.string_id, data["string_id"])
 
+        realm_audit_log = RealmAuditLog.objects.filter(
+            event_type=AuditLogEventType.REALM_SUBDOMAIN_CHANGED, acting_user=desdemona
+        ).last()
+        assert realm_audit_log is not None
+        expected_extra_data = {
+            RealmAuditLog.OLD_VALUE: "zulip",
+            RealmAuditLog.NEW_VALUE: "coolrealm",
+            "was_demo_organization": True,
+        }
+        self.assertEqual(realm_audit_log.extra_data, expected_extra_data)
+        self.assertEqual(realm_audit_log.acting_user, desdemona)
+
     def test_realm_name_length(self) -> None:
         new_name = "A" * (Realm.MAX_REALM_NAME_LENGTH + 1)
         data = dict(name=new_name)
@@ -405,6 +417,7 @@ class RealmTest(ZulipTestCase):
         expected_extra_data = {
             RealmAuditLog.OLD_VALUE: "zulip",
             RealmAuditLog.NEW_VALUE: "newzulip",
+            "was_demo_organization": False,
         }
         self.assertEqual(realm_audit_log.extra_data, expected_extra_data)
         self.assertEqual(realm_audit_log.acting_user, iago)


### PR DESCRIPTION
Adds a `"was_demo_organization"` boolean to the extra data stored for `RealmAuditLog`s with `event_type` `REALM_SUBDOMAIN_CHANGED`, so that we can track demo organization conversions via these logs.

See [#backend > demo organizations: when converted to permanent orgs](https://chat.zulip.org/#narrow/channel/3-backend/topic/demo.20organizations.3A.20when.20converted.20to.20permanent.20orgs/with/2325595) for more context.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
