### PR TITLE
search_results: Prioritize active users over deactivated users in search suggestions

### DIFF
--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -1124,15 +1124,83 @@ export let get_suggestions = function (
     // only make one people_getter to avoid duplicate work
     const people_getter = make_people_getter(last);
 
-    function get_people(
-        flavor: "dm" | "sender" | "dm-including",
-    ): (last: NarrowCanonicalTermSuggestion, base_terms: NarrowCanonicalTerm[]) => Suggestion[] {
-        return function (
-            last: NarrowCanonicalTermSuggestion,
-            base_terms: NarrowCanonicalTerm[],
-        ): Suggestion[] {
-            return get_person_suggestions(people_getter, last, base_terms, flavor);
-        };
+    function get_people_suggestions(
+        last: NarrowCanonicalTermSuggestion,
+        base_terms: NarrowCanonicalTerm[],
+    ): Suggestion[] {
+        const person_operators: ("dm" | "sender" | "dm-including")[] = page_params.is_spectator
+            ? ["sender"]
+            : ["dm", "sender", "dm-including"];
+        const all_person_suggestions: Suggestion[] = [];
+
+        for (const operator of person_operators) {
+            const suggestions = get_person_suggestions(people_getter, last, base_terms, operator);
+            all_person_suggestions.push(...suggestions);
+        }
+
+        const query_suggestions: Suggestion[] = [];
+        const person_suggestions: Suggestion[] = [];
+
+        for (const suggestion of all_person_suggestions) {
+            const parsed = Filter.parse(suggestion);
+            const term = Filter.convert_suggestion_to_term(parsed.at(-1)!);
+
+            if (
+                term !== undefined &&
+                (term.operator === "dm" ||
+                    term.operator === "sender" ||
+                    term.operator === "dm-including")
+            ) {
+                person_suggestions.push(suggestion);
+            } else {
+                query_suggestions.push(suggestion);
+            }
+        }
+
+        person_suggestions.sort((a, b) => {
+            const parsed_a = Filter.parse(a);
+            const parsed_b = Filter.parse(b);
+
+            const term_a = Filter.convert_suggestion_to_term(parsed_a.at(-1)!);
+            const term_b = Filter.convert_suggestion_to_term(parsed_b.at(-1)!);
+
+            assert(term_a !== undefined);
+            assert(term_b !== undefined);
+
+            let active_a: boolean;
+            switch (term_a.operator) {
+                case "dm":
+                case "dm-including":
+                    active_a = term_a.operand.every((user_id) => people.is_person_active(user_id));
+                    break;
+                case "sender":
+                    active_a = people.is_person_active(term_a.operand);
+                    break;
+                default:
+                    assert(false, "Unexpected operator for person suggestion");
+            }
+
+            let active_b: boolean;
+            switch (term_b.operator) {
+                case "dm":
+                case "dm-including":
+                    active_b = term_b.operand.every((user_id) => people.is_person_active(user_id));
+                    break;
+                case "sender":
+                    active_b = people.is_person_active(term_b.operand);
+                    break;
+                default:
+                    assert(false, "Unexpected operator for person suggestion");
+            }
+
+            if (active_a !== active_b) {
+                return active_a ? -1 : 1;
+            }
+
+            return 0;
+        });
+
+        return [...query_suggestions, ...person_suggestions];
     }
 
     // Remember to update the spectator list when changing this.
@@ -1148,9 +1216,7 @@ export let get_suggestions = function (
         get_is_filter_suggestions,
         get_sent_by_me_suggestions,
         get_channel_suggestions,
-        get_people("dm"),
-        get_people("sender"),
-        get_people("dm-including"),
+        get_people_suggestions,
         get_topic_suggestions,
         get_has_filter_suggestions,
     ];
@@ -1161,7 +1227,7 @@ export let get_suggestions = function (
             get_operator_suggestions,
             get_is_filter_suggestions,
             get_channel_suggestions,
-            get_people("sender"),
+            get_people_suggestions,
             get_topic_suggestions,
             get_has_filter_suggestions,
         ];

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -1088,3 +1088,59 @@ test("queries_with_spaces", () => {
     expected = [`channel:${dev_help_id}`];
     assert.deepEqual(suggestions, expected);
 });
+
+test("people_suggestion_sorting", ({override}) => {
+    override(narrow_state, "stream_id", () => undefined);
+
+    const active_user = {
+        email: "active@zulip.com",
+        user_id: 998,
+        full_name: "User A",
+    };
+    people.add_active_user(active_user);
+
+    const deactivated_user = {
+        email: "deactivate@zulip.com",
+        user_id: 999,
+        full_name: "User B",
+    };
+    people._add_user(deactivated_user);
+    people.deactivate(deactivated_user);
+
+    let query = "user";
+    let suggestions = get_suggestions(query);
+    let expected = [
+        "user",
+        "dm:998",
+        "dm:999",
+        "sender:998",
+        "sender:999",
+        "dm-including:998",
+        "dm-including:999",
+    ];
+    assert.deepEqual(suggestions, expected);
+
+    // test with 3 users
+    const another_active_user = {
+        email: "another@zulip.com",
+        user_id: 1000,
+        full_name: "User C",
+    };
+    people.add_active_user(another_active_user);
+
+    query = "user";
+    suggestions = get_suggestions(query);
+    expected = [
+        "user",
+        "dm:998",
+        "dm:999",
+        "dm:1000",
+        "sender:998",
+        "sender:999",
+        "sender:1000",
+        "dm-including:998",
+        "dm-including:999",
+        "dm-including:1000",
+    ];
+    assert.deepEqual(suggestions, expected);
+});


### PR DESCRIPTION
**Search_results: Prioritize active users in search suggestions**

When searching for any user the active users are prioritised over deactivated users, improving discoverability
of currently active team members

Fixes #35976.

This PR continues the work started in https://github.com/zulip/zulip/pull/35981. The original implementation was done by @minhphung152; this PR resolves merge conflicts and updates the changes to work with the current codebase.

While rebasing onto the latest main, a few runtime errors and failing tests appeared due to changes in suggestion handling and operator validation, so I made the necessary fixes to restore compatibility while preserving the original behavior.

**How changes were tested:**

New test users were created before fixing issue and order was checked (shown below). Then after fix order was tested in searchbar shown below.

**Before:**
![before](https://github.com/user-attachments/assets/0f9f0d9c-5c41-428d-8db2-29ec8a3e004e)

**After:**
![after (1)](https://github.com/user-attachments/assets/b2c916a1-29c6-4bbf-92ca-08dc8b34569a)

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed for clarity and maintainability
- [x] Followed AI use policy

**Context:**
- Continued work from PR #35981 (had merge conflicts), rebased on latest main
- Implementation follows maintainer feedback from evykassirer

**Technical choices:**
- Consolidated 4 `get_people()` functions into one `get_people_suggestions()`
- Uses `people.is_person_active()` with type-safe assertions
- Maintains filterers array position (per reviewer guidance)

**Testing:**
- [x] New test: `people_suggestion_sorting` (all 18 tests pass)
- [x] Manual testing: verified dm/sender/dm-including/from operators
- [x] Corner cases: multiple users, spectator mode, same activity status

**Commit:**
- [x] Single coherent commit with clear message
- [x] References #35976

</details>
