### PR TITLE
markdown: Linkify RFC2392 'mid:' URLs.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -97,7 +97,7 @@ html_safelisted_schemes = (
     "wtai",
     "xmpp",
 )
-allowed_schemes = ("http", "https", "ftp", "file", *html_safelisted_schemes)
+allowed_schemes = ("http", "https", "ftp", "file", "mid", *html_safelisted_schemes)
 
 
 class LinkInfo(TypedDict):

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -1080,6 +1080,16 @@
       "input": "Hello @_**Zoe|7** see [this](https://google.com).",
       "expected_output": "<p>Hello <span class=\"user-mention silent\" data-user-id=\"7\">Zoe</span> see <a href=\"https://google.com\">this</a>.</p>",
       "text_content": "Hello Zoe see this."
+    },
+    {
+      "name": "RFC2392 mid links (markdown syntax)",
+      "input": "[message](mid:960830.1639@XIson.com)",
+      "expected_output": "<p><a href=\"mid:960830.1639@XIson.com\">message</a></p>"
+    },
+    {
+      "name": "RFC2392 mid links with part ID (markdown syntax)",
+      "input": "[message](mid:960830.1639@XIson.com/partA.960830.1639@XIson.com)",
+      "expected_output": "<p><a href=\"mid:960830.1639@XIson.com/partA.960830.1639@XIson.com\">message</a></p>"
     }
   ],
   "linkify_tests": [


### PR DESCRIPTION
This PR adds `mid` to the list of allowed URI schemes in the markdown parser. This enables users to create explicit Markdown links to `mid:` URIs (RFC 2392), which are used to reference emails by Message-ID.

Previously, `mid:` links were sanitized and stripped because the scheme was not allowlisted.

**Changes**

Added `mid` to the `allowed_schemes` list in `zerver/lib/markdown/__init__.py`.

Fixes: #36518

<!-- Describe your pull request here.-->


**How changes were tested**

**Backend**: Added regression tests in `zerver/tests/fixtures/markdown_test_cases.json` to verify explicit markdown syntax: `[label](mid:...)`.

Manual Verification: Verified in the development environment that using explicit syntax `[Link](mid:...)` results in a valid, clickable link with the correct `mid:` scheme.



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
1. Before: The parser incorrectly identifies `mid:` URIs as email addresses. The tooltip shows `mailto:`, indicating it stripped the scheme and treated the rest as a standard email link.
<img width="1802" height="1040" alt="image" src="https://github.com/user-attachments/assets/33c580b3-1760-45ea-88ea-c985de69f424" />


2. After: Explicit Markdown links (`[Label](mid:...)`) are now correctly allowlisted. The tooltip confirms the `mid:` scheme is preserved along with the full path (including forward slashes).

<img width="1800" height="792" alt="image" src="https://github.com/user-attachments/assets/adc9c4ed-7d86-444f-99b1-224634bac44a" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
