### PR TITLE
flatpickr: Replace library with native datetime-local picker

### DIFF
--- a/web/src/compose_send_menu_popover.ts
+++ b/web/src/compose_send_menu_popover.ts
@@ -96,19 +96,19 @@ export function open_schedule_message_menu(
             };
             $popper.on("click", ".send_later_custom", (e) => {
                 const current_time = new Date();
-    
+
                 // Hide the popover before showing the date picker
                 popover_menus.hide_current_popover_if_visible(instance);
-    
+
                 // Try to find the schedule button - it might have different selectors
                 let reference_element = document.querySelector(".send_later");
-    
+
                 // If not found, try the message send controls area
                 reference_element ??= document.querySelector("#compose-send-button");
-    
+
                 // If still not found, use the compose textarea as fallback
                 reference_element ??= document.querySelector("#compose-textarea");
-    
+
                 // Final fallback - use body and center the picker
                 let final_element: HTMLElement;
                 if (reference_element instanceof HTMLElement) {
@@ -127,13 +127,13 @@ export function open_schedule_message_menu(
                         minDate: new Date(
                             current_time.getTime() +
                                 scheduled_messages.MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS * 1000,
-                            ),
-                        },
-                    );
-    
-                    e.preventDefault();
-                    e.stopPropagation();
-                });
+                        ),
+                    },
+                );
+
+                e.preventDefault();
+                e.stopPropagation();
+            });
             $popper.one(
                 "click",
                 ".send_later_today, .send_later_tomorrow, .send_later_monday",

--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -450,7 +450,7 @@ export function initialize(): void {
                 },
             );
         } else {
-            flatpickr.flatpickr_instance?.close();
+            flatpickr.close_all();
         }
     });
 

--- a/web/src/flatpickr.ts
+++ b/web/src/flatpickr.ts
@@ -6,13 +6,13 @@ import {$t} from "./i18n.ts";
 // Keep a reference to the current picker state
 let current_picker_state:
     | {
-          container: JQuery<HTMLElement>;
+          container: JQuery;
           input: JQuery<HTMLInputElement>;
           callback: (time: string) => void;
       }
     | undefined;
 
-// For backwards compatibility - some code might reference this
+// For backwards compatibility
 export const flatpickr_instance = undefined;
 
 export function is_open(): boolean {
@@ -29,7 +29,6 @@ export function show_flatpickr(
         ignoredFocusElements?: unknown[];
     },
 ): {close: () => void; destroy: () => void} {
-    // Provide default empty object if options is undefined
     const opts = options ?? {};
 
     // Close any existing picker first
@@ -37,14 +36,11 @@ export function show_flatpickr(
         close_picker();
     }
 
-    // Convert default_timestamp to Date object
     const default_date = new Date(default_timestamp);
-    
-    // Convert minDate if provided
     const min_date = opts.minDate ? new Date(opts.minDate) : undefined;
 
-    // Format date for datetime-local input (YYYY-MM-DDTHH:MM)
-    const format_for_input = (date: Date): string => {
+    // Format date for datetime-local input (YYYY-MM-DDTHH:mm)
+    const format_datetime_local = (date: Date): string => {
         const year = date.getFullYear();
         const month = String(date.getMonth() + 1).padStart(2, "0");
         const day = String(date.getDate()).padStart(2, "0");
@@ -53,84 +49,83 @@ export function show_flatpickr(
         return `${year}-${month}-${day}T${hours}:${minutes}`;
     };
 
-    // Create the native datetime picker
-    const $input = $<HTMLInputElement>("<input>")
+    // Create the native datetime-local picker
+    const $datetime_input = $<HTMLInputElement>("<input>")
         .attr("type", "datetime-local")
         .attr("id", "native-datetime-picker")
-        .val(format_for_input(default_date))
+        .val(format_datetime_local(default_date))
         .css({
             width: "100%",
-            padding: "8px",
+            padding: "10px",
             "font-size": "14px",
-            border: "1px solid hsl(0deg 0% 80%)",
+            border: "1px solid var(--color-border, hsl(0deg 0% 80%))",
             "border-radius": "4px",
             "box-sizing": "border-box",
+            "margin-bottom": "12px",
         });
 
     if (min_date) {
-        $input.attr("min", format_for_input(min_date));
+        $datetime_input.attr("min", format_datetime_local(min_date));
     }
 
-    // Create container for the picker UI
-    const $container = $("<div>")
-        .attr("id", "native-datetime-container")
-        .css({
-            position: "absolute",
-            "z-index": "1000",  // Changed from 105 to 1000
-            background: "hsl(0deg 0% 100%)",
-            padding: "16px",
-            "border-radius": "4px",
-            "box-shadow": "0 2px 8px rgba(0, 0, 0, 0.15)",
-            border: "1px solid hsl(0deg 0% 87%)",
-            "min-width": "280px",
-        });
+    // Create container
+    const $container = $("<div>").attr("id", "native-datetime-container").css({
+        position: "absolute",
+        "z-index": "1000",
+        background: "var(--color-background-modal, hsl(0deg 0% 100%))",
+        padding: "16px",
+        "border-radius": "6px",
+        "box-shadow": "0 4px 20px rgba(0, 0, 0, 0.15)",
+        border: "1px solid var(--color-border, hsl(0deg 0% 87%))",
+        "min-width": "300px",
+    });
 
     // Create confirm button
     const $confirm_button = $("<button>")
-        .addClass("native-datetime-confirm")
+        .attr("type", "button")
         .text($t({defaultMessage: "Confirm"}))
         .css({
-            "margin-top": "10px",
-            padding: "8px 16px",
+            padding: "10px 16px",
             background: "hsl(213deg 100% 50%)",
-            color: "white",
+            color: "hsl(0deg 0% 100%)",
             border: "none",
             "border-radius": "4px",
             cursor: "pointer",
             width: "100%",
             "font-weight": "600",
+            "font-size": "14px",
+        })
+        .on("mouseenter", function () {
+            $(this).css("background", "hsl(213deg 100% 45%)");
+        })
+        .on("mouseleave", function () {
+            $(this).css("background", "hsl(213deg 100% 50%)");
         });
 
-    // Add input and button to container
-    $container.append($input).append($confirm_button);
+    $container.append($datetime_input).append($confirm_button);
     $("body").append($container);
 
-    // Position the container near the trigger element
+    // Position the container
     const position_picker = (): void => {
         const element_rect = element.getBoundingClientRect();
         const container_height = $container.outerHeight() ?? 0;
         const container_width = $container.outerWidth() ?? 0;
-    
-        // Position near the schedule button (clock icon) in the compose box
-        // Default to center-right of the screen if element position is invalid
+
         let top = element_rect.bottom + 5;
         let left = element_rect.left;
 
-        // If element has no valid position (0,0), center the picker
+        // Center if element has no position
         if (element_rect.top === 0 && element_rect.left === 0) {
             top = (window.innerHeight - container_height) / 2;
             left = (window.innerWidth - container_width) / 2;
         } else {
-            // Adjust if it goes off screen
+            // Position below element, adjust if off-screen
             if (top + container_height > window.innerHeight) {
                 top = element_rect.top - container_height - 5;
             }
-        
             if (left + container_width > window.innerWidth) {
                 left = window.innerWidth - container_width - 10;
             }
-        
-            // Ensure minimum margins
             if (left < 10) {
                 left = 10;
             }
@@ -145,33 +140,55 @@ export function show_flatpickr(
         });
     };
 
-    // Position after a short delay to allow popover to close
     setTimeout(() => {
         position_picker();
     }, 10);
 
-    position_picker();
+    // Open the native picker immediately
+    setTimeout(() => {
+        const input_element = $datetime_input[0];
+        if (input_element instanceof HTMLInputElement && input_element.showPicker) {
+            try {
+                input_element.showPicker();
+            } catch {
+                // showPicker() may fail in some contexts, just continue
+            }
+        }
+    }, 100);
 
     // Handle confirm button click
     $confirm_button.on("click", () => {
-        const value = $input.val();
-        if (typeof value === "string" && value) {
-            const selected_date = new Date(value);
-            
-            // Check if date is valid and meets min requirement
-            if (min_date && selected_date < min_date) {
-                // Could show error here, for now just return
-                return;
-            }
-            
-            const iso_time = formatISO(selected_date);
-            callback(iso_time);
-            close_picker();
+        const datetime_value = $datetime_input.val();
+
+        // Reset any error styling
+        $datetime_input.css("border-color", "var(--color-border, hsl(0deg 0% 80%))");
+
+        if (typeof datetime_value !== "string" || !datetime_value) {
+            $datetime_input.css("border-color", "hsl(3deg 90% 63%)");
+            return;
         }
+
+        const selected_date = new Date(datetime_value);
+
+        // Validate date
+        if (Number.isNaN(selected_date.getTime())) {
+            $datetime_input.css("border-color", "hsl(3deg 90% 63%)");
+            return;
+        }
+
+        // Check minimum date
+        if (min_date && selected_date < min_date) {
+            $datetime_input.css("border-color", "hsl(3deg 90% 63%)");
+            return;
+        }
+
+        const iso_time = formatISO(selected_date);
+        callback(iso_time);
+        close_picker();
     });
 
-    // Handle Enter key on input
-    $input.on("keydown", (e) => {
+    // Handle Enter key
+    $datetime_input.on("keydown", (e) => {
         if (e.key === "Enter") {
             e.preventDefault();
             $confirm_button.trigger("click");
@@ -199,22 +216,21 @@ export function show_flatpickr(
             !element.contains(target)
         ) {
             close_picker();
-    }
+        }
     });
 
     // Store current state
     current_picker_state = {
         container: $container,
-        input: $input,
+        input: $datetime_input,
         callback,
     };
 
     // Focus the input
     setTimeout(() => {
-        $input.trigger("focus");
+        $datetime_input.trigger("focus");
     }, 0);
 
-    // Return instance-like object
     return {
         close: close_picker,
         destroy: close_picker,


### PR DESCRIPTION
This PR replaces the flatpickr library with the browser's native datetime-local input as an experiment to see if native pickers work well enough across different browsers.

I kept the same `show_flatpickr()` API so nothing breaks for existing code that calls it. The native picker returns timestamps in the same format through the callback.

**What changed:**
- Replaced flatpickr with a styled native `<input type="datetime-local">`
- Added positioning logic to place the picker near the trigger element
- Fixed a positioning issue when the "Send later" popover closes before the picker opens
- Updated one API call from `flatpickr_instance?.close()` to `close_all()`

**Testing:**
I tested this on Firefox and Edge it works - the native picker opens, you can select a date/time, and messages get scheduled correctly. 

**Screenshots:**

Before (using flatpickr):
<img width="1426" height="721" alt="before-flatpickr-date" src="https://github.com/user-attachments/assets/a1fd294b-e34d-4e06-9e52-3bf3a555441c" />
<img width="1431" height="721" alt="edge" src="https://github.com/user-attachments/assets/831cbafd-a32c-40a8-8672-cf7b46f3b239" />
<img width="1385" height="719" alt="firefox" src="https://github.com/user-attachments/assets/48fb58ce-d75b-487d-a4cc-3e2183934830" />

These are the 3 Screenshot from three different browsers.
 
<img width="1174" height="854" alt="Screenshot 2026-01-14 190528" src="https://github.com/user-attachments/assets/3a1d3ea6-875f-47a9-bf62-3a474376568e" />

<img width="1289" height="810" alt="Screenshot 2026-01-14 190613" src="https://github.com/user-attachments/assets/29f06c34-d298-48c3-9629-cf1c55371a55" />

The main goal here is to get screenshots from people testing on different browsers (Chrome, Safari, Edge, Firefox) to see if the native experience is good enough. If it works well, we can drop the flatpickr dependency entirely.

Fixes #36855