### PR TITLE
peer_data: Keep track of users that have complete subscription data.

### DIFF
--- a/api_docs/unmerged.d/ZF-0c83b4.md
+++ b/api_docs/unmerged.d/ZF-0c83b4.md
@@ -1,0 +1,2 @@
+* * [`POST /register`](/api/register-queue): Added `users_with_complete_subscription_data`
+    to reduce the need for fetching subscriber data when partial subscriber data is present.

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -629,6 +629,7 @@ export const split_state_data_schema = z.object({
         subscriptions: z.array(api_stream_subscription_schema),
         unsubscribed: z.array(api_stream_subscription_schema),
         never_subscribed: z.array(never_subscribed_stream_schema),
+        users_with_complete_subscription_data: z.array(z.number()),
         realm_default_streams: z.array(z.number()),
     }),
     user_groups: z.object({realm_user_groups: z.array(raw_user_group_schema)}),

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -403,7 +403,7 @@ export function get_fetched_streams_for_user(user_id: number): {
     subscribed: StreamSubscription[];
     can_subscribe: StreamSubscription[];
 } {
-    assert(peer_data.subscriber_data_loaded_for_user(user_id));
+    assert(peer_data.subscription_data_loaded_for_user(user_id));
     // Note that we only have access to subscribers of some streams
     // depending on our role.
     const all_subs = get_unsorted_subs();
@@ -1236,6 +1236,7 @@ export function initialize(params: StateData["stream_data"]): void {
     const subscriptions = params.subscriptions;
     const unsubscribed = params.unsubscribed;
     const never_subscribed = params.never_subscribed;
+    const users_with_complete_subscription_data = params.users_with_complete_subscription_data;
     const realm_default_streams = params.realm_default_streams;
 
     /*
@@ -1263,6 +1264,7 @@ export function initialize(params: StateData["stream_data"]): void {
     populate_subscriptions(subscriptions, true, true);
     populate_subscriptions(unsubscribed, false, true);
     populate_subscriptions(never_subscribed, false, false);
+    peer_data.mark_users_with_subscription_data_loaded(users_with_complete_subscription_data);
 }
 
 export function remove_default_stream(stream_id: number): void {

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -340,7 +340,7 @@ function format_user_group_list_item_html(group: UserGroup, user: User): string 
 }
 
 async function render_or_update_user_streams_tab(user: User): Promise<void> {
-    if (!peer_data.subscriber_data_loaded_for_user(user.user_id)) {
+    if (!peer_data.subscription_data_loaded_for_user(user.user_id)) {
         $("#user-profile-streams-tab .stream-list-bottom-section").hide();
         loading.make_indicator($(".stream-list-loader"), {
             height: 56, // 4em at 14px / 1em

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -1366,6 +1366,8 @@ test("initialize", ({override}) => {
                 },
             ],
 
+            users_with_complete_subscription_data: [],
+
             realm_default_streams: [],
         };
     }

--- a/zerver/lib/subscription_info.py
+++ b/zerver/lib/subscription_info.py
@@ -179,6 +179,7 @@ def get_web_public_subs(
         subscriptions=subscribed,
         unsubscribed=[],
         never_subscribed=[],
+        users_with_complete_subscription_data=[],
     )
 
 
@@ -1004,6 +1005,8 @@ def gather_subscriptions_helper(
         subscriptions=subscribed,
         unsubscribed=unsubscribed,
         never_subscribed=never_subscribed,
+        # TODO(evy): populate this
+        users_with_complete_subscription_data=[],
     )
 
 

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -356,6 +356,7 @@ class SubscriptionInfo:
     subscriptions: list[SubscriptionStreamDict]
     unsubscribed: list[SubscriptionStreamDict]
     never_subscribed: list[NeverSubscribedStreamDict]
+    users_with_complete_subscription_data: list[int]
 
 
 class RealmPlaygroundDict(TypedDict):

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17452,6 +17452,19 @@ paths:
                           in `can_administer_channel_group` of a channel that they never
                           subscribed to, but not an organization administrator, the channel
                           in question would not be part of this array.
+                      users_with_complete_subscription_data:
+                        type: array
+                        items:
+                          type: integer
+                        description: |
+                          If [`include_subscribers="partial"`](/api/get-subscriptions#parameter-include_subscribers)
+                          was requested, the server may, at its discretion, send a
+                          `partial_subscribers` list rather than a `subscribers` list
+                          for channels with a large number of subscribers. But for users
+                          in this list, we can guarantee that all of their subscriptions
+                          are represented in the supplied subscriber data in this request.
+
+                          **Changes**: New in Zulip 11.0 (feature level ZF-0c83b4).
                       channel_folders:
                         type: array
                         items:


### PR DESCRIPTION
Now that we can send partial subscriber data, it could be helpful to keep track of the users for which we expect we have a complete subscriber matrix, since some views like the user profile subscribers view can avoid doing a fetch to the server for that data if it was already fetched on page load. 

Discussed here: [#api design > trimming subscriber data #34244 @ 💬](https://chat.zulip.org/#narrow/channel/378-api-design/topic/trimming.20subscriber.20data.20.2334244/near/2328486)