### PR TITLE
marketing_page: Zero out padding-left on bulleted lists.

### DIFF
--- a/web/styles/portico/marketing_page.css
+++ b/web/styles/portico/marketing_page.css
@@ -1132,6 +1132,10 @@ p {
 
 ul {
     font-weight: normal;
+    /* Unordered lists relied on this bit of Bootstrap
+       reset, so we re-introduce it here to avoid
+       indenting vanilla and other bulleted lists. */
+    padding-left: 0;
 }
 
 span a:hover,


### PR DESCRIPTION
After extensive testing of both the marketing and legacy portico pages using BackstopJS, I've determined that the alignment of bullets was the only regression introduced that we'd yet to catch.

This PR reintroduces a bit of Bootstrap's resets to keep bulleted lists left aligned.

| Before | After |
| --- | --- |
| <img width="1000" height="1560" alt="fancy-bullets-before" src="https://github.com/user-attachments/assets/b67805c5-a503-493f-8f75-8e4e1dcc5ecb" /> | <img width="1000" height="1560" alt="fancy-bullets-after" src="https://github.com/user-attachments/assets/c3912f4d-4786-4469-8a48-8d7a2e479e1b" /> |
| <img width="1000" height="1560" alt="vanilla-bullets-before" src="https://github.com/user-attachments/assets/10e4fb78-9ddb-4895-b74c-0e1c87a069dd" /> | <img width="1000" height="1560" alt="vanilla-bullets-after" src="https://github.com/user-attachments/assets/4ee46ee2-e48a-4bbb-85f3-d188c56803f0" /> |