### PR TITLE
webhooks/intercom: Add support for admin events.

### DIFF
--- a/zerver/webhooks/intercom/fixtures/admin_activity_log_event_created.json
+++ b/zerver/webhooks/intercom/fixtures/admin_activity_log_event_created.json
@@ -9,7 +9,7 @@
             "performed_by": {
                 "type": "admin",
                 "id": "1234567",
-                "email": "admin@example.com",
+                "email": "bwilliams@example.com",
                 "ip": "192.0.2.1"
             },
             "metadata": {
@@ -17,7 +17,7 @@
             },
             "created_at": 1768016203,
             "activity_type": "ai_inbox_translation_setting_change",
-            "activity_description": "John Doe disabled the AI inbox translation settings."
+            "activity_description": "Bo Williams disabled the AI inbox translation settings."
         }
     },
     "links": {},

--- a/zerver/webhooks/intercom/fixtures/admin_added_to_workspace.json
+++ b/zerver/webhooks/intercom/fixtures/admin_added_to_workspace.json
@@ -5,9 +5,9 @@
         "type": "notification_event_data",
         "item": {
             "type": "admin",
-            "id": 1234568,
-            "name": "John Doe",
-            "email": "john.doe@example.com",
+            "id": 1234567,
+            "name": "Bo Williams",
+            "email": "bwilliams@example.com",
             "job_title": null,
             "away_mode_enabled": false,
             "away_mode_reassign": false,

--- a/zerver/webhooks/intercom/fixtures/admin_away_mode_updated.json
+++ b/zerver/webhooks/intercom/fixtures/admin_away_mode_updated.json
@@ -6,8 +6,8 @@
         "item": {
             "type": "admin",
             "id": 1234567,
-            "name": "John Doe",
-            "email": "admin@example.com",
+            "name": "Bo Williams",
+            "email": "bwilliams@example.com",
             "job_title": null,
             "away_mode_enabled": true,
             "away_mode_reassign": false,

--- a/zerver/webhooks/intercom/fixtures/admin_logged_in.json
+++ b/zerver/webhooks/intercom/fixtures/admin_logged_in.json
@@ -6,8 +6,8 @@
         "item": {
             "type": "admin",
             "id": 1234567,
-            "name": "John Doe",
-            "email": "admin@example.com",
+            "name": "Bo Williams",
+            "email": "bwilliams@example.com",
             "job_title": null,
             "away_mode_enabled": true,
             "away_mode_reassign": false,

--- a/zerver/webhooks/intercom/fixtures/admin_logged_out.json
+++ b/zerver/webhooks/intercom/fixtures/admin_logged_out.json
@@ -6,8 +6,8 @@
         "item": {
             "type": "admin",
             "id": 1234567,
-            "name": "John Doe",
-            "email": "admin@example.com",
+            "name": "Bo Williams",
+            "email": "bwilliams@example.com",
             "job_title": null,
             "away_mode_enabled": true,
             "away_mode_reassign": false,

--- a/zerver/webhooks/intercom/fixtures/admin_removed_from_workspace.json
+++ b/zerver/webhooks/intercom/fixtures/admin_removed_from_workspace.json
@@ -5,9 +5,9 @@
         "type": "notification_event_data",
         "item": {
             "type": "admin",
-            "id": 1234568,
-            "name": "John Doe",
-            "email": "john.doe@example.com",
+            "id": 1234567,
+            "name": "Bo Williams",
+            "email": "bwilliams@example.com",
             "job_title": null,
             "away_mode_enabled": false,
             "away_mode_reassign": false,

--- a/zerver/webhooks/intercom/tests.py
+++ b/zerver/webhooks/intercom/tests.py
@@ -1,3 +1,5 @@
+import orjson
+
 from zerver.lib.test_classes import WebhookTestCase
 
 
@@ -6,3 +8,66 @@ class IntercomWebHookTests(WebhookTestCase):
         expected_topic_name = "Intercom"
         expected_message = "Intercom webhook has been successfully configured."
         self.check_webhook("ping", expected_topic_name, expected_message)
+
+    def test_admin_activity_log_event_created(self) -> None:
+        expected_topic_name = "Admin"
+        expected_message = "John Doe disabled the AI inbox translation settings."
+        self.check_webhook(
+            "admin_activity_log_event_created", expected_topic_name, expected_message
+        )
+
+    def test_admin_added_to_workspace(self) -> None:
+        expected_topic_name = "Admin: John Doe"
+        expected_message = "John Doe is now an admin."
+        self.check_webhook("admin_added_to_workspace", expected_topic_name, expected_message)
+
+    def test_admin_away_mode_enabled(self) -> None:
+        expected_topic_name = "Admin: John Doe"
+        expected_message = "John Doe is away."
+        self.check_webhook("admin_away_mode_updated", expected_topic_name, expected_message)
+
+        payload = orjson.loads(self.webhook_fixture_data("intercom", "admin_away_mode_updated"))
+        payload["data"]["item"]["away_status_reason"] = "😜 On a vacation"
+        self.subscribe(self.test_user, self.channel_name)
+        msg = self.send_webhook_payload(
+            self.test_user,
+            self.url,
+            orjson.dumps(payload).decode(),
+            content_type="application/json",
+        )
+        self.assert_channel_message(
+            message=msg,
+            channel_name=self.channel_name,
+            topic_name=expected_topic_name,
+            content="John Doe is away (😜 On a vacation).",
+        )
+
+    def test_admin_away_mode_disabled(self) -> None:
+        self.subscribe(self.test_user, self.channel_name)
+        payload = self.webhook_fixture_data(self.webhook_dir_name, "admin_away_mode_updated")
+        data = orjson.loads(payload)
+        data["data"]["item"]["away_mode_enabled"] = False
+        msg = self.send_webhook_payload(
+            self.test_user, self.url, orjson.dumps(data).decode(), content_type="application/json"
+        )
+        self.assert_channel_message(
+            message=msg,
+            channel_name=self.channel_name,
+            topic_name="Admin: John Doe",
+            content="John Doe is now available.",
+        )
+
+    def test_admin_logged_in(self) -> None:
+        expected_topic_name = "Admin: John Doe"
+        expected_message = "John Doe logged in."
+        self.check_webhook("admin_logged_in", expected_topic_name, expected_message)
+
+    def test_admin_logged_out(self) -> None:
+        expected_topic_name = "Admin: John Doe"
+        expected_message = "John Doe logged out."
+        self.check_webhook("admin_logged_out", expected_topic_name, expected_message)
+
+    def test_admin_removed_from_workspace(self) -> None:
+        expected_topic_name = "Admin: John Doe"
+        expected_message = "John Doe is no longer an admin."
+        self.check_webhook("admin_removed_from_workspace", expected_topic_name, expected_message)

--- a/zerver/webhooks/intercom/tests.py
+++ b/zerver/webhooks/intercom/tests.py
@@ -1,4 +1,7 @@
+import orjson
+
 from zerver.lib.test_classes import WebhookTestCase
+from zerver.webhooks.fixtureless_integrations import BO_NAME
 
 
 class IntercomWebHookTests(WebhookTestCase):
@@ -6,3 +9,66 @@ class IntercomWebHookTests(WebhookTestCase):
         expected_topic_name = "Intercom"
         expected_message = "Intercom webhook has been successfully configured."
         self.check_webhook("ping", expected_topic_name, expected_message)
+
+    def test_admin_activity_log_event_created(self) -> None:
+        expected_topic_name = "Admin activity log"
+        expected_message = f"{BO_NAME} disabled the AI inbox translation settings."
+        self.check_webhook(
+            "admin_activity_log_event_created", expected_topic_name, expected_message
+        )
+
+    def test_admin_added_to_workspace(self) -> None:
+        expected_topic_name = f"Admin: {BO_NAME}"
+        expected_message = f"{BO_NAME} is now an admin."
+        self.check_webhook("admin_added_to_workspace", expected_topic_name, expected_message)
+
+    def test_admin_away_mode_enabled(self) -> None:
+        expected_topic_name = f"Admin: {BO_NAME}"
+        expected_message = f"{BO_NAME} is away."
+        self.check_webhook("admin_away_mode_updated", expected_topic_name, expected_message)
+
+        payload = orjson.loads(self.webhook_fixture_data("intercom", "admin_away_mode_updated"))
+        payload["data"]["item"]["away_status_reason"] = "😜 On a vacation"
+        self.subscribe(self.test_user, self.channel_name)
+        msg = self.send_webhook_payload(
+            self.test_user,
+            self.url,
+            orjson.dumps(payload).decode(),
+            content_type="application/json",
+        )
+        self.assert_channel_message(
+            message=msg,
+            channel_name=self.channel_name,
+            topic_name=expected_topic_name,
+            content=f"{BO_NAME} is away (😜 On a vacation).",
+        )
+
+    def test_admin_away_mode_disabled(self) -> None:
+        self.subscribe(self.test_user, self.channel_name)
+        payload = self.webhook_fixture_data(self.webhook_dir_name, "admin_away_mode_updated")
+        data = orjson.loads(payload)
+        data["data"]["item"]["away_mode_enabled"] = False
+        msg = self.send_webhook_payload(
+            self.test_user, self.url, orjson.dumps(data).decode(), content_type="application/json"
+        )
+        self.assert_channel_message(
+            message=msg,
+            channel_name=self.channel_name,
+            topic_name=f"Admin: {BO_NAME}",
+            content=f"{BO_NAME} is now available.",
+        )
+
+    def test_admin_logged_in(self) -> None:
+        expected_topic_name = f"Admin: {BO_NAME}"
+        expected_message = f"{BO_NAME} logged in."
+        self.check_webhook("admin_logged_in", expected_topic_name, expected_message)
+
+    def test_admin_logged_out(self) -> None:
+        expected_topic_name = f"Admin: {BO_NAME}"
+        expected_message = f"{BO_NAME} logged out."
+        self.check_webhook("admin_logged_out", expected_topic_name, expected_message)
+
+    def test_admin_removed_from_workspace(self) -> None:
+        expected_topic_name = f"Admin: {BO_NAME}"
+        expected_message = f"{BO_NAME} is no longer an admin."
+        self.check_webhook("admin_removed_from_workspace", expected_topic_name, expected_message)

--- a/zerver/webhooks/intercom/view.py
+++ b/zerver/webhooks/intercom/view.py
@@ -4,23 +4,71 @@ from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import return_success_on_head_request, webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError
+from zerver.lib.partial import partial
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
-from zerver.lib.validator import WildValue, check_string
+from zerver.lib.validator import WildValue, check_bool, check_string
 from zerver.lib.webhooks.common import check_send_webhook_message, get_setup_webhook_message
 from zerver.models import UserProfile
+
+ADMIN_ROLE_UPDATED_TEMPLATE = "{name} is {phrase} an admin."
+
+ADMIN_AWAY_MODE_UPDATED_TEMPLATE = "{name} is {away_status}{reason}."
+
+ADMIN_LOGIN_LOGOUT_TEMPLATE = "{name} {phrase}."
+
+
+def get_admin_name(payload: WildValue) -> str:
+    return payload["data"]["item"]["name"].tame(check_string)
 
 
 def get_topic_name(event_category: str, payload: WildValue) -> str:
     match event_category:
         case "ping":
             return "Intercom"
+        case "admin":
+            if payload["topic"].tame(check_string) == "admin.activity_log_event.created":
+                return "Admin"
+            return f"Admin: {get_admin_name(payload)}"
         case _:  # nocoverage
             raise UnsupportedWebhookEventTypeError(payload["topic"].tame(check_string))
 
 
 def get_ping_message(payload: WildValue) -> str:
     return get_setup_webhook_message("Intercom")
+
+
+def get_admin_activity_log_event_created_message(payload: WildValue) -> str:
+    return payload["data"]["item"]["activity_description"].tame(check_string)
+
+
+def get_admin_role_updated_message(phrase: str, payload: WildValue) -> str:
+    return ADMIN_ROLE_UPDATED_TEMPLATE.format(name=get_admin_name(payload), phrase=phrase)
+
+
+def get_admin_login_logout_message(phrase: str, payload: WildValue) -> str:
+    return ADMIN_LOGIN_LOGOUT_TEMPLATE.format(name=get_admin_name(payload), phrase=phrase)
+
+
+def get_admin_away_mode_updated_message(payload: WildValue) -> str:
+    admin_name = get_admin_name(payload)
+    away_mode_enabled = payload["data"]["item"]["away_mode_enabled"].tame(check_bool)
+
+    if away_mode_enabled:
+        away_status = "away"
+        reason_value = payload["data"]["item"]["away_status_reason"].tame(check_string)
+
+        # Strip trailing period if exists,
+        # since reason will be wrapped inside parentheses.
+        reason_value = reason_value.removesuffix(".")
+        reason = f" ({reason_value})" if reason_value else ""
+    else:
+        away_status = "now available"
+        reason = ""
+
+    return ADMIN_AWAY_MODE_UPDATED_TEMPLATE.format(
+        name=admin_name, away_status=away_status, reason=reason
+    )
 
 
 IGNORED_EVENTS = [
@@ -45,7 +93,15 @@ IGNORED_EVENTS = [
 ]
 
 
-EVENT_TO_FUNCTION_MAPPER: dict[str, Callable[[WildValue], str]] = {"ping": get_ping_message}
+EVENT_TO_FUNCTION_MAPPER: dict[str, Callable[[WildValue], str]] = {
+    "ping": get_ping_message,
+    "admin.activity_log_event.created": get_admin_activity_log_event_created_message,
+    "admin.away_mode_updated": get_admin_away_mode_updated_message,
+    "admin.added_to_workspace": partial(get_admin_role_updated_message, "now"),
+    "admin.removed_from_workspace": partial(get_admin_role_updated_message, "no longer"),
+    "admin.logged_in": partial(get_admin_login_logout_message, "logged in"),
+    "admin.logged_out": partial(get_admin_login_logout_message, "logged out"),
+}
 
 ALL_EVENT_TYPES = list(EVENT_TO_FUNCTION_MAPPER.keys())
 

--- a/zerver/webhooks/intercom/view.py
+++ b/zerver/webhooks/intercom/view.py
@@ -11,10 +11,16 @@ from zerver.lib.webhooks.common import check_send_webhook_message, get_setup_web
 from zerver.models import UserProfile
 
 
-def get_ping_message(payload: WildValue) -> tuple[str, str]:
-    body = get_setup_webhook_message("Intercom")
-    topic_name = "Intercom"
-    return (topic_name, body)
+def get_topic_name(event_category: str, payload: WildValue) -> str:
+    match event_category:
+        case "ping":
+            return "Intercom"
+        case _:  # nocoverage
+            raise UnsupportedWebhookEventTypeError(payload["topic"].tame(check_string))
+
+
+def get_ping_message(payload: WildValue) -> str:
+    return get_setup_webhook_message("Intercom")
 
 
 IGNORED_EVENTS = [
@@ -39,9 +45,7 @@ IGNORED_EVENTS = [
 ]
 
 
-EVENT_TO_FUNCTION_MAPPER: dict[str, Callable[[WildValue], tuple[str, str]]] = {
-    "ping": get_ping_message
-}
+EVENT_TO_FUNCTION_MAPPER: dict[str, Callable[[WildValue], str]] = {"ping": get_ping_message}
 
 ALL_EVENT_TYPES = list(EVENT_TO_FUNCTION_MAPPER.keys())
 
@@ -65,7 +69,8 @@ def api_intercom_webhook(
     handler = EVENT_TO_FUNCTION_MAPPER.get(event_type)
     if handler is None:
         raise UnsupportedWebhookEventTypeError(event_type)
-    topic_name, body = handler(payload)
+    body = handler(payload)
+    topic_name = get_topic_name(event_category, payload)
 
     check_send_webhook_message(request, user_profile, topic_name, body, event_type)
     return json_success(request)

--- a/zerver/webhooks/intercom/view.py
+++ b/zerver/webhooks/intercom/view.py
@@ -4,23 +4,71 @@ from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import return_success_on_head_request, webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError
+from zerver.lib.partial import partial
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
-from zerver.lib.validator import WildValue, check_string
+from zerver.lib.validator import WildValue, check_bool, check_string
 from zerver.lib.webhooks.common import check_send_webhook_message, get_setup_webhook_message
 from zerver.models import UserProfile
+
+ADMIN_ROLE_UPDATED_TEMPLATE = "{name} is {phrase} an admin."
+
+ADMIN_AWAY_MODE_UPDATED_TEMPLATE = "{name} is {away_status}{reason}."
+
+ADMIN_LOGIN_LOGOUT_TEMPLATE = "{name} {phrase}."
+
+
+def get_admin_name(payload: WildValue) -> str:
+    return payload["data"]["item"]["name"].tame(check_string)
 
 
 def get_topic_name(event_category: str, payload: WildValue) -> str:
     match event_category:
         case "ping":
             return "Intercom"
+        case "admin":
+            if payload["topic"].tame(check_string) == "admin.activity_log_event.created":
+                return "Admin activity log"
+            return f"Admin: {get_admin_name(payload)}"
         case _:  # nocoverage
             raise UnsupportedWebhookEventTypeError(payload["topic"].tame(check_string))
 
 
 def get_ping_message(payload: WildValue) -> str:
     return get_setup_webhook_message("Intercom")
+
+
+def get_admin_activity_log_event_created_message(payload: WildValue) -> str:
+    return payload["data"]["item"]["activity_description"].tame(check_string)
+
+
+def get_admin_role_updated_message(phrase: str, payload: WildValue) -> str:
+    return ADMIN_ROLE_UPDATED_TEMPLATE.format(name=get_admin_name(payload), phrase=phrase)
+
+
+def get_admin_login_logout_message(phrase: str, payload: WildValue) -> str:
+    return ADMIN_LOGIN_LOGOUT_TEMPLATE.format(name=get_admin_name(payload), phrase=phrase)
+
+
+def get_admin_away_mode_updated_message(payload: WildValue) -> str:
+    admin_name = get_admin_name(payload)
+    away_mode_enabled = payload["data"]["item"]["away_mode_enabled"].tame(check_bool)
+
+    if away_mode_enabled:
+        away_status = "away"
+        reason_value = payload["data"]["item"]["away_status_reason"].tame(check_string)
+
+        # Strip trailing period if exists,
+        # since reason will be wrapped inside parentheses.
+        reason_value = reason_value.removesuffix(".")
+        reason = f" ({reason_value})" if reason_value else ""
+    else:
+        away_status = "now available"
+        reason = ""
+
+    return ADMIN_AWAY_MODE_UPDATED_TEMPLATE.format(
+        name=admin_name, away_status=away_status, reason=reason
+    )
 
 
 IGNORED_EVENTS = [
@@ -45,7 +93,15 @@ IGNORED_EVENTS = [
 ]
 
 
-EVENT_TO_FUNCTION_MAPPER: dict[str, Callable[[WildValue], str]] = {"ping": get_ping_message}
+EVENT_TO_FUNCTION_MAPPER: dict[str, Callable[[WildValue], str]] = {
+    "ping": get_ping_message,
+    "admin.activity_log_event.created": get_admin_activity_log_event_created_message,
+    "admin.away_mode_updated": get_admin_away_mode_updated_message,
+    "admin.added_to_workspace": partial(get_admin_role_updated_message, "now"),
+    "admin.removed_from_workspace": partial(get_admin_role_updated_message, "no longer"),
+    "admin.logged_in": partial(get_admin_login_logout_message, "logged in"),
+    "admin.logged_out": partial(get_admin_login_logout_message, "logged out"),
+}
 
 ALL_EVENT_TYPES = list(EVENT_TO_FUNCTION_MAPPER.keys())
 


### PR DESCRIPTION
Adds handlers for admin events.
The pr also updates `admin_away_mode_updated` fixture to have a non empty `away_status_reason` value and seperates topic name generation from message formation logic.
**Events supported:**
- `admin.added_to_workspace`
- `admin.removed_from_workspace`
- `admin.logged_in`
- `admin.logged_out`
- `admin.away_mode_updated`
- `admin.activity_log_event.created` -This event does not include a specific admin name in its fixture, so messages are grouped under the generic "Admin" topic. This is appropriate since activity log events are workspace-level actions not tied to a specific admin.
CZO: [#integrations > intercom: Admin events](https://chat.zulip.org/#narrow/channel/127-integrations/topic/intercom.3A.20Admin.20events/with/2362550)
Fixes part of: #31170

**How changes were tested:**

- ALL backend tests pass (`./tools/test-backend`) and added 8 unit tests.
**Screenshots and screen captures:**
<img width="1477" height="443" alt="image" src="https://github.com/user-attachments/assets/cee6d418-b0e7-4e9d-ab55-e0800ea91b03" />

<img width="1044" height="181" alt="image" src="https://github.com/user-attachments/assets/eb97d2e4-941e-4262-9236-8e117d1d9260" />
<img width="621" height="293" alt="image" src="https://github.com/user-attachments/assets/fcfa2b7d-9a97-4a29-9af2-4814235b86c5" />


<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
- [x] Followed the AI use policy
- [x] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

</details>