### PR TITLE
keyboard_shortcuts: Fix Ctrl+P or cmd+P to print full scrollable content

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -30,6 +30,7 @@ import * as hashchange from "./hashchange.ts";
 import {$t} from "./i18n.ts";
 import * as inbox_ui from "./inbox_ui.ts";
 import * as inbox_util from "./inbox_util.ts";
+import * as info_overlay from "./info_overlay.ts";
 import * as lightbox from "./lightbox.ts";
 import * as list_util from "./list_util.ts";
 import * as message_actions_popover from "./message_actions_popover.ts";
@@ -143,6 +144,7 @@ const KEYDOWN_MAPPINGS: Record<string, Hotkey | Hotkey[]> = {
     "Cmd+Enter": {name: "action_with_enter", message_view_only: true},
     "Cmd+C": {name: "copy_with_c", message_view_only: false},
     "Cmd+K": {name: "search_with_k", message_view_only: false},
+    "Cmd+P": {name: "print", message_view_only: false},
     "Cmd+@": {name: "open_mentions_view", message_view_only: true},
     "Cmd+S": {name: "star_message", message_view_only: true},
     "Cmd+.": {name: "narrow_to_compose_target", message_view_only: true},
@@ -150,6 +152,7 @@ const KEYDOWN_MAPPINGS: Record<string, Hotkey | Hotkey[]> = {
     "Ctrl+Enter": {name: "action_with_enter", message_view_only: true},
     "Ctrl+C": {name: "copy_with_c", message_view_only: false},
     "Ctrl+K": {name: "search_with_k", message_view_only: false},
+    "Ctrl+P": {name: "print", message_view_only: false},
     "Ctrl+@": {name: "open_mentions_view", message_view_only: true},
     "Ctrl+S": {name: "star_message", message_view_only: true},
     "Ctrl+.": {name: "narrow_to_compose_target", message_view_only: true},
@@ -955,6 +958,17 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
             overlays.close_active();
             return true;
         }
+        if (event_name === "print") {
+            info_overlay.print_current_pane();
+            return true;
+        }
+        return false;
+    }
+
+    if (event_name === "print") {
+        // Only the informational overlays have special print
+        // handling; everywhere else, the browser's print of the
+        // current page (styled by print.css) is what we want.
         return false;
     }
 

--- a/web/src/info_overlay.ts
+++ b/web/src/info_overlay.ts
@@ -3,11 +3,13 @@ import assert from "minimalistic-assert";
 
 import render_keyboard_shortcut from "../templates/keyboard_shortcuts.hbs";
 import render_markdown_help from "../templates/markdown_help.hbs";
+import render_print_info_overlay from "../templates/print_info_overlay.hbs";
 import render_search_operator from "../templates/search_operators.hbs";
 import render_status_message_example from "../templates/status_message_example.hbs";
 import render_poll_widget_example from "../templates/widgets/poll_widget_example.hbs";
 import render_todo_widget_example from "../templates/widgets/todo_widget_example.hbs";
 
+import * as blueslip from "./blueslip.ts";
 import * as browser_history from "./browser_history.ts";
 import * as common from "./common.ts";
 import * as components from "./components.ts";
@@ -29,6 +31,36 @@ export let toggler: Toggle | undefined;
 
 const mock_sub = {stream_id: 0, name: $t({defaultMessage: "channel name"})};
 const mock_topic = $t({defaultMessage: "topic name"});
+
+export function print_current_pane(): void {
+    const pane_key = toggler?.key();
+    const title = toggler?.value();
+    if (pane_key === undefined || title === undefined) {
+        blueslip.warn("print_current_pane: no active pane found");
+        return;
+    }
+
+    const $pane = $(`#${CSS.escape(pane_key)} .overlay-scroll-container`);
+    if ($pane.length === 0) {
+        blueslip.warn("print_current_pane: scroll container not found", {pane_key});
+        return;
+    }
+
+    // Extract just the pane's content, leaving SimpleBar's wrapper and
+    // scrollbar elements out of the printed DOM.
+    const body_html = scroll_util.get_content_element($pane).html() ?? "";
+    const html = render_print_info_overlay({title, body_html});
+    const $container = $(html);
+    $("body").append($container);
+
+    const after_print = (): void => {
+        $container.remove();
+        window.removeEventListener("afterprint", after_print);
+    };
+    window.addEventListener("afterprint", after_print);
+
+    window.print();
+}
 
 function format_usage_html(...keys: string[]): string {
     return $t_html(

--- a/web/styles/print.css
+++ b/web/styles/print.css
@@ -1,3 +1,11 @@
+/* The container used by info_overlay.print_current_pane() to print
+   an informational overlay's full scrollable content. Hidden on
+   screen; the @media print rules below display only it. This rule
+   must precede them so that they win in the cascade. */
+#zulip-print-container {
+    display: none;
+}
+
 @media print {
     /* Hide unnecessary blocks. */
     #navbar_alerts_wrapper,
@@ -103,5 +111,37 @@
     .emoji {
         color-adjust: exact;
         print-color-adjust: exact;
+    }
+
+    /* When a print container has been injected, print only it and
+       hide the rest of the app UI. Use :not() to exclude the
+       container itself, since the `display: none !important` here
+       would otherwise beat the container's `display: block` below,
+       regardless of selector specificity. */
+    body:has(#zulip-print-container) > *:not(#zulip-print-container) {
+        display: none !important;
+    }
+
+    #zulip-print-container {
+        display: block;
+
+        /* Print the pane with its on-screen colors. Dark theme is
+           scoped to `@media screen` (see dark_theme.css), so these
+           resolve to light-theme colors regardless of the user's
+           theme. */
+        color-adjust: exact;
+        print-color-adjust: exact;
+    }
+
+    /* Keep each row's keys and description together across a page
+       break. This also avoids a Firefox bug where a row's borders
+       disappear when it starts at the top of a new printed page. */
+    #zulip-print-container tr {
+        break-inside: avoid;
+    }
+
+    .zulip-print-title {
+        font-size: 1.5714em; /* 22px at 14px/1em */
+        margin: 0 0 12px;
     }
 }

--- a/web/templates/print_info_overlay.hbs
+++ b/web/templates/print_info_overlay.hbs
@@ -1,0 +1,6 @@
+<div id="zulip-print-container">
+    <h1 class="zulip-print-title">{{title}}</h1>
+    <div class="zulip-print-body">
+        {{{body_html}}}
+    </div>
+</div>

--- a/web/tests/hotkey.test.cjs
+++ b/web/tests/hotkey.test.cjs
@@ -47,6 +47,7 @@ const emoji_picker = mock_esm("../src/emoji_picker", {
     start_picker_for_message_reaction() {},
 });
 const gear_menu = mock_esm("../src/gear_menu");
+const info_overlay = mock_esm("../src/info_overlay");
 const lightbox = mock_esm("../src/lightbox");
 const list_util = mock_esm("../src/list_util");
 const message_actions_popover = mock_esm("../src/message_actions_popover");
@@ -206,6 +207,7 @@ run_test("mappings", () => {
     assert.equal(map_down("@", true, true).name, "open_mentions_view");
     assert.equal(map_down("s", false, true).name, "star_message");
     assert.equal(map_down(".", false, true).name, "narrow_to_compose_target");
+    assert.equal(map_down("p", false, true).name, "print");
 
     assert.equal(map_down("p", false, false, false, true).name, "toggle_compose_preview"); // Alt + P
     assert.equal(map_down("+", false).name, "thumbs_up_emoji");
@@ -218,7 +220,6 @@ run_test("mappings", () => {
     assert.equal(map_down("t", false, true), undefined);
     assert.equal(map_down("r", false, true), undefined);
     assert.equal(map_down("o", false, true), undefined);
-    assert.equal(map_down("p", false, true), undefined);
     assert.equal(map_down("a", false, true), undefined);
     assert.equal(map_down("f", false, true), undefined);
     assert.equal(map_down("h", false, true), undefined);
@@ -228,8 +229,12 @@ run_test("mappings", () => {
     assert.equal(map_down("c", false, false, true), undefined);
     assert.equal(map_down("k", false, false, true), undefined);
     assert.equal(map_down("s", false, false, true), undefined);
+    assert.equal(map_down("p", false, false, true), undefined);
     assert.equal(map_down("K", true, true), undefined);
     assert.equal(map_down("S", true, true), undefined);
+    // Ctrl+Shift+P is not intercepted; in Firefox it opens a
+    // private browsing window.
+    assert.equal(map_down("P", true, true), undefined);
     assert.equal(map_down("[", true, true, false), undefined);
     assert.equal(map_down("P", true, false, false, true), undefined);
     assert.equal(map_down("+", false, true), undefined);
@@ -260,6 +265,8 @@ run_test("mappings", () => {
     assert.equal(map_down("s", false, true, false), undefined);
     assert.equal(map_down(".", false, false, true).name, "narrow_to_compose_target");
     assert.equal(map_down(".", false, true, false), undefined);
+    assert.equal(map_down("p", false, false, true).name, "print");
+    assert.equal(map_down("p", false, true, false), undefined);
     // Reset platform
     navigator.platform = "";
 
@@ -300,6 +307,7 @@ run_test("mappings non-latin keyboard", () => {
     assert.equal(map_down("л", "KeyK", false, true).name, "search_with_k");
     assert.equal(map_down("@", "Digit2", true, true).name, "open_mentions_view");
     assert.equal(map_down("ы", "KeyS", false, true).name, "star_message");
+    assert.equal(map_down("з", "KeyP", false, true).name, "print");
     assert.equal(map_down("з", "KeyP", false, false, false, true).name, "toggle_compose_preview");
 
     // More negative tests.
@@ -308,7 +316,6 @@ run_test("mappings non-latin keyboard", () => {
     assert.equal(map_down("е", "KeyT", false, true), undefined);
     assert.equal(map_down("к", "KeyR", false, true), undefined);
     assert.equal(map_down("щ", "KeyO", false, true), undefined);
-    assert.equal(map_down("з", "KeyP", false, true), undefined);
     assert.equal(map_down("ф", "KeyA", false, true), undefined);
     assert.equal(map_down("а", "KeyF", false, true), undefined);
     assert.equal(map_down("р", "KeyH", false, true), undefined);
@@ -318,8 +325,12 @@ run_test("mappings non-latin keyboard", () => {
     assert.equal(map_down("с", "KeyC", false, false, true), undefined);
     assert.equal(map_down("л", "KeyK", false, false, true), undefined);
     assert.equal(map_down("ы", "KeyS", false, false, true), undefined);
+    assert.equal(map_down("з", "KeyP", false, false, true), undefined);
     assert.equal(map_down("Л", "KeyK", true, true), undefined);
     assert.equal(map_down("Ы", "KeyS", true, true), undefined);
+    // Ctrl+Shift+P is not intercepted; in Firefox it opens a
+    // private browsing window.
+    assert.equal(map_down("З", "KeyP", true, true), undefined);
     assert.equal(map_down("Х", "BracketLeft", true, true, false), undefined);
     assert.equal(map_down("З", "KeyP", true, false, false, true), undefined);
 
@@ -336,6 +347,8 @@ run_test("mappings non-latin keyboard", () => {
     assert.equal(map_down("@", "Digit2", true, true, false), undefined);
     assert.equal(map_down("ы", "KeyS", false, false, true).name, "star_message");
     assert.equal(map_down("ы", "KeyS", false, true, false), undefined);
+    assert.equal(map_down("з", "KeyP", false, false, true).name, "print");
+    assert.equal(map_down("з", "KeyP", false, true, false), undefined);
     // Reset platform
     navigator.platform = "";
 
@@ -474,6 +487,20 @@ test_while_not_editing_text("drafts closed w/other overlay", ({override}) => {
 test_while_not_editing_text("drafts closed launch", ({override}) => {
     override(overlays, "any_active", () => false);
     assert_mapping("d", browser_history, "go_to_location");
+});
+
+run_test("print hotkey", ({override}) => {
+    // With an informational overlay open, Ctrl+P prints the full
+    // contents of the overlay's current pane.
+    override(overlays, "info_overlay_open", () => true);
+    stubbing(info_overlay, "print_current_pane", (stub) => {
+        assert.ok(hotkey.process_keydown({key: "p", ctrlKey: true}));
+        assert.equal(stub.num_calls, 1);
+    });
+
+    // Everywhere else, the browser's print dialog is not intercepted.
+    override(overlays, "info_overlay_open", () => false);
+    assert.equal(hotkey.process_keydown({key: "p", ctrlKey: true}), false);
 });
 
 run_test("modal open", ({override}) => {


### PR DESCRIPTION
### Problem

The keyboard shortcuts pop-up is scrollable, but when users press Ctrl + P or Cmd + P, only the currently visible portion of the list is printed.
If the shortcuts span multiple pages, the remaining (hidden) content is missing or repeated incorrectly in the print output.

### Solution

This PR fixes the default Ctrl + P or Cmd + P behavior for the keyboard shortcuts modal by ensuring that all scrollable content—both visible and hidden—is included in the print layout.

Instead of printing only the viewport, the full shortcuts list is rendered correctly for printing.

### Result

Ctrl + P now prints the entire keyboard shortcuts list

No content is missing across pages

No additional UI controls were added

Matches expected browser print behavior

### Screenshots

#### Before

<img width="942" height="619" alt="image" src="https://github.com/user-attachments/assets/60e67927-49eb-4f55-8233-40ca5d44421a" />

<img width="943" height="584" alt="image" src="https://github.com/user-attachments/assets/573d357e-5d3a-4d4d-8c34-64ea0484e555" />

#### After 

##### Keyboard Shortcuts
<img width="729" height="444" alt="image" src="https://github.com/user-attachments/assets/b46f6d0e-d16d-461f-8e70-9facc5bf8ab3" />

<img width="717" height="447" alt="image" src="https://github.com/user-attachments/assets/9d491d59-3654-4059-a4e7-d1e20bd2422f" />

##### Message Formatting

<img width="685" height="445" alt="image" src="https://github.com/user-attachments/assets/d4b97bfe-d887-4397-a646-2d31fc0d4ad2" />

##### Search Filter

<img width="717" height="444" alt="image" src="https://github.com/user-attachments/assets/b6df33d5-c945-4171-90be-96c8495c7298" />

### Related issue

 Fixes #10214


<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability  
  (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g. issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see commit discipline).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>