### PR TITLE
bots: Use 'Created' instead of 'Joined' in bot profile

### DIFF
--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -69,7 +69,7 @@
                                         {{/if}}
                                     </div>
                                     <div id="date-joined" class="default-field">
-                                        <div class="name">{{t "Joined" }}</div>
+                                        <div class="name">{{#if is_bot}}{{t "Created" }}{{else}}{{t "Joined" }}{{/if}}</div>
                                         <div class="value">{{date_joined}}</div>
                                     </div>
                                     {{#if user_time}}


### PR DESCRIPTION
Bots are created rather than joining an organization, so using **“Joined”** in the bot profile was misleading.
This change updates the label to **“Created”** for bot profiles, while keeping regular user profiles unchanged.

Fixes #37251

**How changes were tested:**

* Manually verified that bot profiles display **“Created”** and user profiles continue to display **“Joined”**.
