### PR TITLE
hash_util: Use URL base paramater to simplify get_link_hash.

### DIFF
--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -437,11 +437,8 @@ export function decode_stream_topic_from_url(
 }
 
 export function get_link_hash(link: string): string {
-    if (link.startsWith("/#narrow/")) {
-        return link.slice(1);
-    }
     try {
-        return new URL(link).hash;
+        return new URL(link, window.location.origin).hash;
     } catch {
         return "";
     }


### PR DESCRIPTION
Followup from https://github.com/zulip/zulip/pull/37182#discussion_r2647448544
