### PR TITLE
css: Fix distortion of wide organization logos.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1189,8 +1189,11 @@ nav {
 
         .nav-logo {
             display: inline-block;
+            width: auto;
             height: 1.25em; /* 20px at 16px em */
             max-width: var(--realm-logo-max-width);
+            /* Defensive: Handle wide logos uploaded via API or legacy methods. */
+            object-fit: contain;
 
             @media (height < $short_navbar_cutoff_height) {
                 height: 0.9375em; /* 15px at 16px em */


### PR DESCRIPTION

Previously, the organization logo in the navbar had a fixed height of `1.25em` (approx 20px) and a fixed max-width. This caused logos with an aspect ratio wider than 8:1 to be distorted (squashed horizontally) as the browser forced them to fit both dimensions.

This PR updates the CSS for `.nav-logo` to:
* **Maintain** the fixed `height: 1.25em` to ensure default SVG logos (which often lack intrinsic dimensions) render correctly.
* Add `object-fit: contain` and `width: auto` to allow wide images to scale down proportionally inside the fixed container without squashing.
* Use `object-position: left` to ensure shorter logos align correctly to the left.

Fixes #22121.

**Screenshots**

| Theme | Before (Distorted) | After (Fixed) |
| :--- | :--- | :--- |
| **Dark** | <img width="331" height="201" alt="image" src="https://github.com/user-attachments/assets/1d2cc381-7987-42a0-9c74-2403ffa15e32" /> | <img width="332" height="193" alt="image" src="https://github.com/user-attachments/assets/af130774-fafb-4850-9fe5-8a0bc462fa4b" /> |
| **Light** | <img width="295" height="189" alt="image" src="https://github.com/user-attachments/assets/9f33a6f9-346e-461d-8bc5-75e3e3b8a0ef" /> | <img width="325" height="152" alt="image" src="https://github.com/user-attachments/assets/c69628b5-39c8-4bc8-9e70-79a69cc7042e" /> |
| **Note** | **Forced Fill (Squashed)**<br>Image fills 20px height regardless of width. | **Proportional Scale**<br>Image shrinks to fit inside the 20px box, preserving shape. |

**How changes were tested**
*Note: The standard "Upload Logo" UI includes a built-in cropper that often resizes wide images down to 200px before saving, which masks this CSS bug. To verify the fix reliably, we must bypass the cropper.*

1. Opened the browser DevTools on the Zulip web app.
2. Located the `.nav-logo` image tag in the top-left navbar.
3. Edited the `src` attribute and pasted a URL for a wide (800x40) PNG image.
    * *Test URL:* `https://placehold.co/800x40/red/white.png?text=WIDE+LOGO+TEST`
4. Verified that the image scaled down proportionally (becoming shorter in height with empty space above/below) rather than filling the 20px height and squashing horizontally.
5. **Regression Test:** Verified that the default Zulip SVG logo still appears correctly (the fixed height prevents it from collapsing to 0px).



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
