### PR TITLE
Fix : Prevent hotkey processing when gear menu is open

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -1144,6 +1144,16 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
         return false;
     }
 
+    // Prevent non-menu hotkeys when gear menu popover is open.
+    // Only allow menu navigation hotkeys (arrow keys, enter) and the gear_menu toggle.
+    if (
+        popover_menus.is_gear_menu_popover_displayed() &&
+        !menu_dropdown_hotkeys.has(event_name) &&
+        event_name !== "gear_menu"
+    ) {
+        return false;
+    }
+
     // Shortcuts that don't require a message
     let list_of_channel_topics_channel_id;
     switch (event_name) {


### PR DESCRIPTION
fixes #9270


### Code Changes

**File:** `web/src/hotkey.ts` (lines 1147-1157)

```typescript
// Prevent hotkey navigation when the gear menu (or other popovers) are open.
// The gear menu handles arrow keys and enter internally via handle_popover_events,
// but we need to prevent other hotkeys like 's', 'j', 'k' from being processed
// while the menu is open. Non-menu-related hotkeys should be disabled.
if (popover_menus.is_gear_menu_popover_displayed()) {
    // Allow only menu navigation hotkeys (arrow keys, enter) which are handled above.
    // All other hotkeys should be ignored while gear menu is open.
    if (!menu_dropdown_hotkeys.has(event_name) && event_name !== "gear_menu") {
        return false;
    }
}
```

### Implementation Strategy

The fix is placed strategically in the `process_hotkey()` function:
- **After overlay/modal checks** (lines 1115-1145) - to ensure overlays take precedence
- **Before general hotkey processing** (lines 1159+) - to intercept hotkeys before they execute

This placement ensures:
- Menu navigation continues to work (handled earlier in the function)
- The gear menu check applies to all non-menu hotkeys
- No disruption to existing overlay/modal behavior

### Dependencies

- `popover_menus.is_gear_menu_popover_displayed()` - Returns true when gear menu popover is visible
- `menu_dropdown_hotkeys` - Set containing: `down_arrow`, `up_arrow`, `vim_up`, `vim_down`, `enter`

## Benefits

**Improved UX**: Users can navigate the gear menu without accidental background actions  
**Minimal code change**: Only 11 lines added, no existing functionality modified  
**Consistent behavior**: Aligns gear menu with how other popovers handle hotkeys  
**Maintains functionality**: Menu navigation and toggle hotkey still work as expected  

## Testing Recommendations

### Manual Testing

1. **Open gear menu** (press 'G' or click gear icon)
2. **Try navigation hotkeys**: Arrow keys and Enter should still work
3. **Try other hotkeys**: 
   - Press 's' - should NOT narrow to stream
   - Press 'j'/'k' - should NOT move message selection
   - Press 'c' - should NOT open compose box
4. **Close menu with 'G'**: Should toggle menu closed
5. **After closing menu**: All hotkeys should work normally again

### Automated Testing

Test cases should verify:
- Hotkeys are blocked when `is_gear_menu_popover_displayed()` returns true
- Menu navigation hotkeys continue to work
- Gear menu toggle hotkey works to close the menu
- All hotkeys work normally when gear menu is closed