### PR TITLE
dropdown_widget : Prevent closing overlay on outside click.

### DIFF
--- a/web/src/dropdown_widget.ts
+++ b/web/src/dropdown_widget.ts
@@ -331,6 +331,16 @@ export class DropdownWidget {
             // Custom theme defined in popovers.css
             theme: "dropdown-widget",
             arrow: false,
+            onClickOutside(instance, event) {
+                instance.hide();
+
+                const target = event.target;
+                if (target instanceof Element && $(target).is("div.overlay")) {
+                    event.preventDefault();
+                    event.stopImmediatePropagation();
+                }
+            },
+
             onShow: (instance: tippy.Instance) => {
                 if (util.is_mobile()) {
                     // The dropdown trigger button can be hidden by the


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This bug is caused by a race condition where two click listeners—one for the dropdown(custom-widget) and one for the settings overlay —both react to the same click event. When the user clicks the overlay background, both conditions are met simultaneously, causing both elements to close.

This commit resolves the issue by preventing the propagation of the click event (while dropdown widget is opened) to the settings overlay by introducing `event.stopImmediatePropagation()` in `dropdown_widget.ts`.

Fixes: #33464

**How changes were tested:**

With a custom dropdown open, clicking the overlay background now correctly closes only the dropdown, leaving the settings overlay open. I also:
- Confirmed that clicking the overlay background when no dropdown is open correctly closes the overlay.
- Confirmed that standard HTML elements still function as expected.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Screencast-from-2026-01-07-17-32](https://github.com/user-attachments/assets/79b59eb6-a525-4b9f-a671-2bd771155e3f)




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>