### PR TITLE
Native-browser-data-picker

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -43,13 +43,13 @@ async function open_settings(page: Page): Promise<void> {
 }
 
 async function close_settings_and_date_picker(page: Page): Promise<void> {
-    const date_picker_selector = ".date-field-alt-input";
+    // Now using native date picker - just click the date input to focus it
+    const date_picker_selector = ".datepicker[type='date']";
     await page.click(date_picker_selector);
 
-    await page.waitForSelector(".flatpickr-calendar", {visible: true});
-
+    // Native date picker doesn't have a visible calendar we can wait for,
+    // so we just press Escape to close any open picker and settings
     await page.keyboard.press("Escape");
-    await page.waitForSelector(".flatpickr-calendar", {hidden: true});
     await page.waitForSelector("#settings_overlay_container", {hidden: true});
 }
 

--- a/web/src/bundles/app.ts
+++ b/web/src/bundles/app.ts
@@ -18,8 +18,6 @@ import "tippy.js/dist/tippy.css";
 // https://atomiks.github.io/tippyjs/v6/themes/#arrow-border
 import "tippy.js/dist/border.css";
 import "katex/dist/katex.css";
-import "flatpickr/dist/flatpickr.css";
-import "flatpickr/dist/plugins/confirmDate/confirmDate.css";
 import "../../third/bootstrap/css/bootstrap.app.css";
 import "../../third/bootstrap/css/bootstrap-btn.css";
 import "../../styles/typeahead.css";

--- a/web/src/compose_send_menu_popover.ts
+++ b/web/src/compose_send_menu_popover.ts
@@ -97,6 +97,10 @@ export function open_schedule_message_menu(
             $popper.on("click", ".send_later_custom", (e) => {
                 const $send_later_options_content = $popper.find(".popover-menu-list");
                 const current_time = new Date();
+                const min_date = new Date(
+                    current_time.getTime() +
+                        scheduled_messages.MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS * 1000,
+                );
                 flatpickr.show_flatpickr(
                     util.the($(".send_later_custom")),
                     (send_at_time) => {
@@ -105,16 +109,12 @@ export function open_schedule_message_menu(
                     },
                     new Date(current_time.getTime() + 60 * 60 * 1000),
                     {
-                        minDate: new Date(
-                            current_time.getTime() +
-                                scheduled_messages.MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS * 1000,
-                        ),
-                        onClose(selectedDates, _dateStr, instance) {
+                        minDate: min_date,
+                        onClose(selectedDates, _dateStr, _instance) {
                             // Return to normal state.
                             $send_later_options_content.css("pointer-events", "all");
                             const selected_date = selectedDates[0];
-                            assert(instance.config.minDate !== undefined);
-                            if (selected_date && selected_date < instance.config.minDate) {
+                            if (selected_date && selected_date < min_date) {
                                 scheduled_messages.set_minimum_scheduled_message_delay_minutes_note(
                                     true,
                                 );

--- a/web/src/flatpickr.ts
+++ b/web/src/flatpickr.ts
@@ -1,148 +1,183 @@
-import {formatISO} from "date-fns";
-import flatpickr from "flatpickr";
-import confirmDatePlugin from "flatpickr/dist/plugins/confirmDate/confirmDate";
+import {formatISO, parseISO} from "date-fns";
 import $ from "jquery";
-import assert from "minimalistic-assert";
 
 import {$t} from "./i18n.ts";
 import {user_settings} from "./user_settings.ts";
-import * as util from "./util.ts";
 
-export let flatpickr_instance: flatpickr.Instance | undefined;
+// This module now uses native browser date/time picker instead of flatpickr library.
+// The API is kept similar for compatibility with existing code.
+
+let picker_open = false;
+let $current_picker: JQuery | null = null;
 
 export function is_open(): boolean {
-    return Boolean(flatpickr_instance?.isOpen);
+    return picker_open;
 }
 
-function is_numeric_key(key: string): boolean {
-    return ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"].includes(key);
+// For compatibility with code that references flatpickr_instance
+export const flatpickr_instance: {close: () => void} | undefined = {
+    close(): void {
+        close_all();
+    },
+};
+
+function format_datetime_local(date: Date): string {
+    // Format date for datetime-local input (YYYY-MM-DDTHH:mm)
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    return `${year}-${month}-${day}T${hours}:${minutes}`;
 }
 
 export function show_flatpickr(
     element: HTMLElement,
     callback: (time: string) => void,
-    default_timestamp: flatpickr.Options.DateOption,
-    options: flatpickr.Options.Options = {},
-): flatpickr.Instance {
-    const $flatpickr_input = $<HTMLInputElement>("<input>").attr("id", "#timestamp_flatpickr");
+    default_timestamp: Date | string | number,
+    options: {
+        minDate?: Date;
+        onClose?: (selectedDates: Date[], dateStr: string, instance: unknown) => void;
+        position?: string;
+        ignoredFocusElements?: HTMLElement[];
+    } = {},
+): {close: () => void} {
+    // Close any existing picker first
+    close_all();
 
-    flatpickr_instance = flatpickr(util.the($flatpickr_input), {
-        mode: "single",
-        enableTime: true,
-        clickOpens: false,
-        defaultDate: default_timestamp,
-        plugins: [
-            confirmDatePlugin({
-                showAlways: true,
-                confirmText: $t({defaultMessage: "Confirm"}),
-                confirmIcon: "",
-            }),
-        ],
-        positionElement: element,
-        dateFormat: "Z",
-        formatDate: (date) => formatISO(date),
-        disableMobile: true,
-        time_24hr: user_settings.twenty_four_hour_time,
-        minuteIncrement: 1,
-        onKeyDown(_selectedDates, _dateStr, instance, event: KeyboardEvent) {
-            // See also the keydown handler below.
-            //
-            // TODO: Add a clear explanation of exactly how key
-            // interactions are dispatched; it seems that keyboard
-            // logic from this function, the built-in flatpickr
-            // onKeyDown function, and the below keydown handler are
-            // used, but it's not at all clear in what order they are
-            // called, or what the overall control flow is.
-            if (event.key === "Tab") {
-                // Ensure that tab/shift_tab navigation work to
-                // navigate between the elements in flatpickr itself
-                // and the confirmation button at the bottom of the
-                // popover.
-                const elems = [
-                    instance.selectedDateElem,
-                    instance.hourElement,
-                    instance.minuteElement,
-                    ...(user_settings.twenty_four_hour_time ? [] : [instance.amPM]),
-                    $(".flatpickr-confirm")[0],
-                ];
-                assert(event.target instanceof HTMLElement);
-                const i = elems.indexOf(event.target);
-                const n = elems.length;
-                const remain = (i + (event.shiftKey ? -1 : 1)) % n;
-                const target = elems[Math.floor(remain >= 0 ? remain : remain + n)];
-                event.preventDefault();
-                event.stopPropagation();
-                assert(target !== undefined);
-                target.focus();
-            } else {
-                // Prevent keypresses from propagating to our general hotkey.ts
-                // logic. Without this, `Up` will navigate both in the
-                // flatpickr instance and in the message feed behind
-                // it.
-                event.stopPropagation();
-            }
-        },
-        ...options,
+    // Convert default_timestamp to Date if needed
+    let default_date: Date;
+    if (default_timestamp instanceof Date) {
+        default_date = default_timestamp;
+    } else if (typeof default_timestamp === "string") {
+        default_date = parseISO(default_timestamp);
+    } else {
+        default_date = new Date(default_timestamp);
+    }
+
+    // Create the native picker container
+    const $picker_container = $("<div>").addClass("native-datetime-picker-container");
+
+    // Create datetime-local input
+    const $datetime_input = $<HTMLInputElement>("<input>")
+        .attr("type", "datetime-local")
+        .addClass("native-datetime-picker-input")
+        .val(format_datetime_local(default_date));
+
+    // Set min date if specified
+    if (options.minDate) {
+        $datetime_input.attr("min", format_datetime_local(options.minDate));
+    }
+
+    // Handle 24-hour time format preference (note: browser may not fully respect this)
+    if (user_settings.twenty_four_hour_time) {
+        // Most browsers will use system locale, but we set step for minute precision
+        $datetime_input.attr("step", "60"); // 1 minute increments
+    }
+
+    // Create confirm button
+    const $confirm_button = $("<button>")
+        .addClass("native-datetime-confirm-btn")
+        .text($t({defaultMessage: "Confirm"}));
+
+    $picker_container.append($datetime_input, $confirm_button);
+    $("body").append($picker_container);
+
+    // Position the picker near the element
+    const element_rect = element.getBoundingClientRect();
+    const picker_top = element_rect.bottom + window.scrollY + 5;
+    const picker_left = element_rect.left + window.scrollX;
+
+    $picker_container.css({
+        top: `${picker_top}px`,
+        left: `${picker_left}px`,
     });
 
-    const $container = $(flatpickr_instance.calendarContainer);
+    // Adjust position if picker goes off-screen
+    const picker_rect = $picker_container[0]!.getBoundingClientRect();
+    if (picker_rect.right > window.innerWidth) {
+        $picker_container.css("left", `${window.innerWidth - picker_rect.width - 10}px`);
+    }
+    if (picker_rect.bottom > window.innerHeight) {
+        $picker_container.css(
+            "top",
+            `${element_rect.top + window.scrollY - picker_rect.height - 5}px`,
+        );
+    }
 
-    $container.on("keydown", (e) => {
-        // Main keyboard UI implementation.
+    picker_open = true;
+    $current_picker = $picker_container;
 
-        if (is_numeric_key(e.key)) {
-            // Let users type numeric values
-            return true;
+    // Focus the input and try to open the native picker
+    $datetime_input.trigger("focus");
+
+    // Handle confirm button click
+    $confirm_button.on("click", () => {
+        const value = $datetime_input.val();
+        if (value) {
+            const selected_date = new Date(value);
+            const iso_string = formatISO(selected_date);
+            callback(iso_string);
         }
+        close_all();
+    });
 
-        if (e.key === "Backspace" || e.key === "Delete") {
-            // Let backspace or delete be handled normally
-            return true;
-        }
-
+    // Handle Enter key
+    $datetime_input.on("keydown", (e) => {
         if (e.key === "Enter") {
-            if (e.target.classList[0] === "flatpickr-day") {
-                // use flatpickr's built-in behavior to choose the selected day.
-                return true;
-            }
-            $container.find(".flatpickr-confirm").trigger("click");
+            e.preventDefault();
+            $confirm_button.trigger("click");
+        } else if (e.key === "Escape") {
+            e.preventDefault();
+            close_all();
         }
-
-        if (e.key === "Escape") {
-            flatpickr_instance?.close();
-            flatpickr_instance?.destroy();
-        }
-
-        if (e.key === "Tab") {
-            // Use flatpickr's built-in navigation between elements.
-            return true;
-        }
-
-        if (["ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown"].includes(e.key)) {
-            // use flatpickr's built-in navigation of the date grid.
-            return true;
-        }
-
+        // Stop propagation to prevent hotkeys from triggering
         e.stopPropagation();
-        e.preventDefault();
-
-        return true;
     });
 
-    $container.on("click", ".flatpickr-confirm", () => {
-        const time = $flatpickr_input.val();
-        assert(typeof time === "string");
-        callback(time);
-        flatpickr_instance?.close();
-        flatpickr_instance?.destroy();
-    });
-    flatpickr_instance.open();
-    assert(flatpickr_instance.selectedDateElem !== undefined);
-    flatpickr_instance.selectedDateElem.focus();
+    // Handle click outside to close
+    const close_on_outside_click = (e: MouseEvent): void => {
+        const target = e.target;
+        if (!(target instanceof Element)) {
+            return;
+        }
+        const $target = $(target);
+        if (
+            $target.closest(".native-datetime-picker-container").length === 0 &&
+            !options.ignoredFocusElements?.some((el) => el === target || el.contains(target))
+        ) {
+            // Call onClose callback if provided
+            if (options.onClose) {
+                const value = $datetime_input.val();
+                const selected_dates = value ? [new Date(value)] : [];
+                options.onClose(selected_dates, value ?? "", null);
+            }
+            close_all();
+        }
+    };
 
-    return flatpickr_instance;
+    // Delay adding the click listener to prevent immediate close
+    setTimeout(() => {
+        document.addEventListener("click", close_on_outside_click);
+        $picker_container.data("close_handler", close_on_outside_click);
+    }, 0);
+
+    return {
+        close: close_all,
+    };
 }
 
 export function close_all(): void {
-    $(".flatpickr-calendar").removeClass("open");
+    if ($current_picker) {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const close_handler = $current_picker.data("close_handler") as
+            | ((e: MouseEvent) => void)
+            | undefined;
+        if (close_handler) {
+            document.removeEventListener("click", close_handler);
+        }
+        $current_picker.remove();
+        $current_picker = null;
+    }
+    picker_open = false;
 }

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -551,11 +551,10 @@
     --user-group-popover-horizontal-padding: 0.6666em; /* 10px at 15px/1em */
     --user-group-popover-icon-text-gap: 0.3125em; /* 5px at 16px/1em */
 
+    /* flatpickr variable removed - now using native browser date picker */
     /*
-    This isn't scaled with font-size because the flatpickr is a third
-    party component that doesn't scale with font size.
-    */
     --flatpickr-confirm-button-font-size: 18px;
+    */
 
     /*
     Width to be reserved for document scrollbar when scrolling is disabled.

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1,4 +1,5 @@
-@import url("flatpickr/dist/themes/dark.css");
+/* flatpickr dark theme removed - now using native browser date picker */
+/* @import url("flatpickr/dist/themes/dark.css"); */
 
 %dark-theme {
     color-scheme: dark;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1586,3 +1586,43 @@ ul.popover-menu-list {
     flex: 1;
     min-width: 0;
 }
+
+/* Native datetime picker styles */
+.native-datetime-picker-container {
+    position: absolute;
+    z-index: 9999;
+    background: var(--color-background);
+    border: 1px solid var(--color-border-popover-menu);
+    border-radius: 6px;
+    padding: 16px;
+    box-shadow: 0 4px 20px hsl(0deg 0% 0% / 15%);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+
+    .native-datetime-picker-input {
+        padding: 8px 12px;
+        font-size: 1em;
+        border: 1px solid var(--color-border-popover-menu);
+        border-radius: 4px;
+        background: var(--color-background);
+        color: var(--color-text-default);
+        min-width: 200px;
+    }
+
+    .native-datetime-confirm-btn {
+        padding: 8px 16px;
+        font-size: 1em;
+        font-weight: 600;
+        color: hsl(0deg 0% 100%);
+        background-color: hsl(213deg 90% 65%);
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        align-self: flex-end;
+
+        &:hover {
+            background-color: hsl(213deg 90% 55%);
+        }
+    }
+}

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -898,7 +898,8 @@ input[type="checkbox"] {
     align-items: center;
     width: var(--modal-input-width);
 
-    .flatpickr-wrapper {
+    /* Updated for native date picker */
+    .datepicker {
         grid-column: datepicker-start / close-button-end;
         grid-row: close-button;
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1492,8 +1492,9 @@ div.topic_edit_spinner .loading_indicator_spinner {
     user-select: none;
 }
 
+/* flatpickr styles removed - now using native browser date picker */
+/*
 .flatpickr-calendar {
-    /* Hide the up and down arrows in the Flatpickr datepicker year */
     .flatpickr-months .numInputWrapper span {
         display: none;
     }
@@ -1516,9 +1517,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
     }
 
     @media (width < $md_min) {
-        /* Center align flatpickr on mobile
-         * devices so that it doesn't go out of
-         * the viewport. */
         left: 0 !important;
         right: 0 !important;
         margin: auto;
@@ -1529,6 +1527,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
         }
     }
 }
+*/
 
 #about-zulip {
     .exit {

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -20,7 +20,7 @@
             <div class="input" {{#if editable_by_user}}contenteditable="true"{{/if}}></div>
         </div>
         {{else if is_date_field }}
-        <input class="custom_user_field_value datepicker {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" data-field-id="{{ field.id }}" type="text"
+        <input class="custom_user_field_value datepicker {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" data-field-id="{{ field.id }}" type="date"
           value="{{ field_value.value }}" {{#unless editable_by_user}}disabled{{/unless}}/>
         {{#if editable_by_user}}<span class="remove_date"><i class="zulip-icon zulip-icon-close" aria-hidden="true"></i></span>{{/if}}
         {{else if is_url_field }}


### PR DESCRIPTION
This replaces the flatpickr library with native browser date/time picker inputs to evaluate the user experience with browser-native controls.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.--> #36855 

**How changes were tested:**

  - Manually tested date picker functionality in compose box scheduled messages
  - Tested custom profile field date inputs in user profile settings
  - Verified picker opens, closes, and returns correct date values
  - Tested keyboard navigation (Enter to confirm, Escape to close)
  - Tested click-outside-to-close behavior

**Screenshots and screen captures:**
Chrome
<img width="1440" height="900" alt="chrome" src="https://github.com/user-attachments/assets/6b8220a2-16e3-4708-b277-a3a8793f8682" />

Edge

<img width="1440" height="900" alt="edge" src="https://github.com/user-attachments/assets/a4e6a1df-d3fa-4279-834a-277d7aeed0a0" />

Safari

<img width="1440" height="900" alt="safari" src="https://github.com/user-attachments/assets/2d2fecdb-9efa-4435-a895-f5c365086abf" />

Firefox

<img width="1440" height="900" alt="Firefox" src="https://github.com/user-attachments/assets/307c21f1-3858-464f-b93f-d0851f7f535c" />



<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
