### PR TITLE
get_messages: Add mentions operator for filtering user mentions.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,16 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 446**
+
+* [`GET /messages`](/api/get-messages),
+  [`GET /messages/matches_narrow`](/api/check-messages-match-narrow),
+  [`POST /messages/flags/narrow`](/api/update-message-flags-for-narrow),
+  [`POST /register`](/api/register-queue):
+  Added support for a new [search/narrow filter](/api/construct-narrow#changes),
+  `mentions`. This operator filters messages that contain a direct,
+  visible personal mention of the specified user.
+
 **Feature level 445**
 
 * [`GET /messages`](/api/get-messages): Added a new `date` value for

--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -58,6 +58,10 @@ as an empty string.
 
 ## Changes
 
+* In Zulip 12.0 (feature level 446), add the `mentions` operator,
+  matching messages that contain a direct personal mention of the
+  specified user.
+
 * In Zulip 10.0 (feature level 366), support was added for a new
   `is:muted` operator combination, matching messages in topics and
   channels that the user has [muted](/help/mute-a-topic).

--- a/version.py
+++ b/version.py
@@ -35,7 +35,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 445
+API_FEATURE_LEVEL = 446
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump


### PR DESCRIPTION
This commit introduces server support for a new `mentions` narrow operator that allows users to filter messages mentioning a specific user by their user ID or email. Documentation has been updated to reflect the new operator syntax.

Replaces #36832, which I don't have permission to push fixes to.