### PR TITLE
Fix rate limiting for /emails/generate in dev environments

### DIFF
--- a/zerver/views/development/email_log.py
+++ b/zerver/views/development/email_log.py
@@ -70,35 +70,31 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
 
     # Password reset emails
     # active account in realm
-    result = client.post(
-        "/accounts/password/reset/", {"email": registered_email}, HTTP_HOST=realm.host
+    result = client.post("/accounts/password/reset/", {"client": "internal", "email": registered_email}, HTTP_HOST=realm.host
     )
     assert result.status_code == 302
     # deactivated user
     change_user_is_active(user, False)
-    result = client.post(
-        "/accounts/password/reset/", {"email": registered_email}, HTTP_HOST=realm.host
+    result = client.post("/accounts/password/reset/", {"client": "internal", "email": registered_email}, HTTP_HOST=realm.host
     )
     assert result.status_code == 302
     change_user_is_active(user, True)
     # account on different realm
     assert other_realm is not None
-    result = client.post(
-        "/accounts/password/reset/", {"email": registered_email}, HTTP_HOST=other_realm.host
+    result = client.post("/accounts/password/reset/", {"client": "internal", "email": registered_email}, HTTP_HOST=other_realm.host
     )
     assert result.status_code == 302
     # no account anywhere
-    result = client.post(
-        "/accounts/password/reset/", {"email": unregistered_email_1}, HTTP_HOST=realm.host
+    result = client.post("/accounts/password/reset/", {"client": "internal", "email": unregistered_email_1}, HTTP_HOST=realm.host
     )
     assert result.status_code == 302
 
     # Confirm account email
-    result = client.post("/accounts/home/", {"email": unregistered_email_1}, HTTP_HOST=realm.host)
+    result = client.post("/accounts/home/", {"client": "internal", "email": unregistered_email_1}, HTTP_HOST=realm.host)
     assert result.status_code == 302
 
     # Find account email
-    result = client.post("/accounts/find/", {"emails": registered_email}, HTTP_HOST=realm.host)
+    result = client.post("/accounts/find/", {"client": "internal", "emails": registered_email}, HTTP_HOST=realm.host)
     assert result.status_code == 200
 
     # New login email
@@ -110,6 +106,7 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
     result = client.post(
         "/json/invites",
         {
+            "client": "internal",
             "invitee_emails": unregistered_email_2,
             "invite_expires_in_minutes": invite_expires_in_minutes,
             "stream_ids": orjson.dumps([stream.id]).decode(),
@@ -121,7 +118,7 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
     # Verification for new email
     result = client.patch(
         "/json/settings",
-        urlencode({"email": "hamlets-new@zulip.com"}),
+        urlencode({"client": "internal", "email": "hamlets-new@zulip.com"}),
         content_type="application/x-www-form-urlencoded",
         HTTP_HOST=realm.host,
     )
@@ -130,7 +127,7 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
     # Email change successful
     key = Confirmation.objects.filter(type=Confirmation.EMAIL_CHANGE).latest("id").confirmation_key
     user_profile = get_user_by_delivery_email(registered_email, realm)
-    result = client.post("/accounts/confirm_new_email/", {"key": key})
+    result = client.post("/accounts/confirm_new_email/", {"client": "internal", "key": key})
     assert result.status_code == 200
 
     # Reset the email value so we can run this again


### PR DESCRIPTION
Add 'client': 'internal' parameter to test Client requests so they are exempt from rate limiting in development environments.

Fixes: #27336

**How changes were tested:**
Manually tested by running the `/emails/generate` endpoint in a local development environment. Verified that all requests complete successfully without rate limiting errors.

**Screenshots and screen captures:**
N/A - Backend fix only, no UI changes.

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the AI use policy.

Communicate decisions, questions, and potential concerns.
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.

- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see commit discipline).
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>