### PR TITLE
Fixes #34885 :  Remove hard-coded width from channel privacy icon

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -756,7 +756,6 @@ input.settings_text_input {
     position: relative;
     top: 0.06rem;
     padding-right: 1px;
-    width: 12px;
 
     &.zulip-icon-globe,
     &.zulip-icon-archive,


### PR DESCRIPTION
This PR removes the hard-coded `width: 12px` from the `.channel-privacy-type-icon` CSS rule.

The fixed width was causing the privacy icon to overflow its bounding box at larger font sizes, leading to visual overlap with adjacent text. Removing this constraint allows the icon to size naturally and improves rendering consistency across font sizes.

This change is intended as a first incremental step toward improving inline channel name and icon rendering.

Fixes #34885

**How changes were tested:**
- Verified the CSS change locally by inspecting the updated styles.
- Ensured there are no layout regressions at default font sizes.
- Confirmed the icon renders correctly without overflow when font size is increased.

**Screenshots and screen captures:**
N/A — this change removes a CSS constraint and does not introduce new UI elements.


- [x] Self-reviewed the changes for clarity and maintainability.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

- [x] Visual appearance of the changes.
