### PR TITLE
user_profile: Show `stream-list-loader` only when fetching peer data.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -567,7 +567,7 @@ ul.popover-group-menu-member-list {
             margin-bottom: 8px;
         }
 
-        .stream-list-loader {
+        .stream-list-loader:not(:empty) {
             margin: 10px auto;
         }
 


### PR DESCRIPTION
When we are not fetching peer subscription data, the stream-list-loader takes up space even though it is empty because of its margin. This makes the already loaded stream list spill out of the container.

We apply margin only when `stream-list-loader` is not empty.

Fixes: zulip#37274.

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|Before|After|
|-|-|
|<img width="606" height="693" alt="Screenshot from 2025-12-23 22-21-43" src="https://github.com/user-attachments/assets/72d80298-51fa-4ab9-b1b4-6da28e20f08f" />|<img width="606" height="693" alt="Screenshot from 2025-12-23 22-20-45" src="https://github.com/user-attachments/assets/9ad8d38e-5240-438f-b248-1ca4a1593766" />|


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
