### PR TITLE
buddy_data: Prioritize users with unread messages in sidebar.

### DIFF
--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -115,6 +115,17 @@ export function compare_function(
     pm_ids: Set<number>,
     conversation_participants: Set<number>,
 ): number {
+   
+    const a_unread = get_num_unread(a);
+    const b_unread = get_num_unread(b);
+
+    if (a_unread > 0 && b_unread === 0) {
+        return -1;
+    }
+    if (a_unread === 0 && b_unread > 0) {
+        return 1;
+    }
+
     const a_is_participant = conversation_participants.has(a);
     const b_is_participant = conversation_participants.has(b);
     if (a_is_participant && !b_is_participant) {


### PR DESCRIPTION
This PR modifies the buddy list sorting logic to prioritize users with unread messages. This ensures that any user who sends you a message even if they are offline stays at the very top of your right sidebar so you don't miss the notification.

Previously, the list was sorted primarily by presence (Online > Idle > Offline), which buried unread messages from offline users at the bottom of the list. I updated the compare_function in web/src/buddy_data.ts to check unread counts first. I also updated find_position in web/src/buddy_list.ts to make sure the UI places users in the correct new priority spots.

Fixes: #5553

How changes were tested
I verified the fix manually using my local Zulip development environment on port 9991:

Manual Test: Logged in as Desdemona and saw that Iago was offline (grey circle) and positioned in the middle of the list.

The Fix: Sent a direct message to Desdemona. Iago immediately jumped to the very top of the "Filter users" list with a "1" unread badge, even though he remained offline.

Regressions: Confirmed that users with no unread messages are still sorted alphabetically by their status as usual.

Screenshots and screen captures
Before Fix: Offline users with unreads were buried in the list. <img width="441" height="638" alt="Before" src="https://github.com/user-attachments/assets/d906cae9-af90-4efb-81c7-fb041d2445cb" />

After Fix: Iago (offline) is now at the very top with an unread badge. <img width="407" height="777" alt="After" 
src="https://github.com/user-attachments/assets/48a488a2-bfa8-4c24-90d9-1e2ddab6cae2" />

<details> <summary>Self-review checklist</summary>

-> [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity.

-> Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

-> Highlights technical choices and bugs encountered: Handled port 9991 conflicts and ensured unread weight overrides presence level.

-> Automated tests verify logic where appropriate.

-> Each commit is a coherent idea.

-> Commit message(s) explain reasoning and motivation for changes.

-> Visual appearance of the changes.

-> End-to-end functionality of buttons and flows.

</details>