### PR TITLE
web: Remove redundant home-page-input class.

### DIFF
--- a/web/templates/filter_topics.hbs
+++ b/web/templates/filter_topics.hbs
@@ -1,6 +1,6 @@
 <div class="left-sidebar-filter-input-container">
     {{#> components/input_wrapper input_type="filter-input" custom_classes="topic_search_section filter-topics has-input-pills" icon="search" input_button_icon="close"}}
-        <div class="input-element home-page-input pill-container" id="left-sidebar-filter-topic-input">
+        <div class="input-element pill-container" id="left-sidebar-filter-topic-input">
             <div class="input" contenteditable="true" id="topic_filter_query" data-placeholder="{{t 'Filter topics' }}"></div>
         </div>
     {{/components/input_wrapper}}

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -2,7 +2,7 @@
     <div id="left-sidebar-search" class="zoom-in-hide">
         <div class="input-wrapper-for-tooltip tippy-zulip-delayed-tooltip" data-tooltip-template-id="filter-left-sidebar-tooltip-template">
             {{#> components/input_wrapper input_type="filter-input" custom_classes="left-sidebar-search-section" icon="search" input_button_icon="close"}}
-                <input type="text" class="input-element left-sidebar-search-input home-page-input" autocomplete="off" placeholder="{{t 'Filter left sidebar' }}" />
+                <input type="text" class="input-element left-sidebar-search-input" autocomplete="off" placeholder="{{t 'Filter left sidebar' }}" />
             {{/components/input_wrapper}}
         </div>
         <span id="add_streams_tooltip" class="add-stream-icon-container hidden-for-spectators">
@@ -56,7 +56,7 @@
         </div>
         <div class="zoom-out-hide direct-messages-search-section left-sidebar-filter-input-container">
             {{#> components/input_wrapper input_type="filter-input" icon="search" input_button_icon="close"}}
-                <input type="text" class="input-element direct-messages-list-filter home-page-input" autocomplete="off" placeholder="{{t 'Filter direct messages' }}" />
+                <input type="text" class="input-element direct-messages-list-filter" autocomplete="off" placeholder="{{t 'Filter direct messages' }}" />
             {{/components/input_wrapper}}
         </div>
     </div>

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -27,7 +27,7 @@
                             <div id="searchbox-input-container" class="input-append pill-container">
                                 <i class="search_icon zulip-icon zulip-icon-search"></i>
                                 <div class="search-input-and-pills">
-                                    <div class="search-input input input-block-level home-page-input" id="search_query" type="text" data-placeholder-text="{{t 'Search' }}"
+                                    <div class="search-input input input-block-level" id="search_query" type="text" data-placeholder-text="{{t 'Search' }}"
                                       autocomplete="off" contenteditable="true"></div>
                                 </div>
                                 <button class="search_close_button tippy-zulip-delayed-tooltip" type="button" id="search_exit" aria-label="{{t 'Exit search' }}" data-tippy-content="Close"><i class="zulip-icon zulip-icon-close" aria-hidden="true"></i></button>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -3,7 +3,7 @@
         <div id="user-list">
             <div id="userlist-header">
                 {{#> components/input_wrapper input_type="filter-input" id="userlist-header-search" icon="search" input_button_icon="close"}}
-                    <input type="text" class="input-element user-list-filter home-page-input" autocomplete="off" placeholder="{{t 'Filter users' }}" />
+                    <input type="text" class="input-element user-list-filter" autocomplete="off" placeholder="{{t 'Filter users' }}" />
                 {{/components/input_wrapper}}
                 <span id="buddy-list-menu-icon" class="user-list-sidebar-menu-icon">
                     <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -672,7 +672,7 @@ test("test_no_filter", ({mock_template}) => {
     row_data = generate_topic_data([[1, "topic-1", 0, all_visibility_policies.INHERIT]]);
     i = row_data.length;
     rt.set_default_focus();
-    $(".home-page-input").trigger("focus");
+    $("#search_query").trigger("focus");
     assert.equal(
         rt.filters_should_hide_row({last_msg_id: 1, participated: true, type: "stream"}),
         false,
@@ -778,7 +778,7 @@ test("test_filter_participated", ({mock_template}) => {
     expected_filter_participated = false;
     rt.process_messages(messages);
 
-    $(".home-page-input").trigger("focus");
+    $("#search_query").trigger("focus");
     assert.equal(
         rt.filters_should_hide_row({last_msg_id: 4, participated: true, type: "stream"}),
         false,
@@ -987,7 +987,7 @@ test("basic assertions", ({mock_template, override_rewire}) => {
     // update_topic_visibility_policy now relies on external libraries completely
     // so we don't need to check anythere here.
     generate_topic_data([[1, topic1, 0, all_visibility_policies.INHERIT]]);
-    $(".home-page-input").trigger("focus");
+    $("#search_query").trigger("focus");
     assert.equal(rt.update_topic_visibility_policy(stream1, topic1), true);
     // a topic gets muted which we are not tracking
     assert.equal(rt.update_topic_visibility_policy(stream1, "topic-10"), false);


### PR DESCRIPTION
Removed the `home-page-input` class from HTML templates and tests, as the focus logic has been standardized to use `.input-element`.

Explanation 
The issue #35135 noted that `home-page-input` should be removed to simplify `is_in_focus` logic. I verified that no TypeScript files reference `home-page-input` anymore. I replaced occurrences in `.hbs` templates with `.input-element` (or removed them if redundant) and updated `recent_view.test.cjs`.

**Fixes**
Fixes part of #35135.

How changes were tested
1. Manually verified hotkeys (`/`, `q`, `w`) still focus the correct input fields.
2. Verified `Esc` key blurs the inputs correctly.
3. Ran `./tools/test-js web/tests/recent_view.test.cjs` to ensure no regressions.

** screen captures and videos ** 

<img width="1915" height="1079" alt="Screenshot 2026-01-24 192930" src="https://github.com/user-attachments/assets/13d7ac03-785e-45a5-9ef1-8f0cb8a22c04" />
<img width="1918" height="1079" alt="Screenshot 2026-01-24 192917" src="https://github.com/user-attachments/assets/cadaf0ef-4cd8-4093-bd39-03f751e74d4e" />

https://github.com/user-attachments/assets/d64246c9-8062-4106-8a0e-2330602dc3a7



<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
</details>