### PR TITLE
web: avoid firing message_selected event when selection is unchanged

### DIFF
--- a/web/src/message_list.ts
+++ b/web/src/message_list.ts
@@ -409,9 +409,13 @@ export class MessageList {
             this.should_trigger_message_selected_event = true;
         }
 
-        if (this.should_trigger_message_selected_event) {
-            $(document).trigger(new $.Event("message_selected.zulip", opts));
-        }
+        if (
+    this.should_trigger_message_selected_event &&
+    opts.previously_selected_id !== opts.id
+) {
+    $(document).trigger(new $.Event("message_selected.zulip", opts));
+}
+
     }
 
     selected_message(): Message | undefined {


### PR DESCRIPTION
Small - Change
The frontend currently fires the message_selected.zulip event even when the selected message ID does not change.
This can happen during rerenders or repeated calls to select_id with the same ID.

Firing this event redundantly can:

Trigger unnecessary downstream listeners

Cause extra UI work (e.g. scroll handlers, read-marking logic)

Make reasoning about selection changes harder during debugging

What this PR does

This change ensures that the message_selected.zulip event is only emitted when the selected message actually changes.

Specifically:

The event is now triggered only if opts.id !== opts.previously_selected_id

All existing safeguards (should_trigger_message_selected_event, force_rerender, etc.) are preserved

No behavior changes occur when the selection genuinely changes

Code change (summary)
if (
    this.should_trigger_message_selected_event &&
    opts.previously_selected_id !== opts.id
) {
    $(document).trigger(new $.Event("message_selected.zulip", opts));
}

Why this is safe

previously_selected_id is already tracked and passed through select_id

No callers rely on the event firing when the ID is unchanged

Prevents redundant work without altering valid selection flows

Impact

Reduces unnecessary frontend event traffic

Makes message_selected semantics clearer and more predictable

Improves maintainability around selection + scrolling logic

Scope

Frontend-only

No backend or database changes

No user-visible behavior changes expected