### PR TITLE
resize: Use the right method to get `display` value.

### DIFF
--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -18,7 +18,7 @@ export function get_stream_filters_max_height(): number {
     const GAP = 15;
 
     const $left_sidebar_search = $("#left-sidebar-search");
-    const is_search_visible = $left_sidebar_search.attr("display") !== "none";
+    const is_search_visible = $left_sidebar_search.css("display") !== "none";
 
     let stream_filters_max_height =
         viewport_height -


### PR DESCRIPTION
I am sorry for not being careful while writing the original code. I got too excited after finding the root cause that I forgot to check for something so simple.

discussion: [#issues > large blank space bottom of left sidebar](https://chat.zulip.org/#narrow/channel/9-issues/topic/large.20blank.20space.20bottom.20of.20left.20sidebar/with/2351131)

| before | after |
| --- | --- |
| <img width="504" height="753" alt="image" src="https://github.com/user-attachments/assets/09828378-a0d3-43aa-8fa9-f66c34301948" /> | <img width="504" height="753" alt="Screenshot from 2026-01-13 08-59-39" src="https://github.com/user-attachments/assets/82a82ba8-7e1d-4afb-8b44-6ad38c22b97b" /> |
