### PR TITLE
legacy_portico: Restore thin headings.

### DIFF
--- a/web/styles/portico/legacy_portico.css
+++ b/web/styles/portico/legacy_portico.css
@@ -361,6 +361,10 @@ img.screenshot {
     width: 33%;
 }
 
+.portico-container:not(.help) h1 {
+    font-weight: 300;
+}
+
 label.text-error {
     display: inline;
 


### PR DESCRIPTION
This fixes a regression on the signup/registration pages. It makes the assumption, which I'm not 100% certain to be true, that the only pages getting thinner headings where they weren't wanted were the API docs pages.

Asking @laurynmm to review.

[#documentation > portico style changes on API docs @ 💬](https://chat.zulip.org/#narrow/channel/19-documentation/topic/portico.20style.20changes.20on.20API.20docs/near/2345449)

_Note that the apparent change in the form's width is owing to the different size of the heading at different weights._

| Before | After |
| --- | --- |
| <img width="2120" height="1560" alt="regressed-portico-heading" src="https://github.com/user-attachments/assets/883c9ac1-5ec4-45a6-8971-618fc7fb7a91" /> | <img width="2120" height="1560" alt="restored-portico-heading" src="https://github.com/user-attachments/assets/c7d4f938-bdaa-473a-9548-e3421a4a341c" /> |
