### PR TITLE
integrations/gitlab: Add force-push support for GitLab webhook.

### DIFF
--- a/zerver/webhooks/gitlab/fixtures/push_hook__force_push.json
+++ b/zerver/webhooks/gitlab/fixtures/push_hook__force_push.json
@@ -1,0 +1,81 @@
+{
+   "object_kind":"push",
+   "event_name":"push",
+   "forced": true,
+   "before":"5fcdd5551fc3085df79bece2c32b1400802ac407",
+   "after":"eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9",
+   "ref":"refs/heads/tomek",
+   "checkout_sha":"eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9",
+   "message":null,
+   "user_id":670043,
+   "user_name":"Tomasz Kolek",
+   "user_email":"tomaszkolek0@gmail.com",
+   "user_avatar":"https://secure.gravatar.com/avatar/116a6fdbcfd00466297a39174da11fbb?s=80\u0026d=identicon",
+   "project_id":1534233,
+   "project":{
+      "name":"my-awesome-project",
+      "description":"",
+      "web_url":"https://gitlab.com/tomaszkolek0/my-awesome-project",
+      "avatar_url":null,
+      "git_ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
+      "git_http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git",
+      "namespace":"tomaszkolek0",
+      "visibility_level":0,
+      "path_with_namespace":"tomaszkolek0/my-awesome-project",
+      "default_branch":"master",
+      "homepage":"https://gitlab.com/tomaszkolek0/my-awesome-project",
+      "url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
+      "ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
+      "http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git"
+   },
+   "commits":[
+      {
+         "id":"66abd2da28809ffa128ed0447965cf11d7f863a7",
+         "message":"b\n",
+         "timestamp":"2016-08-17T21:17:54+02:00",
+         "url":"https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7",
+         "author":{
+            "name":"Tomasz Kolek",
+            "email":"tomasz-kolek@o2.pl"
+         },
+         "added":[
+
+         ],
+         "modified":[
+            "a.txt"
+         ],
+         "removed":[
+
+         ]
+      },
+      {
+         "id":"eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9",
+         "message":"c\n",
+         "timestamp":"2016-08-17T21:18:06+02:00",
+         "url":"https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9",
+         "author":{
+            "name":"Tomasz Kolek",
+            "email":"tomasz-kolek@o2.pl"
+         },
+         "added":[
+
+         ],
+         "modified":[
+            "a.txt"
+         ],
+         "removed":[
+
+         ]
+      }
+   ],
+   "total_commits_count":2,
+   "repository":{
+      "name":"my-awesome-project",
+      "url":"git@gitlab.com:tomaszkolek/my-awesome-project.git",
+      "description":"",
+      "homepage":"https://gitlab.com/tomaszkolek0/my-awesome-project",
+      "git_http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git",
+      "git_ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
+      "visibility_level":0
+   }
+}

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -20,6 +20,11 @@ class GitlabHookTests(WebhookTestCase):
         expected_message = "Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/-/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek.\n\n* b ([66abd2da288](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e591e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
         self.check_webhook("push_hook", expected_topic_name, expected_message)
 
+    def test_force_push_event_message(self) -> None:
+        expected_topic_name = "my-awesome-project / tomek"
+        expected_message = "Tomasz Kolek [force pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/-/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek.\n\n* b ([66abd2da288](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e591e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
+        self.check_webhook("push_hook__force_push", expected_topic_name, expected_message)
+
     def test_push_local_branch_without_commits(self) -> None:
         expected_topic_name = "my-awesome-project / changes"
         expected_message = "Eeshan Garg [pushed](https://gitlab.com/eeshangarg/my-awesome-project/-/compare/0000000000000000000000000000000000000000...68d7a5528cf423dfaac37dd62a56ac9cc8a884e3) the branch changes."

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -10,7 +10,7 @@ from zerver.lib.exceptions import UnsupportedWebhookEventTypeError
 from zerver.lib.partial import partial
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
-from zerver.lib.validator import WildValue, check_int, check_none_or, check_string
+from zerver.lib.validator import WildValue, check_bool, check_int, check_none_or, check_string
 from zerver.lib.webhooks.common import (
     OptionalUserSpecifiedTopicStr,
     check_send_webhook_message,
@@ -82,6 +82,7 @@ def get_normal_push_event_body(payload: WildValue) -> str:
         compare_url,
         get_branch_name(payload),
         commits,
+        force_push=payload.get("forced", False).tame(check_bool),
     )
 
 


### PR DESCRIPTION
Adds force-push detection for GitLab push events in `zerver/webhooks/gitlab/view.py` which updates the push notification message template accordingly in `zerver/lib/webhooks/git.py`.
Added tests and fixture for force-push payloads.

Fixes part of #25445.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**
- Added a new GitLab force-push fixture `zerver/webhooks/gitlab/fixtures/push_hook__force_push.json` and corresponding webhook test in `zerver/webhooks/gitlab/tests.py`.
- Ran `./tools/test-backend zerver/webhooks/gitlab` locally and every test pass.
- Manually verified the rendered message using incoming webhook bot.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="1134" height="195" alt="Screenshot 2025-12-24 142341" src="https://github.com/user-attachments/assets/c1bc58a7-4e0e-4b04-9a2c-c147b217a7ac" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
