### PR TITLE
emails: Improve header bars colors and borders in digest emails.

### DIFF
--- a/templates/zerver/emails/digest.html
+++ b/templates/zerver/emails/digest.html
@@ -7,7 +7,7 @@
         <div class='messages'>
             {% with recipient_block=convo.first_few_messages %}
                 <div class='hot_convo_recipient_block'>
-                    <div class='hot_convo_recipient_header'>{{ recipient_block.header.html|safe }}</div>
+                    <div class='hot_convo_recipient_header' style="background-color: {{ recipient_block.header.recipient_bar_color }};">{{ recipient_block.header.html|safe }}</div>
                     <div class='hot_convo_message_content'>
                         {% for sender_block in recipient_block.senders %}
                             {% for message_block in sender_block.content %}

--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -234,14 +234,21 @@ p.digest_paragraph,
 }
 
 .hot_convo_recipient_block {
-    border: 1px solid #000;
+    border: 1px solid #00000029;
+    border-radius: 7px;
 }
 
 .hot_convo_recipient_header {
-    background-color: #9ec9ff;
-    border-bottom: 1px solid #000;
+    color: #262626;
+    border-bottom: 1px solid #00000029;
+    border-radius: 7px 7px 0 0;
     font-weight: bold;
-    padding: 2px;
+    padding: 5px 2px 5px 10px;
+}
+
+.hot_convo_recipient_header a {
+    color: #262626;
+    text-decoration: none;
 }
 
 .hot_convo_message_content {

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -44,7 +44,7 @@ from zerver.lib.url_encoding import (
     stream_narrow_url,
     topic_narrow_url,
 )
-from zerver.models import Message, Realm, Recipient, Stream, UserMessage, UserProfile
+from zerver.models import Message, Realm, Recipient, Stream, Subscription, UserMessage, UserProfile
 from zerver.models.messages import get_context_for_message
 from zerver.models.scheduled_jobs import NotificationTriggers
 from zerver.models.users import get_user_profile_by_id
@@ -230,10 +230,20 @@ def get_channel_privacy_icon(channel: Stream) -> str:
     return "#"
 
 
+def hex_to_rgba(hex_color: str, opacity: float) -> str:
+    # Remove the "#" if present
+    hex_color = hex_color.lstrip("#")
+    r = int(hex_color[0:2], 16)
+    g = int(hex_color[2:4], 16)
+    b = int(hex_color[4:6], 16)
+    return f"rgba({r}, {g}, {b}, {opacity})"
+
+
 def build_message_list(
     user: UserProfile,
     messages: list[Message],
     stream_id_map: dict[int, Stream] | None = None,  # only needs id, name
+    subscription_colors: dict[int, str] | None = None,
 ) -> dict[str, Any]:
     """
     Builds the message list object for the message notification email and
@@ -303,7 +313,10 @@ def build_message_list(
         sender = sender_string(message)
         return {"sender": sender, "content": [build_message_payload(message, sender)]}
 
-    def digest_block_header(message: Message) -> dict[str, Any]:
+    def digest_block_header(
+        message: Message,
+        subscription_colors: dict[int, str],
+    ) -> dict[str, Any]:
         assert message.recipient.type == Recipient.STREAM
         stream_id = message.recipient.type_id
         assert stream_id_map is not None
@@ -311,6 +324,20 @@ def build_message_list(
         stream = stream_id_map[stream_id]
         topic_name = message.topic_name()
         topic_display_name = get_topic_display_name(topic_name, user.default_language)
+        color = subscription_colors.get(
+            message.recipient_id,
+            Subscription.DEFAULT_STREAM_COLOR,
+        )
+
+        # In the web app, recipient header colors are derived by mixing
+        # the stream color with the background color, using specific mix ratios
+        # depending on whether the user is in the light or dark theme.
+        #
+        # For emails, we do not yet have a way to reliably know the theme
+        # of the user. Therefore, we apply a fixed transparency to the raw
+        # stream color as a theme-agnostic approximation that
+        # maintains readability across email clients.
+        recipient_bar_color = hex_to_rgba(color, 0.3)
         narrow_link = topic_narrow_url(
             realm=user.realm,
             stream=stream,
@@ -336,6 +363,7 @@ def build_message_list(
         return {
             "plain": header,
             "html": header_html,
+            "recipient_bar_color": recipient_bar_color,
         }
 
     # Collapse message list to:
@@ -361,7 +389,15 @@ def build_message_list(
     messages_to_render: dict[str, Any] = {"senders": sender_block}
     if stream_id_map:
         # Needed only for digest emails
-        header = digest_block_header(messages[0])
+        # When stream_id_map is provided, subscription_colors should also be provided.
+        # Default to empty dict if None.
+        assert subscription_colors is not None, (
+            "subscription_colors must be provided when stream_id_map is set"
+        )
+        header = digest_block_header(
+            messages[0],
+            subscription_colors=subscription_colors,
+        )
         messages_to_render["header"] = header
 
     for message in messages[1:]:


### PR DESCRIPTION
In this PR, header bars colors are set according to subscribed streams and borders are improved, consistent with the Zulip web app.

Approach for setting header bars colors:
- `subscription_colors` object is created for the user with keys as the `sub.recipient_id` and the value as the color of that subscription.
- `subscription_colors` is accessed inside `digest_block_header` using `message.recipient_id`
- `recipient_bar_color` is finally converted into rgba values using `hex_to_rgba` function to mimic "color mixing" used in the web

Fixes #36685, Fixes #36687

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before:
<img width="764" height="752" alt="Screenshot 2026-01-02 at 7 51 31 PM" src="https://github.com/user-attachments/assets/12752a03-853d-48af-a067-57f3a491a40f" />
<img width="744" height="692" alt="Screenshot 2026-01-02 at 7 51 42 PM" src="https://github.com/user-attachments/assets/57393d63-e960-4011-8904-97fa127d318a" />

After:
<img width="771" height="750" alt="Screenshot 2026-01-02 at 7 00 17 PM" src="https://github.com/user-attachments/assets/9d76e05e-0957-4494-9fb6-89a94562c726" />
<img width="752" height="755" alt="Screenshot 2026-01-02 at 7 00 37 PM" src="https://github.com/user-attachments/assets/befc223e-c5ed-4fc2-ada5-6de5837e32df" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
