### PR TITLE
reload: Preserve "more topics" expanded state.

### DIFF
--- a/web/src/reload.ts
+++ b/web/src/reload.ts
@@ -14,6 +14,7 @@ import {page_params} from "./page_params.ts";
 import * as popup_banners from "./popup_banners.ts";
 import type {ReloadingReason} from "./popup_banners.ts";
 import * as reload_state from "./reload_state.ts";
+import * as stream_list from "./stream_list.ts";
 import * as util from "./util.ts";
 
 // Read https://zulip.readthedocs.io/en/latest/subsystems/hashchange-system.html
@@ -26,6 +27,7 @@ export const reload_metadata_schema = z.object({
     message_view_scroll_offset: z.optional(z.number()),
     compose_active_draft_id: z.optional(z.string()),
     compose_active_draft_send_immediately: z.optional(z.boolean()),
+    left_sidebar_topics_zoomed: z.optional(z.boolean()),
     timestamp: z.number(),
 });
 
@@ -86,6 +88,7 @@ function preserve_state(
         compose_active_draft_id: draft_id,
         message_view_pointer,
         message_view_scroll_offset,
+        left_sidebar_topics_zoomed: stream_list.is_zoomed_in(),
         hash: hash_util.get_reload_hash(),
         timestamp: Date.now(),
     };

--- a/web/src/reload_setup.ts
+++ b/web/src/reload_setup.ts
@@ -11,6 +11,7 @@ import * as message_fetch from "./message_fetch.ts";
 import * as message_view from "./message_view.ts";
 import * as people from "./people.ts";
 import {reload_metadata_schema} from "./reload.ts";
+import * as stream_list from "./stream_list.ts";
 
 // Check if we're doing a compose-preserving reload.  This must be
 // done before the first call to get_events
@@ -102,6 +103,13 @@ export function initialize(): void {
 
         activity.set_new_user_input(false);
         message_view.changehash(data.hash, "reload");
+
+        // Restore the "more topics" zoomed state in the left sidebar.
+        if (data.left_sidebar_topics_zoomed) {
+            // We need to defer this until the stream list is rendered.
+            // The stream_list module handles the actual zoom-in logic.
+            stream_list.set_left_sidebar_topics_zoomed_on_reload();
+        }
     } else {
         load_from_legacy_data(fragment);
     }

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -67,6 +67,28 @@ export function is_zoomed_in(): boolean {
     return zoomed_in;
 }
 
+// This is set during reload_setup.initialize() if the user had
+// "more topics" expanded before the reload.
+let pending_zoom_from_reload = false;
+
+export function set_left_sidebar_topics_zoomed_on_reload(): void {
+    // We can't zoom in immediately because the stream list hasn't
+    // been rendered yet. We set a flag that will be checked when
+    // the stream list is first rendered.
+    pending_zoom_from_reload = true;
+}
+
+export function maybe_zoom_in_from_reload(): void {
+    if (pending_zoom_from_reload) {
+        pending_zoom_from_reload = false;
+        // Only zoom in if there's an active stream in the narrow.
+        const stream_id = topic_list.active_stream_id();
+        if (stream_id !== undefined) {
+            zoom_in();
+        }
+    }
+}
+
 function zoom_in(): void {
     const stream_id = topic_list.active_stream_id();
 
@@ -437,6 +459,10 @@ export function build_stream_list(force_rerender: boolean): void {
     set_sections_states();
     // Show inactive channels when user starts typing.
     $("#streams_list").toggleClass("is_searching", ui_util.get_left_sidebar_search_term() !== "");
+
+    // If we're restoring from a reload and the user had "more topics"
+    // expanded, zoom in now that the stream list is rendered.
+    maybe_zoom_in_from_reload();
 }
 
 export function mention_counts_by_section(): Map<


### PR DESCRIPTION
Fixes: #22484

**How changes were tested:**
- Ran [./tools/lint](cci:7://file:///home/vyagh/Work/oss/zulip/tools/lint:0:0-0:0) on modified files - passed
- Ran [./tools/test-js-with-node](cci:7://file:///home/vyagh/Work/oss/zulip/tools/test-js-with-node:0:0-0:0) for reload and stream_list tests - passed
- TypeScript compilation with `tsc --noEmit` - zero errors

**Screenshots and screen captures:**
N/A (no UI changes - this is state preservation logic)

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans: None, follows Tim's guidance exactly.
- [x] Highlights technical choices: Used deferred flag pattern since stream list isn't rendered during reload_setup.
- [x] Calls out remaining decisions and concerns: None.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review.

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>