### PR TITLE
contributor docs: Make checklist instructions more specific.

### DIFF
--- a/docs/contributing/reviewable-prs.md
+++ b/docs/contributing/reviewable-prs.md
@@ -121,7 +121,8 @@ and professionalism of your work.
 
 The pull request template in the `zulip/zulip` repository has a checklist of
 reminders for points you need to cover in your review. Make sure that all the
-relevant items on the self-review checklist have been addressed.
+relevant items on the self-review checklist have been addressed, and check them
+off on the list.
 
 ## Submit your pull request for review
 


### PR DESCRIPTION
It's become common to delete or replace the checklist.

<img width="732" height="111" alt="Screenshot 2026-01-05 at 12 52 39" src="https://github.com/user-attachments/assets/9e5f04c6-dee4-4858-bbe2-751b8ebaf2bf" />
