### PR TITLE
search: Support multi-channel aggregation in search UI

### DIFF
--- a/info.md
+++ b/info.md
@@ -1,0 +1,77 @@
+# Multi-Channel Search: Implementation Notes
+
+## Summary
+
+This branch enforces canonical single-channel vs multi-channel behavior:
+
+- Single channel:
+  - Operator: `channel`
+  - URL: `/#narrow/channel/<id>-<slug>`
+  - Dedicated channel header is shown.
+- Multiple channels:
+  - Operator: `channels`
+  - URL: `/#narrow/channels/<id1,id2,...>`
+  - Dedicated single-channel header is not shown.
+
+## Core Implementation
+
+### Routing and canonicalization
+
+- `web/src/hash_util.ts`
+  - Canonicalizes legacy comma-`channel` and single-`channels` forms.
+  - Prevents malformed canonical output for invalid operands.
+- `web/src/hashchange.ts`
+  - Redirects only canonicalizable channel/operator transitions.
+
+### Narrow term behavior
+
+- `web/src/filter.ts`
+  - Validates `channels:<id,id,...>` terms strictly (numeric, unique, length >= 2).
+  - Handles local predicate behavior for multi-channel terms.
+- `web/src/narrow_state.ts`
+  - Distinguishes single-channel (`stream_id`) from multi-channel (`stream_ids`) state.
+- `web/src/message_view_header.ts`
+  - Avoids single-channel header path for multi-channel-style operands.
+
+### Search UI and suggestions
+
+- `web/src/search_pill.ts`
+  - Implements grouped channel pill state.
+  - Normalizes and validates channel ID operands.
+  - Automatically downgrades pill operator to `channel` when one channel remains.
+- `web/src/search_suggestion.ts`
+  - Adds grouped channel suggestion flow (`channel -> channels`).
+  - Uses parsed term logic for channel-group suggestion replacement.
+- `web/templates/search_channel_pill.hbs`
+- `web/templates/search_list_item.hbs`
+- `web/styles/search.css`
+
+### Backend validation and query behavior
+
+- `zerver/lib/narrow.py`
+  - Enforces channel-category exclusivity:
+    - no `channel` + `channels` mix
+    - only one positive `channel`
+    - only one positive `channels`
+  - Strictly validates `channels:<id,id,...>` operands:
+    - numeric IDs only
+    - no empty tokens
+    - no duplicates
+    - no unknown/inaccessible IDs
+  - Uses fail-fast web-public checks for channels ID lists.
+  - Updates history-inclusion logic for channels ID-list narrows.
+
+## Tests Updated
+
+- `zerver/tests/test_message_fetch.py`
+- `web/tests/hash_util.test.cjs`
+- `web/tests/filter.test.cjs`
+- `web/tests/search.test.cjs`
+- `web/tests/search_suggestion.test.cjs`
+
+## Why These Changes Were Needed
+
+- Remove duplicate representations for the same single-channel state.
+- Make channel category behavior canonical and mutually exclusive.
+- Eliminate permissive malformed `channels` operand handling.
+- Keep UI/operator/URL/backend state transitions consistent.

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -157,11 +157,27 @@ function build_term_predicate(term: NarrowCanonicalTerm): ((message: Message) =>
         }
 
         case "channel": {
-            const target_id = Number(term.operand);
-            return (message) => message.type === "stream" && message.stream_id === target_id;
+            return (message) =>
+                message.type === "stream" && message.stream_id.toString() === term.operand;
         }
 
         case "channels":
+            if (term.operand.includes(",")) {
+                const channel_id_strings = term.operand
+                    .split(",")
+                    .map((id) => id.trim())
+                    .filter((id) => id !== "");
+                if (
+                    channel_id_strings.length < 2 ||
+                    !channel_id_strings.every((id) => /^\d+$/.test(id)) ||
+                    new Set(channel_id_strings).size !== channel_id_strings.length
+                ) {
+                    return () => false;
+                }
+                const channel_ids = new Set(channel_id_strings);
+                return (message) =>
+                    message.type === "stream" && channel_ids.has(message.stream_id.toString());
+            }
             switch (term.operand) {
                 case "public":
                     return (message) => {
@@ -583,7 +599,23 @@ export class Filter {
             case "channel":
                 return stream_data.get_sub_by_id_string(term.operand) !== undefined;
             case "channels":
-                return channels_operands.has(term.operand);
+                if (channels_operands.has(term.operand)) {
+                    return true;
+                }
+                if (!term.operand.includes(",")) {
+                    return false;
+                }
+                {
+                    const channel_ids = term.operand
+                        .split(",")
+                        .map((id) => id.trim())
+                        .filter((id) => id !== "");
+                    return (
+                        channel_ids.length >= 2 &&
+                        channel_ids.every((id) => /^\d+$/.test(id)) &&
+                        new Set(channel_ids).size === channel_ids.length
+                    );
+                }
             case "topic":
                 return true;
             case "sender":
@@ -640,12 +672,10 @@ export class Filter {
         result += term.operator;
 
         // Using `||` instead of `array.includes` to help with type checking.
-        if (
-            term.operator === "is" ||
-            term.operator === "has" ||
-            term.operator === "in" ||
-            term.operator === "channels"
-        ) {
+        if (term.operator === "is" || term.operator === "has" || term.operator === "in") {
+            result += "-" + term.operand;
+        }
+        if (term.operator === "channels" && channels_operands.has(term.operand)) {
             result += "-" + term.operand;
         }
 
@@ -831,6 +861,21 @@ export class Filter {
                 return {
                     type: "plain_text",
                     content: this.describe_channels_operator(term.negated ?? false, term.operand),
+                };
+            }
+            if (term.operator === "channels" && term.operand.includes(",")) {
+                const channel_names = term.operand
+                    .split(",")
+                    .map((id) => id.trim())
+                    .filter((id) => id !== "")
+                    .map((id) => stream_data.get_sub_by_id_string(id)?.name ?? id);
+                const prefix_for_operator = term.negated
+                    ? "exclude messages in channels #"
+                    : "messages in channels #";
+                return {
+                    type: "prefix_for_operator",
+                    prefix_for_operator,
+                    operand: channel_names.join(", #"),
                 };
             }
             const prefix_for_operator = Filter.operator_to_prefix(term.operator, term.negated);
@@ -1294,9 +1339,8 @@ export class Filter {
             return "/#narrow/has/reaction/sender/me";
         }
         if (_.isEqual(term_types, ["channel", "topic", "search"])) {
-            const sub = stream_data.get_sub_by_id_string(
-                this.terms_with_operator("channel")[0]!.operand,
-            );
+            const channel_operand = this.terms_with_operator("channel")[0]!.operand;
+            const sub = stream_data.get_sub_by_id_string(channel_operand);
             // if channel does not exist, redirect to home view
             if (!sub) {
                 return "#";
@@ -1317,9 +1361,8 @@ export class Filter {
         if (term_types[1] === "search") {
             switch (term_types[0]) {
                 case "channel": {
-                    const sub = stream_data.get_sub_by_id_string(
-                        this.terms_with_operator("channel")[0]!.operand,
-                    );
+                    const channel_operand = this.terms_with_operator("channel")[0]!.operand;
+                    const sub = stream_data.get_sub_by_id_string(channel_operand);
                     // if channel does not exist, redirect to home view
                     if (!sub) {
                         return "#";
@@ -1833,11 +1876,18 @@ export class Filter {
     }
 
     is_channel_view(): boolean {
-        return (
-            this._terms.length === 1 &&
-            this._terms[0] !== undefined &&
-            Filter.term_type(this._terms[0]) === "channel"
-        );
+        if (this._terms.length !== 1) {
+            return false;
+        }
+        const channel_terms = this.terms_with_operator("channel");
+        if (channel_terms.length !== 1) {
+            return false;
+        }
+        const channel_operand = channel_terms[0]!.operand;
+        if (channel_operand === "" || channel_operand.includes(",")) {
+            return false;
+        }
+        return true;
     }
 
     may_contain_multiple_conversations(): boolean {

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -45,7 +45,21 @@ export function encode_operand(term: NarrowCanonicalTerm): string {
             slug = people.user_ids_to_slug([term.operand]);
             break;
         case "channel":
-            return encode_stream_id(Number.parseInt(term.operand, 10));
+            if (term.operand.includes(",")) {
+                return term.operand;
+            }
+            {
+                const stream_id = Number.parseInt(term.operand, 10);
+                if (Number.isNaN(stream_id)) {
+                    return internal_url.encodeHashComponent(term.operand);
+                }
+                return encode_stream_id(stream_id);
+            }
+        case "channels":
+            if (term.operand.includes(",")) {
+                return term.operand;
+            }
+            break;
     }
 
     return slug ?? internal_url.encodeHashComponent(String(term.operand));
@@ -93,11 +107,24 @@ export function decode_operand(
         }
         return util.the(user_ids);
     }
-
+    const raw_operand = operand;
     operand = internal_url.decodeHashComponent(operand);
 
     if (operator === "channel") {
         return stream_data.slug_to_stream_id(operand)?.toString() ?? "";
+    }
+
+    if (operator === "channels" && raw_operand.includes(",")) {
+        const ids = operand.split(",").map((id_str) => {
+            const trimmed = id_str.trim();
+            const stream_id = stream_data.slug_to_stream_id(trimmed);
+            return stream_id?.toString() ?? trimmed;
+        });
+        return ids.join(",");
+    }
+
+    if (operator === "channels" && operand !== "public" && operand !== "web-public") {
+        return stream_data.slug_to_stream_id(operand)?.toString() ?? operand;
     }
 
     return operand;
@@ -128,6 +155,26 @@ export function by_stream_topic_url(stream_id: number, topic: string): string {
     return internal_url.by_stream_topic_url(stream_id, topic, sub_store.maybe_get_stream_name);
 }
 
+function with_operator(
+    term: NarrowCanonicalTerm,
+    operator: NarrowCanonicalOperator,
+): NarrowCanonicalTerm {
+    if (operator === term.operator) {
+        return term;
+    }
+    if (
+        (term.operator === "channel" || term.operator === "channels") &&
+        (operator === "channel" || operator === "channels")
+    ) {
+        return {
+            operator,
+            operand: term.operand,
+            negated: term.negated,
+        };
+    }
+    return term;
+}
+
 // Encodes a term list into the
 // corresponding hash: the # component
 // of the narrow URL
@@ -140,13 +187,24 @@ export function search_terms_to_hash(terms?: NarrowCanonicalTerm[]): string {
         hash = "#narrow";
 
         for (const term of terms) {
+            let operator: NarrowCanonicalOperator = term.operator;
+            if (
+                operator === "channels" &&
+                typeof term.operand === "string" &&
+                term.operand !== "public" &&
+                term.operand !== "web-public" &&
+                /^\d+$/.test(term.operand)
+            ) {
+                operator = "channel";
+            }
             const sign = term.negated ? "-" : "";
+            const canonical_term = with_operator(term, operator);
             hash +=
                 "/" +
                 sign +
-                internal_url.encodeHashComponent(term.operator) +
+                internal_url.encodeHashComponent(operator) +
                 "/" +
-                encode_operand(term);
+                encode_operand(canonical_term);
         }
     }
 
@@ -232,10 +290,24 @@ export function parse_narrow(hash: string[]): NarrowCanonicalTerm[] | undefined 
             return undefined;
         }
 
-        const canonical_operator = filter_util.canonicalize_operator(
+        let canonical_operator = filter_util.canonicalize_operator(
             narrow_operator_schema.parse(operator),
         );
-        const operand = decode_operand(canonical_operator, raw_operand);
+        if (canonical_operator === "channel" && raw_operand.includes(",")) {
+            return undefined;
+        }
+
+        let operand = decode_operand(canonical_operator, raw_operand);
+        if (
+            canonical_operator === "channels" &&
+            typeof operand === "string" &&
+            operand !== "public" &&
+            operand !== "web-public" &&
+            /^\d+$/.test(operand)
+        ) {
+            canonical_operator = "channel";
+            operand = decode_operand(canonical_operator, raw_operand);
+        }
         terms.push({
             negated,
             operator: canonical_operator,

--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -208,6 +208,20 @@ function do_hashchange_normal(from_reload: boolean, restore_selected_id: boolean
                 return false;
             }
 
+            // Auto-redirect from channels/N to channel/N-name when a single ID was provided.
+            // parse_narrow already downgrades the operator, here we just redirect to the canonical URL.
+            const original_hash = window.location.hash;
+            const canonical_hash = hash_util.search_terms_to_hash(terms);
+            const should_redirect_channel_hash =
+                (original_hash.includes("/channels/") &&
+                    terms.some((term) => term.operator === "channel")) ||
+                (original_hash.includes("/channel/") &&
+                    terms.some((term) => term.operator === "channels"));
+            if (original_hash !== canonical_hash && should_redirect_channel_hash) {
+                window.location.replace(canonical_hash);
+                return false;
+            }
+
             // Show inbox style topics list for #topics narrow.
             if (hash[0] === "#topics" && terms.length === 1) {
                 const channel_id_string = hash[2];

--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -102,9 +102,12 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
     });
 
     if (filter.has_operator("channel")) {
-        const current_stream = stream_data.get_sub_by_id_string(
-            filter.terms_with_operator("channel")[0]!.operand,
-        );
+        const channel_operand = filter.terms_with_operator("channel")[0]?.operand;
+        // Skip single-channel header logic for multi-channel narrows (comma-separated IDs)
+        if (channel_operand === undefined || channel_operand.includes(",")) {
+            return context;
+        }
+        const current_stream = stream_data.get_sub_by_id_string(channel_operand);
         if (!current_stream) {
             return {
                 ...context,

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -142,11 +142,30 @@ export function stream_id(
     if (channel_terms.length === 1) {
         const channel_operand = channel_terms[0]?.operand;
         if (channel_operand !== undefined) {
+            // Multi-channel search uses comma-separated IDs; in that case,
+            // return undefined since there's no single channel context.
+            if (channel_operand.includes(",")) {
+                return undefined;
+            }
             const id = Number.parseInt(channel_operand, 10);
             if (!Number.isNaN(id)) {
                 return only_valid_id ? stream_data.get_sub_by_id(id)?.stream_id : id;
             }
         }
+    }
+    return undefined;
+}
+
+// Returns array of stream IDs for multi-channel narrows.
+// Returns undefined if not a multi-channel narrow.
+export function stream_ids(current_filter: Filter | undefined = filter()): number[] | undefined {
+    if (current_filter === undefined) {
+        return undefined;
+    }
+    const channels_operand = current_filter.terms_with_operator("channels")[0]?.operand;
+    if (channels_operand?.includes(",")) {
+        const ids = channels_operand.split(",").map((id_str) => Number.parseInt(id_str.trim(), 10));
+        return ids.filter((id) => !Number.isNaN(id));
     }
     return undefined;
 }

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -2,6 +2,7 @@ import $ from "jquery";
 import assert from "minimalistic-assert";
 
 import render_input_pill from "../templates/input_pill.hbs";
+import render_search_channel_pill from "../templates/search_channel_pill.hbs";
 import render_search_list_item from "../templates/search_list_item.hbs";
 import render_search_user_pill from "../templates/search_user_pill.hbs";
 
@@ -36,7 +37,23 @@ export type SearchUserPillContext = {
     }[];
 };
 
-type SearchPill = ({type: "generic_operator"} & NarrowCanonicalTerm) | SearchUserPill;
+export type SearchChannelPill = {
+    type: "search_channel";
+    operator: "channel" | "channels";
+    negated: boolean;
+    channels: {
+        stream_id: number;
+        name: string;
+        color: string | undefined;
+        invite_only: boolean;
+        is_web_public: boolean;
+    }[];
+};
+
+type SearchPill =
+    | ({type: "generic_operator"} & NarrowCanonicalTerm)
+    | SearchUserPill
+    | SearchChannelPill;
 
 export type SearchPillWidget = InputPillContainer<SearchPill>;
 
@@ -50,7 +67,8 @@ type PillRenderData =
               is_combined_channel_topic?: boolean;
               combined_channel_name?: string;
           })
-    | SearchUserPill;
+    | SearchUserPill
+    | SearchChannelPill;
 
 export function create_item_from_search_string(search_string: string): SearchPill | undefined {
     const search_term = util.the(Filter.parse(search_string));
@@ -66,29 +84,37 @@ export function create_item_from_search_string(search_string: string): SearchPil
     return undefined;
 }
 
-export function get_search_string_from_item(item: SearchPill): string {
-    let operand: string;
-    switch (item.operator) {
-        case "dm":
-        case "dm-including":
-        case "sender":
-            assert(item.type === "search_user");
-            operand = item.users.map((user) => user.email).join(",");
-            break;
-        case "topic":
-            operand = util.get_final_topic_display_name(item.operand);
-            break;
-        case "channel":
-            if (item.operand === "") {
-                operand = "";
-            }
-            operand = stream_data.get_valid_sub_by_id_string(item.operand).name;
-            break;
-        default:
-            operand = item.operand;
+function parse_channel_ids_operand(
+    operand: string,
+    require_multiple = false,
+    require_single = false,
+): number[] | undefined {
+    const id_strings = operand.split(",").map((id_str) => id_str.trim());
+    if (id_strings.some((id_str) => id_str === "" || !/^\d+$/.test(id_str))) {
+        return undefined;
     }
 
+    const stream_ids = id_strings.map((id_str) => Number.parseInt(id_str, 10));
+    const unique_stream_ids = [...new Set(stream_ids)];
+    if (unique_stream_ids.length !== stream_ids.length) {
+        return undefined;
+    }
+    if (require_multiple && unique_stream_ids.length < 2) {
+        return undefined;
+    }
+    if (require_single && unique_stream_ids.length !== 1) {
+        return undefined;
+    }
+
+    return unique_stream_ids;
+}
+
+export function get_search_string_from_item(item: SearchPill): string {
     const sign = item.negated ? "-" : "";
+    const operand = get_search_operand(item, true);
+    if (operand === "") {
+        return `${sign}${item.operator}:`;
+    }
     return `${sign}${item.operator}: ${operand}`;
 }
 
@@ -102,6 +128,47 @@ function on_pill_exit(
     remove_pill: (pill: HTMLElement) => void,
 ): void {
     const $user_pill_container = $(clicked_element).parents(".user-pill-container");
+    const $channel_pill_container = $(clicked_element).parents(".channel-pill-container");
+
+    if ($channel_pill_container.length > 0) {
+        const stream_id_string = $(clicked_element).closest(".pill").attr("data-stream-id");
+        assert(stream_id_string !== undefined);
+        const stream_id = Number.parseInt(stream_id_string, 10);
+
+        const outer_idx = all_pills.findIndex(
+            (pill) => pill.$element[0] === $channel_pill_container[0],
+        );
+        assert(outer_idx !== -1);
+        const channel_container_pill = all_pills[outer_idx]!.item;
+        assert(channel_container_pill?.type === "search_channel");
+
+        if (channel_container_pill.channels.length === 1) {
+            assert(util.the(channel_container_pill.channels).stream_id === stream_id);
+            remove_pill(util.the($channel_pill_container));
+            return;
+        }
+
+        const channel_idx = channel_container_pill.channels.findIndex(
+            (channel) => channel.stream_id === stream_id,
+        );
+        assert(channel_idx !== -1);
+        channel_container_pill.channels.splice(channel_idx, 1);
+
+        channel_container_pill.operator =
+            channel_container_pill.channels.length > 1 ? "channels" : "channel";
+
+        const $outer_container = all_pills[outer_idx]!.$element;
+        const $channel_pill = $($outer_container.children(".pill")[channel_idx]!);
+        assert($channel_pill.attr("data-stream-id") === stream_id.toString());
+        $channel_pill.remove();
+        $outer_container
+            .find("> .pill-label")
+            .text(
+                `${channel_container_pill.negated ? "-" : ""}${channel_container_pill.operator}:`,
+            );
+        return;
+    }
+
     if ($user_pill_container.length === 0) {
         // This is just a regular search pill, so we don't need to do fancy logic.
         const $clicked_pill = $(clicked_element).closest(".pill");
@@ -284,6 +351,14 @@ export function generate_pills_html(suggestion: Suggestion, text_query: string):
                     description_html,
                 };
             }
+            case "channel":
+            case "channels":
+                if (search_pill.operand !== "") {
+                    const channel_pill_data = search_channel_pill_data_from_term(search_pill);
+                    if (channel_pill_data !== undefined) {
+                        return channel_pill_data;
+                    }
+                }
         }
 
         return {
@@ -343,6 +418,32 @@ export function generate_pills_html(suggestion: Suggestion, text_query: string):
                 pills: pill_render_data,
                 description_html,
             });
+        } else if (render_data.type === "search_channel") {
+            // Only show description for single-channel pills (channel operator)
+            if (render_data.operator === "channel") {
+                const is_operator_suggestion =
+                    search_terms[0]!.operator !== "" && !text_query.includes(":");
+                let description_html = Filter.search_description_as_html(
+                    [
+                        {
+                            operator: render_data.operator,
+                            operand: get_search_operand(render_data, false),
+                            negated: render_data.negated,
+                        },
+                    ],
+                    is_operator_suggestion,
+                );
+                const capitalized_first_letter = description_html.charAt(0).toUpperCase();
+                description_html = capitalized_first_letter + description_html.slice(1);
+                return render_search_list_item({
+                    pills: pill_render_data,
+                    description_html,
+                });
+            }
+            // For multi-channel pills (channels operator), don't show description
+            return render_search_list_item({
+                pills: pill_render_data,
+            });
         }
     }
 
@@ -359,28 +460,22 @@ export function create_pills($pill_container: JQuery): SearchPillWidget {
         split_text_on_comma: false,
         convert_to_pill_on_enter: false,
         generate_pill_html(item) {
-            switch (item.operator) {
-                case "dm":
-                case "dm-including":
-                case "sender":
-                    assert(item.type === "search_user");
-                    return render_search_user_pill(item);
-                case "topic":
-                    if (item.operand === "") {
-                        return render_input_pill({
-                            is_empty_string_topic: true,
-                            sign: item.negated ? "-" : "",
-                            topic_display_name: util.get_final_topic_display_name(""),
-                        });
-                    }
-                    return render_input_pill({
-                        display_value: get_search_string_from_item(item),
-                    });
-                default:
-                    return render_input_pill({
-                        display_value: get_search_string_from_item(item),
-                    });
+            if (item.type === "search_user") {
+                return render_search_user_pill(item);
             }
+            if (item.type === "search_channel") {
+                return render_search_channel_pill(item);
+            }
+            if (item.operator === "topic" && item.operand === "") {
+                return render_input_pill({
+                    is_empty_string_topic: true,
+                    sign: item.negated ? "-" : "",
+                    topic_display_name: util.get_final_topic_display_name(""),
+                });
+            }
+            return render_input_pill({
+                display_value: get_search_string_from_item(item),
+            });
         },
         get_display_value_from_item: get_search_string_from_item,
         on_pill_exit,
@@ -407,6 +502,19 @@ function search_user_pill_data_from_term(term: NarrowCanonicalTerm): SearchUserP
     const user_ids = get_user_ids_from_term_with_user_pill_operator(term);
     const users = user_ids.map((user_id) => people.get_by_user_id(user_id));
     return search_user_pill_data(users, term.operator, term.negated ?? false);
+}
+
+function search_channel_pill_data_from_term(
+    term: NarrowCanonicalTerm,
+): SearchChannelPill | undefined {
+    assert(term.operator === "channel" || term.operator === "channels");
+    const require_multiple = term.operator === "channels";
+    const require_single = term.operator === "channel";
+    const stream_ids = parse_channel_ids_operand(term.operand, require_multiple, require_single);
+    if (stream_ids === undefined) {
+        return undefined;
+    }
+    return search_channel_pill_data(stream_ids, term.negated ?? false);
 }
 
 function is_sent_by_me_pill(pill: SearchUserPill): boolean {
@@ -445,6 +553,38 @@ function append_user_pill(
     negated: boolean,
 ): void {
     const pill_data = search_user_pill_data(users, operator, negated);
+    pill_widget.appendValidatedData(pill_data);
+    pill_widget.clear_text();
+}
+
+function search_channel_pill_data(stream_ids: number[], negated: boolean): SearchChannelPill {
+    const normalized_stream_ids = [...new Set(stream_ids)];
+    assert(normalized_stream_ids.length > 0);
+    const operator: "channel" | "channels" =
+        normalized_stream_ids.length > 1 ? "channels" : "channel";
+    return {
+        type: "search_channel",
+        operator,
+        negated,
+        channels: normalized_stream_ids.map((stream_id) => {
+            const sub = stream_data.get_sub_by_id(stream_id);
+            return {
+                stream_id,
+                name: sub?.name ?? `#${stream_id}`,
+                color: sub?.color,
+                invite_only: sub?.invite_only ?? false,
+                is_web_public: sub?.is_web_public ?? false,
+            };
+        }),
+    };
+}
+
+function append_channel_pill(
+    stream_ids: number[],
+    pill_widget: SearchPillWidget,
+    negated: boolean,
+): void {
+    const pill_data = search_channel_pill_data(stream_ids, negated);
     pill_widget.appendValidatedData(pill_data);
     pill_widget.clear_text();
 }
@@ -493,13 +633,43 @@ export function set_search_bar_contents(
             continue;
         }
 
-        switch (term.operator) {
+        switch (narrow_term.operator) {
             case "dm":
             case "dm-including":
             case "sender": {
                 const user_ids = get_user_ids_from_term_with_user_pill_operator(narrow_term);
                 const users = user_ids.map((user_id) => people.get_by_user_id(user_id));
-                append_user_pill(users, pill_widget, term.operator, term.negated ?? false);
+                append_user_pill(
+                    users,
+                    pill_widget,
+                    narrow_term.operator,
+                    narrow_term.negated ?? false,
+                );
+                added_pills_as_input_strings.add(input);
+                break;
+            }
+            case "channel": {
+                const stream_ids = parse_channel_ids_operand(narrow_term.operand, false, true);
+                if (stream_ids === undefined) {
+                    pill_widget.appendValue(input);
+                } else {
+                    append_channel_pill(stream_ids, pill_widget, narrow_term.negated ?? false);
+                }
+                added_pills_as_input_strings.add(input);
+                break;
+            }
+            case "channels": {
+                if (!narrow_term.operand.includes(",")) {
+                    pill_widget.appendValue(input);
+                    added_pills_as_input_strings.add(input);
+                    break;
+                }
+                const stream_ids = parse_channel_ids_operand(narrow_term.operand, true);
+                if (stream_ids === undefined) {
+                    pill_widget.appendValue(input);
+                } else {
+                    append_channel_pill(stream_ids, pill_widget, narrow_term.negated ?? false);
+                }
                 added_pills_as_input_strings.add(input);
                 break;
             }
@@ -525,10 +695,52 @@ export function set_search_bar_contents(
     }
 }
 
+function get_search_operand(item: SearchPill, for_display: boolean): string {
+    if (item.type === "search_user") {
+        return item.users.map((user) => user.email).join(",");
+    }
+    if (item.type === "search_channel") {
+        const unique_channel_ids = [...new Set(item.channels.map((channel) => channel.stream_id))];
+        if (for_display) {
+            return item.channels.map((channel) => channel.name).join(", ");
+        }
+        return unique_channel_ids.map((channel_id) => channel_id.toString()).join(",");
+    }
+
+    if (for_display) {
+        if (item.operator === "channel" && item.operand !== "") {
+            const ids = item.operand.split(",");
+            return ids
+                .map((id) => {
+                    const sub = stream_data.get_valid_sub_by_id_string(id.trim());
+                    return sub?.name ?? id.trim();
+                })
+                .join(", ");
+        }
+        if (item.operator === "topic") {
+            return util.get_final_topic_display_name(item.operand);
+        }
+    }
+
+    if (Array.isArray(item.operand)) {
+        return item.operand.join(",");
+    }
+    return String(item.operand);
+}
+
 export function get_current_search_pill_terms(
     pill_widget: SearchPillWidget,
 ): NarrowCanonicalTerm[] {
     return pill_widget.items().map((item) => {
+        if (item.type === "search_channel") {
+            const operator: "channel" | "channels" =
+                item.channels.length > 1 ? "channels" : "channel";
+            return {
+                operator,
+                operand: get_search_operand(item, false),
+                negated: item.negated,
+            };
+        }
         switch (item.operator) {
             case "dm":
             case "dm-including":

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -268,6 +268,81 @@ function get_channel_suggestions(
     });
 }
 
+// This function enables multi-channel selection by allowing users to add
+// more channels to an existing channel term (similar to get_group_suggestions for DM).
+function get_group_channel_suggestions(
+    last: NarrowCanonicalTermSuggestion,
+    terms: NarrowCanonicalTerm[],
+): Suggestion[] {
+    // We only suggest group channels once a term with a valid channel already exists
+    if (terms.length === 0) {
+        return [];
+    }
+    const last_complete_term = terms.at(-1)!;
+    if (last_complete_term.operator !== "channel" && last_complete_term.operator !== "channels") {
+        return [];
+    }
+
+    // If they started typing since a channel pill, we'll parse that as "search"
+    // but they might actually want to add another channel.
+    let existing_channel_ids: string[];
+    let query: string;
+    if (last.operator === "search") {
+        query = last.operand;
+    } else if (last.operator === "") {
+        query = "";
+    } else {
+        // If they already started another term with another operator, we're
+        // no longer dealing with a group channel situation.
+        return [];
+    }
+
+    if (last_complete_term.operator === "channel") {
+        existing_channel_ids = [last_complete_term.operand];
+    } else {
+        // We only support grouped channel suggestions for explicit channel ID lists.
+        if (!last_complete_term.operand.includes(",")) {
+            return [];
+        }
+        existing_channel_ids = last_complete_term.operand.split(",").map((id) => id.trim());
+    }
+    const existing_ids = new Set(existing_channel_ids);
+
+    let channels = stream_data.subscribed_streams();
+
+    // Filter out channels that are already in the operand
+    channels = channels.filter((channel_name) => {
+        const sub = stream_data.get_sub_by_name(channel_name);
+        if (sub === undefined) {
+            return false;
+        }
+        return !existing_ids.has(sub.stream_id.toString());
+    });
+
+    // Filter by query
+    if (query !== "") {
+        channels = channels.filter((channel_name) => channel_matches_query(channel_name, query));
+    }
+
+    channels = typeahead_helper.sorter(query, channels, (x) => x);
+
+    // Take top 15 channels
+    channels = channels.slice(0, 15);
+
+    return channels.map((channel_name) => {
+        const channel = stream_data.get_sub_by_name(channel_name);
+        assert(channel !== undefined);
+        const new_channel_ids = [...existing_channel_ids, channel.stream_id.toString()];
+        const term: NarrowTerm = {
+            operator: "channels",
+            operand: new_channel_ids.join(","),
+            negated: last_complete_term.negated,
+        };
+        const search_string = Filter.unparse([term]);
+        return search_string;
+    });
+}
+
 function get_group_suggestions(
     group_operator: "dm" | "dm-including",
 ): (last: NarrowCanonicalTermSuggestion, terms: NarrowCanonicalTerm[]) => Suggestion[] {
@@ -929,6 +1004,20 @@ function suggestion_search_string(suggestion_line: SuggestionLine): string {
     return search_strings.join(" ");
 }
 
+function get_channel_term_from_single_suggestion(
+    suggestion: Suggestion,
+): Extract<NarrowCanonicalTerm, {operator: "channel" | "channels"}> | undefined {
+    const parsed_terms = Filter.parse(suggestion);
+    if (parsed_terms.length !== 1) {
+        return undefined;
+    }
+    const term = Filter.convert_suggestion_to_term(parsed_terms[0]!);
+    if (term === undefined || (term.operator !== "channel" && term.operator !== "channels")) {
+        return undefined;
+    }
+    return term;
+}
+
 function suggestions_for_empty_search_query(): SuggestionLine[] {
     // Since the context here is an **empty** search query, we assume
     // that there is no `near:` operator. So it's safe to use
@@ -1011,6 +1100,31 @@ class Attacher {
                     new_search_string.includes(last_base_string)
                 ) {
                     suggestion_line = [...this.base.slice(0, -1), suggestion];
+                } else if (
+                    // When we add a channel to a channel group, we
+                    // replace the last channel pill.
+                    (new_search_string.startsWith("channels:") ||
+                        new_search_string.startsWith("-channels:")) &&
+                    (last_base_string.startsWith("channel:") ||
+                        last_base_string.startsWith("-channel:") ||
+                        last_base_string.startsWith("channels:") ||
+                        last_base_string.startsWith("-channels:"))
+                ) {
+                    const last_channel_term =
+                        get_channel_term_from_single_suggestion(last_base_string);
+                    const new_channel_term =
+                        get_channel_term_from_single_suggestion(new_search_string);
+                    const last_ids =
+                        last_channel_term?.operand.split(",").map((id) => id.trim()) ?? [];
+                    const new_ids =
+                        new_channel_term?.operand.split(",").map((id) => id.trim()) ?? [];
+                    const should_replace =
+                        last_ids.length > 0 && last_ids.every((id) => new_ids.includes(id));
+                    if (should_replace) {
+                        suggestion_line = [...this.base.slice(0, -1), suggestion];
+                    } else {
+                        suggestion_line = [...this.base, suggestion];
+                    }
                 } else {
                     suggestion_line = [...this.base, suggestion];
                 }
@@ -1143,6 +1257,7 @@ export let get_suggestions = function (
         // searching user probably is looking to make a group DM.
         get_group_suggestions("dm"),
         get_group_suggestions("dm-including"),
+        get_group_channel_suggestions,
         get_channels_filter_suggestions,
         get_operator_suggestions,
         get_is_filter_suggestions,

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -222,7 +222,9 @@
     }
 
     #searchbox-input-container .user-pill-container,
-    .typeahead-menu .user-pill-container {
+    #searchbox-input-container .channel-pill-container,
+    .typeahead-menu .user-pill-container,
+    .typeahead-menu .channel-pill-container {
         border: 1px solid transparent;
 
         > .pill-label {
@@ -279,6 +281,12 @@
             background-color: var(--color-background-input-pill-search);
         }
 
+        /* Override generic search pill background for nested user/channel pills */
+        .channel-pill-container .pill:not(.deactivated-pill),
+        .user-pill-container .pill:not(.deactivated-pill) {
+            background-color: var(--color-background-user-pill);
+        }
+
         &:not(.focused) {
             height: var(--search-box-height);
             overflow: hidden;
@@ -293,11 +301,13 @@
             }
         }
 
-        &.focused .user-pill-container {
+        &.focused .user-pill-container,
+        &.focused .channel-pill-container {
             flex-flow: row wrap;
         }
 
-        .user-pill-container {
+        .user-pill-container,
+        .channel-pill-container {
             gap: 2px 5px;
             /* Don't enforce a height, as user-pill containers
                 can contain multiple user pills that wrap onto
@@ -339,6 +349,15 @@
                 align-content: center;
                 /* Don't inherit large line-height for user pills themselves, either. */
                 line-height: 1.1;
+            }
+        }
+
+        .channel-pill-container {
+            .pill {
+                /* Channel pills don't have images, so remove that column */
+                grid-template-columns: minmax(0, 1fr) var(
+                        --length-input-pill-exit
+                    );
             }
         }
     }
@@ -449,7 +468,8 @@
             }
         }
 
-        .user-pill-container {
+        .user-pill-container,
+        .channel-pill-container {
             gap: 5px;
         }
 

--- a/web/templates/search_channel_pill.hbs
+++ b/web/templates/search_channel_pill.hbs
@@ -1,0 +1,16 @@
+<div class="channel-pill-container pill" tabindex=0>
+    <span class="pill-label">
+        {{~#if this.negated}}-{{~/if~}}
+        {{ operator }}:
+    </span>
+    {{#each channels}}
+        <div class="pill" data-stream-id="{{this.stream_id}}">
+            <span class="pill-label">
+                <span class="pill-value">{{this.name}}</span>
+            </span>
+            <div class="exit">
+                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>
+            </div>
+        </div>
+    {{/each}}
+</div>

--- a/web/templates/search_list_item.hbs
+++ b/web/templates/search_list_item.hbs
@@ -4,6 +4,8 @@
             <div class="description">{{{this.description_html}}}</div>
         {{else if (eq this.type "search_user")}}
             <span class="pill-container">{{> search_user_pill this}}</span>
+        {{else if (eq this.type "search_channel")}}
+            <span class="pill-container">{{> search_channel_pill this}}</span>
         {{else}}
             <span class="pill-container">{{> input_pill this}}</span>
         {{/if}}

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -647,6 +647,14 @@ test("basics", () => {
     filter = new Filter(terms);
     assert.ok(filter.is_channel_view());
 
+    terms = [{operator: "channel", operand: "", negated: false}];
+    filter = new Filter(terms);
+    assert.ok(!filter.is_channel_view());
+
+    terms = [{operator: "channel", operand: "1,2", negated: false}];
+    filter = new Filter(terms);
+    assert.ok(!filter.is_channel_view());
+
     // Throw error on invalid operator.
     assert.throws(() => get_predicate([["bogus", "33"]]), {
         name: "$ZodError",
@@ -1763,6 +1771,10 @@ test("describe", ({mock_template, override}) => {
         {operator: "is", operand: "starred"},
     ];
     string = "messages in #devel, starred messages";
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
+
+    narrow = [{operator: "channels", operand: `${devel_id},999`}];
+    string = "messages in channels # devel, #999";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     const river_id = new_stream_id();
@@ -3170,4 +3182,116 @@ run_test("get_stringified_narrow_for_server_query", () => {
         narrow,
         '[{"operator":"channel","operand":1,"negated":false},{"operator":"topic","operand":"bar","negated":false}]',
     );
+});
+
+run_test("multi_channel_predicate", () => {
+    // Create test channels
+    const channel1 = {name: "Channel 1", stream_id: 101};
+    const channel2 = {name: "Channel 2", stream_id: 102};
+    const channel3 = {name: "Channel 3", stream_id: 103};
+    stream_data.add_sub_for_tests(channel1);
+    stream_data.add_sub_for_tests(channel2);
+    stream_data.add_sub_for_tests(channel3);
+
+    // Multi-channel predicate with comma-separated IDs
+    const predicate = get_predicate([["channels", "101,102"]]);
+
+    // Should match messages in any of the specified channels
+    const msg_in_channel1 = {type: "stream", stream_id: 101};
+    const msg_in_channel2 = {type: "stream", stream_id: 102};
+    const msg_in_channel3 = {type: "stream", stream_id: 103};
+    const dm_msg = {type: "private"};
+
+    assert.ok(predicate(msg_in_channel1));
+    assert.ok(predicate(msg_in_channel2));
+    assert.ok(!predicate(msg_in_channel3));
+    assert.ok(!predicate(dm_msg));
+
+    // Invalid operands should never match.
+    const invalid_predicate = get_predicate([["channels", "101,foo"]]);
+    assert.ok(!invalid_predicate(msg_in_channel1));
+});
+
+run_test("multi_channel_is_valid_canonical_term", () => {
+    // is_valid_canonical_term handles multi-channel (comma-separated IDs)
+    const channel1 = {name: "Test1", stream_id: 201};
+    const channel2 = {name: "Test2", stream_id: 202};
+    stream_data.add_sub_for_tests(channel1);
+    stream_data.add_sub_for_tests(channel2);
+
+    // Multi-channel with valid IDs
+    let term = {operator: "channels", operand: "201,202", negated: false};
+    assert.ok(Filter.is_valid_canonical_term(term));
+
+    // Multi-channel with numeric-looking IDs (even if streams don't exist)
+    term = {operator: "channels", operand: "999,888", negated: false};
+    assert.ok(Filter.is_valid_canonical_term(term));
+
+    // Single ID is not valid for channels operator.
+    term = {operator: "channels", operand: "999", negated: false};
+    assert.ok(!Filter.is_valid_canonical_term(term));
+
+    // Mixed token operand is invalid.
+    term = {operator: "channels", operand: "999,foo", negated: false};
+    assert.ok(!Filter.is_valid_canonical_term(term));
+
+    // Duplicate IDs are invalid.
+    term = {operator: "channels", operand: "999,999", negated: false};
+    assert.ok(!Filter.is_valid_canonical_term(term));
+});
+
+run_test("multi_channel_is_common_narrow", () => {
+    // is_common_narrow returns false for multi-channel search
+    const channel1 = {name: "Common1", stream_id: 301};
+    const channel2 = {name: "Common2", stream_id: 302};
+    stream_data.add_sub_for_tests(channel1);
+    stream_data.add_sub_for_tests(channel2);
+
+    // Single channel is a common narrow
+    let filter = new Filter([{operator: "channel", operand: "301"}]);
+    assert.ok(filter.is_common_narrow());
+
+    // Multi-channel is NOT a common narrow
+    filter = new Filter([{operator: "channels", operand: "301,302"}]);
+    assert.ok(!filter.is_common_narrow());
+});
+
+run_test("multi_channel_redirect_url", () => {
+    // generate_redirect_url returns '#' for multi-channel
+    const channel1 = {name: "Redirect1", stream_id: 401};
+    stream_data.add_sub_for_tests(channel1);
+
+    // Single channel + topic + search gets a proper redirect
+    let filter = new Filter([
+        {operator: "channel", operand: "401"},
+        {operator: "topic", operand: "test"},
+        {operator: "search", operand: "keyword"},
+    ]);
+    let redirect_url = filter.generate_redirect_url();
+    assert.ok(redirect_url !== "#");
+
+    // Multi-channel + topic + search redirects to home
+    filter = new Filter([
+        {operator: "channels", operand: "401,402"},
+        {operator: "topic", operand: "test"},
+        {operator: "search", operand: "keyword"},
+    ]);
+    redirect_url = filter.generate_redirect_url();
+    assert.equal(redirect_url, "#");
+
+    // Single channel (without topic) + search gets a proper redirect
+    filter = new Filter([
+        {operator: "channel", operand: "401"},
+        {operator: "search", operand: "keyword"},
+    ]);
+    redirect_url = filter.generate_redirect_url();
+    assert.ok(redirect_url !== "#");
+
+    // Multi-channel + search redirects to home
+    filter = new Filter([
+        {operator: "channels", operand: "401,402"},
+        {operator: "search", operand: "keyword"},
+    ]);
+    redirect_url = filter.generate_redirect_url();
+    assert.equal(redirect_url, "#");
 });

--- a/web/tests/hash_util.test.cjs
+++ b/web/tests/hash_util.test.cjs
@@ -205,6 +205,78 @@ run_test("test_parse_narrow", () => {
     );
 });
 
+run_test("test_parse_narrow_multi_channel", () => {
+    // Multi-channel search uses /channels/{id,id,id} format in URL.
+    // It should be parsed as a channels operator with comma-separated IDs.
+    assert.deepEqual(hash_util.parse_narrow(["narrow", "channels", "1,2,3"]), [
+        {negated: false, operator: "channels", operand: "1,2,3"},
+    ]);
+
+    // Multi-channel with negation
+    assert.deepEqual(hash_util.parse_narrow(["narrow", "-channels", "99,42"]), [
+        {negated: true, operator: "channels", operand: "99,42"},
+    ]);
+
+    // channels:public should remain as channels operator (not converted)
+    assert.deepEqual(hash_util.parse_narrow(["narrow", "channels", "public"]), [
+        {negated: false, operator: "channels", operand: "public"},
+    ]);
+
+    // channels:web-public should remain as channels operator (not converted)
+    assert.deepEqual(hash_util.parse_narrow(["narrow", "channels", "web-public"]), [
+        {negated: false, operator: "channels", operand: "web-public"},
+    ]);
+
+    // Single-channel channels URL should be downgraded to channel canonical form.
+    assert.deepEqual(
+        hash_util.parse_narrow(["narrow", "channels", frontend.stream_id.toString()]),
+        [{negated: false, operator: "channel", operand: frontend.stream_id.toString()}],
+    );
+
+    // Non-numeric single operand should remain `channels` (invalid but not downgraded).
+    assert.deepEqual(hash_util.parse_narrow(["narrow", "channels", "bogus"]), [
+        {negated: false, operator: "channels", operand: "bogus"},
+    ]);
+
+    // Legacy comma-separated channel operator format is no longer supported.
+    assert.equal(hash_util.parse_narrow(["narrow", "channel", "1,2,3"]), undefined);
+});
+
+run_test("test_search_terms_to_hash_multi_channel", () => {
+    // Multi-channel should use /channels/ URL format
+    const multi_channel_terms = [{operator: "channels", operand: "1,2,3", negated: false}];
+    assert.equal(hash_util.search_terms_to_hash(multi_channel_terms), "#narrow/channels/1,2,3");
+
+    // Single channel should continue to use /channel/ URL format
+    const single_channel_terms = [{operator: "channel", operand: "99", negated: false}];
+    assert.equal(
+        hash_util.search_terms_to_hash(single_channel_terms),
+        "#narrow/channel/99-frontend",
+    );
+
+    // Single-channel channels-format should canonicalize to /channel/.
+    const noncanonical_single_channel_terms = [
+        {operator: "channels", operand: "99", negated: false},
+    ];
+    assert.equal(
+        hash_util.search_terms_to_hash(noncanonical_single_channel_terms),
+        "#narrow/channel/99-frontend",
+    );
+
+    // Invalid non-numeric channels operand should not be downgraded into malformed channel hash.
+    const invalid_single_channels_operand = [
+        {operator: "channels", operand: "bogus", negated: false},
+    ];
+    assert.equal(
+        hash_util.search_terms_to_hash(invalid_single_channels_operand),
+        "#narrow/channels/bogus",
+    );
+
+    // Invalid channel operand should not produce NaN slug.
+    const invalid_channel_operand = [{operator: "channel", operand: "bogus", negated: false}];
+    assert.equal(hash_util.search_terms_to_hash(invalid_channel_operand), "#narrow/channel/bogus");
+});
+
 run_test("test_channels_settings_edit_url", () => {
     const sub = {
         name: "research & development",

--- a/web/tests/narrow_state.test.cjs
+++ b/web/tests/narrow_state.test.cjs
@@ -93,9 +93,53 @@ test("stream", () => {
     assert.deepEqual(public_terms, expected_terms);
 });
 
+test("multi_channel", () => {
+    // Multi-channel narrow: stream_id should return undefined
+    set_filter([["channels", "1,2,3"]]);
+    assert.equal(narrow_state.stream_id(), undefined);
+    assert.deepEqual(narrow_state.stream_ids(), [1, 2, 3]);
+
+    // Single channel should still work
+    const test_stream_id = 15;
+    const test_stream = {name: "Test", stream_id: test_stream_id};
+    stream_data.add_sub_for_tests(test_stream);
+    set_filter([["channel", test_stream_id.toString()]]);
+    assert.equal(narrow_state.stream_id(), test_stream_id);
+    assert.equal(narrow_state.stream_ids(), undefined);
+
+    // Multi-channel with various IDs
+    set_filter([["channels", "99,42,15"]]);
+    assert.equal(narrow_state.stream_id(), undefined);
+    assert.deepEqual(narrow_state.stream_ids(), [99, 42, 15]);
+
+    // stream_name should return undefined for multi-channel
+    set_filter([["channels", "1,2"]]);
+    assert.equal(narrow_state.stream_name(), undefined);
+    assert.equal(narrow_state.stream_sub(), undefined);
+
+    // stream_ids with no filter should return undefined (covers line 178)
+    // Reset message_lists to undefined state to test the undefined filter branch
+    message_lists.set_current(undefined);
+    assert.equal(narrow_state.stream_ids(), undefined);
+
+    // Test public_search_terms with multi-channel and narrow_stream set
+    // This covers the branch where multi-channel operands are kept when page_params.narrow_stream exists
+    page_params.narrow_stream = "SomeChannel";
+    set_filter([["channels", "1,2,3"]]);
+    const public_terms = narrow_state.public_search_terms();
+    assert.deepEqual(public_terms, [{negated: false, operator: "channels", operand: "1,2,3"}]);
+    page_params.narrow_stream = undefined;
+
+    // Legacy comma-separated channel operand is not treated as multi-channel.
+    set_filter([["channel", "1,2,3"]]);
+    assert.equal(narrow_state.stream_id(), undefined);
+    assert.equal(narrow_state.stream_ids(), undefined);
+});
+
+const foo_stream_id = 72;
 const foo_stream = make_stream({
     name: "Foo",
-    stream_id: 72,
+    stream_id: foo_stream_id,
 });
 test("narrowed", () => {
     assert.ok(!narrow_state.narrowed_to_pms());

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -57,13 +57,13 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
     mock_template("search_list_item.hbs", true, (_data, html) => html);
     mock_template("search_description.hbs", true, (_data, html) => html);
 
-    let expected_pill_display_value = "";
-    let input_pill_displayed = false;
-    mock_template("input_pill.hbs", true, (data, html) => {
-        assert.equal(data.display_value, expected_pill_display_value);
-        input_pill_displayed = true;
+    let channel_pill_displayed = false;
+    mock_template("search_channel_pill.hbs", true, (_data, html) => {
+        channel_pill_displayed = true;
         return html;
     });
+
+    let input_pill_displayed = false;
 
     override_rewire(search_suggestion, "max_num_of_search_results", 999);
     let terms;
@@ -113,13 +113,11 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             const search_suggestions = ["ver", "stream:Verona"];
 
             /* Test highlighter */
-            let description_html = "Search for ver";
-            let expected_value = `<div class="search_list_item">\n            <div class="description">Search for ver</div>\n    \n</div>\n`;
+            const description_html = "Search for ver";
+            let expected_value = `<div class="search_list_item">\n            <div class="description">${description_html}</div>\n    \n</div>\n`;
             assert.equal(opts.item_html(search_suggestions[0], "ver"), expected_value);
 
-            const search_string = "channel: Verona";
-            description_html = "Messages in #Verona";
-            expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class='pill ' tabindex=0>\n    <span class="pill-label">\n        <span class="pill-value">\n            ${search_string}\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n</span>\n            <div class="description">${description_html}</div>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class="channel-pill-container pill" tabindex=0>\n    <span class="pill-label">channel:\n    </span>\n        <div class="pill" data-stream-id="1">\n            <span class="pill-label">\n                <span class="pill-value">Verona</span>\n            </span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n</span>\n    <div class="description">Messages in #Verona</div>\n</div>\n`;
             assert.equal(opts.item_html(search_suggestions[1], "ver"), expected_value);
 
             /* Test sorter */
@@ -175,7 +173,6 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
                     operand: "ver",
                 },
             ];
-            expected_pill_display_value = null;
             _setup(terms);
             input_pill_displayed = false;
             mock_pill_removes(search.search_pill_widget);
@@ -191,19 +188,20 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
                     operand: verona_stream_id,
                 },
             ];
-            expected_pill_display_value = "channel: Verona";
             _setup(terms);
             input_pill_displayed = false;
+            channel_pill_displayed = false;
             mock_pill_removes(search.search_pill_widget);
             assert.equal(opts.updater(`channel:${verona_stream_id}`), "");
-            assert.ok(input_pill_displayed);
+            assert.ok(channel_pill_displayed);
 
             override_rewire(search, "is_using_input_method", true);
             _setup(terms);
             input_pill_displayed = false;
+            channel_pill_displayed = false;
             mock_pill_removes(search.search_pill_widget);
             assert.equal(opts.updater(`channel:${verona_stream_id}`), "");
-            assert.ok(input_pill_displayed);
+            assert.ok(channel_pill_displayed);
         }
     }
 
@@ -292,7 +290,6 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             operand: "ver",
         },
     ];
-    expected_pill_display_value = "ver";
     _setup(terms);
     ev.key = "Enter";
     override_rewire(search, "is_using_input_method", true);
@@ -349,4 +346,68 @@ run_test("set_search_bar_contents with duplicate pills", () => {
         operand: "attachment",
         negated: false,
     });
+});
+
+run_test("search_channel_pill_term_normalization", () => {
+    const single_channel_widget = {
+        items() {
+            return [
+                {
+                    type: "search_channel",
+                    operator: "channels",
+                    negated: false,
+                    channels: [
+                        {
+                            stream_id: 1,
+                            name: "Verona",
+                            color: "blue",
+                            invite_only: false,
+                            is_web_public: false,
+                        },
+                    ],
+                },
+            ];
+        },
+    };
+    assert.deepEqual(search_pill.get_current_search_pill_terms(single_channel_widget), [
+        {operator: "channel", operand: "1", negated: false},
+    ]);
+
+    const duplicate_channel_widget = {
+        items() {
+            return [
+                {
+                    type: "search_channel",
+                    operator: "channels",
+                    negated: true,
+                    channels: [
+                        {
+                            stream_id: 1,
+                            name: "Verona",
+                            color: "blue",
+                            invite_only: false,
+                            is_web_public: false,
+                        },
+                        {
+                            stream_id: 1,
+                            name: "Verona",
+                            color: "blue",
+                            invite_only: false,
+                            is_web_public: false,
+                        },
+                        {
+                            stream_id: 2,
+                            name: "Denmark",
+                            color: "green",
+                            invite_only: false,
+                            is_web_public: false,
+                        },
+                    ],
+                },
+            ];
+        },
+    };
+    assert.deepEqual(search_pill.get_current_search_pill_terms(duplicate_channel_widget), [
+        {operator: "channels", operand: "1,2", negated: true},
+    ]);
 });

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -85,10 +85,10 @@ function init({override}) {
 }
 
 function get_suggestions(query, pill_query = "") {
-    return search.get_suggestions(
-        Filter.parse(pill_query).map((suggestion) => Filter.convert_suggestion_to_term(suggestion)),
-        Filter.parse(query),
-    );
+    const pill_terms = Filter.parse(pill_query)
+        .map((suggestion) => Filter.convert_suggestion_to_term(suggestion))
+        .filter((term) => term !== undefined);
+    return search.get_suggestions(pill_terms, Filter.parse(query));
 }
 
 function test(label, f) {
@@ -373,6 +373,59 @@ test("group_suggestions", () => {
     suggestions = get_suggestions(query);
     expected = [];
     assert.deepEqual(suggestions, expected);
+});
+
+test("group_channel_suggestions", ({override}) => {
+    override(stream_topic_history_util, "get_server_history", noop);
+    override(narrow_state, "stream_id", noop);
+
+    const devel_id = 1001;
+    const office_id = 1002;
+    const support_id = 1003;
+    stream_data.add_sub_for_tests(
+        make_stream({
+            stream_id: devel_id,
+            name: "devel",
+            subscribed: true,
+        }),
+    );
+    stream_data.add_sub_for_tests(
+        make_stream({
+            stream_id: office_id,
+            name: "office",
+            subscribed: true,
+        }),
+    );
+    stream_data.add_sub_for_tests(
+        make_stream({
+            stream_id: support_id,
+            name: "support",
+            subscribed: true,
+        }),
+    );
+
+    // Adding a second channel should transition channel -> channels.
+    let suggestions = get_suggestions("off", `channel:${devel_id}`);
+    assert.ok(suggestions.includes(`channels:${devel_id},${office_id}`));
+    assert.ok(!suggestions.includes(`channel:${devel_id} channels:${devel_id},${office_id}`));
+
+    // Adding a third channel should keep channels operator and replace the last pill.
+    suggestions = get_suggestions("sup", `channels:${devel_id},${office_id}`);
+    assert.ok(suggestions.includes(`channels:${devel_id},${office_id},${support_id}`));
+
+    // channels:public is a separate category; it should not get grouped channel suggestions.
+    suggestions = get_suggestions("off", "channels:public");
+    assert.ok(
+        !suggestions.some((suggestion) => suggestion.includes(`channels:public,${office_id}`)),
+    );
+
+    // Invalid grouped channel operand should not produce malformed grouped suggestions.
+    suggestions = get_suggestions("off", `channels:${devel_id},foo`);
+    assert.ok(
+        !suggestions.some(
+            (suggestion) => suggestion.startsWith("channels:") && suggestion.includes(",foo"),
+        ),
+    );
 });
 
 test("empty_query_suggestions", () => {

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -531,6 +531,21 @@ test("basics", () => {
     ]);
 });
 
+test("get_by_id_string", () => {
+    const denmark = {
+        name: "Denmark",
+        stream_id: 1,
+        subscribed: true,
+    };
+    stream_data.add_sub_for_tests(denmark);
+
+    assert.equal(stream_data.get_sub_by_id_string("1"), denmark);
+    assert.equal(stream_data.get_sub_by_id_string("99"), undefined);
+
+    assert.equal(stream_data.get_valid_sub_by_id_string("1"), denmark);
+    assert.throws(() => stream_data.get_valid_sub_by_id_string("99"));
+});
+
 test("get_streams_for_user", async ({override}) => {
     channel.get = (payload) =>
         payload.success({

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -483,6 +483,25 @@ class NarrowBuilder:
         cond = column("recipient_id", Integer) == recipient_id
         return query.where(maybe_negate(cond))
 
+    @staticmethod
+    def parse_channels_id_operand(operand: str) -> list[int]:
+        channel_id_strings = [s.strip() for s in operand.split(",")]
+        if len(channel_id_strings) < 2:
+            raise BadNarrowOperatorError("channels requires at least 2 channel IDs")
+        if any(channel_id_string == "" for channel_id_string in channel_id_strings):
+            raise BadNarrowOperatorError("channels contains invalid channel IDs")
+
+        channel_ids: list[int] = []
+        for channel_id_string in channel_id_strings:
+            if not channel_id_string.isdigit():
+                raise BadNarrowOperatorError("channels contains invalid channel IDs")
+            channel_ids.append(int(channel_id_string))
+
+        if len(set(channel_ids)) != len(channel_ids):
+            raise BadNarrowOperatorError("channels contains duplicate channel IDs")
+
+        return channel_ids
+
     def by_channels(self, query: Select, operand: str, maybe_negate: ConditionTransform) -> Select:
         self.check_not_both_channel_and_dm_narrow(maybe_negate, is_channel_narrow=True)
 
@@ -490,13 +509,30 @@ class NarrowBuilder:
             # Get all both subscribed and non-subscribed public channels
             # but exclude any private subscribed channels.
             recipient_queryset = get_public_streams_queryset(self.realm)
+            recipient_ids = recipient_queryset.values_list("recipient_id", flat=True).order_by("id")
+            cond = column("recipient_id", Integer).in_(recipient_ids)
+            return query.where(maybe_negate(cond))
         elif operand == "web-public":
             recipient_queryset = get_web_public_streams_queryset(self.realm)
-        else:
-            raise BadNarrowOperatorError("unknown channels operand " + operand)
+            recipient_ids = recipient_queryset.values_list("recipient_id", flat=True).order_by("id")
+            cond = column("recipient_id", Integer).in_(recipient_ids)
+            return query.where(maybe_negate(cond))
 
-        recipient_ids = recipient_queryset.values_list("recipient_id", flat=True).order_by("id")
-        cond = column("recipient_id", Integer).in_(recipient_ids)
+        channel_ids = self.parse_channels_id_operand(operand)
+
+        channel_recipient_ids: list[int] = []
+        for channel_id in channel_ids:
+            try:
+                channel = get_stream_by_narrow_operand_access_unchecked(channel_id, self.realm)
+            except Stream.DoesNotExist:
+                raise BadNarrowOperatorError("unknown channel " + str(channel_id))
+            if self.is_web_public_query and not channel.is_web_public:
+                raise BadNarrowOperatorError("unknown web-public channel " + str(channel_id))
+            recipient_id = channel.recipient_id
+            assert recipient_id is not None
+            channel_recipient_ids.append(recipient_id)
+
+        cond = column("recipient_id", Integer).in_(channel_recipient_ids)
         return query.where(maybe_negate(cond))
 
     def by_topic(self, query: Select, operand: str, maybe_negate: ConditionTransform) -> Select:
@@ -848,6 +884,16 @@ def ok_to_include_history(
                 and user_profile.can_access_public_streams()
             ):
                 include_history = True
+            elif term.operator in channels_operators and not term.negated and "," in term.operand:
+                try:
+                    channel_ids = NarrowBuilder.parse_channels_id_operand(term.operand)
+                except BadNarrowOperatorError:
+                    include_history = False
+                    continue
+                include_history = all(
+                    can_access_stream_history_by_id(user_profile, channel_id)
+                    for channel_id in channel_ids
+                )
         # Disable historical messages if the user is narrowing on anything
         # that's a property on the UserMessage table.  There cannot be
         # historical messages in these cases anyway.
@@ -1129,6 +1175,8 @@ def add_narrow_conditions(
     if narrow is None:
         return (query, is_search, False)
 
+    validate_channel_category_narrow(narrow)
+
     # Build the query for the narrow
     builder = NarrowBuilder(user_profile, inner_msg_id_col, realm, is_web_public_query)
     search_operands = []
@@ -1172,6 +1220,31 @@ def add_narrow_conditions(
         query = builder.add_term(query, search_term)
 
     return (query, is_search, builder.is_dm_narrow)
+
+
+def validate_channel_category_narrow(narrow: list[NarrowParameter]) -> None:
+    # Enforce that channel category operators are not mixed in one narrow.
+    # The allowed positive categories are:
+    # - single channel (`channel`)
+    # - multiple channels (`channels` with comma-separated IDs)
+    # - `channels:public`
+    # - `channels:web-public`
+    positive_single_channel_terms = 0
+    positive_channels_terms = 0
+    for term in narrow:
+        if term.negated:
+            continue
+        if term.operator in channel_operators:
+            positive_single_channel_terms += 1
+        elif term.operator in channels_operators:
+            positive_channels_terms += 1
+
+    if positive_single_channel_terms > 0 and positive_channels_terms > 0:
+        raise BadNarrowOperatorError("channel and channels operators cannot be combined")
+    if positive_single_channel_terms > 1:
+        raise BadNarrowOperatorError("only one channel operator is allowed")
+    if positive_channels_terms > 1:
+        raise BadNarrowOperatorError("only one channels operator is allowed")
 
 
 def find_first_unread_anchor(
@@ -1512,6 +1585,9 @@ def fetch_messages(
     num_after: int,
     client_requested_message_ids: list[int] | None = None,
 ) -> FetchedMessages:
+    if narrow is not None:
+        validate_channel_category_narrow(narrow)
+
     if access_narrow(user_profile, narrow, is_web_public_query, realm) is False:
         # If user is requesting messages from a narrow they don't have
         # access to, do an early return.

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -37,6 +37,7 @@ from zerver.lib.narrow import (
     BadNarrowOperatorError,
     NarrowBuilder,
     NarrowParameter,
+    access_narrow,
     add_narrow_conditions,
     exclude_muting_conditions,
     find_first_unread_anchor,
@@ -150,6 +151,55 @@ class NarrowBuilderTest(ZulipTestCase):
     ) -> None:  # NEGATED
         term = NarrowParameter(operator="channels", operand="invalid_operands")
         self.assertRaises(BadNarrowOperatorError, self._build_query, term)
+
+    def test_add_term_using_channels_operator_and_multi_channel_ids(self) -> None:
+        scotland = get_stream("Scotland", self.realm)
+        verona = get_stream("Verona", self.realm)
+        term = NarrowParameter(operator="channels", operand=f"{scotland.id},{verona.id}")
+        self._do_add_term_test(term, "WHERE recipient_id IN (__[POSTCOMPILE_recipient_id_1])")
+
+    def test_add_term_using_channels_operator_and_single_channel_id_should_raise_error(
+        self,
+    ) -> None:
+        scotland = get_stream("Scotland", self.realm)
+        term = NarrowParameter(operator="channels", operand=str(scotland.id))
+        self.assertRaises(BadNarrowOperatorError, self._build_query, term)
+
+    def test_add_term_using_channels_operator_and_malformed_ids_should_raise_error(self) -> None:
+        malformed_operands = [
+            "1,foo",
+            "1,,2",
+            " 1 , , 2 ",
+        ]
+        for operand in malformed_operands:
+            term = NarrowParameter(operator="channels", operand=operand)
+            self.assertRaises(BadNarrowOperatorError, self._build_query, term)
+
+    def test_add_term_using_channels_operator_and_duplicate_ids_should_raise_error(self) -> None:
+        scotland = get_stream("Scotland", self.realm)
+        term = NarrowParameter(operator="channels", operand=f"{scotland.id},{scotland.id}")
+        self.assertRaises(BadNarrowOperatorError, self._build_query, term)
+
+    def test_add_term_using_channels_operator_and_unknown_id_should_raise_error(self) -> None:
+        scotland = get_stream("Scotland", self.realm)
+        unknown_channel_id = 999999
+        term = NarrowParameter(operator="channels", operand=f"{scotland.id},{unknown_channel_id}")
+        self.assertRaises(BadNarrowOperatorError, self._build_query, term)
+
+    def test_add_term_using_channels_operator_in_web_public_query(self) -> None:
+        web_public_channel = self.make_stream("web_public_for_channels", is_web_public=True)
+        private_channel = self.make_stream("non_web_public_for_channels")
+        web_public_builder = NarrowBuilder(
+            user_profile=None,
+            msg_id_column=column("id", Integer),
+            realm=self.realm,
+            is_web_public_query=True,
+        )
+        term = NarrowParameter(
+            operator="channels",
+            operand=f"{web_public_channel.id},{private_channel.id}",
+        )
+        self.assertRaises(BadNarrowOperatorError, web_public_builder.add_term, self.raw_query, term)
 
     def test_add_term_using_channels_operator_and_public_operand(self) -> None:
         term = NarrowParameter(operator="channels", operand="public")
@@ -1333,6 +1383,27 @@ class IncludeHistoryTest(ZulipTestCase):
         ]
         self.assertTrue(ok_to_include_history(narrow, user_profile, False))
 
+        public_channel_1 = get_stream("public_channel", user_profile.realm)
+        public_channel_2 = self.make_stream(
+            "public_channel_multi_history", realm=user_profile.realm
+        )
+        narrow = [
+            NarrowParameter(
+                operator="channels",
+                operand=f"{public_channel_1.id},{public_channel_2.id}",
+            ),
+        ]
+        self.assertTrue(ok_to_include_history(narrow, user_profile, False))
+
+        private_channel_no_history = get_stream("private_channel", user_profile.realm)
+        narrow = [
+            NarrowParameter(
+                operator="channels",
+                operand=f"{public_channel_1.id},{private_channel_no_history.id}",
+            ),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+
         narrow = [
             NarrowParameter(operator="channel", operand="public_channel"),
             NarrowParameter(operator="topic", operand="whatever"),
@@ -2224,7 +2295,7 @@ class GetOldMessagesTest(ZulipTestCase):
         result = self.client_get("/json/messages", dict(non_web_public_channel_get_params))
         self.check_unauthenticated_response(result)
 
-        # Verify that same request would work with channels:web-public added.
+        # Mixing channels:web-public with a specific channel is invalid.
         rome_web_public_get_params: dict[str, int | str | bool] = {
             **get_params,
             "narrow": orjson.dumps(
@@ -2236,9 +2307,13 @@ class GetOldMessagesTest(ZulipTestCase):
             ).decode(),
         }
         result = self.client_get("/json/messages", dict(rome_web_public_get_params))
-        self.assert_json_success(result)
+        self.assert_json_error(
+            result,
+            "Invalid narrow operator: channel and channels operators cannot be combined",
+            status_code=400,
+        )
 
-        # Cannot access non-web-public channel even with channels:web-public narrow.
+        # Non-web-public channel in mixed channel-category narrow is also invalid.
         scotland_web_public_get_params: dict[str, int | str | bool] = {
             **get_params,
             "narrow": orjson.dumps(
@@ -2251,7 +2326,9 @@ class GetOldMessagesTest(ZulipTestCase):
         }
         result = self.client_get("/json/messages", dict(scotland_web_public_get_params))
         self.assert_json_error(
-            result, "Invalid narrow operator: unknown web-public channel Scotland", status_code=400
+            result,
+            "Invalid narrow operator: channel and channels operators cannot be combined",
+            status_code=400,
         )
 
     def test_get_message_ids(self) -> None:
@@ -2409,7 +2486,7 @@ class GetOldMessagesTest(ZulipTestCase):
             self.assertEqual(msg["sender_email"], sender.email)
             self.assertEqual(msg["avatar_url"], avatar_url(sender))
 
-    def test_unauthenticated_narrow_to_web_public_channels(self) -> None:
+    def test_unauthenticated_invalid_mixed_web_public_narrow(self) -> None:
         self.setup_web_public_test()
 
         post_params: dict[str, int | str | bool] = {
@@ -2424,7 +2501,11 @@ class GetOldMessagesTest(ZulipTestCase):
             ).decode(),
         }
         result = self.client_get("/json/messages", dict(post_params))
-        self.verify_web_public_query_result_success(result, 1)
+        self.assert_json_error(
+            result,
+            "Invalid narrow operator: channel and channels operators cannot be combined",
+            status_code=400,
+        )
 
     def test_get_messages_with_web_public(self) -> None:
         """
@@ -3064,8 +3145,8 @@ class GetOldMessagesTest(ZulipTestCase):
         for msg in results["messages"]:
             self.assertIn(msg["id"], msg_ids)
 
-        # Test `with` operator effective with spectator access when
-        # spectator has access to message.
+        # Test `with` operator mixed with channels:web-public is rejected due
+        # channel-category exclusivity.
         self.logout()
         self.setup_web_public_test(5)
         channel = get_stream("web-public-channel", realm)
@@ -3089,11 +3170,14 @@ class GetOldMessagesTest(ZulipTestCase):
         }
 
         result = self.client_get("/json/messages", dict(post_params))
-        self.verify_web_public_query_result_success(result, 5)
+        self.assert_json_error(
+            result,
+            "Invalid narrow operator: channel and channels operators cannot be combined",
+            status_code=400,
+        )
 
-        # Test `with` operator ineffective when spectator does not have
-        # access to message, by trying to access the same set of messages
-        # but when the spectator access is not allowed.
+        # If spectator access is disabled, request should still be rejected
+        # as unauthenticated.
         do_set_realm_property(hamlet.realm, "enable_spectator_access", False, acting_user=hamlet)
 
         result = self.client_get("/json/messages", dict(post_params))
@@ -4094,8 +4178,8 @@ class GetOldMessagesTest(ZulipTestCase):
     def test_invalid_narrow_operand_in_dict(self) -> None:
         self.login("hamlet")
 
-        # str or int is required for "id", "sender", "channel", "dm-including" and "group-pm-with"
-        # operators
+        # str or int is required for "id", "sender", "channel", "dm-including" and
+        # "group-pm-with" operators.
         invalid_operands: list[InvalidParam] = [
             InvalidParam(value=["1"], expected_error="operand is not a string or integer"),
             InvalidParam(value=["2"], expected_error="operand is not a string or integer"),
@@ -4139,6 +4223,53 @@ class GetOldMessagesTest(ZulipTestCase):
         # Disallow empty search terms
         invalid_operands = [InvalidParam(value="", expected_error="operand cannot be blank.")]
         self.exercise_bad_narrow_operand_using_dict_api("search", invalid_operands)
+
+    def test_channel_category_mixing_in_narrow(self) -> None:
+        self.login("hamlet")
+
+        narrow = [
+            dict(operator="channel", operand="Scotland"),
+            dict(operator="channels", operand="public"),
+        ]
+        params = dict(anchor=0, num_before=0, num_after=0, narrow=orjson.dumps(narrow).decode())
+        result = self.client_get("/json/messages", params)
+        self.assert_json_error_contains(
+            result, "Invalid narrow operator: channel and channels operators cannot be combined"
+        )
+
+        narrow = [
+            dict(operator="channels", operand="public"),
+            dict(operator="channels", operand="web-public"),
+        ]
+        params = dict(anchor=0, num_before=0, num_after=0, narrow=orjson.dumps(narrow).decode())
+        result = self.client_get("/json/messages", params)
+        self.assert_json_error_contains(
+            result, "Invalid narrow operator: only one channels operator is allowed"
+        )
+
+        narrow = [
+            dict(operator="channel", operand="Scotland"),
+            dict(operator="channel", operand="Verona"),
+        ]
+        params = dict(anchor=0, num_before=0, num_after=0, narrow=orjson.dumps(narrow).decode())
+        result = self.client_get("/json/messages", params)
+        self.assert_json_error_contains(
+            result, "Invalid narrow operator: only one channel operator is allowed"
+        )
+
+    def test_invalid_channels_id_operands(self) -> None:
+        self.login("hamlet")
+        malformed_operands = [
+            ("1,foo", "Invalid narrow operator: channels contains invalid channel IDs"),
+            ("1,,2", "Invalid narrow operator: channels contains invalid channel IDs"),
+            ("1,1", "Invalid narrow operator: channels contains duplicate channel IDs"),
+        ]
+
+        for operand, expected_error in malformed_operands:
+            narrow = [dict(operator="channels", operand=operand)]
+            params = dict(anchor=0, num_before=0, num_after=0, narrow=orjson.dumps(narrow).decode())
+            result = self.client_get("/json/messages", params)
+            self.assert_json_error_contains(result, expected_error)
 
     # The exercise_bad_narrow_operand helper method uses legacy tuple format to
     # test bad narrow, this method uses the current dict API format
@@ -5534,29 +5665,43 @@ WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.
         )
         self.assertGreater(len(result["messages"]), 0)
 
-    def test_multiple_channel_terms_early_return(self) -> None:
-        """Test that multiple channel terms trigger early return with no messages."""
+    def test_multiple_channel_terms_invalid(self) -> None:
+        """Test that multiple positive channel terms are rejected."""
         hamlet = self.example_user("hamlet")
         self.login_user(hamlet)
 
-        # Multiple channel terms with AND logic will never match any messages,
-        # so we should get an early return with no messages.
-        with mock.patch(
-            "zerver.lib.narrow.get_base_query_for_search",
-        ) as mocked_get_base_query_for_search:
-            narrow = [
-                {"operator": "channel", "operand": "Verona"},
-                {"operator": "channel", "operand": "Scotland"},
-            ]
-            result = self.get_and_check_messages(
-                dict(
-                    narrow=orjson.dumps(narrow).decode(),
-                    anchor=LARGER_THAN_MAX_MESSAGE_ID,
-                ),
-                expected_status=200,
-            )
-            mocked_get_base_query_for_search.assert_not_called()
-            self.assert_length(result["messages"], 0)
+        narrow = [
+            {"operator": "channel", "operand": "Verona"},
+            {"operator": "channel", "operand": "Scotland"},
+        ]
+        result = self.client_get(
+            "/json/messages",
+            dict(
+                narrow=orjson.dumps(narrow).decode(),
+                anchor=LARGER_THAN_MAX_MESSAGE_ID,
+                num_before=0,
+                num_after=0,
+            ),
+        )
+        self.assert_json_error_contains(
+            result, "Invalid narrow operator: only one channel operator is allowed"
+        )
+
+    def test_access_narrow_multiple_channel_terms_returns_false(self) -> None:
+        hamlet = self.example_user("hamlet")
+        narrow = [
+            NarrowParameter(operator="channel", operand="Verona"),
+            NarrowParameter(operator="channel", operand="Scotland"),
+        ]
+        self.assertIs(
+            access_narrow(
+                maybe_user_profile=hamlet,
+                narrow=narrow,
+                is_web_public_query=False,
+                realm=hamlet.realm,
+            ),
+            False,
+        )
 
     def test_deactivated_channel_access_narrow(self) -> None:
         """Test that access_narrow works with deactivated channels."""


### PR DESCRIPTION
## What does this PR do?

This PR introduces multi-channel message narrowing using a dedicated `channels:` operator with comma-separated channel IDs (e.g. `channels:1,2,3`), while keeping `channel:` as the canonical single-channel operator.

It mirrors the interaction model users already know from grouped `dm:` behavior:

- Add one channel → `channel:...`
- Add a second channel → automatically transitions to `channels:...`
- Remove back to one channel → automatically downgrades to `channel:...`

The goal is to let users aggregate messages across multiple channels while keeping URL state, UI state, and backend validation strictly aligned and canonical.

---

## Summary

Users can now search across multiple channels in one narrow, with consistent behavior across:

- URL parsing and canonicalization  
- Search pill state and suggestions  
- Backend validation and query building  
- Message view presentation  

Single-channel behavior remains unchanged and fully canonical.

---

## URL Format and Canonicalization

This PR enforces strict, single representations for each state.

### Single Channel (Canonical)

| Context | Format |
|----------|---------|
| Narrow syntax | `channel:<id>` |
| URL format | `/#narrow/channel/<id>-<slug>` |
| View behavior | Dedicated channel header shown |

Single-channel behavior is unchanged.

---

### Multiple Channels (Canonical)

| Context | Format |
|----------|---------|
| Narrow syntax | `channels:<id,id,...>` |
| URL format | `/#narrow/channels/<id,id,...>` |
| View behavior | Standard search view (no single-channel header) |

**Notes:**

- Uses plural `channels`
- Comma-separated numeric IDs
- No slug in multi-channel URL
- Exactly one canonical representation

---

## Automatic Downgrade Behavior

If a user manually enters:

`/#narrow/channels/1`

It automatically redirects to:

`/#narrow/channel/1-<slug>`

---

## Architecture (High-Level)

The implementation is intentionally split into four layers so behavior stays predictable and easy to maintain:

1. Canonical URL + Parser Layer  
Ensures single-channel and multi-channel states have one canonical form each, and rejects invalid legacy forms.

2. Filter / State Layer  
Keeps narrow state semantics correct (`channel` vs `channels`) and prevents mixed or ambiguous states.

3. Search Bar Pills + Suggestions Layer  
Handles UI transitions (single ↔ multi), rendering, and strict operand normalization.

4. Backend Validation + Query Layer  
Enforces channel-category exclusivity and validates all channel IDs before building SQL conditions and history-access checks.

This keeps UX, URL state, and backend behavior in lockstep.

---

## Edge Cases Handled

| Scenario | Behavior |
|----------|----------|
| Single-channel narrow | Remains `channel:<id>` and `/channel/<id>-<slug>` |
| Multi-channel narrow | Uses `channels:<id,id,...>` and `/channels/<id,id,...>` |
| Manual `/channels/1` | Redirects to canonical single-channel URL |
| `channel` + `channels` combined | Rejected |
| Multiple positive channel-category terms | Rejected |
| `channel:1,2,3` legacy-style operand | Not supported (must use `channels:`) |
| Empty tokens (`channels:1,,2`) | Rejected |
| Non-numeric IDs | Rejected |
| Duplicate IDs | Rejected |
| Unknown or inaccessible channel IDs | Rejected |
| Multi-channel view header | No single-channel header shown |
| Composition with other operators (e.g. `is:muted`) | Preserved and safe |
| History access checks | Evaluated across all listed channels |

---

## Visuals

### Multi-channel narrow in the search bar

<img width="807" height="82" alt="Screenshot 2026-02-25 at 1 26 52 AM" src="https://github.com/user-attachments/assets/f497ddd1-852e-4541-a0dd-8e0607fafed8" />


### Channel pills in the search bar with suggestion with already multiple pills and also with just single pill

<img width="746" height="288" alt="Screenshot 2026-02-25 at 1 27 34 AM" src="https://github.com/user-attachments/assets/f3748a4c-adb1-4a4c-bf24-a58553c423b5" />
<img width="746" height="288" alt="Screenshot 2026-02-25 at 1 27 28 AM" src="https://github.com/user-attachments/assets/53ff74e1-764d-45e2-977c-d0fda8dd1d7e" />

### Aggregated message view (no single-channel header)

<img width="917" height="790" alt="Screenshot 2026-02-25 at 1 28 06 AM" src="https://github.com/user-attachments/assets/e7b0420d-f541-4f8c-8f0c-944cc88cabe7" />


---

## Community Discussion

- [#user questions > search in two or more channels](https://chat.zulip.org/#narrow/channel/138-user-questions/topic/search.20in.20two.20or.20more.20channels/with/2389519)
- [#api design > multiple channel search](https://chat.zulip.org/#narrow/channel/378-api-design/topic/multiple.20channel.20search/with/2367078)
- [#design > Multi-channel search UI behaviour](https://chat.zulip.org/#narrow/channel/101-design/topic/Multi-channel.20search.20UI.20behaviour/with/2382500)

---

<details>
<summary><strong>Self-review checklist</strong></summary>

- [x] Self-reviewed the changes for clarity and maintainability  
- [x] Followed the AI use policy  
- [x] Communicated decisions, questions, and potential concerns  

### Design & implementation notes
- [x] Explained differences from previous plans  
- [x] Highlighted technical choices and bugs encountered  
- [x] Called out remaining decisions and concerns  

### Testing
- [x] Automated tests verify logic where appropriate  

### Commit discipline
- [x] Individual commits are ready for review  
- [x] Each commit is a coherent idea  
- [x] Commit messages explain reasoning and motivation  

### Manual review completed
- [x] Visual appearance of the changes  
- [x] Responsiveness and internationalization  
- [x] Strings and tooltips  
- [x] End-to-end functionality of buttons, interactions, and flows  
- [x] Corner cases, error conditions, and easily imagined bugs  

</details>

---

**Fixes #33343**