### PR TITLE
docs: Clarify BOT_EMAIL_ADDRESS is an identifier, not an email inbox

### DIFF
--- a/api_docs/send-message.md
+++ b/api_docs/send-message.md
@@ -27,6 +27,10 @@ curl -X POST {{ api_url }}/v1/messages \
     --data-urlencode 'content=With mirth and laughter let old wrinkles come.'
 ```
 
+**Note:** `BOT_EMAIL_ADDRESS` refers to the bot's unique username identifier
+(in email format, e.g., `othello-bot@example.com`), not an actual email inbox.
+Bots cannot receive emails; this identifier is used solely for authentication purposes.
+
 {tab|zulip-send}
 
 You can use `zulip-send`


### PR DESCRIPTION
## Description

Adds an explanatory note in the `send-message.md` API documentation to clarify that `BOT_EMAIL_ADDRESS` is a unique username identifier (in email format) used for authentication purposes, not an actual email inbox that can receive messages.

This addresses user confusion reported in issue #479, where the term "BOT_EMAIL_ADDRESS" was misleading since bots cannot actually receive emails.

Fixes #479.

## How this was tested

- Reviewed the documentation change for clarity and accuracy
- Verified the note appears in the correct location (after curl examples, before the zulip-send section)
- Ensured markdown formatting is correct