### PR TITLE
mobile: Fix iOS Safari compose box scrolling issue.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -280,7 +280,7 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=1943053 -->
             if (!compose) {
                 compose = document.getElementById('compose');
             }
-            
+
             if (compose) {
                 // Initialize threshold once
                 if (!viewHeightThreshold) {
@@ -314,7 +314,7 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=1943053 -->
 
         // Start the loop
         requestAnimationFrame(updatePosition);
-        
+
         // Keep ResizeObserver for element size changes (like growing text area)
         var observer = new ResizeObserver(function() {
              lastTop = null; // Force update


### PR DESCRIPTION
This commit addresses the issue where the compose box is covered by the virtual keyboard on iOS Safari (#37369).

The standard `interactive-widget=resizes-content` meta tag was found to be inconsistent on iOS, often leaving the compose box hidden behind the keyboard because `position: fixed; bottom: 0` relates to the layout viewport, which doesn't always resize on iOS.

**Changes:**
- Implements a `visualViewport` API based solution in `index.html`.
- Uses a `requestAnimationFrame` loop to dynamically adjust the compose box position (`top` offset) to anchor it to the visual viewport bottom.
- Handles keyboard open/close states and screen resizing (orientation changes or dynamic text area growth).
- This ensures the compose box remains strictly visible and stable (no jitter) above the software keyboard.

Fixes: #37369

**How changes were tested:**
Manually verified on a physical iPhone (iOS Safari) using a Dockerized development environment exposed via ngrok.
- **Keyboard Open:** Verified the compose box sits correctly above the keyboard.
- **Scrolling:** Confirmed no jitter or "bouncing" when scrolling the message list.
- **Keyboard Closed:** Confirmed strict fallback to standard CSS positioning.

**Screenshots**
<p float="left">
  <img width="300" alt="Keyboard Open" src="https://github.com/user-attachments/assets/15537820-31ca-46d7-bc1c-cbcea9a31a16" />
  <img width="300" alt="Scrolling" src="https://github.com/user-attachments/assets/3362d9f7-2e20-457a-81cb-43cd18f6e2d6" />
  <img width="300" alt="Keyboard Closed" src="https://github.com/user-attachments/assets/9691b4e4-4900-472b-8b74-e34436c23d78" />
</p>

