### PR TITLE
Github Webhooks: Add parameter to hide body on updated issues/PRs

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -678,6 +678,11 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
                 label="Include emoji indicators in the notifications",
                 input_type="checkbox_enabled",
             ),
+            WebhookUrlOption(
+                name="compact_edit",
+                label="Exclude issue and pull request descriptions on edit notifications",
+                input_type="checkbox_enabled",
+            ),
         ],
     ),
     IncomingWebhookIntegration(

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -667,6 +667,11 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
                 label="Include emoji indicators in the notifications",
                 input_type="checkbox_enabled",
             ),
+            WebhookUrlOption(
+                name="compact_edit_format",
+                label="Use a compact message format for edited issue and pull request descriptions",
+                input_type="checkbox_enabled",
+            ),
         ],
     ),
     IncomingWebhookIntegration(

--- a/zerver/webhooks/github/doc.md
+++ b/zerver/webhooks/github/doc.md
@@ -21,7 +21,7 @@ Get GitHub notifications in Zulip!
     - Whether to exclude notifications from private repositories.
     - Whether to include the repository name in the notifications.
     - Whether to include emoji indicators in the notifications.
-
+    - Whether to exclude issue and pull request descriptions on edit notifications.
 
 1. On your repository's web page, go to **Settings**. Select **Webhooks**,
    and click **Add webhook**. GitHub may prompt you for your password.

--- a/zerver/webhooks/github/doc.md
+++ b/zerver/webhooks/github/doc.md
@@ -21,6 +21,7 @@ Get GitHub notifications in Zulip!
     - Whether to exclude notifications from private repositories.
     - Whether to include the repository name in the notifications.
     - Whether to include emoji indicators in the notifications.
+    - Whether to use a compact message format for edited issue and pull request descriptions.
 
 
 1. On your repository's web page, go to **Settings**. Select **Webhooks**,

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -153,15 +153,24 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("fork", TOPIC_REPO, expected_message)
 
     def test_issues_edited_body(self) -> None:
+        self.url = self.build_webhook_url(compact_edit="false")
         expected_topic_name = "test-repo / issue #6 New Issue edited"
         expected_message = "Pritesh-30 edited [issue #6](https://github.com/Pritesh-30/test-repo/issues/6):\n\n``` quote\nThe body of the issue is edited.\n```"
         self.check_webhook("issues__edited_body", expected_topic_name, expected_message)
 
     def test_issues_edited_title(self) -> None:
+        self.url = self.build_webhook_url(compact_edit="false")
         long_title = "This is a very long issue title used to exceed Zulip's maximum topic length so that truncation logic is exercised when the issue title is edited via the GitHub webhook"
         expected_topic_name = truncate_topic(f"test-repo / issue #6 {long_title}")
         expected_message = "Pritesh-30 edited [issue #6](https://github.com/Pritesh-30/test-repo/issues/6):\n\n``` quote\nThe body of the issue is edited.\n```"
         self.check_webhook("issues__edited_title", expected_topic_name, expected_message)
+
+    def test_issues_edited_body_compact(self) -> None:
+        expected_topic_name = "test-repo / issue #6 New Issue edited"
+        expected_message = (
+            "Pritesh-30 edited [issue #6](https://github.com/Pritesh-30/test-repo/issues/6)."
+        )
+        self.check_webhook("issues__edited_body", expected_topic_name, expected_message)
 
     def test_issue_comment_msg(self) -> None:
         expected_message = "baxterthehacker [commented](https://github.com/baxterthehacker/public-repo/issues/2#issuecomment-99262140) on [issue #2](https://github.com/baxterthehacker/public-repo/issues/2):\n\n``` quote\nYou are totally right! I'll get this fixed right away.\n```"
@@ -450,7 +459,14 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("pull_request__edited", TOPIC_PR, expected_message)
 
     def test_pull_request_edited_with_body_change(self) -> None:
+        self.url = self.build_webhook_url(compact_edit="false")
         expected_message = "cozyrohan edited [PR #1](https://github.com/cozyrohan/public-repo/pull/1):\n\n``` quote\nPR EDITED\n```"
+        self.check_webhook("pull_request__edited_with_body_change", TOPIC_PR, expected_message)
+
+    def test_pull_request_edited_with_body_change_compact(self) -> None:
+        expected_message = (
+            "cozyrohan edited [PR #1](https://github.com/cozyrohan/public-repo/pull/1)."
+        )
         self.check_webhook("pull_request__edited_with_body_change", TOPIC_PR, expected_message)
 
     def test_pull_request_synchronized_with_body(self) -> None:

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -168,15 +168,24 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("fork", TOPIC_REPO, expected_message)
 
     def test_issues_edited_body(self) -> None:
+        self.url = self.build_webhook_url(compact_edit_format="false")
         expected_topic_name = "test-repo / issue #6 New Issue edited"
         expected_message = "Pritesh-30 edited [issue #6](https://github.com/Pritesh-30/test-repo/issues/6):\n\n``` quote\nThe body of the issue is edited.\n```"
         self.check_webhook("issues__edited_body", expected_topic_name, expected_message)
 
     def test_issues_edited_title(self) -> None:
+        self.url = self.build_webhook_url(compact_edit_format="false")
         long_title = "This is a very long issue title used to exceed Zulip's maximum topic length so that truncation logic is exercised when the issue title is edited via the GitHub webhook"
         expected_topic_name = truncate_topic(f"test-repo / issue #6 {long_title}")
         expected_message = "Pritesh-30 edited [issue #6](https://github.com/Pritesh-30/test-repo/issues/6):\n\n``` quote\nThe body of the issue is edited.\n```"
         self.check_webhook("issues__edited_title", expected_topic_name, expected_message)
+
+    def test_issues_edited_body_compact(self) -> None:
+        expected_topic_name = "test-repo / issue #6 New Issue edited"
+        expected_message = (
+            "Pritesh-30 edited [issue #6](https://github.com/Pritesh-30/test-repo/issues/6)."
+        )
+        self.check_webhook("issues__edited_body", expected_topic_name, expected_message)
 
     def test_issue_comment_msg(self) -> None:
         expected_message = "baxterthehacker [commented](https://github.com/baxterthehacker/public-repo/issues/2#issuecomment-99262140) on [issue #2](https://github.com/baxterthehacker/public-repo/issues/2):\n\n``` quote\nYou are totally right! I'll get this fixed right away.\n```"
@@ -475,7 +484,14 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("pull_request__edited", TOPIC_PR, expected_message)
 
     def test_pull_request_edited_with_body_change(self) -> None:
+        self.url = self.build_webhook_url(compact_edit_format="false")
         expected_message = "cozyrohan edited [PR #1](https://github.com/cozyrohan/public-repo/pull/1):\n\n``` quote\nPR EDITED\n```"
+        self.check_webhook("pull_request__edited_with_body_change", TOPIC_PR, expected_message)
+
+    def test_pull_request_edited_with_body_change_compact(self) -> None:
+        expected_message = (
+            "cozyrohan edited [PR #1](https://github.com/cozyrohan/public-repo/pull/1)."
+        )
         self.check_webhook("pull_request__edited_with_body_change", TOPIC_PR, expected_message)
 
     def test_pull_request_synchronized_with_body(self) -> None:

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -69,6 +69,7 @@ class Helper:
         include_repository_name: bool,
         include_emoji_indicators: bool,
         user_profile: UserProfile,
+        compact_edit: bool,
     ) -> None:
         self.request = request
         self.payload = payload
@@ -76,6 +77,7 @@ class Helper:
         self.include_repository_name = include_repository_name
         self.include_emoji_indicators = include_emoji_indicators
         self.realm = user_profile.realm
+        self.compact_edit = compact_edit
 
     def log_unsupported(self, event: str) -> None:
         summary = f"The '{event}' event isn't currently supported by the GitHub webhook; ignoring"
@@ -94,7 +96,7 @@ def get_opened_or_update_pull_request_body(helper: Helper) -> str:
         assignee = pull_request["assignee"]["login"].tame(check_string)
     description = None
     changes = payload.get("changes", {})
-    if "body" in changes or action == "opened":
+    if action == "opened" or (action == "edited" and not helper.compact_edit and "body" in changes):
         description = pull_request["body"].tame(check_none_or(check_string))
     target_branch = None
     base_branch = None
@@ -178,16 +180,20 @@ def get_issue_body(helper: Helper) -> str:
     include_title = helper.include_title
     action = payload["action"].tame(check_string)
     issue = payload["issue"]
+    is_compact_edit = action == "edited" and helper.compact_edit
+    is_assignment_action = action in ("assigned", "unassigned")
+    message = (
+        None
+        if (is_compact_edit or is_assignment_action)
+        else issue["body"].tame(check_none_or(check_string))
+    )
+
     return get_issue_event_message(
         user_name=get_sender_name(helper),
         action=action,
         url=issue["html_url"].tame(check_string),
         number=issue["number"].tame(check_int),
-        message=(
-            None
-            if action in ("assigned", "unassigned")
-            else issue["body"].tame(check_none_or(check_string))
-        ),
+        message=message,
         title=issue["title"].tame(check_string) if include_title else None,
         assignee_updated=(
             payload["assignee"]["login"].tame(check_string) if "assignee" in payload else None
@@ -1153,6 +1159,7 @@ def api_github_webhook(
     ignore_private_repositories: Json[bool] = False,
     include_repository_name: Json[bool] = False,
     include_emoji_indicators: Json[bool] = True,
+    compact_edit: Json[bool] = True,
 ) -> HttpResponse:
     """
     GitHub sends the event as an HTTP header.  We have our
@@ -1199,6 +1206,7 @@ def api_github_webhook(
         include_repository_name=include_repository_name,
         include_emoji_indicators=include_emoji_indicators,
         user_profile=user_profile,
+        compact_edit=compact_edit,
     )
     body = body_function(helper)
 

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -100,6 +100,7 @@ class Helper:
         include_repository_name: bool,
         include_emoji_indicators: bool,
         user_profile: UserProfile,
+        compact_edit_format: bool,
     ) -> None:
         self.request = request
         self.payload = payload
@@ -107,6 +108,7 @@ class Helper:
         self.include_repository_name = include_repository_name
         self.include_emoji_indicators = include_emoji_indicators
         self.realm = user_profile.realm
+        self.compact_edit_format = compact_edit_format
 
     def log_unsupported(self, event: str) -> None:
         summary = f"The '{event}' event isn't currently supported by the GitHub webhook; ignoring"
@@ -125,7 +127,9 @@ def get_opened_or_update_pull_request_body(helper: Helper) -> str:
         assignee = pull_request["assignee"]["login"].tame(check_string)
     description = None
     changes = payload.get("changes", {})
-    if "body" in changes or action == "opened":
+    if action == "opened" or (
+        action == "edited" and not helper.compact_edit_format and "body" in changes
+    ):
         description = pull_request["body"].tame(check_none_or(check_string))
     target_branch = None
     base_branch = None
@@ -210,16 +214,20 @@ def get_issue_body(helper: Helper) -> str:
     include_title = helper.include_title
     action = payload["action"].tame(check_string)
     issue = payload["issue"]
+    use_compact_format = action == "edited" and helper.compact_edit_format
+    is_assignment_action = action in ("assigned", "unassigned")
+    message = (
+        None
+        if (use_compact_format or is_assignment_action)
+        else issue["body"].tame(check_none_or(check_string))
+    )
+
     return get_issue_event_message(
         user_name=get_sender_name(helper),
         action=action,
         url=issue["html_url"].tame(check_string),
         number=issue["number"].tame(check_int),
-        message=(
-            None
-            if action in ("assigned", "unassigned")
-            else issue["body"].tame(check_none_or(check_string))
-        ),
+        message=message,
         title=issue["title"].tame(check_string) if include_title else None,
         assignee_updated=(
             payload["assignee"]["login"].tame(check_string) if "assignee" in payload else None
@@ -1208,6 +1216,7 @@ def api_github_webhook(
     ignore_private_repositories: Json[bool] = False,
     include_repository_name: Json[bool] = False,
     include_emoji_indicators: Json[bool] = True,
+    compact_edit_format: Json[bool] = True,
 ) -> HttpResponse:
     """
     GitHub sends the event as an HTTP header.  We have our
@@ -1254,6 +1263,7 @@ def api_github_webhook(
         include_repository_name=include_repository_name,
         include_emoji_indicators=include_emoji_indicators,
         user_profile=user_profile,
+        compact_edit_format=compact_edit_format,
     )
     body = body_function(helper)
 


### PR DESCRIPTION
Fixes part of #32323.

This PR adds support for a new `compact_edit` URL option in the GitHub webhook
integration to hide body content for **edited issues and pull requests**.

Added the `compact_edit` URL option to `integrations.py` and updated the gitHubs integration documentation

**How changes were tested:**
- Ran `./tools/test-backend zerver/webhooks/github` all test suites pass

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
When no compact_edit or compact_edit=false
<img width="1094" height="162" alt="image" src="https://github.com/user-attachments/assets/abcbb785-9eba-45c7-a615-a9c7334409be" />
when compact_edit=true
<img width="1121" height="74" alt="image" src="https://github.com/user-attachments/assets/fb725fb2-d471-4e4b-a2a7-3a7e40e3652e" />
When PR is edited
<img width="1124" height="138" alt="image" src="https://github.com/user-attachments/assets/4e6a4475-fe4e-4965-a64a-df7470302e3c" />


<img width="761" height="827" alt="image" src="https://github.com/user-attachments/assets/882e2f3a-22ef-44a0-9a3a-9bc09c2d2bc9" />
<img width="752" height="824" alt="image" src="https://github.com/user-attachments/assets/2960c261-be11-426a-ae5b-6b6df80915c9" />


<img width="1499" height="789" alt="image" src="https://github.com/user-attachments/assets/5e7ace6d-f852-4768-a3c9-c85d6a3a9872" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
