### PR TITLE
click: Prevent composebox refocus on double/triple clicks.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -949,10 +949,13 @@ export function initialize(): void {
         if (compose_state.composing() && $(e.target).parents("#compose").length === 0) {
             const is_click_within_link = $(e.target).closest("a").length > 0;
             if (is_click_within_link || $(e.target).closest(".copy_codeblock").length > 0) {
-                const is_selecting_link_text = is_click_within_link && mouse_drag.is_drag(e);
+                const is_selecting_link_text =
+                    is_click_within_link &&
+                    (mouse_drag.is_drag(e) || document.getSelection()?.type === "Range");
                 if (is_selecting_link_text) {
                     // Avoid triggering the click handler for a link
-                    // when just dragging over it to select the text.
+                    // when just dragging over it to select the text or
+                    // double/triple clicking it to select link text.
                     e.preventDefault();
                     return;
                 }


### PR DESCRIPTION



Clicking on the DM box in the left sidebar to select recipient text leads to a refocus on the composebox.
This patch is meant to fix that and other related behaviors that might occur when double/triple clicking links with an open composebox.

Fixes:
https://github.com/zulip/zulip/pull/37157#issuecomment-3739081221.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/a0c4fc97-ac31-4a91-9caf-5739220f7942

https://github.com/user-attachments/assets/cb2ce2e9-2678-4ac5-8bef-b3e40ab006b6


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
