### PR TITLE
inbox_ui: Update empty state text for "followed topics" filter.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1038,8 +1038,20 @@ function show_empty_inbox_text(has_visible_unreads: boolean): void {
             $("#inbox-empty-without-search").hide();
         } else {
             $("#inbox-empty-with-search").hide();
-            // Use display value specified in CSS.
+
+            // Undo .hide() by returning to display value specified in CSS.
             $("#inbox-empty-without-search").css("display", "");
+
+            // Check if current filter is "followed topics" so that we
+            // can show the appropriate empty view message.
+            const is_followed_filter_selected = filters.has(views_util.FILTERS.FOLLOWED_TOPICS);
+            if (is_followed_filter_selected) {
+                $(".inbox-empty-action-default").hide();
+                $(".inbox-empty-action-filtered").show();
+            } else {
+                $(".inbox-empty-action-default").show();
+                $(".inbox-empty-action-filtered").hide();
+            }
         }
     } else {
         $(".inbox-empty-text").hide();
@@ -2436,6 +2448,14 @@ export function initialize({hide_other_views}: {hide_other_views: () => void}): 
             const $elt = $(e.currentTarget);
             $elt.trigger("click");
         }
+    });
+
+    $("body").on("click", ".inbox-toggle-followed-filter", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        filters.delete(views_util.FILTERS.FOLLOWED_TOPICS);
+        save_data_to_ls();
+        complete_rerender();
     });
 
     $(document).on("compose_canceled.zulip", () => {

--- a/web/templates/inbox_view/inbox_no_unreads.hbs
+++ b/web/templates/inbox_view/inbox_no_unreads.hbs
@@ -3,9 +3,16 @@
     <div class="inbox-empty-title">
         {{t "There are no unread messages in your inbox."}}
     </div>
-    <div class="inbox-empty-action">
+    <div class="inbox-empty-action inbox-empty-action-default">
         {{#tr}}
             You might be interested in <z-link>recent conversations</z-link>.
+            {{#*inline "z-link"}}<a class="inbox-empty-action-link" href="#recent">{{> @partial-block}}</a>{{/inline}}
+        {{/tr}}
+    </div>
+    <div class="inbox-empty-action inbox-empty-action-filtered">
+        {{#tr}}
+            You can <z-link-unfollowed>include topics you don't follow</z-link-unfollowed> or <z-link>view recent conversations</z-link>.
+            {{#*inline "z-link-unfollowed"}}<a class="inbox-empty-action-link inbox-toggle-followed-filter">{{> @partial-block}}</a>{{/inline}}
             {{#*inline "z-link"}}<a class="inbox-empty-action-link" href="#recent">{{> @partial-block}}</a>{{/inline}}
         {{/tr}}
     </div>


### PR DESCRIPTION
This PR updates the empty state text when the "followed topics" filter is selected.

Previously for all of the fileters state a generic message - "You might be interested in recent conversations.", was displayed. 

Now, when the "followed topics" filter is selected a custom message: "You can include topics you don't follow or view recent conversations." is displayed. Wherein,
"include topics you don't follow" - programmatically changes the filter state to standard view 
"view recent conversations" - redirects the user to recents conversations page

It does so by:
- adding a new `inbox-empty-action` in `inbox_no_unreads.hbs` which is conditionally displayed from `inbox_ui.ts`.
- a new event handler is added to this new `inbox-empty-action` which changes the state of filter to "standard view"
Thus solving the issue.

The previous plan by hobzz2 did not use `inbox_no_unreads.hbs` and rather added the text via js which was pointer out by the maintainers.

Fixes: #36958

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="1463" height="751" alt="Screenshot 2025-12-23 at 10 34 18 AM" src="https://github.com/user-attachments/assets/81286391-e5d4-4cff-841f-eb196665a3d6" />
<img width="1467" height="747" alt="Screenshot 2025-12-23 at 10 35 04 AM" src="https://github.com/user-attachments/assets/4d39702b-c662-4f5a-81c7-ad16be949a7b" />
https://github.com/user-attachments/assets/7d189bd5-dafb-43d9-9695-b44820ed6960


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ x] Explains differences from previous plans (e.g., issue description).
- [ x] Highlights technical choices and bugs encountered.
- [ x] Calls out remaining decisions and concerns.
- [ x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ x] Each commit is a coherent idea.
- [ x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ x] Visual appearance of the changes.
- [ x] Responsiveness and internationalization.
- [ x] Strings and tooltips.
- [ x] End-to-end functionality of buttons, interactions and flows.
- [ x] Corner cases, error conditions, and easily imagined bugs.
</details>
