### PR TITLE
streams: Do not prefetch group settings using select_related.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -82,7 +82,7 @@ from zerver.lib.topic import (
 from zerver.lib.topic_link_util import get_stream_topic_link_syntax
 from zerver.lib.types import DirectMessageEditRequest, EditHistoryEvent, StreamMessageEditRequest
 from zerver.lib.url_encoding import stream_message_url
-from zerver.lib.user_groups import get_recursive_membership_groups
+from zerver.lib.user_groups import UserGroupMembershipDetails
 from zerver.lib.user_message import bulk_insert_all_ums
 from zerver.lib.user_topics import get_users_with_user_topic_visibility_policy
 from zerver.lib.widget import is_widget_message
@@ -1654,9 +1654,7 @@ def check_update_message(
             check_user_group_mention_allowed(user_profile, mentioned_group_ids)
 
     if isinstance(message_edit_request, StreamMessageEditRequest):
-        user_recursive_group_ids = set(
-            get_recursive_membership_groups(user_profile).values_list("id", flat=True)
-        )
+        user_group_membership_details = UserGroupMembershipDetails(user_recursive_group_ids=None)
         system_groups_name_dict = get_realm_system_groups_name_dict(user_profile.realm_id)
         if message_edit_request.is_stream_edited:
             assert message.is_channel_message
@@ -1666,7 +1664,7 @@ def check_update_message(
             check_stream_access_based_on_can_send_message_group(
                 user_profile,
                 message_edit_request.target_stream,
-                user_recursive_group_ids,
+                user_group_membership_details,
                 system_groups_name_dict,
             )
 
@@ -1703,7 +1701,7 @@ def check_update_message(
                 user_profile,
                 message_edit_request.target_stream,
                 message_edit_request.target_topic_name,
-                user_recursive_group_ids,
+                user_group_membership_details,
                 system_groups_name_dict,
             )
 

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -83,9 +83,9 @@ from zerver.lib.topic import get_topic_display_name, participants_for_topic
 from zerver.lib.topic_link_util import get_stream_link_syntax
 from zerver.lib.url_preview.types import UrlEmbedData
 from zerver.lib.user_groups import (
+    UserGroupMembershipDetails,
     check_any_user_has_permission_by_role,
     check_user_has_permission_by_role,
-    get_recursive_membership_groups,
     is_any_user_in_group,
     is_user_in_group,
 )
@@ -1787,9 +1787,7 @@ def check_message(
             type=Recipient.STREAM,
         )
 
-        user_recursive_group_ids = set(
-            get_recursive_membership_groups(sender).values_list("id", flat=True)
-        )
+        user_group_membership_details = UserGroupMembershipDetails(user_recursive_group_ids=None)
         system_groups_name_dict = get_realm_system_groups_name_dict(stream.realm_id)
         if not skip_stream_access_check:
             access_stream_for_send_message(
@@ -1797,7 +1795,7 @@ def check_message(
                 stream=stream,
                 forwarder_user_profile=forwarder_user_profile,
                 archived_channel_notice=archived_channel_notice,
-                user_recursive_group_ids=user_recursive_group_ids,
+                user_group_membership_details=user_group_membership_details,
                 system_groups_name_dict=system_groups_name_dict,
             )
         else:
@@ -1811,7 +1809,7 @@ def check_message(
             user_profile=sender,
             stream=stream,
             topic_name=topic_name,
-            user_recursive_group_ids=user_recursive_group_ids,
+            user_group_membership_details=user_group_membership_details,
             system_groups_name_dict=system_groups_name_dict,
         )
 

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1401,7 +1401,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         incoming_valid_message["To"] = mm_address
         incoming_valid_message["Reply-to"] = user_profile.delivery_email
 
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(18):
             process_message(incoming_valid_message)
 
         # confirm that Hamlet got the message

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -1563,7 +1563,7 @@ class MessageMoveStreamTest(ZulipTestCase):
             "iago", "test move stream", "new stream", "test"
         )
 
-        with self.assert_database_query_count(63), self.assert_memcached_count(17):
+        with self.assert_database_query_count(60), self.assert_memcached_count(17):
             result = self.client_patch(
                 f"/json/messages/{msg_id}",
                 {

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -420,7 +420,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         # state + 1/user with a UserTopic row for the events data)
         # beyond what is typical were there not UserTopic records to
         # update. Ideally, we'd eliminate the per-user component.
-        with self.assert_database_query_count(29):
+        with self.assert_database_query_count(28):
             check_update_message(
                 user_profile=hamlet,
                 message_id=message_id,
@@ -517,7 +517,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
-        with self.assert_database_query_count(31):
+        with self.assert_database_query_count(30):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -547,7 +547,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         ]
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
-        with self.assert_database_query_count(37):
+        with self.assert_database_query_count(36):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -580,7 +580,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
-        with self.assert_database_query_count(33):
+        with self.assert_database_query_count(32):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -603,7 +603,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         second_message_id = self.send_stream_message(
             hamlet, stream_name, topic_name="changed topic name", content="Second message"
         )
-        with self.assert_database_query_count(27):
+        with self.assert_database_query_count(26):
             check_update_message(
                 user_profile=desdemona,
                 message_id=second_message_id,
@@ -682,7 +682,7 @@ class MessageMoveTopicTest(ZulipTestCase):
             users_to_be_notified_via_muted_topics_event.append(user_topic.user_profile_id)
 
         change_all_topic_name = "Topic 1 edited"
-        with self.assert_database_query_count(34):
+        with self.assert_database_query_count(33):
             check_update_message(
                 user_profile=hamlet,
                 message_id=message_id,

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1786,7 +1786,7 @@ class StreamMessagesTest(ZulipTestCase):
             setting_value=UserProfile.AUTOMATICALLY_CHANGE_VISIBILITY_POLICY_NEVER,
             acting_user=None,
         )
-        with self.assert_database_query_count(15):
+        with self.assert_database_query_count(14):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1806,7 +1806,7 @@ class StreamMessagesTest(ZulipTestCase):
         # 5 queries: 1 to check if it is the first message in the topic +
         # 1 to check if the topic is already followed + 3 to follow the topic.
         flush_per_request_caches()
-        with self.assert_database_query_count(20):
+        with self.assert_database_query_count(19):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1826,7 +1826,7 @@ class StreamMessagesTest(ZulipTestCase):
         # a message to a topic with visibility policy other than FOLLOWED.
         # 1 to check if the topic is already followed + 3 queries to follow the topic.
         flush_per_request_caches()
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(18):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1837,7 +1837,7 @@ class StreamMessagesTest(ZulipTestCase):
         # If the topic is already FOLLOWED, there will be an increase in the query
         # count of 1 to check if the topic is already followed.
         flush_per_request_caches()
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(15):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1862,7 +1862,7 @@ class StreamMessagesTest(ZulipTestCase):
         # 1 to get the user_id of the mentioned user + 1 to check if the topic
         # is already followed + 3 queries to follow the topic.
         flush_per_request_caches()
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(23):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1875,7 +1875,7 @@ class StreamMessagesTest(ZulipTestCase):
         # 1 to get the user_id of the mentioned user + 1 to check if the topic is
         # already followed.
         flush_per_request_caches()
-        with self.assert_database_query_count(21):
+        with self.assert_database_query_count(20):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1885,7 +1885,7 @@ class StreamMessagesTest(ZulipTestCase):
             )
 
         flush_per_request_caches()
-        with self.assert_database_query_count(18):
+        with self.assert_database_query_count(17):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4041,7 +4041,7 @@ class SubscriptionAPITest(ZulipTestCase):
         streams_to_sub = ["multi_user_stream"]
         with (
             self.capture_send_event_calls(expected_num_events=5) as events,
-            self.assert_database_query_count(45),
+            self.assert_database_query_count(44),
         ):
             self.subscribe_via_post(
                 self.test_user,
@@ -4950,7 +4950,7 @@ class SubscriptionAPITest(ZulipTestCase):
         ]
 
         # Test creating a public stream when realm does not have a notification stream.
-        with self.assert_database_query_count(45):
+        with self.assert_database_query_count(44):
             self.subscribe_via_post(
                 self.test_user,
                 [new_streams[0]],
@@ -4958,7 +4958,7 @@ class SubscriptionAPITest(ZulipTestCase):
             )
 
         # Test creating private stream.
-        with self.assert_database_query_count(53):
+        with self.assert_database_query_count(52):
             self.subscribe_via_post(
                 self.test_user,
                 [new_streams[1]],
@@ -4970,7 +4970,7 @@ class SubscriptionAPITest(ZulipTestCase):
         new_stream_announcements_stream = get_stream(self.streams[0], self.test_realm)
         self.test_realm.new_stream_announcements_stream_id = new_stream_announcements_stream.id
         self.test_realm.save()
-        with self.assert_database_query_count(58):
+        with self.assert_database_query_count(56):
             self.subscribe_via_post(
                 self.test_user,
                 [new_streams[2]],

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -481,7 +481,7 @@ class TypingHappyPathTestStreams(ZulipTestCase):
         )
 
         with (
-            self.assert_database_query_count(8),
+            self.assert_database_query_count(7),
             self.capture_send_event_calls(expected_num_events=1) as events,
         ):
             result = self.api_post(sender, "/api/v1/typing", params)
@@ -514,7 +514,7 @@ class TypingHappyPathTestStreams(ZulipTestCase):
         )
 
         with (
-            self.assert_database_query_count(8),
+            self.assert_database_query_count(7),
             self.capture_send_event_calls(expected_num_events=1) as events,
         ):
             result = self.api_post(sender, "/api/v1/typing", params)
@@ -549,7 +549,7 @@ class TypingHappyPathTestStreams(ZulipTestCase):
         )
         with self.settings(MAX_STREAM_SIZE_FOR_TYPING_NOTIFICATIONS=5):
             with (
-                self.assert_database_query_count(7),
+                self.assert_database_query_count(6),
                 self.capture_send_event_calls(expected_num_events=0) as events,
             ):
                 result = self.api_post(sender, "/api/v1/typing", params)
@@ -606,7 +606,7 @@ class TypingHappyPathTestStreams(ZulipTestCase):
         )
 
         with (
-            self.assert_database_query_count(8),
+            self.assert_database_query_count(7),
             self.capture_send_event_calls(expected_num_events=1) as events,
         ):
             result = self.api_post(sender, "/api/v1/typing", params)


### PR DESCRIPTION
We pre-fetched `can_send_message_group` and `can_create_topic_group settings`
using `select_related` in `get_stream_by_id_for_sending_message` and
`get_stream_by_name_for_sending_message` for saving DB queries when checking
permission to send and edit messages.

This PR updates the permission checking code to work by getting the recursive
group memberships of the user, and then just comparing those with the IDs on
the Stream object. After this change we do not need to prefetch those settings
and can make the code efficient by avoiding generating lot of SQL which took
time to parse.

This commit also removes `get_stream_by_name_for_sending_message`,
`get_stream_by_id_for_sending_message` and `access_stream_by_id_for_message`
because these functions were added as other functions did not prefetch the group
settings. But we do not prefetch group settings anymore, so there is no need of
these message-specific fucntions.

Fixes #36875.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
