### PR TITLE
typeahead: Introduce grid layout for items.

### DIFF
--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -21,10 +21,11 @@
         overflow-wrap: anywhere;
 
         & > a {
-            display: flex;
+            display: grid;
+            grid-template-columns: auto 1fr;
             align-items: center;
             padding: 0.2142em 0.7142em; /* 3px 10px at 14px em */
-            gap: 0.3571em; /* 5px at 14px em */
+            column-gap: 0.3571em; /* 5px at 14px em */
             font-weight: normal;
             /* We want to keep this `max-width` less than 320px. */
             max-width: 292px;
@@ -53,12 +54,13 @@
             }
 
             &.topic-typeahead-link {
-                gap: 5px;
+                column-gap: 5px;
             }
 
             &.topic-edit-typeahead {
-                display: flex;
-                flex-wrap: wrap;
+                display: grid;
+                grid-template-columns: 1fr;
+                grid-column: 1;
 
                 .typeahead-strong-section {
                     /* We want to wrap the topic but preserve
@@ -69,12 +71,12 @@
 
             .typeahead-text-container {
                 display: flex;
-                align-self: center;
+                align-items: center;
                 overflow: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
                 gap: 3px;
-                align-items: baseline;
+                min-width: 0;
             }
 
             .compose-stream-name {
@@ -108,7 +110,6 @@
 
     .pronouns,
     .autocomplete_secondary {
-        align-self: baseline;
         opacity: 0.8;
         font-size: 85%;
         overflow: hidden;
@@ -123,7 +124,7 @@
     }
 
     .autocomplete_secondary {
-        flex: 1 1 0;
+        min-width: 0;
     }
 
     .active .pronouns,
@@ -157,10 +158,8 @@
         /* Can't use flex to display this item if
            we want `text-overflow: ellipsis` to work
            which only works on block elements. */
-        overflow: hidden;
         text-overflow: ellipsis;
         white-space: pre;
-        align-items: baseline;
         font-weight: 500;
 
         .channel-privacy-type-icon {
@@ -190,16 +189,16 @@
 
 /* For FontAwesome icons and zulip icons used in place of images for some users. */
 .typeahead-image {
-    flex: 0 0 auto;
     position: relative;
     height: 1.3125em; /* 21px at 16px/1em */
     width: 1.3125em; /* 21px at 16px/1em */
     border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     .typeahead-image-avatar {
         border-radius: 4px;
-        /* Override bootstrap img */
-        vertical-align: baseline;
     }
 
     .user-circle {


### PR DESCRIPTION
Refactor typeahead item rows to use CSS Grid instead of flexbox, improving column alignment and consistency.

<!-- Describe your pull request here.-->

Fixes:(https://github.com/zulip/zulip/issues/37030)

**How changes were tested:**
- Manually tested on the Zulip development server
- Verify typeahead dropdowns display correctly for all item types (users, streams, topics, emojis, etc.)
- Check alignment of avatars/icons with text content
- Check consistency with different font configurations
- Ensure secondary text (pronouns, autocomplete_secondary) displays properly
- Verify responsive behavior at different screen sizes
- Check topic edit typeahead functionality
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Tested with different font size and line spacing for all cases (topic-edit, emoji, long username, etc..)
<img width="985" height="603" alt="Screenshot 2026-01-07 at 1 33 27 PM" src="https://github.com/user-attachments/assets/20677703-88f4-4962-b80b-6c8e2dd2ae92" />
<img width="990" height="605" alt="Screenshot 2026-01-07 at 1 34 05 PM" src="https://github.com/user-attachments/assets/9a73f726-ed0a-4f47-abb4-daad0e80173d" />
<img width="811" height="515" alt="Screenshot 2026-01-08 at 12 44 58 AM" src="https://github.com/user-attachments/assets/7cf5ae76-6a00-4f77-9b06-48850d0eb537" />

This change does not introduce any visual or behavioral changes to the typeahead UI.
The update only restructures the internal layout logic.
<details>

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
