### PR TITLE
Replace .css("display", "none") with .hide() for unmatched streams table

### DIFF
--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -107,7 +107,7 @@ function rerender_ui(): void {
     }
 
     if (unmatched_streams.length === 0) {
-        $unmatched_streams_table.css("display", "none");
+        $unmatched_streams_table.hide();
         $("#customize_stream_notifications_widget .dropdown_widget_value").text(
             $t({defaultMessage: "Customize a channel"}),
         );


### PR DESCRIPTION
Fixes: [#18723](https://github.com/zulip/zulip/issues/18723)

**How changes were tested:**

- Ran Zulip development server locally
- Opened **Settings → Notifications**
- Verified that the unmatched streams table is hidden correctly
- Confirmed no visual or functional regression

**Screenshots and screen captures:**
Not applicable — no visual change in UI, behavior remains the same.

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see commit discipline).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
