### PR TITLE
Input pills improvments

### DIFF
--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -308,8 +308,95 @@ export function create<ItemType extends {type: string}>(
             }
             return true;
         },
-    };
 
+        // Edit a pill by converting it to an editable input at the same position.
+        // This is triggered by double-clicking on a pill or pressing Enter while focused.
+        editPill($pill: JQuery) {
+            const pill_data = this.getByElement($pill[0]!);
+            if (!pill_data || pill_data.disabled) {
+                return;
+            }
+
+            // Store original item data for restoration on cancel
+            const original_item = pill_data.item;
+
+            // Get text value from the item
+            const text = store.get_text_from_item(pill_data.item);
+
+            // Create editable input element using DOM building (not HTML parsing)
+            const editable = document.createElement("div");
+            editable.className = "input editable-pill";
+            editable.contentEditable = "true";
+            editable.textContent = text;
+            const $editable = $(editable);
+
+            // Insert at pill's position, then remove pill
+            $pill.before($editable);
+            this.removePill($pill[0]!, "backspace");
+
+            // Focus and place cursor at end
+            $editable.trigger("focus");
+            ui_util.place_caret_at_end(util.the($editable));
+
+            // Handle keydown events on the editable pill.
+            // We use native addEventListener with capture:true to intercept
+            // Escape BEFORE Micromodal's document-level handler closes the modal.
+            editable.addEventListener(
+                "keydown",
+                (e) => {
+                    // Check for Enter key (with IME composing check)
+                    if (e.key === "Enter" && !e.isComposing) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        const value = $editable.text().trim();
+                        if (value.length > 0) {
+                            const ret = this.appendPill(value);
+                            if (ret) {
+                                $editable.remove();
+                                store.$input.trigger("focus");
+                            }
+                        }
+                    }
+                    // Escape to cancel edit - restore original pill
+                    if (e.key === "Escape") {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        e.stopImmediatePropagation();
+
+                        // Restore the original pill
+                        this.appendValidatedData(original_item, false, true);
+
+                        // Remove the editable input
+                        $editable.remove();
+                        store.$input.trigger("focus");
+                    }
+                },
+                true, // capture phase - runs before bubbling
+            );
+
+            // Handle blur on editable pill - pillify or discard
+            $editable.on("blur", function (this: HTMLElement, e) {
+                // Don't pillify if clicking on typeahead menu
+                const related_target = e.relatedTarget;
+                if (
+                    related_target instanceof Element &&
+                    related_target.closest(".typeahead-menu")
+                ) {
+                    return;
+                }
+
+                const value = $(this).text().trim();
+                if (value.length > 0) {
+                    const ret = funcs.appendPill(value);
+                    if (ret) {
+                        $(this).remove();
+                    }
+                } else {
+                    $(this).remove();
+                }
+            });
+        },
+    };
     {
         store.$parent.on("keydown", ".input", function (this: HTMLElement, e) {
             // `convert_to_pill_on_enter = false` allows some pill containers,
@@ -408,6 +495,11 @@ export function create<ItemType extends {type: string}>(
                 case "ArrowRight":
                     $pill.next().trigger("focus");
                     break;
+                case "Enter":
+                    // Edit the focused pill
+                    e.preventDefault();
+                    funcs.editPill($pill);
+                    break;
                 case "Backspace": {
                     const $prev = $pill.prev();
                     const $next = $pill.next();
@@ -423,6 +515,13 @@ export function create<ItemType extends {type: string}>(
                     break;
                 }
             }
+        });
+
+        // Double-click on pill to edit it
+        store.$parent.on("dblclick", ".pill", function (this: HTMLElement, e) {
+            e.stopPropagation();
+            const $pill = $(this);
+            funcs.editPill($pill);
         });
 
         // when the shake animation is applied to the ".input" on invalid input,
@@ -492,6 +591,30 @@ export function create<ItemType extends {type: string}>(
             e.originalEvent.clipboardData?.setData("text/plain", store.get_text_from_item(item));
             e.preventDefault();
         });
+
+        // Pillify valid input when user clicks outside the input field (Item 4 of #29510).
+        // This is most relevant to the invite modal (emails) but applies elsewhere too.
+        // store.$parent.on("blur", ".input:not(.editable-pill)", function (this: HTMLElement, e) {
+        //     const related_target = e.relatedTarget;
+
+        //     // Don't pillify if clicking on typeahead menu
+        //     if (related_target instanceof Element && related_target.closest(".typeahead-menu")) {
+        //         return;
+        //     }
+
+        //     // Don't pillify if focus is moving to another element in the same container
+        //     if (related_target instanceof Node && store.$parent[0]?.contains(related_target)) {
+        //         return;
+        //     }
+
+        //     const value = funcs.value(this).trim();
+        //     if (value.length > 0) {
+        //         const ret = funcs.appendPill(value);
+        //         if (ret) {
+        //             funcs.clear(this);
+        //         }
+        //     }
+        // });
     }
 
     // the external, user-accessible prototype.

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -222,6 +222,15 @@
             backface-visibility: hidden;
             perspective: 1000px;
         }
+
+        /* Styling for editable pill - when user double-clicks or presses Enter on a pill */
+        &.editable-pill {
+            flex: 0 1 auto;
+            border-radius: 4px;
+            background-color: var(--color-background-input-pill);
+            outline: 2px solid var(--color-focus-outline-input-pill);
+            outline-offset: -1px;
+        }
     }
 
     &.not-editable-by-user {


### PR DESCRIPTION
## Description

Implements **Item 3 from issue #29510** by adding support for **inline editing of pills**.

This change allows users to edit existing pills directly in place, improving usability when correcting or modifying pill values.

> **Note:** This PR intentionally focuses only on inline pill editing (Item 3).  
> Blur-based pillification (Item 4) will be handled in a follow-up PR.

---

## Files Modified

- **`web/src/input_pill.ts`** – Inline pill editing logic (edit mode, save/cancel handling)
- **`web/src/input_pill.css`** – Visual styling for pills in editable state

---

## Implementation Details

### Item 3: Inline Pill Editing

- Users can **double-click a pill** to enter inline edit mode
- The pill is replaced with an inline `contenteditable` element at the same position
- Editing behavior:
  - **Enter** → saves the edited value and restores it as a pill
  - **Escape** → cancels editing and restores the original pill
  - **Blur (while editing)** → finalizes the edit if non-empty, otherwise discards

The editable state is visually distinguished using existing Zulip focus outline variables to remain consistent with other focused inputs.

---

## Screenshots

<!-- Add screenshots here -->

1. **Before editing**  
   _Pills in their normal (non-editable) state_
<img width="1437" height="847" alt="Screenshot 2026-01-11 at 5 13 01 PM" src="https://github.com/user-attachments/assets/97153dde-2fb9-43e8-80af-f75cfc504720" />


2. **Inline edit mode**  
   _A pill after double-clicking, showing the caret and editable styling_
<img width="1438" height="848" alt="Screenshot 2026-01-11 at 5 13 25 PM" src="https://github.com/user-attachments/assets/5fa48db3-9a3e-4856-9bae-29dcd1de54dc" />



3. **After saving edit**  
   _The pill restored with the updated value after pressing Enter_
<img width="1439" height="852" alt="Screenshot 2026-01-11 at 5 13 46 PM" src="https://github.com/user-attachments/assets/55e8c2d6-620c-4e04-9e89-e4479be21074" />


---

## How Changes Were Tested

Manual testing was performed in the **Invite Users** modal:

- Double-clicking a pill reliably enters inline edit mode
- Pressing **Enter** saves the edited value
- Pressing **Escape** cancels editing and restores the original pill
- Blurring the editable pill finalizes the edit appropriately

---

## Closes

Partially addresses **#29510 (Item 3 only)**

---

## Related

Builds on existing pill UX improvements in the main branch:

- Item 1 — Hover behavior
- Item 2 — Selection outline
- Item 5 — Centered × button
