### PR TITLE
navbar: Channel description popover for touchscreens.

### DIFF
--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
+import render_extended_narrow_description_overlay from "../templates/extended_narrow_description_overlay.hbs";
 import render_inline_decorated_channel_name from "../templates/inline_decorated_channel_name.hbs";
 import render_message_view_header from "../templates/message_view_header.hbs";
 
@@ -11,6 +12,7 @@ import * as inbox_util from "./inbox_util.ts";
 import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as peer_data from "./peer_data.ts";
+import * as popovers from "./popovers.ts";
 import * as recent_view_util from "./recent_view_util.ts";
 import * as rendered_markdown from "./rendered_markdown.ts";
 import * as search from "./search.ts";
@@ -186,10 +188,8 @@ function build_message_view_header(filter: Filter | undefined): void {
 export function initialize(): void {
     render_title_area();
 
-    const hide_stream_settings_button_width_threshold = 620;
     $("body").on("mouseenter mouseleave", ".narrow_description", function (event) {
         const $view_description_elt = $(this);
-        const window_width = $(window).width()!;
         let hover_timeout;
 
         if (event.type === "mouseenter") {
@@ -203,12 +203,6 @@ export function initialize(): void {
                 $(".top-navbar-container").addClass(
                     "top-navbar-container-allow-description-extension",
                 );
-
-                if (window_width <= hide_stream_settings_button_width_threshold) {
-                    $(".message-header-stream-settings-button").hide();
-                    // Let it expand naturally on smaller screens
-                    $view_description_elt.css("width", "");
-                }
             }, 250);
             $view_description_elt.data("hover_timeout", hover_timeout);
         } else if (event.type === "mouseleave") {
@@ -224,15 +218,28 @@ export function initialize(): void {
             setTimeout(() => {
                 $view_description_elt.removeClass("view-description-extended");
                 $view_description_elt.removeClass("leaving-extended-view-description");
-                if (window_width <= hide_stream_settings_button_width_threshold) {
-                    $(".message-header-stream-settings-button").show();
-                    $view_description_elt.css("width", "");
-                } else {
-                    // Reset to flexbox-determined width
-                    $view_description_elt.css("width", "");
-                }
+                // Reset to flexbox-determined width
+                $view_description_elt.css("width", "");
             }, 100);
         }
+    });
+
+    $("body").on("click", "#extend-narrow-description", () => {
+        const filter = narrow_state.filter();
+        const context = get_message_view_header_context(filter);
+
+        const $extended_narrow_description_overlay = $(
+            render_extended_narrow_description_overlay(context),
+        );
+        $("#header-container").append($extended_narrow_description_overlay);
+
+        $("#extended-narrow-description-overlay").addClass("expanded");
+        popovers.hide_all();
+    });
+
+    $("body").on("click", "#extended-narrow-description-overlay-exit", () => {
+        $("#extended-narrow-description-overlay").removeClass("expanded");
+        $("#header-container #extended-narrow-description-overlay").remove();
     });
 }
 

--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -1,19 +1,5 @@
-#message_view_header {
-    color: var(--color-text-message-view-header);
-    z-index: 2;
-    float: left;
-    height: var(--header-height);
-    width: 100%;
-    line-height: var(--header-height);
-    display: flex;
-    align-items: baseline;
-    white-space: nowrap;
-    cursor: default;
-
-    .hidden {
-        display: none;
-    }
-
+#message_view_header,
+#extended-narrow-description-overlay {
     /* TODO: Remove the `.navbar_title` span from the `message_view_header.hbs`
        template. That span predates the use of flexbox, and makes it so that
        elements like the `.narrow_description` have different line-height and
@@ -69,11 +55,43 @@
             width: auto;
         }
     }
+}
+
+#message_view_header {
+    color: var(--color-text-message-view-header);
+    z-index: 2;
+    float: left;
+    height: var(--header-height);
+    width: 100%;
+    line-height: var(--header-height);
+    display: flex;
+    align-items: baseline;
+    white-space: nowrap;
+    cursor: default;
+
+    .hidden {
+        display: none;
+    }
 
     .message-header-archived {
         color: var(--color-text-message-header-archived);
         cursor: default;
         padding-left: 5px;
+    }
+
+    #extend-narrow-description {
+        margin: 0 6px 0 5px;
+        padding: 0;
+        align-self: center;
+        color: var(--color-navbar-icon);
+        background: none;
+        border: none;
+        line-height: 0;
+        outline: none;
+
+        .info-icon {
+            font-size: 1em;
+        }
     }
 
     .narrow_description {
@@ -135,6 +153,70 @@
 
         &.leaving-extended-view-description {
             animation: contract-extended-description 100ms ease-in both !important;
+        }
+    }
+}
+
+#header-container #extended-narrow-description-overlay {
+    display: none;
+    width: 100%;
+    box-sizing: border-box;
+    background: var(--color-background-search);
+    color: var(--color-text-search);
+    margin-top: 0;
+    position: absolute;
+    top: 0;
+    z-index: 1;
+    min-height: 100%;
+    max-height: 60vh;
+    overflow-y: scroll;
+    scrollbar-width: none;
+
+    &.expanded {
+        display: block;
+        box-shadow: inset 0 -1px 0 var(--color-navbar-bottom-border);
+    }
+
+    .overlay-header {
+        height: var(--header-height);
+        width: 100%;
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        white-space: nowrap;
+
+        #extended-narrow-description-overlay-exit {
+            width: 2.75em;
+            height: 100%;
+            background: none;
+            border: none;
+            opacity: 0.5;
+            line-height: 0;
+            border-radius: 4px;
+            color: var(--color-search-icons);
+            padding: 0;
+            outline: none;
+        }
+    }
+
+    .content-container {
+        display: block;
+        padding: 0 0.75em 0.75em;
+        hyphens: auto;
+        overflow-wrap: break-word;
+    }
+}
+
+@container header-container (width > $cq_sm_min) {
+    #extend-narrow-description {
+        display: none;
+    }
+}
+
+@media (width > $sm_min) {
+    .without-container-query-support {
+        #extend-narrow-description {
+            display: none;
         }
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -375,6 +375,10 @@ p.n-margin {
     box-shadow: 0 1px 0 0 var(--color-background);
 }
 
+#header-container {
+    position: relative;
+}
+
 #navbar-middle .column-middle-inner,
 .header,
 #message_view_header {

--- a/web/templates/extended_narrow_description_overlay.hbs
+++ b/web/templates/extended_narrow_description_overlay.hbs
@@ -1,0 +1,27 @@
+<div id="extended-narrow-description-overlay" tabindex="0">
+    <div class="overlay-header">
+        {{#if stream_settings_link}}
+            <a class="message-header-stream-settings-button tippy-zulip-tooltip" data-tooltip-template-id="stream-details-tooltip-template" data-tippy-placement="bottom" href="{{stream_settings_link}}">
+                {{> navbar_icon_and_title . }}
+            </a>
+        {{else}}
+            <span class="navbar_title">
+                {{> navbar_icon_and_title . }}
+            </span>
+        {{/if}}
+        <button type="button" id="extended-narrow-description-overlay-exit" aria-label="{{t 'Exit description' }}"><i class="zulip-icon zulip-icon-close" aria-hidden="true"></i></button>
+    </div>
+    <span class="sub-stream-description rendered_markdown content-container">
+        {{#if (and stream_settings_link rendered_narrow_description)}}
+            {{rendered_markdown rendered_narrow_description}}
+        {{/if}}
+        {{#if description}}
+            {{description}}
+            {{#if link}}
+            <a class="help_link_widget" href="{{link}}" target="_blank" rel="noopener noreferrer">
+                <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+            </a>
+            {{/if}}
+        {{/if}}
+    </span>
+</div>

--- a/web/templates/message_view_header.hbs
+++ b/web/templates/message_view_header.hbs
@@ -2,6 +2,12 @@
 <a class="message-header-stream-settings-button tippy-zulip-tooltip" data-tooltip-template-id="stream-details-tooltip-template" data-tippy-placement="bottom" href="{{stream_settings_link}}">
     {{> navbar_icon_and_title . }}
 </a>
+{{#if rendered_narrow_description}}
+<button id="extend-narrow-description" class="tippy-zulip-delayed-tooltip" type="button" aria-label="{{t 'View description'}}" data-tooltip-template-id="narrow-description-tooltip-template">
+    <i class="info-icon zulip-icon zulip-icon-info" data-tooltip-template-id="narrow-description-tooltip-template" aria-hidden="true"></i>
+</button>
+{{/if}}
+
 <template id="stream-details-tooltip-template">
     <div>
         <div>{{t "Go to channel settings" }}</div>
@@ -28,6 +34,9 @@
     {{> navbar_icon_and_title . }}
 </span>
 {{#if description}}
+    <button id="extend-narrow-description" class="tippy-zulip-delayed-tooltip" type="button" aria-label="{{t 'View description'}}" data-tooltip-template-id="narrow-description-tooltip-template">
+        <i class="info-icon zulip-icon zulip-icon-info" data-tooltip-template-id="narrow-description-tooltip-template" aria-hidden="true"></i>
+    </button>
     <span class="narrow_description rendered_markdown single-line-rendered-markdown">{{description}}
         {{#if link}}
         <a class="help_link_widget" href="{{link}}" target="_blank" rel="noopener noreferrer">

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -311,3 +311,6 @@
         </div>
     </div>
 </template>
+<template id="narrow-description-tooltip-template">
+    {{t 'View description' }}
+</template>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #33147 
Related to: #37188 

This PR is an attempt to solve the problem on mobile devices where the channel description is hidden due to broken design. It adds a popover support for navbar to display channel description.
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<table>
  <tr>
    <td>Closed</td>
    <td>Opened</td>
  </tr>
  <tr>
    <td>
<img width="468" height="692" alt="Screenshot 2026-01-19 at 11 52 45 PM" src="https://github.com/user-attachments/assets/f87a7d59-0540-4bac-b54e-7db42fb79612" />


</td>
    <td>
<img width="460" height="653" alt="Screenshot 2026-01-05 at 8 21 42 PM" src="https://github.com/user-attachments/assets/5f62f25c-f495-4caf-82fe-0c07f84cab63" />
</td>
  </tr>
</table>


[chrome-capture-2026-01-19.webm](https://github.com/user-attachments/assets/b6407250-7f7e-47f8-a671-c9d664602b9b)



**Remaining decisions and concerns.**
1 ) The design for this popover is inspired by the previous work done on this codebase but it might not resemble it completely; Work needs to be done here.
2 ) I studied the previous codebase and found a popover implementation using `tippy.js` library but was unsuitable for this usecase, so I used `jquery API` to implement this popover just as search area is implemented.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
