### PR TITLE
compose: Show clear error when dragging folders into compose box.

### DIFF
--- a/web/src/upload.ts
+++ b/web/src/upload.ts
@@ -11,6 +11,7 @@ import render_upload_banner from "../templates/compose_banner/upload_banner.hbs"
 import * as blueslip from "./blueslip.ts";
 import * as compose_actions from "./compose_actions.ts";
 import * as compose_banner from "./compose_banner.ts";
+import * as compose_recipient from "./compose_recipient.ts";
 import * as compose_reply from "./compose_reply.ts";
 import * as compose_state from "./compose_state.ts";
 import * as compose_ui from "./compose_ui.ts";
@@ -40,6 +41,42 @@ export function feature_check(): XMLHttpRequestUpload {
 export function get_translated_status(filename: string): string {
     const status = $t({defaultMessage: "Uploading {filename}…"}, {filename});
     return "[" + status + "]()";
+}
+
+function contains_folder(data_transfer: DataTransfer): boolean {
+    if (!data_transfer.items) {
+        return false;
+    }
+
+    for (const item of data_transfer.items) {
+        if (item.kind !== "file") {
+            continue;
+        }
+
+        // https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry
+        // Note: This function is implemented as webkitGetAsEntry() in non-WebKit
+        // browsers including Firefox at this time; it may be renamed to getAsEntry()
+        // in the future, so you should code defensively, looking for both.
+        // @ts-expect-error -- getAsEntry/webkitGetAsEntry not in lib.dom.d.ts yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+        const entry = item.getAsEntry?.() ?? item.webkitGetAsEntry?.();
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if (entry?.isDirectory) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function show_folder_upload_error(config: Config): void {
+    show_error_message(
+        config,
+        $t({
+            defaultMessage: "Folders can't be uploaded. Instead, please upload the files you need.",
+        }),
+    );
 }
 
 type Config = ({mode: "compose"} | {mode: "edit"; row: number}) & {
@@ -456,6 +493,17 @@ export function setup_upload(config: Config): Uppy<ZulipMeta, TusBody> {
         event.stopPropagation();
         assert(event.originalEvent !== undefined);
         assert(event.originalEvent.dataTransfer !== null);
+
+        if (contains_folder(event.originalEvent.dataTransfer)) {
+            setTimeout(() => {
+                if ($("#compose_select_recipient_widget").hasClass("widget-open")) {
+                    compose_recipient.toggle_compose_recipient_dropdown();
+                }
+            }, 0);
+            show_folder_upload_error(config);
+            return;
+        }
+
         const files = event.originalEvent.dataTransfer.files;
         if (config.mode === "compose" && !compose_state.composing()) {
             compose_reply.respond_to_message({
@@ -692,6 +740,37 @@ export function initialize(): void {
         const $drag_drop_edit_containers = $(".message_edit_form form");
         assert(event.originalEvent !== undefined);
         assert(event.originalEvent.dataTransfer !== null);
+
+        if (contains_folder(event.originalEvent.dataTransfer)) {
+            const was_dropdown_open = $("#compose_select_recipient_widget").hasClass("widget-open");
+
+            if (!compose_state.composing()) {
+                if (message_lists.current?.selected_message()) {
+                    compose_reply.respond_to_message({
+                        trigger: "drag_drop_file",
+                        keep_composebox_empty: true,
+                    });
+                } else {
+                    compose_actions.start({
+                        message_type: "stream",
+                        trigger: "drag_drop_file",
+                        keep_composebox_empty: true,
+                    });
+                }
+            }
+
+            if (was_dropdown_open) {
+                setTimeout(() => {
+                    if ($("#compose_select_recipient_widget").hasClass("widget-open")) {
+                        compose_recipient.toggle_compose_recipient_dropdown();
+                    }
+                }, 0);
+            }
+
+            show_folder_upload_error(compose_config);
+            return;
+        }
+
         const files = event.originalEvent.dataTransfer.files;
         const $last_drag_drop_edit_container = $drag_drop_edit_containers.last();
 


### PR DESCRIPTION
Previously, dragging a folder into the compose box produced confusing behavior: Chrome showed a generic upload failure, while Firefox and Safari uploaded an empty file. This gave users no indication of what went wrong.

This PR prevents empty file uploads, avoids unnecessary requests, and provides consistent behavior across browsers.

Fixes #22564.

<!-- Describe your pull request here.-->

**How changes were tested:**

Tested on Chrome, Firefox, and Safari:
-Folder drag shows error

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Current Error Msg**
<img width="1366" height="815" alt="Screenshot 2026-01-07 at 10 34 34" src="https://github.com/user-attachments/assets/3ff18f51-db71-4c01-987a-49095886fb36" />

<details> 
<summary>Earlier Behaviour</summary> 

**On Chrome**


https://github.com/user-attachments/assets/deb0c4a1-c571-437f-9913-2efbac0412de

**On Safari and Firefox**

https://github.com/user-attachments/assets/8268b79d-9723-4a02-9ef8-dedb342248c3



</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
