### PR TITLE
markdown: Render invalid timestamps as plain text.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 451**
+
+* [Message formatting](/api/message-formatting): Changed the
+rendering of invalid timestamps from a `<span class="timestamp-error">`
+element to plain escaped text.
+
 **Feature level 450**
 
 * [`GET /events`](/api/get-events): The `push_device` events now

--- a/api_docs/message-formatting.md
+++ b/api_docs/message-formatting.md
@@ -19,6 +19,19 @@ for syntax highlighting. This field is used in the
 
 ## Global times
 
+**Changes**: In Zulip 12.0 (feature level 451), invalid timestamp formats
+are now rendered as escaped literal text instead of a `<span>` element with
+`timestamp-error` class and an error message.
+
+Previously, an invalid timestamp string would be rendered as:
+``` html
+<span class="timestamp-error">Invalid time format: invalid</span>
+```
+Now, it is rendered as:
+``` html
+&lt;time:invalid&gt;
+```
+
 **Changes**: In Zulip 3.0 (feature level 8), added [global time
 mentions][help-global-time] to supported Markdown message formatting
 features.

--- a/version.py
+++ b/version.py
@@ -35,7 +35,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 450
+API_FEATURE_LEVEL = 451
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -289,7 +289,8 @@ export const update_elements = ($content: JQuery): void => {
             blueslip.error("Could not parse datetime supplied by backend", {time_str});
         }
     });
-
+    // Maintains backward compatibility for legacy 'timestamp-error' spans.
+    // The server no longer generates this markup, but older records may still contain it.
     $content.find("span.timestamp-error").each(function (): void {
         const match_array = /^Invalid time format: (.*)$/.exec($(this).text());
         assert(match_array !== null);

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1226,7 +1226,7 @@ class CompiledInlineProcessor(markdown.inlinepatterns.InlineProcessor):
 
 class Timestamp(markdown.inlinepatterns.Pattern):
     @override
-    def handleMatch(self, match: Match[str]) -> Element | None:
+    def handleMatch(self, match: Match[str]) -> Element | str:
         time_input_string = match.group("time")
         try:
             timestamp = dateutil.parser.parse(time_input_string, tzinfos=common_timezones)
@@ -1237,12 +1237,7 @@ class Timestamp(markdown.inlinepatterns.Pattern):
                 timestamp = None
 
         if not timestamp:
-            error_element = Element("span")
-            error_element.set("class", "timestamp-error")
-            error_element.text = markdown.util.AtomicString(
-                f"Invalid time format: {time_input_string}"
-            )
-            return error_element
+            return f"&lt;time:{time_input_string}&gt;"
 
         # Use HTML5 <time> element for valid timestamps.
         time_element = Element("time")
@@ -1250,12 +1245,7 @@ class Timestamp(markdown.inlinepatterns.Pattern):
             try:
                 timestamp = timestamp.astimezone(timezone.utc)
             except (ValueError, OverflowError):
-                error_element = Element("span")
-                error_element.set("class", "timestamp-error")
-                error_element.text = markdown.util.AtomicString(
-                    f"Invalid time format: {time_input_string}"
-                )
-                return error_element
+                return f"&lt;time:{time_input_string}&gt;"
         else:
             timestamp = timestamp.replace(tzinfo=timezone.utc)
         time_element.set("datetime", timestamp.isoformat().replace("+00:00", "Z"))

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -826,9 +826,9 @@
     {
       "name": "timestamp_invalid_input",
       "input": "<time:<alert(1)>>",
-      "expected_output": "<p><span class=\"timestamp-error\">Invalid time format: &lt;alert(1)</span>&gt;</p>",
+      "expected_output": "<p>&lt;time:&lt;alert(1)&gt;&gt;</p>",
       "marked_expected_output": "<p><span>&lt;alert(1)</span>&gt;</p>",
-      "text_content": "Invalid time format: <alert(1)>"
+      "text_content": "<time:<alert(1)>>"
     },
     {
       "name": "timestamp_timezone",
@@ -840,23 +840,23 @@
     {
       "name": "timestamp_incorrect",
       "input": "<time:**hello world**>",
-      "expected_output": "<p><span class=\"timestamp-error\">Invalid time format: **hello world**</span></p>",
+      "expected_output": "<p>&lt;time:**hello world**&gt;</p>",
       "marked_expected_output": "<p><span>**hello world**</span></p>",
-      "text_content": "Invalid time format: **hello world**"
+      "text_content": "<time:**hello world**>"
     },
     {
       "name": "timestamp_invalid_timezone",
       "input": "<time:1969-12-31T00:00:00+32:00>",
-      "expected_output": "<p><span class=\"timestamp-error\">Invalid time format: 1969-12-31T00:00:00+32:00</span></p>",
+      "expected_output": "<p>&lt;time:1969-12-31T00:00:00+32:00&gt;</p>",
       "marked_expected_output": "<p><span>1969-12-31T00:00:00+32:00</span></p>",
-      "text_content": "Invalid time format: 1969-12-31T00:00:00+32:00"
+      "text_content": "<time:1969-12-31T00:00:00+32:00>"
     },
     {
       "name": "timestamp_overflow",
       "input": "<time:0001-01-01T01:00:00+02:00>",
-      "expected_output": "<p><span class=\"timestamp-error\">Invalid time format: 0001-01-01T01:00:00+02:00</span></p>",
+      "expected_output": "<p>&lt;time:0001-01-01T01:00:00+02:00&gt;</p>",
       "marked_expected_output": "<p><span>0001-01-01T01:00:00+02:00</span></p>",
-      "text_content": "Invalid time format: 0001-01-01T01:00:00+02:00"
+      "text_content": "<time:0001-01-01T01:00:00+02:00>"
     },
     {
       "name": "timestamp_unix",
@@ -867,9 +867,9 @@
     {
       "name": "timestamp_unix_overflow",
       "input": "Let's meet at <time:1234567890123>.",
-      "expected_output": "<p>Let's meet at <span class=\"timestamp-error\">Invalid time format: 1234567890123</span>.</p>",
+      "expected_output": "<p>Let's meet at &lt;time:1234567890123&gt;.</p>",
       "marked_expected_output": "<p>Let's meet at <time datetime=\"+041091-11-25T05:02:03Z\">1234567890123</time>.</p>",
-      "text_content": "Let's meet at Invalid time format: 1234567890123."
+      "text_content": "Let's meet at <time:1234567890123>."
     },
     {
       "name": "tex_inline",


### PR DESCRIPTION
### Summary

Previously, invalid timestamps (e.g. `<time:invalid>`) were rendered as
`<span class="timestamp-error">` elements. This resulted in error-style
UI output for what are often simple user typos.

This PR changes the behavior to render these invalid inputs as **plain text** (escaped), effectively treating them as unknown Markdown.

### Changes

* **Backend:** Updated `zerver/lib/markdown/__init__.py` to treat invalid timestamps (including natural language dates) as plain text, returning escaped content instead of `timestamp-error` spans.
* **Tests:** Update Markdown fixtures to reflect the new rendering behavior.
* **Docs:** Bumped API feature level to 448 and updated `message-formatting.md`.
* **Legacy:** Preserved backward compatibility for existing `timestamp-error` spans.


**Screenshots**

| Before (Error Span) | After (Plain Text) |
| --- | --- |
| <img width="517" height="46" alt="image" src="https://github.com/user-attachments/assets/aa7753e1-6284-4029-9115-f6bac4e75b5c" /> | <img width="492" height="94" alt="Screenshot 2025-12-24 024108" src="https://github.com/user-attachments/assets/0750fd04-f537-43e6-9d22-a6ea0c410b8d" /> |

### Relationship to other PRs

I implemented this PR from scratch to ensure a clean solution, having reviewed the prior attempts listed on the issue:

* **#36387 (aakarsh-2004):** This PR has been inactive for over a month and currently has unresolved merge conflicts. It also received feedback regarding API documentation and timestamp parsing logic that I have addressed here.

* **#36399 (harsh-791):** Work on this PR appears to have paused in November, with failing CI checks that were not resolved.

* **#36750 (Drishtipixiee):** This PR was closed by maintainers.

This PR takes a fresh approach that aligns backend rendering, tests, and API documentation, while preserving backward compatibility for previously rendered messages.

**Fixes**

Fixes #36374.


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

