### PR TITLE
settings: Use different header prefix for personal and org type.

### DIFF
--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -148,7 +148,7 @@
     </div>
     <div class="content-wrapper right">
         <div class="settings-header">
-            <h1>{{t "Settings" }}<span class="section"></span></h1>
+            <h1><span class="header-prefix"></span><span class="section"></span></h1>
             <div class="exit">
                 <span class="exit-sign">&times;</span>
             </div>


### PR DESCRIPTION
Before 3d5ed79c894, we had two different header prefix for personal and organization settings on the settings overlay, i.e. the header was "PERSONAL SETTINGS / PROFILE" for "Profile" panel and "ORGANIZATION SETTINGS / ORGANIZATION PROFILE" for "Organization Profile" panel.

In 3d5ed79c894, it was unintentionally changed to use "Settings" for both type of settings, i.e. it was "SETTINGS / PROFILE" for "Profile" panel and  "SETTINGS / ORGANIZATION PROFILE" for "Organization Profile" panel, so this PR reverts that change and we have now separate header prefix for both type of settings like before.

There is no change in header for narrow screens when only single column is used where we used "Settings" as header prefix before 3d5ed79c894 as well.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
| ------ | ------ |
|<img width="1262" height="502" alt="image" src="https://github.com/user-attachments/assets/a5cba1ef-9da9-410a-a3e9-d49388c82d91" /> | <img width="1262" height="502" alt="image" src="https://github.com/user-attachments/assets/2422dfb9-059e-48cc-ba03-b78863d99f91" /> |
|<img width="1262" height="502" alt="image" src="https://github.com/user-attachments/assets/875d57d5-a248-43b7-a0d5-c939d171fcf1" /> | <img width="1262" height="502" alt="image" src="https://github.com/user-attachments/assets/8cfd72ed-be4e-49ab-b135-990cc5ddbd05" /> |
| <img width="748" height="493" alt="image" src="https://github.com/user-attachments/assets/bcb8f35d-ad13-4c8a-aa52-abdb0dec939a" /> |<img width="748" height="493" alt="image" src="https://github.com/user-attachments/assets/489b223f-e6f9-4de3-b79d-a8009ef32501" /> |
|<img width="748" height="493" alt="image" src="https://github.com/user-attachments/assets/027793f1-9aca-4a26-af07-f86a705f9785" /> |<img width="748" height="493" alt="image" src="https://github.com/user-attachments/assets/7097fc1b-9ee0-4342-86bd-7f9e4c5c9ccb" /> |
|<img width="748" height="493" alt="image" src="https://github.com/user-attachments/assets/4b529b1c-ca5c-4ace-bfb5-fe4ed137d760" /> |<img width="748" height="493" alt="image" src="https://github.com/user-attachments/assets/04a047eb-e577-498a-9810-844456265ca0" /> |





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
