### PR TITLE
peer_data: Add error JSON to blueslip reporting.

### DIFF
--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -148,6 +148,7 @@ async function fetch_stream_subscribers_from_server(
                 } else {
                     blueslip.error("Failure fetching channel subscribers", {
                         stream_id,
+                        error_json: xhr.responseJSON,
                     });
                     resolve(null);
                 }


### PR DESCRIPTION
For investigating [#kandra js errors > Error: Failure fetching channel subscribers @ 💬](https://chat.zulip.org/#narrow/channel/464-kandra-js-errors/topic/Error.3A.20Failure.20fetching.20channel.20subscribers/near/2353163)