### PR TITLE
tests: Fix typo in drafts test comment

### DIFF
--- a/zerver/tests/test_drafts.py
+++ b/zerver/tests/test_drafts.py
@@ -446,7 +446,7 @@ class DraftDeleteTests(ZulipTestCase):
         resp = self.api_delete(hamlet, f"/api/v1/drafts/{new_draft_id}")
         self.assert_json_success(resp)
 
-        # Now make sure that the there are no more drafts.
+        # Now make sure that there are no more drafts.
         self.assertEqual(Draft.objects.count() - initial_count, 0)
 
     def test_delete_non_existent_draft(self) -> None:


### PR DESCRIPTION
I removed a duplicate word ('the') in a comment within `zerver/tests/test_drafts.py`.
I looked for if it was a short form or anything but I didn't find it so corrected it.

The reason that I didn't pick any issues that was already there because All the "Good First Issues" or "Help wanted" labelled issues have been claimed.

I am a first year B.tech student who recently started learning about contribution on Open Source,
This is my first contribution in the Zulip repository so if i have made any mistake or breaked any instructions then I apologize and look forward to learn.