### PR TITLE
hotkeys: Generalize input handling in recent topics view.

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -846,6 +846,24 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
         case "open_recent_view":
             if (recent_view_ui.is_in_focus()) {
                 assert(e.target instanceof HTMLElement);
+                const $target = $(e.target);
+
+                if ($target.is("input, textarea")) {
+                    // Differentiating between typing and navigating keys
+                    const navigation_keys = new Set([
+                        "ArrowUp",
+                        "ArrowDown",
+                        "ArrowLeft",
+                        "ArrowRight",
+                        "Escape",
+                        "Enter",
+                        "Tab",
+                    ]);
+
+                    if (!navigation_keys.has(e.key)) {
+                        return false;
+                    }
+                }
                 return recent_view_ui.change_focused_element($(e.target), event_name);
             }
     }

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1683,12 +1683,7 @@ export function change_focused_element($elt: JQuery, input_key: string): boolean
         switch (input_key) {
             //  Allow browser to handle all
             //  character keypresses.
-            case "vim_left":
-            case "vim_right":
-            case "vim_down":
-            case "vim_up":
-            case "open_recent_view":
-                return false;
+
             case "left_arrow":
                 if (start !== 0 || is_selected) {
                     return false;


### PR DESCRIPTION
<!-- Describe your pull request here.-->
As mentioned in the issue every single key press of Recent Conversations had to be passed to recent_view_ui.ts , instead of being handled directly be the hotkey.ts file. When a click consisted of a hotkey , it had to be passed to recent_view_ui.ts along with a hardcoded check which classifies if the element from where the click has been initiated is a text element or not . If it is a text element then hotkeys are treated as String (eg: j, k, h, l).Now this has been replaced by introducing a dynamic check in hotkey.ts file. 

 -If it's a typing key (like 'j', 'k', 'r', etc.), the hotkey.ts lets the browser handle it as normal text input. This is what allows typing in any text box.

 -If it's a navigation key (ArrowDown, Escape, etc.), the hotkey.ts allows it to pass through to recent_view_ui.ts,  which already has the correct logic to handle moving focus between elements.

Fixes: <!-- Issue link, or clear description.-->#21858

**How changes were tested:**
-Created a new temporary adjacent input field near the filter field (using browzer inspect tools) and tested specific keys which are also used for navigation(h,j,k,l).
-Made sure hotkeys were not disabled outside of textarea.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Untitled design](https://github.com/user-attachments/assets/754333e3-ccc6-4d3d-82a1-2f905b06c45a)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
