### PR TITLE
stats: Reinstate 300-weight page headers.

### DIFF
--- a/web/styles/portico/stats.css
+++ b/web/styles/portico/stats.css
@@ -26,6 +26,10 @@ p {
     text-align: center;
 }
 
+.stats-page h1 {
+    font-weight: 300;
+}
+
 .summary-stats {
     vertical-align: top;
     margin: 0 auto;


### PR DESCRIPTION
This PR restores the 300 font-weight to headings on `/stats`.

[#documentation > portico style changes on API docs @ 💬](https://chat.zulip.org/#narrow/channel/19-documentation/topic/portico.20style.20changes.20on.20API.20docs/near/2350492)

| Before | After |
| --- | --- |
| <img width="1800" height="1400" alt="stats-heading-before" src="https://github.com/user-attachments/assets/2ff4c4ba-fc56-4aa2-9b5e-fae4872a0ef9" /> | <img width="1800" height="1400" alt="stats-heading-after" src="https://github.com/user-attachments/assets/97accd59-136b-427d-8269-99df740d96e6" /> |
