### PR TITLE
bookend: Convert "not subscribed" notice to info banner with action buttons

### DIFF
--- a/web/src/message_list.ts
+++ b/web/src/message_list.ts
@@ -453,12 +453,8 @@ export class MessageList {
         // trailing bookend if user is subscribed.
         const sub = stream_data.get_sub_by_id(stream_id);
 
-        if (sub && !stream_data.can_toggle_subscription(sub)) {
-            // If the user is not subscribed and cannot subscribe
-            // (e.g., they don't have content access to the channel),
-            // then we don't show a trailing bookend.
-            return;
-        }
+        // Note: We used to return early if can_toggle_subscription was false,
+        // but now we show the banner even if user can't subscribe (just hide the Subscribe button).
 
         if (
             sub &&
@@ -481,6 +477,14 @@ export class MessageList {
             just_unsubscribed = true;
         }
 
+        const can_toggle_subscription = sub ? stream_data.can_toggle_subscription(sub) : false;
+
+        // If the user is not subscribed and cannot subscribe to the
+        // private channel, no bookend is shown.
+        if (!subscribed && invite_only && !can_toggle_subscription) {
+            return;
+        }
+
         this.view.render_trailing_bookend(
             stream_id,
             sub?.name,
@@ -490,6 +494,7 @@ export class MessageList {
             page_params.is_spectator,
             invite_only ?? false,
             is_web_public ?? false,
+            can_toggle_subscription,
         );
     }
 

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -14,6 +14,7 @@ import render_single_message from "../templates/single_message.hbs";
 
 import * as activity from "./activity.ts";
 import * as blueslip from "./blueslip.ts";
+import type {ActionButton} from "./buttons.ts";
 import * as compose_fade from "./compose_fade.ts";
 import * as condense from "./condense.ts";
 import * as hash_util from "./hash_util.ts";
@@ -1933,9 +1934,34 @@ export class MessageListView {
         is_spectator: boolean,
         invite_only: boolean,
         is_web_public: boolean,
+        can_toggle_subscription: boolean,
     ): void {
         // This is not the only place we render bookends; see also the
         // partial in message_group.hbs, which do not set is_trailing_bookend.
+
+        // Build buttons array for not subscribed case
+        const not_subscribed_buttons: ActionButton[] | undefined =
+            !subscribed && !deactivated && !just_unsubscribed
+                ? [
+                      {
+                          variant: "text" as const,
+                          intent: "info" as const,
+                          label: $t({defaultMessage: "Load updates"}),
+                          id: "bookend-load-updates-button",
+                      },
+                      ...(can_toggle_subscription
+                          ? [
+                                {
+                                    variant: "subtle" as const,
+                                    intent: "info" as const,
+                                    label: $t({defaultMessage: "Subscribe"}),
+                                    id: "bookend-subscribe-button",
+                                },
+                            ]
+                          : []),
+                  ]
+                : undefined;
+
         const $rendered_trailing_bookend = $(
             render_bookend({
                 stream_id,
@@ -1947,6 +1973,7 @@ export class MessageListView {
                 is_trailing_bookend: true,
                 invite_only,
                 is_web_public,
+                not_subscribed_buttons,
             }),
         );
         this.$list.append($rendered_trailing_bookend);

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -26,6 +26,8 @@ import type {DropdownWidget} from "./dropdown_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
+import * as message_fetch from "./message_fetch.ts";
+import * as message_lists from "./message_lists.ts";
 import * as narrow_state from "./narrow_state.ts";
 import type {User} from "./people.ts";
 import * as people from "./people.ts";
@@ -718,6 +720,41 @@ function show_stream_email_address_modal(address: string, sub: StreamSubscriptio
 
 export function initialize(): void {
     $("#main_div").on("click", ".stream_sub_unsub_button", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const sub = narrow_state.stream_sub();
+        if (sub === undefined) {
+            return;
+        }
+
+        stream_settings_components.sub_or_unsub(sub);
+    });
+
+    // Handle "Load updates" button in bookend banner
+    $("#main_div").on("click", "#bookend-load-updates-button", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (message_lists.current === undefined) {
+            return;
+        }
+
+        const msg_list = message_lists.current;
+
+        // Reload the current narrow to fetch the latest messages
+        const anchor = message_fetch.get_backfill_anchor(msg_list.data);
+        message_fetch.load_messages_for_narrow({
+            anchor,
+            msg_list,
+            cont() {
+                msg_list.update_trailing_bookend();
+            },
+        });
+    });
+
+    // Handle "Subscribe" button in bookend banner
+    $("#main_div").on("click", "#bookend-subscribe-button", (e) => {
         e.preventDefault();
         e.stopPropagation();
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1266,6 +1266,29 @@
             margin-left: 0.1667em; /* 2px at 12px / em */
         }
     }
+
+    /* Styles for the not-subscribed banner */
+    .bookend-not-subscribed-banner {
+        text-align: start;
+        margin: 0;
+
+        .banner-content {
+            align-items: center;
+        }
+
+        .banner-label {
+            text-align: start;
+
+            .stream-status {
+                display: inline;
+                opacity: 1; /* Override the 0.6 opacity from .bookend .stream-status */
+            }
+        }
+
+        .banner-action-buttons {
+            flex-shrink: 0;
+        }
+    }
 }
 
 .bookend-label {

--- a/web/templates/bookend.hbs
+++ b/web/templates/bookend.hbs
@@ -5,28 +5,34 @@
             <a href="#recent">{{t "Browse recent conversations" }}</a>
         </span>
     {{else}}
-        <span class="stream-status bookend-label">
-            {{#if deactivated}}
+        {{#if deactivated}}
+            <span class="stream-status bookend-label">
                 {{t "This channel has been archived." }}
-            {{else if subscribed }}
+            </span>
+        {{else if subscribed }}
+            <span class="stream-status bookend-label">
                 {{#tr}}
                     You subscribed to <z-stream-name></z-stream-name>. <channel-settings-link></channel-settings-link>
                     {{#*inline "z-stream-name"}}{{> stream_privacy . }} {{stream_name}}{{/inline}}
                     {{#*inline "channel-settings-link"}} <a class="bookend-channel-settings-link" href="#channels/{{stream_id}}/{{stream_name}}/personal">{{t 'Manage channel settings'}}</a>{{/inline}}
                 {{/tr}}
-            {{else if just_unsubscribed }}
+            </span>
+        {{else if just_unsubscribed }}
+            <span class="stream-status bookend-label">
                 {{#tr}}
                     You unsubscribed from <z-stream-name></z-stream-name>. <channel-settings-link></channel-settings-link>
                     {{#*inline "z-stream-name"}}{{> stream_privacy . }} {{stream_name}}{{/inline}}
                     {{#*inline "channel-settings-link"}} <a class="bookend-channel-settings-link" href="#channels/{{stream_id}}/{{stream_name}}/general">{{t 'View in channel settings'}}</a>{{/inline}}
                 {{/tr}}
-            {{else}}
+            </span>
+        {{else}}
+            {{! Use banner component for not subscribed case }}
+            {{#> components/banner intent="info" custom_classes="bookend-not-subscribed-banner" buttons=not_subscribed_buttons stream_id=stream_id stream_name=stream_name invite_only=invite_only is_web_public=is_web_public}}
                 {{#tr}}
-                    You are not subscribed to <z-stream-name></z-stream-name>. <subscribe-button></subscribe-button>
-                    {{#*inline "z-stream-name"}}{{> stream_privacy . }} {{stream_name}}{{/inline}}
-                    {{#*inline "subscribe-button"}} <a class="stream_sub_unsub_button">{{t 'Subscribe'}}</a>{{/inline}}
+                    Because you aren't subscribed to <z-stream-name></z-stream-name>, you won't see new messages, reactions, and other updates.
+                    {{#*inline "z-stream-name"}}<span class="stream-status">{{> stream_privacy . }}</span> {{stream_name}}{{/inline}}
                 {{/tr}}
-            {{/if}}
-        </span>
+            {{/components/banner}}
+        {{/if}}
     {{/if}}
 </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: https://github.com/zulip/zulip/issues/35901

Replaces the simple "You are not subscribed to" text notice with an info banner that includes action buttons and clearer messaging.

**Changes:**
- Converted the text notice to an info banner component
- Updated message: "Because you aren't subscribed to {channel}, you won't see new messages, reactions, and other updates."
- Added "Load updates" button (low emphasis, borderless) to fetch current messages
- Added "Subscribe" button (medium emphasis, quiet) - only shown when user has permission to subscribe
- Banner remains visible even when Subscribe button is hidden

**How changes were tested:**
Manually tested across all supported responsive breakpoints.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="1621" height="887" alt="image" src="https://github.com/user-attachments/assets/df09a5b6-b574-497c-b959-b292f4718cd1" />
<img width="1384" height="895" alt="image" src="https://github.com/user-attachments/assets/f1043325-b477-4ee5-b273-c747fe6f8514" />
<img width="994" height="925" alt="image" src="https://github.com/user-attachments/assets/e25cd4b8-fe77-448b-b150-38d2dd6cbbf1" />
<img width="501" height="770" alt="image" src="https://github.com/user-attachments/assets/6c14acaf-8fc2-4e93-b253-138bdc070a7b" />
<img width="497" height="739" alt="image" src="https://github.com/user-attachments/assets/e6e22bd2-ebb3-4c41-853c-a152366b120f" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>