### PR TITLE
docs: Fix incorrect 'local_id' to 'local_message_id' in API and subsystem docs.

### DIFF
--- a/docs/subsystems/sending-messages.md
+++ b/docs/subsystems/sending-messages.md
@@ -144,17 +144,17 @@ messages.
   visually).
 - The `POST /messages` API request to the server to send the message
   is passed two special parameters that clients not implementing local
-  echo don't use: `queue_id` and `local_id`. The `queue_id` is the ID
+  echo don't use: `queue_id` and `local_message_id`. The `queue_id` is the ID
   of the client's event queue; here, it is used just as a unique
   identifier for the specific client (e.g., a browser tab) that sent
-  the message. And the `local_id` is, by the construction above, a
+  the message. And the `local_message_id` is, by the construction above, a
   unique value within that namespace identifying the message.
 - The `do_send_messages` backend code path includes the `queue_id` and
-  `local_id` in the data it passes to the
+  `local_message_id` in the data it passes to the
   [events system](events-system.md). The events
   system will extend the `message` event dictionary it delivers to
   the client containing the `queue_id` with `local_message_id` field,
-  containing the `local_id` that the relevant client used when sending
+  containing the `local_message_id` that the relevant client used when sending
   the message. This allows the client to know that the `message`
   event it is receiving is the same message it itself had sent.
 - Using that information, rather than adding the "new message" to the
@@ -169,7 +169,7 @@ messages.
 Zulip also supports local echo in the message editing code path for
 edits to just the content of a message. The approach is analogous
 (using `markdown.contains_backend_only_syntax`, etc.), except we
-don't need any of the `local_id` tracking logic, because the message
+don't need any of the `local_message_id` tracking logic, because the message
 already has a permanent message id; as a result, the whole
 implementation was under 150 lines of code.
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8390,15 +8390,15 @@ paths:
                     For clients supporting
                     [local echo](https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html#local-echo),
                     the [event queue](/api/register-queue)
-                    ID for the client. If passed, `local_id` is required. If the message is
-                    successfully sent, the server will include `local_id` in the `message` event
+                    ID for the client. If passed, `local_message_id` is required. If the message is
+                    successfully sent, the server will include `local_message_id` in the `message` event
                     that the client with this `queue_id` will receive notifying it of the new message
                     via [`GET /events`](/api/get-events). This lets the client know unambiguously
                     that it should replace the locally echoed message, rather than adding this new
                     message (which would be correct if the user had sent the new message from another
                     device).
                   example: "fb67bf8a-c031-47cc-84cf-ed80accacda8"
-                local_id:
+                local_message_id:
                   type: string
                   description: |
                     For clients supporting local echo, a unique string-format identifier


### PR DESCRIPTION
…stem docs.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
Fixes issue #34164 – Documentation incorrectly references local_id instead of local_message_id.
**How changes were tested:**

Verified schema changes via inspection
Ran local search to ensure no remaining incorrect documentation references
Confirmed wording and formatting render correctly in Markdown
CI will validate linting and documentation build

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary></summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

- [ ] Explains differences from previous plans (e.g., issue description).
-[ ]  Commits are clean and focused

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

</details>
