### PR TITLE
legacy_portico: Remove lighter h1 style.

### DIFF
--- a/web/styles/portico/legacy_portico.css
+++ b/web/styles/portico/legacy_portico.css
@@ -361,10 +361,6 @@ img.screenshot {
     width: 33%;
 }
 
-.portico-page h1 {
-    font-weight: 300;
-}
-
 label.text-error {
     display: inline;
 


### PR DESCRIPTION
This style was previously applied only to h1 elements inside of the `.hero` portion of the old portico (marketing) pages, so it can be removed here so as to not cause specificity problems with the intended styles specified in the portico's markdown.css file.

<!-- Describe your pull request here.-->

[CZO discussion](https://chat.zulip.org/#narrow/channel/19-documentation/topic/portico.20style.20changes.20on.20API.20docs/with/2339264)

**Screenshots:**

| Before | After |
| --- | --- |
| <img width="2120" height="1600" alt="legacy-portico-h1-before" src="https://github.com/user-attachments/assets/5926957d-968b-42df-80d9-8a4dc0f931a4" /> | <img width="2120" height="1600" alt="legacy-portico-h1-after" src="https://github.com/user-attachments/assets/52162b8c-0ac6-49f8-baee-5bc0465c7515" /> |
