### PR TITLE
settings: Hide unauthorized bot action buttons.

### DIFF
--- a/web/src/settings_bots.ts
+++ b/web/src/settings_bots.ts
@@ -4,7 +4,7 @@ import type * as tippy from "tippy.js";
 
 import render_add_new_bot_form from "../templates/settings/add_new_bot_form.hbs";
 import render_bot_settings_tip from "../templates/settings/bot_settings_tip.hbs";
-import render_settings_user_list_row from "../templates/settings/settings_user_list_row.hbs";
+import render_settings_bot_list_row from "../templates/settings/settings_bot_list_row.hbs";
 
 import * as avatar from "./avatar.ts";
 import * as bot_data from "./bot_data.ts";
@@ -639,7 +639,7 @@ function create_all_bots_table(
     section.list_widget = ListWidget.create($all_bots_table, bot_user_ids, {
         name: widget_name,
         get_item: bot_info,
-        modifier_html: render_settings_user_list_row,
+        modifier_html: render_settings_bot_list_row,
         html_selector: (item) => $(`tr[data-user-id='${CSS.escape(item.user_id.toString())}']`),
         filter: {
             predicate(item) {
@@ -681,7 +681,7 @@ function create_your_bots_table(
     section.list_widget = ListWidget.create($your_bots_table, bot_user_ids, {
         name: widget_name,
         get_item: bot_info,
-        modifier_html: render_settings_user_list_row,
+        modifier_html: render_settings_bot_list_row,
         html_selector: (item) => $(`tr[data-user-id='${CSS.escape(item.user_id.toString())}']`),
         filter: {
             predicate(item) {

--- a/web/src/settings_bots.ts
+++ b/web/src/settings_bots.ts
@@ -68,9 +68,10 @@ type BotInfo = {
     no_owner: boolean;
     is_current_user: boolean;
     can_modify: boolean;
-    cannot_deactivate: boolean;
-    cannot_edit: boolean;
+    show_edit_button: boolean;
+    show_deactivate_or_reactivate_button: boolean;
     display_email: string;
+    is_system_bot: boolean;
     show_download_zuliprc_button: boolean;
     show_generate_integration_url_button: boolean;
 } & (
@@ -426,6 +427,11 @@ function bot_info(bot_user_id: number): BotInfo {
 
     const is_bot_owner = owner_id === current_user.user_id;
     const can_modify_bot = current_user.is_admin || is_bot_owner;
+    const is_system_bot = bot_user.is_system_bot ?? false;
+
+    const show_edit_button = can_modify_bot || (is_system_bot && current_user.is_admin);
+    const show_deactivate_or_reactivate_button =
+        can_modify_bot || (is_system_bot && current_user.is_admin);
 
     return {
         is_bot: true,
@@ -442,8 +448,7 @@ function bot_info(bot_user_id: number): BotInfo {
         no_owner: !owner_full_name,
         is_current_user: false,
         can_modify: can_modify_bot,
-        cannot_deactivate: (bot_user.is_system_bot ?? false) || !can_modify_bot,
-        cannot_edit: (bot_user.is_system_bot ?? false) || !can_modify_bot,
+        is_system_bot,
         // It's always safe to show the real email addresses for bot users
         display_email: bot_user.email,
         ...(owner_id
@@ -458,7 +463,25 @@ function bot_info(bot_user_id: number): BotInfo {
         show_download_zuliprc_button: is_bot_owner && bot_user.bot_type === GENERIC_BOT_TYPE,
         show_generate_integration_url_button:
             can_modify_bot && bot_user.bot_type === INCOMING_WEBHOOK_BOT_TYPE_INT,
+        show_edit_button,
+        show_deactivate_or_reactivate_button,
     };
+}
+
+function should_show_actions_column(bot_user_ids: number[]): boolean {
+    for (const bot_user_id of bot_user_ids) {
+        const info = bot_info(bot_user_id);
+
+        if (
+            info.show_download_zuliprc_button ||
+            info.show_generate_integration_url_button ||
+            info.show_edit_button ||
+            info.show_deactivate_or_reactivate_button
+        ) {
+            return true;
+        }
+    }
+    return false;
 }
 
 function handle_bot_deactivation($tbody: JQuery): void {
@@ -624,12 +647,24 @@ function reset_scrollbar($sel: JQuery): () => void {
     };
 }
 
+function update_actions_column_header_visibility(
+    section: BotSettingsSection,
+    $container: JQuery,
+): void {
+    const current_list = section.list_widget?.get_current_list() ?? [];
+    const filtered_ids = current_list.map((item) => item.user_id);
+    const show_actions = should_show_actions_column(filtered_ids);
+
+    $container.find(".actions-header").toggle(show_actions);
+    $container.find("td.actions").toggle(show_actions);
+}
+
 function create_all_bots_table(
     section: BotSettingsSection,
     $container: JQuery,
     widget_name: string,
 ): void {
-    loading.make_indicator($container.find("loading-indicator"), {
+    loading.make_indicator($container.find(".loading-indicator"), {
         text: $t({defaultMessage: "Loading…"}),
     });
     const $all_bots_table = $container.find(".bot-table");
@@ -649,7 +684,10 @@ function create_all_bots_table(
                 const $search_input = $container.find(".search");
                 return are_filters_active(section.filters, $search_input);
             },
-            onupdate: reset_scrollbar($all_bots_table),
+            onupdate() {
+                update_actions_column_header_visibility(section, $container);
+                reset_scrollbar($all_bots_table)();
+            },
         },
         $parent_container: $container.expectOne(),
         init_sort: "full_name_alphabetic",
@@ -663,7 +701,9 @@ function create_all_bots_table(
     });
     settings_users.set_text_search_value($all_bots_table, section.filters.text_search);
 
-    loading.destroy_indicator($container.find("loading-indicator"));
+    update_actions_column_header_visibility(section, $container);
+
+    loading.destroy_indicator($container.find(".loading-indicator"));
     $all_bots_table.show();
 }
 
@@ -672,7 +712,7 @@ function create_your_bots_table(
     $container: JQuery,
     widget_name: string,
 ): void {
-    loading.make_indicator($container.find("loading-indicator"), {
+    loading.make_indicator($container.find(".loading-indicator"), {
         text: $t({defaultMessage: "Loading…"}),
     });
     const $your_bots_table = $container.find(".bot-table");
@@ -691,7 +731,10 @@ function create_your_bots_table(
                 const $search_input = $container.find(".search");
                 return are_filters_active(section.filters, $search_input);
             },
-            onupdate: reset_scrollbar($your_bots_table),
+            onupdate() {
+                update_actions_column_header_visibility(section, $container);
+                reset_scrollbar($your_bots_table)();
+            },
         },
         $parent_container: $container.expectOne(),
         init_sort: "full_name_alphabetic",
@@ -705,7 +748,9 @@ function create_your_bots_table(
     });
     settings_users.set_text_search_value($your_bots_table, section.filters.text_search);
 
-    loading.destroy_indicator($container.find("loading-indicator"));
+    update_actions_column_header_visibility(section, $container);
+
+    loading.destroy_indicator($container.find(".loading-indicator"));
     $your_bots_table.show();
 }
 

--- a/web/src/settings_bots.ts
+++ b/web/src/settings_bots.ts
@@ -70,6 +70,7 @@ type BotInfo = {
     can_modify: boolean;
     cannot_deactivate: boolean;
     cannot_edit: boolean;
+    show_manage_buttons: boolean;
     display_email: string;
     show_download_zuliprc_button: boolean;
     show_generate_integration_url_button: boolean;
@@ -426,6 +427,11 @@ function bot_info(bot_user_id: number): BotInfo {
 
     const is_bot_owner = owner_id === current_user.user_id;
     const can_modify_bot = current_user.is_admin || is_bot_owner;
+    const is_system_bot = bot_user.is_system_bot ?? false;
+
+    // can_modify_bot is already true for admins, so the extra
+    // is_system_bot check added nothing — collapsed into one flag.
+    const show_manage_buttons = can_modify_bot;
 
     return {
         is_bot: true,
@@ -442,8 +448,8 @@ function bot_info(bot_user_id: number): BotInfo {
         no_owner: !owner_full_name,
         is_current_user: false,
         can_modify: can_modify_bot,
-        cannot_deactivate: (bot_user.is_system_bot ?? false) || !can_modify_bot,
-        cannot_edit: (bot_user.is_system_bot ?? false) || !can_modify_bot,
+        cannot_deactivate: is_system_bot || !can_modify_bot,
+        cannot_edit: is_system_bot || !can_modify_bot,
         // It's always safe to show the real email addresses for bot users
         display_email: bot_user.email,
         ...(owner_id
@@ -458,7 +464,17 @@ function bot_info(bot_user_id: number): BotInfo {
         show_download_zuliprc_button: is_bot_owner && bot_user.bot_type === GENERIC_BOT_TYPE,
         show_generate_integration_url_button:
             can_modify_bot && bot_user.bot_type === INCOMING_WEBHOOK_BOT_TYPE_INT,
+        show_manage_buttons,
     };
+}
+
+function should_show_actions_column(bot_list: BotInfo[]): boolean {
+    return bot_list.some(
+        (info) =>
+            info.show_download_zuliprc_button ||
+            info.show_generate_integration_url_button ||
+            info.show_manage_buttons,
+    );
 }
 
 function handle_bot_deactivation($tbody: JQuery): void {
@@ -624,6 +640,12 @@ function reset_scrollbar($sel: JQuery): () => void {
     };
 }
 
+function update_actions_column_visibility(section: BotSettingsSection, $container: JQuery): void {
+    const current_list = section.list_widget?.get_current_list() ?? [];
+    const show_actions = should_show_actions_column(current_list);
+    $container.find(".bot-list-table").toggleClass("hide-actions-column", !show_actions);
+}
+
 function create_all_bots_table(
     section: BotSettingsSection,
     $container: JQuery,
@@ -649,7 +671,10 @@ function create_all_bots_table(
                 const $search_input = $container.find(".search");
                 return are_filters_active(section.filters, $search_input);
             },
-            onupdate: reset_scrollbar($all_bots_table),
+            onupdate() {
+                update_actions_column_visibility(section, $container);
+                reset_scrollbar($all_bots_table)();
+            },
         },
         $parent_container: $container.expectOne(),
         init_sort: "full_name_alphabetic",
@@ -662,6 +687,8 @@ function create_all_bots_table(
         $simplebar_container: $container.find(".progressive-table-wrapper"),
     });
     settings_users.set_text_search_value($all_bots_table, section.filters.text_search);
+
+    update_actions_column_visibility(section, $container);
 
     loading.destroy_indicator($container.find(".loading-indicator"));
     $all_bots_table.show();
@@ -691,7 +718,10 @@ function create_your_bots_table(
                 const $search_input = $container.find(".search");
                 return are_filters_active(section.filters, $search_input);
             },
-            onupdate: reset_scrollbar($your_bots_table),
+            onupdate() {
+                update_actions_column_visibility(section, $container);
+                reset_scrollbar($your_bots_table)();
+            },
         },
         $parent_container: $container.expectOne(),
         init_sort: "full_name_alphabetic",
@@ -704,6 +734,8 @@ function create_your_bots_table(
         $simplebar_container: $container.find(".progressive-table-wrapper"),
     });
     settings_users.set_text_search_value($your_bots_table, section.filters.text_search);
+
+    update_actions_column_visibility(section, $container);
 
     loading.destroy_indicator($container.find(".loading-indicator"));
     $your_bots_table.show();

--- a/web/src/settings_bots.ts
+++ b/web/src/settings_bots.ts
@@ -629,7 +629,7 @@ function create_all_bots_table(
     $container: JQuery,
     widget_name: string,
 ): void {
-    loading.make_indicator($container.find("loading-indicator"), {
+    loading.make_indicator($container.find(".loading-indicator"), {
         text: $t({defaultMessage: "Loading…"}),
     });
     const $all_bots_table = $container.find(".bot-table");
@@ -663,7 +663,7 @@ function create_all_bots_table(
     });
     settings_users.set_text_search_value($all_bots_table, section.filters.text_search);
 
-    loading.destroy_indicator($container.find("loading-indicator"));
+    loading.destroy_indicator($container.find(".loading-indicator"));
     $all_bots_table.show();
 }
 
@@ -672,7 +672,7 @@ function create_your_bots_table(
     $container: JQuery,
     widget_name: string,
 ): void {
-    loading.make_indicator($container.find("loading-indicator"), {
+    loading.make_indicator($container.find(".loading-indicator"), {
         text: $t({defaultMessage: "Loading…"}),
     });
     const $your_bots_table = $container.find(".bot-table");
@@ -705,7 +705,7 @@ function create_your_bots_table(
     });
     settings_users.set_text_search_value($your_bots_table, section.filters.text_search);
 
-    loading.destroy_indicator($container.find("loading-indicator"));
+    loading.destroy_indicator($container.find(".loading-indicator"));
     $your_bots_table.show();
 }
 

--- a/web/src/user_deactivation_ui.ts
+++ b/web/src/user_deactivation_ui.ts
@@ -126,6 +126,7 @@ export function confirm_bot_deactivation(
         modal_submit_button_text: $t({defaultMessage: "Deactivate"}),
         on_click: handle_confirm,
         loading_spinner,
+        focus_submit_on_open: true,
     });
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -408,6 +408,7 @@ select.settings_select {
 #personal-bot-list .user-status-settings {
     display: flex;
     justify-content: flex-end;
+    min-height: 2.1875em;
 }
 
 .config-download-text {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -408,6 +408,18 @@ select.settings_select {
 #personal-bot-list .user-status-settings {
     display: flex;
     justify-content: flex-end;
+    /* Matches the height of one row of action icon-buttons, so rows keep a consistent height even when no buttons are shown. */
+    min-height: 2.1875em;
+}
+
+.bot-list-table td {
+    /* Keeps row height consistent whether or not the actions column is shown for this table. */
+    height: 2.1875em;
+}
+
+.bot-list-table.hide-actions-column th.actions,
+.bot-list-table.hide-actions-column td.actions {
+    display: none;
 }
 
 .config-download-text {

--- a/web/templates/settings/bot_list.hbs
+++ b/web/templates/settings/bot_list.hbs
@@ -26,7 +26,7 @@
                 <th data-sort="alphabetic" data-sort-prop="bot_type" class="bot_type">{{t "Bot type" }}
                     <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                 </th>
-                <th class="actions">{{t "Actions" }}</th>
+                <th class="actions actions-header">{{t "Actions" }}</th>
             </tr>
         </thead>
         <tbody id="{{prefix}}_{{section_name}}_table" class="bot-table"

--- a/web/templates/settings/bot_list.hbs
+++ b/web/templates/settings/bot_list.hbs
@@ -8,7 +8,7 @@
 </div>
 
 <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
-    <table class="table table-striped wrapped-table">
+    <table class="table table-striped wrapped-table bot-list-table">
         <thead class="table-sticky-headers">
             <tr>
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}

--- a/web/templates/settings/settings_bot_list_row.hbs
+++ b/web/templates/settings/settings_bot_list_row.hbs
@@ -1,0 +1,78 @@
+<tr class="user_row{{#if is_active}} active-user{{else}} deactivated_user{{/if}}" data-user-id="{{user_id}}">
+    <td class="user_name panel_user_list">
+        {{> ../user_display_only_pill display_value=full_name user_id=user_id is_bot=true img_src=img_src is_active=is_active is_current_user=false}}
+    </td>
+    <td class="email settings-email-column">
+        <span class="email">{{display_email}}</span>
+    </td>
+    <td>
+        <span class="user_role">{{user_role_text}}</span>
+    </td>
+    <td>
+        <span class="owner panel_user_list">
+            {{#if no_owner}}
+            {{bot_owner_full_name}}
+            {{else}}
+            {{> ../user_display_only_pill display_value=bot_owner_full_name user_id=bot_owner_id img_src=owner_img_src is_active=is_bot_owner_active}}
+            {{/if}}
+        </span>
+    </td>
+    <td class="bot_type">
+        <span class="bot type">{{bot_type}}</span>
+    </td>
+    <td class="actions">
+        <span class="user-status-settings">
+            {{#if show_download_zuliprc_button}}
+            <a type="submit" download="zuliprc" data-user-id="{{user_id}}" class="hidden-zuliprc-download" hidden></a>
+            <span class="tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Download zuliprc'}}">
+                {{> ../components/icon_button
+                  icon="download"
+                  intent="neutral"
+                  custom_classes="download-bot-zuliprc-button"
+                  }}
+            </span>
+            {{/if}}
+            {{#if show_generate_integration_url_button}}
+            <span class="tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Generate URL for integration'}}">
+                {{> ../components/icon_button
+                  icon="link-2"
+                  intent="neutral"
+                  custom_classes="generate-integration-url-button"
+                  }}
+            </span>
+            {{/if}}
+            <span class="{{#if cannot_edit}}tippy-zulip-tooltip{{else}}tippy-zulip-delayed-tooltip{{/if}}"
+              {{#if cannot_edit}}
+              data-tippy-content="{{t 'This bot cannot be managed.'}}"
+              {{else}}
+              data-tippy-content="{{t 'Manage bot'}}"
+              {{/if}}>
+                {{> ../components/icon_button
+                  icon="user-cog"
+                  intent="neutral"
+                  custom_classes="open-user-form manage-user-button"
+                  disabled=cannot_edit
+                  }}
+            </span>
+            {{#if is_active}}
+            <span class="deactivate-bot-tooltip {{#if cannot_deactivate}}tippy-zulip-tooltip{{/if}}"
+              {{#if cannot_deactivate}}data-tippy-content="{{t 'This bot cannot be deactivated.'}}"{{/if}}>
+                {{> ../components/icon_button
+                  icon="user-x"
+                  intent="danger"
+                  custom_classes="deactivate"
+                  disabled=cannot_deactivate
+                  }}
+            </span>
+            {{else}}
+            <span class="reactivate-bot-tooltip">
+                {{> ../components/icon_button
+                  icon="user-plus"
+                  intent="success"
+                  custom_classes="reactivate"
+                  }}
+            </span>
+            {{/if}}
+        </span>
+    </td>
+</tr>

--- a/web/templates/settings/settings_bot_list_row.hbs
+++ b/web/templates/settings/settings_bot_list_row.hbs
@@ -41,8 +41,9 @@
                   }}
             </span>
             {{/if}}
-            <span class="{{#if cannot_edit}}tippy-zulip-tooltip{{else}}tippy-zulip-delayed-tooltip{{/if}}"
-              {{#if cannot_edit}}
+            {{#if show_edit_button}}
+            <span class="{{#if is_system_bot}}tippy-zulip-tooltip{{else}}tippy-zulip-delayed-tooltip{{/if}}"
+              {{#if is_system_bot}}
               data-tippy-content="{{t 'This bot cannot be managed.'}}"
               {{else}}
               data-tippy-content="{{t 'Manage bot'}}"
@@ -51,27 +52,32 @@
                   icon="user-cog"
                   intent="neutral"
                   custom_classes="open-user-form manage-user-button"
-                  disabled=cannot_edit
+                  disabled=is_system_bot
                   }}
             </span>
-            {{#if is_active}}
-            <span class="deactivate-bot-tooltip {{#if cannot_deactivate}}tippy-zulip-tooltip{{/if}}"
-              {{#if cannot_deactivate}}data-tippy-content="{{t 'This bot cannot be deactivated.'}}"{{/if}}>
-                {{> ../components/icon_button
-                  icon="user-x"
-                  intent="danger"
-                  custom_classes="deactivate"
-                  disabled=cannot_deactivate
-                  }}
-            </span>
-            {{else}}
-            <span class="reactivate-bot-tooltip">
-                {{> ../components/icon_button
-                  icon="user-plus"
-                  intent="success"
-                  custom_classes="reactivate"
-                  }}
-            </span>
+            {{/if}}
+            {{#if show_deactivate_or_reactivate_button}}
+                {{#if is_active}}
+                <span class="deactivate-bot-tooltip {{#if is_system_bot}}tippy-zulip-tooltip{{/if}}"
+                  {{#if is_system_bot}}data-tippy-content="{{t 'This bot cannot be deactivated.'}}"{{/if}}>
+                    {{> ../components/icon_button
+                      icon="user-x"
+                      intent="danger"
+                      custom_classes="deactivate"
+                      disabled=is_system_bot
+                      }}
+                </span>
+                {{else}}
+                <span class="reactivate-bot-tooltip {{#if is_system_bot}}tippy-zulip-tooltip{{/if}}"
+                  {{#if is_system_bot}}data-tippy-content="{{t 'This bot cannot be reactivated.'}}"{{/if}}>
+                    {{> ../components/icon_button
+                      icon="user-plus"
+                      intent="success"
+                      custom_classes="reactivate"
+                      disabled=is_system_bot
+                      }}
+                </span>
+                {{/if}}
             {{/if}}
         </span>
     </td>

--- a/web/templates/settings/settings_bot_list_row.hbs
+++ b/web/templates/settings/settings_bot_list_row.hbs
@@ -41,6 +41,7 @@
                   }}
             </span>
             {{/if}}
+            {{#if show_manage_buttons}}
             <span class="{{#if cannot_edit}}tippy-zulip-tooltip{{else}}tippy-zulip-delayed-tooltip{{/if}}"
               {{#if cannot_edit}}
               data-tippy-content="{{t 'This bot cannot be managed.'}}"
@@ -72,6 +73,7 @@
                   custom_classes="reactivate"
                   }}
             </span>
+            {{/if}}
             {{/if}}
         </span>
     </td>

--- a/web/templates/settings/settings_user_list_row.hbs
+++ b/web/templates/settings/settings_user_list_row.hbs
@@ -14,20 +14,7 @@
     <td>
         <span class="user_role">{{user_role_text}}</span>
     </td>
-    {{#if is_bot}}
-    <td>
-        <span class="owner panel_user_list">
-            {{#if no_owner }}
-            {{bot_owner_full_name}}
-            {{else}}
-            {{> ../user_display_only_pill display_value=bot_owner_full_name user_id=bot_owner_id img_src=owner_img_src is_active=is_bot_owner_active}}
-            {{/if}}
-        </span>
-    </td>
-    <td class="bot_type">
-        <span class="bot type">{{bot_type}}</span>
-    </td>
-    {{else if display_last_active_column}}
+    {{#if display_last_active_column}}
     <td class="last_active">
         {{#if last_active_date}}
             {{last_active_date}}
@@ -36,34 +23,10 @@
         {{/if}}
     </td>
     {{/if}}
-    {{#if (or is_bot can_modify)}}
+    {{#if can_modify}}
     <td class="actions">
         <span class="user-status-settings">
-            {{#if (and is_bot show_download_zuliprc_button)}}
-            <a type="submit" download="zuliprc" data-user-id="{{user_id}}" class="hidden-zuliprc-download" hidden></a>
-            <span class="tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Download zuliprc'}}">
-                {{> ../components/icon_button
-                  icon="download"
-                  intent="neutral"
-                  custom_classes="download-bot-zuliprc-button"
-                  }}
-            </span>
-            {{/if}}
-            {{#if (and is_bot show_generate_integration_url_button)}}
-            <span class="tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Generate URL for integration'}}">
-                {{> ../components/icon_button
-                  icon="link-2"
-                  intent="neutral"
-                  custom_classes="generate-integration-url-button"
-                  }}
-            </span>
-            {{/if}}
-            <span class="{{#if (and is_bot cannot_edit)}}tippy-zulip-tooltip{{else}}tippy-zulip-delayed-tooltip{{/if}}"
-              {{#if (and is_bot cannot_edit)}}
-              data-tippy-content="{{t 'This bot cannot be managed.'}}"
-              {{else}}
-              data-tippy-content="{{#if is_bot}}{{#unless cannot_edit}}{{t 'Manage bot'}}{{/unless}}{{else}}{{t 'Manage user'}}{{/if}}"
-              {{/if}}>
+            <span class="tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Manage user'}}">
                 {{> ../components/icon_button
                   icon="user-cog"
                   intent="neutral"
@@ -72,8 +35,8 @@
                   }}
             </span>
             {{#if is_active}}
-            <span class="{{#if is_bot}}deactivate-bot-tooltip{{else}}deactivate-user-tooltip{{/if}} {{#if cannot_deactivate}}tippy-zulip-tooltip{{/if}}"
-              {{#if (and is_bot cannot_deactivate)}}data-tippy-content="{{t 'This bot cannot be deactivated.'}}"{{else if cannot_deactivate}}data-tippy-content="{{t 'This user cannot be deactivated.'}}"{{/if}}>
+            <span class="deactivate-user-tooltip {{#if cannot_deactivate}}tippy-zulip-tooltip{{/if}}"
+              {{#if cannot_deactivate}}data-tippy-content="{{t 'This user cannot be deactivated.'}}"{{/if}}>
                 {{> ../components/icon_button
                   icon="user-x"
                   intent="danger"
@@ -82,7 +45,7 @@
                   }}
             </span>
             {{else}}
-            <span class="{{#if is_bot}}reactivate-bot-tooltip{{else}}reactivate-user-tooltip{{/if}}">
+            <span class="reactivate-user-tooltip">
                 {{> ../components/icon_button
                   icon="user-plus"
                   intent="success"


### PR DESCRIPTION
For non-admin users, hide bot action buttons they are not allowed to use instead of showing them as disabled. If no actions are available, hide the Actions column entirely. Admin behavior for system bots remains unchanged.

Fixes: #37252

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
| --- | --- |
| <img width="1191" height="756" alt="Screenshot 2025-12-30 at 13 02 53" src="https://github.com/user-attachments/assets/4a8bfec2-5248-4f3b-8e83-25b079e20bd6" /> | <img width="1226" height="754" alt="Screenshot 2025-12-30 at 12 28 55" src="https://github.com/user-attachments/assets/ede2b719-2e30-4eeb-8002-cf2312c39120" /> |
| <img width="1199" height="754" alt="Screenshot 2025-12-30 at 13 02 36" src="https://github.com/user-attachments/assets/c9558e22-b98e-4758-bde1-03382ac409c6" />| <img width="1182" height="750" alt="Screenshot 2025-12-30 at 11 11 25" src="https://github.com/user-attachments/assets/de902fbe-0be0-44d8-b56a-50536f2be2ed" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
