### PR TITLE
message_edit: Handle visibility policies for partial message moves. 

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -85,7 +85,10 @@ from zerver.lib.types import DirectMessageEditRequest, EditHistoryEvent, StreamM
 from zerver.lib.url_encoding import stream_message_url
 from zerver.lib.user_groups import UserGroupMembershipDetails
 from zerver.lib.user_message import bulk_insert_all_ums
-from zerver.lib.user_topics import get_users_with_user_topic_visibility_policy
+from zerver.lib.user_topics import (
+    get_users_with_user_topic_visibility_policy,
+    topic_has_visibility_policy,
+)
 from zerver.lib.widget import is_widget_message
 from zerver.models import (
     ArchivedAttachment,
@@ -630,6 +633,8 @@ def update_user_topic_visibility_policies_on_move(
     target_topic_name: str,
     target_topic_has_messages: bool,
     users_losing_access: Iterable[UserProfile],
+    remove_orig_topic_visibility_policy: bool,
+    filter_to_user_ids: set[int] | None = None,
 ) -> dict[UserProfile, int]:
     stream_inaccessible_to_user_profiles: list[UserProfile] = []
     orig_topic_user_profile_to_visibility_policy: dict[UserProfile, int] = {}
@@ -639,6 +644,9 @@ def update_user_topic_visibility_policies_on_move(
     for user_topic in get_users_with_user_topic_visibility_policy(
         stream_being_edited.id, orig_topic_name
     ):
+        if filter_to_user_ids is not None and user_topic.user_profile_id not in filter_to_user_ids:
+            continue
+
         if is_stream_edited and user_topic.user_profile_id in user_ids_losing_access:
             stream_inaccessible_to_user_profiles.append(user_topic.user_profile)
         else:
@@ -649,6 +657,9 @@ def update_user_topic_visibility_policies_on_move(
     for user_topic in get_users_with_user_topic_visibility_policy(
         target_stream.id, target_topic_name
     ):
+        if filter_to_user_ids is not None and user_topic.user_profile_id not in filter_to_user_ids:
+            continue
+
         target_topic_user_profile_to_visibility_policy[user_topic.user_profile] = (
             user_topic.visibility_policy
         )
@@ -684,18 +695,19 @@ def update_user_topic_visibility_policies_on_move(
             (orig_topic_visibility_policy, target_topic_visibility_policy)
         ].append(user_profile_with_policy)
 
-    # If the messages are being moved to a stream the user
-    # cannot access, then we treat this as the
-    # messages/topic being deleted for this user. This is
-    # important for security reasons; we don't want to
-    # give users a UserTopic row in a stream they cannot
-    # access. Remove the user topic rows for such users.
-    bulk_do_set_user_topic_visibility_policy(
-        stream_inaccessible_to_user_profiles,
-        stream_being_edited,
-        orig_topic_name,
-        visibility_policy=UserTopic.VisibilityPolicy.INHERIT,
-    )
+    if remove_orig_topic_visibility_policy:
+        # If the messages are being moved to a stream the user
+        # cannot access, then we treat this as the
+        # messages/topic being deleted for this user. This is
+        # important for security reasons; we don't want to
+        # give users a UserTopic row in a stream they cannot
+        # access. Remove the user topic rows for such users.
+        bulk_do_set_user_topic_visibility_policy(
+            stream_inaccessible_to_user_profiles,
+            stream_being_edited,
+            orig_topic_name,
+            visibility_policy=UserTopic.VisibilityPolicy.INHERIT,
+        )
 
     # If the messages are being moved to a stream the user _can_
     # access, we move the user topic records, by removing the old
@@ -715,7 +727,10 @@ def update_user_topic_visibility_policies_on_move(
     ) in user_profiles_for_visibility_policy_pair.items():
         orig_topic_visibility_policy, target_topic_visibility_policy = visibility_policy_pair
 
-        if orig_topic_visibility_policy != UserTopic.VisibilityPolicy.INHERIT:
+        if (
+            remove_orig_topic_visibility_policy
+            and orig_topic_visibility_policy != UserTopic.VisibilityPolicy.INHERIT
+        ):
             bulk_do_set_user_topic_visibility_policy(
                 user_profiles,
                 stream_being_edited,
@@ -801,16 +816,12 @@ def apply_automatic_unmute_follow_topics_policy(
     target_stream: Stream,
     target_topic_name: str,
 ) -> None:
+    visibility_policy = None
     if (
         user_profile.automatically_follow_topics_policy
         == UserProfile.AUTOMATICALLY_CHANGE_VISIBILITY_POLICY_ON_INITIATION
     ):
-        bulk_do_set_user_topic_visibility_policy(
-            [user_profile],
-            target_stream,
-            target_topic_name,
-            visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED,
-        )
+        visibility_policy = UserTopic.VisibilityPolicy.FOLLOWED
     elif (
         user_profile.automatically_unmute_topics_in_muted_streams_policy
         == UserProfile.AUTOMATICALLY_CHANGE_VISIBILITY_POLICY_ON_INITIATION
@@ -823,12 +834,27 @@ def apply_automatic_unmute_follow_topics_policy(
         ).first()
 
         if subscription is not None and subscription.is_muted:
-            bulk_do_set_user_topic_visibility_policy(
-                [user_profile],
-                target_stream,
-                target_topic_name,
-                visibility_policy=UserTopic.VisibilityPolicy.UNMUTED,
-            )
+            visibility_policy = UserTopic.VisibilityPolicy.UNMUTED
+
+    if visibility_policy is not None:
+        # We check if the policy is already set, because we might have
+        # already updated the user's visibility policy from the
+        # original topic.
+        # This avoids unnecessary db operations and INFO logs.
+        if topic_has_visibility_policy(
+            user_profile,
+            target_stream.id,
+            target_topic_name,
+            visibility_policy,
+        ):
+            return
+
+        bulk_do_set_user_topic_visibility_policy(
+            [user_profile],
+            target_stream,
+            target_topic_name,
+            visibility_policy=visibility_policy,
+        )
 
 
 # This must be called already in a transaction, with a write lock on
@@ -1281,6 +1307,7 @@ def do_update_message(
                 target_topic_name=target_topic_name,
                 target_topic_has_messages=target_topic_has_messages,
                 users_losing_access=users_losing_access,
+                remove_orig_topic_visibility_policy=True,
             )
         )
 
@@ -1291,6 +1318,22 @@ def do_update_message(
         target_topic = message_edit_request.target_topic_name
 
         assert target_stream.recipient_id is not None
+
+        participant_user_ids_in_moved_messages = get_participant_user_ids_in_moved_messages(
+            changed_message_ids
+        )
+
+        update_user_topic_visibility_policies_on_move(
+            is_stream_edited=message_edit_request.is_stream_edited,
+            stream_being_edited=stream_being_edited,
+            orig_topic_name=orig_topic_name,
+            target_stream=target_stream,
+            target_topic_name=target_topic,
+            target_topic_has_messages=target_topic_has_messages,
+            users_losing_access=users_losing_access,
+            remove_orig_topic_visibility_policy=False,
+            filter_to_user_ids=participant_user_ids_in_moved_messages,
+        )
 
         messages_in_target_topic = messages_for_topic(
             realm.id, target_stream.recipient_id, target_topic

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -85,7 +85,10 @@ from zerver.lib.types import DirectMessageEditRequest, EditHistoryEvent, StreamM
 from zerver.lib.url_encoding import stream_message_url
 from zerver.lib.user_groups import UserGroupMembershipDetails
 from zerver.lib.user_message import bulk_insert_all_ums
-from zerver.lib.user_topics import get_users_with_user_topic_visibility_policy
+from zerver.lib.user_topics import (
+    get_users_with_user_topic_visibility_policy,
+    topic_has_visibility_policy,
+)
 from zerver.lib.widget import is_widget_message
 from zerver.models import (
     ArchivedAttachment,
@@ -630,6 +633,8 @@ def update_user_topic_visibility_policies_on_move(
     target_topic_name: str,
     target_topic_has_messages: bool,
     users_losing_access: Iterable[UserProfile],
+    remove_orig_topic_visibility_policy: bool,
+    filter_to_user_ids: set[int] | None = None,
 ) -> dict[UserProfile, int]:
     stream_inaccessible_to_user_profiles: list[UserProfile] = []
     orig_topic_user_profile_to_visibility_policy: dict[UserProfile, int] = {}
@@ -639,6 +644,9 @@ def update_user_topic_visibility_policies_on_move(
     for user_topic in get_users_with_user_topic_visibility_policy(
         stream_being_edited.id, orig_topic_name
     ):
+        if filter_to_user_ids is not None and user_topic.user_profile_id not in filter_to_user_ids:
+            continue
+
         if is_stream_edited and user_topic.user_profile_id in user_ids_losing_access:
             stream_inaccessible_to_user_profiles.append(user_topic.user_profile)
         else:
@@ -649,6 +657,9 @@ def update_user_topic_visibility_policies_on_move(
     for user_topic in get_users_with_user_topic_visibility_policy(
         target_stream.id, target_topic_name
     ):
+        if filter_to_user_ids is not None and user_topic.user_profile_id not in filter_to_user_ids:
+            continue
+
         target_topic_user_profile_to_visibility_policy[user_topic.user_profile] = (
             user_topic.visibility_policy
         )
@@ -684,18 +695,19 @@ def update_user_topic_visibility_policies_on_move(
             (orig_topic_visibility_policy, target_topic_visibility_policy)
         ].append(user_profile_with_policy)
 
-    # If the messages are being moved to a stream the user
-    # cannot access, then we treat this as the
-    # messages/topic being deleted for this user. This is
-    # important for security reasons; we don't want to
-    # give users a UserTopic row in a stream they cannot
-    # access. Remove the user topic rows for such users.
-    bulk_do_set_user_topic_visibility_policy(
-        stream_inaccessible_to_user_profiles,
-        stream_being_edited,
-        orig_topic_name,
-        visibility_policy=UserTopic.VisibilityPolicy.INHERIT,
-    )
+    if remove_orig_topic_visibility_policy:
+        # If the messages are being moved to a stream the user
+        # cannot access, then we treat this as the
+        # messages/topic being deleted for this user. This is
+        # important for security reasons; we don't want to
+        # give users a UserTopic row in a stream they cannot
+        # access. Remove the user topic rows for such users.
+        bulk_do_set_user_topic_visibility_policy(
+            stream_inaccessible_to_user_profiles,
+            stream_being_edited,
+            orig_topic_name,
+            visibility_policy=UserTopic.VisibilityPolicy.INHERIT,
+        )
 
     # A case-only rename within the same channel resolves to the
     # same UserTopic rows for both the original and target topic,
@@ -723,7 +735,10 @@ def update_user_topic_visibility_policies_on_move(
     ) in user_profiles_for_visibility_policy_pair.items():
         orig_topic_visibility_policy, target_topic_visibility_policy = visibility_policy_pair
 
-        if orig_topic_visibility_policy != UserTopic.VisibilityPolicy.INHERIT:
+        if (
+            remove_orig_topic_visibility_policy
+            and orig_topic_visibility_policy != UserTopic.VisibilityPolicy.INHERIT
+        ):
             bulk_do_set_user_topic_visibility_policy(
                 user_profiles,
                 stream_being_edited,
@@ -814,16 +829,12 @@ def apply_automatic_unmute_follow_topics_policy(
     target_stream: Stream,
     target_topic_name: str,
 ) -> None:
+    visibility_policy = None
     if (
         user_profile.automatically_follow_topics_policy
         == UserProfile.AUTOMATICALLY_CHANGE_VISIBILITY_POLICY_ON_INITIATION
     ):
-        bulk_do_set_user_topic_visibility_policy(
-            [user_profile],
-            target_stream,
-            target_topic_name,
-            visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED,
-        )
+        visibility_policy = UserTopic.VisibilityPolicy.FOLLOWED
     elif (
         user_profile.automatically_unmute_topics_in_muted_streams_policy
         == UserProfile.AUTOMATICALLY_CHANGE_VISIBILITY_POLICY_ON_INITIATION
@@ -836,12 +847,27 @@ def apply_automatic_unmute_follow_topics_policy(
         ).first()
 
         if subscription is not None and subscription.is_muted:
-            bulk_do_set_user_topic_visibility_policy(
-                [user_profile],
-                target_stream,
-                target_topic_name,
-                visibility_policy=UserTopic.VisibilityPolicy.UNMUTED,
-            )
+            visibility_policy = UserTopic.VisibilityPolicy.UNMUTED
+
+    if visibility_policy is not None:
+        # We check if the policy is already set, because we might have
+        # already updated the user's visibility policy from the
+        # original topic.
+        # This avoids unnecessary db operations and INFO logs.
+        if topic_has_visibility_policy(
+            user_profile,
+            target_stream.id,
+            target_topic_name,
+            visibility_policy,
+        ):
+            return
+
+        bulk_do_set_user_topic_visibility_policy(
+            [user_profile],
+            target_stream,
+            target_topic_name,
+            visibility_policy=visibility_policy,
+        )
 
 
 # This must be called already in a transaction, with a write lock on
@@ -1294,6 +1320,7 @@ def do_update_message(
                 target_topic_name=target_topic_name,
                 target_topic_has_messages=target_topic_has_messages,
                 users_losing_access=users_losing_access,
+                remove_orig_topic_visibility_policy=True,
             )
         )
 
@@ -1304,6 +1331,22 @@ def do_update_message(
         target_topic = message_edit_request.target_topic_name
 
         assert target_stream.recipient_id is not None
+
+        participant_user_ids_in_moved_messages = get_participant_user_ids_in_moved_messages(
+            changed_message_ids
+        )
+
+        update_user_topic_visibility_policies_on_move(
+            is_stream_edited=message_edit_request.is_stream_edited,
+            stream_being_edited=stream_being_edited,
+            orig_topic_name=orig_topic_name,
+            target_stream=target_stream,
+            target_topic_name=target_topic,
+            target_topic_has_messages=target_topic_has_messages,
+            users_losing_access=users_losing_access,
+            remove_orig_topic_visibility_policy=False,
+            filter_to_user_ids=participant_user_ids_in_moved_messages,
+        )
 
         messages_in_target_topic = messages_for_topic(
             realm.id, target_stream.recipient_id, target_topic

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -667,13 +667,55 @@ class MessageMoveTopicTest(ZulipTestCase):
         assert_is_topic_muted(cordelia, new_public_stream.id, "changed topic name", muted=True)
         assert_is_topic_muted(aaron, new_public_stream.id, "changed topic name", muted=False)
 
-        # Moving only half the messages doesn't move UserTopic records.
-        second_message_id = self.send_stream_message(
-            hamlet, stream_name, topic_name="changed topic name", content="Second message"
+        # Test move messages partially from a topic.
+        #
+        # We don't need to test each stream type variation (public, private,
+        # cross-stream, etc.) since those are already covered by the full
+        # topic move tests above. This single test verifies the two key
+        # behaviors unique to partial moves:
+        # 1. Policies on the original topic are NOT removed (remain unchanged).
+        # 2. Only moved message participant policies are updated on the target topic.
+        # This includes senders, mentioned users, reaction senders, and
+        # submessage senders in the moved messages.
+        self.send_stream_message(
+            cordelia, stream_name, topic_name="partial move topic", content="First message"
         )
-        with self.assert_database_query_count(22):
+        self.subscribe(aaron, new_public_stream.name)
+
+        second_message_id = self.send_stream_message(
+            hamlet,
+            stream_name,
+            topic_name="partial move topic",
+            content=f"Second message @**{aaron.full_name}**",
+        )
+
+        othello = self.example_user("othello")
+        iago = self.example_user("iago")
+        self.subscribe(othello, stream_name)
+        self.subscribe(iago, stream_name)
+        self.subscribe(othello, new_public_stream.name)
+        self.subscribe(iago, new_public_stream.name)
+        check_add_reaction(
+            user_profile=othello,
+            message_id=second_message_id,
+            emoji_name="smile",
+            emoji_code=None,
+            reaction_type=None,
+        )
+        do_add_submessage(
+            realm=iago.realm,
+            sender_id=iago.id,
+            message_id=second_message_id,
+            msg_type="whatever",
+            content='"stuff"',
+        )
+        for user in [hamlet, cordelia, aaron, othello, iago]:
+            set_topic_visibility_policy(
+                user, [[stream_name, "partial move topic"]], UserTopic.VisibilityPolicy.MUTED
+            )
+        with self.assert_database_query_count(35):
             check_update_message(
-                user_profile=desdemona,
+                user_profile=hamlet,
                 message_id=second_message_id,
                 stream_id=new_public_stream.id,
                 topic_name="final topic name",
@@ -682,13 +724,20 @@ class MessageMoveTopicTest(ZulipTestCase):
                 send_notification_to_new_thread=False,
                 content=None,
             )
+        # Visibility policy for all users on the original topic should remain unchanged.
+        for user in [hamlet, cordelia, aaron, othello, iago]:
+            assert_is_topic_muted(user, stream.id, "partial move topic", muted=True)
 
-        assert_is_topic_muted(desdemona, new_public_stream.id, "changed topic name", muted=True)
-        assert_is_topic_muted(cordelia, new_public_stream.id, "changed topic name", muted=True)
-        assert_is_topic_muted(aaron, new_public_stream.id, "changed topic name", muted=False)
-        assert_is_topic_muted(desdemona, new_public_stream.id, "final topic name", muted=False)
+        # hamlet (sender) and aaron (mentioned) should have their policy on the target topic.
+        for user in [hamlet, aaron]:
+            assert_is_topic_muted(user, new_public_stream.id, "final topic name", muted=True)
+
+        # othello (reacted) and iago (submessage) should have their policy on the target topic.
+        for user in [othello, iago]:
+            assert_is_topic_muted(user, new_public_stream.id, "final topic name", muted=True)
+
+        # cordelia (only on first message, not moved) should NOT have a policy on the target topic.
         assert_is_topic_muted(cordelia, new_public_stream.id, "final topic name", muted=False)
-        assert_is_topic_muted(aaron, new_public_stream.id, "final topic name", muted=False)
 
     @mock.patch("zerver.actions.user_topics.send_event_on_commit")
     def test_edit_unmuted_topic(self, mock_send_event_on_commit: mock.MagicMock) -> None:
@@ -824,6 +873,88 @@ class MessageMoveTopicTest(ZulipTestCase):
         self.assert_has_visibility_policy(
             aaron, change_all_topic_name, stream, UserTopic.VisibilityPolicy.MUTED, expected=False
         )
+
+        # Test move messages partially from a topic.
+        self.send_stream_message(
+            cordelia, stream_name, topic_name="partial move topic", content="First message"
+        )
+        second_message_id = self.send_stream_message(
+            hamlet,
+            stream_name,
+            topic_name="partial move topic",
+            content=f"Second message @**{aaron.full_name}**",
+        )
+
+        desdemona = self.example_user("desdemona")
+        iago = self.example_user("iago")
+        self.subscribe(desdemona, stream_name)
+        self.subscribe(iago, stream_name)
+        check_add_reaction(
+            user_profile=desdemona,
+            message_id=second_message_id,
+            emoji_name="smile",
+            emoji_code=None,
+            reaction_type=None,
+        )
+        do_add_submessage(
+            realm=iago.realm,
+            sender_id=iago.id,
+            message_id=second_message_id,
+            msg_type="whatever",
+            content='"stuff"',
+        )
+        for user in [hamlet, aaron, desdemona, iago]:
+            set_topic_visibility_policy(
+                user, [[stream_name, "partial move topic"]], UserTopic.VisibilityPolicy.UNMUTED
+            )
+        for user in [cordelia, othello]:
+            set_topic_visibility_policy(
+                user, [[stream_name, "partial move topic"]], UserTopic.VisibilityPolicy.MUTED
+            )
+        with self.assert_database_query_count(27):
+            check_update_message(
+                user_profile=hamlet,
+                message_id=second_message_id,
+                stream_id=None,
+                topic_name="final topic name",
+                propagate_mode="change_later",
+                send_notification_to_old_thread=False,
+                send_notification_to_new_thread=False,
+                content=None,
+            )
+
+        # Visibility policy for all users on the original topic should remain unchanged.
+        for user in [hamlet, aaron, desdemona, iago]:
+            self.assert_has_visibility_policy(
+                user,
+                "partial move topic",
+                stream,
+                UserTopic.VisibilityPolicy.UNMUTED,
+                expected=True,
+            )
+        for user in [cordelia, othello]:
+            self.assert_has_visibility_policy(
+                user, "partial move topic", stream, UserTopic.VisibilityPolicy.MUTED, expected=True
+            )
+
+        # hamlet (sender) and aaron (mentioned) should have their policy on the target topic.
+        for user in [hamlet, aaron]:
+            self.assert_has_visibility_policy(
+                user, "final topic name", stream, UserTopic.VisibilityPolicy.UNMUTED, expected=True
+            )
+
+        # desdemona (reacted) and iago (submessage) should have their policy on the target topic.
+        for user in [desdemona, iago]:
+            self.assert_has_visibility_policy(
+                user, "final topic name", stream, UserTopic.VisibilityPolicy.UNMUTED, expected=True
+            )
+
+        # cordelia (only on first message) and othello (no stake in moved message)
+        # should NOT have policies on the target topic.
+        for user in [cordelia, othello]:
+            self.assert_has_visibility_policy(
+                user, "final topic name", stream, UserTopic.VisibilityPolicy.MUTED, expected=False
+            )
 
     def test_merge_user_topic_states_on_move_messages(self) -> None:
         stream_name = "Stream 123"

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -758,29 +758,6 @@ class MessageMoveTopicTest(ZulipTestCase):
         assert_is_topic_muted(cordelia, new_public_stream.id, "changed topic name", muted=True)
         assert_is_topic_muted(aaron, new_public_stream.id, "changed topic name", muted=False)
 
-        # Moving only half the messages doesn't move UserTopic records.
-        second_message_id = self.send_stream_message(
-            hamlet, stream_name, topic_name="changed topic name", content="Second message"
-        )
-        with self.assert_database_query_count(22):
-            check_update_message(
-                user_profile=desdemona,
-                message_id=second_message_id,
-                stream_id=new_public_stream.id,
-                topic_name="final topic name",
-                propagate_mode="change_later",
-                send_notification_to_old_thread=False,
-                send_notification_to_new_thread=False,
-                content=None,
-            )
-
-        assert_is_topic_muted(desdemona, new_public_stream.id, "changed topic name", muted=True)
-        assert_is_topic_muted(cordelia, new_public_stream.id, "changed topic name", muted=True)
-        assert_is_topic_muted(aaron, new_public_stream.id, "changed topic name", muted=False)
-        assert_is_topic_muted(desdemona, new_public_stream.id, "final topic name", muted=False)
-        assert_is_topic_muted(cordelia, new_public_stream.id, "final topic name", muted=False)
-        assert_is_topic_muted(aaron, new_public_stream.id, "final topic name", muted=False)
-
     @mock.patch("zerver.actions.user_topics.send_event_on_commit")
     def test_edit_unmuted_topic(self, mock_send_event_on_commit: mock.MagicMock) -> None:
         stream_name = "Stream 123"
@@ -915,6 +892,109 @@ class MessageMoveTopicTest(ZulipTestCase):
         self.assert_has_visibility_policy(
             aaron, change_all_topic_name, stream, UserTopic.VisibilityPolicy.MUTED, expected=False
         )
+
+    def test_visibility_policy_partial_topic_move(self) -> None:
+        # We don't need to test each stream type variation (public, private,
+        # cross-stream, etc.) since those are already covered by the full
+        # topic move tests above. This single test verifies the two key
+        # behaviors unique to partial moves:
+        # 1. Policies on the original topic are NOT removed (remain unchanged).
+        # 2. Only moved message participant policies are updated on the target topic.
+        # This includes senders, mentioned users, reaction senders, and
+        # submessage senders in the moved messages.
+        stream_name = "Stream 123"
+        stream = self.make_stream(stream_name)
+
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        aaron = self.example_user("aaron")
+        othello = self.example_user("othello")
+        desdemona = self.example_user("desdemona")
+        iago = self.example_user("iago")
+
+        for user in [hamlet, cordelia, aaron, othello, desdemona, iago]:
+            self.subscribe(user, stream_name)
+
+        self.send_stream_message(
+            cordelia, stream_name, topic_name="partial move topic", content="First message"
+        )
+        second_message_id = self.send_stream_message(
+            hamlet,
+            stream_name,
+            topic_name="partial move topic",
+            content=f"Second message @**{aaron.full_name}**",
+        )
+
+        check_add_reaction(
+            user_profile=desdemona,
+            message_id=second_message_id,
+            emoji_name="smile",
+            emoji_code=None,
+            reaction_type=None,
+        )
+        do_add_submessage(
+            realm=iago.realm,
+            sender_id=iago.id,
+            message_id=second_message_id,
+            msg_type="whatever",
+            content='"stuff"',
+        )
+
+        # Distribute all four visibility policies among the participants of the moved message:
+        # hamlet (sender) -- UNMUTED, aaron (mentioned) -- MUTED, iago (submessage) -- FOLLOWED,
+        # desdemona (reaction) -- INHERIT (by default).
+        for user, policy in [
+            (hamlet, UserTopic.VisibilityPolicy.UNMUTED),
+            (aaron, UserTopic.VisibilityPolicy.MUTED),
+            (iago, UserTopic.VisibilityPolicy.FOLLOWED),
+        ]:
+            set_topic_visibility_policy(user, [[stream_name, "partial move topic"]], policy)
+
+        # Non-participants cordelia (only on first message) and othello (no stake in moved message)
+        # have MUTED on the original topic.
+        for user in [cordelia, othello]:
+            set_topic_visibility_policy(
+                user, [[stream_name, "partial move topic"]], UserTopic.VisibilityPolicy.MUTED
+            )
+
+        with self.assert_database_query_count(31):
+            check_update_message(
+                user_profile=hamlet,
+                message_id=second_message_id,
+                stream_id=None,
+                topic_name="final topic name",
+                propagate_mode="change_later",
+                send_notification_to_old_thread=False,
+                send_notification_to_new_thread=False,
+                content=None,
+            )
+
+        # Visibility policy for all users on the original topic should remain unchanged.
+        for user, policy in [
+            (hamlet, UserTopic.VisibilityPolicy.UNMUTED),
+            (aaron, UserTopic.VisibilityPolicy.MUTED),
+            (iago, UserTopic.VisibilityPolicy.FOLLOWED),
+            (desdemona, UserTopic.VisibilityPolicy.INHERIT),
+            (cordelia, UserTopic.VisibilityPolicy.MUTED),
+            (othello, UserTopic.VisibilityPolicy.MUTED),
+        ]:
+            self.assert_has_visibility_policy(user, "partial move topic", stream, policy)
+
+        # Moved message participants should have their policy on the target topic.
+        for user, policy in [
+            (hamlet, UserTopic.VisibilityPolicy.UNMUTED),
+            (aaron, UserTopic.VisibilityPolicy.MUTED),
+            (iago, UserTopic.VisibilityPolicy.FOLLOWED),
+            (desdemona, UserTopic.VisibilityPolicy.INHERIT),
+        ]:
+            self.assert_has_visibility_policy(user, "final topic name", stream, policy)
+
+        # cordelia (only on first message) and othello (no stake in moved message)
+        # should NOT have policies on the target topic.
+        for user in [cordelia, othello]:
+            self.assert_has_visibility_policy(
+                user, "final topic name", stream, UserTopic.VisibilityPolicy.INHERIT
+            )
 
     def test_merge_user_topic_states_on_move_messages(self) -> None:
         stream_name = "Stream 123"


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #35224

This PR uses the existing logic written for moving all the messages in a topic for partial moves (splitting a topic) too by adding a filter to only update policies for users who are senders of the moved messages and conditioning to not remove the visibility policies of original topic.

- First commit is a preparatory commit for extracting the migration logic to an helper function.
- Second commit adds a filter logic for partial moves.

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

I've included screenshots and screen captures to show how the changes were tested. 

**Screenshots and screen captures:**

<details>
<summary>Split a topic</summary>

![move-messages](https://github.com/user-attachments/assets/2995f65c-8e91-4c47-a6b8-1c9ccf3a7220)

</details>

<details>
<summary>Topic 1(moved from) remains same; Topic 2(moved to) followed for affected users</summary>

<img width="459" height="135" alt="Screenshot from 2026-01-06 20-25-33" src="https://github.com/user-attachments/assets/6d7620be-adda-4985-8443-d8394b3bb9c2" />

</details>

<details>
<summary>No visibility policy migration for Zoe since message not moved</summary>

<img width="838" height="771" alt="Screenshot from 2025-12-25 20-45-50" src="https://github.com/user-attachments/assets/ea491565-de0e-4871-b3a7-8c1cb6c1bab0" />

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
