### PR TITLE
bots: Notify bot owners when bots lack stream access.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -77,6 +77,7 @@ from zerver.lib.string_validation import check_stream_name
 from zerver.lib.thumbnail import manifest_and_get_user_upload_previews, rewrite_thumbnailed_images
 from zerver.lib.timestamp import timestamp_to_datetime
 from zerver.lib.topic import get_topic_display_name, participants_for_topic
+from zerver.lib.topic_link_util import get_stream_link_syntax
 from zerver.lib.types import UserProfileChangeDict
 from zerver.lib.url_preview.types import UrlEmbedData
 from zerver.lib.user_groups import (
@@ -1547,6 +1548,31 @@ def send_pm_if_empty_stream(
         send_rate_limited_pm_notification_to_bot_owner(sender, realm, content)
 
 
+def send_pm_if_not_authorized_to_stream(
+    stream: Stream,
+    realm: Realm,
+    sender: UserProfile,
+) -> None:
+    """If a bot tries to send a message to a stream and does not have
+    permission to send to that stream, sends a notification to the bot
+    owner (if not a cross-realm bot) so that the owner can correct the
+    issue."""
+    assert sender.bot_owner is not None
+    with override_language(sender.bot_owner.default_language):
+        channel_link = get_stream_link_syntax(stream.id, stream.name)
+        permissions_url = f"#channels/{stream.id}/{stream.name}/permissions"
+        content = _(
+            "{bot_mention} failed to send a message to {channel_link} "
+            "because it doesn't have permission to do so. "
+            "[Update permissions]({permissions_url})"
+        ).format(
+            bot_mention=silent_mention_syntax_for_user(sender),
+            channel_link=channel_link,
+            permissions_url=permissions_url,
+        )
+    send_rate_limited_pm_notification_to_bot_owner(sender, realm, content)
+
+
 def validate_stream_name_with_pm_notification(
     stream_name: str, realm: Realm, sender: UserProfile
 ) -> Stream:
@@ -1770,14 +1796,20 @@ def check_message(
         user_group_membership_details = UserGroupMembershipDetails(user_recursive_group_ids=None)
         system_groups_name_dict = get_realm_system_groups_name_dict(stream.realm_id)
         if not skip_stream_access_check:
-            access_stream_for_send_message(
-                sender=sender,
-                stream=stream,
-                forwarder_user_profile=forwarder_user_profile,
-                archived_channel_notice=archived_channel_notice,
-                user_group_membership_details=user_group_membership_details,
-                system_groups_name_dict=system_groups_name_dict,
-            )
+            try:
+                access_stream_for_send_message(
+                    sender=sender,
+                    stream=stream,
+                    forwarder_user_profile=forwarder_user_profile,
+                    archived_channel_notice=archived_channel_notice,
+                    user_group_membership_details=user_group_membership_details,
+                    system_groups_name_dict=system_groups_name_dict,
+                )
+            except JsonableError:
+                # Notify bot owner about access failure
+                if sender.is_bot and sender.bot_owner is not None:
+                    send_pm_if_not_authorized_to_stream(stream, sender.realm, sender)
+                raise
         else:
             # Defensive assertion - the only currently supported use case
             # for this option is for outgoing webhook bots and since this

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -62,10 +62,7 @@ from zerver.lib.notification_data import (
 from zerver.lib.query_helpers import query_for_ids
 from zerver.lib.queue import queue_event_on_commit
 from zerver.lib.recipient_users import recipient_for_user_profiles
-from zerver.lib.stream_subscription import (
-    get_subscriptions_for_send_message,
-    num_subscribers_for_stream_id,
-)
+from zerver.lib.stream_subscription import get_subscriptions_for_send_message
 from zerver.lib.stream_topic import StreamTopicTarget
 from zerver.lib.streams import (
     access_stream_for_send_message,
@@ -80,7 +77,6 @@ from zerver.lib.string_validation import check_stream_name
 from zerver.lib.thumbnail import manifest_and_get_user_upload_previews, rewrite_thumbnailed_images
 from zerver.lib.timestamp import timestamp_to_datetime
 from zerver.lib.topic import get_topic_display_name, participants_for_topic
-from zerver.lib.topic_link_util import get_stream_link_syntax
 from zerver.lib.types import UserProfileChangeDict
 from zerver.lib.url_preview.types import UrlEmbedData
 from zerver.lib.user_groups import (
@@ -1519,52 +1515,35 @@ def send_pm_if_empty_stream(
     stream_name: str | None = None,
     stream_id: int | None = None,
 ) -> None:
-    """If a bot sends a message to a stream that doesn't exist or has no
-    subscribers, sends a notification to the bot owner (if not a
-    cross-realm bot) so that the owner can correct the issue."""
+    """If a bot sends a message to a stream that doesn't exist, sends a
+    notification to the bot owner (if not a cross-realm bot) so that the
+    owner can correct the issue."""
     if not sender.is_bot or sender.bot_owner is None:
+        return
+
+    if stream is not None:
         return
 
     if sender.bot_owner is not None:
         with override_language(sender.bot_owner.default_language):
-            arg_dict: dict[str, Any] = {
-                "bot_identity": f"`{sender.delivery_email}`",
-            }
-            if stream is None:
-                if stream_id is not None:
-                    arg_dict = {
-                        **arg_dict,
-                        "channel_id": stream_id,
-                    }
-                    content = _(
-                        "Your bot {bot_identity} tried to send a message to channel ID "
-                        "{channel_id}, but there is no channel with that ID."
-                    ).format(**arg_dict)
-                else:
-                    assert stream_name is not None
-                    arg_dict = {
-                        **arg_dict,
-                        "channel_name": f"#**{stream_name}**",
-                        "new_channel_link": "#channels/new",
-                    }
-                    content = _(
-                        "Your bot {bot_identity} tried to send a message to channel "
-                        "{channel_name}, but that channel does not exist. "
-                        "Click [here]({new_channel_link}) to create it."
-                    ).format(**arg_dict)
-            else:
-                if num_subscribers_for_stream_id(stream.id) > 0:
-                    return
-                arg_dict = {
-                    **arg_dict,
-                    "channel_name": f"{get_stream_link_syntax(stream.id, stream.name)}",
-                }
+            if stream_id is not None:
                 content = _(
-                    "Your bot {bot_identity} tried to send a message to "
-                    "channel {channel_name}. The channel exists but "
-                    "does not have any subscribers."
-                ).format(**arg_dict)
-
+                    "{bot_mention} failed to send a message because there is no "
+                    "channel with ID {channel_id}."
+                ).format(
+                    bot_mention=silent_mention_syntax_for_user(sender),
+                    channel_id=stream_id,
+                )
+            else:
+                assert stream_name is not None
+                content = _(
+                    "{bot_mention} failed to send a message to "
+                    "#**{channel_name}** because the channel does not exist. "
+                    "[Create it](#channels/new)"
+                ).format(
+                    bot_mention=silent_mention_syntax_for_user(sender),
+                    channel_name=stream_name,
+                )
         send_rate_limited_pm_notification_to_bot_owner(sender, realm, content)
 
 

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -3671,6 +3671,46 @@ class CheckMessageTest(ZulipTestCase):
         self.assertEqual(ret.message.sender.email, "othello-bot@zulip.com")
         self.assertEqual(ret.message.content, message_content)
 
+    def test_bot_pm_feature_for_access_denied(self) -> None:
+        """We send a direct message to a bot's owner if their bot tries to
+        send a message to a stream it doesn't have access to"""
+        parent = self.example_user("othello")
+        bot = do_create_user(
+            email="othello-bot@zulip.com",
+            password="",
+            realm=parent.realm,
+            full_name="Othello Bot",
+            bot_type=UserProfile.DEFAULT_BOT,
+            bot_owner=parent,
+            acting_user=None,
+        )
+        bot.last_reminder = None
+
+        sender = bot
+        client = make_client(name="test suite")
+        stream_name = "private_stream"
+        topic_name = "test"
+        message_content = "whatever"
+
+        # Create a private stream that the bot doesn't have access to
+        stream = self.make_stream(stream_name, invite_only=True)
+        addressee = Addressee.for_stream(stream, topic_name)
+        old_count = message_stream_count(parent)
+
+        # Try sending to stream that bot doesn't have access to
+        with self.assertRaises(JsonableError):
+            check_message(sender, client, addressee, message_content)
+
+        new_count = message_stream_count(parent)
+        self.assertEqual(new_count, old_count + 1)
+
+        recent_msg = most_recent_message(parent).content
+        self.assertIn(silent_mention_syntax_for_user(bot), recent_msg)
+        self.assertIn(f"#**{stream_name}**", recent_msg)
+        self.assertIn("doesn't have permission to do so", recent_msg)
+        self.assertIn("[Update permissions]", recent_msg)
+        self.assertIn(f"#channels/{stream.id}/{stream_name}/permissions", recent_msg)
+
     def test_bot_pm_error_handling(self) -> None:
         # This just test some defensive code.
         cordelia = self.example_user("cordelia")

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -48,11 +48,11 @@ from zerver.lib.exceptions import (
     MessagesNotAllowedInEmptyTopicError,
     TopicsNotAllowedError,
 )
+from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.message import get_raw_unread_data, get_recent_private_conversations
 from zerver.lib.message_cache import MessageDict
 from zerver.lib.per_request_cache import flush_per_request_caches
 from zerver.lib.stream_subscription import create_stream_subscription
-from zerver.lib.streams import create_stream_if_needed
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import (
     get_user_messages,
@@ -159,6 +159,7 @@ class MessagePOSTTest(ZulipTestCase):
         bot = self.create_test_bot(
             short_name="whatever",
             user_profile=cordelia,
+            full_name="Whatever Bot",
         )
         result = self.api_post(
             bot,
@@ -174,78 +175,8 @@ class MessagePOSTTest(ZulipTestCase):
 
         msg = self.get_last_message()
         expected = (
-            "Your bot `whatever-bot@zulip.testserver` tried to send a message to "
-            "channel ID 99999, but there is no channel with that ID."
-        )
-        self.assertEqual(msg.content, expected)
-
-    def test_message_to_stream_with_no_subscribers(self) -> None:
-        """
-        Sending a message to an empty stream succeeds, but sends a warning
-        to the owner.
-        """
-        realm = get_realm("zulip")
-        cordelia = self.example_user("cordelia")
-        bot = self.create_test_bot(
-            short_name="whatever",
-            user_profile=cordelia,
-        )
-        stream = create_stream_if_needed(realm, "Acropolis")[0]
-        result = self.api_post(
-            bot,
-            "/api/v1/messages",
-            {
-                "type": "channel",
-                "to": orjson.dumps(stream.name).decode(),
-                "content": "Stream message to an empty stream by name.",
-                "topic": "Test topic for empty stream name message",
-            },
-        )
-        self.assert_json_success(result)
-
-        msg = self.get_last_message()
-        expected = "Stream message to an empty stream by name."
-        self.assertEqual(msg.content, expected)
-
-        msg = self.get_second_to_last_message()
-        expected = (
-            "Your bot `whatever-bot@zulip.testserver` tried to send a message to "
-            "channel #**Acropolis**. The channel exists but does not have any subscribers."
-        )
-        self.assertEqual(msg.content, expected)
-
-    def test_message_to_stream_with_no_subscribers_by_id(self) -> None:
-        """
-        Sending a message to an empty stream succeeds, but sends a warning
-        to the owner.
-        """
-        realm = get_realm("zulip")
-        cordelia = self.example_user("cordelia")
-        bot = self.create_test_bot(
-            short_name="whatever",
-            user_profile=cordelia,
-        )
-        stream = create_stream_if_needed(realm, "Acropolis")[0]
-        result = self.api_post(
-            bot,
-            "/api/v1/messages",
-            {
-                "type": "channel",
-                "to": orjson.dumps([stream.id]).decode(),
-                "content": "Stream message to an empty stream by id.",
-                "topic": "Test topic for empty stream id message",
-            },
-        )
-        self.assert_json_success(result)
-
-        msg = self.get_last_message()
-        expected = "Stream message to an empty stream by id."
-        self.assertEqual(msg.content, expected)
-
-        msg = self.get_second_to_last_message()
-        expected = (
-            "Your bot `whatever-bot@zulip.testserver` tried to send a message to "
-            "channel #**Acropolis**. The channel exists but does not have any subscribers."
+            f"{silent_mention_syntax_for_user(bot)} failed to send a message because there is no "
+            "channel with ID 99999."
         )
         self.assertEqual(msg.content, expected)
 
@@ -3696,7 +3627,7 @@ class CheckMessageTest(ZulipTestCase):
 
     def test_bot_pm_feature(self) -> None:
         """We send a direct message to a bot's owner if their bot sends a
-        message to an unsubscribed stream"""
+        message to a non-existent stream"""
         parent = self.example_user("othello")
         bot = do_create_user(
             email="othello-bot@zulip.com",
@@ -3717,34 +3648,28 @@ class CheckMessageTest(ZulipTestCase):
         message_content = "whatever"
         old_count = message_stream_count(parent)
 
-        # Try sending to stream that doesn't exist sends a reminder to
-        # the sender
+        # Try sending to stream that doesn't exist sends a reminder to the sender
         with self.assertRaises(JsonableError):
             check_message(sender, client, addressee, message_content)
-
         new_count = message_stream_count(parent)
         self.assertEqual(new_count, old_count + 1)
-        self.assertIn("that channel does not exist.", most_recent_message(parent).content)
 
-        # Try sending to stream that exists with no subscribers soon
-        # after; due to rate-limiting, this should send nothing.
+        recent_msg = most_recent_message(parent).content
+        self.assertIn(silent_mention_syntax_for_user(bot), recent_msg)
+        self.assertIn(f"#**{stream_name}**", recent_msg)
+        self.assertIn("does not exist", recent_msg)
+        self.assertIn("[Create it](#channels/new)", recent_msg)
+
         self.make_stream(stream_name)
+
+        # Send message to existing stream with no subscribers
+        # This should succeed WITHOUT sending a notification
         ret = check_message(sender, client, addressee, message_content)
         new_count = message_stream_count(parent)
         self.assertEqual(new_count, old_count + 1)
 
-        # Try sending to stream that exists with no subscribers longer
-        # after; this should send an error to the bot owner that the
-        # stream doesn't exist
-        assert sender.last_reminder is not None
-        sender.last_reminder -= timedelta(hours=1)
-        sender.save(update_fields=["last_reminder"])
-        ret = check_message(sender, client, addressee, message_content)
-
-        new_count = message_stream_count(parent)
-        self.assertEqual(new_count, old_count + 2)
         self.assertEqual(ret.message.sender.email, "othello-bot@zulip.com")
-        self.assertIn("does not have any subscribers", most_recent_message(parent).content)
+        self.assertEqual(ret.message.content, message_content)
 
     def test_bot_pm_error_handling(self) -> None:
         # This just test some defensive code.

--- a/zerver/webhooks/helloworld/tests.py
+++ b/zerver/webhooks/helloworld/tests.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.test_classes import WebhookTestCase
 from zerver.models.realms import get_realm
 from zerver.models.users import get_system_bot
@@ -46,12 +47,15 @@ class HelloWorldHookTests(WebhookTestCase):
         )
 
     def test_stream_error_pm_to_bot_owner(self) -> None:
-        # Note that this is really just a test for check_send_webhook_message
         self.channel_name = "nonexistent"
         self.url = self.build_webhook_url()
         realm = get_realm("zulip")
         notification_bot = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
-        expected_message = "Your bot `webhook-bot@zulip.com` tried to send a message to channel #**nonexistent**, but that channel does not exist. Click [here](#channels/new) to create it."
+        expected_message = (
+            f"{silent_mention_syntax_for_user(self.test_user)} failed to send a message to "
+            "#**nonexistent** because the channel does not exist. "
+            "[Create it](#channels/new)"
+        )
         self.send_and_test_private_message(
             "goodbye",
             expected_message=expected_message,


### PR DESCRIPTION
Previously, when a bot tried to send a message to a stream it didn't have access to, the bot owner received no notification about why the message failed. Additionally, existing bot notification messages used inconsistent formatting with bot email addresses.

This extends the notification system to send notifications when a bot is denied access to a stream, and updates all bot notifications to use silent mentions and direct action links.

Fixes #16431

**How changes were tested:**

Manually tested with a bot attempting to send to an inaccessible private stream. The bot owner received the expected notification with working permission link and rate limiting.


<img width="821" height="199" alt="Screenshot 2026-02-07 at 15 35 23" src="https://github.com/user-attachments/assets/d780cf35-0078-4ad5-8bb2-d4e95a26ca1d" />

<img width="820" height="70" alt="Screenshot 2026-02-07 at 16 40 14" src="https://github.com/user-attachments/assets/e7f98942-8fcb-488a-a0dc-4d39579f9646" />



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
