### PR TITLE
message_header: Avoid hiding icons on smaller widths.

### DIFF
--- a/web/src/css_variables.ts
+++ b/web/src/css_variables.ts
@@ -22,9 +22,6 @@ const base_em_px = 16;
 // em to user-chosen font-size.
 const settings_overlay_sidebar_collapse_breakpoint = 800;
 
-// Breakpoint for hiding message action buttons
-const message_actions_hide_width = 730;
-
 export const media_breakpoints = {
     xs_min: xs + "px",
     sm_min: sm + "px",
@@ -38,7 +35,6 @@ export const media_breakpoints = {
     short_navbar_cutoff_height: "600px",
     settings_overlay_sidebar_collapse_breakpoint:
         settings_overlay_sidebar_collapse_breakpoint / 14 + "em",
-    message_actions_hide_width_min: message_actions_hide_width + "px",
 };
 
 export const container_breakpoints = {
@@ -49,7 +45,6 @@ export const container_breakpoints = {
     cq_ml_min: ml / base_em_px + "em",
     cq_sm_min: sm / base_em_px + "em",
     cq_mm_min: mm / base_em_px + "em",
-    cq_message_actions_hide_width_min: message_actions_hide_width / base_em_px + "em",
 };
 
 export const media_breakpoints_num = {
@@ -63,5 +58,4 @@ export const media_breakpoints_num = {
     mm,
     ms,
     settings_overlay_sidebar_collapse_breakpoint,
-    message_actions_hide_width,
 };

--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -328,46 +328,6 @@
     }
 }
 
-@container message-lists (width <  $cq_message_actions_hide_width_min) {
-    .recipient_bar_controls {
-        /* We don't want the controls container to occupy the space freed
-        up by hiding the message action icons so it can be
-        utilized to show more of the topic */
-        flex-grow: 0;
-        margin-right: auto;
-
-        .recipient-bar-control {
-            display: none;
-
-            /* Always show the vdots */
-            &.recipient-row-topic-menu {
-                display: block;
-            }
-        }
-    }
-}
-
-@media (width < $message_actions_hide_width_min) {
-    .without-container-query-support {
-        .recipient_bar_controls {
-            /* We don't want the controls container to occupy the space freed
-            up by hiding the message action icons so it can be
-            utilized to show more of the topic */
-            flex-grow: 0;
-            margin-right: auto;
-
-            .recipient-bar-control {
-                display: none;
-
-                /* Always show the vdots */
-                &.recipient-row-topic-menu {
-                    display: block;
-                }
-            }
-        }
-    }
-}
-
 .spectator-view .recipient_bar_controls .recipient-bar-control {
     &.recipient-bar-copy-link-to-topic {
         display: flex;


### PR DESCRIPTION
Hiding icons based on the message-lists container didn’t work well. It ended up hiding icons in the message header even when #channel > topic wasn’t wide enough for that to meaningfully improve readability.

This is a flawed mechanism because we decide to hide the icons based on some predetermined width of the container instead of the actual width occupied by
the recipient text in the header.

This reverts commit fb40a7fc61f3dea72e2e5646a37b2948273997a2.

The proper fix would involve rewriting
`.message-header-contents` to use CSS grid. This
is elaborted by Karl in #37491.

Discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/conversation.20header.20icons.20not.20showing.20on.20pretty.20wide.20width/near/2352063

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
