### PR TITLE
user_groups: Improve groups list sidebar when there are no groups to show

### DIFF
--- a/web/src/user_group_components.ts
+++ b/web/src/user_group_components.ts
@@ -1,5 +1,6 @@
 import $ from "jquery";
 
+import render_nothing_selected_title from "../templates/user_group_settings/nothing_selected_title.hbs";
 import render_selected_group_title from "../templates/user_group_settings/selected_group_title.hbs";
 
 import {$t_html} from "./i18n.ts";
@@ -46,11 +47,7 @@ export const show_user_group_settings_pane = {
         $("#groups_overlay .settings, #user-group-creation").hide();
         reset_active_group_id();
         $("#groups_overlay .nothing-selected").show();
-        $("#groups_overlay .user-group-info-title").text(
-            $t_html({defaultMessage: "User group settings"}),
-        );
-        $("#groups_overlay .deactivated-user-group-icon").hide();
-        $("#groups_overlay .user-group-settings-header-actions").hide();
+        $("#user_group_settings_title").html(render_nothing_selected_title({}));
         resize.resize_settings_overlay($("#groups_overlay_container"));
     },
     settings(group: UserGroup) {
@@ -77,7 +74,6 @@ export const show_user_group_settings_pane = {
         reset_active_group_id();
         $("#user-group-creation").show();
         $("#groups_overlay .deactivated-user-group-icon").hide();
-        $("#groups_overlay .user-group-settings-header-actions").hide();
         resize.resize_settings_overlay($("#groups_overlay_container"));
         resize.resize_settings_creation_overlay($("#groups_overlay_container"));
         $("#user_group_creation_form .two-pane-settings-creation-simplebar-container").toggleClass(

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -18,7 +18,6 @@ import render_user_group_settings from "../templates/user_group_settings/user_gr
 import render_user_group_settings_empty_notice from "../templates/user_group_settings/user_group_settings_empty_notice.hbs";
 import render_user_group_settings_overlay from "../templates/user_group_settings/user_group_settings_overlay.hbs";
 
-import type {Banner} from "./banners.ts";
 import * as blueslip from "./blueslip.ts";
 import * as browser_history from "./browser_history.ts";
 import * as buttons from "./buttons.ts";
@@ -85,22 +84,6 @@ const initial_group_filter = FILTERS.ACTIVE_GROUPS;
 
 let group_list_widget: ListWidget.ListWidget<UserGroup, UserGroup>;
 let group_list_toggler: Toggle;
-
-const GROUP_INFO_BANNER: Banner = {
-    intent: "info",
-    label: $t({
-        defaultMessage:
-            "User groups offer a flexible way to manage permissions in your organization.",
-    }),
-    buttons: [
-        {
-            label: $t({defaultMessage: "Learn more"}),
-            custom_classes: "banner-external-link",
-            variant: "subtle",
-        },
-    ],
-    close_button: false,
-};
 
 function get_user_group_id(target: HTMLElement): number {
     const $row = $(target).closest(
@@ -2058,11 +2041,6 @@ export function setup_page(callback: () => void): void {
         );
         $groups_overlay_container.html(groups_overlay_html);
         update_displayed_groups(initial_group_filter);
-        settings_banner.set_up_banner(
-            $(".group-info-banner"),
-            GROUP_INFO_BANNER,
-            "/help/user-groups",
-        );
 
         settings_banner.set_up_upgrade_banners();
         // Initially as the overlay is build with empty right panel,

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1416,6 +1416,18 @@ export function set_up_click_handlers(): void {
         e.stopPropagation();
         e.preventDefault();
     });
+
+    $("#groups_overlay").on("click", ".no-groups-to-show .view-all-groups-button", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        group_list_toggler.goto("all-groups");
+    });
+
+    $("#groups_overlay").on("click", ".no-groups-to-show .create-user-group-button", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        open_create_user_group();
+    });
 }
 
 function create_user_group_clicked(): void {
@@ -1812,11 +1824,32 @@ export function update_empty_left_panel_message(): void {
         active_tab_key,
     );
 
+    const has_any_groups = user_groups.get_realm_user_groups(true).length > 0;
+
+    // We don't show any action buttons when the user is searching
+    // or has a filter applied, since the empty state is due to
+    // filters, not the actual absence of groups.
+    const is_filtered =
+        current_group_filter !== FILTERS.ACTIVE_AND_DEACTIVATED_GROUPS ||
+        $("#search_group_name").val() !== "";
+
+    const can_create_user_groups =
+        settings_data.user_can_create_user_groups() && realm.zulip_plan_is_not_limited;
+
+    let show_view_all_groups_button = false;
+    let show_create_user_group_button = false;
+    if (!is_filtered && active_tab_key !== "roles") {
+        if (has_any_groups) {
+            show_view_all_groups_button = active_tab_key === "your-groups";
+        } else {
+            show_create_user_group_button = can_create_user_groups;
+        }
+    }
+
     const args = {
         empty_user_group_list_message,
-        can_create_user_groups:
-            settings_data.user_can_create_user_groups() && realm.zulip_plan_is_not_limited,
-        all_groups_tab: active_tab_key === "all-groups",
+        show_view_all_groups_button,
+        show_create_user_group_button,
     };
 
     $(".no-groups-to-show").html(render_user_group_settings_empty_notice(args)).show();
@@ -1834,7 +1867,15 @@ function get_empty_user_group_list_message(
         return $t({defaultMessage: "There are no groups matching your filters."});
     }
 
+    const organization_has_zero_non_system_groups =
+        user_groups.get_realm_user_groups(true).length === 0;
+
     if (active_tab_key === "your-groups") {
+        if (organization_has_zero_non_system_groups) {
+            return $t({
+                defaultMessage: "There are no user groups you can view in this organization.",
+            });
+        }
         return $t({defaultMessage: "You are not a member of any user groups."});
     }
     if (active_tab_key === "roles") {

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1580,7 +1580,6 @@ export function update_group(event: UserGroupUpdateEvent, group: UserGroup): voi
     }
 
     if (event.data.deactivated !== undefined) {
-        update_filter_widget_visibility();
         if (event.data.deactivated) {
             handle_deleted_group(group.id);
         } else {
@@ -1712,6 +1711,7 @@ function redraw_left_panel(tab_name: string): void {
         return;
     }
     group_list_widget.replace_list_data(groups_list_data);
+    update_filter_widget_visibility(tab_name);
     update_empty_left_panel_message();
 }
 
@@ -1728,7 +1728,6 @@ export function switch_group_tab(tab_name: string): void {
         use `group_list_toggler.goto`.
     */
 
-    update_filter_widget_visibility(tab_name);
     redraw_left_panel(tab_name);
     setup_group_list_tab_hash(tab_name);
 }
@@ -1795,6 +1794,10 @@ export function add_or_remove_from_group(
     }
 }
 
+function is_group_search_active(): boolean {
+    return $("#group_filter").css("display") !== "none" && $("#search_group_name").val() !== "";
+}
+
 export function update_empty_left_panel_message(): void {
     // Check if we have any groups in panel to decide whether to
     // display a notice.
@@ -1830,8 +1833,7 @@ export function update_empty_left_panel_message(): void {
     // or has a filter applied, since the empty state is due to
     // filters, not the actual absence of groups.
     const is_filtered =
-        current_group_filter !== FILTERS.ACTIVE_AND_DEACTIVATED_GROUPS ||
-        $("#search_group_name").val() !== "";
+        current_group_filter !== FILTERS.ACTIVE_AND_DEACTIVATED_GROUPS || is_group_search_active();
 
     const can_create_user_groups =
         settings_data.user_can_create_user_groups() && realm.zulip_plan_is_not_limited;
@@ -1859,8 +1861,10 @@ function get_empty_user_group_list_message(
     current_group_filter: string,
     active_tab_key: string,
 ): string {
-    const is_searching = $("#search_group_name").val() !== "";
-    if (is_searching || current_group_filter !== FILTERS.ACTIVE_AND_DEACTIVATED_GROUPS) {
+    if (
+        is_group_search_active() ||
+        current_group_filter !== FILTERS.ACTIVE_AND_DEACTIVATED_GROUPS
+    ) {
         if (active_tab_key === "roles") {
             return $t({defaultMessage: "There are no roles matching your filters."});
         }
@@ -1968,21 +1972,53 @@ function setup_dropdown_filters_widget(): void {
 
 function update_filter_widget_visibility(tab_name?: string): void {
     const active_tab = tab_name ?? get_active_data().$tabs.first().attr("data-tab-key");
+
+    // Roles tab is special: roles cannot be deactivated, so the
+    // active/deactivated dropdown is not applicable. The search box is
+    // always shown, and the filter value is ignored for this tab.
     if (active_tab === "roles") {
-        // Roles cannot be deactivated, so the active/deactivated filter
-        // dropdown is not applicable on the roles tab. We hide the dropdown
-        // and ignore the filter value completely for this tab.
+        $("#group_filter").show();
         $("#user-group-edit-filter-options").hide();
         update_displayed_groups(FILTERS.ACTIVE_GROUPS);
-    } else if (!user_groups.realm_has_deactivated_user_groups()) {
-        $("#user-group-edit-filter-options").hide();
-        update_displayed_groups(FILTERS.ACTIVE_GROUPS);
-        if (filters_dropdown_widget) {
+        return;
+    }
+
+    const groups =
+        active_tab === "your-groups"
+            ? user_groups.get_user_groups_of_user(people.my_current_user_id(), true)
+            : user_groups.get_realm_user_groups(true);
+    const has_active_groups = groups.some((group) => !group.deactivated);
+    const has_deactivated_groups = groups.some((group) => group.deactivated);
+
+    // Search box: shown when at least one group exists in this tab.
+    // Dropdown filter: shown only when both active and deactivated groups
+    // coexist, since otherwise there is nothing to switch between.
+    $("#group_filter").toggle(has_active_groups || has_deactivated_groups);
+    $("#user-group-edit-filter-options").toggle(has_active_groups && has_deactivated_groups);
+
+    // If both kinds coexist (in this tab), honor the dropdown's current value;
+    // otherwise show everything (the dropdown is hidden in that case anyway).
+    let current_filter: string;
+    if (has_active_groups && has_deactivated_groups) {
+        current_filter =
+            z.optional(z.string()).parse(filters_dropdown_widget?.value()) ?? FILTERS.ACTIVE_GROUPS;
+    } else {
+        current_filter = FILTERS.ACTIVE_AND_DEACTIVATED_GROUPS;
+
+        // Reset the dropdown value only when the realm has only one kind
+        // of group left. This way, if the user is on the "All groups" tab
+        // with both kinds and switches to "Your groups" (where the dropdown
+        // is hidden because they only joined active groups), their selection
+        // is preserved when they switch back.
+        const realm_groups = user_groups.get_realm_user_groups(true);
+        const realm_has_both_kinds =
+            realm_groups.some((group) => !group.deactivated) &&
+            realm_groups.some((group) => group.deactivated);
+        if (!realm_has_both_kinds && filters_dropdown_widget) {
             filters_dropdown_widget.render(FILTERS.ACTIVE_GROUPS);
         }
-    } else {
-        $("#user-group-edit-filter-options").show();
     }
+    update_displayed_groups(current_filter);
 }
 
 export function setup_page(callback: () => void): void {

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -139,13 +139,6 @@ export function get_user_group_from_name(name: string): UserGroup | undefined {
     return user_group_name_dict.get(name);
 }
 
-export function realm_has_deactivated_user_groups(): boolean {
-    const realm_user_groups = get_realm_user_groups(true);
-    const deactivated_group_count = realm_user_groups.filter((group) => group.deactivated).length;
-
-    return deactivated_group_count > 0;
-}
-
 export function get_realm_user_groups(include_deactivated = false): UserGroup[] {
     const user_groups = [...user_group_by_id_dict.values()];
     user_groups.sort((a, b) => a.id - b.id);

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -770,8 +770,7 @@ h4.stream_setting_subsection_title {
     .right .nothing-selected {
         padding: 5px 5px 0;
 
-        .stream-info-banner a,
-        .group-info-banner a {
+        .stream-info-banner a {
             color: inherit;
         }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -670,6 +670,13 @@ h4.stream_setting_subsection_title {
     }
 }
 
+.left .no-groups-to-show .settings-empty-option-text {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+}
+
 .two-pane-settings-container {
     display: grid;
     grid-template:
@@ -752,9 +759,12 @@ h4.stream_setting_subsection_title {
         }
     }
 
-    .left .no-streams-to-show,
-    .left .no-groups-to-show {
+    .left .no-streams-to-show {
         margin-top: calc(45vh - 75px);
+    }
+
+    .left .no-groups-to-show {
+        margin-top: 1.25em;
     }
 
     .right .nothing-selected {

--- a/web/templates/user_group_settings/nothing_selected_title.hbs
+++ b/web/templates/user_group_settings/nothing_selected_title.hbs
@@ -1,0 +1,2 @@
+<span class="user-group-info-title-text">{{t 'User group settings' }}</span>
+{{> ../help_link_widget link="/help/user-groups" }}

--- a/web/templates/user_group_settings/user_group_settings_empty_notice.hbs
+++ b/web/templates/user_group_settings/user_group_settings_empty_notice.hbs
@@ -1,13 +1,11 @@
 <div class="no-groups-to-show-message">
     <span class="settings-empty-option-text">
         {{empty_user_group_list_message}}
-        {{#if all_groups_tab}}
-            {{#if can_create_user_groups}}
-                <a href="#groups/new">{{t "Create a user group"}}</a>
-            {{/if}}
-        {{else}}
-            <a href="#groups/all">{{t "View all user groups"}}</a>
+        {{#if show_view_all_groups_button}}
+            {{> ../components/action_button label=(t "View all groups") custom_classes="view-all-groups-button" type="button" variant="subtle" intent="neutral" }}
+        {{/if}}
+        {{#if show_create_user_group_button}}
+            {{> ../components/action_button label=(t "Create user group") custom_classes="create-user-group-button" type="button" variant="subtle" intent="brand" }}
         {{/if}}
     </span>
 </div>
-

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -43,12 +43,11 @@
                 <div class="right">
                     <div class="two-pane-settings-subheader">
                         <div class="display-type">
-                            <div id="user_group_settings_title" class="user-group-info-title">{{t 'User group settings' }}</div>
+                            <div id="user_group_settings_title" class="user-group-info-title"></div>
                         </div>
                     </div>
                     <div class="two-pane-settings-body">
                         <div class="nothing-selected">
-                            <div class="group-info-banner banner-wrapper"></div>
                             <div class="create-group-button-container">
                                 {{> ../settings/upgrade_tip_widget . }}
                                 <button type="button" class="create_user_group_button animated-purple-button">{{t 'Create user group' }}</button>

--- a/web/tests/user_groups.test.cjs
+++ b/web/tests/user_groups.test.cjs
@@ -1342,31 +1342,6 @@ run_test("update_group_permission_settings", () => {
     assert.equal(user_groups.get_user_group_from_id(group.id).can_remove_members_group, 7);
 });
 
-run_test("realm_has_deactivated_user_groups", () => {
-    user_groups.init();
-    const active = make_user_group({
-        name: "Active",
-        id: 1,
-        members: [1],
-        is_system_group: false,
-        direct_subgroup_ids: [],
-        deactivated: false,
-    });
-    user_groups.add(active);
-    assert.ok(!user_groups.realm_has_deactivated_user_groups());
-
-    const deactivated = make_user_group({
-        name: "Deactivated",
-        id: 2,
-        members: [2],
-        is_system_group: false,
-        direct_subgroup_ids: [],
-        deactivated: true,
-    });
-    user_groups.add(deactivated);
-    assert.ok(user_groups.realm_has_deactivated_user_groups());
-});
-
 run_test("get_system_groups_list", ({override}) => {
     user_groups.init();
     const {nobody, owners, admins, moderators, members, everyone, full_members, internet} =


### PR DESCRIPTION
This PR converts the text links in the groups sidebar to styled buttons and improves the messaging. Buttons now have proper click handlers and the appropriate message is shown directly in the "Your groups" panel and "All groups" panel based on whether the organization has groups. Existing filter and search behavior is maintained.

Fixes: #35556
Also fixes: #36118 some points 

> - Drop the info banner about groups.
> - Add a ? link to /help/user-groups on the right side of the "User group settings" header area.

<hr>

### Screenshots and screen captures:
<br>

**When we have no group to see, and we are in the "Your Groups" section, and have permission to create a group.**

| Before | After |
|--------|-------|
|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/11e14fb2-1968-47bf-bfa6-ddf215ebb07d" />|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/71c4665a-48fa-460f-9e89-b7815c3893f8" />|

| Light Theme Before | Light Theme After |
|--------|-------|
|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5f6a3146-4fac-489e-a320-120cc9d8f14c" />|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a6b8195a-1f5c-4941-936f-df79343961fe" />|


**When we are in the "All Groups" section, and permission to create a group.**

| Before | After |
|--------|-------|
|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/22941416-2358-4b92-85c1-fa88fcbec6b6" />|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2a352b94-b446-4669-90e7-12a173574277" />|

| Light Theme Before | Light Theme After |
|--------|-------|
|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/82326c3b-cef5-4ebd-b761-b793837274dd" />|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/85ed5f3e-a2c4-44ab-993f-71951d580644" />|


**When we are in the "Your Groups" section and have no permission to create a new group.)**

| Before | After |
|--------|-------|
|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b2fdf040-9e15-4fdb-b0ab-5d2feca2a5b0" />|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a1959869-1d09-47ad-8dc3-6202d244733f" />|

| Light Theme Before | Light Theme After |
|--------|-------|
|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/da9ccf40-c82b-4e82-b416-2defe00fdf24" />|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5e7c9ce4-006b-48fd-b8f8-0e334b5e26f1" />|

**When we are in the "All Groups" section and have no permission to create a new group.)**

| Before | After |
|--------|-------|
|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3a4b16a6-d958-4ce9-94d1-0a8c0609d868" />|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3747a3d0-3e8a-4c72-a07e-b1ce33a06143" />|

| Light Theme Before | Light Theme After |
|--------|-------|
|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3f18f470-3471-4c57-9dfc-a2ee20879c87" />|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7ecb71a7-51c8-4fc9-86cb-4d8964a2bb5a" />|


**When you have both Active and Deactive groups vs only Active/Deactive group**

| Have Both Active and Deactive | Have only Active/Deactive |
|--------|-------|
|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8a1c756c-4e29-4ee5-b547-1a942ff5dc74" />|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/41c28144-275d-47d4-a4f9-95d00443b3ba" />|

**When there is no group matching your filter in your group tab**

| Before | After |
|--------|-------|
|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/76f2f0b6-04d8-43b4-82a3-09b2c52fec2b" />|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5749bbe3-ab49-44ef-8383-c4ff4b33e492" />|

**When there is no group matching your filter in the All group tab**

| Before | After |
|--------|-------|
|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9640c12b-aff2-4c3c-9307-f5d5b0eeea96" />|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/052f0c4a-d8f8-4263-9418-a595964217d5" />|


**Add new (?) icon and remove info banner.**

| Before | After |
|--------|-------|
|<img width="1080" height="949" alt="image" src="https://github.com/user-attachments/assets/54645921-d757-4cd8-8a9c-2ee80073b9a3" />|<img width="1080" height="949" alt="image" src="https://github.com/user-attachments/assets/b7db043c-3d98-4ee0-a01c-d27428f5c957" />|

| Light Theme Before | Light Theme After |
|--------|-------|
|<img width="1080" height="949" alt="image" src="https://github.com/user-attachments/assets/5408c5b4-557b-4961-97d4-d12f30be7faa" />|<img width="1080" height="949" alt="image" src="https://github.com/user-attachments/assets/59349088-1b69-4512-be7f-470ff26b075c" />|

| When you have permission to create groups | When you don't have permission to create groups |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/14dc0d38-8ef2-48c4-a8a7-5a3c5becefd8" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/29b5833f-f567-4dc1-baee-33270ff80152" width="400" controls></video> |

The filter box and the filter dropdown are only visible when there is at least one active/deactive group.
|--------------|
| <video src="https://github.com/user-attachments/assets/9db0910f-731d-432c-8544-bc603a7f80d0" width="400" controls></video> | 


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
