### PR TITLE
webhooks/intercom: Send confirmation on ping event. 

### DIFF
--- a/zerver/webhooks/intercom/fixtures/ping.json
+++ b/zerver/webhooks/intercom/fixtures/ping.json
@@ -5,7 +5,7 @@
         "type":"notification_event_data",
         "item":{
             "type":"ping",
-            "message":"something something interzen"
+            "message":"This is a ping notification test message."
         }
     },
     "links":{

--- a/zerver/webhooks/intercom/tests.py
+++ b/zerver/webhooks/intercom/tests.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock, patch
-
 from zerver.lib.test_classes import WebhookTestCase
 
 
@@ -8,13 +6,10 @@ class IntercomWebHookTests(WebhookTestCase):
     URL_TEMPLATE = "/api/v1/external/intercom?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "intercom"
 
-    @patch("zerver.webhooks.intercom.view.check_send_webhook_message")
-    def test_ping_ignore(self, check_send_webhook_message_mock: MagicMock) -> None:
-        self.url = self.build_webhook_url()
-        payload = self.get_body("ping")
-        result = self.client_post(self.url, payload, content_type="application/json")
-        self.assertFalse(check_send_webhook_message_mock.called)
-        self.assert_json_success(result)
+    def test_ping(self) -> None:
+        expected_topic_name = "Intercom"
+        expected_message = "Intercom webhook has been successfully configured."
+        self.check_webhook("ping", expected_topic_name, expected_message)
 
     def test_company_created(self) -> None:
         expected_topic_name = "Companies"

--- a/zerver/webhooks/intercom/view.py
+++ b/zerver/webhooks/intercom/view.py
@@ -10,7 +10,7 @@ from zerver.lib.partial import partial
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
 from zerver.lib.validator import WildValue, check_int, check_none_or, check_string
-from zerver.lib.webhooks.common import check_send_webhook_message
+from zerver.lib.webhooks.common import check_send_webhook_message, get_setup_webhook_message
 from zerver.models import UserProfile
 
 COMPANY_CREATED = """
@@ -290,6 +290,12 @@ def get_user_unsubscribed_message(payload: WildValue) -> tuple[str, str]:
     return (topic_name, body)
 
 
+def get_ping_message(payload: WildValue) -> tuple[str, str]:
+    body = get_setup_webhook_message("Intercom")
+    topic_name = "Intercom"
+    return (topic_name, body)
+
+
 EVENT_TO_FUNCTION_MAPPER: dict[str, Callable[[WildValue], tuple[str, str]]] = {
     "company.created": get_company_created_message,
     "contact.added_email": get_contact_added_email_message,
@@ -308,6 +314,7 @@ EVENT_TO_FUNCTION_MAPPER: dict[str, Callable[[WildValue], tuple[str, str]]] = {
     "conversation.user.created": get_conversation_user_created_message,
     "conversation.user.replied": get_conversation_user_replied_message,
     "event.created": get_event_created_message,
+    "ping": get_ping_message,
     "user.created": get_user_created_message,
     "user.deleted": get_user_deleted_message,
     "user.email.updated": get_user_email_updated_message,
@@ -333,8 +340,6 @@ def api_intercom_webhook(
     payload: JsonBodyPayload[WildValue],
 ) -> HttpResponse:
     event_type = payload["topic"].tame(check_string)
-    if event_type == "ping":
-        return json_success(request)
 
     handler = EVENT_TO_FUNCTION_MAPPER.get(event_type)
     if handler is None:


### PR DESCRIPTION
<!-- Describe your pull request here.-->

When Intercom sends a ping/test notification to verify the webhook URL is
working, we now send a confirmation message to Zulip instead of silently
returning success.
This pr is a continuation of #37247
This makes it easier for users to verify their Intercom integration is
correctly set up, as they'll see "Intercom integration test successful."
appear in their configured stream.

**Changes:**
- Added [get_ping_message()](cci:1://file:///home/sathwik/zulip/zerver/webhooks/intercom/view.py:294:0-295:33) handler following the existing function pattern
- Added `"ping"` to `EVENT_TO_FUNCTION_MAPPER` for consistency with other events
- Updated test to verify the confirmation message is sent

Fixes part of: #31170

**How changes were tested:**

- All 25 Intercom webhook tests pass (`./tools/test-backend zerver.webhooks.intercom.tests`)
- The new [test_ping](cci:1://file:///home/sathwik/zulip/zerver/webhooks/intercom/tests.py:8:4-15:9) verifies that the ping event sends the expected message

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>