### PR TITLE
webhooks: Add option to ignore events from private GitLab Projects.

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -677,7 +677,14 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
             )
         ],
         display_name="GitLab",
-        url_options=[WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES)],
+        url_options=[
+            WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES),
+            WebhookUrlOption(
+                name="ignore_private_projects",
+                label="Exclude notifications from private projects",
+                validator=check_bool,
+            ),
+        ],
     ),
     IncomingWebhookIntegration(
         "gocd",

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -1122,7 +1122,7 @@ def api_github_webhook(
     """
     header_event = get_event_header(request, "X-GitHub-Event", "GitHub")
 
-    # Check if the repository is private and skip processing if ignore_private_repositories is True
+    # Ignore events from private repositories if the URL option is set
     if (
         "repository" in payload
         and payload["repository"]["private"].tame(check_bool)

--- a/zerver/webhooks/gitlab/doc.md
+++ b/zerver/webhooks/gitlab/doc.md
@@ -6,7 +6,10 @@ Receive GitLab notifications in Zulip!
 
 1. {!create-an-incoming-webhook.md!}
 
-1. {!generate-webhook-url-with-branch-filtering.md!}
+1. Decide where to send {{ integration_display_name }} notifications, and
+   [generate the integration URL](/help/generate-integration-url). You'll be
+   able to configure which branches you'll receive notifications from,
+   and whether to exclude notifications from private projects.
 
 1. Go to your repository on GitLab and click **Settings** on the left
    sidebar.  Click on **Webhooks** and select **Add new webhook**.

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -16,6 +16,10 @@ class GitlabHookTests(WebhookTestCase):
         expected_message = "Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/-/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek.\n\n* b ([66abd2da288](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e591e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
         self.check_webhook("push_hook", expected_topic_name, expected_message)
 
+    def test_push_event_private_project_ignored(self) -> None:
+        self.url = self.build_webhook_url(ignore_private_projects="true")
+        self.check_webhook(fixture_name="push_hook", expect_noop=True)
+
     def test_push_local_branch_without_commits(self) -> None:
         expected_topic_name = "my-awesome-project / changes"
         expected_message = "Eeshan Garg [pushed](https://gitlab.com/eeshangarg/my-awesome-project/-/compare/0000000000000000000000000000000000000000...68d7a5528cf423dfaac37dd62a56ac9cc8a884e3) the branch changes."
@@ -420,6 +424,13 @@ A trivial change that should probably be ignored.
 
         self.check_webhook(
             "merge_request_hook__merge_request_merged", expected_topic_name, expected_message
+        )
+
+    def test_merge_request_merged_event_message_ignored(self) -> None:
+        self.url = self.build_webhook_url(ignore_private_projects="true")
+        self.check_webhook(
+            fixture_name="merge_request_hook__merge_request_merged",
+            expect_noop=True,
         )
 
     def test_wiki_page_opened_event_message(self) -> None:

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -589,8 +589,18 @@ def api_gitlab_webhook(
     branches: str | None = None,
     use_merge_request_title: Json[bool] = True,
     user_specified_topic: OptionalUserSpecifiedTopicStr = None,
+    ignore_private_projects: Json[bool] = False,
 ) -> HttpResponse:
     event = get_event(request, payload, branches)
+
+    # Ignore events from private projects if the URL option is set
+    if (
+        "project" in payload
+        and payload["project"]["visibility_level"].tame(check_int) == 0
+        and ignore_private_projects
+    ):
+        return json_success(request)
+
     if event is not None:
         event_body_function = get_body_based_on_event(event)
         body = event_body_function(


### PR DESCRIPTION
PR adds an option to ignore webhook events coming from private GitLab Projects.

- Adds a new `ignore_private_projects` `WebhookUrlOption` for the GitLab integration.
- When enabled, webhook events from private Gitlab projects `(project.visibility_level == 0)` are ignored.
- The behavior is applied consistently for both push events and merge request events.
- Existing private-project fixtures are reused to cover the new behavior.
- Follows same pattern as that of GitHub

Fixes: #31766 

_Note : Currently Existing `push_hook.json` and `merge_request_hook__merge_request_merged.json`
fixtures are reused, since they already have `project.visibility_level set to 0`. We can change and add new fixtures if needed._

**How changes were tested:**

Changes tested and verifed using the integrations dev panel

**Screenshots and screen captures:**
<img width="550" height="539" alt="image" src="https://github.com/user-attachments/assets/cce471f8-f02c-44da-a41a-4c61b91675e4" />

Doc Update

<img width="1074" height="935" alt="image" src="https://github.com/user-attachments/assets/3dd7b4b1-535f-45e9-9c81-bbadb527b5ef" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
