### PR TITLE
emails: Improve message content styling in digest emails.

### DIFF
--- a/templates/zerver/emails/digest.html
+++ b/templates/zerver/emails/digest.html
@@ -11,7 +11,7 @@
                     <div class='hot_convo_message_content'>
                         {% for sender_block in recipient_block.senders %}
                             {% for message_block in sender_block.content %}
-                            <div class='hot_convo_message_content_block'>
+                            <div class='hot_convo_message_content_block digest_rendered_markdown'>
                                 {{ message_block.html|safe }}
                             </div>
                             {% endfor %}

--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -355,3 +355,142 @@ p.digest_paragraph,
         max-width: 200px;
     }
 }
+
+.digest_rendered_markdown {
+    font-family: sans-serif;
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+.digest_rendered_markdown p {
+    margin: 5px 0;
+}
+
+.digest_rendered_markdown ul,
+.digest_rendered_markdown ol {
+    margin: 0 0 5px;
+    padding-left: 18px;
+}
+
+.digest_rendered_markdown li {
+    margin: 2px 0;
+}
+
+.digest_rendered_markdown strong,
+.digest_rendered_markdown b {
+    font-weight: bold;
+}
+
+.digest_rendered_markdown em {
+    font-style: italic;
+}
+
+.digest_rendered_markdown code {
+    font-family: monospace;
+    font-size: 0.9em;
+    color: #000;
+    background-color: #f2f2f2;
+    padding: 1px 3px;
+    border-radius: 3px;
+}
+
+.digest_rendered_markdown pre {
+    margin: 5px 0;
+    padding: 5px;
+    font-family: monospace;
+    font-size: 0.85em;
+    line-height: 1.4;
+    background-color: #f7f7f7;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    overflow-x: auto;
+}
+
+.digest_rendered_markdown pre code {
+    background-color: transparent;
+    padding: 0;
+}
+
+.digest_rendered_markdown blockquote {
+    margin: 5px 0;
+    padding-left: 8px;
+    border-left: 4px solid #ccc;
+}
+
+.digest_rendered_markdown h1,
+.digest_rendered_markdown h2,
+.digest_rendered_markdown h3,
+.digest_rendered_markdown h4,
+.digest_rendered_markdown h5,
+.digest_rendered_markdown h6 {
+    margin: 15px 0 5px;
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+.digest_rendered_markdown h4 {
+    font-size: 1.1em;
+}
+
+.digest_rendered_markdown a {
+    color: #06c;
+    text-decoration: underline;
+    overflow-wrap: break-word;
+}
+
+.digest_rendered_markdown a:hover {
+    color: #004a99;
+}
+
+.digest_rendered_markdown .user-mention {
+    background-color: #e6e9ff;
+    padding: 0 3px;
+    border-radius: 3px;
+    white-space: nowrap;
+}
+
+.digest_rendered_markdown img {
+    height: 20px;
+    width: 20px;
+    vertical-align: middle;
+    border: none;
+}
+
+.digest_rendered_markdown .spoiler-block {
+    width: fit-content;
+    margin: 5px 0;
+    padding-left: 5px;
+    padding-right: 5px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    background-color: #fafafa;
+}
+
+.spoiler-block .spoiler-title {
+    font-style: italic;
+}
+
+.digest_rendered_markdown time {
+    font-size: 0.95em;
+    background-color: #eee;
+    padding: 1px 4px;
+    border-radius: 3px;
+    white-space: nowrap;
+}
+
+.digest_rendered_markdown table {
+    margin: 5px 0;
+    border-collapse: collapse;
+}
+
+.digest_rendered_markdown th,
+.digest_rendered_markdown td {
+    border: 1px solid #ccc;
+    padding: 4px;
+    text-align: left;
+}
+
+.digest_rendered_markdown .katex-display {
+    margin: 0 0 5px;
+    overflow-x: auto;
+}

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -143,7 +143,7 @@ def fix_emojis(fragment: lxml.html.HtmlElement, emojiset: str) -> None:
 
 def fix_spoilers_in_html(fragment: lxml.html.HtmlElement, language: str) -> None:
     with override_language(language):
-        spoiler_title: str = _("Open Zulip to see the spoiler content")
+        spoiler_title: str = _("View spoiler content in Zulip")
     spoilers = fragment.find_class("spoiler-block")
     for spoiler in spoilers:
         header = spoiler.find_class("spoiler-header")[0]
@@ -157,7 +157,7 @@ def fix_spoilers_in_html(fragment: lxml.html.HtmlElement, language: str) -> None
             # Add a space.
             rear = header_content[-1] if len(header_content) else header_content
             rear.tail = (rear.tail or "") + " "
-        span_elem = e.SPAN(f"({spoiler_title})", **e.CLASS("spoiler-title"), title=spoiler_title)
+        span_elem = e.SPAN(f" {spoiler_title}", **e.CLASS("spoiler-title"), title=spoiler_title)
         header_content.append(span_elem)
         header.drop_tag()
         spoiler_content.drop_tree()
@@ -165,7 +165,7 @@ def fix_spoilers_in_html(fragment: lxml.html.HtmlElement, language: str) -> None
 
 def fix_spoilers_in_text(content: str, language: str) -> str:
     with override_language(language):
-        spoiler_title: str = _("Open Zulip to see the spoiler content")
+        spoiler_title: str = _("View spoiler content in Zulip")
     lines = content.split("\n")
     output = []
     open_fence = None
@@ -177,7 +177,7 @@ def fix_spoilers_in_text(content: str, language: str) -> str:
             if lang == "spoiler":
                 open_fence = fence
                 output.append(line)
-                output.append(f"({spoiler_title})")
+                output.append(f" {spoiler_title}")
             elif fence == open_fence:
                 open_fence = None
                 output.append(line)

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -1705,7 +1705,7 @@ class TestMessageNotificationEmails(ZulipTestCase):
         fragment = lxml.html.fromstring(test_data)
         fix_spoilers_in_html(fragment, "en")
         actual_output = lxml.html.tostring(fragment, encoding="unicode")
-        expected_output = '<div><div class="spoiler-block">\n\n<p><a>header</a> text <span class="spoiler-title" title="Open Zulip to see the spoiler content">(Open Zulip to see the spoiler content)</span></p>\n</div>\n\n<p>outside spoiler</p></div>'
+        expected_output = '<div><div class="spoiler-block">\n\n<p><a>header</a> text <span class="spoiler-title" title="View spoiler content in Zulip"> View spoiler content in Zulip</span></p>\n</div>\n\n<p>outside spoiler</p></div>'
         self.assertEqual(actual_output, expected_output)
 
         # test against our markdown_test_cases so these features do not get out of sync.
@@ -1726,7 +1726,7 @@ class TestMessageNotificationEmails(ZulipTestCase):
     def test_spoilers_in_text_emails(self) -> None:
         content = "@**King Hamlet**\n\n```spoiler header text\nsecret-text\n```"
         msg_id = self.send_stream_message(self.example_user("othello"), "Denmark", content)
-        verify_body_include = ["header text", "Open Zulip to see the spoiler content"]
+        verify_body_include = ["header text", "View spoiler content in Zulip"]
         verify_body_does_not_include = ["secret-text"]
         email_subject = "#Denmark > test"
         self._test_cases(


### PR DESCRIPTION
Message content styling in digest emails now matches `rendered_markdown` styling.

Approach of solving the issue:
- Note down all the variables from the original `rendered_markdown` styling, since those can't be added to `emails` styling directly
- Add identical visual styling to the `emails` styling, for the class `digest_rendered_markdown`, already added to the html template

That way, both the rendered markdowns, in the digest and in the chat, look identical, expect for these more complex fields: math, poll, todo and spoiler.

Fixes #36684.

<!-- Describe your pull request here.-->
**Screenshots and screen captures:**
Before:
<img width="742" height="756" alt="Screenshot 2026-01-01 at 6 54 43 PM" src="https://github.com/user-attachments/assets/982a655c-cf8a-48fd-9319-5ff4af1c8e6a" />
<img width="733" height="756" alt="Screenshot 2026-01-01 at 6 54 56 PM" src="https://github.com/user-attachments/assets/ca16962b-383e-4608-8eac-c65750216cef" />
<img width="737" height="757" alt="Screenshot 2026-01-01 at 6 55 11 PM" src="https://github.com/user-attachments/assets/7ee78328-f33f-4dcc-a391-eb107c2aa2aa" />
<img width="731" height="168" alt="Screenshot 2026-01-01 at 6 55 20 PM" src="https://github.com/user-attachments/assets/51f87d84-8c69-4abd-b566-22681134fb8d" />

After:
<img width="750" height="755" alt="Screenshot 2026-01-01 at 6 51 56 PM" src="https://github.com/user-attachments/assets/bdf26d40-3813-4ef8-9ec0-6dfa5b29586f" />
<img width="740" height="758" alt="Screenshot 2026-01-01 at 6 52 08 PM" src="https://github.com/user-attachments/assets/2643d932-4abc-4779-a837-9fbe3b0c84d1" />
<img width="737" height="512" alt="Screenshot 2026-01-01 at 6 52 21 PM" src="https://github.com/user-attachments/assets/1f1365fe-0ab7-4d9b-9ef4-606e7ec299c9" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
