### PR TITLE
timerender: Use Intl.RelativeTimeFormat for last seen status.

### DIFF
--- a/web/tests/timerender.test.cjs
+++ b/web/tests/timerender.test.cjs
@@ -519,7 +519,7 @@ run_test("last_seen_status_from_date", () => {
 
     assert_same({minutes: -30}, $t({defaultMessage: "Active 30 minutes ago"}));
 
-    assert_same({hours: -1}, $t({defaultMessage: "Active an hour ago"}));
+    assert_same({hours: -1}, $t({defaultMessage: "Active 1 hour ago"}));
 
     assert_same({hours: -2}, $t({defaultMessage: "Active 2 hours ago"}));
 
@@ -549,7 +549,7 @@ run_test("last_seen_status_from_date", () => {
     base_date = new Date(2016, 4, 2, 23, 30);
     MockDate.set(base_date.getTime());
 
-    assert_same({hours: -1}, $t({defaultMessage: "Active an hour ago"}));
+    assert_same({hours: -1}, $t({defaultMessage: "Active 1 hour ago"}));
 
     assert_same({hours: -2}, $t({defaultMessage: "Active 2 hours ago"}));
 


### PR DESCRIPTION

<!-- Describe your pull request here.-->
Refactor last_seen_status_from_date to use the Intl API. This fixes incorrect pluralization in Russian and other languages while improving performance via a cached formatter map. Also, updated ```web/tests/timerender.test.cjs``` to reflect the Intl API's output of "1 hour ago", replacing the previous "an hour ago" string.

Fixes: <!-- Issue link, or clear description.--> #19776

**How changes were tested:** 
Automated testing: Ran ```test-js-with-node``` to make sure all tests are passed.
Manual testing: Changed the zulip language to russian and verified the correct pluralization.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="533" height="175" alt="Screenshot 2026-01-14 at 17 32 04" src="https://github.com/user-attachments/assets/b6c09109-faa7-47a1-8321-ceaa45fb5ecb" />
"Active 3 minutes ago" in Russian

<img width="548" height="257" alt="Screenshot 2026-01-14 at 20 20 00" src="https://github.com/user-attachments/assets/4bdca11d-9ef2-440f-81fb-9d6e319f3017" />

"Active 2 hours ago" in Russian

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>



