### PR TITLE
support: Add redirect URL toggle for subdomain changes.

### DIFF
--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -417,6 +417,7 @@ def support(
     minimum_licenses: Json[NonNegativeInt] | None = None,
     required_plan_tier: Json[NonNegativeInt] | None = None,
     new_subdomain: str | None = None,
+    add_redirect_url: str | None = None,
     status: RemoteServerStatus | None = None,
     billing_modality: BillingModality | None = None,
     sponsorship_pending: Json[bool] | None = None,
@@ -535,13 +536,23 @@ def support(
                     f"Cannot update maximum number of daily invitations for {realm.string_id}, because {update_text}."
                 )
         elif new_subdomain is not None:
+            add_deactivated_redirect = True
+            if add_redirect_url is None:
+                add_deactivated_redirect = False
+            else:
+                assert add_redirect_url == "true"
             old_subdomain = realm.string_id
             try:
                 check_subdomain_available(new_subdomain)
             except ValidationError as error:
                 context["error_message"] = error.message
             else:
-                do_change_realm_subdomain(realm, new_subdomain, acting_user=acting_user)
+                do_change_realm_subdomain(
+                    realm,
+                    new_subdomain,
+                    acting_user=acting_user,
+                    add_deactivated_redirect=add_deactivated_redirect,
+                )
                 request.session["success_message"] = (
                     f"Subdomain changed from {old_subdomain} to {new_subdomain}"
                 )

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -89,13 +89,6 @@
         </form>
         {% if not realm.deactivated %}
         <form method="POST" class="support-form">
-            <b>New subdomain</b>:<br />
-            {{ csrf_input }}
-            <input type="hidden" name="realm_id" value="{{ realm.id }}" />
-            <input type="text" name="new_subdomain" required />
-            <button type="submit" class="support-submit-button">Update</button>
-        </form>
-        <form method="POST" class="support-form">
             <b>Organization type</b>:<br />
             {{ csrf_input }}
             <input type="hidden" name="realm_id" value="{{ realm.id }}" />
@@ -134,6 +127,17 @@
             {{ csrf_input }}
             <input type="hidden" name="realm_id" value="{{ realm.id }}" />
             <input type="number" name="max_invites" value="{{ realm.max_invites }}" min="0" required />
+            <button type="submit" class="support-submit-button">Update</button>
+        </form>
+        <form method="POST" class="support-form">
+            <b>New subdomain</b>: (max 40 characters)<br />
+            {{ csrf_input }}
+            <input type="hidden" name="realm_id" value="{{ realm.id }}" />
+            <input type="text" id="new_subdomain" name="new_subdomain" placeholder="lowercase letters, numbers, and '-'s" required />
+            <span class="support-add-redirect-url-section">
+                <input type="checkbox" id="add_redirect_url" name="add_redirect_url" value="true" checked />
+                <label class="support-redirect-url-label" for="add_redirect_url">Redirect to new subdomain?</label>
+            </span>
             <button type="submit" class="support-submit-button">Update</button>
         </form>
         {% endif %}

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -191,6 +191,25 @@ tr.admin td:first-child {
     }
 }
 
+.realm-management-actions {
+    #new_subdomain {
+        width: 225px;
+    }
+
+    .support-add-redirect-url-section {
+        display: block;
+        padding: 6px 10px;
+
+        #add_redirect_url {
+            width: auto;
+        }
+
+        .support-redirect-url-label {
+            display: inline;
+        }
+    }
+}
+
 .reactivate-remote-server-button,
 .deactivate-remote-server-button,
 .delete-next-fixed-price-plan-button,


### PR DESCRIPTION
Adds a checkbox toggle for adding a redirect URL when changing a realm's subdomain in the support panel. This will allow support staff without database access change a defunct organization's subdomain so that it can be reused.

**Notes**:
- The prep commit removes a stale comment and unused variable in the support view function.
- The checkbox is checked by default.
- Adds a note for the max length of a subdomain and a placeholder with the acceptable characters for subdomains.
- Moves the change subdomain form to the bottom of the **Realm management** section.
- If the defunct realm was previously moved and a redirect was added, then that redirect will be updated for the new subdomain.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="613" height="592" alt="Screenshot From 2025-12-30 17-54-06" src="https://github.com/user-attachments/assets/a7c92539-8d58-41e9-8ffe-6db068b5c808" /> | <img width="613" height="685" alt="Screenshot From 2025-12-30 17-54-27" src="https://github.com/user-attachments/assets/73526628-094e-4bc4-a2b7-de4f4682113c" />


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
