### PR TITLE
filter: Use `excludes_muted_users` similar to `excludes_muted_topics`.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1797,6 +1797,21 @@ export class Filter {
         );
     }
 
+    excludes_muted_users(): boolean {
+        return (
+            // Don't exclude messages sent by muted users if we're
+            // searching for a specific group or user, since the user
+            // presumably wants to see those messages.
+            !this.is_search_for_specific_group_or_user() &&
+            // not narrowed to starred messages
+            !this.has_operand("is", "starred") &&
+            // not narrowed to negated home messages
+            !this.has_negated_operand("in", "home") &&
+            // not narrowed to muted users messages
+            !this.has_operand("is", "muted")
+        );
+    }
+
     try_adjusting_for_moved_with_target(message?: Message): void {
         // If we have the message named in a `with` operator
         // available, either via parameter or message_store,

--- a/web/src/message_list_data.ts
+++ b/web/src/message_list_data.ts
@@ -246,10 +246,7 @@ export class MessageListData {
     }
 
     messages_filtered_for_user_mutes(messages: Message[]): Message[] {
-        // Don't exclude messages sent by muted users if we're
-        // searching for a specific group or user, since the user
-        // presumably wants to see those messages.
-        if (!this.excludes_muted_users || this.filter.is_search_for_specific_group_or_user()) {
+        if (!this.excludes_muted_users) {
             return [...messages];
         }
 

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -160,6 +160,7 @@ function create_and_update_message_list(
     restore_rendered_list: boolean;
 } {
     const excludes_muted_topics = filter.excludes_muted_topics();
+    const excludes_muted_users = filter.excludes_muted_users();
 
     // Check if we already have a rendered message list for the `filter`.
     // TODO: If we add a message list other than `is_in_home` to be save as rendered,
@@ -189,6 +190,7 @@ function create_and_update_message_list(
         let msg_data = new MessageListData({
             filter,
             excludes_muted_topics,
+            excludes_muted_users,
         });
 
         const original_id_info = {...id_info};
@@ -214,6 +216,7 @@ function create_and_update_message_list(
                 msg_data = new MessageListData({
                     filter,
                     excludes_muted_topics,
+                    excludes_muted_users,
                 });
             }
         }
@@ -228,6 +231,7 @@ function create_and_update_message_list(
             msg_data = new MessageListData({
                 filter,
                 excludes_muted_topics,
+                excludes_muted_users,
             });
         }
 
@@ -986,6 +990,7 @@ function navigate_to_anchor_message(opts: {
         const msg_list_data = new MessageListData({
             filter: message_lists.current.data.filter,
             excludes_muted_topics: message_lists.current.data.excludes_muted_topics,
+            excludes_muted_users: message_lists.current.data.excludes_muted_users,
         });
         load_local_messages(msg_list_data, all_messages_data);
         // It is still possible that `all_messages_data` doesn't have any messages
@@ -999,6 +1004,7 @@ function navigate_to_anchor_message(opts: {
     const msg_list_data = new MessageListData({
         filter: message_lists.current.data.filter,
         excludes_muted_topics: message_lists.current.data.excludes_muted_topics,
+        excludes_muted_users: message_lists.current.data.excludes_muted_users,
     });
 
     message_fetch.load_messages_around_anchor(

--- a/web/tests/message_list_data.test.cjs
+++ b/web/tests/message_list_data.test.cjs
@@ -129,9 +129,11 @@ run_test("basics", () => {
 });
 
 run_test("muting", () => {
+    const dm_filter = new Filter([{operator: "dm", operand: "alice@example.com"}]);
     let mld = new MessageListData({
-        excludes_muted_topics: false,
-        filter: new Filter([{operator: "dm", operand: "alice@example.com"}]),
+        excludes_muted_topics: dm_filter.excludes_muted_topics(),
+        excludes_muted_users: dm_filter.excludes_muted_users(),
+        filter: dm_filter,
     });
 
     const msgs = [
@@ -177,6 +179,7 @@ run_test("muting", () => {
     // Test actual behaviour of `messages_filtered_for_*` methods.
     mld.excludes_muted_topics = true;
     mld.filter = new Filter([{operator: "stream", operand: "general"}]);
+    mld.excludes_muted_users = mld.filter.excludes_muted_users();
     const res = mld.messages_filtered_for_topic_mutes(msgs);
     assert.deepEqual(res, [
         {id: 2, type: "stream", stream_id: 1, topic: "whatever"},


### PR DESCRIPTION
Define `exclude_muted_users` similar to how `exclude_muted_topics` is being used.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/Show.20all.20starred.20messages.20in.20the.20.22Starred.20messages.22.20view