### PR TITLE
events: Don't check for sub before unsetting compose on channel delete.

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -731,15 +731,11 @@ export function dispatch_normal_event(event) {
                     break;
                 case "delete":
                     for (const stream_id of event.stream_ids) {
-                        const was_subscribed = sub_store.get(stream_id).subscribed;
                         stream_data.delete_sub(stream_id);
                         stream_settings_ui.remove_stream(stream_id);
-                        if (was_subscribed) {
-                            stream_list.remove_sidebar_row(stream_id);
-                            if (stream_id === compose_state.selected_recipient_id) {
-                                compose_state.set_selected_recipient_id("");
-                                compose_recipient.on_compose_select_recipient_update();
-                            }
+                        if (stream_id === compose_state.selected_recipient_id) {
+                            compose_state.set_selected_recipient_id("");
+                            compose_recipient.on_compose_select_recipient_update();
                         }
                         settings_streams.update_default_streams_table();
                         stream_data.remove_default_stream(stream_id);

--- a/web/src/typing.ts
+++ b/web/src/typing.ts
@@ -81,6 +81,11 @@ function send_stream_typing_notification(
     operation: "start" | "stop",
 ): void {
     const stream = stream_data.get_sub_by_id(stream_id)!;
+    // If the user lost access to the stream while typing, stream might
+    // be undefined for us, in which case, we need to to return early.
+    if (stream === undefined) {
+        return;
+    }
     if (!stream_data.can_post_messages_in_stream(stream)) {
         return;
     }

--- a/web/tests/dispatch_subs.test.cjs
+++ b/web/tests/dispatch_subs.test.cjs
@@ -203,6 +203,7 @@ test("stream delete (normal)", ({override}) => {
         stream_id: event.stream_ids[0],
         name: "devel",
         is_archived: false,
+        subscribed: false,
     };
 
     const test_sub = {
@@ -224,10 +225,6 @@ test("stream delete (normal)", ({override}) => {
         removed_stream_ids.push(stream_id);
     });
 
-    let removed_sidebar_rows = 0;
-    override(stream_list, "remove_sidebar_row", () => {
-        removed_sidebar_rows += 1;
-    });
     override(stream_list, "update_subscribe_to_more_streams_link", noop);
 
     override(unread_ops, "process_read_messages_event", noop);
@@ -236,8 +233,6 @@ test("stream delete (normal)", ({override}) => {
     dispatch(event);
 
     assert.deepEqual(removed_stream_ids, [event.stream_ids[0], event.stream_ids[1]]);
-
-    assert.equal(removed_sidebar_rows, 1);
 });
 
 test("stream delete (special streams)", ({override}) => {
@@ -275,7 +270,6 @@ test("stream delete (special streams)", ({override}) => {
 
     override(settings_org, "sync_realm_settings", noop);
     override(settings_streams, "update_default_streams_table", noop);
-    override(stream_list, "remove_sidebar_row", noop);
     override(stream_list, "update_subscribe_to_more_streams_link", noop);
 
     override(unread_ops, "process_read_messages_event", noop);
@@ -312,7 +306,6 @@ test("stream delete (stream is selected in compose)", ({override}) => {
     stream_data.add_sub_for_tests(devel_sub);
     stream_data.add_sub_for_tests(test_sub);
 
-    stream_data.subscribe_myself(devel_sub);
     compose_state.set_stream_id(event.stream_ids[0]);
 
     const removed_stream_ids = [];
@@ -323,10 +316,6 @@ test("stream delete (stream is selected in compose)", ({override}) => {
 
     override(settings_streams, "update_default_streams_table", noop);
 
-    let removed_sidebar_rows = 0;
-    override(stream_list, "remove_sidebar_row", () => {
-        removed_sidebar_rows += 1;
-    });
     override(stream_list, "update_subscribe_to_more_streams_link", noop);
 
     override(unread_ops, "process_read_messages_event", noop);
@@ -338,6 +327,4 @@ test("stream delete (stream is selected in compose)", ({override}) => {
     assert.deepEqual(removed_stream_ids, [event.stream_ids[0], event.stream_ids[1]]);
 
     assert.equal(compose_state.stream_name(), "");
-
-    assert.equal(removed_sidebar_rows, 1);
 });


### PR DESCRIPTION
When a user is typing a message to a private channel, and they are unsubscribed from that channel while typing, we did not use to unset the channel in the compose box. This did not use to happen because the delete channel event was checking for subscription before unsetting the compose box channel, but since the unsubscribe event would fire before the delete channel event, the current user would show up as unsubscribed and the unsetting of compose box would not happen.

Fixes [#issues > 🛠️ assertion failed when sending to unknown channel](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.9B.A0.EF.B8.8F.20assertion.20failed.20when.20sending.20to.20unknown.20channel/with/2352117)

<!-- Describe your pull request here.-->


**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
