### PR TITLE
keyboard: Add shortcut to open set status modal.

### DIFF
--- a/starlight_help/src/content/docs/keyboard-shortcuts.mdx
+++ b/starlight_help/src/content/docs/keyboard-shortcuts.mdx
@@ -48,6 +48,7 @@ reference in the Zulip app to add more to your repertoire as needed.
 * **Next unread followed topic**: <kbd>Shift</kbd> + <kbd>N</kbd>
 * **Next unread direct message**: <kbd>P</kbd>
 * **Search messages**: <kbd>/</kbd>
+* **Set status**: <kbd>Shift</kbd> + <kbd>Y</kbd>
 * **Toggle keyboard shortcuts view**: <kbd>?</kbd>
 * **Go to your home view**: <kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>\[</kbd>
   (or <kbd>Esc</kbd>, [if enabled][disable-escape])

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -64,6 +64,7 @@ import * as unread_ops from "./unread_ops.ts";
 import * as user_card_popover from "./user_card_popover.ts";
 import * as user_group_popover from "./user_group_popover.ts";
 import {user_settings} from "./user_settings.ts";
+import * as user_status_ui from "./user_status_ui.ts";
 import * as user_topics_ui from "./user_topics_ui.ts";
 import * as util from "./util.ts";
 
@@ -163,6 +164,7 @@ const KEYDOWN_MAPPINGS: Record<string, Hotkey | Hotkey[]> = {
         {name: "view_selected_stream", message_view_only: false},
         {name: "toggle_read_receipts", message_view_only: true},
     ],
+    "Shift+Y": {name: "set_status", message_view_only: false},
     "Shift+Tab": {name: "shift_tab", message_view_only: false},
     "Shift+ ": {name: "shift_spacebar", message_view_only: true},
     "Shift+ArrowLeft": {name: "left_arrow", message_view_only: false},
@@ -1165,6 +1167,12 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
             return true;
         case "gear_menu":
             gear_menu.toggle();
+            return true;
+        case "set_status":
+            if (page_params.is_spectator) {
+                return false;
+            }
+            user_status_ui.open_user_status_modal();
             return true;
         case "show_shortcuts": // Show keyboard shortcuts page
             browser_history.go_to_location("keyboard-shortcuts");

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -101,6 +101,10 @@
                     </td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'Set status' }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>Y</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{{t 'Show keyboard shortcuts' }}</td>
                     <td><span class="hotkey"><kbd>?</kbd></span></td>
                 </tr>

--- a/web/tests/hotkey.test.cjs
+++ b/web/tests/hotkey.test.cjs
@@ -90,6 +90,7 @@ const settings_data = mock_esm("../src/settings_data");
 const sidebar_ui = mock_esm("../src/sidebar_ui");
 const stream_popover = mock_esm("../src/stream_popover");
 const stream_settings_ui = mock_esm("../src/stream_settings_ui");
+const user_status_ui = mock_esm("../src/user_status_ui");
 
 mock_esm("../src/recent_view_ui", {
     is_in_focus: () => false,
@@ -186,6 +187,7 @@ run_test("mappings", () => {
         map_down("V", true).map((item) => item.name),
         ["view_selected_stream", "toggle_read_receipts"],
     );
+    assert.equal(map_down("Y", true).name, "set_status");
 
     assert.equal(map_down("/").name, "search");
     assert.equal(map_down("j").name, "vim_down");
@@ -269,6 +271,7 @@ run_test("mappings non-latin keyboard", () => {
         map_down("М", "KeyV", true).map((item) => item.name),
         ["view_selected_stream", "toggle_read_receipts"],
     );
+    assert.equal(map_down("Н", "KeyY", true).name, "set_status");
     assert.equal(map_down("о", "KeyJ").name, "vim_down");
     assert.equal(map_down("х", "BracketLeft", false, true).name, "escape");
     assert.equal(map_down("с", "KeyC", false, true).name, "copy_with_c");
@@ -362,7 +365,7 @@ run_test("unmapped keys return false easily", () => {
     // calling any functions outside of hotkey.ts.
     // (unless we are editing text)
     assert_unmapped("bfo");
-    assert_unmapped("BEFLOQTWXYZ");
+    assert_unmapped("BEFLOQTWXZ");
 });
 
 run_test("allow normal typing when editing text", ({override, override_rewire}) => {
@@ -415,6 +418,7 @@ test_while_not_editing_text("basic mappings", () => {
     assert_mapping("x", compose_actions, "start");
     assert_mapping("P", message_view, "show", true);
     assert_mapping("g", gear_menu, "toggle");
+    assert_mapping("Y", user_status_ui, "open_user_status_modal", true);
 });
 
 test_while_not_editing_text("drafts open", ({override}) => {


### PR DESCRIPTION
Add Shift + Y as a keyboard shortcut for opening the user status modal, reducing the number of steps required to set a status.

The shortcut is documented in the keyboard shortcuts modal and the keyboard shortcuts help page.

Fixes #16356

<!-- Describe your pull request here.-->


**How changes were tested:**

-Pressed Shift + Y to open the Set status modal.

-Verified the shortcut does not trigger while typing in the compose box
  or other input fields.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/6ef51506-d33e-4d22-a24e-1f87664d295f


| | |
| --- | --- |
| <img width="797" height="631" alt="Screenshot 2026-01-02 at 12 17 01" src="https://github.com/user-attachments/assets/85de15aa-d62b-4d00-b13a-5379b0fb9251" /> | <img width="804" height="674" alt="Screenshot 2026-01-02 at 12 01 32" src="https://github.com/user-attachments/assets/45c58f27-1999-40c0-a301-0f4bdb3262e3" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
