### PR TITLE
#37135 Fixes  invalid custom time indicator and added red outline

### DIFF
--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -904,7 +904,7 @@ export function deactivate_organization(e: JQuery.Event): void {
         let time_in_minutes: number;
         if (delete_data_value === "custom") {
             if (!util.validate_custom_time_input(custom_deletion_time_input)) {
-                return $t({defaultMessage: "Invalid custom time"});
+                return "";
             }
             time_in_minutes = util.get_custom_time_in_minutes(
                 custom_deletion_time_unit,
@@ -935,22 +935,22 @@ export function deactivate_organization(e: JQuery.Event): void {
         const $custom_deletion_time_input = $<HTMLInputElement>("input#custom-deletion-time-input");
 
         if (time_period === "custom") {
-            $custom_deletion_time_input.removeClass("custom-time-input--error");
+            $custom_deletion_time_input.removeClass("inavalid-input");
             return true;
         }
         if (time_period === "null") {
             if (maximum_allowed_days === null) {
-                $custom_deletion_time_input.removeClass("custom-time-input--error");
+                $custom_deletion_time_input.removeClass("invalid-input");
                 return true;
             }
 
-            $custom_deletion_time_input.addClass("custom-time-input--error");
+            $custom_deletion_time_input.addClass("invalid-input");
             return false;
         }
         if (typeof time_period === "number") {
             if (maximum_allowed_days === null) {
                 if (time_period >= minimum_allowed_days * 24 * 60) {
-                    $custom_deletion_time_input.removeClass("custom-time-input--error");
+                    $custom_deletion_time_input.removeClass("invalid-input");
                     return true;
                 }
             } else {
@@ -958,13 +958,13 @@ export function deactivate_organization(e: JQuery.Event): void {
                     time_period >= minimum_allowed_days * 24 * 60 &&
                     time_period <= maximum_allowed_days * 24 * 60
                 ) {
-                    $custom_deletion_time_input.removeClass("custom-time-input--error");
+                    $custom_deletion_time_input.removeClass("invalid-input");
                     return true;
                 }
             }
         }
 
-        $custom_deletion_time_input.addClass("custom-time-input--error");
+        $custom_deletion_time_input.addClass("invalid-input");
         return false;
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1406,19 +1406,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206deg 80% 62% / 60%);
     }
-
-    &.custom-time-input--error {
-        border-color: var(--color-invalid-input-border);
-        box-shadow:
-            inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
-            0 0 6px var(--color-invalid-input-border);
-    }
-
-    &.custom-time-input--error:focus {
-        box-shadow:
-            inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
-            0 0 8px var(--color-invalid-input-border);
-    }
 }
 
 .custom-time-input-unit {


### PR DESCRIPTION
This PR Fixes invalid custom time indicator and added red outline.
Fixes #37135 

PROBLEM:
When a user enters an invalid custom time (e.g., in the invite modal or org deactivation modal), the UI currently displays an inline “Invalid custom time” message below the field. This behavior is inconsistent with error handling elsewhere in Zulip and can feel noisy. Additionally, the error state is not always reset correctly when the user fixes the input, leading to a confusing user experience.
<img width="252" height="117" alt="Screenshot 2025-12-18 164942" src="https://github.com/user-attachments/assets/2410a5e5-24c2-429d-92fb-6eee03800aa9" />

OVERVIEW:
This PR fixes the custom expiration time validation by reusing Zulip’s existing invalid-input error handling instead of a custom error class. It ensures consistent UI behavior and correct error state handling across inputs.
Improved validation timing (invite.ts)

WHAT CHANGED:
-Removed the inline “Invalid custom time” text and relied on visual error indication instead.
-Centralized validation handling so description/helper functions remain pure and UI error states are managed in submit/validation logic.
-Cleaned up related code paths to avoid duplicate or conflicting validation behavior.
-Replaced the previously added custom error class with Zulip’s existing invalid-input class.
-Fixed an issue where the red error outline did not disappear after entering a valid value following an invalid one.

WHY THIS CHANGE:
-Zulip already provides a standard invalid-input mechanism for error states; reusing it improves consistency and reduces duplication.
-Removing inline error text avoids conflicting signals and matches existing UI patterns.
-Previously, once an invalid value was entered, switching back to a valid input did not fully reset the error UI.
-This approach aligns better with Zulip’s coding philosophy of clarity, consistency, and maintainability.

TESTING:
-Tested invalid custom time inputs (including values > 29 days).
-Verified that the red outline appears for invalid input and is removed immediately after entering a valid value.
-Checked related UI paths to ensure no regression.

BEFORE:
<img width="506" height="737" alt="Screenshot (86)" src="https://github.com/user-attachments/assets/7995ef5f-431a-44c6-8d33-4aa76eb8fb31" />
<img width="252" height="117" alt="Screenshot 2025-12-18 164942" src="https://github.com/user-attachments/assets/a5cf36ba-2b3a-4038-9cd1-8ca5400632ea" />
<img width="495" height="734" alt="Screenshot (89)" src="https://github.com/user-attachments/assets/775d20f7-8f7f-4ab1-996e-162738d3d3b4" />

AFTER:
<img width="1920" height="1080" alt="Screenshot (102)" src="https://github.com/user-attachments/assets/23ebf206-d8dc-4f5d-a43d-dd54e91fde5a" />
<img width="1920" height="1080" alt="Screenshot (103)" src="https://github.com/user-attachments/assets/a80e6197-7f45-4220-bb0a-94254550fac9" />
<img width="1920" height="1080" alt="Screenshot (104)" src="https://github.com/user-attachments/assets/840b829a-4a73-4fd0-921d-667a9624bdf3" />
<img width="1920" height="1080" alt="Screenshot (105)" src="https://github.com/user-attachments/assets/c2ca1d39-3222-4484-983f-21a31daee397" />
<img width="1920" height="1080" alt="Screenshot (108)" src="https://github.com/user-attachments/assets/5a2be131-b6e5-44be-a7ed-6168d32a7bfc" />


.


