### PR TITLE
settings_ui: Improve invalid custom time indicator  #37135

### DIFF
--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -904,14 +904,14 @@ export function deactivate_organization(e: JQuery.Event): void {
         let time_in_minutes: number;
         if (delete_data_value === "custom") {
             if (!util.validate_custom_time_input(custom_deletion_time_input)) {
-                return $t({defaultMessage: "Invalid custom time"});
+                return "";
             }
             time_in_minutes = util.get_custom_time_in_minutes(
                 custom_deletion_time_unit,
                 custom_deletion_time_input,
             );
             if (!is_valid_time_period(time_in_minutes)) {
-                return $t({defaultMessage: "Invalid custom time"});
+                return "";
             }
         } else {
             // These options were already filtered for is_valid_time_period.
@@ -932,18 +932,25 @@ export function deactivate_organization(e: JQuery.Event): void {
     const maximum_allowed_days = realm.server_max_deactivated_realm_deletion_days;
 
     function is_valid_time_period(time_period: string | number): boolean {
+        const $custom_deletion_time_input = $<HTMLInputElement>("input#custom-deletion-time-input");
+
         if (time_period === "custom") {
+            $custom_deletion_time_input.removeClass("inavalid-input");
             return true;
         }
         if (time_period === "null") {
             if (maximum_allowed_days === null) {
+                $custom_deletion_time_input.removeClass("invalid-input");
                 return true;
             }
+
+            $custom_deletion_time_input.addClass("invalid-input");
             return false;
         }
         if (typeof time_period === "number") {
             if (maximum_allowed_days === null) {
                 if (time_period >= minimum_allowed_days * 24 * 60) {
+                    $custom_deletion_time_input.removeClass("invalid-input");
                     return true;
                 }
             } else {
@@ -951,10 +958,13 @@ export function deactivate_organization(e: JQuery.Event): void {
                     time_period >= minimum_allowed_days * 24 * 60 &&
                     time_period <= maximum_allowed_days * 24 * 60
                 ) {
+                    $custom_deletion_time_input.removeClass("invalid-input");
                     return true;
                 }
             }
         }
+
+        $custom_deletion_time_input.addClass("invalid-input");
         return false;
     }
 


### PR DESCRIPTION
settings_ui: Improve invalid custom time indicator.
Fixes #37135

PROBLEM:
When an invalid custom time is entered (for example, in the invite modal or organization deactivation modal), the UI currently shows an inline “Invalid custom time” message below the field. This does not match the behavior described in the issue.
<img width="252" height="117" alt="Screenshot 2025-12-18 164942" src="https://github.com/user-attachments/assets/2410a5e5-24c2-429d-92fb-6eee03800aa9" />

OVERVIEW:
This PR updates the custom time input to follow the behavior specified in #37135 by removing the inline error message and using on a red outline to indicate invalid input.

WHAT CHANGED:
->Removed the inline “Invalid custom time” message.
->Added a red outline to the custom time input to indicate invalid values.
->Applied the same behavior in both the invite modal and organization deactivation settings.

HOW IT WAS DONE
->Removed the default "Invalid custom time" return messages from `invite.ts` and `settings_org.ts`.
->Added default zulip's error class
->Fix Validation Lag: Replaced the `change` event with the `input` event for the `custom_expiration_time` text field in `invite.ts`. This ensures validation runs instantly while typing, rather than waiting for the user to click away.

TESTING:
->Entered invalid custom time values (including values greater than 29 days).
->Verified that the input is outlined in red for invalid values.
->Verified that no inline error message is shown.
->Tested the behavior in both the invite and organization deactivation flows.

BEFORE:
<img width="506" height="737" alt="Screenshot (86)" src="https://github.com/user-attachments/assets/7995ef5f-431a-44c6-8d33-4aa76eb8fb31" />

AFTER:
<img width="1920" height="1080" alt="Screenshot (103)" src="https://github.com/user-attachments/assets/a80e6197-7f45-4220-bb0a-94254550fac9" />

<img width="1920" height="1080" alt="Screenshot (105)" src="https://github.com/user-attachments/assets/c2ca1d39-3222-4484-983f-21a31daee397" />

<img width="1920" height="1080" alt="Screenshot (108)" src="https://github.com/user-attachments/assets/5a2be131-b6e5-44be-a7ed-6168d32a7bfc" />