### PR TITLE
email: Adjust borders in digest email to match web app styling.

### DIFF
--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -229,14 +229,16 @@ p.digest_paragraph,
 }
 
 .hot_convo_recipient_block {
-    border: 1px solid #000;
+    border: 1px solid #d6d6d6;
+    border-radius: 7px;
 }
 
 .hot_convo_recipient_header {
     background-color: #9ec9ff;
-    border-bottom: 1px solid #000;
+    border-bottom: 1px solid #f2f2f2;
     font-weight: bold;
     padding: 2px;
+    border-radius: 7px 7px 0 0;
 }
 
 .hot_convo_message_content {


### PR DESCRIPTION
Updates digest email borders to match the Zulip web app styling. Changes the recipient block and header borders from black (#36687) to light gray colors that match the web app's CSS variables, and adds border-radius to match the rounded corners used in the web interface.

Fixes: #36687
@alya please review this PR

**How changes were tested:**

The changes were verified by:
1. Comparing the CSS variables used in the web app (`--color-message-list-border` and `--color-message-header-contents-border-bottom`) with the converted hex values used in the email CSS
2. Ensuring border-radius values match the web app (7px for the block, 7px 7px 0 0 for the header)
3. Code review to verify the structure matches the web app's message header and recipient row styling

**Note:** Visual testing can be done by:
- Starting the dev server (`./tools/run-dev`)
- Logging in and visiting `/digest/` to preview the digest email
- Comparing the borders visually with the web app's message list
