### PR TITLE
search: Avoid showing topic suggestions from negated channels.

### DIFF
--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -712,6 +712,17 @@ test("topic_suggestions", ({override, mock_template}) => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
+    suggestions = get_suggestions("topic:", `-channel:${office_id}`);
+    expected = [
+        `-channel:${office_id} topic:`,
+        `-channel:${office_id} channel:${devel_id} topic:REXX`,
+    ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    suggestions = get_suggestions("topic:", `-channel:${office_id} -channel:${devel_id}`);
+    expected = [`-channel:${office_id} -channel:${devel_id} topic:`];
+    assert.deepEqual(suggestions.strings, expected);
+
     suggestions = get_suggestions(`is:alerted channel:${devel_id} is:starred topic:`);
     expected = [
         `is:alerted channel:${devel_id} is:starred topic:`,


### PR DESCRIPTION
Fixes:
https://chat.zulip.org/#narrow/channel/9-issues/topic/topic.20search.20suggestions.20show.20topics.20from.20negated.20channels/with/2332600.

| Before | After |
|----|-----|
|<img width="840" height="142" alt="image" src="https://github.com/user-attachments/assets/d28a16ef-5341-4302-ab17-50b0a1829fd8" />| <img width="1133" height="258" alt="image" src="https://github.com/user-attachments/assets/eab22d67-1008-45e0-bdc2-92fc9dea597b" />|