### PR TITLE
settings_ui: Add red shadow and border on invalid time inputs.

### DIFF
--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -338,6 +338,8 @@ function generate_multiuse_invite(): void {
 }
 
 function valid_to(): string {
+    const $custom_expiration_time_elm = $<HTMLInputElement>("input#custom-expiration-time-input");
+    $custom_expiration_time_elm.removeClass("invalid-input");
     const $expires_in = $<HTMLSelectOneElement>("select:not([multiple])#expires_in");
     const time_input_value = $expires_in.val()!;
 
@@ -348,7 +350,8 @@ function valid_to(): string {
     let time_in_minutes: number;
     if (time_input_value === "custom") {
         if (!util.validate_custom_time_input(custom_expiration_time_input, false)) {
-            return $t({defaultMessage: "Invalid custom time"});
+            $custom_expiration_time_elm.addClass("invalid-input");
+            return "";
         }
         time_in_minutes = util.get_custom_time_in_minutes(
             custom_expiration_time_unit,

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -929,6 +929,8 @@ export function deactivate_organization(e: JQuery.Event): void {
     }
 
     function delete_data_in_text(): string {
+        const $custom_deletion_time_input = $<HTMLInputElement>("input#custom-deletion-time-input");
+        $custom_deletion_time_input.removeClass("invalid-input");
         const $delete_in = $<HTMLSelectOneElement>("select:not([multiple])#delete-realm-data-in");
         const delete_data_value = $delete_in.val()!;
 
@@ -939,14 +941,16 @@ export function deactivate_organization(e: JQuery.Event): void {
         let time_in_minutes: number;
         if (delete_data_value === "custom") {
             if (!util.validate_custom_time_input(custom_deletion_time_input)) {
-                return $t({defaultMessage: "Invalid custom time"});
+                $custom_deletion_time_input.addClass("invalid-input");
+                return "";
             }
             time_in_minutes = util.get_custom_time_in_minutes(
                 custom_deletion_time_unit,
                 custom_deletion_time_input,
             );
             if (!is_valid_time_period(time_in_minutes)) {
-                return $t({defaultMessage: "Invalid custom time"});
+                $custom_deletion_time_input.addClass("invalid-input");
+                return "";
             }
         } else {
             // These options were already filtered for is_valid_time_period.


### PR DESCRIPTION
This PR improves the invalid custom time indicator's UI.

It does so by the following:
- [x] Invalid custom time inputs are shown with a red outline and shadow, consistent with other UI inputs, by utilizing `.invalid-input` class.
- [x] No notices are shown below the input fields.

It uses the same approach as in #37233 of programmatically setting/removing `.invalid-input` class, and removing inline error notices. Unlike that PR, this change does not modify any existing validation logic.

Fixes: #37135 

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before:
<img width="606" height="733" alt="Screenshot 2026-01-10 at 12 39 49 AM" src="https://github.com/user-attachments/assets/ec912633-a342-48e9-a1f2-bb2d25cccaf8" />
<img width="609" height="734" alt="Screenshot 2026-01-10 at 12 40 25 AM" src="https://github.com/user-attachments/assets/52a9b6d2-7e3d-4a5d-84b9-29f6c92a1ae1" />
<img width="594" height="89" alt="Screenshot 2026-01-10 at 12 25 52 PM" src="https://github.com/user-attachments/assets/47dc6623-1641-47e0-b0e4-eb007390c80f" />
<img width="612" height="410" alt="Screenshot 2026-01-10 at 12 40 52 AM" src="https://github.com/user-attachments/assets/c74d6e80-5b2d-4f9a-9092-144facd6ff5c" />
<img width="609" height="404" alt="Screenshot 2026-01-10 at 11 46 50 AM" src="https://github.com/user-attachments/assets/9768b713-b0f1-4f7a-8480-6c931ab9272c" />

After:
<img width="608" height="735" alt="Screenshot 2026-01-09 at 11 19 10 PM" src="https://github.com/user-attachments/assets/5434e5ac-0dde-4352-9c53-796c8e507edb" />
<img width="607" height="735" alt="Screenshot 2026-01-09 at 11 19 20 PM" src="https://github.com/user-attachments/assets/e827b362-7e5e-45b2-86cb-738557a73ae2" />
<img width="598" height="74" alt="Screenshot 2026-01-10 at 12 26 40 PM" src="https://github.com/user-attachments/assets/f68167ad-5cc8-42a0-a939-705173a53825" />
<img width="607" height="382" alt="Screenshot 2026-01-10 at 11 43 11 AM" src="https://github.com/user-attachments/assets/a098bf16-658f-4ae5-bcdf-7184b721523a" />
<img width="610" height="382" alt="Screenshot 2026-01-09 at 11 18 39 PM" src="https://github.com/user-attachments/assets/bcb5d07e-d8f9-4251-90b4-a6b7a9a35eb8" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
