### PR TITLE
settings: Full and New members in organization settings.

### DIFF
--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -436,6 +436,31 @@ export function get_user_time(user_id: number): string | undefined {
     return undefined;
 }
 
+export function get_effective_role_code(user_id: number): number {
+    const user_profile = get_by_user_id(user_id);
+    const account_age = Date.now() - new Date(user_profile.date_joined).getTime();
+    const waiting_period_time = realm.realm_waiting_period_threshold * 24 * 60 * 60 * 1000;
+
+    return account_age < waiting_period_time
+        ? settings_config.user_role_values_with_provisional_member.provisional_member.code
+        : settings_config.user_role_values_with_provisional_member.full_member.code;
+}
+
+export function get_user_type_with_waiting_period(user_id: number): string | undefined {
+    const user_profile = get_by_user_id(user_id);
+
+    if (
+        realm.realm_waiting_period_threshold === 0 ||
+        user_profile.role !== settings_config.user_role_values.member.code
+    ) {
+        return settings_config.user_role_map.get(user_profile.role);
+    }
+
+    const role_code = get_effective_role_code(user_id);
+
+    return settings_config.user_role_map_with_provisional_member.get(role_code);
+}
+
 export function get_user_type(user_id: number): string | undefined {
     const user_profile = get_by_user_id(user_id);
     return settings_config.user_role_map.get(user_profile.role);
@@ -1819,7 +1844,16 @@ export function matches_user_settings_search(person: User, value: string): boole
 }
 
 function matches_user_settings_role(person: User, role_code: number): boolean {
-    if (role_code === 0 || role_code === person.role) {
+    let user_role_code = person.role;
+
+    if (
+        person.role === settings_config.user_role_values.member.code &&
+        realm.realm_waiting_period_threshold > 0
+    ) {
+        user_role_code = get_effective_role_code(person.user_id);
+    }
+
+    if (role_code === 0 || role_code === user_role_code) {
         return true;
     }
     return false;

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -473,6 +473,36 @@ export const user_role_values: Record<
     },
 };
 
+export const user_role_values_with_provisional_member: Record<
+    "guest" | "provisional_member" | "full_member" | "moderator" | "admin" | "owner",
+    SettingDescription<number>
+> = {
+    guest: {
+        code: 600,
+        description: $t({defaultMessage: "Guest"}),
+    },
+    provisional_member: {
+        code: 401,
+        description: $t({defaultMessage: "New member"}),
+    },
+    full_member: {
+        code: 402,
+        description: $t({defaultMessage: "Full member"}),
+    },
+    moderator: {
+        code: 300,
+        description: $t({defaultMessage: "Moderator"}),
+    },
+    admin: {
+        code: 200,
+        description: $t({defaultMessage: "Administrator"}),
+    },
+    owner: {
+        code: 100,
+        description: $t({defaultMessage: "Owner"}),
+    },
+};
+
 // When org_type was added to the database model, 'unspecified'
 // was the default for existing organizations. To discourage
 // organizations keeping (or selecting) it as an option, we
@@ -493,6 +523,10 @@ export const all_org_type_values: Record<
     | "other",
     SettingDescription<number>
 > = {
+    // When org_type was added to the database model, 'unspecified'
+    // was the default for existing organizations. To discourage
+    // organizations keeping (or selecting) it as an option, we
+    // use an empty string for its description.
     unspecified: {
         code: 0,
         description: "",
@@ -664,6 +698,13 @@ export const realm_deletion_in_values = {
 
 const user_role_array = Object.values(user_role_values);
 export const user_role_map = new Map(user_role_array.map((role) => [role.code, role.description]));
+
+const user_role_with_provisional_member_array = Object.values(
+    user_role_values_with_provisional_member,
+);
+export const user_role_map_with_provisional_member = new Map(
+    user_role_with_provisional_member_array.map((role) => [role.code, role.description]),
+);
 
 export const preferences_settings_labels = {
     default_language_settings_label: $t({defaultMessage: "Language"}),

--- a/web/src/settings_users.ts
+++ b/web/src/settings_users.ts
@@ -21,7 +21,7 @@ import * as presence from "./presence.ts";
 import * as scroll_util from "./scroll_util.ts";
 import * as settings_config from "./settings_config.ts";
 import * as setting_invites from "./settings_invites.ts";
-import {current_user} from "./state_data.ts";
+import {current_user, realm} from "./state_data.ts";
 import * as timerender from "./timerender.ts";
 import * as user_deactivation_ui from "./user_deactivation_ui.ts";
 import * as user_profile from "./user_profile.ts";
@@ -255,7 +255,14 @@ function count_users_by_role(user_ids: number[]): Record<number, number> {
 
     for (const user_id of user_ids) {
         const user = people.get_by_user_id(user_id);
-        const role_code = user.role;
+        let role_code = user.role;
+
+        if (
+            realm.realm_waiting_period_threshold > 0 &&
+            role_code === settings_config.user_role_values.member.code
+        ) {
+            role_code = people.get_effective_role_code(user_id);
+        }
 
         role_counts[role_code] = (role_counts[role_code] ?? 0) + 1;
     }
@@ -265,12 +272,17 @@ function count_users_by_role(user_ids: number[]): Record<number, number> {
 
 function get_roles_with_counts(user_ids: number[]): dropdown_widget.Option[] {
     const role_counts = count_users_by_role(user_ids);
+    const waiting_period = realm.realm_waiting_period_threshold ?? 0;
+    const roles_to_show =
+        waiting_period === 0
+            ? Object.values(settings_config.user_role_values)
+            : Object.values(settings_config.user_role_values_with_provisional_member);
     return [
         {
             unique_id: 0,
             name: $t({defaultMessage: "All roles ({count})"}, {count: user_ids.length}),
         },
-        ...Object.values(settings_config.user_role_values)
+        ...roles_to_show
             .map((user_role_value) => ({
                 unique_id: user_role_value.code,
                 name: $t(
@@ -411,7 +423,7 @@ function human_info(person: User): {
 } {
     return {
         is_bot: false,
-        user_role_text: people.get_user_type(person.user_id),
+        user_role_text: people.get_user_type_with_waiting_period(person.user_id),
         is_active: people.is_person_active(person.user_id),
         user_id: person.user_id,
         full_name: person.full_name,

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -713,6 +713,79 @@ run_test("user_type", () => {
     assert.equal(people.get_user_type(realm_owner.user_id), $t({defaultMessage: "Owner"}));
     assert.equal(people.get_user_type(moderator.user_id), $t({defaultMessage: "Moderator"}));
     assert.equal(people.get_user_type(bot_botson.user_id), $t({defaultMessage: "Moderator"}));
+
+    const original_threshold = realm.realm_waiting_period_threshold;
+
+    realm.realm_waiting_period_threshold = 0;
+    assert.equal(
+        people.get_user_type_with_waiting_period(me.user_id),
+        $t({defaultMessage: "Member"}),
+    );
+
+    realm.realm_waiting_period_threshold = 3;
+    const alex = {
+        email: "alex@example.com",
+        user_id: 101,
+        full_name: "alex",
+        timezone: "America/Los_Angeles",
+        role: 400,
+        date_joined: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+    people.add_active_user(alex);
+    assert.equal(
+        people.get_user_type_with_waiting_period(alex.user_id),
+        $t({defaultMessage: "New member"}),
+    );
+
+    const john = {
+        email: "john@example.com",
+        user_id: 102,
+        full_name: "john",
+        timezone: "America/Los_Angeles",
+        role: 400,
+        date_joined: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+    people.add_active_user(john);
+    assert.equal(
+        people.get_user_type_with_waiting_period(john.user_id),
+        $t({defaultMessage: "Full member"}),
+    );
+
+    me.date_joined = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    assert.equal(
+        people.get_user_type_with_waiting_period(me.user_id),
+        $t({defaultMessage: "Full member"}),
+    );
+
+    realm_admin.date_joined = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    assert.equal(
+        people.get_user_type_with_waiting_period(realm_admin.user_id),
+        $t({defaultMessage: "Administrator"}),
+    );
+
+    guest.date_joined = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    assert.equal(
+        people.get_user_type_with_waiting_period(guest.user_id),
+        $t({defaultMessage: "Guest"}),
+    );
+
+    realm_owner.date_joined = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    assert.equal(
+        people.get_user_type_with_waiting_period(realm_owner.user_id),
+        $t({defaultMessage: "Owner"}),
+    );
+
+    moderator.date_joined = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    assert.equal(
+        people.get_user_type_with_waiting_period(moderator.user_id),
+        $t({defaultMessage: "Moderator"}),
+    );
+    delete me.date_joined;
+    delete realm_admin.date_joined;
+    delete guest.date_joined;
+    delete realm_owner.date_joined;
+    delete moderator.date_joined;
+    realm.realm_waiting_period_threshold = original_threshold;
 });
 
 run_test("updates", () => {
@@ -1493,6 +1566,130 @@ run_test("predicate_for_user_settings_filters", ({override}) => {
         people.predicate_for_user_settings_filters(fred_smith, {text_search: "de", role_code: 300}),
         false,
     );
+
+    const original_threshold = realm.realm_waiting_period_threshold;
+    realm.realm_waiting_period_threshold = 3;
+
+    const alex = {
+        email: "alex@example.com",
+        user_id: 304,
+        full_name: "alex",
+        timezone: "America/Los_Angeles",
+        is_admin: false,
+        is_guest: false,
+        is_moderator: false,
+        is_bot: false,
+        role: 400,
+        date_joined: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+    people.add_active_user(alex);
+    // `text_search` is true, role_code is false
+    assert.equal(
+        people.predicate_for_user_settings_filters(alex, {text_search: "al", role_code: 0}),
+        true,
+    );
+    // `text_search` is false, role_code is true
+    assert.equal(
+        people.predicate_for_user_settings_filters(alex, {text_search: "", role_code: 401}),
+        true,
+    );
+    // Both `text_search` and role_code are true
+    assert.equal(
+        people.predicate_for_user_settings_filters(alex, {text_search: "alex", role_code: 401}),
+        true,
+    );
+    // Test only when `text_search` filter is false.
+    assert.equal(
+        people.predicate_for_user_settings_filters(alex, {text_search: "hm", role_code: 0}),
+        false,
+    );
+    // Test only when role_code filter is false.
+    assert.equal(
+        people.predicate_for_user_settings_filters(alex, {text_search: "", role_code: 200}),
+        false,
+    );
+
+    const john = {
+        email: "john@example.com",
+        user_id: 404,
+        full_name: "john",
+        role: 400,
+        date_joined: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+    people.add_active_user(john);
+    // `text_search` is true, role_code is false
+    assert.equal(
+        people.predicate_for_user_settings_filters(john, {text_search: "jo", role_code: 0}),
+        true,
+    );
+    // `text_search` is false, role_code is true
+    assert.equal(
+        people.predicate_for_user_settings_filters(john, {text_search: "", role_code: 402}),
+        true,
+    );
+    // Both `text_search` and role_code are true
+    assert.equal(
+        people.predicate_for_user_settings_filters(john, {text_search: "joh", role_code: 402}),
+        true,
+    );
+    // Test only when `text_search` filter is false.
+    assert.equal(
+        people.predicate_for_user_settings_filters(john, {text_search: "hm", role_code: 0}),
+        false,
+    );
+    // Test only when role_code filter is false.
+    assert.equal(
+        people.predicate_for_user_settings_filters(john, {text_search: "", role_code: 200}),
+        false,
+    );
+
+    john.date_joined = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+
+    // `text_search` is true, role_code is false
+    assert.equal(
+        people.predicate_for_user_settings_filters(john, {text_search: "jo", role_code: 0}),
+        true,
+    );
+    // `text_search` is false, role_code is true
+    assert.equal(
+        people.predicate_for_user_settings_filters(john, {text_search: "", role_code: 402}),
+        true,
+    );
+    // Both `text_search` and role_code are true
+    assert.equal(
+        people.predicate_for_user_settings_filters(john, {text_search: "joh", role_code: 402}),
+        true,
+    );
+    // Test only when `text_search` filter is false.
+    assert.equal(
+        people.predicate_for_user_settings_filters(john, {text_search: "hm", role_code: 0}),
+        false,
+    );
+    // Test only when role_code filter is false.
+    assert.equal(
+        people.predicate_for_user_settings_filters(john, {text_search: "", role_code: 200}),
+        false,
+    );
+
+    realm.realm_waiting_period_threshold = 0;
+
+    // To check if no waiting period users are treated as members
+    assert.equal(
+        people.predicate_for_user_settings_filters(alex, {
+            text_search: "",
+            role_code: 401,
+        }),
+        false,
+    );
+    assert.equal(
+        people.predicate_for_user_settings_filters(john, {
+            text_search: "",
+            role_code: 402,
+        }),
+        false,
+    );
+
+    realm.realm_waiting_period_threshold = original_threshold;
 });
 
 run_test("matches_user_settings_search", ({override}) => {


### PR DESCRIPTION
Changes distinguish full and new member in admin/org settings under Users tab when waiting period configured. this improves user experience and helps to identify new and full members and avoid just using members.

<!-- Describe your pull request here.-->

Fixes: #16040 ,  #16134 (Older-PR)

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Default (No waiting period) | New Member filter | Full Member filter |
|-----------------------------|------------------|--------------------|
| ![](https://github.com/user-attachments/assets/25e8390d-65d0-4e11-b3ff-3092c45a8957) | ![](https://github.com/user-attachments/assets/30389176-2e1b-4b05-9fde-67b225b836be) | ![](https://github.com/user-attachments/assets/473e451c-6784-417b-8536-78ac9b53191f) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
