### PR TITLE
Renamed #recent_topics to #recent in the default_view database table. Fixes: #25781

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 454**
+
+- [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults)
+  [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),
+  [`PATCH /settings`](/api/update-settings): Changed the `web_home_view`
+  value for the recent view to "recent".
+
 **Feature level 453**
 
 * [`POST /register`](/api/register-queue): `gif_rating_options`

--- a/version.py
+++ b/version.py
@@ -35,7 +35,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 453
+API_FEATURE_LEVEL = 454
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/browser_history.ts
+++ b/web/src/browser_history.ts
@@ -196,9 +196,6 @@ export function get_current_state_show_more_topics(): boolean | undefined {
 
 export function get_home_view_hash(): string {
     let home_view_hash = `#${user_settings.web_home_view}`;
-    if (home_view_hash === "#recent_topics") {
-        home_view_hash = "#recent";
-    }
 
     if (home_view_hash === "#all_messages") {
         home_view_hash = "#feed";

--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -129,7 +129,7 @@ function show_home_view(narrow_opts?: message_view.ShowMessageViewOpts): void {
     // We only allow the primary recommended options for home views
     // rendered without a hash.
     switch (user_settings.web_home_view) {
-        case "recent_topics": {
+        case "recent": {
             recent_view_ui.show();
             break;
         }

--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -246,7 +246,7 @@ export function get_view_rows_by_view_name(view: string): JQuery {
         return $(".top_left_all_messages");
     }
 
-    if (view === settings_config.web_home_view_values.recent_topics.code) {
+    if (view === settings_config.web_home_view_values.recent.code) {
         return $(".top_left_recent_view");
     }
 

--- a/web/src/left_sidebar_navigation_area_popovers.ts
+++ b/web/src/left_sidebar_navigation_area_popovers.ts
@@ -261,7 +261,7 @@ export function initialize(): void {
             assert(instance.reference instanceof HTMLElement);
             ui_util.show_left_sidebar_menu_icon(instance.reference);
             popovers.hide_all();
-            const view_code = settings_config.web_home_view_values.recent_topics.code;
+            const view_code = settings_config.web_home_view_values.recent.code;
             const counts = unread.get_counts();
             const unread_messages_present =
                 counts.home_unread_messages + counts.muted_topic_unread_messages_count > 0;

--- a/web/src/navigation_views.ts
+++ b/web/src/navigation_views.ts
@@ -50,7 +50,7 @@ export const built_in_views_meta_data: Record<string, BuiltInViewBasicMetadata> 
         hidden_for_spectators: false,
         menu_icon_class: "recent-view-sidebar-menu-icon",
         menu_aria_label: $t({defaultMessage: "Recent conversations options"}),
-        home_view_code: "recent_topics",
+        home_view_code: "recent",
         prioritize_in_condensed_view: true,
     },
     all_messages: {

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1443,7 +1443,7 @@ export function show(): void {
         const html_body = render_introduce_zulip_view_modal({
             zulip_view: "recent_conversations",
             current_home_view_and_escape_navigation_enabled:
-                user_settings.web_home_view === "recent_topics" &&
+                user_settings.web_home_view === "recent" &&
                 user_settings.web_escape_navigates_to_home_view,
         });
         dialog_widget.launch({

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -972,9 +972,7 @@ export function dispatch_normal_event(event) {
                 // under settings, so we set the hash to the previous
                 // value of the home view.
                 if (!browser_history.state.hash_before_overlay && overlays.settings_open()) {
-                    browser_history.state.hash_before_overlay =
-                        "#" +
-                        (original_home_view === "recent_topics" ? "recent" : original_home_view);
+                    browser_history.state.hash_before_overlay = "#" + original_home_view;
                 }
             }
             if (event.property === "twenty_four_hour_time") {

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -159,8 +159,8 @@ export const web_home_view_values = {
         code: "inbox",
         description: $t({defaultMessage: "Inbox"}),
     },
-    recent_topics: {
-        code: "recent_topics",
+    recent: {
+        code: "recent",
         description: $t({defaultMessage: "Recent conversations"}),
     },
     all_messages: {

--- a/web/src/user_settings.ts
+++ b/web/src/user_settings.ts
@@ -77,7 +77,7 @@ export const user_settings_schema = z.object({
     web_channel_default_view: z.number(),
     web_escape_navigates_to_home_view: z.boolean(),
     web_font_size_px: z.number(),
-    web_home_view: z.enum(["inbox", "recent_topics", "all_messages"]),
+    web_home_view: z.enum(["inbox", "recent", "all_messages"]),
     web_inbox_show_channel_folders: z.boolean(),
     web_left_sidebar_show_channel_folders: z.boolean(),
     web_left_sidebar_unreads_count_summary: z.boolean(),

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -1312,12 +1312,12 @@ run_test("user_settings", ({override}) => {
         event = event_fixtures.user_settings__web_home_view_recent_topics;
         override(user_settings, "web_home_view", "all_messages");
         dispatch(event);
-        assert.equal(user_settings.web_home_view, "recent_topics");
+        assert.equal(user_settings.web_home_view, "recent");
     }
 
     {
         event = event_fixtures.user_settings__web_home_view_all_messages;
-        override(user_settings, "web_home_view", "recent_topics");
+        override(user_settings, "web_home_view", "recent");
         dispatch(event);
         assert.equal(user_settings.web_home_view, "all_messages");
     }

--- a/web/tests/hashchange.test.cjs
+++ b/web/tests/hashchange.test.cjs
@@ -240,7 +240,7 @@ function test_helper({override, override_rewire, change_tab}) {
 
 run_test("hash_interactions", ({override, override_rewire}) => {
     $window_stub = $.create("window-stub");
-    override(user_settings, "web_home_view", "recent_topics");
+    override(user_settings, "web_home_view", "recent");
 
     const helper = test_helper({override, override_rewire, change_tab: true});
 

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -1267,7 +1267,7 @@ exports.fixtures = {
         type: "user_settings",
         op: "update",
         property: "web_home_view",
-        value: "recent_topics",
+        value: "recent",
     },
 
     user_settings__web_inbox_show_channel_folders: {

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -233,7 +233,7 @@ def fetch_initial_state_data(
             id=0,
             default_language=spectator_requested_language,
             # Set home view to recent conversations for spectators regardless of default.
-            web_home_view="recent_topics",
+            web_home_view="recent",
         )
 
     # We fetch early some collections of group that we need to

--- a/zerver/migrations/0769_rename_recent_topics_to_recent.py
+++ b/zerver/migrations/0769_rename_recent_topics_to_recent.py
@@ -1,0 +1,50 @@
+# Migration to rename 'recent_topics' to 'recent' in web_home_view field
+
+from django.db import migrations, transaction
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from django.db.models import Max, Min
+
+
+def rename_recent_topics_to_recent(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    BATCH_SIZE = 10000
+    UserProfile = apps.get_model("zerver", "UserProfile")
+    RealmUserDefault = apps.get_model("zerver", "RealmUserDefault")
+
+    # Migrate UserProfile records
+    applicable_user_rows = UserProfile.objects.filter(web_home_view="recent_topics")
+    max_id = applicable_user_rows.aggregate(Max("id"))["id__max"]
+    lower_bound = applicable_user_rows.aggregate(Min("id"))["id__min"]
+
+    if max_id is not None and lower_bound is not None:
+        while lower_bound <= max_id:
+            upper_bound = lower_bound + BATCH_SIZE - 1
+            print(f"Processing UserProfile batch {lower_bound} to {upper_bound}")
+            with transaction.atomic():
+                UserProfile.objects.filter(
+                    id__gte=lower_bound,
+                    id__lte=upper_bound,
+                    web_home_view="recent_topics",
+                ).update(web_home_view="recent")
+            lower_bound = upper_bound + 1
+
+    # Migrate RealmUserDefault records (small table, no batching needed)
+    RealmUserDefault.objects.filter(web_home_view="recent_topics").update(web_home_view="recent")
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("zerver", "0768_realmauditlog_scrubbed"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            rename_recent_topics_to_recent,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14156,11 +14156,14 @@ paths:
                     The [home view](/help/configure-home-view) used when opening a new
                     Zulip web app window or hitting the `Esc` keyboard shortcut repeatedly.
 
-                    - "recent_topics" - Recent conversations view
+                    - "recent" - Recent conversations view
                     - "inbox" - Inbox view
                     - "all_messages" - Combined feed view
 
-                    **Changes**: New in Zulip 8.0 (feature level 219). Previously, this was
+                    **Changes**: Before Zulip 12.0 (feature level 454), the Recent
+                    view had `"recent_topics"` as its string encoding.
+
+                    New in Zulip 8.0 (feature level 219). Previously, this was
                     called `default_view`, which was new in Zulip 4.0 (feature level 42).
                   type: string
                   example: all_messages
@@ -17897,11 +17900,14 @@ paths:
                               The [home view](/help/configure-home-view) used when opening a new
                               Zulip web app window or hitting the `Esc` keyboard shortcut repeatedly.
 
-                              - "recent_topics" - Recent conversations view
+                              - "recent" - Recent conversations view
                               - "inbox" - Inbox view
                               - "all_messages" - Combined feed view
 
-                              **Changes**: New in Zulip 8.0 (feature level 219). Previously, this was
+                              **Changes**: Before Zulip 12.0 (feature level 454), the Recent
+                              view had `"recent_topics"` as its string encoding.
+
+                              New in Zulip 8.0 (feature level 219). Previously, this was
                               called `default_view`, which was new in Zulip 4.0 (feature level 42).
                           web_escape_navigates_to_home_view:
                             type: boolean
@@ -20201,11 +20207,14 @@ paths:
                               The [home view](/help/configure-home-view) used when opening a new
                               Zulip web app window or hitting the `Esc` keyboard shortcut repeatedly.
 
-                              - "recent_topics" - Recent conversations view
+                              - "recent" - Recent conversations view
                               - "inbox" - Inbox view
                               - "all_messages" - Combined feed view
 
-                              **Changes**: New in Zulip 8.0 (feature level 219). Previously, this was
+                              **Changes**: Before Zulip 12.0 (feature level 454), the Recent
+                              view had `"recent_topics"` as its string encoding.
+
+                              New in Zulip 8.0 (feature level 219). Previously, this was
                               called `default_view`, which was new in Zulip 4.0 (feature level 42).
                           web_escape_navigates_to_home_view:
                             type: boolean
@@ -21516,12 +21525,15 @@ paths:
                     The [home view](/help/configure-home-view) used when opening a new
                     Zulip web app window or hitting the `Esc` keyboard shortcut repeatedly.
 
-                    - "recent_topics" - Recent conversations view
+                    - "recent" - Recent conversations view
                     - "inbox" - Inbox view
                     - "all_messages" - Combined feed view
 
-                    **Changes**: New in Zulip 8.0 (feature level 219). Previously, this was
-                    called `default_view`, which was new in Zulip 4.0 (feature level 42).
+                    **Changes**: Before Zulip 12.0 (feature level 454), the Recent
+                    view had `"recent_topics"` as its string encoding.
+
+                    New in Zulip 8.0 (feature level 219). Previously, this was called
+                    `default_view`, which was new in Zulip 4.0 (feature level 42).
 
                     Before Zulip 5.0 (feature level 80), this setting was managed by
                     the `PATCH /settings/display` endpoint.

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -4713,7 +4713,7 @@ class RealmPropertyActionTest(BaseAction):
             web_font_size_px=[UserProfile.WEB_FONT_SIZE_PX_COMPACT],
             web_line_height_percent=[UserProfile.WEB_LINE_HEIGHT_PERCENT_COMPACT],
             color_scheme=UserProfile.COLOR_SCHEME_CHOICES,
-            web_home_view=["recent_topics", "inbox", "all_messages"],
+            web_home_view=["recent", "inbox", "all_messages"],
             emojiset=[emojiset["key"] for emojiset in RealmUserDefault.emojiset_choices()],
             demote_inactive_streams=UserProfile.DEMOTE_STREAMS_CHOICES,
             web_mark_read_on_scroll_policy=UserProfile.WEB_MARK_READ_ON_SCROLL_POLICY_CHOICES,
@@ -4850,7 +4850,7 @@ class UserDisplayActionTest(BaseAction):
         test_changes: dict[str, Any] = dict(
             emojiset=["twitter"],
             default_language=["es", "de", "en"],
-            web_home_view=["all_messages", "inbox", "recent_topics"],
+            web_home_view=["all_messages", "inbox", "recent"],
             demote_inactive_streams=[2, 3, 1],
             web_mark_read_on_scroll_policy=[2, 3, 1],
             web_channel_default_view=[2, 1, 3, 4],

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -2628,7 +2628,7 @@ class RealmAPITest(ZulipTestCase):
             web_font_size_px=[UserProfile.WEB_FONT_SIZE_PX_COMPACT],
             web_line_height_percent=[UserProfile.WEB_LINE_HEIGHT_PERCENT_COMPACT],
             color_scheme=UserProfile.COLOR_SCHEME_CHOICES,
-            web_home_view=["recent_topics", "inbox", "all_messages"],
+            web_home_view=["recent", "inbox", "all_messages"],
             emojiset=[emojiset["key"] for emojiset in RealmUserDefault.emojiset_choices()],
             demote_inactive_streams=UserProfile.DEMOTE_STREAMS_CHOICES,
             web_mark_read_on_scroll_policy=UserProfile.WEB_MARK_READ_ON_SCROLL_POLICY_CHOICES,

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1740,7 +1740,7 @@ class UserProfileTest(ZulipTestCase):
         realm = get_realm("zulip")
         realm_user_default = RealmUserDefault.objects.get(realm=realm)
 
-        realm_user_default.web_home_view = "recent_topics"
+        realm_user_default.web_home_view = "recent"
         realm_user_default.emojiset = "twitter"
         realm_user_default.color_scheme = UserProfile.COLOR_SCHEME_LIGHT
         realm_user_default.enable_offline_email_notifications = False
@@ -1755,7 +1755,7 @@ class UserProfileTest(ZulipTestCase):
         with self.capture_send_event_calls(expected_num_events=0):
             copy_default_settings(realm_user_default, cordelia)
 
-        self.assertEqual(cordelia.web_home_view, "recent_topics")
+        self.assertEqual(cordelia.web_home_view, "recent")
         self.assertEqual(cordelia.emojiset, "twitter")
         self.assertEqual(cordelia.color_scheme, UserProfile.COLOR_SCHEME_LIGHT)
         self.assertEqual(cordelia.enable_offline_email_notifications, False)

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -763,7 +763,7 @@ def update_realm_user_settings_defaults(
     | None = None,
     web_escape_navigates_to_home_view: Json[bool] | None = None,
     web_font_size_px: Json[int] | None = None,
-    web_home_view: Literal["recent_topics", "inbox", "all_messages"] | None = None,
+    web_home_view: Literal["recent", "inbox", "all_messages"] | None = None,
     web_inbox_show_channel_folders: Json[bool] | None = None,
     web_left_sidebar_show_channel_folders: Json[bool] | None = None,
     web_left_sidebar_unreads_count_summary: Json[bool] | None = None,

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -202,7 +202,7 @@ def confirm_email_change(request: HttpRequest, *, key: str) -> HttpResponse:
 
 
 emojiset_choices = {emojiset["key"] for emojiset in UserProfile.emojiset_choices()}
-web_home_view_options = ["recent_topics", "inbox", "all_messages"]
+web_home_view_options = ["recent", "inbox", "all_messages"]
 web_animate_image_previews_options = ["always", "on_hover", "never"]
 
 


### PR DESCRIPTION
Added migration that updates both UserProfile and RealmUserDefault tables and renamed the `web_home_view` database value from `"recent_topics"` to `"recent"`.

**Changes Made:**
- Added migration 0769 that updates both `UserProfile` and `RealmUserDefault` tables using batched updates for performance
- Updated backend validation in `zerver/views/user_settings.py` and `zerver/views/realm.py`
- Updated frontend validation in `web/src/user_settings.ts` and `web/src/settings_config.ts`
- Updated spectator default in `zerver/lib/events.py`
- Updated all test fixtures to use the new value
- Preserved backward compatibility for old `#recent_topics` URLs in hash parser and hashchange handler

**How changes were tested:**

1. Verified migration works correctly by:
   - Rolling back to migration 0768
   - Manually setting test users to `web_home_view="recent_topics"`
   - Reapplying migration 0769
   - Confirming all values were updated to `"recent"`

2. Ran backend tests: `./tools/test-backend zerver.tests.test_events zerver.tests.test_users zerver.tests.test_realm`

3. Ran frontend tests: `./tools/test-js-with-node dispatch hashchange`

4. Manually tested in development server:
   - Changed home view setting to "Recent conversations" in Settings → Preferences → Navigation
   - Verified the setting saves correctly and loads on page refresh
   - Confirmed URL shows `#recent` when viewing Recent conversations
   - Tested that old `#recent_topics` URLs still redirect to `#recent` correctly

Fixes: #25781 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
