### PR TITLE
web: Use `apply_markdown` to get raw markdown.

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -817,11 +817,14 @@ export function start($row: JQuery, edit_box_open_callback?: () => void): void {
     const msg_list = message_lists.current;
     void channel.get({
         url: "/json/messages/" + message.id,
-        data: {allow_empty_topic_name: true},
-        success(data) {
-            const {raw_content} = z.object({raw_content: z.string()}).parse(data);
+        data: {allow_empty_topic_name: true, apply_markdown: false},
+        success(raw_data) {
+            const data = message_store.single_message_content_schema.parse(raw_data);
+            assert(data.message.content_type === "text/x-markdown");
+
+            const message_markdown_content = data.message.content;
             if (message_lists.current === msg_list) {
-                message.raw_content = raw_content;
+                message.raw_content = message_markdown_content;
                 start_edit_with_content($row, message.raw_content, edit_box_open_callback);
             }
         },

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -57,6 +57,13 @@ const message_reaction_schema = z.object({
 
 export type MessageReaction = z.infer<typeof message_reaction_schema>;
 
+export const single_message_content_schema = z.object({
+    message: z.object({
+        content: z.string(),
+        content_type: z.enum(["text/html", "text/x-markdown"]),
+    }),
+});
+
 export const submessage_schema = z.object({
     id: z.number(),
     sender_id: z.number(),

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -507,6 +507,15 @@ test("quote_message", ({disallow, override, override_rewire}) => {
         success_function = opts.success;
     });
 
+    function run_success_callback() {
+        success_function({
+            message: {
+                content: "Testing.",
+                content_type: "text/x-markdown",
+            },
+        });
+    }
+
     override(compose_ui, "insert_syntax_and_focus", (syntax, _$textarea, mode) => {
         assert.equal(syntax, "translated: [Quoting…]");
         assert.equal(mode, "block");
@@ -532,9 +541,7 @@ test("quote_message", ({disallow, override, override_rewire}) => {
 
     quote_message(opts);
 
-    success_function({
-        raw_content: "Testing.",
-    });
+    run_success_callback();
     assert.ok(replaced);
 
     opts = {
@@ -548,9 +555,7 @@ test("quote_message", ({disallow, override, override_rewire}) => {
 
     quote_message(opts);
 
-    success_function({
-        raw_content: "Testing.",
-    });
+    run_success_callback();
     assert.ok(replaced);
 
     opts = {

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -293,6 +293,15 @@ run_test("quote_message", ({override, override_rewire}) => {
         success_function = opts.success;
     });
 
+    function run_success_callback() {
+        success_function({
+            message: {
+                content: quote_text,
+                content_type: "text/x-markdown",
+            },
+        });
+    }
+
     // zjquery does not simulate caret handling, so we provide
     // our own versions of val() and caret()
     let textarea_val = "";
@@ -370,10 +379,7 @@ run_test("quote_message", ({override, override_rewire}) => {
     override_with_quote_text(quote_text);
     set_compose_content_with_caret("hello %there"); // "%" is used to encode/display position of focus before change
     compose_reply.quote_message({message_id: 100});
-
-    success_function({
-        raw_content: quote_text,
-    });
+    run_success_callback();
 
     reset_test_state();
 
@@ -388,9 +394,7 @@ run_test("quote_message", ({override, override_rewire}) => {
 
     quote_text = "Testing with caret initially positioned at 0.";
     override_with_quote_text(quote_text);
-    success_function({
-        raw_content: quote_text,
-    });
+    run_success_callback();
 
     override_rewire(compose_reply, "respond_to_message", () => {
         // Reset compose state to replicate the re-opening of compose-box.
@@ -410,9 +414,7 @@ run_test("quote_message", ({override, override_rewire}) => {
 
     quote_text = "Testing with compose-box closed initially.";
     override_with_quote_text(quote_text);
-    success_function({
-        raw_content: quote_text,
-    });
+    run_success_callback();
 
     reset_test_state();
 
@@ -425,9 +427,7 @@ run_test("quote_message", ({override, override_rewire}) => {
 
     quote_text = "Testing with compose-box containing whitespaces and newlines only.";
     override_with_quote_text(quote_text);
-    success_function({
-        raw_content: quote_text,
-    });
+    run_success_callback();
 
     reset_test_state();
 
@@ -445,9 +445,7 @@ run_test("quote_message", ({override, override_rewire}) => {
     assert.ok(new_message);
 
     override_with_quote_text(quote_text);
-    success_function({
-        raw_content: quote_text,
-    });
+    run_success_callback();
 
     reset_test_state();
 
@@ -462,9 +460,7 @@ run_test("quote_message", ({override, override_rewire}) => {
 
     quote_text = "Testing with caret on a new line between 2 lines of text.";
     override_with_quote_text(quote_text);
-    success_function({
-        raw_content: quote_text,
-    });
+    run_success_callback();
 
     reset_test_state();
 
@@ -479,9 +475,7 @@ run_test("quote_message", ({override, override_rewire}) => {
 
     quote_text = "Testing with caret on a new line between many empty newlines.";
     override_with_quote_text(quote_text);
-    success_function({
-        raw_content: quote_text,
-    });
+    run_success_callback();
 });
 
 run_test("set_compose_box_top", () => {


### PR DESCRIPTION
We replace the use of the deprecated `raw_content` property in the single message fetch response and
switch to passing `apply_markdown:false` as one of the query parameters to get the raw markdown in
the `content` property of the response, which is
the recommended way to get the raw markdown for a
message according to our API documentation.

Reference: https://zulip.com/api/get-message
Fixes: https://chat.zulip.org/#narrow/channel/92-learning/topic/raw_content/near/2347489.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
