### PR TITLE
Fix : Reset scroll position when filtering settings lists

### DIFF
--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -531,6 +531,10 @@ export function create<Key, Item = Key>(
         clean_redraw() {
             widget.filter_and_sort();
             widget.clear();
+            // Reset scroll position to top when list is filtered/redrawn.
+            // This prevents the list from appearing empty when filtering reduces
+            // the number of items and the previous scroll position is beyond the new content height.
+            meta.$scroll_container[0]!.scrollTop = 0;
             widget.render(DEFAULTS.INITIAL_RENDER_COUNT);
         },
 


### PR DESCRIPTION
fixes #8221

## Solution

Reset the scroll position to the top (scrollTop = 0) in the `clean_redraw()` method, right after clearing the container and before rendering the new filtered results.

## Technical Details

### Code Changes

**File:** `web/src/list_widget.ts` (lines 531-538)

```typescript
clean_redraw() {
    widget.filter_and_sort();
    widget.clear();
    // Reset scroll position to top when list is filtered/redrawn.
    // This prevents the list from appearing empty when filtering reduces
    // the number of items and the previous scroll position is beyond the new content height.
    meta.$scroll_container[0]!.scrollTop = 0;
    widget.render(DEFAULTS.INITIAL_RENDER_COUNT);
},
```

**Change:** Added one line that resets `scrollTop` to 0 on the scroll container element.

### Implementation Details

- **Location:** The fix is placed in `clean_redraw()` method, which is called by:
  - `hard_redraw()` - used when filters change (search input, status dropdown)
  - Filter's clear button click handler
  - Various filter update handlers in settings pages

- **Scope:** This affects all list widgets in Zulip that use filtering:
  - Organization settings → Bots
  - Organization settings → Users
  - Any other paginated/filtered lists using `list_widget.ts`

- **Timing:** The scroll reset happens:
  1. After the container is cleared (DOM is empty)
  2. Before new items are rendered (ensures viewport is at top when items appear)

### Why This Works

When `scrollTop = 0` is set:
- The viewport returns to the top of the container
- Subsequent `widget.render()` draws filtered items starting from the top
- Users immediately see the filtered results without needing to scroll up manually
- The scroll position naturally adjusts as the user scrolls through the filtered list