### PR TITLE
Use 'Created' instead of 'Joined' for bot profiles (#37251)

### DIFF
--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -69,7 +69,13 @@
                                         {{/if}}
                                     </div>
                                     <div id="date-joined" class="default-field">
-                                        <div class="name">{{t "Joined" }}</div>
+                                        <div class="name">
+                                            {{#if is_bot}}
+                                                {{t "Created"}}
+                                            {{else}}
+                                                {{t "Joined"}}
+                                            {{/if}}
+                                        </div>
                                         <div class="value">{{date_joined}}</div>
                                     </div>
                                     {{#if user_time}}


### PR DESCRIPTION
This PR updates the bot profile text to use "Created" instead of "Joined".

Related to #37251

**How changes were tested:**
- Verified locally in development environment
- Confirmed text appears correctly in bot profile UI

**Screenshots and screen captures:**
<img width="543" height="372" alt="Screenshot 2025-12-30 144401" src="https://github.com/user-attachments/assets/5c302eb3-b60a-4178-af2b-48967a4a7e8a" />
