### PR TITLE
streams: Add join/leave notifications for private streams

### DIFF
--- a/starlight_help/src/content/docs/configure-automated-notices.mdx
+++ b/starlight_help/src/content/docs/configure-automated-notices.mdx
@@ -48,8 +48,11 @@ settings are updated. If enabled, Notification Bot will send messages about
 updates to settings such as the channel [name](/help/rename-a-channel),
 [description](/help/change-the-channel-description),
 [privacy](/help/change-the-privacy-of-a-channel) and [posting
-policy](/help/channel-posting-policy). Messages will be sent to the “channel
-events” topic in the modified channel.
+policy](/help/channel-posting-policy). In private channels, Notification Bot
+also posts a message when members are subscribed or unsubscribed. Messages will
+be sent to the “channel events” topic in the modified channel, or to the
+“*general chat*” topic in [“*general chat*”
+channels](/help/general-chat-channels).
 
 <FlattenedSteps>
   <NavigationSteps target="settings/organization-settings" />

--- a/starlight_help/src/content/docs/configure-automated-notices.mdx
+++ b/starlight_help/src/content/docs/configure-automated-notices.mdx
@@ -43,13 +43,17 @@ announced.
 
 ### Channel events
 
-You can configure whether Zulip will send an automated message when a channel's
-settings are updated. If enabled, Notification Bot will send messages about
-updates to settings such as the channel [name](/help/rename-a-channel),
+You can configure whether Zulip will send automated messages about channel
+events. If enabled, Notification Bot will send messages about updates to
+settings such as the channel [name](/help/rename-a-channel),
 [description](/help/change-the-channel-description),
 [privacy](/help/change-the-privacy-of-a-channel) and [posting
-policy](/help/channel-posting-policy). Messages will be sent to the “channel
-events” topic in the modified channel.
+policy](/help/channel-posting-policy). In private channels, it will also send a
+message when members are subscribed or unsubscribed.
+
+Messages will be sent to the “channel events” topic in the channel, or to the
+“*general chat*” topic in [“*general chat*”
+channels](/help/general-chat-channels).
 
 <FlattenedSteps>
   <NavigationSteps target="settings/organization-settings" />

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -16,7 +16,11 @@ from zerver.actions.message_send import (
     internal_send_private_message,
     internal_send_stream_message,
 )
-from zerver.actions.streams import bulk_add_subscriptions, send_peer_subscriber_events
+from zerver.actions.streams import (
+    bulk_add_subscriptions,
+    send_peer_subscriber_events,
+    send_subscription_change_notices,
+)
 from zerver.actions.user_groups import (
     bulk_add_members_to_user_groups,
     do_send_user_group_members_update_event,
@@ -140,6 +144,9 @@ def set_up_streams_and_groups_for_new_human_user(
 
     if prereg_user is not None:
         streams: list[Stream] = list(prereg_user.streams.all())
+        # Channels named in the invitation, as opposed to ones the new user
+        # adds via default channel groups at signup.
+        invite_stream_ids: set[int] = {stream.id for stream in streams}
         user_groups: list[NamedUserGroup] = list(prereg_user.groups.all())
         acting_user: UserProfile | None = prereg_user.referred_by
 
@@ -147,6 +154,7 @@ def set_up_streams_and_groups_for_new_human_user(
         assert prereg_user.created_user is None, "PregistrationUser should not be reused"
     else:
         streams = []
+        invite_stream_ids = set()
         user_groups = []
         acting_user = None
 
@@ -168,13 +176,29 @@ def set_up_streams_and_groups_for_new_human_user(
     else:
         streams = []
 
-    bulk_add_subscriptions(
+    subscribed, _already_subscribed = bulk_add_subscriptions(
         realm,
         streams,
         [user_profile],
         from_user_creation=True,
         acting_user=acting_user,
     )
+    # Announce the new member in each private channel the invitation granted
+    # (not ones pulled in via default groups, and not when the inviter is
+    # deactivated). Mark it read for the new user so it doesn't sit unread on
+    # their first login; existing members still see it unread.
+    if acting_user is not None and acting_user.is_active:
+        send_subscription_change_notices(
+            realm,
+            acting_user=acting_user,
+            changed_subs=[
+                (sub_info.user, sub_info.stream)
+                for sub_info in subscribed
+                if sub_info.stream.id in invite_stream_ids
+            ],
+            subscribed=True,
+            mark_as_read_user_ids={user_profile.id},
+        )
 
     bulk_add_members_to_user_groups(
         user_groups,

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -16,7 +16,11 @@ from zerver.actions.message_send import (
     internal_send_private_message,
     internal_send_stream_message,
 )
-from zerver.actions.streams import bulk_add_subscriptions, send_peer_subscriber_events
+from zerver.actions.streams import (
+    bulk_add_subscriptions,
+    send_peer_subscriber_events,
+    send_subscription_change_notices,
+)
 from zerver.actions.user_groups import (
     bulk_add_members_to_user_groups,
     do_send_user_group_members_update_event,
@@ -168,13 +172,23 @@ def set_up_streams_and_groups_for_new_human_user(
     else:
         streams = []
 
-    bulk_add_subscriptions(
+    subscribed, _already_subscribed = bulk_add_subscriptions(
         realm,
         streams,
         [user_profile],
         from_user_creation=True,
         acting_user=acting_user,
     )
+    # Announce the new member in each private channel they joined, marked read
+    # for them so it isn't unread on their first login.
+    if acting_user is not None:
+        send_subscription_change_notices(
+            realm,
+            acting_user=acting_user,
+            changed_subs=[(sub_info.user, sub_info.stream) for sub_info in subscribed],
+            subscribed=True,
+            mark_as_read_user_ids={user_profile.id},
+        )
 
     bulk_add_members_to_user_groups(
         user_groups,

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -2099,8 +2099,10 @@ def internal_prep_stream_message(
     topic_name: str,
     content: str,
     *,
+    realm: Realm | None = None,
     email_gateway: bool = False,
     message_type: int = Message.MessageType.NORMAL,
+    mention_backend: MentionBackend | None = None,
     limit_unread_user_ids: set[int] | None = None,
     forged: bool = False,
     forged_timestamp: float | None = None,
@@ -2110,7 +2112,8 @@ def internal_prep_stream_message(
     """
     See _internal_prep_message for details of how this works.
     """
-    realm = stream.realm
+    if realm is None:
+        realm = stream.realm
     addressee = Addressee.for_stream(stream, topic_name)
 
     return _internal_prep_message(
@@ -2120,6 +2123,7 @@ def internal_prep_stream_message(
         content=content,
         email_gateway=email_gateway,
         message_type=message_type,
+        mention_backend=mention_backend,
         limit_unread_user_ids=limit_unread_user_ids,
         forged=forged,
         forged_timestamp=forged_timestamp,

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -7,13 +7,18 @@ from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 from django.utils.translation import override as override_language
 
 from zerver.actions.default_streams import (
     do_remove_default_stream,
     do_remove_streams_from_default_stream_group,
 )
-from zerver.actions.message_send import maybe_send_channel_events_notice
+from zerver.actions.message_send import (
+    do_send_messages,
+    internal_prep_stream_message,
+    maybe_send_channel_events_notice,
+)
 from zerver.lib.cache import (
     cache_delete_many,
     cache_set,
@@ -22,7 +27,7 @@ from zerver.lib.cache import (
 )
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.mention import silent_mention_syntax_for_user, silent_mention_syntax_for_user_group
-from zerver.lib.message import get_last_message_id
+from zerver.lib.message import SendMessageRequest, get_last_message_id
 from zerver.lib.queue import queue_event_on_commit
 from zerver.lib.stream_color import pick_colors
 from zerver.lib.stream_subscription import (
@@ -38,6 +43,7 @@ from zerver.lib.stream_subscription import (
 from zerver.lib.stream_traffic import get_streams_traffic
 from zerver.lib.streams import (
     can_access_stream_metadata_user_ids,
+    channel_events_topic_name,
     check_basic_stream_access,
     get_anonymous_group_membership_dict_for_streams,
     get_stream_permission_policy_key,
@@ -752,6 +758,136 @@ def send_user_creation_events_on_adding_subscriptions(
 
 
 SubT: TypeAlias = tuple[list[SubInfo], list[SubInfo]]
+
+
+# Subscription changes affecting up to this many users name everyone
+# inline; larger changes collapse to a count with the full roster in an
+# expandable spoiler block, so the "channel events" topic isn't flooded.
+MAX_INLINE_SUBSCRIPTION_NOTICE_USERS = 3
+
+
+def get_subscription_change_notice_content(
+    *, acting_user: UserProfile, users: list[UserProfile], subscribed: bool
+) -> str:
+    """Build the "channel events" notice for a subscription change.
+
+    A change affecting a few users names them inline.  A larger change
+    collapses to a count, with the full list of names tucked into an
+    expandable spoiler block, so the topic isn't flooded -- and we send a
+    single message instead of one per user.
+    """
+    acting_user_mention = silent_mention_syntax_for_user(acting_user)
+    # The acting user is named as the actor, so don't also list them among the
+    # targets (which would read as "Iago subscribed Iago and Hamlet ...").
+    targets = sorted(
+        (user for user in users if user.id != acting_user.id),
+        key=lambda user: (user.full_name.lower(), user.id),
+    )
+
+    # A user changing only their own membership reads without a target list.
+    if not targets:
+        if subscribed:
+            return _("{acting_user} subscribed to this channel.").format(
+                acting_user=acting_user_mention
+            )
+        return _("{acting_user} unsubscribed from this channel.").format(
+            acting_user=acting_user_mention
+        )
+
+    count = len(targets)
+    mentions = [silent_mention_syntax_for_user(user) for user in targets]
+
+    if count <= MAX_INLINE_SUBSCRIPTION_NOTICE_USERS:
+        if count == 1:
+            target_users = mentions[0]
+        elif count == 2:
+            target_users = _("{first} and {second}").format(first=mentions[0], second=mentions[1])
+        else:
+            target_users = _("{users}, and {last}").format(
+                users=", ".join(mentions[:-1]), last=mentions[-1]
+            )
+        if subscribed:
+            return _("{acting_user} subscribed {target_users} to this channel.").format(
+                acting_user=acting_user_mention, target_users=target_users
+            )
+        return _("{acting_user} unsubscribed {target_users} from this channel.").format(
+            acting_user=acting_user_mention, target_users=target_users
+        )
+
+    if subscribed:
+        header = ngettext(
+            "{acting_user} subscribed {count} user to this channel.",
+            "{acting_user} subscribed {count} users to this channel.",
+            count,
+        ).format(acting_user=acting_user_mention, count=count)
+    else:
+        header = ngettext(
+            "{acting_user} unsubscribed {count} user from this channel.",
+            "{acting_user} unsubscribed {count} users from this channel.",
+            count,
+        ).format(acting_user=acting_user_mention, count=count)
+
+    member_list = ", ".join(mentions)
+    return f"```spoiler {header}\n{member_list}\n```"
+
+
+def send_subscription_change_notices(
+    realm: Realm,
+    *,
+    acting_user: UserProfile,
+    changed_subs: list[tuple[UserProfile, Stream]],
+    subscribed: bool,
+    skip_stream_ids: Collection[int] = (),
+    mark_as_read_user_ids: Collection[int] = (),
+) -> None:
+    """Post a "channel events" notice for an interactive membership change.
+
+    Only private (invite-only), non-deactivated channels notify, and each
+    such channel gets a single grouped message regardless of how many users
+    changed.  This is deliberately triggered from the interactive
+    subscribe/unsubscribe flows (rather than from bulk_add_subscriptions /
+    bulk_remove_subscriptions, which are also called for user deletion,
+    stream merges, and management commands), matching how the other
+    channel-events notices are sent from their specific actions.
+
+    The notice is marked read for mark_as_read_user_ids and left unread for
+    everyone else (the invitation flow marks it read for the new user).
+    """
+    if not realm.send_channel_events_messages:
+        return
+
+    streams_by_id: dict[int, Stream] = {}
+    users_by_stream_id: dict[int, list[UserProfile]] = defaultdict(list)
+    for user, stream in changed_subs:
+        if not stream.invite_only or stream.deactivated or stream.id in skip_stream_ids:
+            continue
+        streams_by_id[stream.id] = stream
+        users_by_stream_id[stream.id].append(user)
+
+    if not streams_by_id:
+        return
+
+    sender = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
+    with override_language(realm.default_language):
+        message_requests: list[SendMessageRequest | None] = []
+        for stream_id, stream in streams_by_id.items():
+            content = get_subscription_change_notice_content(
+                acting_user=acting_user,
+                users=users_by_stream_id[stream_id],
+                subscribed=subscribed,
+            )
+            message_requests.append(
+                internal_prep_stream_message(
+                    sender,
+                    stream,
+                    channel_events_topic_name(stream),
+                    content,
+                    acting_user=acting_user,
+                )
+            )
+
+        # Send every channel's notice in one batch, not one send per channel.
+        do_send_messages(message_requests, mark_as_read=list(mark_as_read_user_ids))
 
 
 @transaction.atomic(savepoint=False)

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -7,13 +7,18 @@ from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 from django.utils.translation import override as override_language
 
 from zerver.actions.default_streams import (
     do_remove_default_stream,
     do_remove_streams_from_default_stream_group,
 )
-from zerver.actions.message_send import maybe_send_channel_events_notice
+from zerver.actions.message_send import (
+    do_send_messages,
+    internal_prep_stream_message,
+    maybe_send_channel_events_notice,
+)
 from zerver.lib.cache import (
     cache_delete_many,
     cache_set,
@@ -21,8 +26,16 @@ from zerver.lib.cache import (
     to_dict_cache_key_id,
 )
 from zerver.lib.exceptions import JsonableError
-from zerver.lib.mention import silent_mention_syntax_for_user, silent_mention_syntax_for_user_group
-from zerver.lib.message import get_last_message_id
+from zerver.lib.mention import (
+    MentionBackend,
+    silent_mention_syntax_for_user,
+    silent_mention_syntax_for_user_group,
+)
+from zerver.lib.message import (
+    SendMessageRequest,
+    get_last_message_id,
+    get_user_mentions_for_display,
+)
 from zerver.lib.queue import queue_event_on_commit
 from zerver.lib.stream_color import pick_colors
 from zerver.lib.stream_subscription import (
@@ -38,6 +51,7 @@ from zerver.lib.stream_subscription import (
 from zerver.lib.stream_traffic import get_streams_traffic
 from zerver.lib.streams import (
     can_access_stream_metadata_user_ids,
+    channel_events_topic_name,
     check_basic_stream_access,
     get_anonymous_group_membership_dict_for_streams,
     get_stream_permission_policy_key,
@@ -744,6 +758,136 @@ def send_user_creation_events_on_adding_subscriptions(
 
 
 SubT: TypeAlias = tuple[list[SubInfo], list[SubInfo]]
+
+
+# Changes affecting more than this many users collapse to a count with the
+# roster in a spoiler block, so the topic isn't flooded with names.
+MAX_INLINE_SUBSCRIPTION_NOTICE_USERS = 3
+
+
+def get_subscription_change_notice_content(
+    *, acting_user: UserProfile, users: list[UserProfile], subscribed: bool
+) -> str:
+    assert users
+    acting_user_mention = silent_mention_syntax_for_user(acting_user)
+
+    # Someone changing only their own membership needs no target list.
+    if len(users) == 1 and users[0].id == acting_user.id:
+        if subscribed:
+            return _("{acting_user} subscribed to this channel.").format(
+                acting_user=acting_user_mention
+            )
+        return _("{acting_user} unsubscribed from this channel.").format(
+            acting_user=acting_user_mention
+        )
+
+    count = len(users)
+
+    if count <= MAX_INLINE_SUBSCRIPTION_NOTICE_USERS:
+        target_users = get_user_mentions_for_display(users)
+        if subscribed:
+            return _("{acting_user} subscribed {target_users} to this channel.").format(
+                acting_user=acting_user_mention, target_users=target_users
+            )
+        return _("{acting_user} unsubscribed {target_users} from this channel.").format(
+            acting_user=acting_user_mention, target_users=target_users
+        )
+
+    if subscribed:
+        header = ngettext(
+            "{acting_user} subscribed {count} user to this channel.",
+            "{acting_user} subscribed {count} users to this channel.",
+            count,
+        ).format(acting_user=acting_user_mention, count=count)
+    else:
+        header = ngettext(
+            "{acting_user} unsubscribed {count} user from this channel.",
+            "{acting_user} unsubscribed {count} users from this channel.",
+            count,
+        ).format(acting_user=acting_user_mention, count=count)
+
+    member_list = ", ".join(sorted(silent_mention_syntax_for_user(user) for user in users))
+    return f"```spoiler {header}\n{member_list}\n```"
+
+
+def prep_subscription_change_notices(
+    realm: Realm,
+    *,
+    acting_user: UserProfile,
+    changed_subs: list[tuple[UserProfile, Stream]],
+    subscribed: bool,
+    mention_backend: MentionBackend | None = None,
+) -> list[SendMessageRequest | None]:
+    """Prepare the "channel events" notices for an interactive membership change.
+
+    Only private, non-archived channels notify, with one message per channel
+    however many users changed.  Callers that have other messages to send for
+    the same request pass a shared mention_backend and send everything in one
+    batch.
+
+    Callers are the interactive subscribe/unsubscribe flows, not
+    bulk_add_subscriptions / bulk_remove_subscriptions; those are also used for
+    user deletion, channel merges, and management commands, where a notice
+    would be noise.
+    """
+    if not realm.send_channel_events_messages:
+        return []
+
+    streams_by_id: dict[int, Stream] = {}
+    users_by_stream_id: dict[int, list[UserProfile]] = defaultdict(list)
+    for user, stream in changed_subs:
+        if not stream.invite_only or stream.deactivated:
+            continue
+        streams_by_id[stream.id] = stream
+        users_by_stream_id[stream.id].append(user)
+
+    if not streams_by_id:
+        return []
+
+    sender = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
+    if mention_backend is None:
+        # MentionBackend's caches are only valid for a single sender, which
+        # every notice in this batch shares.
+        mention_backend = MentionBackend(realm.id)
+
+    message_requests: list[SendMessageRequest | None] = []
+    with override_language(realm.default_language):
+        for stream_id, stream in streams_by_id.items():
+            content = get_subscription_change_notice_content(
+                acting_user=acting_user,
+                users=users_by_stream_id[stream_id],
+                subscribed=subscribed,
+            )
+            message_requests.append(
+                internal_prep_stream_message(
+                    sender,
+                    stream,
+                    channel_events_topic_name(stream),
+                    content,
+                    realm=realm,
+                    mention_backend=mention_backend,
+                    acting_user=acting_user,
+                )
+            )
+    return message_requests
+
+
+def send_subscription_change_notices(
+    realm: Realm,
+    *,
+    acting_user: UserProfile,
+    changed_subs: list[tuple[UserProfile, Stream]],
+    subscribed: bool,
+    mark_as_read_user_ids: Collection[int] = (),
+) -> None:
+    message_requests = prep_subscription_change_notices(
+        realm,
+        acting_user=acting_user,
+        changed_subs=changed_subs,
+        subscribed=subscribed,
+    )
+    if message_requests:
+        do_send_messages(message_requests, mark_as_read=list(mark_as_read_user_ids))
 
 
 @transaction.atomic(savepoint=False)

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -1749,7 +1749,9 @@ def is_message_to_self(message: Message) -> bool:
     return False
 
 
-def get_user_mentions_for_display(user_list: list[UserProfile | UserDisplayRecipient]) -> str:
+def get_user_mentions_for_display(
+    user_list: Sequence[UserProfile | UserDisplayRecipient],
+) -> str:
     recipient_list = sorted(silent_mention_syntax_for_user(user) for user in user_list)
 
     if len(recipient_list) == 1:

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -116,6 +116,9 @@ def fetch_api_key() -> dict[str, object]:
         "/messages/{message_id}:patch",
         "/messages/{message_id}:delete",
         "/messages/{message_id}/reactions:post",
+        "/messages/{message_id}/read_receipts:get",
+        "/messages/{message_id}/report:post",
+        "/messages/{message_id}/typing:post",
     ]
 )
 def iago_message_id() -> dict[str, object]:

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -31,7 +31,11 @@ from zerver.actions.create_user import (
     process_new_human_user,
     set_up_streams_and_groups_for_new_human_user,
 )
-from zerver.actions.default_streams import do_add_default_stream, do_remove_default_stream
+from zerver.actions.default_streams import (
+    do_add_default_stream,
+    do_create_default_stream_group,
+    do_remove_default_stream,
+)
 from zerver.actions.invites import (
     do_create_multiuse_invite_link,
     do_get_invites_controlled_by_user,
@@ -67,6 +71,7 @@ from zerver.models import (
     RealmAuditLog,
     ScheduledEmail,
     Stream,
+    Subscription,
     UserMessage,
     UserProfile,
 )
@@ -1295,7 +1300,7 @@ class InviteUserTest(InviteUserBase):
         realm.save(update_fields=["signup_announcements_stream"])
 
         private_stream_name = "Secret"
-        self.make_stream(private_stream_name, invite_only=True)
+        private_stream = self.make_stream(private_stream_name, invite_only=True)
         self.subscribe(user_profile, private_stream_name)
         public_msg_id = self.send_stream_message(
             self.example_user("hamlet"),
@@ -1322,11 +1327,36 @@ class InviteUserTest(InviteUserBase):
         self.assertFalse(secret_msg_id in invitee_msg_ids)
         self.assertFalse(invitee_profile.is_realm_admin)
 
-        invitee_msg, signups_stream_msg, inviter_msg, secret_msg = Message.objects.all().order_by(
-            "-id"
-        )[0:4]
+        (
+            invitee_msg,
+            signups_stream_msg,
+            inviter_msg,
+            private_channel_join_msg,
+            secret_msg,
+        ) = Message.objects.all().order_by("-id")[0:5]
 
         self.assertEqual(secret_msg.id, secret_msg_id)
+
+        self.assertEqual(private_channel_join_msg.sender.email, "notification-bot@zulip.com")
+        self.assertEqual(private_channel_join_msg.recipient.type_id, private_stream.id)
+        self.assertEqual(private_channel_join_msg.topic_name(), "channel events")
+        self.assertEqual(
+            private_channel_join_msg.content,
+            f"@_**{user_profile.full_name}|{user_profile.id}** subscribed "
+            f"@_**{invitee_profile.full_name}|{invitee_profile.id}** to this channel.",
+        )
+        self.assertIn(private_channel_join_msg.id, invitee_msg_ids)
+
+        # The invitee's own join notice is marked read; the existing member
+        # (the inviter) still sees it unread.
+        invitee_join_um = UserMessage.objects.get(
+            user_profile=invitee_profile, message=private_channel_join_msg
+        )
+        self.assertTrue(invitee_join_um.flags.read.is_set)
+        inviter_join_um = UserMessage.objects.get(
+            user_profile=user_profile, message=private_channel_join_msg
+        )
+        self.assertFalse(inviter_join_um.flags.read.is_set)
 
         self.assertEqual(inviter_msg.sender.email, "notification-bot@zulip.com")
         self.assertTrue(
@@ -1345,6 +1375,78 @@ class InviteUserTest(InviteUserBase):
         self.assertEqual(invitee_msg.sender.email, "welcome-bot@zulip.com")
         self.assertTrue(invitee_msg.content.startswith("Hello, and welcome to Zulip!"))
         self.assertNotIn("demo organization", invitee_msg.content)
+
+    def get_channel_events_messages(self, stream: Stream) -> list[Message]:
+        return [
+            message
+            for message in Message.objects.filter(realm=stream.realm, recipient=stream.recipient)
+            if message.topic_name() == "channel events"
+        ]
+
+    def test_invite_from_deactivated_user_sends_no_private_channel_notice(self) -> None:
+        """
+        The private-channel join notice names the inviter, so we skip it
+        when the inviter has been deactivated between sending the invitation
+        and its acceptance, matching the invitation-accepted direct message.
+        """
+        inviter = self.example_user("hamlet")
+        self.login_user(inviter)
+        private_stream = self.make_stream("Secret", invite_only=True)
+        self.subscribe(inviter, "Secret")
+
+        invitee = self.nonreg_email("alice")
+        self.assert_json_success(self.invite(invitee, ["Secret"]))
+        prereg_user = PreregistrationUser.objects.get(email=invitee)
+
+        change_user_is_active(inviter, False)
+        invitee_profile = do_create_user(
+            invitee,
+            "password",
+            inviter.realm,
+            "full name",
+            prereg_user=prereg_user,
+            acting_user=None,
+        )
+
+        # The new user is subscribed, but the deactivated inviter is not named.
+        self.assertTrue(
+            Subscription.objects.filter(
+                user_profile=invitee_profile, recipient=private_stream.recipient, active=True
+            ).exists()
+        )
+        self.assert_length(self.get_channel_events_messages(private_stream), 0)
+
+    def test_default_stream_group_private_channel_not_attributed_to_inviter(self) -> None:
+        """
+        A private channel pulled in via a default channel group is the new
+        user's own signup selection, not a membership the inviter granted, so
+        it must not generate a join notice attributed to the inviter.
+        """
+        inviter = self.example_user("hamlet")
+        realm = inviter.realm
+        self.login_user(inviter)
+
+        # A private channel reachable only through a default channel group.
+        group_private_stream = self.make_stream("group-secret", invite_only=True)
+        do_create_default_stream_group(
+            realm, "onboarding", "onboarding description", [group_private_stream]
+        )
+
+        invitee = self.nonreg_email("alice")
+        self.assert_json_success(self.invite(invitee, ["Denmark"]))
+        self.submit_reg_form_for_user(invitee, "password", default_stream_groups=["onboarding"])
+        invitee_profile = self.nonreg_user("alice")
+
+        # The new user is subscribed, but the group's private channel is not
+        # misattributed to the inviter.
+        self.assertTrue(
+            Subscription.objects.filter(
+                user_profile=invitee_profile,
+                recipient=group_private_stream.recipient,
+                active=True,
+            ).exists()
+        )
+        self.assert_length(self.get_channel_events_messages(group_private_stream), 0)
 
     def test_multi_user_invite(self) -> None:
         """

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -1295,7 +1295,7 @@ class InviteUserTest(InviteUserBase):
         realm.save(update_fields=["signup_announcements_stream"])
 
         private_stream_name = "Secret"
-        self.make_stream(private_stream_name, invite_only=True)
+        private_stream = self.make_stream(private_stream_name, invite_only=True)
         self.subscribe(user_profile, private_stream_name)
         public_msg_id = self.send_stream_message(
             self.example_user("hamlet"),
@@ -1322,11 +1322,36 @@ class InviteUserTest(InviteUserBase):
         self.assertFalse(secret_msg_id in invitee_msg_ids)
         self.assertFalse(invitee_profile.is_realm_admin)
 
-        invitee_msg, signups_stream_msg, inviter_msg, secret_msg = Message.objects.all().order_by(
-            "-id"
-        )[0:4]
+        (
+            invitee_msg,
+            signups_stream_msg,
+            inviter_msg,
+            private_channel_join_msg,
+            secret_msg,
+        ) = Message.objects.all().order_by("-id")[0:5]
 
         self.assertEqual(secret_msg.id, secret_msg_id)
+
+        self.assertEqual(private_channel_join_msg.sender.email, "notification-bot@zulip.com")
+        self.assertEqual(private_channel_join_msg.recipient.type_id, private_stream.id)
+        self.assertEqual(private_channel_join_msg.topic_name(), "channel events")
+        self.assertEqual(
+            private_channel_join_msg.content,
+            f"@_**{user_profile.full_name}|{user_profile.id}** subscribed "
+            f"@_**{invitee_profile.full_name}|{invitee_profile.id}** to this channel.",
+        )
+        self.assertIn(private_channel_join_msg.id, invitee_msg_ids)
+
+        # The invitee's own join notice is marked read; the existing member
+        # (the inviter) still sees it unread.
+        invitee_join_um = UserMessage.objects.get(
+            user_profile=invitee_profile, message=private_channel_join_msg
+        )
+        self.assertTrue(invitee_join_um.flags.read.is_set)
+        inviter_join_um = UserMessage.objects.get(
+            user_profile=user_profile, message=private_channel_join_msg
+        )
+        self.assertFalse(inviter_join_um.flags.read.is_set)
 
         self.assertEqual(inviter_msg.sender.email, "notification-bot@zulip.com")
         self.assertTrue(

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1,6 +1,7 @@
 import hashlib
 import random
 from collections.abc import Sequence
+from contextlib import redirect_stdout
 from datetime import timedelta
 from io import StringIO
 from typing import TYPE_CHECKING, Any
@@ -9,6 +10,7 @@ from unittest import mock
 import orjson
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.core.management import call_command
 from django.db import transaction
 from django.http import HttpResponse
 from django.utils.timezone import now as timezone_now
@@ -34,6 +36,7 @@ from zerver.actions.streams import (
     do_deactivate_stream,
     do_set_stream_property,
     do_unarchive_stream,
+    get_subscription_change_notice_content,
 )
 from zerver.actions.user_groups import bulk_add_members_to_user_groups, check_add_user_group
 from zerver.actions.users import do_deactivate_user
@@ -3298,8 +3301,10 @@ class StreamAdminTest(ZulipTestCase):
         If you're a realm admin, you can remove other people from private streams you
         are on.
         """
+        # The count is higher than for a public channel because unsubscribing
+        # from a private channel also posts a "channel events" notice.
         result = self.attempt_unsubscribe_of_principal(
-            query_count=18,
+            query_count=34,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3315,8 +3320,10 @@ class StreamAdminTest(ZulipTestCase):
         If you're a realm admin, you can remove people from private
         streams you aren't on.
         """
+        # The count is higher than for a public channel because unsubscribing
+        # from a private channel also posts a "channel events" notice.
         result = self.attempt_unsubscribe_of_principal(
-            query_count=18,
+            query_count=34,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=False,
@@ -5804,3 +5811,332 @@ class NoRecipientIDsTest(ZulipTestCase):
         #
         # This covers a rare corner case.
         self.assert_length(subs, 0)
+
+
+class PrivateStreamEventTest(ZulipTestCase):
+    def mention_syntax_for_user(self, user: UserProfile) -> str:
+        return f"@_**{user.full_name}|{user.id}**"
+
+    def latest_channel_event_message_content(self, witness: UserProfile, stream: Stream) -> str:
+        return get_topic_messages(witness, stream, "channel events")[-1].content
+
+    def unsubscribe_via_delete(
+        self, stream: Stream, principals: Sequence[UserProfile] = ()
+    ) -> None:
+        data = {"subscriptions": orjson.dumps([stream.name]).decode()}
+        if principals:
+            data["principals"] = orjson.dumps([user.id for user in principals]).decode()
+        self.assert_json_success(self.client_delete("/json/users/me/subscriptions", data))
+
+    def assert_notice_read_only_for_acting_user(
+        self, stream: Stream, acting_user: UserProfile, witness: UserProfile
+    ) -> None:
+        message = get_topic_messages(witness, stream, "channel events")[-1]
+        self.assertTrue(
+            UserMessage.objects.get(user_profile=acting_user, message=message).flags.read.is_set
+        )
+        self.assertFalse(
+            UserMessage.objects.get(user_profile=witness, message=message).flags.read.is_set
+        )
+
+    def assert_subscribed(
+        self, users: Sequence[UserProfile], stream: Stream, subscribed: bool
+    ) -> None:
+        for user in users:
+            self.assertEqual(
+                Subscription.objects.filter(
+                    user_profile=user, recipient=stream.recipient, active=True
+                ).exists(),
+                subscribed,
+            )
+
+    def test_join_leave_notifications(self) -> None:
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        realm = iago.realm
+
+        stream = self.make_stream("secret", realm=realm, invite_only=True)
+        self.subscribe(iago, stream.name)
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 0)
+
+        iago_mention = self.mention_syntax_for_user(iago)
+        hamlet_mention = self.mention_syntax_for_user(hamlet)
+
+        self.login_user(iago)
+        self.subscribe_via_post(
+            iago, [stream.name], dict(principals=orjson.dumps([hamlet.id]).decode())
+        )
+        self.assert_subscribed([hamlet], stream, True)
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 1)
+        self.assertEqual(
+            self.latest_channel_event_message_content(iago, stream),
+            f"{iago_mention} subscribed {hamlet_mention} to this channel.",
+        )
+
+        self.unsubscribe_via_delete(stream, [hamlet])
+        self.assert_subscribed([hamlet], stream, False)
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 2)
+        self.assertEqual(
+            self.latest_channel_event_message_content(iago, stream),
+            f"{iago_mention} unsubscribed {hamlet_mention} from this channel.",
+        )
+
+        do_change_stream_group_based_setting(
+            stream,
+            "can_subscribe_group",
+            UserGroupMembersData(direct_members=[hamlet.id], direct_subgroups=[]),
+            acting_user=iago,
+        )
+        self.login_user(hamlet)
+        self.subscribe_via_post(hamlet, [stream.name])
+        self.assert_subscribed([hamlet], stream, True)
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 3)
+        self.assertEqual(
+            self.latest_channel_event_message_content(iago, stream),
+            f"{hamlet_mention} subscribed to this channel.",
+        )
+
+        self.unsubscribe_via_delete(stream)
+        self.assert_subscribed([hamlet], stream, False)
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 4)
+        self.assertEqual(
+            self.latest_channel_event_message_content(iago, stream),
+            f"{hamlet_mention} unsubscribed from this channel.",
+        )
+
+        public_stream = self.make_stream("not-secret", realm=realm)
+        self.subscribe(iago, public_stream.name)
+        self.login_user(iago)
+        self.subscribe_via_post(
+            iago, [public_stream.name], dict(principals=orjson.dumps([hamlet.id]).decode())
+        )
+        self.assert_subscribed([hamlet], public_stream, True)
+        self.unsubscribe_via_delete(public_stream, [hamlet])
+        self.assert_subscribed([hamlet], public_stream, False)
+        self.assert_length(get_topic_messages(iago, public_stream, "channel events"), 0)
+
+    def test_notice_is_read_only_for_the_acting_user(self) -> None:
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
+        realm = iago.realm
+
+        stream = self.make_stream("read-state-secret", realm=realm, invite_only=True)
+        self.subscribe(iago, stream.name)
+        self.subscribe(cordelia, stream.name)
+        self.login_user(iago)
+
+        self.subscribe_via_post(
+            iago, [stream.name], dict(principals=orjson.dumps([hamlet.id]).decode())
+        )
+        self.assert_notice_read_only_for_acting_user(stream, iago, cordelia)
+
+        self.unsubscribe_via_delete(stream, [hamlet])
+        self.assert_notice_read_only_for_acting_user(stream, iago, cordelia)
+
+    def test_private_stream_bulk_notifications(self) -> None:
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+        prospero = self.example_user("prospero")
+        realm = iago.realm
+
+        stream = self.make_stream("bulk-secret", realm=realm, invite_only=True)
+        self.subscribe(iago, stream.name)
+        self.login_user(iago)
+
+        iago_mention = self.mention_syntax_for_user(iago)
+        cordelia_mention = self.mention_syntax_for_user(cordelia)
+        hamlet_mention = self.mention_syntax_for_user(hamlet)
+        othello_mention = self.mention_syntax_for_user(othello)
+
+        def add(users: list[UserProfile]) -> None:
+            self.subscribe_via_post(
+                iago,
+                [stream.name],
+                dict(principals=orjson.dumps([user.id for user in users]).decode()),
+            )
+            self.assert_subscribed(users, stream, True)
+
+        def remove(users: list[UserProfile]) -> None:
+            self.unsubscribe_via_delete(stream, users)
+            self.assert_subscribed(users, stream, False)
+
+        # Two users are named inline, sorted by name rather than input order.
+        add([hamlet, cordelia])
+        self.assertEqual(
+            self.latest_channel_event_message_content(iago, stream),
+            f"{iago_mention} subscribed {cordelia_mention} and {hamlet_mention} to this channel.",
+        )
+        remove([hamlet, cordelia])
+
+        add([othello, cordelia, hamlet])
+        self.assertEqual(
+            self.latest_channel_event_message_content(iago, stream),
+            f"{iago_mention} subscribed {cordelia_mention}, {hamlet_mention}, "
+            f"and {othello_mention} to this channel.",
+        )
+        remove([othello, cordelia, hamlet])
+
+        # Past MAX_INLINE_SUBSCRIPTION_NOTICE_USERS, a single message collapses
+        # to a count with the roster in a spoiler block.
+        members = [prospero, othello, cordelia, hamlet]
+        roster = ", ".join(
+            self.mention_syntax_for_user(user) for user in [cordelia, hamlet, othello, prospero]
+        )
+        add(members)
+        self.assertEqual(
+            self.latest_channel_event_message_content(iago, stream),
+            f"```spoiler {iago_mention} subscribed 4 users to this channel.\n{roster}\n```",
+        )
+        remove(members)
+        self.assertEqual(
+            self.latest_channel_event_message_content(iago, stream),
+            f"```spoiler {iago_mention} unsubscribed 4 users from this channel.\n{roster}\n```",
+        )
+
+    def test_acting_user_included_in_target_list(self) -> None:
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        iago_mention = self.mention_syntax_for_user(iago)
+        hamlet_mention = self.mention_syntax_for_user(hamlet)
+
+        # Acting on themselves alongside others still names them as a target,
+        # so the notice accounts for everyone whose membership changed.
+        self.assertEqual(
+            get_subscription_change_notice_content(
+                acting_user=iago, users=[iago, hamlet], subscribed=True
+            ),
+            f"{iago_mention} subscribed {iago_mention} and {hamlet_mention} to this channel.",
+        )
+        self.assertEqual(
+            get_subscription_change_notice_content(
+                acting_user=iago, users=[iago, hamlet], subscribed=False
+            ),
+            f"{iago_mention} unsubscribed {iago_mention} and {hamlet_mention} from this channel.",
+        )
+        # Acting only on themselves needs no target list.
+        self.assertEqual(
+            get_subscription_change_notice_content(acting_user=iago, users=[iago], subscribed=True),
+            f"{iago_mention} subscribed to this channel.",
+        )
+        self.assertEqual(
+            get_subscription_change_notice_content(
+                acting_user=iago, users=[iago], subscribed=False
+            ),
+            f"{iago_mention} unsubscribed from this channel.",
+        )
+
+    def test_general_chat_channel_notifications(self) -> None:
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        realm = iago.realm
+
+        stream = self.make_stream(
+            "general-chat-secret",
+            realm=realm,
+            invite_only=True,
+            topics_policy=StreamTopicsPolicyEnum.empty_topic_only.value,
+        )
+        self.subscribe(iago, stream.name)
+        self.assert_length(get_topic_messages(iago, stream, ""), 0)
+
+        iago_mention = self.mention_syntax_for_user(iago)
+        hamlet_mention = self.mention_syntax_for_user(hamlet)
+
+        self.login_user(iago)
+        self.subscribe_via_post(
+            iago, [stream.name], dict(principals=orjson.dumps([hamlet.id]).decode())
+        )
+        self.unsubscribe_via_delete(stream, [hamlet])
+
+        # A channel with no "channel events" topic notifies in general chat.
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 0)
+        messages = get_topic_messages(iago, stream, "")
+        self.assertEqual(
+            [message.content for message in messages],
+            [
+                f"{iago_mention} subscribed {hamlet_mention} to this channel.",
+                f"{iago_mention} unsubscribed {hamlet_mention} from this channel.",
+            ],
+        )
+
+    def test_archived_channel_no_notifications(self) -> None:
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        realm = iago.realm
+
+        stream = self.make_stream("archived-secret", realm=realm, invite_only=True)
+        self.subscribe(iago, stream.name)
+        self.subscribe(hamlet, stream.name)
+        do_deactivate_stream(stream, acting_user=iago)
+        # Archiving the channel posts a "channel events" notice of its own.
+        notice_count = len(get_topic_messages(iago, stream, "channel events"))
+
+        # Subscriptions survive archiving, so they can still be removed, but an
+        # archived channel accepts no messages.
+        self.login_user(iago)
+        with self.assertNoLogs(level="ERROR"):
+            self.unsubscribe_via_delete(stream, [hamlet])
+        self.assert_subscribed([hamlet], stream, False)
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), notice_count)
+
+    def test_bulk_primitives_do_not_send_notifications(self) -> None:
+        """
+        Administrative callers such as user deletion and channel merges use
+        these primitives directly, and must not post to private channels.
+        """
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        realm = iago.realm
+
+        stream = self.make_stream("primitive-secret", realm=realm, invite_only=True)
+        self.subscribe(iago, stream.name)
+
+        bulk_add_subscriptions(realm, [stream], [hamlet], acting_user=None)
+        bulk_remove_subscriptions(realm, [hamlet], [stream], acting_user=None)
+
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 0)
+
+    def test_no_notice_when_setting_disabled(self) -> None:
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        realm = iago.realm
+        do_set_realm_property(realm, "send_channel_events_messages", False, acting_user=None)
+
+        stream = self.make_stream("quiet-secret", realm=realm, invite_only=True)
+        self.subscribe(iago, stream.name)
+
+        self.login_user(iago)
+        self.subscribe_via_post(
+            iago, [stream.name], dict(principals=orjson.dumps([hamlet.id]).decode())
+        )
+        self.assert_subscribed([hamlet], stream, True)
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 0)
+
+    def test_merge_streams_and_delete_user_commands_send_no_notice(self) -> None:
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        realm = iago.realm
+
+        # merge_streams moves subscribers from the destroyed private channel to
+        # the surviving one, which Iago is subscribed to.
+        keep = self.make_stream("keep-secret", realm=realm, invite_only=True)
+        destroy = self.make_stream("destroy-secret", realm=realm, invite_only=True)
+        self.subscribe(iago, keep.name)
+        self.subscribe(hamlet, destroy.name)
+        # Both commands print status lines with print(), which the test suite's
+        # console-output check would otherwise reject.
+        with redirect_stdout(StringIO()):
+            call_command("merge_streams", keep.name, destroy.name, "-r", realm.string_id)
+        self.assert_length(get_topic_messages(iago, keep, "channel events"), 0)
+
+        # delete_user unsubscribes the deleted user from every private channel.
+        secret = self.make_stream("delete-secret", realm=realm, invite_only=True)
+        self.subscribe(iago, secret.name)
+        self.subscribe(cordelia, secret.name)
+        with redirect_stdout(StringIO()):
+            call_command("delete_user", "-f", "-r", realm.string_id, "-u", cordelia.delivery_email)
+        self.assert_length(get_topic_messages(iago, secret, "channel events"), 0)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1,6 +1,7 @@
 import hashlib
 import random
 from collections.abc import Sequence
+from contextlib import redirect_stdout
 from datetime import timedelta
 from io import StringIO
 from typing import TYPE_CHECKING, Any
@@ -9,6 +10,7 @@ from unittest import mock
 import orjson
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.core.management import call_command
 from django.db import transaction
 from django.http import HttpResponse
 from django.utils.timezone import now as timezone_now
@@ -34,6 +36,7 @@ from zerver.actions.streams import (
     do_deactivate_stream,
     do_set_stream_property,
     do_unarchive_stream,
+    get_subscription_change_notice_content,
 )
 from zerver.actions.user_groups import bulk_add_members_to_user_groups, check_add_user_group
 from zerver.actions.users import do_deactivate_user
@@ -3298,8 +3301,11 @@ class StreamAdminTest(ZulipTestCase):
         If you're a realm admin, you can remove other people from private streams you
         are on.
         """
+        # The query count is higher than the public-stream equivalent because
+        # removing a user from a private channel posts a "channel events"
+        # notification message, which takes additional queries to send.
         result = self.attempt_unsubscribe_of_principal(
-            query_count=18,
+            query_count=35,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3315,8 +3321,11 @@ class StreamAdminTest(ZulipTestCase):
         If you're a realm admin, you can remove people from private
         streams you aren't on.
         """
+        # The query count is higher than the public-stream equivalent because
+        # removing a user from a private channel posts a "channel events"
+        # notification message, which takes additional queries to send.
         result = self.attempt_unsubscribe_of_principal(
-            query_count=18,
+            query_count=35,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=False,
@@ -5804,3 +5813,337 @@ class NoRecipientIDsTest(ZulipTestCase):
         #
         # This covers a rare corner case.
         self.assert_length(subs, 0)
+
+
+class PrivateStreamEventTest(ZulipTestCase):
+    """Interactive subscribe/unsubscribe posts a "channel events" notice to
+    private channels (see get_subscription_change_notice_content and
+    send_subscription_change_notices)."""
+
+    def enable_channel_events(self, realm: Realm) -> None:
+        realm.send_channel_events_messages = True
+        realm.save(update_fields=["send_channel_events_messages"])
+
+    def latest_channel_event(self, witness: UserProfile, stream: Stream) -> str:
+        return get_topic_messages(witness, stream, "channel events")[-1].content
+
+    def test_private_stream_join_leave_notifications(self) -> None:
+        """
+        Subscribing/unsubscribing a user names the acting user when they act
+        on someone else, and stays actor-less when a user changes their own
+        membership.  Iago stays subscribed throughout as the witness who
+        receives every notification.
+        """
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        realm = iago.realm
+        self.enable_channel_events(realm)
+
+        stream = self.make_stream("secret", realm=realm, invite_only=True)
+        # Iago witnesses the notices; this setup subscription posts none.
+        self.subscribe(iago, stream.name)
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 0)
+
+        iago_mention = f"@_**{iago.full_name}|{iago.id}**"
+        hamlet_mention = f"@_**{hamlet.full_name}|{hamlet.id}**"
+
+        # An admin adding another user names both the actor and the target.
+        self.login_user(iago)
+        self.subscribe_via_post(
+            iago, [stream.name], dict(principals=orjson.dumps([hamlet.id]).decode())
+        )
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 1)
+        self.assertEqual(
+            self.latest_channel_event(iago, stream),
+            f"{iago_mention} subscribed {hamlet_mention} to this channel.",
+        )
+
+        # An admin removing another user likewise names both.
+        self.client_delete(
+            "/json/users/me/subscriptions",
+            {
+                "subscriptions": orjson.dumps([stream.name]).decode(),
+                "principals": orjson.dumps([hamlet.id]).decode(),
+            },
+        )
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 2)
+        self.assertEqual(
+            self.latest_channel_event(iago, stream),
+            f"{iago_mention} unsubscribed {hamlet_mention} from this channel.",
+        )
+
+        # A user changing their own membership is not named as an actor.
+        # Allow Hamlet to subscribe himself to this private channel.
+        do_change_stream_group_based_setting(
+            stream,
+            "can_subscribe_group",
+            UserGroupMembersData(direct_members=[hamlet.id], direct_subgroups=[]),
+            acting_user=iago,
+        )
+        self.login_user(hamlet)
+        self.subscribe_via_post(hamlet, [stream.name])
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 3)
+        self.assertEqual(
+            self.latest_channel_event(iago, stream),
+            f"{hamlet_mention} subscribed to this channel.",
+        )
+
+        self.client_delete(
+            "/json/users/me/subscriptions",
+            {"subscriptions": orjson.dumps([stream.name]).decode()},
+        )
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 4)
+        self.assertEqual(
+            self.latest_channel_event(iago, stream),
+            f"{hamlet_mention} unsubscribed from this channel.",
+        )
+
+    def test_private_stream_bulk_notifications(self) -> None:
+        """
+        A bulk membership change posts a single message: up to three users
+        are named inline; four or more collapse to a count with the full
+        roster in an expandable spoiler block.  Names are listed
+        alphabetically regardless of input order.
+        """
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+        prospero = self.example_user("prospero")
+        realm = iago.realm
+        self.enable_channel_events(realm)
+
+        stream = self.make_stream("bulk-secret", realm=realm, invite_only=True)
+        # Iago witnesses the notices; this setup subscription posts none.
+        self.subscribe(iago, stream.name)
+        self.login_user(iago)
+
+        iago_mention = f"@_**{iago.full_name}|{iago.id}**"
+
+        def mention(user: UserProfile) -> str:
+            return f"@_**{user.full_name}|{user.id}**"
+
+        def add(users: list[UserProfile]) -> None:
+            self.subscribe_via_post(
+                iago,
+                [stream.name],
+                dict(principals=orjson.dumps([user.id for user in users]).decode()),
+            )
+
+        def remove(users: list[UserProfile]) -> None:
+            self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([stream.name]).decode(),
+                    "principals": orjson.dumps([user.id for user in users]).decode(),
+                },
+            )
+
+        # Two users: named inline as "A and B" (sorted by name, not input order).
+        add([hamlet, cordelia])
+        self.assertEqual(
+            self.latest_channel_event(iago, stream),
+            f"{iago_mention} subscribed {mention(cordelia)} and {mention(hamlet)} to this channel.",
+        )
+        remove([hamlet, cordelia])
+
+        # Three users: named inline as "A, B, and C".
+        add([othello, cordelia, hamlet])
+        self.assertEqual(
+            self.latest_channel_event(iago, stream),
+            f"{iago_mention} subscribed {mention(cordelia)}, {mention(hamlet)}, "
+            f"and {mention(othello)} to this channel.",
+        )
+        remove([othello, cordelia, hamlet])
+
+        # Four users: collapses to a count with the roster in a spoiler block.
+        members = [prospero, othello, cordelia, hamlet]
+        roster = ", ".join(mention(user) for user in [cordelia, hamlet, othello, prospero])
+        add(members)
+        self.assertEqual(
+            self.latest_channel_event(iago, stream),
+            f"```spoiler {iago_mention} subscribed 4 users to this channel.\n{roster}\n```",
+        )
+        remove(members)
+        self.assertEqual(
+            self.latest_channel_event(iago, stream),
+            f"```spoiler {iago_mention} unsubscribed 4 users from this channel.\n{roster}\n```",
+        )
+
+    def test_acting_user_excluded_from_target_list(self) -> None:
+        """
+        When the acting user is among those changed (e.g. an admin subscribing
+        themselves alongside others), they are named as the actor but not also
+        listed as one of the targets.
+        """
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        iago_mention = f"@_**{iago.full_name}|{iago.id}**"
+        hamlet_mention = f"@_**{hamlet.full_name}|{hamlet.id}**"
+
+        # Acting on themselves alongside another user: only the other user is
+        # named as a target.
+        self.assertEqual(
+            get_subscription_change_notice_content(
+                acting_user=iago, users=[iago, hamlet], subscribed=True
+            ),
+            f"{iago_mention} subscribed {hamlet_mention} to this channel.",
+        )
+        self.assertEqual(
+            get_subscription_change_notice_content(
+                acting_user=iago, users=[iago, hamlet], subscribed=False
+            ),
+            f"{iago_mention} unsubscribed {hamlet_mention} from this channel.",
+        )
+        # Acting only on themselves: no separate target list.
+        self.assertEqual(
+            get_subscription_change_notice_content(acting_user=iago, users=[iago], subscribed=True),
+            f"{iago_mention} subscribed to this channel.",
+        )
+
+    def test_general_chat_channel_notifications(self) -> None:
+        """
+        A channel where the general chat topic is the only allowed topic has no
+        "channel events" topic to post to, so its membership notices go to
+        general chat instead.
+        """
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        realm = iago.realm
+        self.enable_channel_events(realm)
+
+        stream = self.make_stream(
+            "general-chat-secret",
+            realm=realm,
+            invite_only=True,
+            topics_policy=StreamTopicsPolicyEnum.empty_topic_only.value,
+        )
+        # Iago witnesses the notices; this setup subscription posts none.
+        self.subscribe(iago, stream.name)
+        self.assert_length(get_topic_messages(iago, stream, ""), 0)
+
+        iago_mention = f"@_**{iago.full_name}|{iago.id}**"
+        hamlet_mention = f"@_**{hamlet.full_name}|{hamlet.id}**"
+
+        self.login_user(iago)
+        self.subscribe_via_post(
+            iago, [stream.name], dict(principals=orjson.dumps([hamlet.id]).decode())
+        )
+        self.client_delete(
+            "/json/users/me/subscriptions",
+            {
+                "subscriptions": orjson.dumps([stream.name]).decode(),
+                "principals": orjson.dumps([hamlet.id]).decode(),
+            },
+        )
+
+        # Both notices land in general chat, and nothing is posted to a
+        # "channel events" topic.
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 0)
+        messages = get_topic_messages(iago, stream, "")
+        self.assertEqual(
+            [message.content for message in messages],
+            [
+                f"{iago_mention} subscribed {hamlet_mention} to this channel.",
+                f"{iago_mention} unsubscribed {hamlet_mention} from this channel.",
+            ],
+        )
+
+    def test_public_stream_no_join_leave_notifications(self) -> None:
+        """
+        Public channels never receive subscription notifications; the notice
+        is only sent for private (invite-only) channels.
+        """
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        realm = iago.realm
+        self.enable_channel_events(realm)
+
+        stream = self.make_stream("public-stream", realm=realm, invite_only=False)
+        self.subscribe(iago, stream.name)
+
+        self.login_user(iago)
+        self.subscribe_via_post(
+            iago, [stream.name], dict(principals=orjson.dumps([hamlet.id]).decode())
+        )
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 0)
+
+    def test_bulk_primitives_do_not_send_notifications(self) -> None:
+        """
+        The low-level bulk_add_subscriptions/bulk_remove_subscriptions
+        primitives never post channel-events notices; the notice is sent only
+        from the interactive subscribe/unsubscribe flows.  This is what keeps
+        administrative callers -- user deletion, stream merges, and management
+        commands, all of which call the primitives directly -- from spamming
+        private channels.
+        """
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        realm = iago.realm
+        self.enable_channel_events(realm)
+
+        stream = self.make_stream("primitive-secret", realm=realm, invite_only=True)
+        # Iago witnesses any messages that might be posted to the channel.
+        self.subscribe(iago, stream.name)
+
+        bulk_add_subscriptions(realm, [stream], [hamlet], acting_user=None)
+        bulk_remove_subscriptions(realm, [hamlet], [stream], acting_user=None)
+
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 0)
+
+    def test_no_notice_when_setting_disabled(self) -> None:
+        """
+        With "Send automated messages for channel events" disabled, no notice
+        is posted even for a private-channel membership change.  The helper
+        returns before fetching the notification bot, so the disabled case
+        adds no query.
+        """
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        realm = iago.realm
+        realm.send_channel_events_messages = False
+        realm.save(update_fields=["send_channel_events_messages"])
+
+        stream = self.make_stream("quiet-secret", realm=realm, invite_only=True)
+        self.subscribe(iago, stream.name)
+
+        self.login_user(iago)
+        self.subscribe_via_post(
+            iago, [stream.name], dict(principals=orjson.dumps([hamlet.id]).decode())
+        )
+        self.assert_length(get_topic_messages(iago, stream, "channel events"), 0)
+
+    def test_merge_streams_and_delete_user_commands_send_no_notice(self) -> None:
+        """
+        The management commands flagged in review -- `merge_streams` and
+        `delete_user` -- subscribe/unsubscribe users through the primitives
+        with no acting user.  Driving the actual commands, neither posts a
+        channel-events notice even with the setting enabled.
+        """
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        realm = iago.realm
+        self.enable_channel_events(realm)
+
+        # `manage.py merge_streams keep-secret destroy-secret -r zulip` moves
+        # subscribers from the destroyed private channel to the surviving one;
+        # Iago witnesses the survivor.
+        keep = self.make_stream("keep-secret", realm=realm, invite_only=True)
+        destroy = self.make_stream("destroy-secret", realm=realm, invite_only=True)
+        self.subscribe(iago, keep.name)
+        self.subscribe(hamlet, destroy.name)
+        # Both commands print status lines via print(); capture that so it
+        # doesn't trip the test suite's console-output check.
+        with redirect_stdout(StringIO()):
+            call_command("merge_streams", keep.name, destroy.name, "-r", realm.string_id)
+        self.assert_length(get_topic_messages(iago, keep, "channel events"), 0)
+
+        # `manage.py delete_user -f -r zulip -u cordelia@zulip.com` unsubscribes
+        # the deleted user from every private channel.
+        secret = self.make_stream("delete-secret", realm=realm, invite_only=True)
+        self.subscribe(iago, secret.name)
+        self.subscribe(cordelia, secret.name)
+        with redirect_stdout(StringIO()):
+            call_command("delete_user", "-f", "-r", realm.string_id, "-u", cordelia.delivery_email)
+        self.assert_length(get_topic_messages(iago, secret, "channel events"), 0)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1146,10 +1146,11 @@ class QueryCountTest(ZulipTestCase):
 
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
+        # The two private channels' join notices are sent in a single batch.
         with (
-            self.assert_database_query_count(99),
-            self.assert_memcached_count(24),
-            self.capture_send_event_calls(expected_num_events=11) as events,
+            self.assert_database_query_count(121),
+            self.assert_memcached_count(35),
+            self.capture_send_event_calls(expected_num_events=13) as events,
         ):
             fred = do_create_user(
                 email="fred@zulip.com",

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1147,10 +1147,12 @@ class QueryCountTest(ZulipTestCase):
 
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
+        # Includes the two private channels' join notices, which share a
+        # mention cache and are sent in one batch.
         with (
-            self.assert_database_query_count(99),
-            self.assert_memcached_count(24),
-            self.capture_send_event_calls(expected_num_events=11) as events,
+            self.assert_database_query_count(118),
+            self.assert_memcached_count(35),
+            self.capture_send_event_calls(expected_num_events=13) as events,
         ):
             fred = do_create_user(
                 email="fred@zulip.com",

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -44,6 +44,7 @@ from zerver.actions.streams import (
     do_set_stream_property,
     do_unarchive_stream,
     get_subscriber_ids,
+    send_subscription_change_notices,
 )
 from zerver.actions.user_topics import bulk_do_set_user_topic_visibility_policy
 from zerver.context_processors import get_valid_realm_from_request
@@ -647,6 +648,14 @@ def remove_subscriptions_backend(
     (removed, not_subscribed) = bulk_remove_subscriptions(
         realm, people_to_unsub, streams, acting_user=user_profile
     )
+    # Announce the membership change in each private channel's "channel
+    # events" topic.
+    send_subscription_change_notices(
+        realm,
+        acting_user=user_profile,
+        changed_subs=removed,
+        subscribed=False,
+    )
 
     for subscriber, removed_stream in removed:
         result["removed"].append(removed_stream.name)
@@ -959,6 +968,19 @@ def add_subscriptions_backend(
 
     result["subscribed"] = dict(result["subscribed"])
     result["already_subscribed"] = dict(result["already_subscribed"])
+
+    # Announce the membership change in each private channel's "channel events"
+    # topic.  Newly created channels are excluded: choosing a channel's initial
+    # members is part of creating it, not a join event.  This is sent before the
+    # direct-message notifications below so those stay the newly subscribed
+    # users' most recent message.
+    send_subscription_change_notices(
+        realm,
+        acting_user=user_profile,
+        changed_subs=[(sub_info.user, sub_info.stream) for sub_info in subscribed],
+        subscribed=True,
+        skip_stream_ids={stream.id for stream in created_streams},
+    )
 
     if send_new_subscription_messages:
         send_user_subscribed_direct_messages = (

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -1,6 +1,6 @@
 import time
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Annotated, Any, Literal
 
 import orjson
@@ -44,6 +44,8 @@ from zerver.actions.streams import (
     do_set_stream_property,
     do_unarchive_stream,
     get_subscriber_ids,
+    prep_subscription_change_notices,
+    send_subscription_change_notices,
 )
 from zerver.actions.user_topics import bulk_do_set_user_topic_visibility_policy
 from zerver.context_processors import get_valid_realm_from_request
@@ -61,7 +63,7 @@ from zerver.lib.exceptions import (
     OrganizationOwnerRequiredError,
 )
 from zerver.lib.mention import MentionBackend, silent_mention_syntax_for_user
-from zerver.lib.message import bulk_access_stream_messages_query
+from zerver.lib.message import SendMessageRequest, bulk_access_stream_messages_query
 from zerver.lib.response import json_success
 from zerver.lib.retention import STREAM_MESSAGE_BATCH_SIZE as RETENTION_STREAM_MESSAGE_BATCH_SIZE
 from zerver.lib.retention import parse_message_retention_days
@@ -647,6 +649,13 @@ def remove_subscriptions_backend(
     (removed, not_subscribed) = bulk_remove_subscriptions(
         realm, people_to_unsub, streams, acting_user=user_profile
     )
+    send_subscription_change_notices(
+        realm,
+        acting_user=user_profile,
+        changed_subs=removed,
+        subscribed=False,
+        mark_as_read_user_ids={user_profile.id},
+    )
 
     for subscriber, removed_stream in removed:
         result["removed"].append(removed_stream.name)
@@ -942,6 +951,12 @@ def add_subscriptions_backend(
 
     id_to_user_profile: dict[str, UserProfile] = {}
 
+    # Newly created channels are excluded from the join notices, since choosing
+    # a channel's initial members is part of creating it rather than a join
+    # event.
+    created_stream_ids = {stream.id for stream in created_streams}
+    changed_subs: list[tuple[UserProfile, Stream]] = []
+
     result: dict[str, Any] = dict(
         subscribed=defaultdict(list), already_subscribed=defaultdict(list)
     )
@@ -951,6 +966,8 @@ def add_subscriptions_backend(
         user_id = str(subscriber.id)
         result["subscribed"][user_id].append(stream.name)
         id_to_user_profile[user_id] = subscriber
+        if stream.id not in created_stream_ids:
+            changed_subs.append((subscriber, stream))
     for sub_info in already_subscribed:
         subscriber = sub_info.user
         stream = sub_info.stream
@@ -959,6 +976,17 @@ def add_subscriptions_backend(
 
     result["subscribed"] = dict(result["subscribed"])
     result["already_subscribed"] = dict(result["already_subscribed"])
+
+    # Prepared rather than sent here, so the notices go out in the same batch
+    # as the direct messages below and share one MentionBackend.
+    mention_backend = MentionBackend(realm.id)
+    subscription_change_notices = prep_subscription_change_notices(
+        realm,
+        acting_user=user_profile,
+        changed_subs=changed_subs,
+        subscribed=True,
+        mention_backend=mention_backend,
+    )
 
     if send_new_subscription_messages:
         send_user_subscribed_direct_messages = (
@@ -975,6 +1003,8 @@ def add_subscriptions_backend(
         created_streams=created_streams,
         announce=announce,
         send_user_subscribed_direct_messages=send_user_subscribed_direct_messages,
+        subscription_change_notices=subscription_change_notices,
+        mention_backend=mention_backend,
     )
 
     result["subscribed"] = dict(result["subscribed"])
@@ -992,6 +1022,8 @@ def send_user_subscribed_and_new_channel_notifications(
     created_streams: list[Stream],
     announce: bool,
     send_user_subscribed_direct_messages: bool = True,
+    subscription_change_notices: Sequence[SendMessageRequest | None] = [],
+    mention_backend: MentionBackend | None = None,
 ) -> None:
     """
     If a user is subscribing lots of other users to existing channels,
@@ -1001,15 +1033,18 @@ def send_user_subscribed_and_new_channel_notifications(
     excessive query counts by mocking this function so that it
     doesn't drown out query counts from other code.
     """
-    notifications = []
+    # The "channel events" notices come first so the direct messages below stay
+    # the newly subscribed users' most recent message.
+    notifications: list[SendMessageRequest | None] = [*subscription_change_notices]
     # Inform users if someone else subscribed them to an existing channel.
     if new_subscriptions and send_user_subscribed_direct_messages:
         bots = {str(subscriber.id): subscriber.is_bot for subscriber in subscribers}
 
         newly_created_stream_names = {s.name for s in created_streams}
 
-        realm = user_profile.realm
-        mention_backend = MentionBackend(realm.id)
+        # Only add_subscriptions_backend passes subscriptions, and it always
+        # shares its MentionBackend so the notices below join its batch.
+        assert mention_backend is not None
         for id, subscribed_stream_names in new_subscriptions.items():
             if id == str(user_profile.id):
                 # Don't send a notification DM if you subscribed yourself.


### PR DESCRIPTION
Fixes #2746

This adds channel-event notifications for private streams, so join/leave actions generate messages in the "channel events" topic when `send_channel_events_messages` is enabled.

The main change updates subscription logic to trigger notifications for `invite_only` streams, while adding a guard in `maybe_send_channel_events_notice` to prevent crashes on deactivated streams.

This required updating several existing tests that assume no subscription messages are generated, along with introducing a small helper `disable_channel_events_notifications()` to isolate legacy tests with strict assumptions.

---

## Screenshots 

### Case 1: Admin self-subscribe 
<img width="2560" height="1600" alt="Self-Subscribe Iago" src="https://github.com/user-attachments/assets/003622a9-d247-4deb-b488-2bea0906fec3" />

---

### Case 2: Admin adds user
<img width="2560" height="1600" alt="Iago sub Desdemona" src="https://github.com/user-attachments/assets/f642c21d-c1cb-4256-97a8-e57941cc1177" />

---

### Case 3: Admin removes user
<img width="2560" height="1600" alt="Iago unsub Desdemona" src="https://github.com/user-attachments/assets/2ec13ad4-1573-4ad7-88f8-cbe63e2af6aa" />

---

### Case 4: Admin self-unsubscribe 
<img width="2560" height="1600" alt="Self-Unsubscribe Iago" src="https://github.com/user-attachments/assets/7b478741-498e-4a28-bf73-ad810289787f" />



---

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

**Communicate decisions, questions, and potential concerns**

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

**Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html))**

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

**Completed manual review and testing of the following**

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>