### PR TITLE
web: fix typos in comments

### DIFF
--- a/web/src/compose_paste.ts
+++ b/web/src/compose_paste.ts
@@ -341,7 +341,7 @@ export function paste_handler_converter(
     });
 
     /*
-        Below lies the the thought process behind the parsing for math blocks and inline math expressions.
+        Below lies the thought process behind the parsing for math blocks and inline math expressions.
 
         The general structure of the katex-displays i.e. math blocks is:
         <p>

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1656,7 +1656,7 @@ export function initialize_compose_typeahead($element: JQuery<HTMLTextAreaElemen
             },
             getCustomItemClassname(item) {
                 // Inject this class for non stream items in the typeahead menu to remove extra
-                // gap between the stream name, chevron and the the topic name.
+                // gap between the stream name, chevron and the topic name.
                 return item.type === "topic_list" && !item.is_channel_link
                     ? "topic-typeahead-link"
                     : "";

--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -329,7 +329,7 @@ export function postprocess_content(html: string): string {
         );
 
         if (is_part_of_open_gallery) {
-            // If the the current media element's previous sibling is a gallery,
+            // If the current media element's previous sibling is a gallery,
             // it should be kept with the other media in that gallery.
             gallery_element = elt.previousElementSibling;
         } else {


### PR DESCRIPTION
Fix typos: `the the` → `the` (x3)