### PR TITLE
portico: Fix built-in emoji rendering in organization descriptions

### DIFF
--- a/web/src/base_page_params.ts
+++ b/web/src/base_page_params.ts
@@ -11,6 +11,12 @@ const default_params_schema = z.object({
     google_analytics_id: z.optional(z.string()),
     request_language: z.string(),
 });
+// Sync this with zerver.context_processors.login_context.
+const login_page_params_schema = z.object({
+    ...default_params_schema.shape,
+    page_type: z.literal("login"),
+    realm_default_emojiset: z.string(),
+});
 
 // These parameters are sent in #page-params for both users and spectators.
 //
@@ -103,6 +109,7 @@ const upgrade_params_schema = z.object({
 
 const page_params_schema = z.discriminatedUnion("page_type", [
     default_params_schema,
+    login_page_params_schema,
     home_params_schema,
     stats_params_schema,
     team_params_schema,

--- a/web/src/emojisets.ts
+++ b/web/src/emojisets.ts
@@ -1,9 +1,12 @@
+// This module is shared with portico code (login/signup pages).
+// Do not import any web app-only modules here (e.g., user_settings, ui_init, etc.).
+// Only import modules that are available in both contexts.
+
 import octopus_url from "../../static/generated/emoji/images-google-64/1f419.png";
 import google_sheet from "../generated/emoji/google.webp";
 import twitter_sheet from "../generated/emoji/twitter.webp";
 
 import * as blueslip from "./blueslip.ts";
-import {user_settings} from "./user_settings.ts";
 
 import google_css from "!style-loader?injectType=lazyStyleTag!css-loader!../generated/emoji-styles/google-sprite.css";
 import twitter_css from "!style-loader?injectType=lazyStyleTag!css-loader!../generated/emoji-styles/twitter-sprite.css";
@@ -93,8 +96,8 @@ export async function select(name: string): Promise<void> {
     current_emojiset = new_emojiset;
 }
 
-export function initialize(): void {
-    void select(user_settings.emojiset);
+export function initialize(emojiset_name: string): void {
+    void select(emojiset_name);
 
     // Load the octopus image in the background, so that the browser
     // will cache it for later use.  Note that we hardcode the octopus

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -3,7 +3,9 @@ import _ from "lodash";
 import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
+import {page_params as base_page_params} from "../base_page_params.ts";
 import * as common from "../common.ts";
+import * as emojisets from "../emojisets.ts";
 import {$t} from "../i18n.ts";
 import {password_quality, password_warning} from "../password_quality.ts";
 import * as settings_config from "../settings_config.ts";
@@ -14,6 +16,10 @@ import * as portico_modals from "./portico_modals.ts";
 import "altcha";
 
 $(() => {
+    // Initialize emoji rendering for login/signup pages
+    if (base_page_params.page_type === "login" && "realm_default_emojiset" in base_page_params) {
+        emojisets.initialize(base_page_params.realm_default_emojiset);
+    }
     // NB: this file is included on multiple pages.  In each context,
     // some of the jQuery selectors below will return empty lists.
 

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -564,7 +564,7 @@ export async function initialize_everything(state_data) {
     });
     alert_words.initialize(state_data.alert_words);
     saved_snippets.initialize(state_data.saved_snippets);
-    emojisets.initialize();
+    emojisets.initialize(user_settings.emojiset);
     scroll_bar.initialize();
     message_viewport.initialize();
     banners.initialize();


### PR DESCRIPTION
## Description

Fixes built-in emoji rendering in organization descriptions on login/signup pages.

**Problem:** Built-in emoji (like `:rocket:`) were not rendering in organization descriptions on portico pages (login/signup). Only custom realm emoji and Zulip extension emoji were working. Standard emoji displayed as plain text instead of rendered images.

**Root Cause:** The login pages weren't initializing the emoji rendering system with the realm's default emojiset, so built-in emoji couldn't be processed.

**Solution:** 
- Created a new `login_page_params_schema` in `base_page_params.ts` specifically for login/signup pages
- Modified `login_context` in `context_processors.py` to pass `realm_default_emojiset` via `page_params` (which properly merges with `default_page_params` from the context processor)
- Added emoji initialization in `signup.ts` to select the realm's emojiset on login pages

This approach follows the maintainer's suggestion to use a dedicated schema for login pages, avoiding unnecessary database queries on other pages.

## Changes

- **web/src/base_page_params.ts**: Added `login_page_params_schema` with `realm_default_emojiset` field
- **web/src/portico/signup.ts**: Initialize emoji rendering when `page_type === "login"`
- **zerver/context_processors.py**: 
  - Import `RealmUserDefault` to access realm's emojiset
  - Modified `login_context` to fetch and pass `realm_default_emojiset` via `page_params`

## Testing

Tested manually:
1. Set organization description to: `:rocket: Testing Emoji :blush:`
2. Logged out and navigated to login page
3. Verified emojis now render as 🚀 and 😊 instead of plain text

Backend tests pass without modification since we're using `page_params` which properly merges with existing context.

## Screenshots
<img width="1568" height="1329" alt="Screenshot 2026-01-16 122503" src="https://github.com/user-attachments/assets/4dbf756e-f6cb-4bd4-a090-52a87fe5669f" />

<img width="1028" height="707" alt="Screenshot 2026-01-16 122239" src="https://github.com/user-attachments/assets/09de7d8f-84a5-448c-af59-a4a5d4e7b4c5" />

Fixes: #36394