### PR TITLE
channel-ui: standardize spacing for privacy icons

### DIFF
--- a/web/styles/components.css
+++ b/web/styles/components.css
@@ -131,6 +131,7 @@ select.bootstrap-focus-style {
         transition: none;
     }
 }
+
 .channel-privacy-type-icon {
     margin-right: 0.25em;
 }

--- a/web/templates/inline_decorated_channel_name.hbs
+++ b/web/templates/inline_decorated_channel_name.hbs
@@ -1,18 +1,18 @@
 {{! This controls whether the swatch next to streams in the left sidebar has a lock icon. }}
 {{~#if stream.is_archived ~}}
 <i class="zulip-icon zulip-icon-archive channel-privacy-type-icon"
-   {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}}
-   aria-hidden="true"></i><span class="decorated-channel-name">{{stream.name ~}}</span>
+  {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}}
+  aria-hidden="true"></i><span class="decorated-channel-name">{{stream.name ~}}</span>
 {{~ else if stream.invite_only ~}}
 <i class="zulip-icon zulip-icon-lock channel-privacy-type-icon"
-   {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}}
-   aria-hidden="true"></i><span class="decorated-channel-name">{{stream.name ~}}</span>
+  {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}}
+  aria-hidden="true"></i><span class="decorated-channel-name">{{stream.name ~}}</span>
 {{~ else if stream.is_web_public ~}}
 <i class="zulip-icon zulip-icon-globe channel-privacy-type-icon"
-   {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}}
-   aria-hidden="true"></i><span class="decorated-channel-name">{{stream.name ~}}</span>
+  {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}}
+  aria-hidden="true"></i><span class="decorated-channel-name">{{stream.name ~}}</span>
 {{~ else ~}}
 <i class="zulip-icon zulip-icon-hashtag channel-privacy-type-icon"
-   {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}}
-   aria-hidden="true"></i><span class="decorated-channel-name">{{stream.name ~}}</span>
+  {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}}
+  aria-hidden="true"></i><span class="decorated-channel-name">{{stream.name ~}}</span>
 {{~/if~}}


### PR DESCRIPTION
Fixes #36987.

This PR removes a legacy literal whitespace character from
`inline_decorated_channel_name.hbs` that caused inconsistent spacing
between the channel privacy icon and channel name across the UI.

Spacing is now handled consistently via CSS using an em-based margin
on `.channel-privacy-type-icon`, avoiding reliance on template
whitespace.

### Changes
- Removed the literal space between the privacy icon and channel name
  in `inline_decorated_channel_name.hbs`
- Added a reusable, em-based margin to `.channel-privacy-type-icon`
  in `components.css`

### Verification
Manually verified correct rendering in:
- Left sidebar stream list
- Channel picker dropdowns
- Move-topic modal header
- Dropdown inside the modal
- Compose `#channel` autocomplete

No regressions observed.
