### PR TITLE
docs: clarify docker group activation and daemon requirement

### DIFF
--- a/docs/development/setup/install-docker.md
+++ b/docs/development/setup/install-docker.md
@@ -7,15 +7,17 @@ Adding user YOURUSERNAME to group docker
 Done.
 ```
 
-You will need to reboot for this change to take effect. If it worked,
-you will see `docker` in your list of groups:
+You will need to log out and log back in (or reboot) for this change to take effect.
+If it worked, you will see `docker` in your list of groups:
 
 ```console
 $ groups | grep docker
 YOURUSERNAME adm cdrom sudo dip plugdev lpadmin sambashare docker
 ```
 
-##### 3. Make sure the Docker daemon is running:
+##### 3. Make sure the Docker daemon is running
+
+Docker runs as a background service (daemon), which must be running for Docker commands to work.
 
 If you had previously installed and removed an older version of
 Docker, an [Ubuntu


### PR DESCRIPTION
This change clarifies the Docker setup steps for new contributors by:

- Noting that logging out and back in is sufficient after adding a user to the docker group, avoiding unnecessary reboots
- Briefly explaining that the Docker daemon must be running for Docker commands to work

No functional behavior is changed.

Fixes: Documentation clarity for Docker setup instructions.

How changes were tested:
Manual review of the updated documentation for clarity and correctness.

Screenshots and screen captures:
Screenshot included below showing the updated Docker setup instructions.
<img width="978" height="472" alt="image" src="https://github.com/user-attachments/assets/1c324bb4-124e-4045-ac83-44166b26877c" />

