### PR TITLE
left_sidebar: Replace text input with contenteditable pill input.

### DIFF
--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -301,7 +301,7 @@ async function arrow(page: Page, direction: "Up" | "Down"): Promise<void> {
 }
 
 async function test_search_venice(page: Page): Promise<void> {
-    await common.clear_and_type(page, ".left-sidebar-search-input", "vEnI"); // Must be case insensitive.
+    await common.clear_and_type(page, "#left-sidebar-filter-query", "vEnI"); // Must be case insensitive.
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {hidden: true});
     await page.waitForSelector(await get_stream_li(page, "Verona"), {hidden: true});
     await arrow(page, "Down");
@@ -310,7 +310,7 @@ async function test_search_venice(page: Page): Promise<void> {
     });
 
     // Clearing list gives back all the streams in the list
-    await common.clear_and_type(page, ".left-sidebar-search-input", "");
+    await common.clear_and_type(page, "#left-sidebar-filter-query", "");
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {visible: true});
     await page.waitForSelector(await get_stream_li(page, "Venice"), {visible: true});
     await page.waitForSelector(await get_stream_li(page, "Verona"), {visible: true});
@@ -327,7 +327,7 @@ async function test_stream_search_filters_stream_list(page: Page): Promise<void>
     await page.waitForSelector(await get_stream_li(page, "Verona"), {visible: true});
 
     // Enter the search box and test highlighted suggestion
-    await page.click(".left-sidebar-search-input");
+    await page.click("#left-sidebar-filter-query");
 
     // Selection is not highlighted until user wants to move the cursor.
     await page.waitForSelector(".top_left_inbox.top_left_row.highlighted_row", {hidden: true});
@@ -372,14 +372,14 @@ async function test_stream_search_filters_stream_list(page: Page): Promise<void>
     await test_search_venice(page);
 
     // Search for beginning of "Verona".
-    await page.type(".left-sidebar-search-input", "ver");
+    await page.type("#left-sidebar-filter-query", "ver");
     await page.waitForSelector(await get_stream_li(page, "core team"), {hidden: true});
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {hidden: true});
     await page.waitForSelector(await get_stream_li(page, "Venice"), {hidden: true});
     await page.click(await get_stream_li(page, "Verona"));
     await expect_verona_stream_top_topic(page);
     assert.strictEqual(
-        await common.get_text_from_selector(page, ".left-sidebar-search-input"),
+        await common.get_text_from_selector(page, "#left-sidebar-filter-query"),
         "",
         "Clicking on stream didn't clear search",
     );

--- a/web/src/left_sidebar_filter.ts
+++ b/web/src/left_sidebar_filter.ts
@@ -36,6 +36,17 @@ export function get_raw_topics_state(): string {
     return pills[0]!.syntax;
 }
 
+export function get_effective_topics_state_for_search(): string {
+    const topics_state = get_raw_topics_state();
+    if (topics_state === "" || get_narrowed_subscribed_stream_id() === undefined) {
+        return "";
+    }
+
+    // Existing topic-state pills stay active in subscribed-stream narrows,
+    // even when the current narrow is too limited to offer them in typeahead.
+    return topics_state;
+}
+
 const filter_placeholder_text = $t({defaultMessage: "Filter"});
 const default_filter_placeholder_text = $t({defaultMessage: "Filter left sidebar"});
 

--- a/web/src/left_sidebar_filter.ts
+++ b/web/src/left_sidebar_filter.ts
@@ -1,0 +1,169 @@
+import $ from "jquery";
+import assert from "minimalistic-assert";
+
+import * as blueslip from "./blueslip.ts";
+import {Typeahead} from "./bootstrap_typeahead.ts";
+import type {TypeaheadInputElement} from "./bootstrap_typeahead.ts";
+import {$t} from "./i18n.ts";
+import * as narrow_state from "./narrow_state.ts";
+import * as stream_data from "./stream_data.ts";
+import * as stream_topic_history from "./stream_topic_history.ts";
+import * as topic_filter_pill from "./topic_filter_pill.ts";
+import type {TopicFilterPill, TopicFilterPillWidget} from "./topic_filter_pill.ts";
+
+let left_sidebar_filter_pill_widget: TopicFilterPillWidget | null = null;
+let left_sidebar_filter_typeahead: Typeahead<TopicFilterPill> | undefined;
+
+function get_narrowed_subscribed_stream_id(): number | undefined {
+    const stream_id = narrow_state.stream_id(narrow_state.filter(), true);
+    if (stream_id === undefined || !stream_data.is_subscribed(stream_id)) {
+        return undefined;
+    }
+
+    return stream_id;
+}
+
+export function get_raw_topics_state(): string {
+    const pills = left_sidebar_filter_pill_widget?.items() ?? [];
+    if (pills.length === 0) {
+        return "";
+    }
+
+    if (pills.length > 1) {
+        blueslip.warn("Multiple pills found in left sidebar filter input.");
+    }
+
+    return pills[0]!.syntax;
+}
+
+const filter_placeholder_text = $t({defaultMessage: "Filter"});
+const default_filter_placeholder_text = $t({defaultMessage: "Filter left sidebar"});
+
+function update_left_sidebar_filter_placeholder(): void {
+    const $input = $("#left-sidebar-filter-query");
+    const has_filter_pill = (left_sidebar_filter_pill_widget?.items().length ?? 0) > 0;
+    const has_search_term = $input.text().trim() !== "";
+    if (has_search_term) {
+        $input.attr("data-placeholder", "");
+        return;
+    }
+    $input.attr(
+        "data-placeholder",
+        has_filter_pill ? filter_placeholder_text : default_filter_placeholder_text,
+    );
+}
+
+export function has_left_sidebar_filter_value(): boolean {
+    return $("#left-sidebar-filter-query").text().trim() !== "" || get_raw_topics_state() !== "";
+}
+
+function notify_left_sidebar_filter_changed(): void {
+    $("#left-sidebar-filter-input").trigger("input");
+}
+
+export function clear_query_text(): void {
+    $("#left-sidebar-filter-query").empty();
+    update_left_sidebar_filter_placeholder();
+}
+
+export function clear_query(): void {
+    clear_query_text();
+    notify_left_sidebar_filter_changed();
+}
+
+function update_left_sidebar_filter_after_content_change(): void {
+    update_left_sidebar_filter_placeholder();
+    // Left-sidebar filtering listens to the pill container's `input` event.
+    // Trigger it after pill add/remove so the sidebar recomputes visible
+    // rows immediately.
+    notify_left_sidebar_filter_changed();
+}
+
+export function clear_left_sidebar_filter(): void {
+    left_sidebar_filter_typeahead?.hide();
+    left_sidebar_filter_pill_widget?.clear(true);
+    clear_query();
+    $("#left-sidebar-filter-query").trigger("blur");
+}
+
+export function handle_clear_left_sidebar_filter_click(e: JQuery.Event): void {
+    e.stopPropagation();
+    clear_left_sidebar_filter();
+}
+
+export function is_typeahead_shown(): boolean {
+    return left_sidebar_filter_typeahead?.shown ?? false;
+}
+
+function handle_typeahead_keydown(e: JQuery.KeyDownEvent): void {
+    if (e.key === "Enter") {
+        // Reserve Enter for the typeahead and left-sidebar keyboard navigation.
+        // Do not let other handlers process it here.
+        e.preventDefault();
+        e.stopPropagation();
+    } else if (e.key === ",") {
+        // input_pill.ts converts comma-separated text into pills by default.
+        // Topic-state filters only allow a single pill, so we block that
+        // generic comma handling and keep pill creation on the typeahead path.
+        e.stopPropagation();
+    }
+}
+
+export function setup_left_sidebar_filter_typeahead(): void {
+    left_sidebar_filter_typeahead?.unlisten();
+    left_sidebar_filter_typeahead = undefined;
+    left_sidebar_filter_pill_widget = null;
+
+    const $input = $("#left-sidebar-filter-query");
+    const $pill_container = $("#left-sidebar-filter-input");
+
+    if ($input.length === 0 || $pill_container.length === 0) {
+        return;
+    }
+
+    left_sidebar_filter_pill_widget = topic_filter_pill.create_pills($pill_container);
+    left_sidebar_filter_pill_widget.onPillCreate(update_left_sidebar_filter_after_content_change);
+    left_sidebar_filter_pill_widget.onTextInputHook(update_left_sidebar_filter_placeholder);
+
+    const typeahead_input: TypeaheadInputElement = {
+        $element: $input,
+        type: "contenteditable",
+    };
+
+    const options = {
+        ...topic_filter_pill.get_typeahead_base_options(),
+        source() {
+            const stream_id = get_narrowed_subscribed_stream_id();
+            if (stream_id === undefined) {
+                return [];
+            }
+
+            const pills = left_sidebar_filter_pill_widget?.items() ?? [];
+            const query = $input.text().trim();
+
+            const has_locally_available_resolved_topics =
+                stream_topic_history.stream_has_locally_available_resolved_topics(stream_id);
+            return topic_filter_pill.get_matching_filter_options({
+                current_items: pills,
+                query,
+                allow_resolved_topic_filters: has_locally_available_resolved_topics,
+            });
+        },
+        updater(item: TopicFilterPill) {
+            assert(left_sidebar_filter_pill_widget !== null);
+            left_sidebar_filter_pill_widget.clear(true);
+            left_sidebar_filter_pill_widget.appendValue(item.syntax);
+            $input.text("");
+            $input.trigger("focus");
+            return $input.text().trim();
+        },
+    };
+
+    left_sidebar_filter_typeahead = new Typeahead(typeahead_input, options);
+
+    $input.on("keydown", handle_typeahead_keydown);
+
+    left_sidebar_filter_pill_widget.onPillRemove(update_left_sidebar_filter_after_content_change);
+
+    update_left_sidebar_filter_placeholder();
+}

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -56,6 +56,7 @@ import {
     message_edit_history_visibility_policy_values,
     web_mark_read_on_scroll_policy_values,
 } from "./settings_config.ts";
+import * as sidebar_ui from "./sidebar_ui.ts";
 import * as spectators from "./spectators.ts";
 import type {NarrowTerm} from "./state_data.ts";
 import {realm} from "./state_data.ts";
@@ -1625,6 +1626,9 @@ function handle_post_view_change(
     left_sidebar_navigation_area.handle_narrow_activated(filter);
     stream_list.handle_narrow_activated(filter, opts.change_hash, opts.show_more_topics);
     pm_list.handle_narrow_activated(filter);
+    // A message-view narrow change can activate or deactivate a left-sidebar
+    // topic-state pill, so refresh sidebar matches after the narrow updates.
+    sidebar_ui.refresh_left_sidebar_search_for_narrow_change();
     // This also builds the user sidebar.
     activity_ui.clear_search();
 }

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -17,6 +17,7 @@ import {localstorage} from "./localstorage.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_reminder from "./message_reminder.ts";
 import * as message_viewport from "./message_viewport.ts";
+import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as pm_list from "./pm_list.ts";
 import * as popover_menus from "./popover_menus.ts";
@@ -594,8 +595,6 @@ function actually_update_left_sidebar_for_search(): void {
         is_left_sidebar_search_active
     ) {
         left_sidebar_navigation_area.expand_views($views_label_container, $views_label_icon);
-    } else if (!is_left_sidebar_search_active) {
-        left_sidebar_navigation_area.restore_views_state();
     }
 
     // Update left sidebar DM list.
@@ -612,38 +611,141 @@ function actually_update_left_sidebar_for_search(): void {
     );
 }
 
+type LeftSidebarSearchState = {
+    search_term: string;
+    topics_state: string;
+    narrow_stream_id: number | undefined;
+    narrow_topic: string | undefined;
+};
+
 // Scroll position before user started searching.
 let pre_search_scroll_position = 0;
-let previous_search_term = "";
+let previous_search_state: LeftSidebarSearchState = {
+    search_term: "",
+    topics_state: "",
+    narrow_stream_id: undefined,
+    narrow_topic: undefined,
+};
+
+// Current narrow affects which topic matches keep a stream visible during search.
+function get_left_sidebar_search_state(): LeftSidebarSearchState {
+    return {
+        search_term: ui_util.get_left_sidebar_search_term(),
+        topics_state: left_sidebar_filter.get_effective_topics_state_for_search(),
+        narrow_stream_id: narrow_state.stream_id(),
+        narrow_topic: narrow_state.topic(),
+    };
+}
+
+function same_left_sidebar_search_state(
+    search_state: LeftSidebarSearchState,
+    other_search_state: LeftSidebarSearchState,
+): boolean {
+    return (
+        search_state.search_term === other_search_state.search_term &&
+        search_state.topics_state === other_search_state.topics_state &&
+        search_state.narrow_stream_id === other_search_state.narrow_stream_id &&
+        search_state.narrow_topic === other_search_state.narrow_topic
+    );
+}
+
+function restore_left_sidebar_after_text_search(): void {
+    left_sidebar_navigation_area.restore_views_state();
+    scroll_util.get_left_sidebar_scroll_container().scrollTop(pre_search_scroll_position);
+}
+
+function apply_left_sidebar_search_ui_transition({
+    search_state,
+    was_left_sidebar_search_active,
+    use_request_animation_frame,
+}: {
+    search_state: LeftSidebarSearchState;
+    was_left_sidebar_search_active: boolean;
+    use_request_animation_frame: boolean;
+}): void {
+    const is_left_sidebar_search_active = search_state.search_term !== "";
+    const left_sidebar_scroll_container = scroll_util.get_left_sidebar_scroll_container();
+
+    if (is_left_sidebar_search_active && !was_left_sidebar_search_active) {
+        // Store original scroll position to be restored later.
+        pre_search_scroll_position = left_sidebar_scroll_container.scrollTop()!;
+    }
+
+    const apply_update = (): void => {
+        actually_update_left_sidebar_for_search();
+
+        if (!is_left_sidebar_search_active) {
+            if (was_left_sidebar_search_active) {
+                restore_left_sidebar_after_text_search();
+            }
+            return;
+        }
+
+        // Always scroll to top during stream-name search.
+        left_sidebar_scroll_container.scrollTop(0);
+    };
+
+    if (use_request_animation_frame) {
+        requestAnimationFrame(apply_update);
+        return;
+    }
+
+    apply_update();
+}
+
+function save_and_apply_left_sidebar_search_state({
+    search_state,
+    use_request_animation_frame,
+}: {
+    search_state: LeftSidebarSearchState;
+    use_request_animation_frame: boolean;
+}): void {
+    const was_left_sidebar_search_active = previous_search_state.search_term !== "";
+    previous_search_state = {...search_state};
+    apply_left_sidebar_search_ui_transition({
+        search_state,
+        was_left_sidebar_search_active,
+        use_request_animation_frame,
+    });
+}
 
 const update_left_sidebar_for_search = _.throttle(() => {
-    const search_term = ui_util.get_left_sidebar_search_term();
-    const is_previous_search_term_empty = previous_search_term === "";
-    previous_search_term = search_term;
+    const search_state = get_left_sidebar_search_state();
+    const search_term = search_state.search_term;
     if (search_term === "") {
         // Contenteditable inputs may keep an empty <br>; clear it so
         // empty-state placeholder styles continue to apply.
         $("#left-sidebar-filter-query").empty();
     }
-    const left_sidebar_scroll_container = scroll_util.get_left_sidebar_scroll_container();
-    if (search_term === "") {
-        requestAnimationFrame(() => {
-            actually_update_left_sidebar_for_search();
-            // Restore previous scroll position.
-            left_sidebar_scroll_container.scrollTop(pre_search_scroll_position);
-        });
-    } else {
-        if (is_previous_search_term_empty) {
-            // Store original scroll position to be restored later.
-            pre_search_scroll_position = left_sidebar_scroll_container.scrollTop()!;
-        }
-        requestAnimationFrame(() => {
-            actually_update_left_sidebar_for_search();
-            // Always scroll to top when there is a search term present.
-            left_sidebar_scroll_container.scrollTop(0);
-        });
-    }
+    save_and_apply_left_sidebar_search_state({
+        search_state,
+        use_request_animation_frame: true,
+    });
 }, 50);
+
+export function refresh_left_sidebar_search_for_narrow_change(): void {
+    const search_state = get_left_sidebar_search_state();
+    if (
+        search_state.search_term === "" &&
+        search_state.topics_state === "" &&
+        previous_search_state.search_term === "" &&
+        previous_search_state.topics_state === ""
+    ) {
+        previous_search_state = {...search_state};
+        return;
+    }
+
+    if (same_left_sidebar_search_state(search_state, previous_search_state)) {
+        return;
+    }
+
+    // Apply narrow-transition changes immediately to avoid a visible
+    // intermediate state from throttled search-update scheduling.
+    save_and_apply_left_sidebar_search_state({
+        search_state,
+        use_request_animation_frame: false,
+    });
+}
 
 function focus_left_sidebar_filter(e: JQuery.ClickEvent): void {
     left_sidebar_cursor.reset();
@@ -684,6 +786,7 @@ export function set_event_handlers(): void {
             return;
         }
 
+        const pre_navigation_search_state = get_left_sidebar_search_state();
         // Keep topic-state pills while navigating; only clear typed query text.
         left_sidebar_filter.clear_query_text();
         const $nearest_link = $row.find("a").first();
@@ -695,9 +798,16 @@ export function set_event_handlers(): void {
             // let the browser handle it or add special
             // handling logic for it here.
         }
+        const search_state = get_left_sidebar_search_state();
         // Don't trigger `input` which confuses the search input
         // for zoomed in topic search.
-        actually_update_left_sidebar_for_search();
+        // Restore the pre-navigation state first so we still apply
+        // the correct text-search enter/exit transition below.
+        previous_search_state = {...pre_navigation_search_state};
+        save_and_apply_left_sidebar_search_state({
+            search_state,
+            use_request_animation_frame: false,
+        });
         $search_input.trigger("blur");
     }
 

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -10,6 +10,7 @@ import * as channel from "./channel.ts";
 import * as compose_ui from "./compose_ui.ts";
 import {$t} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
+import * as left_sidebar_filter from "./left_sidebar_filter.ts";
 import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area.ts";
 import {ListCursor} from "./list_cursor.ts";
 import {localstorage} from "./localstorage.ts";
@@ -353,6 +354,7 @@ export function initialize_left_sidebar(): void {
     left_sidebar_navigation_area.reorder_left_sidebar_navigation_list(user_settings.web_home_view);
     stream_list.update_unread_counts_visibility();
     initialize_left_sidebar_cursor();
+    left_sidebar_filter.setup_left_sidebar_filter_typeahead();
     set_event_handlers();
 }
 
@@ -618,7 +620,11 @@ const update_left_sidebar_for_search = _.throttle(() => {
     const search_term = ui_util.get_left_sidebar_search_term();
     const is_previous_search_term_empty = previous_search_term === "";
     previous_search_term = search_term;
-
+    if (search_term === "") {
+        // Contenteditable inputs may keep an empty <br>; clear it so
+        // empty-state placeholder styles continue to apply.
+        $("#left-sidebar-filter-query").empty();
+    }
     const left_sidebar_scroll_container = scroll_util.get_left_sidebar_scroll_container();
     if (search_term === "") {
         requestAnimationFrame(() => {
@@ -652,7 +658,9 @@ export function focus_pm_search_filter(): void {
 }
 
 export function set_event_handlers(): void {
-    const $search_input = $(".left-sidebar-search-input").expectOne();
+    const $search_input = $("#left-sidebar-filter-query").expectOne();
+    const $pill_container = $("#left-sidebar-filter-input").expectOne();
+    const $close_button = $("#left-sidebar-search .input-close-filter-button").expectOne();
 
     function keydown_enter_key(): void {
         const $row = left_sidebar_cursor.get_key();
@@ -675,9 +683,9 @@ export function set_event_handlers(): void {
             $row.trigger("click");
             return;
         }
-        // Clear search input so that there is no confusion
-        // about which search input is active.
-        $search_input.val("");
+
+        // Keep topic-state pills while navigating; only clear typed query text.
+        left_sidebar_filter.clear_query_text();
         const $nearest_link = $row.find("a").first();
         if ($nearest_link.length > 0) {
             // If the row has a link, we click it.
@@ -697,14 +705,23 @@ export function set_event_handlers(): void {
         $elem: $search_input,
         handlers: {
             Enter() {
+                if (left_sidebar_filter.is_typeahead_shown()) {
+                    return false;
+                }
                 keydown_enter_key();
                 return true;
             },
             ArrowUp() {
+                if (left_sidebar_filter.is_typeahead_shown()) {
+                    return false;
+                }
                 left_sidebar_cursor.prev();
                 return true;
             },
             ArrowDown() {
+                if (left_sidebar_filter.is_typeahead_shown()) {
+                    return false;
+                }
                 left_sidebar_cursor.next();
                 return true;
             },
@@ -715,13 +732,14 @@ export function set_event_handlers(): void {
     $search_input.on("focusout", () => {
         left_sidebar_cursor.clear();
     });
-    $search_input.on("input", update_left_sidebar_for_search);
+    $close_button.on("click", left_sidebar_filter.handle_clear_left_sidebar_filter_click);
+    $pill_container.on("input", update_left_sidebar_for_search);
 }
 
 export function initiate_search(): void {
     popovers.hide_all();
 
-    const $filter = $(".left-sidebar-search-input").expectOne();
+    const $filter = $("#left-sidebar-filter-query").expectOne();
 
     show_left_sidebar();
     $filter.trigger("focus");

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -432,12 +432,14 @@ export function build_stream_list(force_rerender: boolean): void {
     //
     // The main logic to build the list is in stream_list_sort.ts
     const streams = stream_data.subscribed_stream_ids();
-    const stream_groups = stream_list_sort.sort_groups(
-        streams,
-        ui_util.get_left_sidebar_search_term(),
-    );
+    const search_term = ui_util.get_left_sidebar_search_term();
+    const topics_state = left_sidebar_filter.get_effective_topics_state_for_search();
+    const stream_groups = stream_list_sort.sort_groups(streams, search_term, topics_state);
+    const is_stream_name_search_active = search_term !== "";
 
     if (stream_groups.same_as_before && !force_rerender) {
+        set_sections_states();
+        $("#streams_list").toggleClass("is_searching", is_stream_name_search_active);
         return;
     }
 
@@ -505,10 +507,10 @@ export function build_stream_list(force_rerender: boolean): void {
                 section.id !== "pinned-streams",
             );
         }
-        // If a section appears empty, due to only having inactive or muted channels,
-        // we collapse it, since there's nothing to easily see. But don't do this during
-        // search, since sections can enter that state temporarily.
-        if (!searching()) {
+        // If a section appears empty due to only having inactive or muted channels,
+        // we collapse it. But don't do this while stream-name search is active,
+        // since sections can enter that state temporarily.
+        if (!is_stream_name_search_active) {
             if (!is_empty && section.default_visible_streams.length === 0) {
                 collapsed_sections.add(section.id);
                 sections_with_only_inactive_or_muted.add(section.id);
@@ -525,8 +527,8 @@ export function build_stream_list(force_rerender: boolean): void {
     update_stream_section_mention_indicators();
     update_unread_counts_visibility();
     set_sections_states();
-    // Show inactive channels when user starts typing.
-    $("#streams_list").toggleClass("is_searching", ui_util.get_left_sidebar_search_term() !== "");
+    // Show inactive channels only during stream-name search.
+    $("#streams_list").toggleClass("is_searching", is_stream_name_search_active);
 }
 
 export function mention_counts_by_section(): Map<
@@ -667,21 +669,19 @@ function restore_collapsed_sections_state(): void {
 }
 
 export let set_sections_states = function (): void {
-    if (ui_util.get_left_sidebar_search_term() === "") {
-        // Restore the collapsed state of sections.
-        for (const section_id of collapsed_sections) {
-            const $container = $(`#stream-list-${section_id}-container`);
-            // This can happen if the section isn't currently visible
-            // (e.g. the setting to show folders is off).
-            if ($container.length === 0) {
-                continue;
-            }
-            $container.toggleClass("collapsed", true);
-            $container
-                .find(".stream-list-section-toggle")
-                .toggleClass("rotate-icon-down", false)
-                .toggleClass("rotate-icon-right", true);
+    const restore_collapsed_state = ui_util.get_left_sidebar_search_term() === "";
+    for (const section_id of collapsed_sections) {
+        const $container = $(`#stream-list-${section_id}-container`);
+        // This can happen if the section isn't currently visible
+        // (e.g. the setting to show folders is off).
+        if ($container.length === 0) {
+            continue;
         }
+        $container.toggleClass("collapsed", restore_collapsed_state);
+        $container
+            .find(".stream-list-section-toggle")
+            .toggleClass("rotate-icon-down", !restore_collapsed_state)
+            .toggleClass("rotate-icon-right", restore_collapsed_state);
     }
     for (const section_id of sections_showing_inactive_or_muted) {
         $(`#stream-list-${section_id}-container`).toggleClass("showing-inactive-or-muted", true);

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -20,6 +20,7 @@ import type {Filter} from "./filter.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
+import * as left_sidebar_filter from "./left_sidebar_filter.ts";
 import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area.ts";
 import {localstorage} from "./localstorage.ts";
 import type {Message} from "./message_store.ts";
@@ -1635,14 +1636,19 @@ function toggle_inactive_or_muted_channels($section_container: JQuery): void {
 }
 
 export function searching(): boolean {
-    return $(".left-sidebar-search-input").expectOne().is(":focus");
+    const $filter_input = $("#left-sidebar-filter-query").expectOne();
+    const $left_sidebar_pills = $("#left-sidebar-filter-input .pill");
+    return (
+        $filter_input.is(":focus") ||
+        ($left_sidebar_pills.length > 0 && $left_sidebar_pills.is(":focus"))
+    );
 }
 
 export function clear_search(): void {
-    const $filter = $(".left-sidebar-search-input").expectOne();
-    if ($filter.val() !== "") {
-        $filter.val("");
-        $filter.trigger("input");
+    const $filter = $("#left-sidebar-filter-query").expectOne();
+    if (left_sidebar_filter.has_left_sidebar_filter_value()) {
+        $("#left-sidebar-search .input-close-filter-button").trigger("click");
+        return;
     }
     $filter.trigger("blur");
 }

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1402,7 +1402,17 @@ export function on_sidebar_channel_click(
     e: JQuery.ClickEvent | null,
     show_channel_feed: (stream_id: number, trigger: string) => void,
 ): void {
-    clear_search();
+    const had_search_term = ui_util.get_left_sidebar_search_term() !== "";
+    // Keep any active topic-state pill when opening a channel from the sidebar;
+    // only the typed stream-name query should be cleared by this navigation.
+    if (had_search_term) {
+        left_sidebar_filter.clear_query();
+    } else {
+        left_sidebar_filter.clear_query_text();
+    }
+    // Leave the search field so the clicked channel, rather than the filter
+    // input, becomes the active target for subsequent keyboard input.
+    $("#left-sidebar-filter-query").trigger("blur");
     if (e !== null) {
         e.preventDefault();
         e.stopPropagation();
@@ -1451,6 +1461,11 @@ export function on_sidebar_channel_click(
     }
 
     let topics = stream_topic_history.get_recent_topic_names(stream_id);
+    // Capture the click-time pill so an async history fetch cannot retarget
+    // this navigation if the user changes it while waiting. We use the raw
+    // pill state here because channel-click routing should honor a preserved
+    // pill even when the view the user is leaving treated it as inactive.
+    const topics_state = left_sidebar_filter.get_raw_topics_state();
 
     const navigate_to_stream = (): void => {
         // Muted topics are not included in the unzoomed topic list
@@ -1458,7 +1473,13 @@ export function on_sidebar_channel_click(
         const topic_list_info = topic_list_data.get_list_info(
             stream_id,
             false,
-            (topic_names: string[]) => topic_names,
+            (topic_names: string[]) =>
+                topic_list_data.filter_topics_by_search_term(
+                    stream_id,
+                    topic_names,
+                    "",
+                    topics_state,
+                ),
         );
         // This initial value handles both the top_topic_in_channel
         // mode as well as the top_unread_topic_in_channel fallback

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -118,9 +118,36 @@ type StreamListSortResult = {
     sections: StreamListSection[];
 };
 
+function stream_has_matching_topics({
+    stream_id,
+    topic_search_term,
+    topics_state,
+    current_topic_name,
+}: {
+    stream_id: number;
+    topic_search_term: string;
+    topics_state: string;
+    current_topic_name: string | undefined;
+}): boolean {
+    const topics = topic_list_data.get_filtered_topic_names(stream_id, (topic_names) =>
+        topic_list_data.filter_topics_by_search_term(
+            stream_id,
+            topic_names,
+            topic_search_term,
+            topics_state,
+        ),
+    );
+    return topics.some(
+        (topic) =>
+            topic.toLowerCase() === current_topic_name ||
+            !user_topics.is_topic_muted(stream_id, topic),
+    );
+}
+
 export function sort_groups(
     all_subscribed_stream_ids: number[],
     search_term: string,
+    topics_state = "",
 ): StreamListSortResult {
     const pinned_section: StreamListSection = {
         id: "pinned-streams",
@@ -166,30 +193,21 @@ export function sort_groups(
 
     const current_channel_id = narrow_state.stream_id(narrow_state.filter(), true);
     const current_topic_name = narrow_state.topic()?.toLowerCase();
-    if (
+    const include_current_channel_for_topic_match =
         current_channel_id !== undefined &&
         stream_data.is_subscribed(current_channel_id) &&
-        !matching_stream_ids.includes(current_channel_id)
-    ) {
+        !matching_stream_ids.includes(current_channel_id) &&
         // If any of the unmuted topics of the channel match the search
         // term, or a muted topic matches the current topic, we include
         // the channel in the list of matches.
-        const topics = topic_list_data.get_filtered_topic_names(current_channel_id, (topic_names) =>
-            topic_list_data.filter_topics_by_search_term(
-                current_channel_id,
-                topic_names,
-                search_term,
-            ),
-        );
-        if (
-            topics.some(
-                (topic) =>
-                    topic.toLowerCase() === current_topic_name ||
-                    !user_topics.is_topic_muted(current_channel_id, topic),
-            )
-        ) {
-            matching_stream_ids.push(current_channel_id);
-        }
+        stream_has_matching_topics({
+            stream_id: current_channel_id,
+            topic_search_term: search_term,
+            topics_state,
+            current_topic_name,
+        });
+    if (include_current_channel_for_topic_match) {
+        matching_stream_ids.push(current_channel_id);
     }
 
     // If the channel folder matches the search term, include all channels

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -10,6 +10,7 @@ import render_topic_list_new_topic from "../templates/topic_list_new_topic.hbs";
 import * as blueslip from "./blueslip.ts";
 import {Typeahead} from "./bootstrap_typeahead.ts";
 import type {TypeaheadInputElement} from "./bootstrap_typeahead.ts";
+import * as left_sidebar_filter from "./left_sidebar_filter.ts";
 import {ListCursor} from "./list_cursor.ts";
 import * as mouse_drag from "./mouse_drag.ts";
 import * as popover_menus from "./popover_menus.ts";
@@ -448,23 +449,21 @@ export class TopicListWidget {
     }
 }
 
-function filter_topics_left_sidebar(topic_names: string[]): string[] {
+function filter_topics_left_sidebar(stream_id: number, topic_names: string[]): string[] {
     const search_term = get_left_sidebar_topic_search_term();
-    const stream_id = active_stream_id();
-    if (stream_id === undefined) {
-        return topic_names;
-    }
     return topic_list_data.filter_topics_by_search_term(
         stream_id,
         topic_names,
         search_term,
-        get_typeahead_search_pills_syntax(),
+        get_active_topic_state_filter_syntax(),
     );
 }
 
 export class LeftSidebarTopicListWidget extends TopicListWidget {
     constructor($stream_li: JQuery, my_stream_id: number, for_modal: boolean) {
-        super($stream_li, my_stream_id, for_modal, filter_topics_left_sidebar);
+        super($stream_li, my_stream_id, for_modal, (topic_names: string[]) =>
+            filter_topics_left_sidebar(my_stream_id, topic_names),
+        );
     }
 
     override build(spinner = false): void {
@@ -642,8 +641,12 @@ export function get_left_sidebar_topic_search_term(): string {
     return ui_util.get_left_sidebar_search_term();
 }
 
-export function get_typeahead_search_pills_syntax(): string {
+function get_active_topic_state_filter_syntax(): string {
     const pills = topic_filter_pill_widget?.items() ?? [];
+
+    if (!zoomed) {
+        return left_sidebar_filter.get_effective_topics_state_for_search();
+    }
 
     if (pills.length === 0) {
         return "";

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -1,5 +1,4 @@
 import $ from "jquery";
-import assert from "minimalistic-assert";
 import type * as tippy from "tippy.js";
 
 import * as blueslip from "./blueslip.ts";
@@ -338,16 +337,11 @@ export function enable_element_and_remove_tooltip($element: JQuery): void {
 }
 
 export function get_left_sidebar_search_term(): string {
-    const $search_box = $<HTMLInputElement>("input.left-sidebar-search-input").expectOne();
-    const search_term = $search_box.val();
-    assert(search_term !== undefined);
-    return search_term.trim();
+    return $("#left-sidebar-filter-query").expectOne().text().trim();
 }
 
 export function disable_left_sidebar_search(): void {
-    if ($<HTMLInputElement>("#left-sidebar-search input").val()) {
-        // Triggle click on the close button to clear the search term and
-        // update the left sidebar.
+    if (get_left_sidebar_search_term() !== "" || $("#left-sidebar-filter-input .pill").length > 0) {
         $("#left-sidebar-search .input-close-filter-button").trigger("click");
     }
     $("#left-sidebar-search").toggleClass("no-display", true);

--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -108,6 +108,10 @@ export function show(opts: {
 
     // Hide selected elements in the left sidebar.
     opts.highlight_view_in_left_sidebar();
+    // Switching between message and non-message views changes the active narrow
+    // context, which can change whether a left-sidebar topic-state pill applies
+    // and which channels/topics remain visible.
+    sidebar_ui.refresh_left_sidebar_search_for_narrow_change();
 
     unread_ui.hide_unread_banner();
     opts.update_compose();

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -127,6 +127,41 @@
     }
 }
 
+#left-sidebar-search .left-sidebar-search-section.has-input-pills {
+    .pill-container {
+        grid-area: input-element;
+        padding-left: calc(
+            var(--input-icon-starting-offset) + var(--input-icon-width) +
+                var(--input-icon-content-gap)
+        );
+        padding-right: calc(
+            var(--input-button-content-gap) + var(--input-button-width) +
+                var(--input-button-ending-offset)
+        );
+    }
+
+    /* Match the empty filter-input state for the pill container: hide the
+       clear button and remove its reserved padding when there is no value. */
+    &:not(:has(.pill)):has(.input:empty) {
+        .input-element,
+        .pill-container {
+            padding-right: 0.5em;
+        }
+
+        .input-close-filter-button {
+            visibility: hidden;
+        }
+    }
+
+    &:has(.pill),
+    &:has(.input:not(:empty)) {
+        .input-element,
+        .pill-container {
+            @extend .input-active-styles;
+        }
+    }
+}
+
 #stream_filters {
     overflow: visible;
     margin-bottom: 5px;

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -1,8 +1,10 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
     <div id="left-sidebar-search">
         <div class="input-wrapper-for-tooltip tippy-zulip-delayed-tooltip" data-tooltip-template-id="filter-left-sidebar-tooltip-template">
-            {{#> components/input_wrapper input_type="filter-input" custom_classes="left-sidebar-search-section" icon="search" input_button_icon="close"}}
-                <input type="text" class="input-element left-sidebar-search-input" autocomplete="off" placeholder="{{t 'Filter left sidebar' }}" />
+            {{#> components/input_wrapper input_type="filter-input" custom_classes="left-sidebar-search-section has-input-pills" icon="search" input_button_icon="close"}}
+                <div class="pill-container" id="left-sidebar-filter-input">
+                    <div class="input" contenteditable="true" id="left-sidebar-filter-query" data-placeholder="{{t 'Filter left sidebar' }}"></div>
+                </div>
             {{/components/input_wrapper}}
         </div>
         <span id="add_streams_button" class="add-stream-icon-container hidden-for-spectators">

--- a/web/tests/left_sidebar_filter.test.cjs
+++ b/web/tests/left_sidebar_filter.test.cjs
@@ -1,0 +1,274 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {$t} = require("./lib/i18n.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
+const $ = require("./lib/zjquery.cjs");
+
+const bootstrap_typeahead = mock_esm("../src/bootstrap_typeahead");
+const input_pill = mock_esm("../src/input_pill");
+const state = {
+    narrowed_stream_id: undefined,
+    is_subscribed: false,
+    has_resolved_topics: false,
+    clear_called_with: undefined,
+    append_called_with: undefined,
+    hide_called: false,
+    captured_input: undefined,
+    captured_config: undefined,
+};
+mock_esm("../src/narrow_state", {
+    filter: () => ({}),
+    stream_id: () => state.narrowed_stream_id,
+});
+mock_esm("../src/stream_data", {
+    is_subscribed: () => state.is_subscribed,
+});
+
+mock_esm("../src/stream_topic_history", {
+    stream_has_locally_available_resolved_topics: () => state.has_resolved_topics,
+});
+
+const blueslip = zrequire("blueslip");
+const topic_filter_pill = zrequire("topic_filter_pill");
+const filter_options = topic_filter_pill.filter_options;
+const left_sidebar_filter = zrequire("left_sidebar_filter");
+const filter_placeholder = $t({defaultMessage: "Filter"});
+const default_placeholder = $t({defaultMessage: "Filter left sidebar"});
+
+function set_up(
+    {override},
+    {narrowed_stream_id = undefined, is_subscribed = true, has_resolved_topics = true} = {},
+) {
+    $.reset_selector("#left-sidebar-filter-query");
+    $.reset_selector("#left-sidebar-filter-input");
+    const $input = $("#left-sidebar-filter-query");
+    const $pill_container = $("#left-sidebar-filter-input");
+    $input.text("");
+
+    Object.assign(state, {
+        narrowed_stream_id,
+        is_subscribed,
+        has_resolved_topics,
+        clear_called_with: undefined,
+        append_called_with: undefined,
+        hide_called: false,
+        captured_input: undefined,
+        captured_config: undefined,
+    });
+    const pill_items = [];
+    const handlers = {
+        on_pill_create: noop,
+        on_pill_remove: noop,
+        on_text_input: noop,
+    };
+    const pill_widget = {
+        items() {
+            return pill_items;
+        },
+        clear(suppress) {
+            state.clear_called_with = suppress;
+            pill_items.length = 0;
+        },
+        appendValue(syntax) {
+            state.append_called_with = syntax;
+            pill_items.push({syntax});
+            handlers.on_pill_create();
+        },
+        onPillCreate(callback) {
+            handlers.on_pill_create = callback;
+        },
+        onPillRemove(callback) {
+            handlers.on_pill_remove = callback;
+        },
+        onTextInputHook(callback) {
+            handlers.on_text_input = callback;
+        },
+        createPillonPaste: noop,
+    };
+
+    override(input_pill, "create", (opts) => {
+        assert.equal(opts.$container.selector, "#left-sidebar-filter-input");
+        return pill_widget;
+    });
+
+    function FakeTypeahead(input_element, config) {
+        state.captured_input = input_element;
+        state.captured_config = config;
+        return {
+            hide() {
+                state.hide_called = true;
+            },
+            unlisten: noop,
+        };
+    }
+    override(bootstrap_typeahead, "Typeahead", FakeTypeahead);
+
+    left_sidebar_filter.setup_left_sidebar_filter_typeahead();
+
+    return {
+        $input,
+        $pill_container,
+        pill_items,
+        state,
+        handlers,
+    };
+}
+
+run_test("get_raw_topics_state", ({override}) => {
+    const {pill_items} = set_up({override});
+    assert.equal(left_sidebar_filter.get_raw_topics_state(), "");
+
+    pill_items.push({syntax: "is:resolved"});
+    assert.equal(left_sidebar_filter.get_raw_topics_state(), "is:resolved");
+
+    let warning_message;
+    override(blueslip, "warn", (message) => {
+        warning_message = message;
+    });
+    pill_items.push({syntax: "is:followed"});
+    assert.equal(left_sidebar_filter.get_raw_topics_state(), "is:resolved");
+    assert.equal(warning_message, "Multiple pills found in left sidebar filter input.");
+});
+
+run_test("clear_left_sidebar_filter", ({override}) => {
+    const info = set_up({override});
+    const {$input, $pill_container, state} = info;
+    $input.html("filter");
+
+    const input_events = [];
+    $input.on("blur", () => {
+        input_events.push("blur");
+    });
+
+    const container_events = [];
+    $pill_container.on("input", () => {
+        container_events.push("input");
+    });
+
+    let stop_called = false;
+    const event = {
+        stopPropagation() {
+            stop_called = true;
+        },
+    };
+
+    left_sidebar_filter.handle_clear_left_sidebar_filter_click(event);
+    assert.ok(stop_called);
+    assert.ok(state.hide_called);
+    assert.equal(state.clear_called_with, true);
+    assert.equal($input.html(), "");
+    assert.deepEqual(container_events, ["input"]);
+    assert.deepEqual(input_events, ["blur"]);
+});
+
+run_test("query_helpers", ({override}) => {
+    const info = set_up({override});
+    const {$input, $pill_container, pill_items} = info;
+
+    assert.equal(left_sidebar_filter.has_left_sidebar_filter_value(), false);
+
+    pill_items.push({syntax: "is:resolved"});
+    assert.equal(left_sidebar_filter.has_left_sidebar_filter_value(), true);
+
+    const container_events = [];
+    $pill_container.on("input", () => {
+        container_events.push("input");
+    });
+    $input.html("devel");
+    left_sidebar_filter.clear_query();
+    assert.equal($input.html(), "");
+    assert.deepEqual(container_events, ["input"]);
+});
+
+run_test("setup_left_sidebar_filter_typeahead", ({override}) => {
+    assert.equal(left_sidebar_filter.is_typeahead_shown(), false);
+
+    $.set_results("#left-sidebar-filter-query", []);
+    $.set_results("#left-sidebar-filter-input", []);
+    left_sidebar_filter.setup_left_sidebar_filter_typeahead();
+    assert.equal(left_sidebar_filter.is_typeahead_shown(), false);
+
+    const info = set_up({override});
+    const {$input, $pill_container, pill_items, state, handlers} = info;
+    assert.equal(left_sidebar_filter.is_typeahead_shown(), false);
+
+    const input_events = [];
+    $input.on("focus", () => {
+        input_events.push("focus");
+    });
+
+    const container_events = [];
+    $pill_container.on("input", () => {
+        container_events.push("input");
+    });
+
+    $input.text("");
+    assert.equal($input.attr("data-placeholder"), default_placeholder);
+    assert.equal(state.captured_input.$element.selector, $input.selector);
+
+    $input.text("has-text");
+    handlers.on_text_input();
+    assert.equal($input.attr("data-placeholder"), "");
+
+    $input.text("");
+    pill_items.push({syntax: "is:followed"});
+    container_events.length = 0;
+    handlers.on_pill_create();
+    assert.equal($input.attr("data-placeholder"), filter_placeholder);
+    assert.deepEqual(container_events, ["input"]);
+
+    $input.text("is:");
+    state.narrowed_stream_id = undefined;
+    assert.deepEqual(state.captured_config.source(), []);
+
+    state.narrowed_stream_id = 5;
+    pill_items.length = 0;
+    assert.ok(state.captured_config.source().some((option) => option.syntax === "is:resolved"));
+
+    state.has_resolved_topics = false;
+    assert.ok(state.captured_config.source().every((option) => option.syntax !== "is:resolved"));
+
+    $input.text("is:");
+    const result = state.captured_config.updater(filter_options[1]);
+    assert.equal(state.clear_called_with, true);
+    assert.equal(state.append_called_with, "is:resolved");
+    assert.equal($input.text(), "");
+    assert.equal(result, "");
+    assert.ok(input_events.includes("focus"));
+    assert.ok(container_events.includes("input"));
+    assert.equal(pill_items.length, 1);
+
+    const keydown_handler = $input.get_on_handler("keydown");
+    let prevent_called = false;
+    let stop_called = false;
+    keydown_handler({
+        key: "Enter",
+        preventDefault() {
+            prevent_called = true;
+        },
+        stopPropagation() {
+            stop_called = true;
+        },
+    });
+    assert.ok(prevent_called);
+    assert.ok(stop_called);
+
+    let comma_stop_called = false;
+    keydown_handler({
+        key: ",",
+        stopPropagation() {
+            comma_stop_called = true;
+        },
+    });
+    assert.ok(comma_stop_called);
+
+    container_events.length = 0;
+    $input.text("");
+    pill_items.length = 0;
+    handlers.on_pill_remove();
+    assert.deepEqual(container_events, ["input"]);
+    assert.equal($input.attr("data-placeholder"), default_placeholder);
+});

--- a/web/tests/left_sidebar_filter.test.cjs
+++ b/web/tests/left_sidebar_filter.test.cjs
@@ -133,6 +133,18 @@ run_test("get_raw_topics_state", ({override}) => {
     assert.equal(warning_message, "Multiple pills found in left sidebar filter input.");
 });
 
+run_test("effective_topics_state_for_search", ({override}) => {
+    const info = set_up({override}, {is_subscribed: false});
+    assert.equal(left_sidebar_filter.get_effective_topics_state_for_search(), "");
+
+    info.pill_items.push({syntax: "is:followed"});
+    info.state.narrowed_stream_id = 5;
+    assert.equal(left_sidebar_filter.get_effective_topics_state_for_search(), "");
+
+    info.state.is_subscribed = true;
+    assert.equal(left_sidebar_filter.get_effective_topics_state_for_search(), "is:followed");
+});
+
 run_test("clear_left_sidebar_filter", ({override}) => {
     const info = set_up({override});
     const {$input, $pill_container, state} = info;

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -195,6 +195,9 @@ mock_esm("../src/resize", {
     set_recent_view_participants_rerender: noop,
     set_recent_view_participants_column_class_update: noop,
 });
+mock_esm("../src/sidebar_ui", {
+    refresh_left_sidebar_search_for_narrow_change: noop,
+});
 mock_esm("../src/popup_banners", {
     close_found_missing_unreads_banner: noop,
 });

--- a/web/tests/stream_list.test.cjs
+++ b/web/tests/stream_list.test.cjs
@@ -25,6 +25,11 @@ let unread_unmuted_count;
 let stream_has_any_unread_mentions;
 
 const topic_list = mock_esm("../src/topic_list");
+mock_esm("../src/left_sidebar_filter", {
+    has_left_sidebar_filter_value: () =>
+        $("#left-sidebar-filter-query").text().trim() !== "" ||
+        $("#left-sidebar-filter-input .pill").length > 0,
+});
 mock_esm("../src/unread", {
     unread_count_info_for_stream: () => ({
         unmuted_count: unread_unmuted_count,
@@ -157,6 +162,9 @@ function test_ui(label, f) {
     run_test(label, (helpers) => {
         stream_data.clear_subscriptions();
         stream_list.stream_sidebar.rows.clear();
+        $("#left-sidebar-filter-query").text("");
+        $.reset_selector("#left-sidebar-filter-input .pill");
+        $.set_results("#left-sidebar-filter-input .pill", []);
         f(helpers);
     });
 }
@@ -284,6 +292,77 @@ test_ui("pinned_streams_never_inactive", ({mock_template, override_rewire}) => {
 
     row.update_whether_active();
     assert.ok(!$devel_sidebar.hasClass("inactive_stream"));
+});
+
+test_ui("clear_search", () => {
+    const scenarios = [
+        {
+            search_term: "",
+            has_topic_state_pill: false,
+            expected_filter_events: ["blur"],
+            expected_close_button_events: [],
+        },
+        {
+            search_term: "",
+            has_topic_state_pill: true,
+            expected_filter_events: [],
+            expected_close_button_events: ["click"],
+        },
+    ];
+
+    for (const scenario of scenarios) {
+        $.reset_selector("#left-sidebar-filter-query");
+        $.reset_selector("#left-sidebar-search .input-close-filter-button");
+        $.reset_selector("#left-sidebar-filter-input .pill");
+        $.set_results("#left-sidebar-filter-input .pill", []);
+        const $filter = $("#left-sidebar-filter-query");
+        $filter.text(scenario.search_term);
+        if (scenario.has_topic_state_pill) {
+            const $pill = $.create("left-sidebar-topic-state-pill");
+            $.reset_selector("#left-sidebar-filter-input .pill");
+            $.set_results("#left-sidebar-filter-input .pill", [$pill[0]]);
+        }
+
+        const filter_events = [];
+        $filter.on("blur", () => {
+            filter_events.push("blur");
+        });
+
+        const close_button_events = [];
+        const $close_button = $("#left-sidebar-search .input-close-filter-button");
+        $close_button.on("click", () => {
+            close_button_events.push("click");
+        });
+
+        stream_list.clear_search();
+
+        assert.deepEqual(filter_events, scenario.expected_filter_events);
+        assert.deepEqual(close_button_events, scenario.expected_close_button_events);
+    }
+});
+
+test_ui("searching", () => {
+    const $filter = $("#left-sidebar-filter-query");
+    $.reset_selector("#left-sidebar-filter-input .pill");
+    $.set_results("#left-sidebar-filter-input .pill", []);
+
+    assert.equal(stream_list.searching(), false);
+
+    $filter.trigger("focus");
+    assert.equal(stream_list.searching(), true);
+
+    $filter.trigger("blur");
+    assert.equal(stream_list.searching(), false);
+
+    const $pill = $.create("left-sidebar-topic-state-pill-searching");
+    $.reset_selector("#left-sidebar-filter-input .pill");
+    $.set_results("#left-sidebar-filter-input .pill", [$pill[0]]);
+
+    $pill.trigger("focus");
+    assert.equal(stream_list.searching(), true);
+
+    $pill.trigger("blur");
+    assert.equal(stream_list.searching(), false);
 });
 
 function add_row(sub) {

--- a/web/tests/stream_list.test.cjs
+++ b/web/tests/stream_list.test.cjs
@@ -24,13 +24,29 @@ set_current_user(current_user);
 let unread_unmuted_count;
 let stream_has_any_unread_mentions;
 let left_sidebar_topics_state = "";
+let browser_history_navigated_to;
+
+mock_esm("../src/browser_history", {
+    go_to_location(url) {
+        browser_history_navigated_to = url;
+    },
+    update_current_history_state_data: noop,
+});
 
 const topic_list = mock_esm("../src/topic_list");
 mock_esm("../src/left_sidebar_filter", {
+    get_raw_topics_state: () => left_sidebar_topics_state,
+    get_effective_topics_state_for_search: () => left_sidebar_topics_state,
     has_left_sidebar_filter_value: () =>
         $("#left-sidebar-filter-query").text().trim() !== "" ||
         $("#left-sidebar-filter-input .pill").length > 0,
-    get_effective_topics_state_for_search: () => left_sidebar_topics_state,
+    clear_query_text() {
+        $("#left-sidebar-filter-query").empty();
+    },
+    clear_query() {
+        $("#left-sidebar-filter-query").empty();
+        $("#left-sidebar-filter-input").trigger("input");
+    },
 });
 mock_esm("../src/unread", {
     unread_count_info_for_stream: () => ({
@@ -45,6 +61,9 @@ mock_esm("../src/unread", {
     }),
     stream_has_any_unread_mentions: () => stream_has_any_unread_mentions,
     stream_has_any_unmuted_mentions: () => noop,
+    get_missing_topics: () => [],
+    get_topics_with_unread_mentions: () => new Set(),
+    num_unread_for_topic: () => 0,
 });
 
 const {Filter} = zrequire("../src/filter");
@@ -53,7 +72,9 @@ const stream_data = zrequire("stream_data");
 const stream_list = zrequire("stream_list");
 stream_list.set_update_inbox_channel_view_callback(noop);
 const stream_list_sort = zrequire("stream_list_sort");
+const stream_topic_history = zrequire("stream_topic_history");
 const user_groups = zrequire("user_groups");
+const user_topics = zrequire("user_topics");
 const {initialize_user_settings} = zrequire("user_settings");
 const settings_config = zrequire("settings_config");
 mock_esm("../src/settings_data", {
@@ -164,10 +185,13 @@ function test_ui(label, f) {
     run_test(label, (helpers) => {
         stream_data.clear_subscriptions();
         stream_list.stream_sidebar.rows.clear();
+        stream_topic_history.reset();
+        user_topics.set_user_topics([]);
         $("#left-sidebar-filter-query").text("");
         $.reset_selector("#left-sidebar-filter-input .pill");
         $.set_results("#left-sidebar-filter-input .pill", []);
         left_sidebar_topics_state = "";
+        browser_history_navigated_to = undefined;
         f(helpers);
     });
 }
@@ -366,6 +390,79 @@ test_ui("searching", () => {
 
     $pill.trigger("blur");
     assert.equal(stream_list.searching(), false);
+});
+
+test_ui("on_sidebar_channel_click_with_preserved_topic_state_filter", ({override}) => {
+    stream_data.add_sub_for_tests(develSub);
+
+    override(
+        user_settings,
+        "web_channel_default_view",
+        settings_config.web_channel_default_view_values.top_topic_in_channel.code,
+    );
+
+    const $filter = $("#left-sidebar-filter-query");
+    const scenarios = [
+        {
+            search_term: "de",
+            add_matching_followed_topic() {
+                user_topics.update_user_topics(
+                    develSub.stream_id,
+                    develSub.name,
+                    "topic 2",
+                    user_topics.all_visibility_policies.FOLLOWED,
+                    1,
+                );
+            },
+            expected_topic_name: "topic 2",
+            expected_show_channel_feed_called: false,
+        },
+        {
+            search_term: "",
+            add_matching_followed_topic: noop,
+            expected_topic_name: undefined,
+            expected_show_channel_feed_called: true,
+        },
+    ];
+
+    for (const scenario of scenarios) {
+        left_sidebar_topics_state = "is:followed";
+        $filter.text(scenario.search_term);
+        $filter.html(scenario.search_term);
+
+        stream_topic_history.add_message({
+            stream_id: develSub.stream_id,
+            topic_name: "topic 1",
+            message_id: 1,
+        });
+        stream_topic_history.add_message({
+            stream_id: develSub.stream_id,
+            topic_name: "topic 2",
+            message_id: 2,
+        });
+        scenario.add_matching_followed_topic();
+        const expected_url =
+            scenario.expected_topic_name === undefined
+                ? undefined
+                : stream_topic_history.channel_topic_permalink_hash(
+                      develSub.stream_id,
+                      scenario.expected_topic_name,
+                  );
+
+        let show_channel_feed_called = false;
+        stream_list.on_sidebar_channel_click(develSub.stream_id, null, () => {
+            show_channel_feed_called = true;
+        });
+
+        assert.equal($filter.html(), "");
+        assert.equal(browser_history_navigated_to, expected_url);
+        assert.equal(show_channel_feed_called, scenario.expected_show_channel_feed_called);
+
+        stream_topic_history.reset();
+        user_topics.set_user_topics([]);
+        browser_history_navigated_to = undefined;
+        left_sidebar_topics_state = "";
+    }
 });
 
 function add_row(sub) {

--- a/web/tests/stream_list.test.cjs
+++ b/web/tests/stream_list.test.cjs
@@ -23,12 +23,14 @@ set_current_user(current_user);
 // We use this with override.
 let unread_unmuted_count;
 let stream_has_any_unread_mentions;
+let left_sidebar_topics_state = "";
 
 const topic_list = mock_esm("../src/topic_list");
 mock_esm("../src/left_sidebar_filter", {
     has_left_sidebar_filter_value: () =>
         $("#left-sidebar-filter-query").text().trim() !== "" ||
         $("#left-sidebar-filter-input .pill").length > 0,
+    get_effective_topics_state_for_search: () => left_sidebar_topics_state,
 });
 mock_esm("../src/unread", {
     unread_count_info_for_stream: () => ({
@@ -165,6 +167,7 @@ function test_ui(label, f) {
         $("#left-sidebar-filter-query").text("");
         $.reset_selector("#left-sidebar-filter-input .pill");
         $.set_results("#left-sidebar-filter-input .pill", []);
+        left_sidebar_topics_state = "";
         f(helpers);
     });
 }

--- a/web/tests/stream_list_sort.test.cjs
+++ b/web/tests/stream_list_sort.test.cjs
@@ -17,6 +17,7 @@ const settings_config = zrequire("settings_config");
 const stream_topic_history = zrequire("stream_topic_history");
 const message_lists = zrequire("message_lists");
 const channel_folders = zrequire("channel_folders");
+const user_topics = zrequire("user_topics");
 const {initialize_user_settings} = zrequire("user_settings");
 
 state_data.set_realm(
@@ -178,6 +179,7 @@ function sort_groups(query) {
 function test(label, f) {
     run_test(label, (helpers) => {
         stream_data.clear_subscriptions();
+        user_topics.set_user_topics([]);
         f(helpers);
     });
 }
@@ -523,6 +525,39 @@ test("left_sidebar_search", ({override}) => {
     assert.deepEqual(sorted_sections[1].default_visible_streams, [fast_tortoise.stream_id]);
     assert.deepEqual(sorted_sections[0].default_visible_streams, []);
     assert.deepEqual(sorted_sections[2].default_visible_streams, []);
+});
+
+test("left_sidebar_topic_state_filter_does_not_filter_stream_rows", () => {
+    add_all_subs();
+
+    {
+        const history = stream_topic_history.find_or_create(scalene.stream_id);
+        history.add_or_update("followed topic", 2);
+    }
+    {
+        const history = stream_topic_history.find_or_create(fast_tortoise.stream_id);
+        history.add_or_update("unfollowed topic", 2);
+    }
+
+    user_topics.update_user_topics(
+        scalene.stream_id,
+        scalene.name,
+        "followed topic",
+        user_topics.all_visibility_policies.FOLLOWED,
+        1,
+    );
+
+    const unfiltered_sections = stream_list_sort.sort_groups(
+        stream_data.subscribed_stream_ids(),
+        "",
+    ).sections;
+    const topic_filtered_sections = stream_list_sort.sort_groups(
+        stream_data.subscribed_stream_ids(),
+        "",
+        "is:followed",
+    ).sections;
+
+    assert.deepEqual(topic_filtered_sections, unfiltered_sections);
 });
 
 test("filter inactives", ({override}) => {


### PR DESCRIPTION
This PR replaces the left sidebar filter input with a pill-enabled contenteditable field.
It adds typeahead support for resolved, unresolved, followed and unfollowed, matching the “all topics” view UX.

Fixes https://github.com/zulip/zulip/issues/36877
Fixes https://github.com/zulip/zulip/issues/36878

Related discussion: [#design > conditional visibility of filters](https://chat.zulip.org/#narrow/channel/101-design/topic/conditional.20visibility.20of.20filters/with/2382303)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<table>
  <tr>
    <td align="center">
      <b>Default</b><br>
      <img src="https://github.com/user-attachments/assets/cff50b46-5714-49d7-bcae-0318e22368f1" width="500">
    </td>
    <td align="center">
      <b>resolved</b><br>
      <img src="https://github.com/user-attachments/assets/b6dab8b5-4212-4fcd-abd7-52a36af2157d" width="500">
    </td>
  </tr>
  <tr>
    <td align="center">
      <b>followed</b><br>
      <img src="https://github.com/user-attachments/assets/b8d6bbea-cf34-4d8b-9cf5-7f760eb148c6" width="500">
    </td>
    <td align="center">
      <b>unresolved</b><br>
      <img src="https://github.com/user-attachments/assets/8f33b8bc-2881-4158-a225-b0222a321c5a" width="500">
    </td>
  </tr>
  <tr>
    <td align="center">
      <b>unfollowed</b><br>
      <img src="https://github.com/user-attachments/assets/72f56b48-835b-4a83-b508-157300587c5b" width="500">
    </td>
    <td align="center">
      <b>Typeahead (is:)</b><br>
      <img src="https://github.com/user-attachments/assets/35bc8acf-248b-4ffd-8a52-97f1359bd299" width="500">
    </td>
  </tr>
    <tr>
    <td align="center">
      <b>Typeahead (-is:)</b><br>
      <img src="https://github.com/user-attachments/assets/4f80ec19-6bbb-4f0a-a751-dcabcb5fb53e" width="500">
    </td>
    <td align="center">
      <b>Typeahead (is:) when resolved topics do not exist</b><br>
      <img src="https://github.com/user-attachments/assets/0dcf110e-4c35-466a-8d7d-6cc636f501ca" width="500">
    </td>
  </tr>
</table>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
