### PR TITLE
support: Change "update status" button to deactivate/reactivate realm buttons.

### DIFF
--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -96,17 +96,31 @@
 <div>
     <div class="realm-management-actions">
         <p class="support-section-header">🛠️ Realm management:</p>
+        {% if realm.deactivated %}
         <form method="POST" class="support-form">
-            <b>Status</b>:<br />
+            <b>Reactivate</b>:<br />
             {{ csrf_input }}
             <input type="hidden" name="realm_id" value="{{ realm.id }}" />
-            <select name="status">
-                <option value="active" {% if not realm.deactivated %}selected{% endif %}>Active</option>
-                <option value="deactivated" {% if realm.deactivated %}selected{% endif %}>Deactivated</option>
-            </select>
-            <button type="submit" class="support-submit-button">Update</button>
+            <input type="hidden" name="status" value="active" />
+            <button type="submit" class="support-submit-button">Send reactivation email to owners</button>
         </form>
-        {% if not realm.deactivated %}
+        {% else %}
+        <form method="POST" class="support-form">
+            <b>Deactivate</b>: (select reason)<br />
+            {{ csrf_input }}
+            <input type="hidden" name="realm_id" value="{{ realm.id }}" />
+            <input type="hidden" name="status" value="deactivated" />
+            <select name="deactivation_reason" id="deactivation_reason">
+                {% for reason in DEACTIVATION_REASONS %}
+                    {% if reason == "owner_request" %}
+                        <option value="{{ reason }}" selected>{{ reason }}</option>
+                    {% else %}
+                        <option value="{{ reason }}">{{ reason }}</option>
+                    {% endif %}
+                {% endfor %}
+            </select>
+            <button type="submit" class="support-submit-button">Deactivate realm</button>
+        </form>
         <form method="POST" class="support-form">
             <b>Organization type</b>:<br />
             {{ csrf_input }}


### PR DESCRIPTION
Instead of having a dropdown option for a realm's status, we now have a separate form for deactivating an active realm and for reactivating a deactivated realm.

The deactivate realm form has a dropdown for selecting a reason for the deactivation, which will be stored in the `RealmAuditLog` data. Currently, all the supported deactivation reasons are included in the dropdown options. I don't know if we want to only have a subset of those shown for the support panel. The default value is set to "owner_request", which is what the support action has been using as a default prior to these changes.

The reactivate realm form button makes it clearer that this action sends an email to the realm owners vs immediately reactivating the realm. Also, sending this email can no longer be triggered for an active realm by a support admin clicking the form's "Update" button accidentally.

---

**Screenshots and screen captures:**

*ACTIVE REALM*
| Before | After |
| --- | --- |
| <img width="727" height="1231" alt="Screenshot From 2026-01-05 16-12-15" src="https://github.com/user-attachments/assets/d96ecaa1-301b-49f4-b959-cb7292eb2d80" /> | <img width="727" height="1231" alt="Screenshot From 2026-01-05 16-01-29" src="https://github.com/user-attachments/assets/0aa20270-3c49-4c36-a0cb-f1762ee1b278" />

*DEACTIVATED REALM*
| Before | After |
| --- | --- |
| <img width="727" height="1203" alt="Screenshot From 2026-01-05 16-12-00" src="https://github.com/user-attachments/assets/78677645-c0b7-4575-aca5-01fb67f1a1f8" /> | <img width="727" height="1210" alt="Screenshot From 2026-01-05 16-01-37" src="https://github.com/user-attachments/assets/3aafc141-de09-4c3d-9c13-c3addf46cc7c" />

*DEACTIVATION REASONS*
<img width="727" height="421" alt="Screenshot From 2026-01-05 16-09-00" src="https://github.com/user-attachments/assets/e206cb18-2598-4a91-aa5e-bae544059711" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
