### PR TITLE
custom_profile_fields: Delete modal will not appear in select field for edge case #29879

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -400,33 +400,15 @@ export type SelectFieldData = z.output<typeof select_field_data_schema>;
 
 function read_select_field_data_from_form(
     $profile_field_form: JQuery,
-    old_field_data: unknown,
+    _old_field_data: unknown,
 ): SelectFieldData {
     const field_data: SelectFieldData = {};
     let field_order = 1;
 
-    const old_option_value_map = new Map<string, string>();
-    if (old_field_data !== undefined) {
-        for (const [value, choice] of Object.entries(
-            select_field_data_schema.parse(old_field_data),
-        )) {
-            assert(typeof choice !== "string");
-            old_option_value_map.set(choice.text, value);
-        }
-    }
     $profile_field_form.find("div.choice-row").each(function (this: HTMLElement) {
         const text = util.the($(this).find("input")).value;
         if (text) {
-            let value = old_option_value_map.get(text);
-            if (value !== undefined) {
-                // Resetting the data-value in the form is
-                // important if the user removed an option string
-                // and then added it back again before saving
-                // changes.
-                $(this).attr("data-value", value);
-            } else {
-                value = $(this).attr("data-value")!;
-            }
+            const value = $(this).attr("data-value")!;
             field_data[value] = {text, order: field_order.toString()};
             field_order += 1;
         }
@@ -471,6 +453,24 @@ function read_external_account_field_data(
 }
 
 export type FieldData = SelectFieldData | ExternalAccountFieldData;
+
+export function get_select_field_duplicate_options($profile_field_form: JQuery): string[] {
+    const seen_texts = new Set<string>();
+    const duplicates: string[] = [];
+    $profile_field_form.find("div.choice-row").each(function (this: HTMLElement) {
+        const text = util.the($(this).find("input")).value.trim();
+        if (text) {
+            if (seen_texts.has(text)) {
+                if (!duplicates.includes(text)) {
+                    duplicates.push(text);
+                }
+            } else {
+                seen_texts.add(text);
+            }
+        }
+    });
+    return duplicates;
+}
 
 export function read_field_data_from_form(
     field_type_id: number,

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -315,15 +315,34 @@ function open_custom_profile_field_creation_form_modal(): void {
     });
 
     function create_profile_field(): void {
+        const field_types = realm.custom_profile_field_types;
         let field_data: FieldData | undefined = {};
         const field_type = $<HTMLSelectOneElement>(
             "select:not([multiple])#profile_field_type",
         ).val()!;
-        field_data = settings_components.read_field_data_from_form(
-            Number.parseInt(field_type, 10),
-            $(".new-profile-field-form"),
-            undefined,
-        );
+        const field_type_id = Number.parseInt(field_type, 10);
+        const $form = $(".new-profile-field-form");
+
+        // Check for duplicate options in select fields before saving
+        if (field_type_id === field_types.SELECT.id) {
+            const duplicate_options = settings_components.get_select_field_duplicate_options($form);
+            if (duplicate_options.length > 0) {
+                ui_report.client_error(
+                    $t(
+                        {
+                            defaultMessage:
+                                "Cannot save because there are duplicate options: {options}",
+                        },
+                        {options: duplicate_options.join(", ")},
+                    ),
+                    $("#dialog_error"),
+                );
+                dialog_widget.hide_dialog_spinner();
+                return;
+            }
+        }
+
+        field_data = settings_components.read_field_data_from_form(field_type_id, $form, undefined);
         const data = {
             name: $("#profile_field_name").val(),
             hint: $("#profile_field_hint").val(),
@@ -680,29 +699,65 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
             dialog_widget.submit_api_request(channel.patch, url, data, opts);
         }
 
-        if (field.type === field_types.SELECT.id && data["field_data"] !== undefined) {
-            const new_values = new Set(
-                Object.keys(
-                    settings_components.select_field_data_schema.parse(
-                        JSON.parse(data["field_data"].toString()),
+        if (field.type === field_types.SELECT.id) {
+            // Check for duplicate options before saving
+            const duplicate_options =
+                settings_components.get_select_field_duplicate_options($profile_field_form);
+            if (duplicate_options.length > 0) {
+                ui_report.client_error(
+                    $t(
+                        {
+                            defaultMessage:
+                                "Cannot save because there are duplicate options: {options}",
+                        },
+                        {options: duplicate_options.join(", ")},
                     ),
-                ),
-            );
-            const deleted_values: Record<string, string> = {};
-            const select_field_data =
-                settings_components.select_field_data_schema.parse(field_data);
-            for (const [value, option] of Object.entries(select_field_data)) {
-                if (!new_values.has(value)) {
-                    deleted_values[value] = option.text;
-                }
+                    $("#dialog_error"),
+                );
+                dialog_widget.hide_dialog_spinner();
+                return;
             }
 
-            if (Object.keys(deleted_values).length > 0) {
-                const edit_select_field_modal_callback = (): void => {
-                    show_modal_for_deleting_options(field, deleted_values, update_profile_field);
-                };
-                dialog_widget.close(edit_select_field_modal_callback);
-                return;
+            // Get the field data from the form for submission.
+            // Each option keeps its DOM data-value, so deleted options
+            // are properly detected even if new options with the same text are added.
+            const submission_field_data = settings_components.read_field_data_from_form(
+                field.type,
+                $profile_field_form,
+                JSON.parse(field.field_data),
+            );
+            if (submission_field_data !== undefined) {
+                data["field_data"] = JSON.stringify(submission_field_data);
+            }
+
+            if (data["field_data"] !== undefined) {
+                const new_values = new Set(
+                    Object.keys(
+                        settings_components.select_field_data_schema.parse(
+                            JSON.parse(data["field_data"].toString()),
+                        ),
+                    ),
+                );
+                const deleted_values: Record<string, string> = {};
+                const select_field_data =
+                    settings_components.select_field_data_schema.parse(field_data);
+                for (const [value, option] of Object.entries(select_field_data)) {
+                    if (!new_values.has(value)) {
+                        deleted_values[value] = option.text;
+                    }
+                }
+
+                if (Object.keys(deleted_values).length > 0) {
+                    const edit_select_field_modal_callback = (): void => {
+                        show_modal_for_deleting_options(
+                            field,
+                            deleted_values,
+                            update_profile_field,
+                        );
+                    };
+                    dialog_widget.close(edit_select_field_modal_callback);
+                    return;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes two bugs in the Dropdown (select) custom profile field editor in organization settings.

**Bug 1: Missing delete confirmation when removing options**

When editing a Dropdown custom profile field, deleting an existing option (e.g., "example_option") and then adding a new option did not show a confirmation dialog warning that the original option would be removed from users' profiles.

Root cause: The `read_select_field_data_from_form` function was mapping option text back to old option value IDs, which made it appear as if no deletion occurred.

**Bug 2: No validation for duplicate dropdown options**

When adding a duplicate option (same text as an existing option) and clicking "Save changes", no validation error was shown. The UI silently saved, but the duplicate did not persist when reopening the editor.

Fix: Added client-side validation that detects duplicate option texts and shows a clear error message before submitting.

**Additional fix:** If a user deletes an option "hello" and creates a new option with text "hello", the system now correctly detects that the original option was deleted and shows the delete confirmation warning.

**How changes were tested:**

1. Created a Dropdown custom profile field with options "A", "B", "C"
2. Assigned option "B" to a user's profile
3. Edited the field: deleted option "B", added new option "D" → Verified delete confirmation dialog appears
4. Edited the field: deleted option "A", added new option "A" → Verified delete confirmation dialog appears (previously it silently preserved the option)
5. Edited the field: changed option "C" to "A" (duplicate) → Verified error message: "Cannot save because there are duplicate options: A"
6. Created a new Dropdown field with duplicate options → Verified same error message appears

**Screenshots and screen captures:**

for delete modal not appearing :
<img width="857" height="346" alt="Screenshot 2026-01-17 234826" src="https://github.com/user-attachments/assets/d86fd995-d042-459d-9628-483c31836907" />

for dublicate check : 
<img width="848" height="991" alt="Screenshot 2026-01-17 234756" src="https://github.com/user-attachments/assets/1a92397c-8c4e-4ac9-be5b-b7c642089a80" />


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>