### PR TITLE
kandra: Chown to zulip:zulip after mounting.

### DIFF
--- a/puppet/kandra/manifests/app_frontend_tmpfs.pp
+++ b/puppet/kandra/manifests/app_frontend_tmpfs.pp
@@ -22,8 +22,6 @@ class kandra::app_frontend_tmpfs {
   file { '/tmp/slack-conversions':
     ensure => 'directory',
     mode   => '0755',
-    owner  => 'root',
-    group  => 'root',
   }
   mount { '/tmp/slack-conversions':
     ensure  => 'mounted',
@@ -32,5 +30,14 @@ class kandra::app_frontend_tmpfs {
     atboot  => true,
     options => 'defaults,noatime,discard,commit=60,errors=remount-ro',
     require => Exec['format partition'],
+  }
+
+  # We want ownership to be enforced after the mount, so the File
+  # directive above doesn't have user/group, and we manage it
+  # explicitly via chown.
+  exec { 'chown-slack-conversions':
+    command => '/bin/chown zulip:zulip /tmp/slack-conversions',
+    unless  => '/usr/bin/test "$(stat -c %U:%G /tmp/slack-conversions)" = "zulip:zulip"',
+    require => Mount['/tmp/slack-conversions'],
   }
 }


### PR DESCRIPTION
Remove the user/group on the mountpoint, since it will be wrong if the mount has already happened.  We cannot have a _second_ occurrence of the directory to set ownership after the mount, so we use an exec to manage it instead.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
