### PR TITLE
activity: Add filter parameter to installation activity view.

### DIFF
--- a/templates/corporate/activity/installation_activity_table.html
+++ b/templates/corporate/activity/installation_activity_table.html
@@ -34,6 +34,18 @@
     <li><strong>Human message</strong> - message sent by non-bot user, and not with known-bot client</li>
 </ul>
 
+<div class="installation-activity-filter-container">
+    <h4>Current filter: {{ current_filter }}</h4>
+    <p>
+        <b>Filters:</b>
+        <a href="/activity?filter=all">All</a> |
+        <a href="/activity?filter=demo">Demo</a> |
+        <a href="/activity?filter=sponsored">100% sponsored</a> |
+        <a href="/activity?filter=free">On free plan</a> |
+        <a href="/activity?filter=paid">On paid plan</a>
+    </p>
+</div>
+
 <table class="table summary-table sortable table-striped table-bordered">
 
     <thead class="activity-head">

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -31,6 +31,15 @@
     }
 }
 
+.installation-activity-filter-container {
+    width: fit-content;
+    border-radius: 4px;
+    background-color: hsl(0deg 0% 92%);
+    border: 1px solid hsl(0deg 0% 68%);
+    padding: 0 8px;
+    margin: 8px;
+}
+
 .summary-table,
 .analytics-table {
     border: 1px solid hsl(0deg 0% 87%);


### PR DESCRIPTION
Adds a filter parameter to the installation view that allows for adjusting the realms returned by the database query to a limited subset of realms, e.g., realms on paid plans or demo realms.

**Notes**:
- This changes the database query for each filter, so the page will reload with the new data.
  - Another way to go could be to add logic on the frontend for the filtering, maybe something to hide/show table rows based on the value of the plan type in the row's plan type data.
- Updates the database query for all realms to always show all paid plan types. Currently, it only always shows "Standard" plans and not "Plus" plans.

---

**Screenshots and screen captures:**

| Filter | Screenshot |
| --- | --- |
| all | <img width="1822" height="591" alt="Screenshot From 2026-01-16 13-01-39" src="https://github.com/user-attachments/assets/c528782c-29fb-49fa-9480-4e2ff473ffa4" />
| demo | <img width="1822" height="412" alt="Screenshot From 2026-01-16 13-01-53" src="https://github.com/user-attachments/assets/42565895-c515-46ad-a264-cae84bffa522" />
| sponsored | <img width="1822" height="312" alt="Screenshot From 2026-01-16 13-02-00" src="https://github.com/user-attachments/assets/18e8f70f-b1e7-4b35-8bea-884082db93b3" />
| free | <img width="1822" height="312" alt="Screenshot From 2026-01-16 13-02-05" src="https://github.com/user-attachments/assets/a94d460f-32c7-4e81-82a4-75df189e1980" />
| paid | <img width="1822" height="324" alt="Screenshot From 2026-01-16 13-02-12" src="https://github.com/user-attachments/assets/abcb254d-74d9-4fd5-a0f2-1281293ca59b" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
