### PR TITLE
custom_check: Remove unused exclusion for french.md

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -545,7 +545,6 @@ prose_style_rules: list["Rule"] = [
     {
         "pattern": "[oO]rganisation",  # exclude usage in hrefs/divs
         "description": "Organization is spelled with a z",
-        "exclude_line": {("docs/translating/french.md", "- organization - **organisation**")},
     },
     {"pattern": "!!! warning", "description": "!!! warning is invalid; it's spelled '!!! warn'"},
     {"pattern": "Terms of service", "description": "The S in Terms of Service is capitalized"},


### PR DESCRIPTION
Commit 72e93cf5d218ce4a85d5d8da561234eafdbefe3d (#37195) removed this line, resulting in non-fatal complaints from tools/lint.