### PR TITLE
bots: Rename "joined" to "created" in bot profile 

### DIFF
--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -69,7 +69,13 @@
                                         {{/if}}
                                     </div>
                                     <div id="date-joined" class="default-field">
-                                        <div class="name">{{t "Joined" }}</div>
+                                        <div class="name">
+                                            {{#if is_bot}}
+                                                {{t "Created"}}
+                                            {{else}}
+                                                {{t "Joined"}}
+                                            {{/if}}
+                                        </div>
                                         <div class="value">{{date_joined}}</div>
                                     </div>
                                     {{#if user_time}}


### PR DESCRIPTION
Fixes #37251.

Bots are created, not joined. The previous "joined" label was confusing,
so this updates it to better match how bots are added.

Bot profile is changed, showing "created" only - 


**Screenshots and screen captures:<img width="592" height="620" alt="Screenshot 2025-12-30 at 11 00 52 PM" src="https://github.com/user-attachments/assets/0f6cea8d-a51b-4256-a27c-f57f9a2816a7" />**

Normal user profile is unchanged, showing "joined" only - 

<img width="597" height="617" alt="Screenshot 2025-12-31 at 3 01 26 AM" src="https://github.com/user-attachments/assets/7f9e6e62-5882-4766-b6f7-8f0f1a45edff" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
