### PR TITLE
Fix extra gap and outer scrollbar in subscribers list on channel sett…

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -163,7 +163,10 @@ h4.user_group_setting_subsection_title {
     display: flex;
     align-items: center;
     margin: auto;
-    margin-top: 100px;
+
+    &:not(:empty) {
+        margin-top: 100px;
+    }
 }
 
 #people_to_add_in_group,


### PR DESCRIPTION
This PR fixes the extra bottom gap below nested scrollbar in the channel settings subscribers list, and aligns the layout with the group settings modal’s members section for visual consistency.

The issue was caused by an unnecessary top margin on the loading state that introduced an extra gap at bottom .

**Fixes:** Extra gap below inner scrollbar in subscribers list (reported in the issues section on Zulip chat: [link](https://chat.zulip.org/#narrow/channel/9-issues/topic/Extra.20gap.20after.20subscribers.20list/with/2333797))

**Before**
<img width="1896" height="922" alt="Screenshot (73)" src="https://github.com/user-attachments/assets/45e98d55-aed4-47c8-9e48-91c14bd8f312" />



 - Extra bottom gap visible
 - Nested scrollbar inside the modal


**After**
<img width="1920" height="926" alt="Screenshot (100)" src="https://github.com/user-attachments/assets/664019d2-9792-4a57-9b15-6b730190b64d" />





- Gap removed
- Layout matches other group settings 


## Self-review checklist

* [x] Self-reviewed the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
* [x] Communicated decisions, questions, and potential concerns (e.g., JS height behavior for bottom space).
* [x] Individual commits are ready for review:
  * Commit history follows Zulip commit guidelines.
  * Commit message explains reasoning and motivation for changes.
* [x] Completed manual review and testing of the following:
  * Visual appearance of the changes (including before/after screenshots).
  * Responsiveness and internationalization (if applicable).
  * Strings and tooltips (not applicable for this UI change).
  * End-to-end functionality of buttons, interactions and flows.
  * Corner cases, error conditions, and easily imagined bugs.
