### PR TITLE
Update link format in code of conduct document

### DIFF
--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,1 +1,1 @@
-../CODE_OF_CONDUCT.md
+[../CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)


### PR DESCRIPTION
Previously, the CODE_OF_CONDUCT.md file (or the reference to it) was missing a direct link to the full policy. This PR adds a link to the official Code of Conduct to improve accessibility and transparency for contributors, ensuring everyone can easily find and understand the community standards.

Fixes:
How changes were tested: Verified the link is functional and points to the correct section of the documentation.

Screenshots and screen captures:

<details> <summary>Self-review checklist</summary>

[x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.

[x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

[x] Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

[x] Each commit is a coherent idea.

[x] Commit message(s) explain reasoning and motivation for changes.

</details>