### PR TITLE
markdown: Remove support for file:// links.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -97,7 +97,7 @@ html_safelisted_schemes = (
     "wtai",
     "xmpp",
 )
-allowed_schemes = ("http", "https", "ftp", "file", "mid", *html_safelisted_schemes)
+allowed_schemes = ("http", "https", "ftp", "mid", *html_safelisted_schemes)
 
 
 class LinkInfo(TypedDict):
@@ -250,7 +250,6 @@ def get_web_link_regex() -> Pattern[str]:
         nested_paren_chunk %= (paren_group,)
     nested_paren_chunk %= (inner_paren_contents,)
 
-    file_links = r"| (?:file://(/[^/ ]*)+/?)" if settings.ENABLE_FILE_LINKS else r""
     REGEX = rf"""
         (?<![^\s'"\(,:<])    # Start after whitespace or specified chars
                              # (Double-negative lookbehind to allow start-of-string)
@@ -268,7 +267,6 @@ def get_web_link_regex() -> Pattern[str]:
                 (?: \? (?![)\"\s]|\Z) {nested_paren_chunk} ) # Query starting with ? (must not be trailing punctuation)
             )?)              # Path is optional
             | (?:[\w.-]+\@[\w.-]+\.[\w]+) # Email is separate, since it can't have a path
-            {file_links}               # File path start with file:///, enable by setting ENABLE_FILE_LINKS=True
             | (?:bitcoin:[13][a-km-zA-HJ-NP-Z1-9]{{25,34}})  # Bitcoin address pattern, see https://mokagio.github.io/tech-journal/2014/11/21/regex-bitcoin.html
         )
         (?=                            # URL must be followed by (not included in group)

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -49,6 +49,11 @@
       "expected_output": "<p>it's lunch time</p>"
     },
     {
+      "name": "file_links_ignored",
+      "input": "Check file:///etc/passwd out",
+      "expected_output": "<p>Check file:///etc/passwd out</p>"
+    },
+    {
       "name": "codeblock_trailing_whitespace",
       "input": "Hamlet once said\n~~~~\ndef func():\n    x = 1\n\n    y = 2\t\t\n\n    z = 3       \n~~~~\nAnd all was good.",
       "expected_output": "<p>Hamlet once said</p>\n<div class=\"codehilite\"><pre><span></span><code>def func():\n    x = 1\n\n    y = 2\n\n    z = 3\n</code></pre></div>\n<p>And all was good.</p>",

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -38,7 +38,6 @@ from zerver.lib.markdown import (
     InlineInterestingLinkProcessor,
     MarkdownListPreprocessor,
     MessageRenderingResult,
-    clear_web_link_regex_for_testing,
     content_has_emoji_syntax,
     image_preview_enabled,
     markdown_convert,
@@ -734,25 +733,10 @@ class MarkdownLinkTest(ZulipTestCase):
 
     def test_inline_file(self) -> None:
         msg = "Check out this file file:///Volumes/myserver/Users/Shared/pi.py"
-
-        # Make separate realms because the markdown engines cache the
-        # linkifiers on them, including if ENABLE_FILE_LINKS was used
-        realm = do_create_realm(string_id="file_links_disabled", name="File links disabled")
         self.assertEqual(
-            markdown_convert(msg, message_realm=realm).rendered_content,
+            markdown_convert_wrapper(msg),
             "<p>Check out this file file:///Volumes/myserver/Users/Shared/pi.py</p>",
         )
-        clear_web_link_regex_for_testing()
-
-        try:
-            with self.settings(ENABLE_FILE_LINKS=True):
-                realm = do_create_realm(string_id="file_links_enabled", name="File links enabled")
-                self.assertEqual(
-                    markdown_convert(msg, message_realm=realm).rendered_content,
-                    '<p>Check out this file <a href="file:///Volumes/myserver/Users/Shared/pi.py">file:///Volumes/myserver/Users/Shared/pi.py</a></p>',
-                )
-        finally:
-            clear_web_link_regex_for_testing()
 
     def test_inline_bitcoin(self) -> None:
         msg = "To bitcoin:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa or not to bitcoin"

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -225,7 +225,6 @@ USING_TORNADO = True
 POLICIES_DIRECTORY: str = "zerver/policies_absent"
 
 # Security
-ENABLE_FILE_LINKS = False
 ENABLE_GRAVATAR = True
 ## Overrides the above setting for individual realms, by integer ID.
 GRAVATAR_REALM_OVERRIDE: dict[int, bool] = {}


### PR DESCRIPTION
Modern browsers generally block navigation to `file://` URLs from web pages for security reasons. Consequently, these links are non-functional for users even when rendered as clickable links by the server.

This PR removes the server-side logic, regexes, and the `ENABLE_FILE_LINKS` configuration setting that previously attempted to linkify these URLs.

`file://` paths will now render as plain text.

**Changes:**
* Removed `file` from `allowed_schemes` in `zerver/lib/markdown/__init__.py`.
* Removed `ENABLE_FILE_LINKS` from `zproject/default_settings.py`.
* Updated backend tests in `zerver/tests/test_markdown.py` to verify that file paths render as plain text.
* Verified manually that the frontend does not auto-link `file://` patterns.

Fixes #19720.

**How changes were tested:**
1. **Backend Tests:** Ran `./tools/test-backend zerver/tests/test_markdown.py`.
    * Verified that the updated `test_inline_file` passes and correctly asserts that `file://` input renders as a plain `<p>` tag instead of an `<a>` tag.
2. **Manual UI Testing:**
    * Temporarily added `ENABLE_FILE_LINKS = True` to `zproject/dev_settings.py` to attempt to force-enable the feature.
    * Started the development server (`./tools/run-dev`).
    * Typed `file:///tmp/test` in the compose box.
    * Verified that the text remained black (plain text) and did not turn blue (link) either while typing or after sending, confirming the removal of the logic was successful.
3. **Frontend Logic Check:** Verified via `grep` and manual code inspection that the frontend parser does not contain explicit logic to whitelist the `file` protocol.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
