### PR TITLE
Add tests for topic resolution behavior

### DIFF
--- a/zerver/tests/test_topic.py
+++ b/zerver/tests/test_topic.py
@@ -1,0 +1,14 @@
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.topic import get_topic_resolution_and_bare_name
+
+
+class TestTopic(ZulipTestCase):
+    def test_get_topic_resolution_and_bare_name_resolved(self) -> None:
+        resolved, topic = get_topic_resolution_and_bare_name("✔ Fix login bug")
+        self.assertTrue(resolved)
+        self.assertEqual(topic, "Fix login bug")
+
+    def test_get_topic_resolution_and_bare_name_unresolved(self) -> None:
+        resolved, topic = get_topic_resolution_and_bare_name("Fix login bug")
+        self.assertFalse(resolved)
+        self.assertEqual(topic, "Fix login bug")


### PR DESCRIPTION
This PR adds backend tests for resolved topic handling in **Zulip**.

In Zulip, a topic is considered resolved when its name starts with ✔ .
The function **_get_topic_resolution_and_bare_name (in zerver/lib/topic.py)_**
is responsible for detecting this and returning the topic name without the prefix.

This PR adds a new test file, **_zerver/tests/test_topic.py,_** which covers this
behavior. The tests verify that:

Topics with the ✔ prefix are correctly marked as resolved

The ✔ prefix is removed from the topic name

Topics without the prefix are treated as unresolved

The goal is to ensure that this existing behavior is explicitly covered by
backend tests, so it does not accidentally break during future changes or
refactoring.