### PR TITLE
navbar: Make icon sizing and stroke widths uniform.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -558,7 +558,7 @@ body.has-overlay-scrollbar {
 
             & i {
                 color: var(--color-navbar-icon);
-                font-size: 1.6em;
+                font-size: 1em;
             }
         }
     }
@@ -2436,12 +2436,12 @@ body:not(.spectator-view) {
     }
 
     .zulip-icon-gear {
-        font-size: 1.125em; /* 18px at 16px em */
+        font-size: 1em; /* 18px at 16px em */
     }
 
     .zulip-icon-help-bigger,
     .zulip-icon-user-list {
-        font-size: 1.25em; /* 20px at 16px em */
+        font-size: 1em; /* 20px at 16px em */
     }
 
     .zulip-icon-help {
@@ -2454,7 +2454,7 @@ body:not(.spectator-view) {
 .left-sidebar-toggle-button {
     .zulip-icon-panel-left,
     .zulip-icon-panel-left-dashed {
-        font-size: 1.25em; /* 20px at 16px em */
+        font-size: 1em; /* 20px at 16px em */
     }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes inconsistent icon sizing in the navbar by standardizing all navbar icon font-sizes to 1em (16px), ensuring uniform stroke widths across all icons.

## Changes

Changed the following navbar icon font-sizes from varying values to uniform 1em:
- Login icon: `1.6em` → `1em` 
- Gear/settings icon: `1.125em` → `1em`
- Help icon: `1.25em` → `1em`
- User-list toggle icon: `1.25em` → `1em`
- Left sidebar toggle icons: `1.25em` → `1em`

## Testing

Tested the changes at multiple viewport heights (short and tall) as requested in the issue. All navbar icons now have consistent sizing and stroke widths.

### Screenshots

**Logged-in view (navbar with settings, help, user avatar, user-list icons):**
<img width="2620" height="1445" alt="Screenshot 2026-01-02 101442" src="https://github.com/user-attachments/assets/19b39580-05d5-4074-96d0-b6d7c75fce07" />
![WhatsApp Image 2026-01-02 at 10 21 26](https://github.com/user-attachments/assets/89d9c876-6f63-49a8-9777-5bd1e8e382a8)

**Spectator view (navbar with login button):**
<img width="2726" height="1419" alt="Screenshot 2026-01-02 104515" src="https://github.com/user-attachments/assets/a3c56fd1-6210-4b11-b4da-a1ac84c6b912" />

## Fixes

Fixes #36992

## Self-review checklist

- [x] I have tested my changes at different viewport heights
- [x] All icons in the navbar now have uniform sizing
- [x] The clickable areas of the icons are maintained
- [x] Linter passed (`./tools/lint --modified`)
- [x] Changes follow Zulip's code style guidelines
