### PR TITLE
support: Add realm deactivation audit log data to Cloud support view.

### DIFF
--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -702,6 +702,7 @@ def support(
     )
     context["DEACTIVATION_REASONS"] = get_args(RealmDeactivationReasonType)
     context["remote_support_view"] = False
+    context["format_optional_datetime"] = format_optional_datetime
 
     return render(request, "corporate/support/support.html", context=context)
 

--- a/templates/corporate/support/deactivation_data.html
+++ b/templates/corporate/support/deactivation_data.html
@@ -1,0 +1,19 @@
+<div class="deactivation-information">
+    <p class="support-section-header">❌ Scrub realm:</p>
+    {% if deactivation_data %}
+    <b>Deactivation audit log data:</b><br />
+    <ul>
+        <li><b>Event time (UTC)</b>: {{ format_optional_datetime(deactivation_data.event_time, True) }}</li>
+        {% if deactivation_data.acting_user %}
+        <li><b>Acting user</b>: {{ deactivation_data.acting_user.delivery_email}} (ID: {{deactivation_data.acting_user.id }})</li>
+        {% else %}
+        <li><b>Acting user</b>: Not in audit log data</li>
+        {% endif %}
+        {% if deactivation_data.reason %}
+        <li><b>Deactivation reason</b>: {{ deactivation_data.reason }}</li>
+        {% else %}
+        <li><b>Deactivation reason</b>: Not in audit log data</li>
+        {% endif %}
+    </ul>
+    {% endif %}
+</div>

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -234,13 +234,18 @@
     {% endif %}
     {% endif %}
     {% if realm.deactivated %}
-    <form method="POST" class="scrub-realm-form support-form">
-        <h3>❌ Scrub realm</h3>
-        {{ csrf_input }}
-        <input type="hidden" name="realm_id" value="{{ realm.id }}" />
-        <input type="hidden" name="scrub_realm" value="true" />
-        <button data-string-id="{{realm.string_id}}" class="scrub-realm-button">Scrub realm (danger)</button>
-    </form>
+    <div class="deactivation-information-container">
+        {% with %}
+            {% set deactivation_data = realm_support_data[realm.id].deactivation_data %}
+            {% include 'corporate/support/deactivation_data.html' %}
+        {% endwith %}
+        <form method="POST" class="scrub-realm-form support-form">
+            {{ csrf_input }}
+            <input type="hidden" name="realm_id" value="{{ realm.id }}" />
+            <input type="hidden" name="scrub_realm" value="true" />
+            <button data-string-id="{{realm.string_id}}" class="scrub-realm-button">Scrub realm (danger)</button>
+        </form>
+    </div>
     {% endif %}
 </div>
 {% endif %}

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -396,7 +396,7 @@ tr.admin td:first-child {
 }
 
 .scrub-realm-form {
-    padding-bottom: 10px;
+    padding-top: 10px;
 }
 
 .search-query.input-xxlarge {
@@ -498,6 +498,7 @@ tr.admin td:first-child {
     padding-bottom: 25px;
 }
 
+.deactivation-information-container,
 .activity-header-information,
 .push-notification-status,
 .realm-management-actions,
@@ -524,6 +525,11 @@ tr.admin td:first-child {
 .realm-management-actions {
     border: 2px solid hsl(186deg 76% 36%);
     background-color: hsl(188deg 35% 87%);
+}
+
+.deactivation-information-container {
+    border: 2px solid hsl(2deg 64% 58%);
+    background-color: hsl(23deg 100% 95%);
 }
 
 .next-plan-container,


### PR DESCRIPTION
If a realm is deactivated and there is an audit log with the event type `REALM_DEACTIVATED`, then we now show some of the audit log data in the support view.

If the acting user and deactivation reason are not in the audit log data, then the view shows "Not in audit log data" for those bullet points. Instead of this string, we could just not show the bullet point, but it seemed potentially helpful to note that the audit log didn't have information for that field.

We expect to have audit log data for deactivated Cloud realms. But if there isn't one, we just show the scrub realm header and button without the audit log data so that the support view doesn't break in that case.

---

**Screenshots and screen captures:**

*DEACTIVATED VIA MANAGEMENT COMMAND - NO ACTING USER*
| Before | After |
| --- | --- |
| <img width="621" height="1375" alt="Screenshot From 2026-01-06 13-30-25" src="https://github.com/user-attachments/assets/48994da6-cfc6-46e1-b900-cd2793df54de" /> | <img width="621" height="1375" alt="Screenshot From 2026-01-06 13-30-40" src="https://github.com/user-attachments/assets/027bbe98-ff46-4c01-aa92-94cc9a134f28" />

*DEACTIVATED VIA SUPPORT PANEL - ACTING USER IS SUPPORT STAFF*
| Before | After |
| --- | --- |
| <img width="621" height="1375" alt="Screenshot From 2026-01-06 13-30-52" src="https://github.com/user-attachments/assets/427989e0-793b-4eaa-8023-7dbe828a783b" /> | <img width="621" height="1375" alt="Screenshot From 2026-01-06 13-31-04" src="https://github.com/user-attachments/assets/5c3278e7-78ca-4034-86cb-d4620252a6e4" />

*DEACTIVATED BY OWNER - ACTING USER IS OWNER*
| Before | After |
| --- | --- |
| <img width="621" height="1182" alt="Screenshot From 2026-01-06 13-31-52" src="https://github.com/user-attachments/assets/491382d4-a96b-4a15-ba4f-a740004c18d7" /> | <img width="621" height="1182" alt="Screenshot From 2026-01-06 13-32-05" src="https://github.com/user-attachments/assets/e7f5ad5f-628c-4dc8-959a-315f8265f90b" />

*USED PYTHON SHELL IN DEV TO DEACTIVATE REALM WITHOUT CREATING AUDIT LOG*
| Before | After |
| --- | --- |
| <img width="621" height="1225" alt="Screenshot From 2026-01-06 13-42-57" src="https://github.com/user-attachments/assets/1e95a458-b839-4e37-a1be-7a121237e6fc" /> | <img width="621" height="1225" alt="Screenshot From 2026-01-06 13-43-05" src="https://github.com/user-attachments/assets/f777c021-0204-4e8e-bfad-d92692028af9" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
