### PR TITLE
intercom: Send confirmation message on ping test notification.

### DIFF
--- a/zerver/webhooks/intercom/tests.py
+++ b/zerver/webhooks/intercom/tests.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock, patch
-
 from zerver.lib.test_classes import WebhookTestCase
 
 
@@ -8,13 +6,14 @@ class IntercomWebHookTests(WebhookTestCase):
     URL_TEMPLATE = "/api/v1/external/intercom?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "intercom"
 
-    @patch("zerver.webhooks.intercom.view.check_send_webhook_message")
-    def test_ping_ignore(self, check_send_webhook_message_mock: MagicMock) -> None:
-        self.url = self.build_webhook_url()
-        payload = self.get_body("ping")
-        result = self.client_post(self.url, payload, content_type="application/json")
-        self.assertFalse(check_send_webhook_message_mock.called)
-        self.assert_json_success(result)
+    def test_ping(self) -> None:
+        expected_topic_name = "Ping"
+        expected_message = "Intercom integration test successful."
+        self.check_webhook(
+            "ping",
+            expected_topic_name,
+            expected_message,
+        )
 
     def test_company_created(self) -> None:
         expected_topic_name = "Companies"

--- a/zerver/webhooks/intercom/view.py
+++ b/zerver/webhooks/intercom/view.py
@@ -60,6 +60,8 @@ CONVERSATION_ADMIN_INITIATED_CONVERSATION = """
 
 EVENT_CREATED = "New event **{event_name}** created."
 
+PING_MESSAGE = "Intercom integration test successful."
+
 USER_CREATED = """
 New user created:
 * **Name**: {name}
@@ -290,6 +292,10 @@ def get_user_unsubscribed_message(payload: WildValue) -> tuple[str, str]:
     return (topic_name, body)
 
 
+def get_ping_message(payload: WildValue) -> tuple[str, str]:
+    return ("Ping", PING_MESSAGE)
+
+
 EVENT_TO_FUNCTION_MAPPER: dict[str, Callable[[WildValue], tuple[str, str]]] = {
     "company.created": get_company_created_message,
     "contact.added_email": get_contact_added_email_message,
@@ -308,6 +314,7 @@ EVENT_TO_FUNCTION_MAPPER: dict[str, Callable[[WildValue], tuple[str, str]]] = {
     "conversation.user.created": get_conversation_user_created_message,
     "conversation.user.replied": get_conversation_user_replied_message,
     "event.created": get_event_created_message,
+    "ping": get_ping_message,
     "user.created": get_user_created_message,
     "user.deleted": get_user_deleted_message,
     "user.email.updated": get_user_email_updated_message,
@@ -333,8 +340,6 @@ def api_intercom_webhook(
     payload: JsonBodyPayload[WildValue],
 ) -> HttpResponse:
     event_type = payload["topic"].tame(check_string)
-    if event_type == "ping":
-        return json_success(request)
 
     handler = EVENT_TO_FUNCTION_MAPPER.get(event_type)
     if handler is None:


### PR DESCRIPTION
<!-- Describe your pull request here.-->

When Intercom sends a ping/test notification to verify the webhook URL is
working, we now send a confirmation message to Zulip instead of silently
returning success.

This makes it easier for users to verify their Intercom integration is
correctly set up, as they'll see "Intercom integration test successful."
appear in their configured stream.

**Changes:**
- Added [get_ping_message()](cci:1://file:///home/sathwik/zulip/zerver/webhooks/intercom/view.py:294:0-295:33) handler following the existing function pattern
- Added `"ping"` to `EVENT_TO_FUNCTION_MAPPER` for consistency with other events
- Updated test to verify the confirmation message is sent

Partially Fixes: #31170

**How changes were tested:**

- All 25 Intercom webhook tests pass (`./tools/test-backend zerver.webhooks.intercom.tests`)
- The new [test_ping](cci:1://file:///home/sathwik/zulip/zerver/webhooks/intercom/tests.py:8:4-15:9) verifies that the ping event sends the expected message

**Screenshots and screen captures:**

tested with this curl command
```
curl -X POST "http://localhost:9991/api/v1/external/intercom?api_key=2sxpIMLGBucI1htnBNRJ6UmwvwQRNdL0&stream=13" \
  -H "Content-Type: application/json" \
  -d '{
    "type": "notification_event",
    "app_id": "test123",
    "data": {
        "type": "notification_event_data",
        "item": {
            "type": "ping",
            "message": "test ping"
        }
    },
    "id": null,
    "topic": "ping",
    "delivery_status": null,
    "delivery_attempts": 1,
    "delivered_at": 0,
    "first_sent_at": 1553288147,
    "created_at": 1553288147
}'

```

UI screenshot
<img width="1910" height="869" alt="image" src="https://github.com/user-attachments/assets/457e015f-bea7-489b-8de8-c88501a57d65" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>