### PR TITLE
docs: Clarify Nextcloud integration setup and bot usage (#37288).

### DIFF
--- a/templates/zerver/integrations/nextcloud.md
+++ b/templates/zerver/integrations/nextcloud.md
@@ -1,0 +1,42 @@
+# Zulip Nextcloud integration
+
+Send Nextcloud files in Zulip messages as uploaded files, public shared links,
+or internal shared links.
+
+{start_tabs}
+
+## Configure Zulip
+
+1. {!create-a-generic-bot.md!}
+
+!!! tip "Using a bot"
+
+    You can use your own Zulip account's API key for testing, but using a bot is
+    recommended for improved security and more reliable channel discovery,
+    especially on Zulip Cloud.
+
+2. From **Settings → Personal settings → Bots**, copy the bot's **email address**
+   and **API key**.
+
+## Configure Nextcloud
+
+1. Follow the instructions in the
+   [Nextcloud App Store](https://apps.nextcloud.com/apps/integration_zulip)
+   to install and enable the **Zulip Integration** app.
+
+2. In Nextcloud, go to **User settings → Connected accounts**, and enter your
+   **Zulip server URL**, **email address**, and **API key**.
+
+{end_tabs}
+
+Congrats, you're done! You should be able to send Nextcloud files to Zulip.
+
+!!! tip "Channel discovery issues"
+
+    If the **Conversation** dropdown shows "failed to load Zulip channels", ensure
+    that you are using a bot account subscribed to the target streams, or a Zulip
+    server that allows listing streams via the API.
+
+### Related documentation
+
+* [Zulip Integration in the Nextcloud App Store](https://apps.nextcloud.com/apps/integration_zulip)


### PR DESCRIPTION
This PR completes the documentation for the Zulip–Nextcloud integration.

While testing the integration end-to-end, I verified the full setup flow
and identified a few areas where the documentation could be clarified to
better match real-world usage:

- The integration works with a personal API key, but using a bot provides
  more reliable channel discovery on Zulip Cloud.
- Downloading a `zuliprc` file is unnecessary; Nextcloud only requires the
  Zulip server URL, email address, and API key.
- Users may see a “failed to load Zulip channels” message if the account
  used does not have permission to list streams via the API.

This update clarifies the recommended use of a bot, removes the unnecessary
`zuliprc` dependency, and adds a short tip addressing the channel-loading
issue, while continuing to link to Nextcloud’s own setup instructions
rather than duplicating them.

Fixes #36853

---

### Screenshot

Screenshot of the rendered Nextcloud integration documentation (previewed locally):
<img width="1394" height="726" alt="Screenshot 2026-01-16 at 6 21 41 AM" src="https://github.com/user-attachments/assets/44105f49-f93b-477b-885f-219040eae9da" />
