### PR TITLE
 Diacrtic behaviour in composebox

### DIFF
--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -720,6 +720,115 @@ test("topics_seen_for", ({override, override_rewire}) => {
     assert.deepEqual(ct.topics_seen_for(""), []);
 });
 
+
+
+run_test("mention typeahead prioritizes exact diacritic matches over fuzzy matches", () => {
+    // Create two users that differ only by diacritics
+    const aa_plain = {
+        user_id: 1,
+        full_name: "Aa",
+        email: "aa@example.com",
+        is_active: true,
+        is_bot: false,
+    };
+
+    const aa_diacritic = {
+        user_id: 2,
+        full_name: "Ąa",
+        email: "aa_diacritic@example.com",
+        is_active: true,
+        is_bot: false,
+    };
+
+    // Add users to the people module (test-only state)
+    people.add_active_user(aa_plain);
+    people.add_active_user(aa_diacritic);
+
+    // Simulate typing "@ą"
+    const suggestions = composebox_typeahead.get_person_suggestions("ą", {
+        want_broadcast: false,
+        filter_pills: false,
+        stream_id: undefined,
+        topic: undefined,
+    });
+
+    const names = suggestions.filter((item) => item.type === "user").map((item) => item.user.full_name);
+
+
+    // Exact diacritic match should be ranked before fuzzy match
+    assert.deepEqual(names.slice(0, 2), ["Ąa", "Aa"]);
+});
+run_test("mention typeahead keeps fuzzy matching for ascii queries", () => {
+    const users = [
+        {
+            user_id: 3,
+            full_name: "Aa",
+            email: "aa2@example.com",
+            is_active: true,
+            is_bot: false,
+        },
+        {
+            user_id: 4,
+            full_name: "Ąa",
+            email: "a2-diacritic@example.com",
+            is_active: true,
+            is_bot: false,
+        },
+    ];
+
+    people._add_test_users(users);
+
+    const results = composebox_typeahead.get_person_suggestions("a", {
+        want_broadcast: false,
+        filter_pills: false,
+        stream_id: undefined,
+        topic: undefined,
+    });
+
+    const names = results
+    .filter((r) => r.type === "user")
+    .map((r) => r.user.full_name);
+
+    assert.deepEqual(names.slice(0, 2), ["Aa", "Ąa"]);
+});
+run_test("mention typeahead handles case with diacritics correctly", () => {
+    const users = [
+        {
+            user_id: 5,
+            full_name: "ądam",
+            email: "adam1@example.com",
+            is_active: true,
+            is_bot: false,
+        },
+        {
+            user_id: 6,
+            full_name: "Adam",
+            email: "adam2@example.com",
+            is_active: true,
+            is_bot: false,
+        },
+    ];
+
+    people._add_test_users(users);
+
+    const results = composebox_typeahead.get_person_suggestions("Ą", {
+        want_broadcast: false,
+        filter_pills: false,
+        stream_id: undefined,
+        topic: undefined,
+    });
+
+    const names = results
+    .filter((r) => r.type === "user")
+    .map((r) => r.user.full_name);
+
+    assert.deepEqual(names.slice(0, 2), ["ądam", "Adam"]);
+});
+
+
+
+
+
 test("content_typeahead_selected", ({override}) => {
     const input_element = {
         $element: {},


### PR DESCRIPTION
**Add tests defining expected diacritic-aware ranking in mention typeahead**

<!-- Describe your pull request here.-->
This PR adds tests that define the expected ranking behavior for mention
typeahead when queries include diacritics.

Context:
- Zulip intentionally supports fuzzy matching so ASCII queries (e.g. `a`)
  match names with diacritics (e.g. `ą`).
- However, when a user types a diacritic explicitly (e.g. `ą`), exact
  diacritic matches should be prioritized over fuzzy matches.
- Previous PRs stalled due to unclear expectations and missing tests.

What this PR does:
- Adds tests covering:
  - Exact diacritic vs fuzzy match prioritization
  - ASCII queries continuing to match diacritics
  - Case + diacritic interactions
- Makes no changes to ranking logic yet.

These tests currently fail on `main`, and are intended to serve as a clear,
reviewable baseline before implementing minimal ranking changes.

How changes were tested
- Ran ./tools/test-js-with-node web/tests/composebox_typeahead.test.cjs
- New tests fail on current behavior, as expected

Related to #32634




<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
