### PR TITLE
for #37134

### DIFF
--- a/web/src/emoji_frequency.ts
+++ b/web/src/emoji_frequency.ts
@@ -1,96 +1,203 @@
 import assert from "minimalistic-assert";
 
 import * as all_messages_data from "./all_messages_data.ts";
+import * as emoji from "./emoji.ts";
 import * as emoji_picker from "./emoji_picker.ts";
 import * as message_store from "./message_store.ts";
+import type {Message} from "./message_store.ts";
 import * as reactions from "./reactions.ts";
 import {current_user} from "./state_data.ts";
 import * as typeahead from "./typeahead.ts";
 
+/*
+    Weighted Emoji Frequency Algorithm:
+    
+    Base scoring (per message):
+    - 5 points for each message where you used that emoji
+    - 1 point for each message where someone else used that emoji
+
+    Bonuses:
+    - 18-point bonus for the 6 built-in popular emoji (not guaranteed to show)
+    - 30-point bonus for custom emoji you uploaded (first week only)
+    - 10-point bonus for custom emoji uploaded by others (first week only)
+
+    Display:
+    - Show complete rows (6 emojis each) where the last emoji scores >= 10
+    - Maximum of 5 rows (30 emojis)
+*/
+
+// Scoring constants
+const CURRENT_USER_REACTION_WEIGHT = 5;
+const OTHER_USER_REACTION_WEIGHT = 1;
+const BUILTIN_EMOJI_BONUS = 18;
+const CUSTOM_EMOJI_SELF_UPLOADED_BONUS = 30;
+const CUSTOM_EMOJI_OTHER_UPLOADED_BONUS = 10;
+const CUSTOM_EMOJI_BONUS_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
+
+// Display constants
+const EMOJIS_PER_ROW = 6;
+const MAX_ROWS = 5;
+const MIN_SCORE_THRESHOLD = 10;
+
 export type ReactionUsage = {
-    score: number;
+    base_score: number;
+    bonus_score: number;
+    total_score: number;
     emoji_code: string;
     emoji_type: string;
+    emoji_name?: string;
     message_ids: Set<number>;
     current_user_reacted_message_ids: Set<number>;
+    author_id?: number;
+    created_at?: number;
 };
 
-const MAX_FREQUENTLY_USED_EMOJIS = 12;
-const CURRENT_USER_REACTION_WEIGHT = 5;
 export const reaction_data = new Map<string, ReactionUsage>();
 
-export function update_frequently_used_emojis_list(): void {
-    const frequently_used_emojis = [...reaction_data.values()].toSorted(
-        (a, b) => b.score - a.score,
-    );
+function get_builtin_emoji_bonus(emoji_code: string): number {
+    if (typeahead.popular_emojis.includes(emoji_code)) {
+        return BUILTIN_EMOJI_BONUS;
+    }
+    return 0;
+}
 
-    const top_frequently_used_emojis = [];
-    let popular_emojis = typeahead.get_popular_emojis();
-    for (const emoji of frequently_used_emojis) {
-        if (
-            top_frequently_used_emojis.length + popular_emojis.length ===
-            MAX_FREQUENTLY_USED_EMOJIS
-        ) {
+function get_custom_emoji_bonus(
+    emoji_type: string,
+    author_id: number | undefined,
+    created_at: number | undefined,
+): number {
+    if (emoji_type !== "realm_emoji") {
+        return 0;
+    }
+    if (created_at === undefined) {
+        return 0;
+    }
+    const now = Date.now();
+    const age_ms = now - created_at;
+    if (age_ms > CUSTOM_EMOJI_BONUS_DURATION_MS) {
+        return 0;
+    }
+    if (author_id === current_user.user_id) {
+        return CUSTOM_EMOJI_SELF_UPLOADED_BONUS;
+    }
+    return CUSTOM_EMOJI_OTHER_UPLOADED_BONUS;
+}
+
+function calculate_total_score(usage: ReactionUsage): number {
+    const builtin_bonus = get_builtin_emoji_bonus(usage.emoji_code);
+    const custom_bonus = get_custom_emoji_bonus(
+        usage.emoji_type,
+        usage.author_id,
+        usage.created_at,
+    );
+    usage.bonus_score = builtin_bonus + custom_bonus;
+    usage.total_score = usage.base_score + usage.bonus_score;
+    return usage.total_score;
+}
+
+function calculate_rows_to_show(sorted_emojis: ReactionUsage[]): number {
+    let rows_to_show = 0;
+    for (let row = 1; row <= MAX_ROWS; row++) {
+        const last_index_in_row = row * EMOJIS_PER_ROW - 1;
+        if (last_index_in_row >= sorted_emojis.length) {
             break;
         }
-        assert(emoji !== undefined);
-        top_frequently_used_emojis.push({
-            emoji_type: emoji.emoji_type,
-            emoji_code: emoji.emoji_code,
-        });
-        popular_emojis = popular_emojis.filter(
-            (popular_emoji) => popular_emoji.emoji_code !== emoji.emoji_code,
-        );
+        const last_emoji_in_row = sorted_emojis[last_index_in_row];
+        if (last_emoji_in_row && last_emoji_in_row.total_score >= MIN_SCORE_THRESHOLD) {
+            rows_to_show = row;
+        } else {
+            break;
+        }
+    }
+    return rows_to_show;
+}
+
+function get_custom_emoji_metadata(
+    emoji_code: string,
+    emoji_type: string,
+): {author_id?: number; created_at?: number} {
+    if (emoji_type !== "realm_emoji") {
+        return {};
+    }
+    const realm_emoji = emoji.active_realm_emojis.get(emoji_code);
+    if (realm_emoji && "id" in realm_emoji) {
+        const id_num = Number.parseInt(realm_emoji.id, 10);
+        if (!Number.isNaN(id_num)) {
+            return {created_at: id_num * 1000};
+        }
+    }
+    return {};
+}
+
+export function update_frequently_used_emojis_list(): void {
+    for (const usage of reaction_data.values()) {
+        calculate_total_score(usage);
     }
 
-    const final_frequently_used_emoji_list = [...top_frequently_used_emojis, ...popular_emojis];
-    typeahead.set_frequently_used_emojis(
-        final_frequently_used_emoji_list.slice(0, MAX_FREQUENTLY_USED_EMOJIS),
+    const sorted_emojis = [...reaction_data.values()].toSorted(
+        (a, b) => b.total_score - a.total_score,
     );
+
+    const rows_to_show = calculate_rows_to_show(sorted_emojis);
+    const emojis_to_show = rows_to_show * EMOJIS_PER_ROW;
+
+    const frequently_used_emojis = sorted_emojis.slice(0, emojis_to_show).map((usage) => ({
+        emoji_type: usage.emoji_type,
+        emoji_code: usage.emoji_code,
+    }));
+
+    typeahead.set_frequently_used_emojis(frequently_used_emojis);
     emoji_picker.rebuild_catalog();
 }
 
-/*
-    This function assumes reactions.add_reaction has already been called.
-    TODO: Split reactions.ts into data and UI modules, so that this can
-    be called from directly from reactions.add_reaction without creating
-    an import cycle.
-*/
-export function update_emoji_frequency_on_add_reaction_event(event: reactions.ReactionEvent): void {
+export function update_emoji_frequency_on_add_reaction_event(
+    event: reactions.ReactionEvent,
+): void {
     const message_id = event.message_id;
     const message = message_store.get(message_id);
     if (message === undefined) {
         return;
     }
+
     const emoji_id = reactions.get_local_reaction_id(event);
     const clean_reaction_object = message.clean_reactions.get(emoji_id);
 
     assert(clean_reaction_object !== undefined);
 
     if (!reaction_data.has(emoji_id)) {
+        const metadata = get_custom_emoji_metadata(
+            clean_reaction_object.emoji_code,
+            clean_reaction_object.reaction_type,
+        );
+
         reaction_data.set(emoji_id, {
-            score: 0,
+            base_score: 0,
+            bonus_score: 0,
+            total_score: 0,
             emoji_code: clean_reaction_object.emoji_code,
             emoji_type: clean_reaction_object.reaction_type,
+            emoji_name: clean_reaction_object.emoji_name,
             message_ids: new Set(),
             current_user_reacted_message_ids: new Set(),
+            ...metadata,
         });
     }
 
-    const reaction_usage = reaction_data.get(emoji_id);
-    assert(reaction_usage !== undefined);
+    const usage = reaction_data.get(emoji_id);
+    assert(usage !== undefined);
 
-    if (reaction_usage.message_ids.has(message_id)) {
+    if (usage.message_ids.has(message_id)) {
         return;
     }
-    reaction_usage.message_ids.add(message_id);
+    usage.message_ids.add(message_id);
 
     if (event.user_id === current_user.user_id) {
-        reaction_usage.score += CURRENT_USER_REACTION_WEIGHT;
-        reaction_usage.current_user_reacted_message_ids.add(message.id);
+        usage.base_score += CURRENT_USER_REACTION_WEIGHT;
+        usage.current_user_reacted_message_ids.add((message as Message).id);
     } else {
-        reaction_usage.score += 1;
+        usage.base_score += OTHER_USER_REACTION_WEIGHT;
     }
+
     update_frequently_used_emojis_list();
 }
 
@@ -104,22 +211,23 @@ export function update_emoji_frequency_on_remove_reaction_event(
     }
 
     const emoji_id = reactions.get_local_reaction_id(event);
-    const reaction_usage = reaction_data.get(emoji_id);
-    if (reaction_usage === undefined) {
+    const usage = reaction_data.get(emoji_id);
+    if (usage === undefined) {
         return;
     }
 
-    if (!reaction_usage.message_ids.has(message_id)) {
+    if (!usage.message_ids.has(message_id)) {
         return;
     }
-    reaction_usage.message_ids.delete(message_id);
+    usage.message_ids.delete(message_id);
 
     if (event.user_id === current_user.user_id) {
-        reaction_usage.score -= CURRENT_USER_REACTION_WEIGHT;
-        reaction_usage.current_user_reacted_message_ids.delete(message.id);
+        usage.base_score -= CURRENT_USER_REACTION_WEIGHT;
+        usage.current_user_reacted_message_ids.delete((message as Message).id);
     } else {
-        reaction_usage.score -= 1;
+        usage.base_score -= OTHER_USER_REACTION_WEIGHT;
     }
+
     update_frequently_used_emojis_list();
 }
 
@@ -127,21 +235,24 @@ export function update_emoji_frequency_on_messages_deletion(message_ids: number[
     for (const message_id of message_ids) {
         const message = message_store.get(message_id);
         assert(message !== undefined);
+
         const message_reactions = message.clean_reactions.values();
-        for (const emoji of message_reactions) {
-            const emoji_id = emoji.local_id;
-            const reaction_usage = reaction_data.get(emoji_id);
-            if (reaction_usage === undefined) {
-                return;
+        for (const reaction of message_reactions) {
+            const emoji_id = reaction.local_id;
+            const usage = reaction_data.get(emoji_id);
+            if (usage === undefined) {
+                continue;
             }
-            if (reaction_usage.message_ids.delete(message_id)) {
-                reaction_usage.score -= 1;
+
+            if (usage.message_ids.delete(message_id)) {
+                usage.base_score -= OTHER_USER_REACTION_WEIGHT;
             }
-            if (reaction_usage.current_user_reacted_message_ids.delete(message_id)) {
-                reaction_usage.score -= CURRENT_USER_REACTION_WEIGHT - 1;
+            if (usage.current_user_reacted_message_ids.delete(message_id)) {
+                usage.base_score -= CURRENT_USER_REACTION_WEIGHT - OTHER_USER_REACTION_WEIGHT;
             }
         }
     }
+
     update_frequently_used_emojis_list();
 }
 
@@ -152,28 +263,42 @@ export function initialize_frequently_used_emojis(): void {
     for (let i = messages.length - 1; i >= 0; i -= 1) {
         const message = messages[i];
         assert(message !== undefined);
+
         const message_reactions = message.clean_reactions.values();
-        for (const emoji of message_reactions) {
-            const emoji_id = emoji.local_id;
+        for (const reaction of message_reactions) {
+            const emoji_id = reaction.local_id;
+
             if (!reaction_data.has(emoji_id)) {
+                const metadata = get_custom_emoji_metadata(
+                    reaction.emoji_code,
+                    reaction.reaction_type,
+                );
+
                 reaction_data.set(emoji_id, {
-                    score: 0,
-                    emoji_code: emoji.emoji_code,
-                    emoji_type: emoji.reaction_type,
+                    base_score: 0,
+                    bonus_score: 0,
+                    total_score: 0,
+                    emoji_code: reaction.emoji_code,
+                    emoji_type: reaction.reaction_type,
+                    emoji_name: reaction.emoji_name,
                     message_ids: new Set(),
                     current_user_reacted_message_ids: new Set(),
+                    ...metadata,
                 });
             }
-            const reaction = reaction_data.get(emoji_id);
-            assert(reaction !== undefined);
-            reaction.score += 1;
-            reaction.message_ids.add(message.id);
 
-            if (emoji.user_ids.includes(current_user.user_id)) {
-                reaction.score += CURRENT_USER_REACTION_WEIGHT - 1;
-                reaction.current_user_reacted_message_ids.add(message.id);
+            const usage = reaction_data.get(emoji_id);
+            assert(usage !== undefined);
+
+            usage.base_score += OTHER_USER_REACTION_WEIGHT;
+            usage.message_ids.add((message as Message).id);
+
+            if (reaction.user_ids.includes(current_user.user_id)) {
+                usage.base_score += CURRENT_USER_REACTION_WEIGHT - OTHER_USER_REACTION_WEIGHT;
+                usage.current_user_reacted_message_ids.add((message as Message).id);
             }
         }
     }
+
     update_frequently_used_emojis_list();
 }


### PR DESCRIPTION
I have tried to add weight as instructed.
I am new to open source, so if I make some mistake, please let me know. I shall work on that.

<!-- Describe your pull request here. -->
I added these private helper functions (not exported, internal use only):

get_builtin_emoji_bonus(emoji_code) - Returns 18 points if the emoji is one of the 6 built-in popular emojis, otherwise 0

get_custom_emoji_bonus(emoji_type, author_id, created_at) - Returns bonus for newly uploaded custom emoji (first week only): 30 points if you uploaded it, 10 points if someone else did

calculate_total_score(usage)—Combines base_score + bonuses to get total_score

calculate_rows_to_show(sorted_emojis) - Determines how many rows to display based on the score threshold (last emoji in row must have score >= 10)

get_custom_emoji_metadata(emoji_code, emoji_type) - Fetches author_id and created_at for custom emoji to calculate the new emoji bonus

I also modified the ReactionUsage type to include new fields:

base_score (was just score before)
bonus_score (new)
total_score (new)
author_id (new, for custom emoji)
created_at (new, for custom emoji)
The original type only had score, emoji_code, emoji_type, message_ids, and current_user_reacted_message_ids.
Fixes: <!-- Issue link, or clear description.--> https://github.com/zulip/zulip/issues/37134

**How changes were tested:**
   I just added some private functions, so I think it should not conflict with the internal ecosystem. 

