### PR TITLE
notifications: Dynamically insert source for audio elements.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -172,14 +172,8 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=1943053 -->
 
 <div id="read-receipts-modal-container"></div>
 
-<audio id="user-notification-sound-audio">
-    <source class="notification-sound-source-ogg" type="audio/ogg" />
-    <source class="notification-sound-source-mp3" type="audio/mpeg" />
-</audio>
-<audio id="realm-default-notification-sound-audio">
-    <source class="notification-sound-source-ogg" type="audio/ogg" />
-    <source class="notification-sound-source-mp3" type="audio/mpeg" />
-</audio>
+<audio id="user-notification-sound-audio"></audio>
+<audio id="realm-default-notification-sound-audio"></audio>
 
 <div id="alert-popup-container">
     <div id="popup_banners_wrapper" class="banner-wrapper alert-box">

--- a/web/src/audible_notifications.ts
+++ b/web/src/audible_notifications.ts
@@ -1,28 +1,35 @@
 import $ from "jquery";
 
+import render_notification_sound_sources from "../templates/notification_sound_sources.hbs";
+
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
 
 export function initialize(): void {
-    update_notification_sound_source($("audio#user-notification-sound-audio"), user_settings);
+    update_notification_sound_source("user-notification-sound-audio", user_settings);
 }
 
 export function update_notification_sound_source(
-    $container_elem: JQuery<HTMLAudioElement>,
+    audio_element_id: string,
     settings_object: {notification_sound: string},
 ): void {
     const notification_sound = settings_object.notification_sound;
-    const audio_file_without_extension = "/static/audio/notification_sounds/" + notification_sound;
-    $container_elem
-        .find(".notification-sound-source-ogg")
-        .attr("src", `${audio_file_without_extension}.ogg`);
-    $container_elem
-        .find(".notification-sound-source-mp3")
-        .attr("src", `${audio_file_without_extension}.mp3`);
+    const $container_elem = $<HTMLAudioElement>(`audio#${CSS.escape(audio_element_id)}`);
 
-    if (notification_sound !== "none") {
-        // Load it so that it is ready to be played; without this the old sound
-        // is played.
-        util.the($container_elem).load();
+    if (notification_sound === "none") {
+        $container_elem.empty();
+        return;
     }
+
+    const audio_file_without_extension = "/static/audio/notification_sounds/" + notification_sound;
+    const rendered_audio = render_notification_sound_sources({
+        audio_element_id,
+        audio_file_ogg: `${audio_file_without_extension}.ogg`,
+        audio_file_mp3: `${audio_file_without_extension}.mp3`,
+    });
+    $container_elem.replaceWith($(rendered_audio));
+
+    // Load it so that it is ready to be played; without this the old sound
+    // is played.
+    util.the($<HTMLAudioElement>(`audio#${CSS.escape(audio_element_id)}`)).load();
 }

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -585,7 +585,7 @@ export function dispatch_normal_event(event) {
 
             if (event.property === "notification_sound") {
                 audible_notifications.update_notification_sound_source(
-                    $("audio#realm-default-notification-sound-audio"),
+                    "realm-default-notification-sound-audio",
                     realm_user_settings_defaults,
                 );
             }
@@ -887,7 +887,7 @@ export function dispatch_normal_event(event) {
                 if (notification_name === "notification_sound") {
                     // Change the sound source with the new page `notification_sound`.
                     audible_notifications.update_notification_sound_source(
-                        $("audio#user-notification-sound-audio"),
+                        "user-notification-sound-audio",
                         user_settings,
                     );
                 }

--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -333,8 +333,6 @@ function reset_stream_notifications(elem: HTMLElement): void {
 export function set_up(settings_panel: SettingsPanel): void {
     const $container = $(settings_panel.container);
     const settings_object = settings_panel.settings_object;
-    assert(settings_panel.notification_sound_elem !== null);
-    const $notification_sound_elem = $<HTMLAudioElement>(settings_panel.notification_sound_elem);
     const for_realm_settings = settings_panel.for_realm_settings;
     const $notification_sound_dropdown = $container.find<HTMLSelectElement & {type: "select-one"}>(
         "select:not([multiple]).setting_notification_sound",
@@ -342,7 +340,10 @@ export function set_up(settings_panel: SettingsPanel): void {
 
     $container.find(".play_notification_sound").on("click", () => {
         if ($notification_sound_dropdown.val()!.toLowerCase() !== "none") {
-            void ui_util.play_audio(util.the($notification_sound_elem));
+            assert(settings_panel.notification_sound_elem !== null);
+            void ui_util.play_audio(
+                util.the($<HTMLAudioElement>(settings_panel.notification_sound_elem)),
+            );
         }
     });
 

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -775,7 +775,7 @@ export function discard_realm_default_property_element_changes(elem: HTMLElement
         case "notification_sound":
             assert(typeof property_value === "string");
             audible_notifications.update_notification_sound_source(
-                $("audio#realm-default-notification-sound-audio"),
+                "realm-default-notification-sound-audio",
                 {
                     notification_sound: property_value,
                 },

--- a/web/src/settings_realm_user_settings_defaults.ts
+++ b/web/src/settings_realm_user_settings_defaults.ts
@@ -59,9 +59,6 @@ export function update_page(property: string): void {
 export function set_up(): void {
     assert(realm_default_settings_panel !== undefined);
     const $container = $(realm_default_settings_panel.container);
-    const $notification_sound_elem = $<HTMLAudioElement>(
-        "audio#realm-default-notification-sound-audio",
-    );
     const $notification_sound_dropdown = $container.find<HTMLSelectOneElement>(
         ".setting_notification_sound",
     );
@@ -69,15 +66,18 @@ export function set_up(): void {
     settings_preferences.set_up(realm_default_settings_panel);
 
     audible_notifications.update_notification_sound_source(
-        $notification_sound_elem,
+        "realm-default-notification-sound-audio",
         realm_default_settings_panel.settings_object,
     );
 
     $notification_sound_dropdown.on("change", () => {
         const sound = $notification_sound_dropdown.val()!.toLowerCase();
-        audible_notifications.update_notification_sound_source($notification_sound_elem, {
-            notification_sound: sound,
-        });
+        audible_notifications.update_notification_sound_source(
+            "realm-default-notification-sound-audio",
+            {
+                notification_sound: sound,
+            },
+        );
     });
 
     $container.find(".info-density-button").on("click", function (this: HTMLElement, e) {

--- a/web/templates/notification_sound_sources.hbs
+++ b/web/templates/notification_sound_sources.hbs
@@ -1,0 +1,4 @@
+<audio id="{{audio_element_id}}">
+    <source class="notification-sound-source-ogg" type="audio/ogg" src="{{audio_file_ogg}}" />
+    <source class="notification-sound-source-mp3" type="audio/mpeg" src="{{audio_file_mp3}}" />
+</audio>


### PR DESCRIPTION
**Summary:**
- problem: distracting warnings in console due to placeholder `<source>` elements without `src` attribute.
- fix: Initially, the `<audio>` elements have no `<source>`. HandleBars template is used to construct the new `<audio>` element with necessary `src` which replaces the existing element.

Fixes #36371.

**How changes were tested:**

- at home page, console had `<source> element has no src..` warning .
- after changes, the warning does not appear.
- audio still worked. verified through play notification sound present in personal settings as well as default user settings in organization settings.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
