### PR TITLE
css: Fix iOS overscroll background color.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2,6 +2,7 @@ html {
     overflow: hidden scroll;
     overscroll-behavior-y: none;
     width: calc(100% - var(--disabled-scrollbar-width));
+    background-color: var(--color-background);
 }
 
 body,


### PR DESCRIPTION
Fixes #37367.

**Issue**: On iOS Safari, the "rubber-band" overscroll area above the navbar shows the default browser background (often white) instead of the theme color, which looks jarring in Dark Mode.

**Fix**: Added `background-color: var(--color-background);` to the `html` element in `zulip.css`.

**Verification**:
- Verified locally on iOS Simulator (Safari).
- Confirmed `html` background color matches the theme in both Light and Dark modes.