### PR TITLE
message_link: Fix message link not copying.

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -1495,7 +1495,7 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
                     show_copied_confirmation(util.the($message_time), {
                         custom_content: $t({defaultMessage: "Message link copied!"}),
                     });
-                });
+                })();
                 return true;
             }
             return false;

--- a/web/src/message_actions_popover.ts
+++ b/web/src/message_actions_popover.ts
@@ -246,7 +246,7 @@ export function initialize({
                     show_copied_confirmation(
                         the($(instance.reference).closest(".message_controls")),
                     );
-                });
+                })();
             });
         },
         onHidden(instance) {


### PR DESCRIPTION
In message action popover and hotkey `L`, message link copy is not invoking the clipboard function.
In b75ac64debd09463962bf194470e8d0f34e694c5, it was rewritten to use async/await, but the usage in hotkey `L` and message action popover was never invoking the function and simply creating it.

We change this to invoke immediately on creation.

<!-- Describe your pull request here.-->

Fixes: [#issues > "Copy link to message" button not working?](https://chat.zulip.org/#narrow/channel/9-issues/topic/.22Copy.20link.20to.20message.22.20button.20not.20working.3F/with/2342117)

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|After|
|-|
|<video src="https://github.com/user-attachments/assets/7a45d004-5a6e-4603-a1f0-92c417fe1966" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
