### PR TITLE
Add GitHub Action to auto-add parent area labels

### DIFF
--- a/.github/workflows/auto-add-parent-label.yml
+++ b/.github/workflows/auto-add-parent-label.yml
@@ -1,0 +1,46 @@
+name: Auto add general area label
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  add-general-label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add general area label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const addedLabel = context.payload.label.name;
+            const issue = context.payload.issue;
+
+            // Explicit allowlist of supported parent labels
+            const allowedParents = new Set([
+              "area: compose",
+              "area: left sidebar",
+              // add more parent labels here if needed
+            ]);
+
+            // Match labels like: "area: compose (uploads)"
+            const match = addedLabel.match(/^area:\s*([^(]+)\s*\(/);
+            if (!match) return;
+
+            const parentLabel = `area: ${match[1].trim()}`;
+
+            // Skip if this parent label isn’t explicitly supported
+            if (!allowedParents.has(parentLabel)) return;
+
+            // Avoid re-adding if parent already exists
+            if (issue.labels.some(l => l.name === parentLabel)) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: [parentLabel],
+            });


### PR DESCRIPTION
This PR adds a small GitHub Action to automatically add a general area: label when a sub-area label is applied.

For example, adding area: compose (uploads) will also add area: compose if it’s missing. The action runs on issues.labeled, only handles labels that follow the existing area: <name> (<subarea>) pattern, and avoids re-adding labels or creating loops.

I referred to the GitHub Actions docs on label-based workflows and used that to design a simple issues.labeled workflow that updates issue labels safely
Fixes: zulip#29739

**How changes were tested:**

Tested in my fork by creating test issues and adding/removing sub-area labels. Verified that the parent label is added automatically and only when needed.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html

**Screenshots:**
<img width="1352" height="878" alt="Screenshot 2026-01-03 at 7 24 36 PM" src="https://github.com/user-attachments/assets/72bd2864-3c3d-4c8f-a3d7-45b17f50b1a9" />

<details>
<summary>Self-review checklist</summary>

•Self-reviewed the changes for clarity and maintainability.
•Followed the AI use policy.
•Explains differences from previous plans.
•Highlights technical choices.
•Commit is a coherent idea.
•Commit message explain the motivation.
•Corner cases and error conditions were reviewed.
</details>
