### PR TITLE
portico: Add frontend job opening.

### DIFF
--- a/templates/corporate/jobs.html
+++ b/templates/corporate/jobs.html
@@ -41,7 +41,8 @@
                         with your resume and cover letter.
                     </p>
                     <p>
-                        All openings are remote, or partially in-person in our San Francisco, CA office.
+                        All openings are remote, or partially in-person in our
+                        San Francisco, CA office, unless indicated otherwise.
                     </p>
                     <hr/>
                     <h2 id="gtm">Go-to-market leader (full-time)</h2>
@@ -255,6 +256,77 @@
                         with your resume and cover letter to apply, or learn
                         more about
                         <a href="/jobs/#how-we-work">how we work</a>.
+                    </p>
+                    <hr />
+                    <h2 id="frontend-engineer">
+                        Senior Frontend Engineer (full-time)
+                    </h2>
+                    <p><b>Emloyer:</b> Kandra Labs, Inc.</p>
+                    <p><b>Job location:</b> San Francisco, CA</p>
+                    <p>
+                        <a href="/">Zulip</a> is an open-source team chat
+                        application designed for seamless remote and hybrid
+                        work. With conversations organized by topic, Zulip is <a
+                        href="/why-zulip">ideal</a> for both live and
+                        asynchronous communication. Zulip’s 100% open-source
+                        software is available as a <a href="/plans/#cloud">cloud
+                        service</a> or a
+                        <a href="/self-hosting">self-hosted solution</a>, and is
+                        used by thousands of organizations around the world.
+                    </p>
+                    <h3>What you’ll do:</h3>
+                    <ul>
+                        <li>
+                            Work directly with Zulip&#39;s product and design
+                            leads to drive work on elements of major initiative
+                            to redesign Zulip&#39;s core surface areas.
+                        </li>
+                        <li>
+                            Write hundreds of Git commits a year in a
+                            fast-moving SaaS codebase where changes are
+                            typically deployed to production less than a week
+                            after completing code review.
+                        </li>
+                        <li>
+                            Design new features and subsystems, write design
+                            proposals for discussion, and build them. Diagnose
+                            and fix bugs small and large and across several
+                            layers of our stack, including spelunking in
+                            third-party dependencies to find the best possible
+                            solution.
+                        </li>
+                        <li>
+                            Share your expertise (both newly-acquired and
+                            longstanding) with the rest of the team, through
+                            short- and long-form written communication.
+                        </li>
+                        <li>
+                            Write primarily Typescript, HTML, CSS, and
+                            occasionally Python.
+                        </li>
+                        <li>
+                            Position is mostly remote.
+                        </li>
+                    </ul>
+                    <h3>Essential qualifications:</h3>
+                    <ul>
+                        <li>
+                            A Bachelor’s degree in Computer Science or a closely
+                            related field.
+                        </li>
+                        <li>
+                            60 months of software engineering experience,
+                            including 36 months of experience writing in
+                            JavaScript, 36 months of experience writing in HTML,
+                            and 24 months of experience using threads-first team
+                            chat applications.
+                        </li>
+                    </ul>
+                    <p>
+                        Email us at <a
+                        href="mailto:jobs+frontend@zulip.com">jobs+frontend@zulip.com</a>
+                        with your resume and cover letter to apply. Please
+                        include desired position in the subject line.
                     </p>
                 </div>
                 <div class="how-we-work">

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -562,6 +562,7 @@ html_rules: list["Rule"] = [
         "exclude": {
             "templates/zerver/email.html",
             "zerver/tests/fixtures/email",
+            "templates/corporate/jobs.html",
             "templates/corporate/zulip-cloud.html",
             "templates/corporate/for/business.html",
             "templates/corporate/support/support_request.html",


### PR DESCRIPTION
The linter issue is bogus; not sure what I'm supposed to do to fix it.

```
html      | avoid subject in templates at templates/corporate/jobs.html line 312:
html      |                         include desired position in the subject line.
```

<details><summary>Screenshot</summary>
<p>

<img width="754" height="885" alt="Screenshot 2026-01-06 at 15 40 06" src="https://github.com/user-attachments/assets/b4bad604-7cc0-4471-99ec-45044e2d53cd" />


</p>
</details> 