### PR TITLE
left_sidebar: Remove references to $(".left-sidebar .right-sidebar-items").

### DIFF
--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -322,7 +322,6 @@ function zoom_in(): void {
     $(".direct-messages-container").removeClass("zoom-out").addClass("zoom-in");
     $("#hide-more-direct-messages").addClass("dm-zoomed-in");
     $("#streams_list").hide();
-    $(".left-sidebar .right-sidebar-items").hide();
 
     const $filter = $(".direct-messages-list-filter").expectOne();
     $filter.trigger("focus");
@@ -335,7 +334,6 @@ function zoom_out(): void {
     $(".direct-messages-container").removeClass("zoom-in").addClass("zoom-out");
     $("#hide-more-direct-messages").removeClass("dm-zoomed-in");
     $("#streams_list").show();
-    $(".left-sidebar .right-sidebar-items").show();
 }
 
 export function clear_search(): void {


### PR DESCRIPTION
This was removed in fbe9a9e539cf7fe042352eb968843341a1034f96.
