### PR TITLE
api: Added two fields for message URL in `POST /messages` API response.

### DIFF
--- a/api_docs/unmerged.d/ZF-1aabde.md
+++ b/api_docs/unmerged.d/ZF-1aabde.md
@@ -1,0 +1,3 @@
+* [`POST /messages`](/api/send-message): Added two new fields,
+  `message_url` and `message_link` containing the URL of the sent
+  message in the response object.

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -80,7 +80,8 @@ from zerver.lib.string_validation import check_stream_name
 from zerver.lib.thumbnail import manifest_and_get_user_upload_previews, rewrite_thumbnailed_images
 from zerver.lib.timestamp import timestamp_to_datetime
 from zerver.lib.topic import get_topic_display_name, participants_for_topic
-from zerver.lib.topic_link_util import get_stream_link_syntax
+from zerver.lib.topic_link_util import get_fallback_markdown_link, get_stream_link_syntax
+from zerver.lib.url_encoding import message_link_url
 from zerver.lib.url_preview.types import UrlEmbedData
 from zerver.lib.user_groups import (
     check_any_user_has_permission_by_role,
@@ -234,6 +235,8 @@ class UserProfileAnnotations(TypedDict):
 @dataclass
 class SentMessageResult:
     message_id: int
+    message_url: str
+    message_link: str
     automatic_new_visibility_policy: int | None = None
 
 
@@ -1090,10 +1093,23 @@ def do_send_messages(
                         visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED,
                     )
 
-        # Deliver events to the real-time push system, as well as
-        # enqueuing any additional processing triggered by the message.
         wide_message_dict = MessageDict.wide_dict(send_request.message, realm_id)
 
+        # Compute URL of the message.
+        send_request.message_url = message_link_url(send_request.realm, wide_message_dict)
+        if send_request.stream:
+            send_request.message_link = get_fallback_markdown_link(
+                send_request.stream.id,
+                send_request.stream.name,
+                send_request.message.topic_name(),
+                send_request.message.id,
+            )
+        else:
+            # There is no special Zulip markdown syntax for direct message URLs.
+            send_request.message_link = send_request.message_url
+
+        # Deliver events to the real-time push system, as well as
+        # enqueuing any additional processing triggered by the message.
         user_flags = user_message_flags.get(send_request.message.id, {})
 
         """
@@ -1300,13 +1316,19 @@ def do_send_messages(
                     },
                 )
 
-    sent_message_results = [
-        SentMessageResult(
+    sent_message_results = []
+    for send_request in send_message_requests:
+        assert send_request.message_url is not None
+        assert send_request.message_link is not None
+
+        result = SentMessageResult(
             message_id=send_request.message.id,
+            message_url=send_request.message_url,
+            message_link=send_request.message_link,
             automatic_new_visibility_policy=send_request.automatic_new_visibility_policy,
         )
-        for send_request in send_message_requests
-    ]
+        sent_message_results.append(result)
+
     return sent_message_results
 
 

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -185,6 +185,8 @@ class SendMessageRequest:
     recipients_for_user_creation_events: dict[UserProfile, set[int]] | None = None
     reminder_target_message_id: int | None = None
     reminder_note: str | None = None
+    message_url: str | None = None
+    message_link: str | None = None
 
 
 @dataclass

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8450,10 +8450,25 @@ paths:
                           user automatically unmuting or following the topic in question.
 
                           **Changes**: New in Zulip 8.0 (feature level 218).
+                      message_url:
+                        type: string
+                        description: |
+                          A URL that links to the sent message within its conversation.
+
+                          **Changes**: New in Zulip 12.0 (feature level ZF-1aabde).
+                      message_link:
+                        type: string
+                        description: |
+                          A [Zulip-flavored Markdown string](/help/format-your-message-using-markdown#links)
+                          representing a link to the sent message within its conversation.
+
+                          **Changes**: New in Zulip 12.0 (feature level ZF-1aabde).
                     example:
                       {
                         "msg": "",
                         "id": 42,
+                        "message_url": "https://example.zulipchat.com/#narrow/channel/399637-core-team/topic/private.20streams/near/382320733",
+                        "message_link": "[#core team > private streams @ 💬](#narrow/channel/399637-core-team/topic/private.20streams/near/382320733)",
                         "automatic_new_visibility_policy": 2,
                         "result": "success",
                       }

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable, Sequence
 from email.headerregistry import Address
-from typing import Annotated, Literal, cast
+from typing import Annotated, Any, Literal, cast
 
 from django.core import validators
 from django.core.exceptions import ValidationError
@@ -218,7 +218,7 @@ def send_message_backend(
         # automatically marked as read for yourself.
         read_by_sender = client.default_read_by_sender()
 
-    data: dict[str, int] = {}
+    data: dict[str, Any] = {}
     sent_message_result = check_send_message(
         sender,
         client,
@@ -236,6 +236,8 @@ def send_message_backend(
         read_by_sender=read_by_sender,
     )
     data["id"] = sent_message_result.message_id
+    data["message_url"] = sent_message_result.message_url
+    data["message_link"] = sent_message_result.message_link
     if sent_message_result.automatic_new_visibility_policy:
         data["automatic_new_visibility_policy"] = (
             sent_message_result.automatic_new_visibility_policy


### PR DESCRIPTION
Adds `message_url` and `message_link` fields in `POST /messages` API response containing the URL of the sent message.

Fixes #15327.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
