### PR TITLE
mesaage_view: fix target_id lookup to use id instead of near

### DIFF
--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -510,7 +510,7 @@ export let show = (raw_terms: NarrowTerm[], show_opts: ShowMessageViewOpts): voi
             id_info.target_id = Number.parseInt(filter.terms_with_operator("near")[0]!.operand, 10);
         }
         if (filter.has_operator("id")) {
-            id_info.target_id = Number.parseInt(filter.terms_with_operator("near")[0]!.operand, 10);
+            id_info.target_id = Number.parseInt(filter.terms_with_operator("id")[0]!.operand, 10);
         }
 
         if (


### PR DESCRIPTION
#### This bug prevented the message list state from being initialized, breaking screenshot generation for webhook integrations and direct message ID links.

Fixes #37321

**How changes were tested:**

While running the script
`./tools/screenshots/generate-integration-docs-screenshot --integration github` with `headless: false` I saw an error in the chrome test window

<img width="1129" height="768" alt="image" src="https://github.com/user-attachments/assets/d6814f67-8a39-4ce3-bf01-fe02aa37e489" />

The code at [message_view.ts](https://github.com/zulip/zulip/blob/e1d57b91b55d1318e5e76cbb7e6e8ede4bbcce53/web/src/message_view.ts#L512) - The line checked for `id` but gets `near` instead which caused the error

 Logs after fix
```bash 
cd /home/harsh_0303/gsoc/zulip-personal && ./tools/screenshots/generate-integration-docs-screenshot --integration github
**INFO** Skipping Firefox download as instructed.
chrome (143.0.7499.169) downloaded to /home/harsh_0303/.cache/puppeteer/chrome/linux-143.0.7499.169
chrome-headless-shell (143.0.7499.169) downloaded to /home/harsh_0303/.cache/puppeteer/chrome-headless-shell/linux-143.0.7499.169
Triggered github webhook
Capturing screenshot for message 235 to static/images/integrations/github/001.png
Screenshot captured to: static/images/integrations/github/001.png
```

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
