### PR TITLE
popovers: Add keyboard shortcut hint for opening "Set status" modal.

### DIFF
--- a/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
@@ -45,6 +45,7 @@
                     <a role="menuitem" tabindex="0" class="update_status_text popover-menu-link">
                         <i class="popover-menu-icon zulip-icon zulip-icon-smile-smaller" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t 'Edit status' }}</span>
+                        {{popover_hotkey_hints "Shift" "Y"}}
                     </a>
                 </li>
                 {{else}}
@@ -52,6 +53,7 @@
                     <a role="menuitem" tabindex="0" class="update_status_text popover-menu-link">
                         <i class="popover-menu-icon zulip-icon zulip-icon-smile-smaller" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t 'Set status' }}</span>
+                        {{popover_hotkey_hints "Shift" "Y"}}
                     </a>
                 </li>
                 {{/if}}

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -67,6 +67,7 @@
                     <a role="menuitem" tabindex="0" class="update_status_text popover-menu-link">
                         <i class="popover-menu-icon zulip-icon zulip-icon-smile-smaller" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t 'Edit status' }}</span>
+                        {{popover_hotkey_hints "Shift" "Y"}}
                     </a>
                 </li>
             {{else}}
@@ -74,6 +75,7 @@
                     <a role="menuitem" tabindex="0" class="update_status_text popover-menu-link">
                         <i class="popover-menu-icon zulip-icon zulip-icon-smile-smaller" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t 'Set status' }}</span>
+                        {{popover_hotkey_hints "Shift" "Y"}}
                     </a>
                 </li>
             {{/if}}


### PR DESCRIPTION
With commit 86d9626fe773bfd83f04e57fae08af99ba743546, we introduced a keyboard shortcut (Shift + Y) to open the "Set status" modal. This PR updates the relevant popover menu options include hints about this new shortcut for user awareness.

Fixes: #37476

**How changes were tested:**
1. Add the popover hotkey hints using our custom Handlebars helper `popover_hotkey_hints`.
2. Check UI manually for the user card popover and personal menu popover.
3. Check whether tooltip is being displayed.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| User Card Popover | Personal Menu Popover |
|--------|--------|
| <img width="280" height="395" alt="Screenshot 2026-01-13 at 2 53 47 PM" src="https://github.com/user-attachments/assets/4415e04c-ad13-4cf0-a1f6-0c92f699d257" /> | <img width="280" height="395" alt="Screenshot 2026-01-13 at 2 52 22 PM" src="https://github.com/user-attachments/assets/d4c8473e-c5b1-47b8-9431-788da3f0869b" /> |
| <img width="280" height="395" alt="Screenshot 2026-01-13 at 2 54 02 PM" src="https://github.com/user-attachments/assets/1566f654-6ca7-4a7a-a2cc-0632c6321d1b" /> | <img width="280" height="395" alt="Screenshot 2026-01-13 at 2 51 49 PM" src="https://github.com/user-attachments/assets/60a61dd9-f5a3-4085-9141-cd090d55d1e8" /> | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
