### PR TITLE
left_sidebar: Visually separate DM section from channels.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -315,6 +315,9 @@
     --sidebar-bottom-spacing: 25px;
     --sidebar-filter-bottom-spacing: 3px;
 
+    /* 5px / 16px em */
+    --left-sidebar-direct-messages-bottom-divider-padding: 0.3125em;
+
     /* We base sidebar row heights on their line heights.
        Prominent rows include things like headers (e.g., VIEWS)
        as well as navigation items. Everything else takes
@@ -834,6 +837,10 @@
     --color-navbar-bottom-border: light-dark(
         hsl(0deg 0% 80%),
         hsl(0deg 0% 0% / 60%)
+    );
+    --color-left-sidebar-direct-messages-bottom-divider: light-dark(
+        hsl(0deg 0% 0% / 15%),
+        hsl(0deg 0% 100% / 15%)
     );
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: light-dark(

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -228,6 +228,23 @@
     }
 }
 
+.direct-message-section-bottom-divider-container {
+    display: block;
+    margin-right: var(--left-sidebar-right-margin);
+    padding: var(--left-sidebar-direct-messages-bottom-divider-padding) 0;
+    position: sticky;
+    top: var(--line-height-sidebar-row-prominent);
+    background: var(--color-background);
+    z-index: 3;
+}
+
+.direct-message-section-bottom-divider {
+    opacity: 1 !important; /* override .dark-theme:root hr */
+    border-color: var(--color-left-sidebar-direct-messages-bottom-divider);
+    border-width: 0.5px;
+    margin: 0;
+}
+
 #hide-more-direct-messages,
 #direct-messages-section-header {
     grid-template-columns:
@@ -400,7 +417,11 @@
     cursor: pointer;
     background-color: var(--color-background);
     position: sticky;
-    top: var(--line-height-sidebar-row-prominent);
+    /* height of DM header + 1px divider line and its top/bottom padding */
+    top: calc(
+        var(--line-height-sidebar-row-prominent) + 1px + 2 *
+            var(--left-sidebar-direct-messages-bottom-divider-padding)
+    );
     /* Must be more than .sidebar-topic-check and less than #left-sidebar-search
        and #direct-messages-section-header */
     z-index: 2;
@@ -2349,6 +2370,10 @@ li.topic-list-item {
 
 #left_sidebar_scroll_container.direct-messages-hidden-by-filters {
     #direct-messages-section-header {
+        display: none;
+    }
+
+    .direct-message-section-bottom-divider-container {
         display: none;
     }
 

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -65,7 +65,9 @@
         <div class="direct-messages-container zoom-out hidden-for-spectators">
             <div id="direct-messages-list"></div>
         </div>
-
+        <div class="direct-message-section-bottom-divider-container">
+            <hr class="direct-message-section-bottom-divider"/>
+        </div>
         <div id="streams_list" class="zoom-out">
             <div id="topics_header">
                 <a class="show-all-streams trigger-click-on-enter" tabindex="0">{{t 'Back to channels' }}</a> <span class="unread_count quiet-count"></span>


### PR DESCRIPTION
CZO conversation:
https://chat.zulip.org/#narrow/channel/101-design/topic/visually.20separate.20DMs.20from.20channels.20.28left.20sidebar.29/with/2327322

Screenshots:
<img width="329" height="312" alt="Screenshot 2026-01-03 at 4 47 00 PM" src="https://github.com/user-attachments/assets/858f9b68-e869-4b83-bf48-592235ceb3a5" />
<img width="323" height="308" alt="Screenshot 2026-01-03 at 4 47 09 PM" src="https://github.com/user-attachments/assets/6689cc55-a2cd-4839-b405-ddde0ee0156c" />
<img width="321" height="313" alt="Screenshot 2026-01-03 at 4 47 14 PM" src="https://github.com/user-attachments/assets/6a0e0002-45c1-4d4d-a705-fd9bc1e5ecfc" />
<img width="332" height="472" alt="Screenshot 2026-01-03 at 4 46 35 PM" src="https://github.com/user-attachments/assets/0d288ad5-9985-4d94-8158-4a71b31ddea2" />
<img width="332" height="386" alt="Screenshot 2026-01-03 at 4 46 42 PM" src="https://github.com/user-attachments/assets/4a61ff0a-3451-4d83-9342-4d2f57084b75" />
<img width="337" height="378" alt="Screenshot 2026-01-03 at 4 46 45 PM" src="https://github.com/user-attachments/assets/776dc7b4-346b-489a-b7e4-530f16a644bb" />

