### PR TITLE
digest: Display italicized “general chat” when topic is empty

### DIFF
--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -219,6 +219,11 @@ p.digest_paragraph,
     z-index: 100;
 }
 
+/* Styling for empty topic placeholders. */
+.empty-topic-display {
+    font-style: italic;
+}
+
 /* CSS for digest email content. */
 .messages {
     width: 600px;

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -309,22 +309,29 @@ def build_message_list(
         assert stream_id_map is not None
         assert stream_id in stream_id_map
         stream = stream_id_map[stream_id]
+        topic_name = message.topic_name()
+        topic_display_name = get_topic_display_name(topic_name, user.default_language)
         narrow_link = topic_narrow_url(
             realm=user.realm,
             stream=stream,
-            topic_name=message.topic_name(),
+            topic_name=topic_name,
         )
         channel_privacy_icon = get_channel_privacy_icon(stream)
-        header = f"{channel_privacy_icon}{stream.name} > {message.topic_name()}"
+        header = f"{channel_privacy_icon}{stream.name} > {topic_display_name}"
+        topic_html: Markup = Markup.escape(topic_display_name)
+        if topic_name == "":
+            topic_html = Markup("<span class='empty-topic-display'>{topic_html}</span>").format(
+                topic_html=topic_html,
+            )
         stream_link = stream_narrow_url(user.realm, stream)
         header_html = Markup(
-            "<a href='{stream_link}'>{channel_privacy_icon}{stream_name}</a> &gt; <a href='{narrow_link}'>{topic_name}</a>"
+            "<a href='{stream_link}'>{channel_privacy_icon}{stream_name}</a> &gt; <a href='{narrow_link}'>{topic_html}</a>"
         ).format(
             stream_link=stream_link,
             channel_privacy_icon=channel_privacy_icon,
             stream_name=stream.name,
             narrow_link=narrow_link,
-            topic_name=message.topic_name(),
+            topic_html=topic_html,
         )
         return {
             "plain": header,


### PR DESCRIPTION
Render the default “general chat” label in italics in digest emails when a message has no topic set.

<!-- Describe your pull request here.-->


Fixes: #36689

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Screenshots and screen captures</summary>

| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/fa76dd66-fd90-4be1-83e4-a9e5b96493a7)| ![image-after](https://github.com/user-attachments/assets/b185a9dd-c2aa-412d-b2b1-16becc62e5b9) 


### Added general chat in Plain Text
| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/1be6e2f0-841e-421d-b715-0dfde64c44b7)| ![image-after](https://github.com/user-attachments/assets/0b98af31-3094-4453-8a86-4f7a2a8c4545) 


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
