### PR TITLE
channel_folders_ui: Fix incorrect `can_manage_folder` usage.

### DIFF
--- a/web/src/channel_folders_ui.ts
+++ b/web/src/channel_folders_ui.ts
@@ -203,7 +203,6 @@ function format_channel_item_html(stream: StreamSubscription): string {
         invite_only: stream.invite_only,
         is_web_public: stream.is_web_public,
         stream_edit_url: hash_util.channels_settings_edit_url(stream, "general"),
-        show_remove_channel_from_folder: true,
         can_manage_folder: can_user_manage_folder(),
     });
 }

--- a/web/templates/stream_list_item.hbs
+++ b/web/templates/stream_list_item.hbs
@@ -1,12 +1,11 @@
 <li class="stream-list-item" role="presentation" data-stream-id="{{stream_id}}">
-    <a class="stream-row {{#if can_manage_folder}}hidden-remove-button-row{{/if}}" href="{{stream_edit_url}}">
+    <a class="stream-row hidden-remove-button-row" href="{{stream_edit_url}}">
         <span class="stream-row-content">
             <span class="stream-privacy-original-color-{{stream_id}} stream-privacy filter-icon" style="color: {{stream_color}}">
                 {{> stream_privacy . }}
             </span>
             <span class="stream-name">{{name}}</span>
         </span>
-        {{#if can_manage_folder}}
         <div class="remove-button-wrapper">
             {{#if show_unsubscribe_button}}
                 {{#if show_private_stream_unsub_tooltip}}
@@ -17,10 +16,9 @@
                     {{> components/icon_button  icon="close" custom_classes="hidden-remove-button remove-button tippy-zulip-delayed-tooltip" intent="danger" aria-label=(t "Unsubscribe") data-tippy-content=(t "Unsubscribe") }}
                 {{/if}}
             {{/if}}
-            {{#if show_remove_channel_from_folder}}
+            {{#if can_manage_folder}}
                 {{> components/icon_button  icon="close" custom_classes="hidden-remove-button remove-button tippy-zulip-delayed-tooltip" intent="danger" aria-label=(t "Remove channel") data-tippy-content=(t "Remove channel") }}
             {{/if}}
         </div>
-        {{/if}}
     </a>
 </li>


### PR DESCRIPTION
`can_manage_folder` was supposed to replace
`show_remove_channel_folder_button` in
f97c88e4611d5eb07011adc6f3c9bba5e8b7baae instead of adding as new. We restore the correct check here.

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
