### PR TITLE
settings: Allow cropping when uploading custom emojis.

### DIFF
--- a/web/src/upload_widget.ts
+++ b/web/src/upload_widget.ts
@@ -1,6 +1,8 @@
 import Uppy from "@uppy/core";
 import type {Body, Meta} from "@uppy/core";
 import ImageEditor from "@uppy/image-editor";
+import type Cropper from "cropperjs";
+import $ from "jquery";
 import assert from "minimalistic-assert";
 
 import render_image_editor_modal from "../templates/image_editor_modal.hbs";
@@ -12,11 +14,14 @@ import * as util from "./util.ts";
 export type UploadWidget = {
     clear: () => void;
     close: () => void;
+    get_file: () => File | null;
 };
 
 export type UploadFunction = (file: File, night: boolean | null, icon: boolean) => void;
 
 const default_max_file_size = 5;
+
+const default_cropping_aspect_ratio = 1;
 
 let uppy_widget: Uppy<Meta, Body> | undefined;
 
@@ -41,6 +46,10 @@ function is_image_format(file: File): boolean {
     return supported_types.includes(type);
 }
 
+function is_animated_gif(file: File): boolean {
+    return file.type === "image/gif";
+}
+
 export function build_widget(
     // function returns a jQuery file input object
     get_file_input: () => JQuery<HTMLInputElement>,
@@ -54,30 +63,224 @@ export function build_widget(
     $upload_button: JQuery,
     $preview_text?: JQuery,
     $preview_image?: JQuery,
+    allow_cropping?: boolean,
     max_file_upload_size = default_max_file_size,
+    cropping_aspect_ratio = default_cropping_aspect_ratio,
 ): UploadWidget {
-    function accept(file: File): void {
-        $file_name_field.text(file.name);
-        $input_error.hide();
-        $clear_button.show();
-        $upload_button.hide();
-        if ($preview_text !== undefined && $preview_image !== undefined) {
-            const image_blob = URL.createObjectURL(file);
-            $preview_image.attr("src", image_blob);
-            $preview_image.addClass("upload_widget_image_preview");
-            $preview_text.show();
+    let selected_file: File | null = null;
+    let cropped_file: File | null = null;
+    let last_crop_box: Cropper.CropBoxData | null = null;
+    let last_canvas_data: Cropper.CanvasData | null = null;
+    let uppy_widget: Uppy<Meta, Body> | undefined;
+
+    const $preview_container = $(".emoji-upload-form-container");
+    const $cropper_container = allow_cropping ? $(".emoji-cropper-container") : undefined;
+    const $cancel_crop_button = allow_cropping ? $(".emoji-cancel-crop-button") : undefined;
+    const $save_crop_button = allow_cropping ? $(".emoji-save-crop-button") : undefined;
+    const $placeholder_icon = $("#emoji_placeholder_icon");
+
+    function transition_to_cropping_state(): void {
+        if (!allow_cropping || selected_file === null) {
+            return;
+        }
+
+        const editor = uppy_widget?.getPlugin<ImageEditor<Meta, Body>>("ImageEditor");
+        const cropper = editor?.cropper;
+
+        // Restore last saved state
+        if (cropper && last_canvas_data && last_crop_box) {
+            cropper.setCanvasData(last_canvas_data);
+            cropper.setCropBoxData(last_crop_box);
+        }
+
+        $preview_container?.hide().attr("data-state", "inactive");
+        $cropper_container?.show().attr("data-state", "active");
+        $save_crop_button?.show();
+        $cancel_crop_button?.show();
+        $("#add-custom-emoji-modal-container .modal__footer").hide();
+    }
+
+    function transition_to_preview_state(): void {
+        $cropper_container?.hide().attr("data-state", "inactive");
+        $preview_container?.show().attr("data-state", "active");
+
+        $save_crop_button?.hide();
+        $cancel_crop_button?.hide();
+        $("#add-custom-emoji-modal-container .modal__footer").show();
+
+        const preview_file = cropped_file ?? selected_file;
+
+        if (preview_file) {
+            $placeholder_icon.hide();
+            $preview_image?.show();
+            $preview_text?.show();
+        } else {
+            $preview_image?.hide().attr("src", "");
+            $preview_text?.show();
+            $placeholder_icon.show();
         }
     }
 
-    function clear(): void {
+    function setup_uppy_cropper(file: File): void {
+        uppy_widget = new Uppy<Meta, Body>({
+            restrictions: {
+                allowedFileTypes: supported_types,
+                maxNumberOfFiles: 1,
+            },
+        }).use(ImageEditor, {
+            target: ".emoji-uppy-target",
+            id: "ImageEditor",
+            quality: 1,
+            actions: {
+                cropSquare: false,
+                cropWidescreen: false,
+                cropWidescreenVertical: false,
+                zoomIn: true,
+                zoomOut: true,
+                revert: false,
+                rotate: false,
+                granularRotate: false,
+                flip: false,
+            },
+        });
+
+        $cropper_container?.on("click", "button", (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+        });
+
+        // Configure aspect ratio if provided
+        if (cropping_aspect_ratio !== undefined && cropping_aspect_ratio !== null) {
+            uppy_widget.getPlugin("ImageEditor")!.setOptions({
+                cropperOptions: {
+                    viewMode: 1,
+                    background: true,
+                    autoCropArea: 1,
+                    croppedCanvasOptions: {},
+                    minCropBoxHeight: 50,
+                    responsive: true,
+                    minCropBoxWidth: 0,
+                    initialAspectRatio: cropping_aspect_ratio,
+                    aspectRatio: cropping_aspect_ratio,
+                },
+            });
+        }
+
+        const uppy_file_id = uppy_widget.addFile({
+            name: file.name,
+            type: file.type,
+            data: file,
+            source: "Local",
+            isRemote: false,
+        });
+
+        const uppy_file = uppy_widget.getFile(uppy_file_id);
+        uppy_widget.getPlugin<ImageEditor<Meta, Body>>("ImageEditor")!.selectFile(uppy_file);
+
+        $save_crop_button?.on("click", (e) => {
+            e.preventDefault();
+
+            const editor = uppy_widget?.getPlugin<ImageEditor<Meta, Body>>("ImageEditor");
+            if (!editor) {
+                return;
+            }
+
+            $file_name_field.text(file.name);
+            editor.save();
+        });
+
+        uppy_widget.on("file-editor:complete", (edited_file) => {
+            assert(edited_file.data instanceof File);
+
+            const editor = uppy_widget?.getPlugin<ImageEditor<Meta, Body>>("ImageEditor");
+            const cropper = editor?.cropper;
+
+            if (cropper) {
+                last_crop_box = cropper.getCropBoxData();
+                last_canvas_data = cropper.getCanvasData();
+            }
+
+            cropped_file = edited_file.data;
+
+            update_preview(cropped_file);
+            $file_name_field.text(cropped_file.name);
+            $preview_text?.show();
+
+            transition_to_preview_state();
+        });
+    }
+
+    function update_preview(file: File): void {
+        if ($preview_image === undefined) {
+            return;
+        }
+
+        const old_src = $preview_image.attr("src");
+        if (old_src?.startsWith("blob:")) {
+            URL.revokeObjectURL(old_src);
+        }
+
+        const image_blob = URL.createObjectURL(file);
+        $preview_image.attr("src", image_blob);
+        $preview_image.addClass("upload_widget_image_preview");
+    }
+
+    function accept(file: File): void {
+        selected_file = file;
+        cropped_file = null;
+
+        $input_error.hide();
+        $clear_button.show();
+        $upload_button.hide();
+
+        if (allow_cropping === true && !is_animated_gif(file)) {
+            setup_uppy_cropper(selected_file);
+            transition_to_cropping_state();
+        } else {
+            // Disable cropping for GIFs
+            update_preview(file);
+            $file_name_field.text(file.name);
+            transition_to_preview_state();
+        }
+    }
+
+    function clear(is_error_state = false): void {
         const $control = get_file_input();
         $control.val("");
+
+        selected_file = null;
+        cropped_file = null;
+        last_canvas_data = null;
+        last_crop_box = null;
+
         $file_name_field.text("");
         $clear_button.hide();
         $upload_button.show();
-        if ($preview_text !== undefined) {
-            $preview_text.hide();
+
+        uppy_widget?.destroy();
+        uppy_widget = undefined;
+
+        if (!is_error_state) {
+            transition_to_preview_state();
+        } else {
+            $preview_image?.hide();
+            $preview_text?.hide();
         }
+    }
+
+    if (allow_cropping === true) {
+        $cancel_crop_button?.on("click", (e) => {
+            e.preventDefault();
+
+            $cropper_container?.hide();
+            requestAnimationFrame(() => {
+                if (cropped_file === null) {
+                    clear();
+                    return;
+                }
+                transition_to_preview_state();
+            });
+        });
     }
 
     $clear_button.on("click", (e) => {
@@ -109,11 +312,11 @@ export function build_widget(
                     ),
                 );
                 $input_error.show();
-                clear();
+                clear(true);
             } else if (!is_image_format(file)) {
                 $input_error.text($t({defaultMessage: "File type is not supported."}));
                 $input_error.show();
-                clear();
+                clear(true);
             } else {
                 accept(file);
             }
@@ -133,6 +336,19 @@ export function build_widget(
         $upload_button.off("drop");
         get_file_input().off("change");
         $upload_button.off("click");
+
+        if (allow_cropping === true) {
+            $cancel_crop_button?.off("click");
+        }
+
+        if (uppy_widget !== undefined) {
+            uppy_widget.destroy();
+            uppy_widget = undefined;
+        }
+    }
+
+    function get_file(): File | null {
+        return cropped_file ?? selected_file;
     }
 
     return {
@@ -142,6 +358,7 @@ export function build_widget(
         // Call back to close() when you are truly done with the widget,
         // so you can release handlers.
         close,
+        get_file,
     };
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -956,7 +956,7 @@ input[type="checkbox"] {
     }
 }
 
-#add-custom-emoji-modal {
+#add-custom-emoji-modal-container {
     & form {
         margin: 0;
     }
@@ -992,6 +992,45 @@ input[type="checkbox"] {
     &:hover {
         opacity: 1;
     }
+}
+
+.emoji-cancel-crop-button {
+    color: var(--color-exit-button-text);
+    background: var(--color-exit-button-background);
+    border: 1px solid var(--color-exit-button-border);
+
+    &:hover {
+        background: var(--color-exit-button-background-interactive);
+    }
+}
+
+.emoji-save-crop-button {
+    margin-left: 12px;
+    background-color: hsl(240deg 96% 68%);
+    color: hsl(0deg 0% 100%) !important;
+}
+
+.add-emoji-modal-container {
+    .uppy-ImageCropper-controls {
+        /* This is needed to override the top padding set for narrow
+        screens by cropperJS. */
+        padding-top: 0;
+    }
+
+    .uppy-c-btn {
+        &:focus:not(:focus-visible) {
+            background-color: unset;
+        }
+
+        &:focus-visible {
+            background-color: hsl(0deg 0% 100% / 50%);
+        }
+    }
+}
+
+.add-emoji-modal-container .emoji-save-crop-button,
+.add-emoji-modal-container .emoji-cancel-crop-button {
+    margin-block: 12px;
 }
 
 .add-new-linkifier-box,

--- a/web/templates/settings/add_emoji.hbs
+++ b/web/templates/settings/add_emoji.hbs
@@ -1,28 +1,33 @@
-<form id="add-custom-emoji-form">
-    <div>
-        <input type="file" name="emoji_file_input" class="notvisible"
-          id="emoji_file_input" value="{{t 'Upload image or GIF' }}"/>
-        {{> ../components/action_button
-          label=(t "Clear image")
-          variant="subtle"
-          intent="danger"
-          id="emoji_image_clear_button"
-          hidden=true
-          }}
-        {{> ../components/action_button
-          label=(t "Upload image or GIF")
-          variant="subtle"
-          intent="brand"
-          id="emoji_upload_button"
-          }}
-        <div style="display: none;" id="emoji_preview_text">
-            {{t "Preview:" }} <i id="emoji_placeholder_icon" class="fa fa-file-image-o" aria-hidden="true"></i><img class="emoji" id="emoji_preview_image" src=""/>
-        </div>
-        <div id="emoji-file-name"></div>
+<div class="add-emoji-modal-container">
+    <div class="emoji-upload-form-container emoji-preview-section" data-state="active">
+        <form id="add-custom-emoji-form">
+            <div>
+                <input type="file" name="emoji_file_input" class="notvisible"
+                  id="emoji_file_input" value="{{t 'Upload image or GIF' }}"/>
+                {{> ../components/action_button
+                  label=(t "Clear image")
+                  variant="subtle"
+                  intent="danger"
+                  id="emoji_image_clear_button"
+                  hidden=true
+                  }}
+                {{> ../components/action_button
+                  label=(t "Upload image or GIF")
+                  variant="subtle"
+                  intent="brand"
+                  id="emoji_upload_button"
+                  }}
+                <div style="display: none;" id="emoji_preview_text">
+                    {{t "Preview:" }} <i id="emoji_placeholder_icon" class="fa fa-file-image-o" aria-hidden="true"></i><img class="emoji" id="emoji_preview_image" src=""/>
+                </div>
+                <div id="emoji-file-name"></div>
+            </div>
+            <div id="emoji_file_input_error" class="text-error"></div>
+            <div class="emoji_name_input">
+                <label for="emoji_name" class="modal-field-label">{{t "Emoji name" }}</label>
+                <input type="text" name="name" id="emoji_name" class="modal_text_input" autocomplete="off" placeholder="{{t 'leafy green vegetable' }}" />
+            </div>
+        </form>
     </div>
-    <div id="emoji_file_input_error" class="text-error"></div>
-    <div class="emoji_name_input">
-        <label for="emoji_name" class="modal-field-label">{{t "Emoji name" }}</label>
-        <input type="text" name="name" id="emoji_name" class="modal_text_input" autocomplete="off" placeholder="{{t 'leafy green vegetable' }}" />
-    </div>
-</form>
+    <div class="emoji-cropper-container" data-state="inactive"><div class="emoji-uppy-target"></div><div class="cropper-actions"><button type="button" class="modal__button hide emoji-cancel-crop-button">{{t "Cancel"}}</button><button type="button" class="modal__button hide emoji-save-crop-button">{{t "Save"}}</button></div></div>
+</div>

--- a/web/tests/settings_emoji.test.cjs
+++ b/web/tests/settings_emoji.test.cjs
@@ -17,12 +17,22 @@ run_test("add_custom_emoji_post_render", () => {
         input_error,
         clear_button,
         upload_button,
+        preview_text,
+        preview_image,
+        allow_cropping,
+        max_file_upload_size,
+        cropping_aspect_ratio,
     ) => {
         assert.deepEqual(get_file_input(), $("#emoji_file_input"));
         assert.deepEqual(file_name_field, $("#emoji-file-name"));
         assert.deepEqual(input_error, $("#emoji_file_input_error"));
         assert.deepEqual(clear_button, $("#emoji_image_clear_button"));
         assert.deepEqual(upload_button, $("#emoji_upload_button"));
+        assert.deepEqual(preview_text, $("#emoji_preview_text"));
+        assert.deepEqual(preview_image, $("#emoji_preview_image"));
+        assert.equal(allow_cropping, true);
+        assert.equal(max_file_upload_size, undefined);
+        assert.equal(cropping_aspect_ratio, undefined);
         build_widget_stub = true;
     };
     settings_emoji.add_custom_emoji_post_render();


### PR DESCRIPTION
This PR allows cropping when uploading custom emojis.

Previously, there was no option to crop custom emojis before upload. Now, uploading a non-gif emoji launches uppy, allowing the user to crop the image.

It does so by the following flow:
- both the uppy cropper target and "Add a new emoji" form exist in the same modal
- by default, the modal is in `preview` state wherein the form and preview are shown
- uppy cropper is triggered when the user uploads a file
- wherein, the form is hidden to show the uppy cropper with buttons to cancel or save the cropped image
- on saving the crop, the modal again goes into `preview` state, to allow to user to see the new preview, add a name and submit the cropped emoji

`.gif` files are exempted from cropping so that the animations do not mess up.

How this approach is different:
- both the `preview` and `cropping` states, along their control buttons live in the same modal
- `build_widget` is modified to allow the flow described above using a control parameter `allow_cropping`, so that existing usages of `build_widget` do not break

Previous two approaches:
PR 36940 :
- utilizes two modals, one with the preview and name for upload and another for uppy based cropping
- directly utilizes the `open_uppy_editor` in `settings_emoji`

PR 36934 :
- also utilizes two modals, one with the preview and name for upload and another for uppy based cropping
- it makes use of `build_direct_upload_widget` to implement the two modal approach using a callback with 300ms timeout to account for an animations

Fixes #36927

**How changes were tested:**
- Manually test the flow for uploading and cropping emojis. Manually test uploading of avatar and bot avatar to check that nothing else is failing.
- Run lint tests before committing

**Screenshots and screen captures:**
<img width="604" height="291" alt="Screenshot 2026-01-09 at 11 55 46 AM" src="https://github.com/user-attachments/assets/c967c86f-d459-4514-a32b-29465c7b2ef3" />
<img width="608" height="540" alt="Screenshot 2026-01-09 at 11 56 08 AM" src="https://github.com/user-attachments/assets/706dfa41-cc25-40e2-942e-f9c1028cf609" />
<img width="610" height="319" alt="Screenshot 2026-01-09 at 11 56 42 AM" src="https://github.com/user-attachments/assets/9db6c956-71a8-40d7-801c-703023712fc9" />
<img width="610" height="316" alt="Screenshot 2026-01-09 at 11 57 10 AM" src="https://github.com/user-attachments/assets/4e7f2179-e2fa-4d32-8588-a9bdd1e7299d" />

Demo:
https://github.com/user-attachments/assets/afd6321b-b770-48e3-82bf-c69985f3f512



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
