### PR TITLE
Left sidebar display option

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -2395,3 +2395,65 @@ li.topic-list-item {
         }
     }
 }
+
+.channel-links-selector {
+    .sidebar-tab-picker {
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+    }
+
+    .popover-menu-link {
+        box-sizing: border-box;
+        display: flex;
+        flex-flow: row nowrap;
+        align-items: flex-start;
+        gap: 5px;
+        padding: 0.2em 0.6666em;
+        font-size: 1em;
+        line-height: 1.0667em;
+        min-height: 1.625em;
+        color: var(--color-text-popover-menu);
+        text-decoration: none;
+        flex-grow: 1;
+
+        &:hover {
+            background: var(--color-background-hover-popover-menu);
+            outline: none;
+        }
+
+        &:focus-visible {
+            border-radius: 4px;
+            outline: 1px solid var(--color-outline-focus);
+            outline-offset: -1px;
+        }
+
+        &:active {
+            background: var(--color-background-active-popover-menu);
+        }
+
+        &:not(.channel-links-selector-header) {
+            .tab-option {
+                width: auto;
+                cursor: pointer;
+                height: 1em;
+                accent-color: hsl(217deg 100% 60%);
+                margin: 0 8px 0 0;
+                margin-top: 2px;
+
+                &:focus {
+                    outline: 1px dotted hsl(0deg 0% 20%);
+                    outline: 5px auto -webkit-focus-ring-color;
+                    outline-offset: -2px;
+                }
+            }
+
+            .popover-menu-label {
+                width: max-content;
+                flex: 1 0 0;
+                margin-top: 2px;
+                color: var(--color-text-popover-menu);
+            }
+        }
+    }
+}

--- a/web/templates/popovers/channel_folder_setting_popover.hbs
+++ b/web/templates/popovers/channel_folder_setting_popover.hbs
@@ -41,5 +41,21 @@
                 {{/each}}
             </div>
         </li>
+
+        <li role="separator" class="popover-menu-separator"></li>
+        <!-- Channel links go to setting -->
+        <li role="none" class="popover-menu-list-item channel-links-selector">
+            <label class="channel-links-selector-header popover-menu-link" role="menuitem">
+                <span class="popover-menu-label">{{t "Channel links go to" }}</span>
+            </label>
+            <div class="sidebar-tab-picker">
+                {{#each channel_links_options}}
+                    <label class="popover-menu-link" role="menuitem" tabindex="0">
+                        <input type="radio" class="tab-option" name="channel-links-display-folders" value="{{this.code}}" {{#if (eq ../channel_links_display this.code)}}checked{{/if}} />
+                        <span class="popover-menu-label">{{this.description}}</span>
+                    </label>
+                {{/each}}
+            </div>
+        </li>
     </ul>
 </div>


### PR DESCRIPTION
## Summary

This PR adds two new user preference settings to the left sidebar channel area three-dot menu , displayed as radio buttons following the same interaction and visual pattern as the existing "User list style" menu in the right sidebar.

## New Features

- **Show unread counts for** — Controls which channels display unread counts
  - All channels
  - Unmuted channels and topics  
  - No channels
- **Channel links go to** — Controls default navigation target when clicking a channel
  - Top topic
  - Top unread topic
  - List of topics
  - Channel feed

## Implementation Details

- Settings are saved immediately on selection via PATCH `/json/settings`
- Bidirectional synchronization with Settings → Preferences page
- Follows existing project patterns (matches buddy list popover style)
- Uses dynamic configuration from [settings_config.ts](cci:7://file:///home/ubuntu/zulip/web/src/settings_config.ts:0:0-0:0)
- Proper accessibility with keyboard navigation and focus indicators

## Testing

- [x] Verified Views menu opens and closes correctly
- [x] Confirmed radio buttons are clickable and save settings immediately
- [x] Verified settings persist after page refresh
- [x] Confirmed bidirectional synchronization with Settings → Preferences
- [x] Verified menu closes automatically after selection
- [x] Checked browser console for JavaScript errors
- [x] Tested visual appearance, hover states, focus indicators, and spacing
- [x] Tested in Chrome and Firefox

Fixes #33845

<img width="1286" height="523" alt="image" src="https://github.com/user-attachments/assets/48b949e0-c428-4ebb-ac8f-ff077318e225" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
