### PR TITLE
marketing_page: Avoid double marker on subnav in Safari.

### DIFF
--- a/web/styles/portico/navbar.css
+++ b/web/styles/portico/navbar.css
@@ -448,6 +448,16 @@ details summary::-webkit-details-marker {
     background: hsl(0deg 0% 100% / 10%);
 }
 
+/* We display: block here instead of the default
+   display: list-item largely for the sake of Safari,
+   which as of early 2026 still ignores the ::marker
+   line below. Because we're overriding the default
+   markers on all browsers, this display mode doesn't
+   impact other browsers, either. */
+.top-menu-mobile-item-summary {
+    display: block;
+}
+
 .top-menu-mobile-item-summary::marker {
     content: "";
 }


### PR DESCRIPTION
This PR fixes a double marker on the `<summary>` elements of the subnav on the marketing pages in Safari (desktop and iOS).

While I consulted https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/summary#default_style for guidance on suppressing the browser-default marker on Safari, the `::-webkit-details-marker` method failed to work as described.

So I reasoned here as is recorded in the comments that a reasonable, cross-browser way forward is to change the display mode to `display: block`. As the extensive before/after screenshots below show, we can do this without introducing any regressions on other browsers.

**Screenshots:**

| iOS Safari, Before | iOS Safari, After |
| --- | --- |
| <img width="590" height="1278" alt="ios-closed-summary-before" src="https://github.com/user-attachments/assets/091f6d4a-2872-4155-9820-b10b16bac334" /> | <img width="590" height="1278" alt="ios-closed-summary-after" src="https://github.com/user-attachments/assets/0859f440-20d4-408c-a79e-f7cbc5fc036f" /> |
| <img width="590" height="1278" alt="ios-open-summary-before" src="https://github.com/user-attachments/assets/0fa620ed-7dcf-491b-a5f3-205861a20fc0" /> | <img width="590" height="1278" alt="ios-open-summaruy-after" src="https://github.com/user-attachments/assets/bd3b4a09-306d-4899-9766-7566abd48716" /> | 

| Desktop Safari, Before | Desktop Safari, After |
| --- | --- |
| <img width="1148" height="1552" alt="safari-closed-summary-before" src="https://github.com/user-attachments/assets/257f6649-bf2d-46bb-b7ec-fd704af6f14e" /> | <img width="1148" height="1552" alt="safari-closed-summary-after" src="https://github.com/user-attachments/assets/1349f8ba-7520-4c3e-bf6d-d6eb0c02f013" /> |
| <img width="1148" height="1552" alt="safari-open-summary-before" src="https://github.com/user-attachments/assets/c76a9be8-be91-4b02-b387-37c46848953f" /> | <img width="1148" height="1552" alt="safari-open-summary-after" src="https://github.com/user-attachments/assets/fefb6a5f-a421-415b-8dd2-819799534a7d" /> |

| Chrome, Before | Chrome, After (no change) |
| --- | --- |
| <img width="1000" height="1654" alt="chrome-closed-summary-before" src="https://github.com/user-attachments/assets/d308c107-70f1-4406-a24c-00f197f53c49" /> | <img width="1000" height="1654" alt="chrome-closed-summary-after--no-change" src="https://github.com/user-attachments/assets/62ce595b-61f4-4aa7-9ba8-f2bd8a2ae37a" /> |
| <img width="1000" height="1654" alt="chrome-open-summary-before" src="https://github.com/user-attachments/assets/a307769c-9654-4497-9dc9-4223f635f075" /> | <img width="1000" height="1654" alt="chrome-open-summary-after--no-change" src="https://github.com/user-attachments/assets/42373c8c-518e-4904-8a4f-3e6e7361fc44" /> |

_The lack of blur is just a compositing error in how Firefox does screen captures:_

| Firefox, Before | Firefox, After (no change) |
| --- | --- |
| <img width="1000" height="1560" alt="firefox-closed-summary-before" src="https://github.com/user-attachments/assets/5f5a4f70-fb64-446c-8c94-bdbd95d992e4" /> | <img width="1000" height="1560" alt="firefox-closed-summary-after--no-change" src="https://github.com/user-attachments/assets/7184e33d-1f3e-4faf-bbb4-03134f993fb1" /> |
| <img width="1000" height="1560" alt="firefox-open-summary-before" src="https://github.com/user-attachments/assets/e1fece5b-fe72-4ee8-9941-74390af212b7" /> | <img width="1000" height="1560" alt="firefox-open-summary-after--no-change" src="https://github.com/user-attachments/assets/8c6068f6-d3d6-4ff1-a9c8-a6be2fc782d0" /> |


