### PR TITLE
color_picker_popover: Fix showing initial color as checked

### DIFF
--- a/web/templates/popovers/color_picker_popover.hbs
+++ b/web/templates/popovers/color_picker_popover.hbs
@@ -23,7 +23,7 @@
             <div role="group" class="color-swatch-list" aria-label="{{t 'Stream color' }}">
                 {{#each stream_color_palette as |row|}}
                     {{#each row as |hex_color|}}
-                        <input type="radio" id="color-{{hex_color}}" class="color-swatch-input" name="color-picker-select" data-swatch-color="{{hex_color}}" {{#if (eq hex_color ../stream_color )}}checked{{/if}} />
+                        <input type="radio" id="color-{{hex_color}}" class="color-swatch-input" name="color-picker-select" data-swatch-color="{{hex_color}}" {{#if (eq hex_color ../../stream_color)}}checked{{/if}} />
                         <label role="menuitemradio" class="color-swatch-label tippy-zulip-delayed-tooltip" for="color-{{hex_color}}" style="background-color: {{hex_color}};" aria-label="{{hex_color}}" data-tippy-content="{{hex_color}}" data-swatch-color="{{hex_color}}" data-row="{{@../index}}" data-column="{{@index}}" tabindex="0"></label>
                     {{/each}}
                 {{/each}}


### PR DESCRIPTION
Commit 7e57477dea0b2736bbc04466c6b90cb5d6567d23 (#32967, cc @sayamsamal) broke this.