### PR TITLE
Add print feature in keyboard Shortcut pop-up

### DIFF
--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -121,3 +121,64 @@
 #search-operators-first-header {
     width: 40%;
 }
+
+.overlay-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 15px;
+    border-bottom: 1px solid var(--grey-200);
+    background-color: var(--grey-50);
+}
+
+.overlay-title {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--grey-900);
+}
+
+.print-help-pane {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    font-size: 13px;
+    font-weight: 500;
+    border: 1px solid var(--grey-250);
+    background-color: var(--grey-0);
+    color: var(--grey-700);
+    cursor: pointer;
+    border-radius: 3px;
+    transition:
+        background-color 0.2s ease,
+        border-color 0.2s ease,
+        box-shadow 0.2s ease;
+
+    &:hover {
+        background-color: var(--grey-50);
+        border-color: var(--grey-300);
+        box-shadow: 0 1px 3px var(--grey-150);
+    }
+
+    &:active {
+        background-color: var(--grey-100);
+        box-shadow: inset 0 1px 2px var(--grey-150);
+    }
+
+    i.fa-print {
+        font-size: 14px;
+        color: var(--grey-700);
+    }
+}
+
+.overlay-scroll-container {
+    display: flex;
+    flex-direction: column;
+
+    > div:first-child {
+        flex: 1;
+        overflow: auto;
+        background-color: var(--grey-0);
+    }
+}

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -1,6 +1,17 @@
 <div class="overlay-modal" id="keyboard-shortcuts" tabindex="-1" role="dialog"
   aria-label="{{t 'Keyboard shortcuts' }}">
-    <div class="overlay-scroll-container" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+    <div class="overlay-header">
+        <h2 id="keyboard-shortcuts-title" class="overlay-title">
+            {{t "Keyboard shortcuts"}}
+        </h2>
+        <button class="btn btn-sm btn-default print-help-pane"
+          data-pane-id="keyboard-shortcuts"
+          aria-label="{{t 'Print keyboard shortcuts'}}"
+          >
+            <i class="fa fa-print"></i> {{t 'Print'}}
+        </button>
+    </div>
+    <div class="overlay-scroll-container" data-simplebar ...>
         <div>
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>
@@ -587,3 +598,4 @@
         <a href="/help/keyboard-shortcuts" target="_blank" rel="noopener noreferrer">{{t 'Detailed keyboard shortcuts documentation' }}</a>
     </div>
 </div>
+

--- a/web/templates/markdown_help.hbs
+++ b/web/templates/markdown_help.hbs
@@ -1,12 +1,35 @@
-<div class="overlay-modal hide" id="message-formatting" tabindex="-1" role="dialog"
-  aria-label="{{t 'Message formatting' }}">
-    <div class="overlay-scroll-container" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+<div
+  class="overlay-modal hide"
+  id="message-formatting"
+  tabindex="-1"
+  role="dialog"
+  aria-label="{{t 'Message formatting'}}"
+  >
+    <div class="overlay-header">
+        <h2 id="message-formatting-title" class="overlay-title">
+            {{t "Message formatting"}}
+        </h2>
+        <button
+          class="btn btn-sm btn-default print-help-pane"
+          data-pane-id="message-formatting"
+          aria-label="{{t 'Print message formatting'}}"
+          >
+            <i class="fa fa-print"></i>
+            {{t "Print"}}
+        </button>
+    </div>
+    <div class="overlay-scroll-container" data-simplebar ...>
         <div id="markdown-instructions">
-            <table class="table table-striped table-rounded table-bordered help-table">
+            <table
+              class="table table-striped table-rounded table-bordered help-table"
+              >
                 <thead>
                     <tr>
-                        <th id="message-formatting-first-header">{{t "You type" }}</th>
-                        <th>{{t "You get" }}</th>
+                        <th id="message-formatting-first-header">{{t
+                                "You type"
+                            }}
+                        </th>
+                        <th>{{t "You get"}}</th>
                     </tr>
                 </thead>
 
@@ -14,10 +37,17 @@
                     {{#each markdown_help_rows}}
                         <tr>
                             {{#if note_html}}
-                            <td colspan="2">{{{note_html}}}</td>
+                                <td colspan="2">{{{note_html}}}</td>
                             {{else}}
-                            <td><div class="preserve_spaces">{{markdown}}</div> {{#if usage_html}}{{{usage_html}}}{{/if}}</td>
-                            <td class="rendered_markdown">{{{output_html}}} {{#if effect_html}}{{{effect_html}}}{{/if}}</td>
+                                <td>
+                                    <div class="preserve_spaces">{{markdown}}
+                                    </div>
+                                    {{#if usage_html}}{{{usage_html}}}
+                                    {{/if}}
+                                </td>
+                                <td class="rendered_markdown">{{{output_html}}}
+                                    {{#if effect_html}}{{{effect_html}}}{{/if}}
+                                </td>
                             {{/if}}
                         </tr>
                     {{/each}}
@@ -25,6 +55,11 @@
             </table>
         </div>
         <hr />
-        <a href="/help/format-your-message-using-markdown" target="_blank" rel="noopener noreferrer">{{t "Detailed message formatting documentation" }}</a>
+        <a
+          href="/help/format-your-message-using-markdown"
+          target="_blank"
+          rel="noopener noreferrer"
+          >{{t "Detailed message formatting documentation"}}
+        </a>
     </div>
 </div>

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -1,5 +1,16 @@
 <div class="overlay-modal hide" id="search-operators" tabindex="-1" role="dialog" aria-label="{{t 'Search filters' }}">
-    <div class="overlay-scroll-container" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+    <div class="overlay-header">
+        <h2 id="search-operators-title" class="overlay-title">
+            {{t "Search filters"}}
+        </h2>
+        <button class="btn btn-sm btn-default print-help-pane"
+          data-pane-id="search-operators"
+          aria-label="{{t 'Print search filters'}}"
+          >
+            <i class="fa fa-print"></i> {{t 'Print'}}
+        </button>
+    </div>
+    <div class="overlay-scroll-container" data-simplebar ...>
         <div id="operators-instructions">
             <table class="table table-striped table-rounded table-bordered help-table">
                 <thead>


### PR DESCRIPTION
This PR adds a print feature to the keyboard shortcuts pop-up.

It allows users to print or save shortcuts as a PDF, including
content that appears in scrollable areas.

This is a small UI enhancement and does not affect existing behavior.

### Screenshots

#### Before 
<img width="701" height="459" alt="Before" src="https://github.com/user-attachments/assets/75eee0a6-09f0-44f1-8014-20b801e7ebf7" />


#### After

##### Keyboard shortcuts

<img width="698" height="523" alt="Key1" src="https://github.com/user-attachments/assets/207cbd13-99d0-469f-a2b7-e2230400533a" />

###### On clicking Print button

<img width="1349" height="730" alt="key2" src="https://github.com/user-attachments/assets/18220a20-ca39-462d-a3e0-0f8aeb3747b5" />


##### Message formatting

<img width="700" height="527" alt="Mess1" src="https://github.com/user-attachments/assets/a77b09aa-6bd0-44bb-aacc-0a900c725067" />

###### On clicking Print button

<img width="1366" height="728" alt="Mess2" src="https://github.com/user-attachments/assets/043401c8-8b01-43d4-99d7-6586bf0e90f0" />

##### Search filters

<img width="704" height="529" alt="Search1" src="https://github.com/user-attachments/assets/a58202c1-2c03-47d7-a533-42be989d2250" />

###### On clicking Print button

<img width="1366" height="725" alt="Search2" src="https://github.com/user-attachments/assets/a0f9326d-04c5-43b7-a714-d8f49fadd827" />


Fixes #10214

