### PR TITLE
stream_list: Rename `StreamListSection.streams`.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -369,12 +369,12 @@ export function build_stream_list(force_rerender: boolean): void {
             $(stream_list_section_container_html(section, can_create_streams)),
         );
         const is_empty =
-            section.streams.length === 0 &&
+            section.default_visible_streams.length === 0 &&
             section.muted_streams.length === 0 &&
             section.inactive_streams.length === 0;
         $(`#stream-list-${section.id}-container`).toggleClass("no-display", is_empty);
 
-        for (const stream_id of section.streams) {
+        for (const stream_id of section.default_visible_streams) {
             add_sidebar_li(stream_id, $(`#stream-list-${section.id}`));
         }
         const muted_and_inactive_streams = [...section.muted_streams, ...section.inactive_streams];
@@ -415,7 +415,7 @@ export function build_stream_list(force_rerender: boolean): void {
         // we collapse it, since there's nothing to easily see. But don't do this during
         // search, since sections can enter that state temporarily.
         if (!searching()) {
-            if (!is_empty && section.streams.length === 0) {
+            if (!is_empty && section.default_visible_streams.length === 0) {
                 collapsed_sections.add(section.id);
                 sections_with_only_inactive_or_muted.add(section.id);
             } else {
@@ -1602,7 +1602,11 @@ export function get_sorted_channel_ids_for_next_unread_navigation(): {
     // Get sorted section ids.
     const sections = stream_list_sort.get_current_sections().map((section) => ({
         id: section.id,
-        channels: [...section.streams, ...section.muted_streams, ...section.inactive_streams],
+        channels: [
+            ...section.default_visible_streams,
+            ...section.muted_streams,
+            ...section.inactive_streams,
+        ],
         is_collapsed: collapsed_sections.has(section.id),
     }));
 

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -41,7 +41,7 @@ function current_section_ids_for_streams(): Map<number, StreamListSection> {
     const map = new Map<number, StreamListSection>();
     for (const section of current_sections) {
         for (const stream_id of [
-            ...section.streams,
+            ...section.default_visible_streams,
             ...section.muted_streams,
             ...section.inactive_streams,
         ]) {
@@ -106,7 +106,7 @@ export type StreamListSection = {
     id: string;
     folder_id: number | null;
     section_title: string;
-    streams: number[];
+    default_visible_streams: number[];
     muted_streams: number[];
     inactive_streams: number[];
     order?: number; // Only used for folder sections
@@ -125,7 +125,7 @@ export function sort_groups(
         id: "pinned-streams",
         folder_id: null,
         section_title: $t({defaultMessage: "PINNED CHANNELS"}),
-        streams: [],
+        default_visible_streams: [],
         muted_streams: [],
         inactive_streams: [],
     };
@@ -133,7 +133,7 @@ export function sort_groups(
         id: "normal-streams",
         folder_id: null,
         section_title: $t({defaultMessage: "CHANNELS"}),
-        streams: [],
+        default_visible_streams: [],
         muted_streams: [],
         inactive_streams: [],
     };
@@ -233,7 +233,7 @@ export function sort_groups(
             } else {
                 // Inactive channels aren't treated differently when pinned,
                 // since the user wants chose to put them in the pinned section.
-                pinned_section.streams.push(stream_id);
+                pinned_section.default_visible_streams.push(stream_id);
             }
         } else if (user_settings.web_left_sidebar_show_channel_folders && sub.folder_id) {
             const folder = channel_folders.get_channel_folder_by_id(sub.folder_id);
@@ -243,7 +243,7 @@ export function sort_groups(
                     id: sub.folder_id.toString(),
                     folder_id: sub.folder_id,
                     section_title: folder.name.toUpperCase(),
-                    streams: [],
+                    default_visible_streams: [],
                     muted_streams: [],
                     inactive_streams: [],
                     order: folder.order,
@@ -255,7 +255,7 @@ export function sort_groups(
             } else if (sub.is_muted) {
                 section.muted_streams.push(stream_id);
             } else {
-                section.streams.push(stream_id);
+                section.default_visible_streams.push(stream_id);
             }
         } else {
             if (!has_recent_activity(sub)) {
@@ -263,7 +263,7 @@ export function sort_groups(
             } else if (sub.is_muted) {
                 normal_section.muted_streams.push(stream_id);
             } else {
-                normal_section.streams.push(stream_id);
+                normal_section.default_visible_streams.push(stream_id);
             }
         }
     }
@@ -276,14 +276,18 @@ export function sort_groups(
 
     // Demote folders where all channels are muted or inactive.
     const regular_folder_sections = sort_by_order(
-        [...folder_sections.values()].filter((section) => section.streams.length > 0),
+        [...folder_sections.values()].filter(
+            (section) => section.default_visible_streams.length > 0,
+        ),
     );
     const demoted_folder_sections = sort_by_order(
-        [...folder_sections.values()].filter((section) => section.streams.length === 0),
+        [...folder_sections.values()].filter(
+            (section) => section.default_visible_streams.length === 0,
+        ),
     );
 
     if (
-        pinned_section.streams.length > 0 ||
+        pinned_section.default_visible_streams.length > 0 ||
         pinned_section.muted_streams.length > 0 ||
         pinned_section.inactive_streams.length > 0 ||
         folder_sections.size > 0 ||
@@ -309,7 +313,7 @@ export function sort_groups(
     ];
 
     for (const section of new_sections) {
-        section.streams.sort(compare_function);
+        section.default_visible_streams.sort(compare_function);
         section.muted_streams.sort(compare_function);
         section.inactive_streams.sort(compare_function);
     }
@@ -321,7 +325,10 @@ export function sort_groups(
             return (
                 new_section.id === current_section?.id &&
                 new_section.section_title === current_section.section_title &&
-                util.array_compare(new_section.streams, current_section.streams) &&
+                util.array_compare(
+                    new_section.default_visible_streams,
+                    current_section.default_visible_streams,
+                ) &&
                 util.array_compare(new_section.muted_streams, current_section.muted_streams) &&
                 util.array_compare(new_section.inactive_streams, current_section.inactive_streams)
             );
@@ -331,7 +338,7 @@ export function sort_groups(
         first_render_completed = true;
         current_sections = new_sections;
         all_rows = current_sections.flatMap((section) => [
-            ...section.streams,
+            ...section.default_visible_streams,
             ...section.muted_streams,
             ...section.inactive_streams,
         ]);

--- a/web/tests/stream_list_sort.test.cjs
+++ b/web/tests/stream_list_sort.test.cjs
@@ -192,7 +192,7 @@ test("no_subscribed_streams", () => {
                 inactive_streams: [],
                 muted_streams: [],
                 section_title: "translated: PINNED CHANNELS",
-                streams: [],
+                default_visible_streams: [],
             },
             {
                 id: "normal-streams",
@@ -200,7 +200,7 @@ test("no_subscribed_streams", () => {
                 inactive_streams: [],
                 muted_streams: [],
                 section_title: "translated: CHANNELS",
-                streams: [],
+                default_visible_streams: [],
             },
         ],
         same_as_before: sorted.same_as_before,
@@ -214,11 +214,11 @@ test("basics", ({override}) => {
     let sorted_sections = sort_groups("").sections;
     const pinned = sorted_sections[0];
     assert.deepEqual(pinned.id, "pinned-streams");
-    assert.deepEqual(pinned.streams, [scalene.stream_id]);
+    assert.deepEqual(pinned.default_visible_streams, [scalene.stream_id]);
     assert.deepEqual(pinned.muted_streams, [muted_pinned.stream_id]);
     const normal = sorted_sections[1];
     assert.deepEqual(normal.id, "normal-streams");
-    assert.deepEqual(normal.streams, [
+    assert.deepEqual(normal.default_visible_streams, [
         clarinet.stream_id,
         fast_tortoise.stream_id,
         stream_hyphen_underscore_slash_colon.stream_id,
@@ -251,80 +251,90 @@ test("basics", ({override}) => {
     sorted_sections = sort_groups("s").sections;
     assert.deepEqual(sorted_sections.length, 2);
     assert.deepEqual(sorted_sections[0].id, "pinned-streams");
-    assert.deepEqual(sorted_sections[0].streams, [scalene.stream_id]);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, [scalene.stream_id]);
     assert.deepEqual(sorted_sections[0].inactive_streams, []);
     assert.deepEqual(sorted_sections[1].id, "normal-streams");
     assert.deepEqual(sorted_sections[1].inactive_streams, []);
-    assert.deepEqual(sorted_sections[1].streams, [stream_hyphen_underscore_slash_colon.stream_id]);
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [
+        stream_hyphen_underscore_slash_colon.stream_id,
+    ]);
 
     // Test searching entire word, case-insensitive
     sorted_sections = sort_groups("PnEuMoNiA").sections;
     assert.deepEqual(sorted_sections.length, 2);
-    assert.deepEqual(sorted_sections[0].streams, []);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, []);
     assert.deepEqual(sorted_sections[0].inactive_streams, []);
-    assert.deepEqual(sorted_sections[1].streams, []);
+    assert.deepEqual(sorted_sections[1].default_visible_streams, []);
     assert.deepEqual(sorted_sections[1].inactive_streams, [pneumonia.stream_id]);
 
     // Test searching part of word
     sorted_sections = sort_groups("tortoise").sections;
     assert.deepEqual(sorted_sections.length, 2);
-    assert.deepEqual(sorted_sections[0].streams, []);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, []);
     assert.deepEqual(sorted_sections[0].inactive_streams, []);
     assert.deepEqual(sorted_sections[1].id, "normal-streams");
-    assert.deepEqual(sorted_sections[1].streams, [fast_tortoise.stream_id]);
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [fast_tortoise.stream_id]);
     assert.deepEqual(sorted_sections[1].inactive_streams, []);
 
     // Test searching stream with spaces
     sorted_sections = sort_groups("fast t").sections;
     assert.deepEqual(sorted_sections.length, 2);
-    assert.deepEqual(sorted_sections[0].streams, []);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, []);
     assert.deepEqual(sorted_sections[0].inactive_streams, []);
     assert.deepEqual(sorted_sections[1].id, "normal-streams");
     assert.deepEqual(sorted_sections[1].inactive_streams, []);
-    assert.deepEqual(sorted_sections[1].streams, [fast_tortoise.stream_id]);
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [fast_tortoise.stream_id]);
 
     // Test searching part of stream name with non space word separators
     sorted_sections = sort_groups("hyphen").sections;
     assert.deepEqual(sorted_sections.length, 2);
-    assert.deepEqual(sorted_sections[0].streams, []);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, []);
     assert.deepEqual(sorted_sections[0].inactive_streams, []);
     assert.deepEqual(sorted_sections[1].id, "normal-streams");
-    assert.deepEqual(sorted_sections[1].streams, [stream_hyphen_underscore_slash_colon.stream_id]);
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [
+        stream_hyphen_underscore_slash_colon.stream_id,
+    ]);
     assert.deepEqual(sorted_sections[1].inactive_streams, []);
 
     sorted_sections = sort_groups("hyphen_underscore").sections;
     assert.deepEqual(sorted_sections.length, 2);
-    assert.deepEqual(sorted_sections[0].streams, []);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, []);
     assert.deepEqual(sorted_sections[0].inactive_streams, []);
     assert.deepEqual(sorted_sections[1].id, "normal-streams");
-    assert.deepEqual(sorted_sections[1].streams, [stream_hyphen_underscore_slash_colon.stream_id]);
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [
+        stream_hyphen_underscore_slash_colon.stream_id,
+    ]);
     assert.deepEqual(sorted_sections[1].inactive_streams, []);
 
     sorted_sections = sort_groups("colon").sections;
     assert.deepEqual(sorted_sections.length, 2);
-    assert.deepEqual(sorted_sections[0].streams, []);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, []);
     assert.deepEqual(sorted_sections[0].inactive_streams, []);
     assert.deepEqual(sorted_sections[1].id, "normal-streams");
-    assert.deepEqual(sorted_sections[1].streams, [stream_hyphen_underscore_slash_colon.stream_id]);
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [
+        stream_hyphen_underscore_slash_colon.stream_id,
+    ]);
     assert.deepEqual(sorted_sections[1].inactive_streams, []);
 
     sorted_sections = sort_groups("underscore").sections;
     assert.deepEqual(sorted_sections.length, 2);
-    assert.deepEqual(sorted_sections[0].streams, []);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, []);
     assert.deepEqual(sorted_sections[0].inactive_streams, []);
     assert.deepEqual(sorted_sections[1].id, "normal-streams");
-    assert.deepEqual(sorted_sections[1].streams, [stream_hyphen_underscore_slash_colon.stream_id]);
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [
+        stream_hyphen_underscore_slash_colon.stream_id,
+    ]);
     assert.deepEqual(sorted_sections[1].inactive_streams, []);
 
     // Only show pinned channels
     sorted_sections = sort_groups("pinned").sections;
     assert.deepEqual(sorted_sections.length, 2);
     assert.deepEqual(sorted_sections[0].id, "pinned-streams");
-    assert.deepEqual(sorted_sections[0].streams, [scalene.stream_id]);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, [scalene.stream_id]);
     assert.deepEqual(sorted_sections[0].inactive_streams, []);
     assert.deepEqual(sorted_sections[1].id, "normal-streams");
     assert.deepEqual(sorted_sections[1].inactive_streams, []);
-    assert.deepEqual(sorted_sections[1].streams, []);
+    assert.deepEqual(sorted_sections[1].default_visible_streams, []);
 
     override(user_settings, "web_left_sidebar_show_channel_folders", true);
     sorted_sections = sort_groups("").sections;
@@ -343,19 +353,21 @@ test("basics", ({override}) => {
     // If both `pin_to_top` is true and folder_id is set, as in
     // the channel `scalene`, then the channel ends up in the pinned
     // section and `folder_id` is ignored.
-    assert.deepEqual(sorted_sections[0].streams, [scalene.stream_id]);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, [scalene.stream_id]);
     assert.deepEqual(sorted_sections[0].muted_streams, [muted_pinned.stream_id]);
     assert.deepEqual(sorted_sections[0].inactive_streams, []);
-    assert.deepEqual(sorted_sections[1].streams, [stream_hyphen_underscore_slash_colon.stream_id]);
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [
+        stream_hyphen_underscore_slash_colon.stream_id,
+    ]);
     assert.deepEqual(sorted_sections[1].muted_streams, []);
     assert.deepEqual(sorted_sections[1].inactive_streams, []);
-    assert.deepEqual(sorted_sections[2].streams, [fast_tortoise.stream_id]);
+    assert.deepEqual(sorted_sections[2].default_visible_streams, [fast_tortoise.stream_id]);
     assert.deepEqual(sorted_sections[2].muted_streams, [muted_active.stream_id]);
     assert.deepEqual(sorted_sections[2].inactive_streams, [pneumonia.stream_id]);
-    assert.deepEqual(sorted_sections[3].streams, [clarinet.stream_id]);
+    assert.deepEqual(sorted_sections[3].default_visible_streams, [clarinet.stream_id]);
     assert.deepEqual(sorted_sections[3].muted_streams, []);
     assert.deepEqual(sorted_sections[3].inactive_streams, []);
-    assert.deepEqual(sorted_sections[4].streams, []);
+    assert.deepEqual(sorted_sections[4].default_visible_streams, []);
     assert.deepEqual(sorted_sections[4].muted_streams, [muted.stream_id]);
     assert.deepEqual(sorted_sections[4].inactive_streams, [inactive.stream_id]);
 
@@ -375,10 +387,10 @@ test("basics", ({override}) => {
     sorted_sections = sort_groups("other").sections;
     assert.deepEqual(sorted_sections.length, 2);
     assert.deepEqual(sorted_sections[0].id, "pinned-streams");
-    assert.deepEqual(sorted_sections[0].streams, []);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, []);
     assert.deepEqual(sorted_sections[0].inactive_streams, []);
     assert.deepEqual(sorted_sections[1].section_title, "translated: OTHER");
-    assert.deepEqual(sorted_sections[1].streams, [clarinet.stream_id]);
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [clarinet.stream_id]);
     assert.deepEqual(sorted_sections[1].muted_streams, []);
     assert.deepEqual(sorted_sections[1].inactive_streams, []);
 });
@@ -431,7 +443,7 @@ test("current_section_id_for_stream", ({override}) => {
             inactive_streams: [],
             muted_streams: [8],
             section_title: "translated: PINNED CHANNELS",
-            streams: [1],
+            default_visible_streams: [1],
         },
         {
             folder_id: 2,
@@ -440,7 +452,7 @@ test("current_section_id_for_stream", ({override}) => {
             muted_streams: [],
             order: 2,
             section_title: "BACKEND",
-            streams: [6],
+            default_visible_streams: [6],
         },
         {
             folder_id: 1,
@@ -449,7 +461,7 @@ test("current_section_id_for_stream", ({override}) => {
             muted_streams: [7],
             order: 3,
             section_title: "FRONTEND",
-            streams: [2],
+            default_visible_streams: [2],
         },
         {
             folder_id: null,
@@ -457,7 +469,7 @@ test("current_section_id_for_stream", ({override}) => {
             inactive_streams: [],
             muted_streams: [],
             section_title: "translated: OTHER",
-            streams: [4],
+            default_visible_streams: [4],
         },
         {
             folder_id: 3,
@@ -466,7 +478,7 @@ test("current_section_id_for_stream", ({override}) => {
             muted_streams: [10],
             order: 1,
             section_title: "EMPTY",
-            streams: [],
+            default_visible_streams: [],
         },
     ]);
 });
@@ -491,15 +503,15 @@ test("left_sidebar_search", ({override}) => {
     // The topic matches the search query, so the stream appears in the search result.
     // Since `pin_to_top` is true for scalene, it should be in that section.
     assert.deepEqual(sorted_sections.length, 2);
-    assert.deepEqual(sorted_sections[0].streams, [scalene.stream_id]);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, [scalene.stream_id]);
 
     sorted_sections = stream_list_sort.sort_groups(
         stream_data.subscribed_stream_ids().filter((id) => id !== scalene.stream_id),
         "any",
     ).sections;
     assert.deepEqual(sorted_sections.length, 2);
-    assert.deepEqual(sorted_sections[0].streams, []);
-    assert.deepEqual(sorted_sections[1].streams, []);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, []);
+    assert.deepEqual(sorted_sections[1].default_visible_streams, []);
 
     // Testing the same for custom sections.
     override(user_settings, "web_left_sidebar_show_channel_folders", true);
@@ -508,9 +520,9 @@ test("left_sidebar_search", ({override}) => {
     // didn't make it to here.
     assert.deepEqual(sorted_sections.length, 3);
     assert.deepEqual(sorted_sections[1].folder_id, fast_tortoise.folder_id);
-    assert.deepEqual(sorted_sections[1].streams, [fast_tortoise.stream_id]);
-    assert.deepEqual(sorted_sections[0].streams, []);
-    assert.deepEqual(sorted_sections[2].streams, []);
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [fast_tortoise.stream_id]);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, []);
+    assert.deepEqual(sorted_sections[2].default_visible_streams, []);
 });
 
 test("filter inactives", ({override}) => {


### PR DESCRIPTION
We rename `StreamListSection.streams` to `visible_streams` to indicate the presence of additional streams to avoid bugs like #37107.
