### PR TITLE
oembed: Replace pyoembed with custom hardcoded providers.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ prod = [
 
   # Needed for link preview
   "beautifulsoup4",
-  "pyoembed",
   "python-magic",
 
   # The Zulip API bindings, from its own repository.
@@ -431,7 +430,6 @@ module = [
     "ldap.*", # https://github.com/python-ldap/python-ldap/issues/368
     "onelogin.*",
     "pyinotify.*",
-    "pyoembed.*",
     "pyuca.*",
     "pyvips.*",
     "scim2_filter_parser.attr_paths",

--- a/uv.lock
+++ b/uv.lock
@@ -3956,17 +3956,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyoembed"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "lxml" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/32/11/7b9549660ae130668cabc886e4012572745508d381cd0005239b082129a8/pyoembed-0.1.2.tar.gz", hash = "sha256:0f755c8308039f1e49238e95ea94ef16aa08add9f32075ba13ab9b65f32ff582", size = 12502, upload-time = "2017-11-17T11:51:21.083Z" }
-
-[[package]]
 name = "pyopenssl"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6274,7 +6263,6 @@ dev = [
     { name = "pyjwt" },
     { name = "pymongo" },
     { name = "pynacl" },
-    { name = "pyoembed" },
     { name = "python-binary-memcached" },
     { name = "python-dateutil" },
     { name = "python-debian" },
@@ -6400,7 +6388,6 @@ prod = [
     { name = "pyjwt" },
     { name = "pymongo" },
     { name = "pynacl" },
-    { name = "pyoembed" },
     { name = "python-binary-memcached" },
     { name = "python-dateutil" },
     { name = "python-ldap" },
@@ -6512,7 +6499,6 @@ dev = [
     { name = "pyjwt" },
     { name = "pymongo" },
     { name = "pynacl" },
-    { name = "pyoembed" },
     { name = "python-binary-memcached" },
     { name = "python-dateutil" },
     { name = "python-debian" },
@@ -6640,7 +6626,6 @@ prod = [
     { name = "pyjwt" },
     { name = "pymongo" },
     { name = "pynacl" },
-    { name = "pyoembed" },
     { name = "python-binary-memcached" },
     { name = "python-dateutil" },
     { name = "python-ldap" },

--- a/zerver/lib/url_preview/oembed.py
+++ b/zerver/lib/url_preview/oembed.py
@@ -1,21 +1,112 @@
 import json
+import re
+from typing import Any
+from urllib.parse import urlencode
 
 import requests
-from pyoembed import PyOembedException, oEmbed
+from django.conf import settings
 
+from version import ZULIP_VERSION
+from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.url_preview.types import UrlEmbedData, UrlOEmbedData
+
+# User-Agent for oEmbed requests
+OEMBED_USER_AGENT = (
+    f"Mozilla/5.0 (compatible; ZulipURLPreview/{ZULIP_VERSION}; +{settings.ROOT_DOMAIN_URI})"
+)
+OEMBED_TIMEOUT = 15
+
+
+class OEmbedSession(OutgoingSession):
+    """Session for oEmbed requests using Zulip's outgoing HTTP infrastructure."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            role="preview",
+            timeout=OEMBED_TIMEOUT,
+            headers={"User-Agent": OEMBED_USER_AGENT},
+        )
+
+
+# Provider registry with hardcoded oEmbed endpoints
+# This avoids autodiscovery which gets blocked by bot detection
+OEMBED_PROVIDERS: dict[str, str] = {
+    # YouTube
+    r"https?://(?:www\.)?youtube\.com/watch": "https://www.youtube.com/oembed",
+    r"https?://(?:www\.)?youtube\.com/shorts/": "https://www.youtube.com/oembed",
+    r"https?://youtu\.be/": "https://www.youtube.com/oembed",
+    # Vimeo
+    r"https?://(?:www\.)?vimeo\.com/": "https://vimeo.com/api/oembed.json",
+    # Twitter/X
+    r"https?://(?:www\.)?twitter\.com/.*/status/": "https://publish.twitter.com/oembed",
+    r"https?://(?:www\.)?x\.com/.*/status/": "https://publish.twitter.com/oembed",
+    # Spotify
+    r"https?://open\.spotify\.com/": "https://open.spotify.com/oembed",
+    # SoundCloud
+    r"https?://soundcloud\.com/": "https://soundcloud.com/oembed",
+    # Flickr
+    r"https?://(?:www\.)?flickr\.com/photos/": "https://www.flickr.com/services/oembed/",
+    # Instagram
+    r"https?://(?:www\.)?instagram\.com/p/": "https://graph.facebook.com/v10.0/instagram_oembed",
+    # TikTok
+    r"https?://(?:www\.)?tiktok\.com/": "https://www.tiktok.com/oembed",
+    # Giphy
+    r"https?://(?:www\.)?giphy\.com/gifs/": "https://giphy.com/services/oembed",
+    r"https?://gph\.is/": "https://giphy.com/services/oembed",
+    # Reddit
+    r"https?://(?:www\.)?reddit\.com/r/.*/comments/": "https://www.reddit.com/oembed",
+    # Imgur
+    r"https?://(?:www\.)?imgur\.com/": "https://api.imgur.com/oembed",
+}
+
+
+def get_oembed_endpoint(url: str) -> str | None:
+    """Find the oEmbed endpoint for a given URL."""
+    for pattern, endpoint in OEMBED_PROVIDERS.items():
+        if re.match(pattern, url, re.IGNORECASE):
+            return endpoint
+    return None
+
+
+def fetch_oembed_data(
+    url: str, endpoint: str, maxwidth: int = 640, maxheight: int = 480
+) -> dict[str, Any] | None:
+    """Fetch oEmbed data using Zulip's PreviewSession."""
+    params = {
+        "url": url,
+        "format": "json",
+        "maxwidth": maxwidth,
+        "maxheight": maxheight,
+    }
+    oembed_url = f"{endpoint}?{urlencode(params)}"
+
+    try:
+        response = OEmbedSession().get(oembed_url)
+        if response.ok:
+            data = response.json()
+            # Ensure response is a dict (valid oEmbed response)
+            if isinstance(data, dict):
+                return data
+    except (requests.exceptions.RequestException, json.decoder.JSONDecodeError):
+        pass
+    return None
 
 
 def get_oembed_data(url: str, maxwidth: int = 640, maxheight: int = 480) -> UrlEmbedData | None:
-    try:
-        data = oEmbed(url, maxwidth=maxwidth, maxheight=maxheight)
-    except (PyOembedException, json.decoder.JSONDecodeError, requests.exceptions.ConnectionError):
+    """Get oEmbed data for a URL using hardcoded provider endpoints."""
+    endpoint = get_oembed_endpoint(url)
+    if endpoint is None:
+        return None
+
+    data = fetch_oembed_data(url, endpoint, maxwidth, maxheight)
+    if data is None:
         return None
 
     oembed_resource_type = data.get("type", "")
     image = data.get("url", data.get("image"))
     thumbnail = data.get("thumbnail_url")
     html = data.get("html", "")
+
     if oembed_resource_type == "photo" and image:
         return UrlOEmbedData(
             image=image,
@@ -33,8 +124,7 @@ def get_oembed_data(url: str, maxwidth: int = 640, maxheight: int = 480) -> UrlE
             description=data.get("description"),
         )
 
-    # Otherwise, use the title/description from pyembed as the basis
-    # for our other parsers
+    # Otherwise, use the title/description as the basis for our other parsers
     return UrlEmbedData(
         title=data.get("title"),
         description=data.get("description"),

--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -32,7 +32,6 @@ ZULIP_URL_PREVIEW_USER_AGENT = (
     f"Mozilla/5.0 (compatible; ZulipURLPreview/{ZULIP_VERSION}; +{settings.ROOT_DOMAIN_URI})"
 )
 
-# FIXME: This header and timeout are not used by pyoembed, when trying to autodiscover!
 HEADERS = {"User-Agent": ZULIP_URL_PREVIEW_USER_AGENT}
 TIMEOUT = 15
 
@@ -91,10 +90,9 @@ def get_link_embed_data(url: str, maxwidth: int = 640, maxheight: int = 480) -> 
     if not valid_content_type(url):
         return None
 
-    # The oembed data from pyoembed may be complete enough to return
-    # as-is; if so, we use it.  Otherwise, we use it as a _base_ for
-    # the other, less sophisticated techniques which we apply as
-    # successive fallbacks.
+    # The oEmbed data may be complete enough to return as-is; if so,
+    # we use it. Otherwise, we use it as a _base_ for the other, less
+    # sophisticated techniques which we apply as successive fallbacks.
     data = get_oembed_data(url, maxwidth=maxwidth, maxheight=maxheight)
     if data is not None and isinstance(data, UrlOEmbedData):
         return data


### PR DESCRIPTION
pyoembed uses autodiscovery which fetches HTML pages first - this gets blocked by YouTube's bot detection on cloud servers, breaking link previews.

  This replaces it with hardcoded oEmbed endpoints for YouTube, Vimeo, Twitter, Spotify, etc. Uses `OEmbedSession` extending `OutgoingSession` for smokescreen compatibility.

  Fixes #31891

  **How changes were tested:**
  - All 39 tests pass
  - Tested YouTube oEmbed fetch via Django shell
  - Linting passes

  **Screenshots and screen captures:**
  N/A (backend change)

  <details>
  <summary>Self-review checklist</summary>

  - [x] Self-reviewed the changes for clarity and maintainability
        (variable names, code reuse, readability, etc.).

  Communicate decisions, questions, and potential concerns.

  - [x] Explains differences from previous plans (e.g., issue description).
  - [x] Highlights technical choices and bugs encountered.
  - [ ] Calls out remaining decisions and concerns.
  - [x] Automated tests verify logic where appropriate.

  Individual commits are ready for review (see commit discipline).

  - [x] Each commit is a coherent idea.
  - [x] Commit message(s) explain reasoning and motivation for changes.

  Completed manual review and testing of the following:

  - [ ] Visual appearance of the changes.
  - [ ] Responsiveness and internationalization.
  - [ ] Strings and tooltips.
  - [ ] End-to-end functionality of buttons, interactions and flows.
  - [x] Corner cases, error conditions, and easily imagined bugs.
  </details>