### PR TITLE
showcase: Implement standalone multi-user poll widget simulation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy Showcase
+on:
+  push:
+    branches: [poll-widget-showcase]
+permissions:
+  contents: write
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install Deps
+        run: npm install
+      - name: Bundle Showcase
+        run: |
+          npx esbuild web/src/showcase.ts \
+          --bundle \
+          --outfile=dist/bundle.js \
+          --loader:.ts=ts \
+          --loader:.hbs=text \
+          --loader:.svg=dataurl \
+          --loader:.png=dataurl \
+          --platform=browser \
+          --format=iife \
+          --define:global=window \
+          --define:process.env.NODE_ENV='"production"' \
+          --alias:jquery=./web/src/jquery-shim.js \
+          --log-level=error
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .
+          publish_branch: gh-pages

--- a/index.html
+++ b/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Zulip Poll Widget - Multi-User Sync Showcase</title>
+    <style>
+        body {
+            font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+            background-color: #f5f5f5;
+            margin: 0;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        #app {
+            display: flex;
+            gap: 40px;
+            width: 100%;
+            max-width: 1200px;
+            justify-content: center;
+            margin-top: 20px;
+        }
+        .user-container {
+            flex: 1;
+            background: white;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            padding: 20px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        h1 { color: #333; margin-bottom: 10px; }
+        h2 { color: #666; border-bottom: 2px solid #eee; padding-bottom: 10px; }
+        .widget-target {
+            min-height: 300px;
+            padding: 10px;
+            border: 1px dashed #ccc;
+            border-radius: 4px;
+        }
+        .status-bar {
+            margin-top: 20px;
+            padding: 10px;
+            background: #e8f4fd;
+            border-radius: 4px;
+            font-size: 0.9em;
+            color: #2b7bb9;
+        }
+    </style>
+</head>
+<body>
+
+    <script>
+        window.DEVELOPMENT = false;
+        window.ZULIP_VERSION = "showcase-demo";
+    </script>
+
+    <div id="page-params" data-params='{"is_admin": false, "realm_uri": "http://localhost:9991", "full_name": "Showcase User", "user_id": 1, "realm_poll_widgets_enabled": true}'></div>
+
+    <h1>Zulip Poll Widget Showcase</h1>
+    <p>Simulating real-time state synchronization between two users without a server.</p>
+
+    <div id="app">
+        <div class="user-container">
+            <h2>Alice (User 9)</h2>
+            <div id="alice-widget" class="widget-target"></div>
+        </div>
+
+        <div class="user-container">
+            <h2>Bob (User 10)</h2>
+            <div id="bob-widget" class="widget-target"></div>
+        </div>
+    </div>
+
+    <div class="status-bar">
+        <strong>Status:</strong> Virtual Server Active. Events are broadcasted locally between widget instances.
+    </div>
+
+    <script src="dist/bundle.js"></script>
+</body>
+</html>

--- a/web/src/jquery_shim.js
+++ b/web/src/jquery_shim.js
@@ -1,0 +1,1 @@
+export const jquery = window.$; export default window.$;

--- a/web/src/showcase.ts
+++ b/web/src/showcase.ts
@@ -1,0 +1,89 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import "./showcase_mock";
+
+import * as hbs_bridge from "./hbs_bridge.ts";
+import * as pure_dom from "./pure_dom.ts";
+import * as poll_widget from "./poll_widget.ts";
+
+// Bypass JQuery type resolution for the showcase environment
+const $: any = (window as any).$;
+
+/**
+ * INITIALIZE: Called by ui_init.js
+ * This sets up the Alice & Bob side-by-side multi-user simulation.
+ */
+export function initialize(): void {
+    // 1. STOP THE ROUTER: Clear the hash so Zulip doesn't try to open #inbox
+    window.location.hash = "";
+
+    // 2. NUKE THE UI: Hide everything that isn't your demo
+    $("body").children().hide();
+    
+    // 3. CREATE A CLEAN CONTAINER: Don't use #app, create a fresh one
+    const $showcase = $('<div id="gsoc-showcase"></div>').appendTo("body");
+    
+    $showcase.css({
+        "position": "fixed",
+        "top": "0",
+        "left": "0",
+        "width": "100vw",
+        "height": "100vh",
+        "z-index": "2147483647", // Maximum possible z-index
+        "background": "#f0f2f5",
+        "display": "flex",
+        "padding": "20px",
+        "gap": "20px",
+        "box-sizing": "border-box",
+        "font-family": "sans-serif"
+    });
+
+    // 4. Build the side-by-side UI
+    $showcase.html(`
+        <div id="alice-view" style="flex: 1; border: 4px solid #007bff; background: white; padding: 20px; border-radius: 12px; box-shadow: 0 10px 25px rgba(0,0,0,0.1); overflow-y: auto;">
+            <h1 style="color: #007bff; margin-top: 0; border-bottom: 2px solid #eee; padding-bottom: 10px;">Alice (User 1)</h1>
+            <div class="widget-content"></div>
+        </div>
+        <div id="bob-view" style="flex: 1; border: 4px solid #28a745; background: white; padding: 20px; border-radius: 12px; box-shadow: 0 10px 25px rgba(0,0,0,0.1); overflow-y: auto;">
+            <h1 style="color: #28a745; margin-top: 0; border-bottom: 2px solid #eee; padding-bottom: 10px;">Bob (User 2)</h1>
+            <div class="widget-content"></div>
+        </div>
+    `);
+
+    // 5. Inject DOM Fragments
+    const alice_dom = (pure_dom.poll_widget() as any).to_dom();
+    const bob_dom = (pure_dom.poll_widget() as any).to_dom();
+
+    $("#alice-view .widget-content").append(alice_dom);
+    $("#bob-view .widget-content").append(bob_dom);
+
+    // 6. Setup the Virtual Server logic
+    const virtual_server = {
+        clients: [] as ((events: any[]) => void)[],
+        broadcast(data: any) {
+            
+            // FIX: Use ID 9 (Desdemona/Current User) instead of 101
+            // Zulip's people.ts knows who User 9 is.
+            const event = { 
+                sender_id: 9, 
+                data: data 
+            };
+
+            for (const client_inbound of this.clients) {
+                client_inbound([event]);
+            }
+        }
+    };
+
+    const setup_user = (selector: string) => {
+        const inbound = (poll_widget as any).activate({
+            $elem: $(`${selector} .poll-widget`),
+            callback: (data: any) => virtual_server.broadcast(data),
+            message: { id: 1 } as any,
+            extra_data: {} as any,
+        });
+        virtual_server.clients.push(inbound);
+    };
+
+    setup_user("#alice-view");
+    setup_user("#bob-view");
+}

--- a/web/src/showcase_mock.ts
+++ b/web/src/showcase_mock.ts
@@ -1,0 +1,21 @@
+declare global {
+    interface Window {
+        blueslip: any;
+        blueslip_stacktrace_default: any;
+    }
+}
+
+// Mock stacktrace to prevent "is not a function" crash
+const blueslip_stacktrace = () => "Showcase stacktrace placeholder";
+window.blueslip_stacktrace_default = blueslip_stacktrace;
+
+// Mock the logger to catch Zulip's internal warnings
+window.blueslip = {
+    error: (msg: string, details?: unknown) => console.error("Blueslip Error:", msg, details),
+    warn: (msg: string) => console.warn("Blueslip Warn:", msg),
+    info: (msg: string) => console.log("Blueslip Info:", msg),
+    debug: (msg: string) => console.log("Blueslip Debug:", msg),
+    exception: (e: Error) => console.error("Blueslip Exception:", e),
+};
+
+export default blueslip_stacktrace;

--- a/web/src/widget_interfaces.ts
+++ b/web/src/widget_interfaces.ts
@@ -1,0 +1,27 @@
+/**
+ * Formalizing the Widget Communication Pattern (The "Henhouse Fox")
+ * as suggested by Steve Howell at 9:44 PM.
+ */
+
+export interface WidgetInboundHandler {
+    /** * Handled by the widget: receives server events (votes, options).
+     * This is the function RETURNED by activate().
+     */
+    (events: any[]): void;
+}
+
+export interface WidgetOutboundHandler {
+    /** * Handled by the 'Server': sends user actions (voting, adding option).
+     * This is the CALLBACK passed into activate().
+     */
+    (data: any): void;
+}
+
+export interface WidgetDefinition {
+    activate(opts: {
+        $elem: JQuery;
+        callback: WidgetOutboundHandler;
+        message: any;
+        extra_data: any;
+    }): WidgetInboundHandler;
+}

--- a/web/tests/html_coverage.test.cjs
+++ b/web/tests/html_coverage.test.cjs
@@ -1,0 +1,59 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const html = zrequire("html");
+
+run_test("Fix missing coverage for html.ts", () => {
+    // Helper to create a proper text element object (satisfies .to_source requirement)
+    const mock_text = (val) => html.text_var({
+        label: "text", 
+        s: html.unescaped_text_string(val)
+    });
+
+    // 1. Hits Lines 502 & 522: Multi-element Block loops
+    const multi_block = html.block({
+        elements: [
+            html.div_tag({children: [mock_text("1")]}),
+            html.div_tag({children: [mock_text("2")]}),
+        ],
+    });
+    
+    // Forces the to_source() loop (Line 502+) 
+    // Checking for "\n" confirms line 508 was hit.
+    const source = multi_block.to_source("");
+    assert.equal(source, "<div>1</div>\n<div>2</div>\n");
+    
+    // Forces the to_dom() loop (Line 522+)
+    const frag = multi_block.to_dom();
+    assert.equal(frag.childNodes.length, 2);
+
+    // 2. Hits Line 690: Conditional Attribute Skip
+    // We pass an empty string for "data-empty" to force the 'if (render_val)' branch to false.
+    const active_attr = html.attr("data-active", html.trusted_simple_string("true"));
+    const empty_attr = html.attr("data-empty", html.trusted_simple_string(""));
+
+    const tagged_element = html.div_tag({
+        attrs: [active_attr, empty_attr],
+    });
+
+    const dom_element = tagged_element.to_dom();
+    assert.equal(dom_element.getAttribute("data-active"), "true");
+    // SUCCESS: If this is false, we proved line 690 skipped the empty attribute.
+    assert.equal(dom_element.hasAttribute("data-empty"), false);
+
+    // 3. Hits Lines 708-712: ParenthesizedTag
+    // This logic wraps a tag in literal parentheses in the DOM.
+    const inner = html.span_tag({children: [mock_text("test")]});
+    const paren_tag = html.parenthesized_tag(inner);
+    
+    // Test to_source (704-706)
+    assert.equal(paren_tag.to_source(""), "(<span>test</span>)");
+    
+    // Test to_dom (708-712)
+    const paren_dom = paren_tag.to_dom();
+    assert.equal(paren_dom.tagName, "DIV");
+    assert.equal(paren_dom.innerHTML, "(<span>test</span>)");
+});


### PR DESCRIPTION
### Summary
This PR implements a standalone, side-by-side simulation of the Zulip Poll Widget to validate the transition to a `pure_dom` architecture. It is based on the official `main` branch as requested by @showell.

### Technical Approach
* **Virtual Server Broker:** Implemented a `virtual_server` in `showcase.ts` that intercepts outbound widget callbacks and broadcasts them to all active widget instances (simulating Alice and Bob). This proves the widget is stateless and reacts correctly to server-sent submessages.
* **Environment Shimming:** Provided minimal mocks for `page_params`, `blueslip`, and the `DEVELOPMENT` flag to satisfy runtime dependencies in a standalone browser environment.
* **DOM-First Rendering:** Confirms that the widget correctly renders and updates using direct DOM fragments (`to_dom`) rather than legacy Handlebars strings.

### Note for Reviewers
@showell This PR contains the work squashed into a single clean commit based on  `main`. I attempted to target your fork as the base, but it was not appearing in the dropdown menu; I am opening this here for review and can redirect it if preferred.

