### PR TITLE
buttons: Rename action button attention values to visual variants.

### DIFF
--- a/templates/zerver/development/showroom/banners.html
+++ b/templates/zerver/development/showroom/banners.html
@@ -71,17 +71,17 @@
                             </div>
                         </div>
 
-                        <div class="showroom-controls-label">Primary Button Settings</div>
+                        <div class="showroom-controls-label">Solid Button Settings</div>
                         <div class="showroom-controls">
                             <div class="showroom-control">
                                 <span class="showroom-control-label">Button</span>
                                 <div role="group" class="tab-picker showroom-control-setting">
-                                    <input type="radio" id="enable_primary_button" class="tab-option" name="primary-button-select"/>
-                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="enable_primary_button" tabindex="0">
+                                    <input type="radio" id="enable_solid_button" class="tab-option" name="solid-button-select"/>
+                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="enable_solid_button" tabindex="0">
                                         <span>Enable</span>
                                     </label>
-                                    <input type="radio" id="disable_primary_button" class="tab-option" name="primary-button-select" checked/>
-                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="disable_primary_button" tabindex="0">
+                                    <input type="radio" id="disable_solid_button" class="tab-option" name="solid-button-select" checked/>
+                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="disable_solid_button" tabindex="0">
                                         <span>Disable</span>
                                     </label>
                                     <span class="slider"></span>
@@ -90,12 +90,12 @@
                             <div class="showroom-control">
                                 <span class="showroom-control-label">Button Icon</span>
                                 <div role="group" class="tab-picker showroom-control-setting">
-                                    <input type="radio" id="enable_primary_button_icon" class="tab-option" name="primary-button-icon-select"/>
-                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="enable_primary_button_icon" tabindex="0">
+                                    <input type="radio" id="enable_solid_button_icon" class="tab-option" name="solid-button-icon-select"/>
+                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="enable_solid_button_icon" tabindex="0">
                                         <span>Enable</span>
                                     </label>
-                                    <input type="radio" id="disable_primary_button_icon" class="tab-option" name="primary-button-icon-select" checked/>
-                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="disable_primary_button_icon" tabindex="0">
+                                    <input type="radio" id="disable_solid_button_icon" class="tab-option" name="solid-button-icon-select" checked/>
+                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="disable_solid_button_icon" tabindex="0">
                                         <span>Disable</span>
                                     </label>
                                     <span class="slider"></span>
@@ -103,7 +103,7 @@
                             </div>
                             <div class="showroom-control">
                                 <span class="showroom-control-label">Select Icon</span>
-                                <select class="showroom-control-element showroom-control-setting" id="primary_button_select_icon">
+                                <select class="showroom-control-element showroom-control-setting" id="solid_button_select_icon">
                                     {% for icon in icons %}
                                         <option value="{{ icon }}" {% if icon == "move-alt" %}selected{% endif %}>{{ icon }}</option>
                                     {% endfor %}
@@ -111,21 +111,21 @@
                             </div>
                             <div class="showroom-control">
                                 <span class="showroom-control-label">Button Text</span>
-                                <input class="showroom-control-element showroom-control-setting" type="text" id="primary_button_text" />
+                                <input class="showroom-control-element showroom-control-setting" type="text" id="solid_button_text" />
                             </div>
                         </div>
 
-                        <div class="showroom-controls-label">Quiet Button Settings</div>
+                        <div class="showroom-controls-label">Subtle Button Settings</div>
                         <div class="showroom-controls">
                             <div class="showroom-control">
                                 <span class="showroom-control-label">Button</span>
                                 <div role="group" class="tab-picker showroom-control-setting">
-                                    <input type="radio" id="enable_quiet_button" class="tab-option" name="quiet-button-select"/>
-                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="enable_quiet_button" tabindex="0">
+                                    <input type="radio" id="enable_subtle_button" class="tab-option" name="subtle-button-select"/>
+                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="enable_subtle_button" tabindex="0">
                                         <span>Enable</span>
                                     </label>
-                                    <input type="radio" id="disable_quiet_button" class="tab-option" name="quiet-button-select" checked/>
-                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="disable_quiet_button" tabindex="0">
+                                    <input type="radio" id="disable_subtle_button" class="tab-option" name="subtle-button-select" checked/>
+                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="disable_subtle_button" tabindex="0">
                                         <span>Disable</span>
                                     </label>
                                     <span class="slider"></span>
@@ -134,12 +134,12 @@
                             <div class="showroom-control">
                                 <span class="showroom-control-label">Button Icon</span>
                                 <div role="group" class="tab-picker showroom-control-setting">
-                                    <input type="radio" id="enable_quiet_button_icon" class="tab-option" name="quiet-button-icon-select"/>
-                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="enable_quiet_button_icon" tabindex="0">
+                                    <input type="radio" id="enable_subtle_button_icon" class="tab-option" name="subtle-button-icon-select"/>
+                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="enable_subtle_button_icon" tabindex="0">
                                         <span>Enable</span>
                                     </label>
-                                    <input type="radio" id="disable_quiet_button_icon" class="tab-option" name="quiet-button-icon-select" checked/>
-                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="disable_quiet_button_icon" tabindex="0">
+                                    <input type="radio" id="disable_subtle_button_icon" class="tab-option" name="subtle-button-icon-select" checked/>
+                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="disable_subtle_button_icon" tabindex="0">
                                         <span>Disable</span>
                                     </label>
                                     <span class="slider"></span>
@@ -147,7 +147,7 @@
                             </div>
                             <div class="showroom-control">
                                 <span class="showroom-control-label">Select Icon</span>
-                                <select class="showroom-control-element showroom-control-setting" id="quiet_button_select_icon">
+                                <select class="showroom-control-element showroom-control-setting" id="subtle_button_select_icon">
                                     {% for icon in icons %}
                                         <option value="{{ icon }}" {% if icon == "move-alt" %}selected{% endif %}>{{ icon }}</option>
                                     {% endfor %}
@@ -155,21 +155,21 @@
                             </div>
                             <div class="showroom-control">
                                 <span class="showroom-control-label">Button Text</span>
-                                <input class="showroom-control-element showroom-control-setting" type="text" id="quiet_button_text" />
+                                <input class="showroom-control-element showroom-control-setting" type="text" id="subtle_button_text" />
                             </div>
                         </div>
 
-                        <div class="showroom-controls-label">Borderless Button Settings</div>
+                        <div class="showroom-controls-label">Text Button Settings</div>
                         <div class="showroom-controls">
                             <div class="showroom-control">
                                 <span class="showroom-control-label">Button</span>
                                 <div role="group" class="tab-picker showroom-control-setting">
-                                    <input type="radio" id="enable_borderless_button" class="tab-option" name="borderless-button-select"/>
-                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="enable_borderless_button" tabindex="0">
+                                    <input type="radio" id="enable_text_button" class="tab-option" name="text-button-select"/>
+                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="enable_text_button" tabindex="0">
                                         <span>Enable</span>
                                     </label>
-                                    <input type="radio" id="disable_borderless_button" class="tab-option" name="borderless-button-select" checked/>
-                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="disable_borderless_button" tabindex="0">
+                                    <input type="radio" id="disable_text_button" class="tab-option" name="text-button-select" checked/>
+                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="disable_text_button" tabindex="0">
                                         <span>Disable</span>
                                     </label>
                                     <span class="slider"></span>
@@ -178,12 +178,12 @@
                             <div class="showroom-control">
                                 <span class="showroom-control-label">Button Icon</span>
                                 <div role="group" class="tab-picker showroom-control-setting">
-                                    <input type="radio" id="enable_borderless_button_icon" class="tab-option" name="borderless-button-icon-select"/>
-                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="enable_borderless_button_icon" tabindex="0">
+                                    <input type="radio" id="enable_text_button_icon" class="tab-option" name="text-button-icon-select"/>
+                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="enable_text_button_icon" tabindex="0">
                                         <span>Enable</span>
                                     </label>
-                                    <input type="radio" id="disable_borderless_button_icon" class="tab-option" name="borderless-button-icon-select" checked/>
-                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="disable_borderless_button_icon" tabindex="0">
+                                    <input type="radio" id="disable_text_button_icon" class="tab-option" name="text-button-icon-select" checked/>
+                                    <label role="menuitemradio" class="tab-option-content showroom-control-element" for="disable_text_button_icon" tabindex="0">
                                         <span>Disable</span>
                                     </label>
                                     <span class="slider"></span>
@@ -191,7 +191,7 @@
                             </div>
                             <div class="showroom-control">
                                 <span class="showroom-control-label">Select Icon</span>
-                                <select class="showroom-control-element showroom-control-setting" id="borderless_button_select_icon">
+                                <select class="showroom-control-element showroom-control-setting" id="text_button_select_icon">
                                     {% for icon in icons %}
                                         <option value="{{ icon }}" {% if icon == "move-alt" %}selected{% endif %}>{{ icon }}</option>
                                     {% endfor %}
@@ -199,7 +199,7 @@
                             </div>
                             <div class="showroom-control">
                                 <span class="showroom-control-label">Button Text</span>
-                                <input class="showroom-control-element showroom-control-setting" type="text" id="borderless_button_text" />
+                                <input class="showroom-control-element showroom-control-setting" type="text" id="text_button_text" />
                             </div>
                         </div>
                     </section>

--- a/templates/zerver/development/showroom/buttons.html
+++ b/templates/zerver/development/showroom/buttons.html
@@ -20,15 +20,15 @@
                         <div class="showroom-component-button-intent-group">
                             <div class="showroom-component-button-intent-label">Neutral Variant</div>
                             <div class="showroom-component-action-button-group">
-                                <button class="action-button action-button-primary-neutral" tabindex=0>
+                                <button class="action-button action-button-solid-neutral" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
-                                <button class="action-button action-button-quiet-neutral" tabindex=0>
+                                <button class="action-button action-button-subtle-neutral" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
-                                <button class="action-button action-button-borderless-neutral" tabindex=0>
+                                <button class="action-button action-button-text-neutral" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
@@ -45,15 +45,15 @@
                         <div class="showroom-component-button-intent-group">
                             <div class="showroom-component-button-intent-label">Brand Variant</div>
                             <div class="showroom-component-action-button-group">
-                                <button class="action-button action-button-primary-brand" tabindex=0>
+                                <button class="action-button action-button-solid-brand" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
-                                <button class="action-button action-button-quiet-brand" tabindex=0>
+                                <button class="action-button action-button-subtle-brand" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
-                                <button class="action-button action-button-borderless-brand" tabindex=0>
+                                <button class="action-button action-button-text-brand" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
@@ -70,15 +70,15 @@
                         <div class="showroom-component-button-intent-group">
                             <div class="showroom-component-button-intent-label">Info Variant</div>
                             <div class="showroom-component-action-button-group">
-                                <button class="action-button action-button-primary-info" tabindex=0>
+                                <button class="action-button action-button-solid-info" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
-                                <button class="action-button action-button-quiet-info" tabindex=0>
+                                <button class="action-button action-button-subtle-info" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
-                                <button class="action-button action-button-borderless-info" tabindex=0>
+                                <button class="action-button action-button-text-info" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
@@ -95,15 +95,15 @@
                         <div class="showroom-component-button-intent-group">
                             <div class="showroom-component-button-intent-label">Success Variant</div>
                             <div class="showroom-component-action-button-group">
-                                <button class="action-button action-button-primary-success" tabindex=0>
+                                <button class="action-button action-button-solid-success" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
-                                <button class="action-button action-button-quiet-success" tabindex=0>
+                                <button class="action-button action-button-subtle-success" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
-                                <button class="action-button action-button-borderless-success" tabindex=0>
+                                <button class="action-button action-button-text-success" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
@@ -120,15 +120,15 @@
                         <div class="showroom-component-button-intent-group">
                             <div class="showroom-component-button-intent-label">Warning Variant</div>
                             <div class="showroom-component-action-button-group">
-                                <button class="action-button action-button-primary-warning" tabindex=0>
+                                <button class="action-button action-button-solid-warning" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
-                                <button class="action-button action-button-quiet-warning" tabindex=0>
+                                <button class="action-button action-button-subtle-warning" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
-                                <button class="action-button action-button-borderless-warning" tabindex=0>
+                                <button class="action-button action-button-text-warning" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
@@ -145,15 +145,15 @@
                         <div class="showroom-component-button-intent-group">
                             <div class="showroom-component-button-intent-label">Danger Variant</div>
                             <div class="showroom-component-action-button-group">
-                                <button class="action-button action-button-primary-danger" tabindex=0>
+                                <button class="action-button action-button-solid-danger" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
-                                <button class="action-button action-button-quiet-danger" tabindex=0>
+                                <button class="action-button action-button-subtle-danger" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>
-                                <button class="action-button action-button-borderless-danger" tabindex=0>
+                                <button class="action-button action-button-text-danger" tabindex=0>
                                     <i class="zulip-icon zulip-icon-move-alt"></i>
                                     <span class="action-button-label">Button joy</span>
                                 </button>

--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -91,7 +91,7 @@ function set_upload_space_stats(): void {
             {
                 label: $t({defaultMessage: "Upgrade"}),
                 custom_classes: "request-upgrade",
-                attention: "quiet",
+                variant: "subtle",
             },
         ];
     }

--- a/web/src/buttons.ts
+++ b/web/src/buttons.ts
@@ -4,12 +4,12 @@ import * as loading from "./loading.ts";
 import {COMPONENT_INTENT_VALUES} from "./types.ts";
 import type {ComponentIntent} from "./types.ts";
 
-export const ACTION_BUTTON_ATTENTION_VALUES = ["primary", "quiet", "borderless"] as const;
+export const ACTION_BUTTON_VARIANT_VALUES = ["solid", "subtle", "text"] as const;
 
-export type ActionButtonAttention = (typeof ACTION_BUTTON_ATTENTION_VALUES)[number];
+export type ActionButtonVariant = (typeof ACTION_BUTTON_VARIANT_VALUES)[number];
 
 export type ActionButton = {
-    attention: ActionButtonAttention;
+    variant: ActionButtonVariant;
     intent?: ComponentIntent;
     label?: string;
     icon?: string;
@@ -56,28 +56,26 @@ export function hide_button_loading_indicator($button: JQuery): void {
 export function modify_action_button_style(
     $button: JQuery,
     opts: {
-        attention?: ActionButtonAttention;
+        variant?: ActionButtonVariant;
         intent?: ComponentIntent;
     },
 ): void {
-    if (opts.attention === undefined && opts.intent === undefined) {
-        // If neither attention nor intent is provided, do nothing.
+    if (opts.variant === undefined && opts.intent === undefined) {
+        // If neither variant nor intent is provided, do nothing.
         return;
     }
-    const action_button_attention_pattern = ACTION_BUTTON_ATTENTION_VALUES.join("|");
+    const action_button_variant_pattern = ACTION_BUTTON_VARIANT_VALUES.join("|");
     const component_intent_pattern = COMPONENT_INTENT_VALUES.join("|");
     const action_button_style_regex = new RegExp(
-        `action-button-(${action_button_attention_pattern})-(${component_intent_pattern})`,
+        `action-button-(${action_button_variant_pattern})-(${component_intent_pattern})`,
     );
     const action_button_style_regex_match = $button.attr("class")?.match(action_button_style_regex);
     if (!action_button_style_regex_match) {
         // If the button doesn't have the expected class, do nothing.
         return;
     }
-    const [action_button_style_class, old_attention, old_intent] = action_button_style_regex_match;
-    // Replace the old attention and intent values with the new ones, if provided.
+    const [action_button_style_class, old_variant, old_intent] = action_button_style_regex_match;
+    // Replace the old variant and intent values with the new ones, if provided.
     $button.removeClass(action_button_style_class);
-    $button.addClass(
-        `action-button-${opts.attention ?? old_attention}-${opts.intent ?? old_intent}`,
-    );
+    $button.addClass(`action-button-${opts.variant ?? old_variant}-${opts.intent ?? old_intent}`);
 }

--- a/web/src/demo_organizations_ui.ts
+++ b/web/src/demo_organizations_ui.ts
@@ -33,7 +33,7 @@ export function insert_demo_organization_warning(): void {
     const days_remaining = get_demo_organization_deadline_days_remaining();
     let buttons: ActionButton[] = [
         {
-            attention: "borderless",
+            variant: "text",
             label: $t({defaultMessage: "Learn more"}),
             custom_classes: "demo-organizations-help",
         },
@@ -42,7 +42,7 @@ export function insert_demo_organization_warning(): void {
         buttons = [
             ...buttons,
             {
-                attention: "quiet",
+                variant: "subtle",
                 label: $t({defaultMessage: "Convert"}),
                 custom_classes: "convert-demo-organization",
             },
@@ -74,7 +74,7 @@ export function show_configure_email_banner(): void {
             label: $t({defaultMessage: "Add your email to access this feature."}),
             buttons: [
                 {
-                    attention: "primary",
+                    variant: "solid",
                     label: $t({defaultMessage: "Add"}),
                     custom_classes: "demo-organization-add-email",
                 },

--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -60,7 +60,7 @@ function show_delete_banner(): void {
         ),
         buttons: [
             {
-                attention: "quiet",
+                variant: "subtle",
                 intent: "success",
                 label: $t({defaultMessage: "Undo"}),
                 custom_classes: "draft-delete-banner-undo-button",

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -288,7 +288,7 @@ const copy_invite_link_banner = (invite_link: string): Banner => ({
     ),
     buttons: [
         {
-            attention: "primary",
+            variant: "solid",
             icon: "copy",
             label: $t({defaultMessage: "Copy link"}),
             id: "copy_generated_invite_link",

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -186,17 +186,17 @@ const DESKTOP_NOTIFICATIONS_BANNER: AlertBanner = {
     }),
     buttons: [
         {
-            attention: "primary",
+            variant: "solid",
             label: $t({defaultMessage: "Enable notifications"}),
             custom_classes: "request-desktop-notifications",
         },
         {
-            attention: "quiet",
+            variant: "subtle",
             label: $t({defaultMessage: "Customize notifications"}),
             custom_classes: "customize-desktop-notifications",
         },
         {
-            attention: "borderless",
+            variant: "text",
             label: $t({defaultMessage: "Never ask on this computer"}),
             custom_classes: "reject-desktop-notifications",
         },
@@ -214,7 +214,7 @@ const CONFIGURE_OUTGOING_MAIL_BANNER: AlertBanner = {
     }),
     buttons: [
         {
-            attention: "quiet",
+            variant: "subtle",
             label: $t({defaultMessage: "Configuration instructions"}),
             custom_classes: "configure-outgoing-mail-instructions",
         },
@@ -232,7 +232,7 @@ const INSECURE_DESKTOP_APP_BANNER: AlertBanner = {
     }),
     buttons: [
         {
-            attention: "quiet",
+            variant: "subtle",
             label: $t({defaultMessage: "Download the latest version"}),
             custom_classes: "download-latest-zulip-version",
         },
@@ -247,7 +247,7 @@ const PROFILE_MISSING_REQUIRED_FIELDS_BANNER: AlertBanner = {
     label: $t({defaultMessage: "Your profile is missing required fields."}),
     buttons: [
         {
-            attention: "quiet",
+            variant: "subtle",
             label: $t({defaultMessage: "Edit your profile"}),
             custom_classes: "edit-profile-required-fields",
         },
@@ -265,7 +265,7 @@ const ORGANIZATION_PROFILE_INCOMPLETE_BANNER: AlertBanner = {
     }),
     buttons: [
         {
-            attention: "quiet",
+            variant: "subtle",
             label: $t({
                 defaultMessage: "Edit profile",
             }),
@@ -284,12 +284,12 @@ const SERVER_NEEDS_UPGRADE_BANNER: AlertBanner = {
     }),
     buttons: [
         {
-            attention: "quiet",
+            variant: "subtle",
             label: $t({defaultMessage: "Learn more"}),
             custom_classes: "server-upgrade-learn-more",
         },
         {
-            attention: "borderless",
+            variant: "text",
             label: $t({defaultMessage: "Dismiss for a week"}),
             custom_classes: "server-upgrade-nag-dismiss",
         },
@@ -329,12 +329,12 @@ const bankruptcy_banner = (): AlertBanner => {
         label,
         buttons: [
             {
-                attention: "quiet",
+                variant: "subtle",
                 label: $t({defaultMessage: "Yes, please!"}),
                 custom_classes: "accept-bankruptcy",
             },
             {
-                attention: "borderless",
+                variant: "text",
                 label: $t({defaultMessage: "No, I'll catch up."}),
                 custom_classes: "banner-close-action",
             },
@@ -348,7 +348,7 @@ const demo_organization_deadline_banner = (): AlertBanner => {
     const days_remaining = demo_organizations_ui.get_demo_organization_deadline_days_remaining();
     let buttons: ActionButton[] = [
         {
-            attention: "borderless",
+            variant: "text",
             label: $t({defaultMessage: "Learn more"}),
             custom_classes: "demo-organizations-help",
         },
@@ -357,7 +357,7 @@ const demo_organization_deadline_banner = (): AlertBanner => {
         buttons = [
             ...buttons,
             {
-                attention: "quiet",
+                variant: "subtle",
                 label: $t({defaultMessage: "Convert"}),
                 custom_classes: "convert-demo-organization",
             },
@@ -397,12 +397,12 @@ const time_zone_update_offer_banner = (): AlertBanner => {
         ),
         buttons: [
             {
-                attention: "quiet",
+                variant: "subtle",
                 label: $t({defaultMessage: "Yes, please!"}),
                 custom_classes: "accept-update-time-zone",
             },
             {
-                attention: "borderless",
+                variant: "text",
                 label: $t({defaultMessage: "No, don't ask again."}),
                 custom_classes: "decline-time-zone-update",
             },

--- a/web/src/popup_banners.ts
+++ b/web/src/popup_banners.ts
@@ -39,7 +39,7 @@ const connection_error_popup_banner = (retry_seconds: number): Banner => ({
     label: get_connection_error_label(retry_seconds),
     buttons: [
         {
-            attention: "quiet",
+            variant: "subtle",
             label: $t({defaultMessage: "Try now"}),
             custom_classes: "retry-connection",
         },
@@ -81,7 +81,7 @@ const FOUND_MISSING_UNREADS_IN_CURRENT_NARROW: Banner = {
     }),
     buttons: [
         {
-            attention: "quiet",
+            variant: "subtle",
             label: $t({defaultMessage: "Jump"}),
             custom_classes: "found-missing-unreads-jump-to-first-unread",
         },

--- a/web/src/portico/showroom.ts
+++ b/web/src/portico/showroom.ts
@@ -10,7 +10,7 @@ import type {HTMLSelectOneElement} from "../types.ts";
 type ComponentIntent = "neutral" | "brand" | "info" | "success" | "warning" | "danger";
 
 type ActionButton = {
-    attention: "primary" | "quiet" | "borderless";
+    variant: "solid" | "subtle" | "text";
     intent: ComponentIntent;
     label: string;
     icon?: string | undefined;
@@ -44,9 +44,9 @@ const custom_normal_banner: Banner = {
     label: "This is a normal banner. Use the controls below to modify this banner.",
     buttons: [
         {
-            attention: "quiet",
+            variant: "subtle",
             intent: "neutral",
-            label: "Quiet Button",
+            label: "Subtle Button",
         },
     ],
     close_button: true,
@@ -59,9 +59,9 @@ const alert_banners: Record<string, AlertBanner> = {
         label: "This is a navbar alerts banner. Use the controls below to modify this banner.",
         buttons: [
             {
-                attention: "quiet",
+                variant: "subtle",
                 intent: "neutral",
-                label: "Quiet Button",
+                label: "Subtle Button",
             },
         ],
         close_button: true,
@@ -73,12 +73,12 @@ const alert_banners: Record<string, AlertBanner> = {
         label: "Welcome back! You have 12 unread messages. Do you want to mark them all as read?",
         buttons: [
             {
-                attention: "quiet",
+                variant: "subtle",
                 intent: "info",
                 label: "Yes, please!",
             },
             {
-                attention: "borderless",
+                variant: "text",
                 intent: "info",
                 label: "No, I'll catch up.",
             },
@@ -92,7 +92,7 @@ const alert_banners: Record<string, AlertBanner> = {
         label: "Zulip needs to send email to confirm users' addresses and send notifications.",
         buttons: [
             {
-                attention: "quiet",
+                variant: "subtle",
                 intent: "warning",
                 label: "Configuration instructions",
             },
@@ -111,12 +111,12 @@ const alert_banners: Record<string, AlertBanner> = {
         ),
         buttons: [
             {
-                attention: "borderless",
+                variant: "text",
                 intent: "info",
                 label: $t({defaultMessage: "Learn more"}),
             },
             {
-                attention: "quiet",
+                variant: "subtle",
                 intent: "info",
                 label: $t({defaultMessage: "Convert"}),
             },
@@ -135,17 +135,17 @@ const alert_banners: Record<string, AlertBanner> = {
         ),
         buttons: [
             {
-                attention: "primary",
+                variant: "solid",
                 intent: "brand",
                 label: "Enable notifications",
             },
             {
-                attention: "quiet",
+                variant: "subtle",
                 intent: "brand",
                 label: "Ask me later",
             },
             {
-                attention: "borderless",
+                variant: "text",
                 intent: "brand",
                 label: "Never ask on this computer",
             },
@@ -159,7 +159,7 @@ const alert_banners: Record<string, AlertBanner> = {
         label: "Your profile is missing required fields.",
         buttons: [
             {
-                attention: "quiet",
+                variant: "subtle",
                 intent: "warning",
                 label: "Edit your profile",
             },
@@ -173,7 +173,7 @@ const alert_banners: Record<string, AlertBanner> = {
         label: "Zulip Desktop is not updating automatically. Please upgrade for security updates and other improvements.",
         buttons: [
             {
-                attention: "quiet",
+                variant: "subtle",
                 intent: "warning",
                 label: "Download the latest version",
             },
@@ -187,7 +187,7 @@ const alert_banners: Record<string, AlertBanner> = {
         label: "Complete your organization profile, which is displayed on your organization's registration and login pages.",
         buttons: [
             {
-                attention: "quiet",
+                variant: "subtle",
                 intent: "info",
                 label: "Edit profile",
             },
@@ -201,12 +201,12 @@ const alert_banners: Record<string, AlertBanner> = {
         label: "This Zulip server is running an old version and should be upgraded.",
         buttons: [
             {
-                attention: "quiet",
+                variant: "subtle",
                 intent: "danger",
                 label: "Learn more",
             },
             {
-                attention: "borderless",
+                variant: "text",
                 intent: "danger",
                 label: "Dismiss for a week",
             },
@@ -217,60 +217,60 @@ const alert_banners: Record<string, AlertBanner> = {
 };
 
 const sortButtons = (buttons: ActionButton[]): void => {
-    const sortOrder: Record<ActionButton["attention"], number> = {
-        primary: 1,
-        quiet: 2,
-        borderless: 3,
+    const sortOrder: Record<ActionButton["variant"], number> = {
+        solid: 1,
+        subtle: 2,
+        text: 3,
     };
 
-    buttons.sort((a, b) => sortOrder[a.attention] - sortOrder[b.attention]);
+    buttons.sort((a, b) => sortOrder[a.variant] - sortOrder[b.variant]);
 };
 
 const update_buttons = (buttons: ActionButton[]): void => {
-    const primary_button = buttons.find((button) => button.attention === "primary");
-    if (primary_button) {
-        $("#enable_primary_button").prop("checked", true);
-        $("#primary_button_text").val(primary_button.label);
-        if (primary_button.icon) {
-            $("#primary_button_select_icon").val(primary_button.icon);
-            $("#enable_primary_button_icon").prop("checked", true);
+    const solid_button = buttons.find((button) => button.variant === "solid");
+    if (solid_button) {
+        $("#enable_solid_button").prop("checked", true);
+        $("#solid_button_text").val(solid_button.label);
+        if (solid_button.icon) {
+            $("#solid_button_select_icon").val(solid_button.icon);
+            $("#enable_solid_button_icon").prop("checked", true);
         } else {
-            $("#disable_primary_button_icon").prop("checked", true);
+            $("#disable_solid_button_icon").prop("checked", true);
         }
     } else {
-        $("#disable_primary_button").prop("checked", true);
-        $("#primary_button_text").val("");
-        $("#disable_primary_button_icon").prop("checked", true);
+        $("#disable_solid_button").prop("checked", true);
+        $("#solid_button_text").val("");
+        $("#disable_solid_button_icon").prop("checked", true);
     }
-    const quiet_button = buttons.find((button) => button.attention === "quiet");
-    if (quiet_button) {
-        $("#enable_quiet_button").prop("checked", true);
-        $("#quiet_button_text").val(quiet_button.label);
-        if (quiet_button.icon) {
-            $("#quiet_button_select_icon").val(quiet_button.icon);
-            $("#enable_quiet_button_icon").prop("checked", true);
+    const subtle_button = buttons.find((button) => button.variant === "subtle");
+    if (subtle_button) {
+        $("#enable_subtle_button").prop("checked", true);
+        $("#subtle_button_text").val(subtle_button.label);
+        if (subtle_button.icon) {
+            $("#subtle_button_select_icon").val(subtle_button.icon);
+            $("#enable_subtle_button_icon").prop("checked", true);
         } else {
-            $("#disable_quiet_button_icon").prop("checked", true);
+            $("#disable_subtle_button_icon").prop("checked", true);
         }
     } else {
-        $("#disable_quiet_button").prop("checked", true);
-        $("#quiet_button_text").val("");
-        $("#disable_quiet_button_icon").prop("checked", true);
+        $("#disable_subtle_button").prop("checked", true);
+        $("#subtle_button_text").val("");
+        $("#disable_subtle_button_icon").prop("checked", true);
     }
-    const borderless_button = buttons.find((button) => button.attention === "borderless");
-    if (borderless_button) {
-        $("#enable_borderless_button").prop("checked", true);
-        $("#borderless_button_text").val(borderless_button.label);
-        if (borderless_button.icon) {
-            $("#borderless_button_select_icon").val(borderless_button.icon);
-            $("#enable_borderless_button_icon").prop("checked", true);
+    const text_button = buttons.find((button) => button.variant === "text");
+    if (text_button) {
+        $("#enable_text_button").prop("checked", true);
+        $("#text_button_text").val(text_button.label);
+        if (text_button.icon) {
+            $("#text_button_select_icon").val(text_button.icon);
+            $("#enable_text_button_icon").prop("checked", true);
         } else {
-            $("#disable_borderless_button_icon").prop("checked", true);
+            $("#disable_text_button_icon").prop("checked", true);
         }
     } else {
-        $("#disable_borderless_button").prop("checked", true);
-        $("#borderless_button_text").val("");
-        $("#disable_borderless_button_icon").prop("checked", true);
+        $("#disable_text_button").prop("checked", true);
+        $("#text_button_text").val("");
+        $("#disable_text_button_icon").prop("checked", true);
     }
 };
 
@@ -397,31 +397,31 @@ $(window).on("load", () => {
         }
     });
 
-    $("input[name='primary-button-select']").on("change", (e) => {
-        if ($(e.target).attr("id") === "enable_primary_button") {
-            if (current_banner.buttons.some((button) => button.attention === "primary")) {
+    $("input[name='solid-button-select']").on("change", (e) => {
+        if ($(e.target).attr("id") === "enable_solid_button") {
+            if (current_banner.buttons.some((button) => button.variant === "solid")) {
                 return;
             }
-            let label = $<HTMLInputElement>("input#primary_button_text").val();
+            let label = $<HTMLInputElement>("input#solid_button_text").val();
             assert(label !== undefined);
             if (label === "") {
-                label = "Primary Button";
+                label = "Solid Button";
             }
-            const is_icon_enabled = $("#enable_primary_button_icon").prop("checked") === true;
+            const is_icon_enabled = $("#enable_solid_button_icon").prop("checked") === true;
             current_banner.buttons.push({
-                attention: "primary",
+                variant: "solid",
                 intent: current_banner.intent,
                 label,
                 icon: is_icon_enabled
                     ? $<HTMLSelectOneElement>(
-                          "select:not([multiple])#primary_button_select_icon",
+                          "select:not([multiple])#solid_button_select_icon",
                       ).val()
                     : undefined,
             });
-            $("#primary_button_text").val(label);
+            $("#solid_button_text").val(label);
         } else {
             current_banner.buttons = current_banner.buttons.filter(
-                (button) => button.attention !== "primary",
+                (button) => button.variant !== "solid",
             );
         }
         sortButtons(current_banner.buttons);
@@ -432,112 +432,17 @@ $(window).on("load", () => {
         }
     });
 
-    $("input[name='primary-button-icon-select']").on("change", (e) => {
-        const primary_button = current_banner.buttons.find(
-            (button) => button.attention === "primary",
-        );
-        if (primary_button === undefined) {
+    $("input[name='solid-button-icon-select']").on("change", (e) => {
+        const solid_button = current_banner.buttons.find((button) => button.variant === "solid");
+        if (solid_button === undefined) {
             return;
         }
-        if ($(e.target).attr("id") === "enable_primary_button_icon") {
-            primary_button.icon =
-                $<HTMLSelectOneElement>(
-                    "select:not([multiple])#primary_button_select_icon",
-                ).val() ?? "";
-        } else {
-            delete primary_button.icon;
-        }
-        $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
-        if (current_banner.process === "custom-banner") {
-            custom_normal_banner.buttons = current_banner.buttons;
-            $("#showroom_component_banner_default_wrapper").html(banner_html(custom_normal_banner));
-        }
-    });
-
-    $<HTMLSelectOneElement>("select:not([multiple])#primary_button_select_icon").on(
-        "change",
-        function () {
-            const primary_button = current_banner.buttons.find(
-                (button) => button.attention === "primary",
-            );
-            if (primary_button === undefined) {
-                return;
-            }
-            if (!primary_button.icon) {
-                return;
-            }
-            primary_button.icon = this.value;
-            $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
-            if (current_banner.process === "custom-banner") {
-                custom_normal_banner.buttons = current_banner.buttons;
-                $("#showroom_component_banner_default_wrapper").html(
-                    banner_html(custom_normal_banner),
-                );
-            }
-        },
-    );
-
-    $<HTMLInputElement>("input#primary_button_text").on("input", function () {
-        const primary_button = current_banner.buttons.find(
-            (button) => button.attention === "primary",
-        );
-        if (primary_button === undefined) {
-            return;
-        }
-        primary_button.label = this.value;
-        $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
-        if (current_banner.process === "custom-banner") {
-            custom_normal_banner.buttons = current_banner.buttons;
-            $("#showroom_component_banner_default_wrapper").html(banner_html(custom_normal_banner));
-        }
-    });
-
-    $("input[name='quiet-button-select']").on("change", (e) => {
-        if ($(e.target).attr("id") === "enable_quiet_button") {
-            if (current_banner.buttons.some((button) => button.attention === "quiet")) {
-                return;
-            }
-            let label = $<HTMLInputElement>("input#quiet_button_text").val();
-            assert(label !== undefined);
-            if (label === "") {
-                label = "Quiet Button";
-            }
-            const is_icon_enabled = $("#enable_quiet_button_icon").prop("checked") === true;
-            current_banner.buttons.push({
-                attention: "quiet",
-                intent: current_banner.intent,
-                label,
-                icon: is_icon_enabled
-                    ? $<HTMLSelectOneElement>(
-                          "select:not([multiple])#quiet_button_select_icon",
-                      ).val()
-                    : undefined,
-            });
-            $("#quiet_button_text").val(label);
-            sortButtons(current_banner.buttons);
-        } else {
-            current_banner.buttons = current_banner.buttons.filter(
-                (button) => button.attention !== "quiet",
-            );
-        }
-        $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
-        if (current_banner.process === "custom-banner") {
-            custom_normal_banner.buttons = current_banner.buttons;
-            $("#showroom_component_banner_default_wrapper").html(banner_html(custom_normal_banner));
-        }
-    });
-
-    $("input[name='quiet-button-icon-select']").on("change", (e) => {
-        const quiet_button = current_banner.buttons.find((button) => button.attention === "quiet");
-        if (quiet_button === undefined) {
-            return;
-        }
-        if ($(e.target).attr("id") === "enable_quiet_button_icon") {
-            quiet_button.icon =
-                $<HTMLSelectOneElement>("select:not([multiple])#quiet_button_select_icon").val() ??
+        if ($(e.target).attr("id") === "enable_solid_button_icon") {
+            solid_button.icon =
+                $<HTMLSelectOneElement>("select:not([multiple])#solid_button_select_icon").val() ??
                 "";
         } else {
-            delete quiet_button.icon;
+            delete solid_button.icon;
         }
         $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
         if (current_banner.process === "custom-banner") {
@@ -546,19 +451,19 @@ $(window).on("load", () => {
         }
     });
 
-    $<HTMLSelectOneElement>("select:not([multiple])#quiet_button_select_icon").on(
+    $<HTMLSelectOneElement>("select:not([multiple])#solid_button_select_icon").on(
         "change",
         function () {
-            const quiet_button = current_banner.buttons.find(
-                (button) => button.attention === "quiet",
+            const solid_button = current_banner.buttons.find(
+                (button) => button.variant === "solid",
             );
-            if (quiet_button === undefined) {
+            if (solid_button === undefined) {
                 return;
             }
-            if (!quiet_button.icon) {
+            if (!solid_button.icon) {
                 return;
             }
-            quiet_button.icon = this.value;
+            solid_button.icon = this.value;
             $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
             if (current_banner.process === "custom-banner") {
                 custom_normal_banner.buttons = current_banner.buttons;
@@ -569,12 +474,12 @@ $(window).on("load", () => {
         },
     );
 
-    $<HTMLInputElement>("input#quiet_button_text").on("input", function () {
-        const quiet_button = current_banner.buttons.find((button) => button.attention === "quiet");
-        if (quiet_button === undefined) {
+    $<HTMLInputElement>("input#solid_button_text").on("input", function () {
+        const solid_button = current_banner.buttons.find((button) => button.variant === "solid");
+        if (solid_button === undefined) {
             return;
         }
-        quiet_button.label = this.value;
+        solid_button.label = this.value;
         $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
         if (current_banner.process === "custom-banner") {
             custom_normal_banner.buttons = current_banner.buttons;
@@ -582,32 +487,32 @@ $(window).on("load", () => {
         }
     });
 
-    $("input[name='borderless-button-select']").on("change", function (this: HTMLElement) {
-        if (this.id === "enable_borderless_button") {
-            if (current_banner.buttons.some((button) => button.attention === "borderless")) {
+    $("input[name='subtle-button-select']").on("change", (e) => {
+        if ($(e.target).attr("id") === "enable_subtle_button") {
+            if (current_banner.buttons.some((button) => button.variant === "subtle")) {
                 return;
             }
-            let label = $<HTMLInputElement>("input#borderless_button_text").val();
+            let label = $<HTMLInputElement>("input#subtle_button_text").val();
             assert(label !== undefined);
             if (label === "") {
-                label = "Borderless Button";
+                label = "Subtle Button";
             }
-            const is_icon_enabled = $("#enable_borderless_button_icon").prop("checked") === true;
+            const is_icon_enabled = $("#enable_subtle_button_icon").prop("checked") === true;
             current_banner.buttons.push({
-                attention: "borderless",
+                variant: "subtle",
                 intent: current_banner.intent,
                 label,
                 icon: is_icon_enabled
                     ? $<HTMLSelectOneElement>(
-                          "select:not([multiple])#borderless_button_select_icon",
+                          "select:not([multiple])#subtle_button_select_icon",
                       ).val()
                     : undefined,
             });
-            $("#borderless_button_text").val(label);
+            $("#subtle_button_text").val(label);
             sortButtons(current_banner.buttons);
         } else {
             current_banner.buttons = current_banner.buttons.filter(
-                (button) => button.attention !== "borderless",
+                (button) => button.variant !== "subtle",
             );
         }
         $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
@@ -617,20 +522,17 @@ $(window).on("load", () => {
         }
     });
 
-    $("input[name='borderless-button-icon-select']").on("change", function () {
-        const borderless_button = current_banner.buttons.find(
-            (button) => button.attention === "borderless",
-        );
-        if (borderless_button === undefined) {
+    $("input[name='subtle-button-icon-select']").on("change", (e) => {
+        const subtle_button = current_banner.buttons.find((button) => button.variant === "subtle");
+        if (subtle_button === undefined) {
             return;
         }
-        if (this.id === "enable_borderless_button_icon") {
-            borderless_button.icon =
-                $<HTMLSelectOneElement>(
-                    "select:not([multiple])#borderless_button_select_icon",
-                ).val() ?? "";
+        if ($(e.target).attr("id") === "enable_subtle_button_icon") {
+            subtle_button.icon =
+                $<HTMLSelectOneElement>("select:not([multiple])#subtle_button_select_icon").val() ??
+                "";
         } else {
-            delete borderless_button.icon;
+            delete subtle_button.icon;
         }
         $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
         if (current_banner.process === "custom-banner") {
@@ -639,19 +541,19 @@ $(window).on("load", () => {
         }
     });
 
-    $<HTMLSelectOneElement>("select:not([multiple])#borderless_button_select_icon").on(
+    $<HTMLSelectOneElement>("select:not([multiple])#subtle_button_select_icon").on(
         "change",
         function () {
-            const borderless_button = current_banner.buttons.find(
-                (button) => button.attention === "borderless",
+            const subtle_button = current_banner.buttons.find(
+                (button) => button.variant === "subtle",
             );
-            if (borderless_button === undefined) {
+            if (subtle_button === undefined) {
                 return;
             }
-            if (!borderless_button.icon) {
+            if (!subtle_button.icon) {
                 return;
             }
-            borderless_button.icon = this.value;
+            subtle_button.icon = this.value;
             $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
             if (current_banner.process === "custom-banner") {
                 custom_normal_banner.buttons = current_banner.buttons;
@@ -662,14 +564,100 @@ $(window).on("load", () => {
         },
     );
 
-    $<HTMLInputElement>("input#borderless_button_text").on("input", function () {
-        const borderless_button = current_banner.buttons.find(
-            (button) => button.attention === "borderless",
-        );
-        if (borderless_button === undefined) {
+    $<HTMLInputElement>("input#subtle_button_text").on("input", function () {
+        const subtle_button = current_banner.buttons.find((button) => button.variant === "subtle");
+        if (subtle_button === undefined) {
             return;
         }
-        borderless_button.label = this.value;
+        subtle_button.label = this.value;
+        $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
+        if (current_banner.process === "custom-banner") {
+            custom_normal_banner.buttons = current_banner.buttons;
+            $("#showroom_component_banner_default_wrapper").html(banner_html(custom_normal_banner));
+        }
+    });
+
+    $("input[name='text-button-select']").on("change", function (this: HTMLElement) {
+        if (this.id === "enable_text_button") {
+            if (current_banner.buttons.some((button) => button.variant === "text")) {
+                return;
+            }
+            let label = $<HTMLInputElement>("input#text_button_text").val();
+            assert(label !== undefined);
+            if (label === "") {
+                label = "Text Button";
+            }
+            const is_icon_enabled = $("#enable_text_button_icon").prop("checked") === true;
+            current_banner.buttons.push({
+                variant: "text",
+                intent: current_banner.intent,
+                label,
+                icon: is_icon_enabled
+                    ? $<HTMLSelectOneElement>(
+                          "select:not([multiple])#text_button_select_icon",
+                      ).val()
+                    : undefined,
+            });
+            $("#text_button_text").val(label);
+            sortButtons(current_banner.buttons);
+        } else {
+            current_banner.buttons = current_banner.buttons.filter(
+                (button) => button.variant !== "text",
+            );
+        }
+        $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
+        if (current_banner.process === "custom-banner") {
+            custom_normal_banner.buttons = current_banner.buttons;
+            $("#showroom_component_banner_default_wrapper").html(banner_html(custom_normal_banner));
+        }
+    });
+
+    $("input[name='text-button-icon-select']").on("change", function () {
+        const text_button = current_banner.buttons.find((button) => button.variant === "text");
+        if (text_button === undefined) {
+            return;
+        }
+        if (this.id === "enable_text_button_icon") {
+            text_button.icon =
+                $<HTMLSelectOneElement>("select:not([multiple])#text_button_select_icon").val() ??
+                "";
+        } else {
+            delete text_button.icon;
+        }
+        $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
+        if (current_banner.process === "custom-banner") {
+            custom_normal_banner.buttons = current_banner.buttons;
+            $("#showroom_component_banner_default_wrapper").html(banner_html(custom_normal_banner));
+        }
+    });
+
+    $<HTMLSelectOneElement>("select:not([multiple])#text_button_select_icon").on(
+        "change",
+        function () {
+            const text_button = current_banner.buttons.find((button) => button.variant === "text");
+            if (text_button === undefined) {
+                return;
+            }
+            if (!text_button.icon) {
+                return;
+            }
+            text_button.icon = this.value;
+            $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
+            if (current_banner.process === "custom-banner") {
+                custom_normal_banner.buttons = current_banner.buttons;
+                $("#showroom_component_banner_default_wrapper").html(
+                    banner_html(custom_normal_banner),
+                );
+            }
+        },
+    );
+
+    $<HTMLInputElement>("input#text_button_text").on("input", function () {
+        const text_button = current_banner.buttons.find((button) => button.variant === "text");
+        if (text_button === undefined) {
+            return;
+        }
+        text_button.label = this.value;
         $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
         if (current_banner.process === "custom-banner") {
             custom_normal_banner.buttons = current_banner.buttons;

--- a/web/src/settings_banner.ts
+++ b/web/src/settings_banner.ts
@@ -27,7 +27,7 @@ export function set_up_upgrade_banners(): void {
             {
                 label: $t({defaultMessage: "Upgrade"}),
                 custom_classes: "request-upgrade",
-                attention: "quiet",
+                variant: "subtle",
             },
         ];
 
@@ -37,7 +37,7 @@ export function set_up_upgrade_banners(): void {
                 {
                     label: $t({defaultMessage: "Request sponsorship"}),
                     custom_classes: "request-sponsorship",
-                    attention: "borderless",
+                    variant: "text",
                 },
             ];
         }

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -649,12 +649,12 @@ export function change_save_button_state($element: JQuery, state: string): void 
         $textEl.text(button_text);
         if (state === "succeeded") {
             buttons.modify_action_button_style($save_button, {
-                attention: "borderless",
+                variant: "text",
                 intent: "success",
             });
         } else {
             buttons.modify_action_button_style($save_button, {
-                attention: "primary",
+                variant: "solid",
                 intent: "brand",
             });
         }

--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -51,7 +51,7 @@ const DESKTOP_NOTIFICATIONS_BANNER: banners.Banner = {
         {
             label: $t({defaultMessage: "Enable notifications"}),
             custom_classes: "desktop-notifications-request",
-            attention: "primary",
+            variant: "solid",
         },
     ],
     close_button: true,
@@ -67,7 +67,7 @@ const MOBILE_PUSH_NOTIFICATION_BANNER: banners.Banner = {
         {
             label: $t({defaultMessage: "Learn more"}),
             custom_classes: "banner-external-link",
-            attention: "quiet",
+            variant: "subtle",
         },
     ],
     custom_classes: "mobile-push-notifications-banner",

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -412,7 +412,7 @@ function update_view_welcome_bot_custom_message_button_status(
 ): void {
     $("#view_welcome_bot_custom_message").remove();
     const args = {
-        attention: is_error ? "borderless" : "quiet",
+        variant: is_error ? "text" : "subtle",
         intent: is_error ? "danger" : "success",
         label: is_error
             ? $t({defaultMessage: "Error sending message"})

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -64,7 +64,7 @@ const STREAM_INFO_BANNER: Banner = {
         {
             label: $t({defaultMessage: "Learn more"}),
             custom_classes: "banner-external-link",
-            attention: "quiet",
+            variant: "subtle",
         },
     ],
     close_button: false,

--- a/web/src/stream_ui_updates.ts
+++ b/web/src/stream_ui_updates.ts
@@ -229,13 +229,13 @@ export function update_settings_button_for_sub(sub: StreamSubscription): void {
     if (sub.subscribed) {
         $settings_button
             .text($t({defaultMessage: "Unsubscribe"}))
-            .removeClass("unsubscribed action-button-quiet-brand")
-            .addClass("action-button-quiet-neutral");
+            .removeClass("unsubscribed action-button-subtle-brand")
+            .addClass("action-button-subtle-neutral");
     } else {
         $settings_button
             .text($t({defaultMessage: "Subscribe"}))
-            .addClass("unsubscribed action-button-quiet-brand")
-            .removeClass("action-button-quiet-neutral");
+            .addClass("unsubscribed action-button-subtle-brand")
+            .removeClass("action-button-subtle-neutral");
     }
     if (stream_data.can_toggle_subscription(sub)) {
         $settings_button.prop("disabled", false);

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -95,7 +95,7 @@ const GROUP_INFO_BANNER: Banner = {
         {
             label: $t({defaultMessage: "Learn more"}),
             custom_classes: "banner-external-link",
-            attention: "quiet",
+            variant: "subtle",
         },
     ],
     close_button: false,
@@ -347,13 +347,13 @@ function update_group_membership_button(group_id: number): void {
     if (is_direct_member) {
         $group_settings_button
             .text($t({defaultMessage: "Leave group"}))
-            .removeClass("action-button-quiet-brand")
+            .removeClass("action-button-subtle-brand")
             .addClass("action-button-neutral");
     } else {
         $group_settings_button
             .text($t({defaultMessage: "Join group"}))
-            .removeClass("action-button-quiet-neutral")
-            .addClass("action-button-quiet-brand");
+            .removeClass("action-button-subtle-neutral")
+            .addClass("action-button-subtle-brand");
     }
 
     const can_join_group = settings_data.can_join_user_group(group_id);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2347,262 +2347,260 @@
         color-mix(in oklch, hsl(0deg 0% 100%) 21%, transparent)
     );
     /* Action buttons -- Neutral Variant */
-    --color-text-neutral-primary-action-button: light-dark(
+    --color-text-neutral-solid-action-button: light-dark(
         hsl(0deg 0% 100%),
         color-mix(in oklch, hsl(0deg 0% 100%) 85%, transparent)
     );
-    --color-background-neutral-primary-action-button: light-dark(
+    --color-background-neutral-solid-action-button: light-dark(
         hsl(229deg 7% 50%),
         hsl(229deg 9% 36%)
     );
-    --color-background-neutral-primary-action-button-hover: light-dark(
+    --color-background-neutral-solid-action-button-hover: light-dark(
         hsl(229deg 7% 47%),
         hsl(229deg 8% 42%)
     );
-    --color-background-neutral-primary-action-button-active: light-dark(
+    --color-background-neutral-solid-action-button-active: light-dark(
         hsl(232deg 7% 44%),
         hsl(229deg 9% 36%)
     );
-    --color-text-neutral-quiet-action-button: light-dark(
+    --color-text-neutral-subtle-action-button: light-dark(
         hsl(229deg 12% 25%),
         hsl(231deg 11% 76%)
     );
-    --color-background-neutral-quiet-action-button: light-dark(
+    --color-background-neutral-subtle-action-button: light-dark(
         color-mix(in oklch, hsl(230deg 7% 50%) 12%, transparent),
         color-mix(in oklch, hsl(231deg 11% 76%) 12%, transparent)
     );
-    --color-background-neutral-quiet-action-button-hover: light-dark(
+    --color-background-neutral-subtle-action-button-hover: light-dark(
         color-mix(in oklch, hsl(230deg 7% 50%) 17%, transparent),
         color-mix(in oklch, hsl(231deg 11% 76%) 17%, transparent)
     );
-    --color-background-neutral-quiet-action-button-active: light-dark(
+    --color-background-neutral-subtle-action-button-active: light-dark(
         color-mix(in oklch, hsl(230deg 7% 50%) 22%, transparent),
         color-mix(in oklch, hsl(231deg 11% 76%) 12%, transparent)
     );
-    --color-text-neutral-borderless-action-button: light-dark(
+    --color-text-neutral-text-action-button: light-dark(
         hsl(229deg 9% 36%),
         hsl(229deg 10% 70%)
     );
-    --color-background-neutral-borderless-action-button-hover: light-dark(
+    --color-background-neutral-text-action-button-hover: light-dark(
         color-mix(in oklch, hsl(229deg 9% 36%) 7%, transparent),
         color-mix(in oklch, hsl(230deg 9% 60%) 14%, transparent)
     );
-    --color-background-neutral-borderless-action-button-active: light-dark(
+    --color-background-neutral-text-action-button-active: light-dark(
         color-mix(in oklch, hsl(229deg 9% 36%) 11%, transparent),
         color-mix(in oklch, hsl(230deg 9% 60%) 18%, transparent)
     );
     /* Action buttons -- Brand Variant */
-    --color-text-brand-primary-action-button: light-dark(
+    --color-text-brand-solid-action-button: light-dark(
         hsl(0deg 0% 100%),
         color-mix(in oklch, hsl(0deg 0% 100%) 85%, transparent)
     );
-    --color-background-brand-primary-action-button: light-dark(
+    --color-background-brand-solid-action-button: light-dark(
         hsl(254deg 99% 68%),
         hsl(261deg 79% 43%)
     );
-    --color-background-brand-primary-action-button-hover: light-dark(
+    --color-background-brand-solid-action-button-hover: light-dark(
         hsl(255deg 81% 61%),
         hsl(258deg 66% 51%)
     );
-    --color-background-brand-primary-action-button-active: light-dark(
+    --color-background-brand-solid-action-button-active: light-dark(
         hsl(258deg 66% 51%),
         hsl(261deg 79% 43%)
     );
-    --color-text-brand-quiet-action-button: light-dark(
+    --color-text-brand-subtle-action-button: light-dark(
         hsl(264deg 95% 34%),
         hsl(244deg 96% 82%)
     );
-    --color-background-brand-quiet-action-button: light-dark(
+    --color-background-brand-subtle-action-button: light-dark(
         color-mix(in oklch, hsl(254deg 99% 68%) 12%, transparent),
         color-mix(in oklch, hsl(246deg 96% 79%) 12%, transparent)
     );
-    --color-background-brand-quiet-action-button-hover: light-dark(
+    --color-background-brand-subtle-action-button-hover: light-dark(
         color-mix(in oklch, hsl(254deg 99% 68%) 17%, transparent),
         color-mix(in oklch, hsl(246deg 96% 79%) 17%, transparent)
     );
-    --color-background-brand-quiet-action-button-active: light-dark(
+    --color-background-brand-subtle-action-button-active: light-dark(
         color-mix(in oklch, hsl(254deg 99% 68%) 22%, transparent),
         color-mix(in oklch, hsl(246deg 96% 79%) 12%, transparent)
     );
-    --color-text-brand-borderless-action-button: light-dark(
+    --color-text-brand-text-action-button: light-dark(
         hsl(255deg 54% 50%),
         hsl(246deg 96% 79%)
     );
-    --color-background-brand-borderless-action-button-hover: light-dark(
+    --color-background-brand-text-action-button-hover: light-dark(
         color-mix(in oklch, hsl(264deg 100% 22%) 5%, transparent),
         color-mix(in oklch, hsl(251deg 100% 72%) 14%, transparent)
     );
-    --color-background-brand-borderless-action-button-active: light-dark(
+    --color-background-brand-text-action-button-active: light-dark(
         color-mix(in oklch, hsl(264deg 100% 22%) 10%, transparent),
         color-mix(in oklch, hsl(251deg 100% 72%) 18%, transparent)
     );
     /* Action buttons -- Info Variant */
-    --color-text-info-primary-action-button: light-dark(
+    --color-text-info-solid-action-button: light-dark(
         hsl(0deg 0% 100%),
         color-mix(in oklch, hsl(0deg 0% 100%) 85%, transparent)
     );
-    --color-background-info-primary-action-button: light-dark(
+    --color-background-info-solid-action-button: light-dark(
         hsl(226deg 100% 62%),
         hsl(228deg 75% 47%)
     );
-    --color-background-info-primary-action-button-hover: hsl(226deg 83% 55%);
-    --color-background-info-primary-action-button-active: hsl(228deg 75% 47%);
-    --color-text-info-quiet-action-button: light-dark(
+    --color-background-info-solid-action-button-hover: hsl(226deg 83% 55%);
+    --color-background-info-solid-action-button-active: hsl(228deg 75% 47%);
+    --color-text-info-subtle-action-button: light-dark(
         hsl(231deg 82% 36%),
         hsl(222deg 98% 79%)
     );
-    --color-background-info-quiet-action-button: light-dark(
+    --color-background-info-subtle-action-button: light-dark(
         color-mix(in oklch, hsl(226deg 100% 62%) 12%, transparent),
         color-mix(in oklch, hsl(222deg 98% 79%) 12%, transparent)
     );
-    --color-background-info-quiet-action-button-hover: light-dark(
+    --color-background-info-subtle-action-button-hover: light-dark(
         color-mix(in oklch, hsl(226deg 100% 62%) 17%, transparent),
         color-mix(in oklch, hsl(222deg 98% 79%) 17%, transparent)
     );
-    --color-background-info-quiet-action-button-active: light-dark(
+    --color-background-info-subtle-action-button-active: light-dark(
         color-mix(in oklch, hsl(226deg 100% 62%) 22%, transparent),
         color-mix(in oklch, hsl(222deg 98% 79%) 12%, transparent)
     );
-    --color-text-info-borderless-action-button: light-dark(
+    --color-text-info-text-action-button: light-dark(
         hsl(227deg 70% 46%),
         hsl(222deg 97% 75%)
     );
-    --color-background-info-borderless-action-button-hover: light-dark(
+    --color-background-info-text-action-button-hover: light-dark(
         color-mix(in oklch, hsl(241deg 95% 25%) 5%, transparent),
         color-mix(in oklch, hsl(224deg 98% 65%) 12%, transparent)
     );
-    --color-background-info-borderless-action-button-active: light-dark(
+    --color-background-info-text-action-button-active: light-dark(
         color-mix(in oklch, hsl(241deg 95% 25%) 9%, transparent),
         color-mix(in oklch, hsl(224deg 98% 65%) 17%, transparent)
     );
     /* Action buttons -- Success Variant */
-    --color-text-success-primary-action-button: light-dark(
+    --color-text-success-solid-action-button: light-dark(
         hsl(0deg 0% 100%),
         color-mix(in oklch, hsl(0deg 0% 100%) 85%, transparent)
     );
-    --color-background-success-primary-action-button: light-dark(
+    --color-background-success-solid-action-button: light-dark(
         hsl(146deg 90% 27%),
         hsl(144deg 84% 22%)
     );
-    --color-background-success-primary-action-button-hover: hsl(145deg 87% 25%);
-    --color-background-success-primary-action-button-active: hsl(
-        144deg 84% 22%
-    );
-    --color-text-success-quiet-action-button: light-dark(
+    --color-background-success-solid-action-button-hover: hsl(145deg 87% 25%);
+    --color-background-success-solid-action-button-active: hsl(144deg 84% 22%);
+    --color-text-success-subtle-action-button: light-dark(
         hsl(144deg 88% 16%),
         hsl(135deg 56% 63%)
     );
-    --color-background-success-quiet-action-button: light-dark(
+    --color-background-success-subtle-action-button: light-dark(
         color-mix(in oklch, hsl(146deg 90% 27%) 13%, transparent),
         color-mix(in oklch, hsl(138deg 46% 47%) 12%, transparent)
     );
-    --color-background-success-quiet-action-button-hover: light-dark(
+    --color-background-success-subtle-action-button-hover: light-dark(
         color-mix(in oklch, hsl(146deg 90% 27%) 18%, transparent),
         color-mix(in oklch, hsl(138deg 46% 47%) 17%, transparent)
     );
-    --color-background-success-quiet-action-button-active: light-dark(
+    --color-background-success-subtle-action-button-active: light-dark(
         color-mix(in oklch, hsl(146deg 90% 27%) 23%, transparent),
         color-mix(in oklch, hsl(138deg 46% 47%) 12%, transparent)
     );
-    --color-text-success-borderless-action-button: light-dark(
+    --color-text-success-text-action-button: light-dark(
         hsl(146deg 90% 27%),
         hsl(136deg 47% 55%)
     );
-    --color-background-success-borderless-action-button-hover: light-dark(
+    --color-background-success-text-action-button-hover: light-dark(
         color-mix(in oklch, hsl(144deg 84% 22%) 8%, transparent),
         color-mix(in oklch, hsl(139deg 54% 40%) 12%, transparent)
     );
-    --color-background-success-borderless-action-button-active: light-dark(
+    --color-background-success-text-action-button-active: light-dark(
         color-mix(in oklch, hsl(144deg 84% 22%) 12%, transparent),
         color-mix(in oklch, hsl(139deg 54% 40%) 17%, transparent)
     );
     /* Action buttons -- Warning Variant */
-    --color-text-warning-primary-action-button: light-dark(
+    --color-text-warning-solid-action-button: light-dark(
         color-mix(in oklch, hsl(0deg 0% 0%) 88%, transparent),
         color-mix(in oklch, hsl(0deg 0% 0%) 90%, transparent)
     );
-    --color-background-warning-primary-action-button: light-dark(
+    --color-background-warning-solid-action-button: light-dark(
         hsl(40deg 99% 62%),
         hsl(39deg 89% 45%)
     );
-    --color-background-warning-primary-action-button-hover: light-dark(
+    --color-background-warning-solid-action-button-hover: light-dark(
         hsl(40deg 94% 56%),
         hsl(41deg 98% 46%)
     );
-    --color-background-warning-primary-action-button-active: light-dark(
+    --color-background-warning-solid-action-button-active: light-dark(
         hsl(41deg 98% 46%),
         hsl(39deg 89% 45%)
     );
-    --color-text-warning-quiet-action-button: light-dark(
+    --color-text-warning-subtle-action-button: light-dark(
         hsl(34deg 89% 25%),
         hsl(40deg 94% 56%)
     );
-    --color-background-warning-quiet-action-button: light-dark(
+    --color-background-warning-subtle-action-button: light-dark(
         color-mix(in oklch, hsl(41deg 98% 46%) 18%, transparent),
         color-mix(in oklch, hsl(39deg 89% 45%) 12%, transparent)
     );
-    --color-background-warning-quiet-action-button-hover: light-dark(
+    --color-background-warning-subtle-action-button-hover: light-dark(
         color-mix(in oklch, hsl(41deg 98% 46%) 23%, transparent),
         color-mix(in oklch, hsl(39deg 89% 45%) 17%, transparent)
     );
-    --color-background-warning-quiet-action-button-active: light-dark(
+    --color-background-warning-subtle-action-button-active: light-dark(
         color-mix(in oklch, hsl(41deg 98% 46%) 28%, transparent),
         color-mix(in oklch, hsl(39deg 89% 45%) 12%, transparent)
     );
-    --color-text-warning-borderless-action-button: light-dark(
+    --color-text-warning-text-action-button: light-dark(
         hsl(37deg 94% 34%),
         hsl(41deg 98% 46%)
     );
-    --color-background-warning-borderless-action-button-hover: light-dark(
+    --color-background-warning-text-action-button-hover: light-dark(
         color-mix(in oklch, hsl(37deg 94% 34%) 10%, transparent),
         color-mix(in oklch, hsl(39deg 88% 42%) 12%, transparent)
     );
-    --color-background-warning-borderless-action-button-active: light-dark(
+    --color-background-warning-text-action-button-active: light-dark(
         color-mix(in oklch, hsl(37deg 94% 34%) 14%, transparent),
         color-mix(in oklch, hsl(39deg 88% 42%) 17%, transparent)
     );
     /* Action buttons -- Danger Variant */
-    --color-text-danger-primary-action-button: light-dark(
+    --color-text-danger-solid-action-button: light-dark(
         hsl(0deg 0% 100%),
         color-mix(in oklch, hsl(0deg 0% 100%) 85%, transparent)
     );
-    --color-background-danger-primary-action-button: light-dark(
+    --color-background-danger-solid-action-button: light-dark(
         hsl(4deg 75% 53%),
         hsl(2deg 74% 47%)
     );
-    --color-background-danger-primary-action-button-hover: light-dark(
+    --color-background-danger-solid-action-button-hover: light-dark(
         hsl(2deg 74% 47%),
         hsl(4deg 75% 53%)
     );
-    --color-background-danger-primary-action-button-active: light-dark(
+    --color-background-danger-solid-action-button-active: light-dark(
         hsl(359deg 93% 39%),
         hsl(2deg 74% 47%)
     );
-    --color-text-danger-quiet-action-button: light-dark(
+    --color-text-danger-subtle-action-button: light-dark(
         hsl(359deg 94% 35%),
         hsl(7deg 100% 74%)
     );
-    --color-background-danger-quiet-action-button: light-dark(
+    --color-background-danger-subtle-action-button: light-dark(
         color-mix(in oklch, hsl(4deg 75% 53%) 13%, transparent),
         color-mix(in oklch, hsl(5deg 98% 65%) 12%, transparent)
     );
-    --color-background-danger-quiet-action-button-hover: light-dark(
+    --color-background-danger-subtle-action-button-hover: light-dark(
         color-mix(in oklch, hsl(4deg 75% 53%) 18%, transparent),
         color-mix(in oklch, hsl(5deg 98% 65%) 17%, transparent)
     );
-    --color-background-danger-quiet-action-button-active: light-dark(
+    --color-background-danger-subtle-action-button-active: light-dark(
         color-mix(in oklch, hsl(4deg 75% 53%) 23%, transparent),
         color-mix(in oklch, hsl(5deg 98% 65%) 12%, transparent)
     );
-    --color-text-danger-borderless-action-button: light-dark(
+    --color-text-danger-text-action-button: light-dark(
         hsl(359deg 93% 39%),
         hsl(7deg 100% 74%)
     );
-    --color-background-danger-borderless-action-button-hover: light-dark(
+    --color-background-danger-text-action-button-hover: light-dark(
         color-mix(in oklch, hsl(359deg 93% 39%) 9%, transparent),
         color-mix(in oklch, hsl(5deg 88% 60%) 12%, transparent)
     );
-    --color-background-danger-borderless-action-button-active: light-dark(
+    --color-background-danger-text-action-button-active: light-dark(
         color-mix(in oklch, hsl(359deg 93% 39%) 13%, transparent),
         color-mix(in oklch, hsl(5deg 88% 60%) 17%, transparent)
     );

--- a/web/styles/buttons.css
+++ b/web/styles/buttons.css
@@ -10,8 +10,8 @@
     font-weight: 500;
     letter-spacing: 0.02ch;
     padding: 0.25em 0.625em;
-    color: var(--color-text-neutral-quiet-action-button);
-    background-color: var(--color-background-neutral-quiet-action-button);
+    color: var(--color-text-neutral-subtle-action-button);
+    background-color: var(--color-background-neutral-subtle-action-button);
     border-radius: 4px;
     white-space: nowrap;
     user-select: none;
@@ -24,7 +24,7 @@
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-neutral-quiet-action-button-hover
+            --color-background-neutral-subtle-action-button-hover
         );
         transition: 0.1s ease-out;
         transition-property: background-color, clip-path;
@@ -32,7 +32,7 @@
 
     &:active {
         background-color: var(
-            --color-background-neutral-quiet-action-button-active
+            --color-background-neutral-subtle-action-button-active
         );
         clip-path: inset(1px round 4px);
     }
@@ -81,337 +81,335 @@
 }
 
 /* Action buttons -- Neutral Intent */
-.action-button-primary-neutral {
-    color: var(--color-text-neutral-primary-action-button);
-    background-color: var(--color-background-neutral-primary-action-button);
+.action-button-solid-neutral {
+    color: var(--color-text-neutral-solid-action-button);
+    background-color: var(--color-background-neutral-solid-action-button);
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-neutral-primary-action-button-hover
+            --color-background-neutral-solid-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-neutral-primary-action-button-active
+            --color-background-neutral-solid-action-button-active
         );
     }
 }
 
-.action-button-quiet-neutral {
-    color: var(--color-text-neutral-quiet-action-button);
-    background-color: var(--color-background-neutral-quiet-action-button);
+.action-button-subtle-neutral {
+    color: var(--color-text-neutral-subtle-action-button);
+    background-color: var(--color-background-neutral-subtle-action-button);
     box-shadow: 0 0 0.5px 0.5px var(--color-inner-shadow-action-button) inset;
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-neutral-quiet-action-button-hover
+            --color-background-neutral-subtle-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-neutral-quiet-action-button-active
+            --color-background-neutral-subtle-action-button-active
         );
     }
 }
 
-.action-button-borderless-neutral {
-    color: var(--color-text-neutral-borderless-action-button);
+.action-button-text-neutral {
+    color: var(--color-text-neutral-text-action-button);
     background-color: transparent;
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-neutral-borderless-action-button-hover
+            --color-background-neutral-text-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-neutral-borderless-action-button-active
+            --color-background-neutral-text-action-button-active
         );
     }
 }
 
 /* Action buttons -- Brand Intent */
-.action-button-primary-brand {
-    color: var(--color-text-brand-primary-action-button);
-    background-color: var(--color-background-brand-primary-action-button);
+.action-button-solid-brand {
+    color: var(--color-text-brand-solid-action-button);
+    background-color: var(--color-background-brand-solid-action-button);
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-brand-primary-action-button-hover
+            --color-background-brand-solid-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-brand-primary-action-button-active
+            --color-background-brand-solid-action-button-active
         );
     }
 }
 
-.action-button-quiet-brand {
-    color: var(--color-text-brand-quiet-action-button);
-    background-color: var(--color-background-brand-quiet-action-button);
+.action-button-subtle-brand {
+    color: var(--color-text-brand-subtle-action-button);
+    background-color: var(--color-background-brand-subtle-action-button);
     box-shadow: 0 0 0.5px 0.5px var(--color-inner-shadow-action-button) inset;
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-brand-quiet-action-button-hover
+            --color-background-brand-subtle-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-brand-quiet-action-button-active
+            --color-background-brand-subtle-action-button-active
         );
     }
 }
 
-.action-button-borderless-brand {
-    color: var(--color-text-brand-borderless-action-button);
+.action-button-text-brand {
+    color: var(--color-text-brand-text-action-button);
     background-color: transparent;
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-brand-borderless-action-button-hover
+            --color-background-brand-text-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-brand-borderless-action-button-active
+            --color-background-brand-text-action-button-active
         );
     }
 }
 
 /* Action buttons -- Info Intent */
-.action-button-primary-info {
-    color: var(--color-text-info-primary-action-button);
-    background-color: var(--color-background-info-primary-action-button);
+.action-button-solid-info {
+    color: var(--color-text-info-solid-action-button);
+    background-color: var(--color-background-info-solid-action-button);
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-info-primary-action-button-hover
+            --color-background-info-solid-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-info-primary-action-button-active
+            --color-background-info-solid-action-button-active
         );
     }
 }
 
-.action-button-quiet-info {
-    color: var(--color-text-info-quiet-action-button);
-    background-color: var(--color-background-info-quiet-action-button);
+.action-button-subtle-info {
+    color: var(--color-text-info-subtle-action-button);
+    background-color: var(--color-background-info-subtle-action-button);
     box-shadow: 0 0 0.5px 0.5px var(--color-inner-shadow-action-button) inset;
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-info-quiet-action-button-hover
+            --color-background-info-subtle-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-info-quiet-action-button-active
+            --color-background-info-subtle-action-button-active
         );
     }
 }
 
-.action-button-borderless-info {
-    color: var(--color-text-info-borderless-action-button);
+.action-button-text-info {
+    color: var(--color-text-info-text-action-button);
     background-color: transparent;
 
     &:hover,
     &:focus-visible {
-        background-color: var(
-            --color-background-info-borderless-action-button-hover
-        );
+        background-color: var(--color-background-info-text-action-button-hover);
     }
 
     &:active {
         background-color: var(
-            --color-background-info-borderless-action-button-active
+            --color-background-info-text-action-button-active
         );
     }
 }
 
 /* Action buttons -- Success Intent */
-.action-button-primary-success {
-    color: var(--color-text-success-primary-action-button);
-    background-color: var(--color-background-success-primary-action-button);
+.action-button-solid-success {
+    color: var(--color-text-success-solid-action-button);
+    background-color: var(--color-background-success-solid-action-button);
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-success-primary-action-button-hover
+            --color-background-success-solid-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-success-primary-action-button-active
+            --color-background-success-solid-action-button-active
         );
     }
 }
 
-.action-button-quiet-success {
-    color: var(--color-text-success-quiet-action-button);
-    background-color: var(--color-background-success-quiet-action-button);
+.action-button-subtle-success {
+    color: var(--color-text-success-subtle-action-button);
+    background-color: var(--color-background-success-subtle-action-button);
     box-shadow: 0 0 0.5px 0.5px var(--color-inner-shadow-action-button) inset;
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-success-quiet-action-button-hover
+            --color-background-success-subtle-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-success-quiet-action-button-active
+            --color-background-success-subtle-action-button-active
         );
     }
 }
 
-.action-button-borderless-success {
-    color: var(--color-text-success-borderless-action-button);
+.action-button-text-success {
+    color: var(--color-text-success-text-action-button);
     background-color: transparent;
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-success-borderless-action-button-hover
+            --color-background-success-text-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-success-borderless-action-button-active
+            --color-background-success-text-action-button-active
         );
     }
 }
 
 /* Action buttons -- Warning Intent */
-.action-button-primary-warning {
-    color: var(--color-text-warning-primary-action-button);
-    background-color: var(--color-background-warning-primary-action-button);
+.action-button-solid-warning {
+    color: var(--color-text-warning-solid-action-button);
+    background-color: var(--color-background-warning-solid-action-button);
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-warning-primary-action-button-hover
+            --color-background-warning-solid-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-warning-primary-action-button-active
+            --color-background-warning-solid-action-button-active
         );
     }
 }
 
-.action-button-quiet-warning {
-    color: var(--color-text-warning-quiet-action-button);
-    background-color: var(--color-background-warning-quiet-action-button);
+.action-button-subtle-warning {
+    color: var(--color-text-warning-subtle-action-button);
+    background-color: var(--color-background-warning-subtle-action-button);
     box-shadow: 0 0 0.5px 0.5px var(--color-inner-shadow-action-button) inset;
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-warning-quiet-action-button-hover
+            --color-background-warning-subtle-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-warning-quiet-action-button-active
+            --color-background-warning-subtle-action-button-active
         );
     }
 }
 
-.action-button-borderless-warning {
-    color: var(--color-text-warning-borderless-action-button);
+.action-button-text-warning {
+    color: var(--color-text-warning-text-action-button);
     background-color: transparent;
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-warning-borderless-action-button-hover
+            --color-background-warning-text-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-warning-borderless-action-button-active
+            --color-background-warning-text-action-button-active
         );
     }
 }
 
 /* Action buttons -- Danger Intent */
-.action-button-primary-danger {
-    color: var(--color-text-danger-primary-action-button);
-    background-color: var(--color-background-danger-primary-action-button);
+.action-button-solid-danger {
+    color: var(--color-text-danger-solid-action-button);
+    background-color: var(--color-background-danger-solid-action-button);
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-danger-primary-action-button-hover
+            --color-background-danger-solid-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-danger-primary-action-button-active
+            --color-background-danger-solid-action-button-active
         );
     }
 }
 
-.action-button-quiet-danger {
-    color: var(--color-text-danger-quiet-action-button);
-    background-color: var(--color-background-danger-quiet-action-button);
+.action-button-subtle-danger {
+    color: var(--color-text-danger-subtle-action-button);
+    background-color: var(--color-background-danger-subtle-action-button);
     box-shadow: 0 0 0.5px 0.5px var(--color-inner-shadow-action-button) inset;
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-danger-quiet-action-button-hover
+            --color-background-danger-subtle-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-danger-quiet-action-button-active
+            --color-background-danger-subtle-action-button-active
         );
     }
 }
 
-.action-button-borderless-danger {
-    color: var(--color-text-danger-borderless-action-button);
+.action-button-text-danger {
+    color: var(--color-text-danger-text-action-button);
     background-color: transparent;
 
     &:hover,
     &:focus-visible {
         background-color: var(
-            --color-background-danger-borderless-action-button-hover
+            --color-background-danger-text-action-button-hover
         );
     }
 
     &:active {
         background-color: var(
-            --color-background-danger-borderless-action-button-active
+            --color-background-danger-text-action-button-active
         );
     }
 }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1377,7 +1377,7 @@ h4.user_group_setting_subsection_title {
     gap: 10px;
     overflow: hidden;
 
-    &.action-button-quiet-neutral {
+    &.action-button-subtle-neutral {
         box-shadow: none;
     }
 }

--- a/web/templates/components/action_button.hbs
+++ b/web/templates/components/action_button.hbs
@@ -1,4 +1,4 @@
-<button type="{{#if type}}{{type}}{{else}}button{{/if}}" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{attention}}-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tippy-content}}data-tippy-content="{{data-tippy-content}}"{{/if}} {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}
+<button type="{{#if type}}{{type}}{{else}}button{{/if}}" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{variant}}-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tippy-content}}data-tippy-content="{{data-tippy-content}}"{{/if}} {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}
   {{#if disabled}}disabled{{/if}}
   >
     {{#if icon}}

--- a/web/templates/compose_banner/message_sent_banner.hbs
+++ b/web/templates/compose_banner/message_sent_banner.hbs
@@ -17,7 +17,7 @@
         {{/if}}
     </p>
     {{#if action_button_text}}
-        <button class="action-button action-button-quiet-success" data-message-id="{{link_msg_id}}">
+        <button class="action-button action-button-subtle-success" data-message-id="{{link_msg_id}}">
             <span class="action-button-label">{{ action_button_text }}</span>
         </button>
     {{/if}}

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -21,7 +21,7 @@
                         <div class="delete-selected-drafts-button-container">
                             {{> ./components/icon_button intent="danger" custom_classes="delete-selected-drafts-button" icon="trash" disabled=true  }}
                         </div>
-                        <button class="action-button action-button-quiet-neutral select-drafts-button" role="checkbox" aria-checked="false">
+                        <button class="action-button action-button-subtle-neutral select-drafts-button" role="checkbox" aria-checked="false">
                             <span>{{t "Select all drafts" }}</span>
                             <i class="fa fa-square-o select-state-indicator" aria-hidden="true"></i>
                         </button>

--- a/web/templates/feedback_container.hbs
+++ b/web/templates/feedback_container.hbs
@@ -3,7 +3,7 @@
         <h3 class="light no-margin small-line-height float-left feedback_title"></h3>
         <div class="feedback-button-container">
             {{#if has_undo_button}}
-                {{> components/action_button intent="neutral" attention="quiet" custom_classes="feedback_undo"}}
+                {{> components/action_button intent="neutral" variant="subtle" custom_classes="feedback_undo"}}
             {{/if}}
             {{> ./components/icon_button intent="neutral" custom_classes="exit-me" icon="close"}}
         </div>

--- a/web/templates/inbox_view/inbox_view.hbs
+++ b/web/templates/inbox_view/inbox_view.hbs
@@ -35,7 +35,7 @@
             <span class="inbox-collapsed-note-span">
                 {{t "All unread conversations are hidden. Click on a section, folder, or channel to expand it."}}
             </span>
-            <button id="inbox-expand-all-button" class="action-button action-button-quiet-neutral" tabindex="0">
+            <button id="inbox-expand-all-button" class="action-button action-button-subtle-neutral" tabindex="0">
                 <span class="action-button-label">{{t "Show all"}}</span>
             </button>
         </div>

--- a/web/templates/message_hidden_dialog.hbs
+++ b/web/templates/message_hidden_dialog.hbs
@@ -2,7 +2,7 @@
     <span class="muted-message-notice">
         {{t "Message from a muted user." }}
     </span>
-    <button class="action-button action-button-borderless-neutral reveal-hidden-message reveal-button" tabindex="0" aria-label="{{t 'Reveal message from muted user' }}">
+    <button class="action-button action-button-text-neutral reveal-hidden-message reveal-button" tabindex="0" aria-label="{{t 'Reveal message from muted user' }}">
         <i class="zulip-icon zulip-icon-eye"></i>
         <span class="action-button-label">{{t 'Reveal'}}</span>
     </button>

--- a/web/templates/muted_user_ui_row.hbs
+++ b/web/templates/muted_user_ui_row.hbs
@@ -6,7 +6,7 @@
         {{#if can_unmute}}
         {{> ./components/action_button
           label=(t "Unmute")
-          attention="quiet"
+          variant="subtle"
           intent="danger"
           custom_classes="settings-unmute-user"
           }}

--- a/web/templates/navigation_tour_video_modal.hbs
+++ b/web/templates/navigation_tour_video_modal.hbs
@@ -4,6 +4,6 @@
         <source src="{{video_src}}" type="video/mp4"/>
     </video>
     <div id="navigation-tour-video-ended-button-wrapper">
-        <button id="navigation-tour-video-ended-button" class="action-button-primary-brand">{{t "Let's go!"}}</button>
+        <button id="navigation-tour-video-ended-button" class="action-button-solid-brand">{{t "Let's go!"}}</button>
     </div>
 </div>

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -38,7 +38,7 @@
                     {{> ../components/action_button
                       id="demo_organization_add_email_button"
                       label=(t "Add email")
-                      attention="quiet"
+                      variant="subtle"
                       intent="brand"
                       }}
                 </div>
@@ -59,7 +59,7 @@
                     <div class="input-group">
                         {{> ../components/action_button
                           label=(t "Change your password")
-                          attention="quiet"
+                          variant="subtle"
                           intent="neutral"
                           id="change_password"
                           }}
@@ -88,7 +88,7 @@
                 <div id="deactivate_account_container" class="inline-block {{#if user_is_only_organization_owner}}disabled_setting_tooltip{{/if}}">
                     {{> ../components/action_button
                       label=(t "Deactivate account")
-                      attention="quiet"
+                      variant="subtle"
                       intent="danger"
                       id="user_deactivate_account_button"
                       disabled=user_is_only_organization_owner
@@ -97,7 +97,7 @@
                 {{#if owner_is_only_user_in_organization}}
                     {{> ../components/action_button
                       label=(t "Deactivate organization")
-                      attention="quiet"
+                      variant="subtle"
                       intent="danger"
                       custom_classes="deactivate_realm_button"
                       }}
@@ -124,7 +124,7 @@
                 <div id="api_key_button_container" class="inline-block {{#unless user_has_email_set}}disabled_setting_tooltip{{/unless}}">
                     {{> ../components/action_button
                       label=(t "Manage your API key")
-                      attention="quiet"
+                      variant="subtle"
                       intent="neutral"
                       id="api_key_button"
                       disabled=(not user_has_email_set)

--- a/web/templates/settings/add_emoji.hbs
+++ b/web/templates/settings/add_emoji.hbs
@@ -4,14 +4,14 @@
           id="emoji_file_input" value="{{t 'Upload image or GIF' }}"/>
         {{> ../components/action_button
           label=(t "Clear image")
-          attention="quiet"
+          variant="subtle"
           intent="danger"
           id="emoji_image_clear_button"
           hidden=true
           }}
         {{> ../components/action_button
           label=(t "Upload image or GIF")
-          attention="quiet"
+          variant="subtle"
           intent="brand"
           id="emoji_upload_button"
           }}

--- a/web/templates/settings/add_new_bot_form.hbs
+++ b/web/templates/settings/add_new_bot_form.hbs
@@ -66,14 +66,14 @@
             </div>
             {{> ../components/action_button
               label=(t "Clear avatar")
-              attention="quiet"
+              variant="subtle"
               intent="danger"
               id="bot_avatar_clear_button"
               hidden=true
               }}
             {{> ../components/action_button
               label=(t "Upload avatar")
-              attention="quiet"
+              variant="subtle"
               intent="neutral"
               id="bot_avatar_upload_button"
               custom_classes="inline-block"

--- a/web/templates/settings/add_new_custom_profile_field_form.hbs
+++ b/web/templates/settings/add_new_custom_profile_field_form.hbs
@@ -29,7 +29,7 @@
               label=(t "Alphabetize choices")
               custom_classes="alphabetize-choices-button"
               intent="neutral"
-              attention="quiet"
+              variant="subtle"
               }}
         </div>
         <div class="input-group" id="custom_external_account_url_pattern">

--- a/web/templates/settings/admin_channel_folders.hbs
+++ b/web/templates/settings/admin_channel_folders.hbs
@@ -6,7 +6,7 @@
             {{> ../components/action_button
               custom_classes="add-channel-folder-button"
               label=(t "Add a new channel folder")
-              attention="quiet"
+              variant="subtle"
               intent="brand"
               }}
         {{/if}}

--- a/web/templates/settings/admin_human_form.hbs
+++ b/web/templates/settings/admin_human_form.hbs
@@ -29,9 +29,9 @@
     <div class="input-group {{#if hide_deactivate_button}}hide{{/if}}">
         <div class="deactivate-user-container {{#if user_is_only_organization_owner}}disabled_setting_tooltip{{/if}}">
             {{#if is_active}}
-            {{> ../components/action_button custom_classes="deactivate-user-button" attention="quiet" intent="danger" label=(t "Deactivate user") aria-label=(t "Deactivate user") disabled=user_is_only_organization_owner }}
+            {{> ../components/action_button custom_classes="deactivate-user-button" variant="subtle" intent="danger" label=(t "Deactivate user") aria-label=(t "Deactivate user") disabled=user_is_only_organization_owner }}
             {{else}}
-            {{> ../components/action_button custom_classes="reactivate-user-button" attention="quiet" intent="success" label=(t "Reactivate user") aria-label=(t "Reactivate user") }}
+            {{> ../components/action_button custom_classes="reactivate-user-button" variant="subtle" intent="success" label=(t "Reactivate user") aria-label=(t "Reactivate user") }}
             {{/if}}
         </div>
     </div>

--- a/web/templates/settings/admin_realm_domains_list.hbs
+++ b/web/templates/settings/admin_realm_domains_list.hbs
@@ -12,7 +12,7 @@
         {{> ../components/action_button
           label=(t "Remove")
           custom_classes="delete_realm_domain"
-          attention="quiet"
+          variant="subtle"
           intent="danger"
           }}
     </td>

--- a/web/templates/settings/alert_word_settings.hbs
+++ b/web/templates/settings/alert_word_settings.hbs
@@ -6,7 +6,7 @@
     </form>
     {{> ../components/action_button
       label=(t "Add alert word")
-      attention="quiet"
+      variant="subtle"
       intent="brand"
       id="open-add-alert-word-modal"
       }}

--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -5,7 +5,7 @@
     <div>
         {{> ../components/action_button
           label=(t "Add a new bot")
-          attention="quiet"
+          variant="subtle"
           intent="brand"
           custom_classes="add-a-new-bot"
           hidden=(not can_create_new_bots)

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -22,7 +22,7 @@
         {{> ../components/action_button
           label=(t "Start export")
           id="start-export-button"
-          attention="quiet"
+          variant="subtle"
           intent="brand"
           type="submit"
           }}

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -8,7 +8,7 @@
                 {{> ../components/action_button
                   id="show-add-default-streams-modal"
                   label=(t "Add channel")
-                  attention="quiet"
+                  variant="subtle"
                   intent="brand"
                   type="submit"
                   }}

--- a/web/templates/settings/edit_bot_form.hbs
+++ b/web/templates/settings/edit_bot_form.hbs
@@ -52,13 +52,13 @@
             </div>
             {{> ../components/action_button
               label=(t "Change avatar")
-              attention="quiet"
+              variant="subtle"
               intent="neutral"
               custom_classes="edit_bot_avatar_upload_button"
               }}
             {{> ../components/action_button
               label=(t "Clear profile picture")
-              attention="quiet"
+              variant="subtle"
               intent="danger"
               custom_classes="edit_bot_avatar_clear_button"
               hidden=true
@@ -70,7 +70,7 @@
     <div class="input-group">
         {{> ../components/action_button
           label=(t "Generate URL for an integration")
-          attention="quiet"
+          variant="subtle"
           intent="neutral"
           custom_classes="generate_url_for_integration"
           }}
@@ -131,7 +131,7 @@
         {{#if is_active}}
         {{> ../components/action_button
           label=(t "Deactivate bot")
-          attention="quiet"
+          variant="subtle"
           intent="danger"
           custom_classes="deactivate-bot-button"
           }}
@@ -139,7 +139,7 @@
         <span>
             {{> ../components/action_button
               label=(t "Reactivate bot")
-              attention="quiet"
+              variant="subtle"
               intent="success"
               custom_classes="reactivate-user-button"
               }}

--- a/web/templates/settings/edit_custom_profile_field_form.hbs
+++ b/web/templates/settings/edit_custom_profile_field_form.hbs
@@ -22,7 +22,7 @@
           label=(t "Alphabetize choices")
           custom_classes="alphabetize-choices-button"
           intent="neutral"
-          attention="quiet"
+          variant="subtle"
           }}
     </div>
     {{else if is_external_account_field}}

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -7,7 +7,7 @@
     </p>
     {{> ../components/action_button
       id="add-custom-emoji-button"
-      attention="quiet"
+      variant="subtle"
       intent="brand"
       label=(t "Add a new emoji")
       hidden=(not can_add_emojis)

--- a/web/templates/settings/generate_integration_url_modal.hbs
+++ b/web/templates/settings/generate_integration_url_modal.hbs
@@ -40,8 +40,8 @@
 <div class="input-group hide" id="integrations-event-container">
     <label for="integrations-event-options">{{t "Events to include:"}}</label>
     <div class="integration-all-events-buttons">
-        {{> ../components/action_button attention="quiet" intent="neutral" id="add-all-integration-events" label=(t "Check all") }}
-        {{> ../components/action_button attention="quiet" intent="neutral" id="remove-all-integration-events" label=(t "Uncheck all") }}
+        {{> ../components/action_button variant="subtle" intent="neutral" id="add-all-integration-events" label=(t "Check all") }}
+        {{> ../components/action_button variant="subtle" intent="neutral" id="remove-all-integration-events" label=(t "Uncheck all") }}
     </div>
     <div id="integrations-event-options"></div>
 </div>

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -17,7 +17,7 @@
     {{/unless}}
     {{> ../components/action_button
       label=(t 'Invite users to organization')
-      attention="quiet"
+      variant="subtle"
       intent="brand"
       custom_classes="user-settings-invite-user-label invite-user-link"
       }}

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -48,7 +48,7 @@
                 </div>
                 {{> ../components/action_button
                   label=(t 'Add linkifier')
-                  attention="quiet"
+                  variant="subtle"
                   intent="brand"
                   type="submit"
                   }}

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -138,7 +138,7 @@
         {{#unless for_realm_settings}}
         {{> ../components/action_button
           label=(t "Send a test notification")
-          attention="quiet"
+          variant="subtle"
           intent="neutral"
           custom_classes="send_test_notification"
           }}

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -50,7 +50,7 @@
           custom_classes="block"
           id="id_org_profile_preview"
           icon="external-link"
-          attention="quiet"
+          variant="subtle"
           intent="brand"
           }}
         <div class="subsection-header">
@@ -90,7 +90,7 @@
                 <div id="deactivate_realm_button_container" class="inline-block">
                     {{> ../components/action_button
                       label=(t "Deactivate organization")
-                      attention="quiet"
+                      variant="subtle"
                       intent="danger"
                       custom_classes="deactivate_realm_button"
                       }}

--- a/web/templates/settings/organization_settings_admin.hbs
+++ b/web/templates/settings/organization_settings_admin.hbs
@@ -91,7 +91,7 @@
                       class="admin-realm-welcome-message-custom-text setting-widget prop-element settings-textarea display-block" maxlength="8000"
                       data-setting-widget-type="string">{{ realm_welcome_message_custom_text }}</textarea>
                     <div id="welcome_message_custom_text_buttons_container">
-                        {{> ../components/action_button attention="quiet" intent="neutral" label=(t "Send me a test message") id="send_test_welcome_bot_custom_message"}}
+                        {{> ../components/action_button variant="subtle" intent="neutral" label=(t "Send me a test message") id="send_test_welcome_bot_custom_message"}}
                     </div>
                 </div>
 

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -57,7 +57,7 @@
                     {{> ../components/action_button
                       id="submit_playground_button"
                       label=(t "Add code playground")
-                      attention="quiet"
+                      variant="subtle"
                       intent="brand"
                       type="submit"
                       }}

--- a/web/templates/settings/profile_field_settings_admin.hbs
+++ b/web/templates/settings/profile_field_settings_admin.hbs
@@ -6,7 +6,7 @@
             {{> ../components/action_button
               id="add-custom-profile-field-button"
               label=(t "Add a new profile field")
-              attention="quiet"
+              variant="subtle"
               intent="brand"
               }}
         {{/if}}

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -69,7 +69,7 @@
             </div>
             {{> ../components/action_button
               label=(t "Preview profile")
-              attention="quiet"
+              variant="subtle"
               intent="brand"
               id="show_my_user_profile_modal"
               icon="external-link"

--- a/web/templates/settings/realm_domains_modal.hbs
+++ b/web/templates/settings/realm_domains_modal.hbs
@@ -21,7 +21,7 @@
                 {{> ../components/action_button
                   label=(t "Add")
                   id="submit-add-realm-domain"
-                  attention="quiet"
+                  variant="subtle"
                   intent="brand"
                   }}
             </td>

--- a/web/templates/settings/settings_save_discard_widget.hbs
+++ b/web/templates/settings/settings_save_discard_widget.hbs
@@ -1,10 +1,10 @@
 {{#unless show_only_indicator}}
 <div class="save-button-controls hide">
     <div class="inline-block subsection-changes-save">
-        {{> ../components/action_button custom_classes="save-button" attention="primary" intent="brand" label=(t "Save changes") }}
+        {{> ../components/action_button custom_classes="save-button" variant="solid" intent="brand" label=(t "Save changes") }}
     </div>
     <div class="inline-block subsection-changes-discard">
-        {{> ../components/action_button custom_classes="discard-button" attention="quiet" intent="neutral" label=(t "Discard") }}
+        {{> ../components/action_button custom_classes="discard-button" variant="subtle" intent="neutral" label=(t "Discard") }}
     </div>
     <div class="inline-block subsection-failed-status"><p class="hide"></p></div>
 </div>

--- a/web/templates/stream_settings/add_subscribers_form.hbs
+++ b/web/templates/stream_settings/add_subscribers_form.hbs
@@ -10,7 +10,7 @@
             {{> ../components/action_button
               label=(t "Add")
               custom_classes="add-subscriber-button add-users-button"
-              attention="quiet"
+              variant="subtle"
               intent="brand"
               type="submit"
               }}

--- a/web/templates/stream_settings/channel_folder.hbs
+++ b/web/templates/stream_settings/channel_folder.hbs
@@ -15,7 +15,7 @@
             {{#if is_admin}}
                 {{> ../components/action_button
                   label=(t "Create new folder")
-                  attention="quiet"
+                  variant="subtle"
                   intent="neutral"
                   type="button"
                   custom_classes="create-channel-folder-button"

--- a/web/templates/stream_settings/edit_channel_folder_modal.hbs
+++ b/web/templates/stream_settings/edit_channel_folder_modal.hbs
@@ -39,7 +39,7 @@
     </div>
     <div class="add_channel_folder_widget">
         {{> ../dropdown_widget widget_name="add_channel_folder"}}
-        {{> ../components/action_button label=(t "Add") custom_classes="add-channel-button" attention="quiet" intent="brand" aria-label=(t "Add") }}
+        {{> ../components/action_button label=(t "Add") custom_classes="add-channel-button" variant="subtle" intent="brand" aria-label=(t "Add") }}
     </div>
 </div>
 {{/if}}

--- a/web/templates/stream_settings/new_stream_user.hbs
+++ b/web/templates/stream_settings/new_stream_user.hbs
@@ -9,9 +9,9 @@
     {{/if}}
     <td class="action-column">
         {{#if soft_removed}}
-            {{> ../components/action_button custom_classes="undo_soft_removed_potential_subscriber" label=(t "Add") attention="quiet" intent="neutral" aria-label=(t "Add") }}
+            {{> ../components/action_button custom_classes="undo_soft_removed_potential_subscriber" label=(t "Add") variant="subtle" intent="neutral" aria-label=(t "Add") }}
         {{else}}
-            {{> ../components/action_button custom_classes="remove_potential_subscriber" label=(t "Remove") attention="quiet" intent="neutral" aria-label=(t "Remove") }}
+            {{> ../components/action_button custom_classes="remove_potential_subscriber" label=(t "Remove") variant="subtle" intent="neutral" aria-label=(t "Remove") }}
         {{/if}}
     </td>
 </tr>

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -47,7 +47,7 @@
                   label=(t "Back to settings")
                   custom_classes="hide"
                   id="stream_creation_go_to_configure_channel_settings"
-                  attention="quiet"
+                  variant="subtle"
                   intent="brand"
                   }}
             </div>
@@ -55,13 +55,13 @@
                 {{> ../components/action_button
                   label=(t "Cancel")
                   custom_classes="create_stream_cancel inline-block"
-                  attention="quiet"
+                  variant="subtle"
                   intent="neutral"
                   }}
                 {{> ../components/action_button
                   label=(t "Create")
                   custom_classes="finalize_create_stream hide"
-                  attention="quiet"
+                  variant="subtle"
                   intent="brand"
                   type="submit"
                   }}
@@ -69,7 +69,7 @@
                   label=(t "Continue to add subscribers")
                   custom_classes="inline-block"
                   id="stream_creation_go_to_subscribers"
-                  attention="quiet"
+                  variant="subtle"
                   intent="brand"
                   }}
             </div>

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -11,7 +11,7 @@
                     {{/tr}}
                 </span>
             </template>
-            <button class="action-button subscribe-button sub_unsub_button {{#if subscribed}}action-button-quiet-neutral{{else}}action-button-quiet-brand{{/if}} {{#if should_display_subscription_button}}toggle-subscription-tooltip{{/if}} {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button"  data-tooltip-template-id="toggle-subscription-tooltip-template" {{#unless should_display_subscription_button}}disabled="disabled"{{/unless}}>
+            <button class="action-button subscribe-button sub_unsub_button {{#if subscribed}}action-button-subtle-neutral{{else}}action-button-subtle-brand{{/if}} {{#if should_display_subscription_button}}toggle-subscription-tooltip{{/if}} {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button"  data-tooltip-template-id="toggle-subscription-tooltip-template" {{#unless should_display_subscription_button}}disabled="disabled"{{/unless}}>
                 {{#if subscribed }}
                     {{t "Unsubscribe" }}
                 {{else}}
@@ -21,7 +21,7 @@
         </div>
         {{> ../components/action_button
           icon="eye"
-          attention="quiet"
+          variant="subtle"
           intent="neutral"
           custom_classes="tippy-zulip-delayed-tooltip"
           data-tooltip-template-id="view-stream-tooltip-template"
@@ -101,7 +101,7 @@
                     </label>
                     {{> ../components/action_button
                       label=(t "Generate email address")
-                      attention="quiet"
+                      variant="subtle"
                       intent="neutral"
                       type="button"
                       custom_classes="copy_email_button"
@@ -132,7 +132,7 @@
                 {{/each}}
                 <div class="input-group">
                     <label class="settings-field-label channel-color-label">{{t "Channel color" }}</label>
-                    <button class="action-button action-button-quiet-neutral stream-settings-color-selector choose_stream_color" data-stream-id="{{ sub.stream_id }}">
+                    <button class="action-button action-button-subtle-neutral stream-settings-color-selector choose_stream_color" data-stream-id="{{ sub.stream_id }}">
                         <span class="stream-settings-color-preview" style="background: {{sub.color}};"></span>
                         <span class="stream-settings-color-selector-label">{{t "Change color"}}</span>
                     </button>
@@ -147,7 +147,7 @@
                 <div class="input-group">
                     {{> ../components/action_button
                       label=(t "Reset to default notifications")
-                      attention="quiet"
+                      variant="subtle"
                       intent="neutral"
                       custom_classes="reset-stream-notifications-button"
                       type="button"

--- a/web/templates/topic_edit_form.hbs
+++ b/web/templates/topic_edit_form.hbs
@@ -9,8 +9,8 @@
         </span>
     {{/unless}}
     <span class="topic-edit-save-wrapper">
-        {{> components/action_button custom_classes="topic_edit_save tippy-zulip-delayed-tooltip" icon="check" attention="quiet" intent="neutral" data-tooltip-template-id="save-button-tooltip-template" }}
+        {{> components/action_button custom_classes="topic_edit_save tippy-zulip-delayed-tooltip" icon="check" variant="subtle" intent="neutral" data-tooltip-template-id="save-button-tooltip-template" }}
     </span>
-    {{> components/action_button custom_classes="topic_edit_cancel tippy-zulip-delayed-tooltip" icon="circle-x" attention="borderless" intent="neutral" data-tooltip-template-id="cancel-button-tooltip-template" }}
+    {{> components/action_button custom_classes="topic_edit_cancel tippy-zulip-delayed-tooltip" icon="circle-x" variant="text" intent="neutral" data-tooltip-template-id="cancel-button-tooltip-template" }}
     <div class="topic_edit_spinner"></div>
 </form>

--- a/web/templates/user_group_settings/add_members_form.hbs
+++ b/web/templates/user_group_settings/add_members_form.hbs
@@ -11,7 +11,7 @@
               label=(t "Add")
               custom_classes="add-member-button add-users-button"
               id="add_member"
-              attention="quiet"
+              variant="subtle"
               intent="brand"
               type="submit"
               }}

--- a/web/templates/user_group_settings/new_user_group_subgroup.hbs
+++ b/web/templates/user_group_settings/new_user_group_subgroup.hbs
@@ -5,9 +5,9 @@
     <td class="empty-email-col-for-user-group"></td>
     <td class="action-column">
         {{#if soft_removed}}
-            {{> ../components/action_button custom_classes="undo_soft_removed_potential_subgroup" label=(t "Add") attention="quiet" intent="neutral" aria-label=(t "Add") }}
+            {{> ../components/action_button custom_classes="undo_soft_removed_potential_subgroup" label=(t "Add") variant="subtle" intent="neutral" aria-label=(t "Add") }}
         {{else}}
-            {{> ../components/action_button custom_classes="remove_potential_subgroup" label=(t "Remove") attention="quiet" intent="neutral" aria-label=(t "Remove") }}
+            {{> ../components/action_button custom_classes="remove_potential_subgroup" label=(t "Remove") variant="subtle" intent="neutral" aria-label=(t "Remove") }}
         {{/if}}
     </td>
 </tr>

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -49,7 +49,7 @@
                 {{> ../components/action_button
                   label=(t "Back to settings")
                   custom_classes="hide"
-                  attention="quiet"
+                  variant="subtle"
                   intent="brand"
                   id="user_group_go_to_configure_settings"
                   }}
@@ -58,13 +58,13 @@
                 {{> ../components/action_button
                   label=(t "Cancel")
                   custom_classes="create_user_group_cancel inline-block"
-                  attention="quiet"
+                  variant="subtle"
                   intent="neutral"
                   }}
                 {{> ../components/action_button
                   label=(t "Create")
                   custom_classes="finalize_create_user_group hide"
-                  attention="quiet"
+                  variant="subtle"
                   intent="brand"
                   type="submit"
                   }}
@@ -72,7 +72,7 @@
                   label=(t "Continue to add members")
                   id="user_group_go_to_members"
                   custom_classes="inline-block"
-                  attention="quiet"
+                  variant="subtle"
                   intent="brand"
                   }}
             </div>

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -4,10 +4,10 @@
         <div class="join_leave_button_wrapper inline-block">
             {{#if is_direct_member}}
             {{> ../components/action_button label=(t "Leave group") custom_classes="join_leave_button" type="button"
-              attention="quiet" intent="neutral" }}
+              variant="subtle" intent="neutral" }}
             {{else}}
             {{> ../components/action_button label=(t "Join group") custom_classes="join_leave_button" type="button"
-              attention="quiet" intent="brand" }}
+              variant="subtle" intent="brand" }}
             {{/if}}
         </div>
         {{> ../components/icon_button icon="user-group-x" intent="danger" custom_classes="deactivate-group-button deactivate tippy-zulip-delayed-tooltip"

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -177,7 +177,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                {{> components/action_button label=(t "Add") custom_classes="add-groups-button" attention="quiet" intent="brand" aria-label=(t "Add") }}
+                                {{> components/action_button label=(t "Add") custom_classes="add-groups-button" variant="subtle" intent="brand" aria-label=(t "Add") }}
                             </div>
                         </div>
                     </div>

--- a/web/templates/user_profile_subscribe_widget.hbs
+++ b/web/templates/user_profile_subscribe_widget.hbs
@@ -1,4 +1,4 @@
 <div class="user_profile_subscribe_widget">
     {{> dropdown_widget widget_name="user_profile_subscribe"}}
-    {{> components/action_button label=(t "Subscribe") custom_classes="add-subscription-button" attention="quiet" intent="brand" aria-label=(t "Subscribe") }}
+    {{> components/action_button label=(t "Subscribe") custom_classes="add-subscription-button" variant="subtle" intent="brand" aria-label=(t "Subscribe") }}
 </div>


### PR DESCRIPTION
This PR updates the action button component terminology to reflect the visual appearance rather than the attention hierarchy.

This renames the `attention` property to `variant` and maps the values as follows:
* primary -> solid
* quiet -> subtle
* borderless -> text

The previous terminology was often counter-intuitive — "borderless" was confusing as in the current implementation the primary buttons also didn't have any borders, and "primary/quiet" implied a attention hierarchy that didn't always match usage context, like when a button in isolation needed to be "quiet".

Switching to visually descriptive names makes the terminology self-evident. This eliminates ambiguity in discussions as these describe the component's actual look and don't require prior knowledge of the attention hierarchy.

Fixes: #37049.

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
