### PR TITLE
frontend: Remove empty DM conversations from sidebar.

### DIFF
--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -25,6 +25,7 @@ import * as message_store from "./message_store.ts";
 import type {DisplayRecipientUser, Message, MessageReaction, RawMessage} from "./message_store.ts";
 import * as message_util from "./message_util.ts";
 import * as people from "./people.ts";
+import * as pm_conversations from "./pm_conversations.ts";
 import * as pm_list from "./pm_list.ts";
 import * as recent_view_data from "./recent_view_data.ts";
 import * as rows from "./rows.ts";
@@ -497,15 +498,20 @@ export let reify_message_id = (local_id: string, server_id: number): void => {
     compose_notifications.reify_message_id(opts);
     recent_view_data.reify_message_id_if_available(opts);
 
-    // We add the message to stream_topic_history only after we receive
-    // it from the server i.e., is acked, so as to maintain integer
-    // message id values there.
+    // We count a message toward its conversation only on ack, both to keep
+    // integer message ids in stream_topic_history and so that an un-acked
+    // echo never inflates pm_conversations' counts.
     if (message.type === "stream") {
         stream_topic_history.add_message({
             stream_id: message.stream_id,
             topic_name: message.topic,
             message_id: message.id,
         });
+    } else {
+        const user_ids = people.pm_with_user_ids(message);
+        if (user_ids !== undefined) {
+            pm_conversations.recent.increment_local_message_count(user_ids);
+        }
     }
     update_topic_hash_to_contain_with_term(message);
 };

--- a/web/src/echo_state.ts
+++ b/web/src/echo_state.ts
@@ -34,6 +34,10 @@ export function _patch_waiting_for_ack(data: Map<string, LocalMessage>): void {
     waiting_for_ack = data;
 }
 
+export function get_waiting_for_ack_private_messages(): LocalMessage[] {
+    return [...waiting_for_ack.values()].filter((message) => message.type === "private");
+}
+
 export function get_waiting_for_ack_local_ids_by_topic(channel_id: number): Map<string, number> {
     const max_message_id_by_topic = new Map<string, number>();
 

--- a/web/src/message_helper.ts
+++ b/web/src/message_helper.ts
@@ -232,7 +232,7 @@ export function process_new_message(opts: NewMessage): ProcessedMessage {
 
         const message = processed_message.message;
 
-        pm_conversations.process_message(message);
+        pm_conversations.process_message(message, processed_message.type === "server_message");
         recent_senders.process_private_message({
             to_user_ids,
             sender_id: message.sender_id,

--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -1,3 +1,7 @@
+import assert from "minimalistic-assert";
+import * as z from "zod/mini";
+
+import * as channel from "./channel.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_store from "./message_store.ts";
 import type {Message} from "./message_store.ts";
@@ -13,6 +17,50 @@ type DirectMessagePermissionHints = {
     is_known_empty_conversation: boolean;
     is_local_echo_safe: boolean;
 };
+
+const last_message_id_response_schema = z.object({
+    messages: z.array(
+        z.object({
+            id: z.number(),
+        }),
+    ),
+});
+
+export function get_last_message_id_in_narrow(
+    narrow: {operator: string; operand: unknown}[],
+    on_success: (last_message_id: number) => void,
+    extra_request_data: Record<string, unknown> = {},
+): void {
+    // Fetches the newest message matching the narrow and, if one exists,
+    // invokes `on_success` with its id.  Both stream_topic_history_util and
+    // pm_conversations_util use this to ask the server whether a topic or DM
+    // conversation still has any messages after a local deletion emptied it.
+    void channel.get({
+        url: "/json/messages",
+        data: {
+            narrow: JSON.stringify(narrow),
+            anchor: "newest",
+            num_before: 1,
+            num_after: 0,
+            ...extra_request_data,
+        },
+        success(raw_data) {
+            const {messages} = last_message_id_response_schema.parse(raw_data);
+            if (messages.length !== 1) {
+                return;
+            }
+
+            const last_message = messages[0];
+            assert(last_message !== undefined);
+            on_success(last_message.id);
+        },
+        error() {
+            // Ideally we would retry since we should always be able to get a
+            // success response from the server for this request, but for now
+            // we just ignore the error.
+        },
+    });
+}
 
 export function do_unread_count_updates(messages: Message[], expect_no_new_unreads = false): void {
     const any_new_unreads = unread.process_loaded_messages(messages, expect_no_new_unreads);

--- a/web/src/pm_conversations.ts
+++ b/web/src/pm_conversations.ts
@@ -49,13 +49,7 @@ class RecentDirectMessages {
     latest_message_id_by_user_id = new Map<number, number>();
 
     insert(user_ids: number[], message_id: number): void {
-        if (user_ids.length === 0) {
-            // The server sends [] for direct messages to oneself.
-            user_ids = [people.my_current_user_id()];
-        }
-        user_ids.sort((a, b) => a - b);
-
-        const user_ids_string = user_ids.join(",");
+        const user_ids_string = people.pm_lookup_key_from_user_ids(user_ids);
         let conversation = this.recent_message_ids.get(user_ids_string);
 
         if (conversation === undefined) {

--- a/web/src/pm_conversations.ts
+++ b/web/src/pm_conversations.ts
@@ -1,3 +1,6 @@
+import assert from "minimalistic-assert";
+
+import * as echo_state from "./echo_state.ts";
 import {FoldDict} from "./fold_dict.ts";
 import type {Message} from "./message_store.ts";
 import * as muted_users from "./muted_users.ts";
@@ -7,9 +10,22 @@ import type {StateData} from "./state_data.ts";
 type PMConversation = {
     user_ids_string: string;
     max_message_id: number;
+    // A lower bound on the messages remaining in this conversation: the
+    // ones we know about locally (we may not have loaded older history).
+    // So a positive count proves the conversation is non-empty, while zero
+    // only means it may be empty, in which case we confirm with the server.
+    // Mirrors the `count` field stream_topic_history keeps per topic.
+    local_message_count: number;
 };
 
 const partners = new Set<number>();
+
+// pm_conversations_util.update_dm_last_message_id, set indirectly to
+// avoid a circular dependency.
+let update_dm_last_message_id: (user_ids_string: string) => void;
+export function set_update_dm_last_message_id(f: (user_ids_string: string) => void): void {
+    update_dm_last_message_id = f;
+}
 
 export let set_partner = (user_id: number): void => {
     partners.add(user_id);
@@ -35,6 +51,19 @@ function filter_muted_pms(conversation: PMConversation): boolean {
     return true;
 }
 
+function conversation_has_unacked_message(user_ids_string: string): boolean {
+    // A locally echoed message that hasn't been acked yet (including a
+    // failed send the user can still retry) is visible in the conversation,
+    // so it should keep the conversation in the sidebar.
+    return echo_state.get_waiting_for_ack_private_messages().some((message) => {
+        const user_ids = people.pm_with_user_ids(message);
+        return (
+            user_ids !== undefined &&
+            people.pm_lookup_key_from_user_ids(user_ids) === user_ids_string
+        );
+    });
+}
+
 class RecentDirectMessages {
     // This data structure keeps track of the sets of users you've had
     // recent conversations with, sorted by time (implemented via
@@ -57,6 +86,7 @@ class RecentDirectMessages {
             conversation = {
                 user_ids_string,
                 max_message_id: message_id,
+                local_message_count: 0,
             };
             this.recent_message_ids.set(user_ids_string, conversation);
 
@@ -88,6 +118,51 @@ class RecentDirectMessages {
         }
 
         this.recent_private_messages.sort((a, b) => b.max_message_id - a.max_message_id);
+    }
+
+    increment_local_message_count(user_ids: number[]): void {
+        // Every message is inserted before it is counted (see process_message
+        // and echo.reify_message_id), so the conversation always exists here.
+        const conversation = this.recent_message_ids.get(
+            people.pm_lookup_key_from_user_ids(user_ids),
+        );
+        assert(conversation !== undefined);
+        conversation.local_message_count += 1;
+    }
+
+    remove(user_ids_string: string): void {
+        this.recent_message_ids.delete(user_ids_string);
+        this.recent_private_messages = this.recent_private_messages.filter(
+            (conversation) => conversation.user_ids_string !== user_ids_string,
+        );
+    }
+
+    maybe_remove(user_ids: number[], num_messages: number): void {
+        // If we still have locally-known messages left, the conversation is
+        // definitely not empty and we just decrement.  Otherwise it may be
+        // empty: optimistically remove it and ask the server to confirm,
+        // re-adding it if messages actually remain (which also covers a new
+        // message arriving mid-check).  Mirrors stream_topic_history.maybe_remove.
+        const user_ids_string = people.pm_lookup_key_from_user_ids(user_ids);
+        const conversation = this.recent_message_ids.get(user_ids_string);
+        if (conversation === undefined) {
+            return;
+        }
+
+        if (conversation.local_message_count <= num_messages) {
+            if (conversation_has_unacked_message(user_ids_string)) {
+                // We know of no delivered messages, but an un-acked local
+                // echo keeps the conversation non-empty, so leave it in the
+                // sidebar.  Mirrors how stream_topic_history surfaces
+                // locally-echoed topics.
+                conversation.local_message_count = 0;
+                return;
+            }
+            this.remove(user_ids_string);
+            update_dm_last_message_id(user_ids_string);
+        } else {
+            conversation.local_message_count -= num_messages;
+        }
     }
 
     get(): PMConversation[] {
@@ -127,7 +202,7 @@ export function get_latest_direct_message_id_with_user(user_id: number): number 
     return recent.latest_message_id_by_user_id.get(user_id);
 }
 
-export function process_message(message: Message): void {
+export function process_message(message: Message, is_delivered_message: boolean): void {
     const user_ids = people.pm_with_user_ids(message);
     if (!user_ids) {
         return;
@@ -138,6 +213,12 @@ export function process_message(message: Message): void {
     }
 
     recent.insert(user_ids, message.id);
+
+    // Locally echoed messages are skipped here; a sent message is counted
+    // on ack instead (echo.reify_message_id), to avoid counting it twice.
+    if (is_delivered_message) {
+        recent.increment_local_message_count(user_ids);
+    }
 }
 
 export function clear_for_testing(): void {

--- a/web/src/pm_conversations_util.ts
+++ b/web/src/pm_conversations_util.ts
@@ -1,0 +1,20 @@
+import * as message_util from "./message_util.ts";
+import * as people from "./people.ts";
+import * as pm_conversations from "./pm_conversations.ts";
+
+export function update_dm_last_message_id(
+    user_ids_string: string,
+    update_dom_on_success: () => void,
+): void {
+    // After a deletion locally empties a DM conversation, ask the server
+    // whether any messages remain and re-add it to the sidebar if so.
+    // Mirrors stream_topic_history_util.update_topic_last_message_id.
+    const user_ids = people.user_ids_string_to_ids_array(user_ids_string);
+    message_util.get_last_message_id_in_narrow(
+        [{operator: "dm", operand: user_ids}],
+        (last_message_id) => {
+            pm_conversations.recent.insert(user_ids, last_message_id);
+            update_dom_on_success();
+        },
+    );
+}

--- a/web/src/pm_list_data.ts
+++ b/web/src/pm_list_data.ts
@@ -68,7 +68,11 @@ export function get_conversations(search_string = ""): DisplayObject[] {
             .map((conversation) => conversation.user_ids_string)
             .includes(active_user_ids_string)
     ) {
-        conversations.unshift({user_ids_string: active_user_ids_string, max_message_id: -1});
+        conversations.unshift({
+            user_ids_string: active_user_ids_string,
+            max_message_id: -1,
+            local_message_count: 0,
+        });
     }
 
     for (const conversation of conversations) {

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -43,6 +43,7 @@ import * as onboarding_steps from "./onboarding_steps.ts";
 import * as overlays from "./overlays.ts";
 import * as peer_data from "./peer_data.ts";
 import * as people from "./people.ts";
+import * as pm_conversations from "./pm_conversations.ts";
 import * as pm_list from "./pm_list.ts";
 import * as reactions from "./reactions.ts";
 import * as realm_icon from "./realm_icon.ts";
@@ -175,6 +176,24 @@ export function dispatch_normal_event(event) {
 
         case "delete_message": {
             const msg_ids = event.message_ids;
+
+            // A delete_message event for DMs doesn't identify the
+            // conversation, so we derive it from a deleted message before
+            // remove_messages below clears it from the cache.  All messages
+            // in one event share a conversation, so any one suffices.
+            let deleted_dm_user_ids;
+            if (event.message_type === "private") {
+                for (const msg_id of msg_ids) {
+                    const message = message_store.get(msg_id);
+                    if (message !== undefined) {
+                        deleted_dm_user_ids = people.pm_with_user_ids(message);
+                        if (deleted_dm_user_ids !== undefined) {
+                            break;
+                        }
+                    }
+                }
+            }
+
             // message is passed to unread.get_unread_messages,
             // which returns all the unread messages out of a given list.
             // So double marking something as read would not occur
@@ -192,6 +211,12 @@ export function dispatch_normal_event(event) {
                     max_removed_msg_id: Math.max(...msg_ids),
                 });
                 stream_list.update_streams_sidebar();
+            } else if (deleted_dm_user_ids !== undefined) {
+                // We may have emptied a DM conversation; remove it from the
+                // sidebar if so.  The recent conversations view is updated
+                // separately, by message_events.remove_messages.
+                pm_conversations.recent.maybe_remove(deleted_dm_user_ids, msg_ids.length);
+                pm_list.update_private_messages();
             }
 
             break;

--- a/web/src/stream_topic_history_util.ts
+++ b/web/src/stream_topic_history_util.ts
@@ -1,7 +1,7 @@
-import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
 import * as channel from "./channel.ts";
+import * as message_util from "./message_util.ts";
 import {get_retry_backoff_seconds} from "./retry_backoff.ts";
 import * as stream_topic_history from "./stream_topic_history.ts";
 
@@ -71,45 +71,20 @@ export function update_topic_last_message_id(
     topic_name: string,
     update_dom_on_success: () => void,
 ): void {
-    void channel.get({
-        url: "/json/messages",
-        data: {
-            narrow: JSON.stringify([
-                {operator: "channel", operand: stream_id},
-                {operator: "topic", operand: topic_name},
-            ]),
-            anchor: "newest",
-            num_before: 1,
-            num_after: 0,
-            allow_empty_topic_name: true,
-        },
-        success(data) {
-            const {messages} = z
-                .object({
-                    messages: z.array(
-                        z.object({
-                            id: z.number(),
-                        }),
-                    ),
-                })
-                .parse(data);
-            if (messages.length !== 1) {
-                return;
-            }
-
-            const last_message = messages[0];
-            assert(last_message !== undefined);
+    message_util.get_last_message_id_in_narrow(
+        [
+            {operator: "channel", operand: stream_id},
+            {operator: "topic", operand: topic_name},
+        ],
+        (last_message_id) => {
             stream_topic_history.add_history(stream_id, [
                 {
                     name: topic_name,
-                    max_id: last_message.id,
+                    max_id: last_message_id,
                 },
             ]);
             update_dom_on_success();
         },
-        error() {
-            // Ideally we would retry since we should always be able to get a success response
-            // from the server for this request, but for now we just ignore the error.
-        },
-    });
+        {allow_empty_topic_name: true},
+    );
 }

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -97,6 +97,7 @@ import * as people from "./people.ts";
 import * as personal_menu_popover from "./personal_menu_popover.ts";
 import * as playground_links_popover from "./playground_links_popover.ts";
 import * as pm_conversations from "./pm_conversations.ts";
+import * as pm_conversations_util from "./pm_conversations_util.ts";
 import * as pm_list from "./pm_list.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as popovers from "./popovers.ts";
@@ -552,6 +553,12 @@ export async function initialize_everything(state_data) {
             stream_id,
             topic_name,
             stream_list.update_streams_sidebar,
+        );
+    });
+    pm_conversations.set_update_dm_last_message_id((user_ids_string) => {
+        pm_conversations_util.update_dm_last_message_id(
+            user_ids_string,
+            pm_list.update_private_messages,
         );
     });
 

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -5,6 +5,7 @@ const assert = require("node:assert/strict");
 const events = require("./lib/events.cjs");
 const {make_user_group} = require("./lib/example_group.cjs");
 const {make_realm} = require("./lib/example_realm.cjs");
+const {make_user} = require("./lib/example_user.cjs");
 const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespace.cjs");
 const {make_stub} = require("./lib/stub.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
@@ -157,6 +158,7 @@ const channel_folders = zrequire("channel_folders");
 const emoji = zrequire("emoji");
 const message_store = zrequire("message_store");
 const people = zrequire("people");
+const pm_conversations = zrequire("pm_conversations");
 const presence = zrequire("presence");
 const user_status = zrequire("user_status");
 const onboarding_steps = zrequire("onboarding_steps");
@@ -1572,6 +1574,65 @@ run_test("delete_message", ({override}) => {
     assert_same(args.opts.topic_name, "topic1");
     assert_same(args.opts.num_messages, 1);
     assert_same(args.opts.max_removed_msg_id, 1337);
+});
+
+run_test("delete_message_private", ({override}) => {
+    const user4 = make_user({user_id: 4, email: "user4@example.com", full_name: "User 4"});
+    people.add_active_user(user4);
+
+    const dm = {
+        id: 501,
+        type: "private",
+        to_user_ids: "4,20",
+        display_recipient: [{id: user4.user_id}, {id: me.user_id}],
+        sender_id: 4,
+        content: "hi",
+    };
+    message_store.update_message_cache({type: "server_message", message: dm});
+
+    override(unread_ops, "process_read_messages_event", noop);
+    override(emoji_frequency, "update_emoji_frequency_on_messages_deletion", noop);
+    override(message_events, "remove_messages", noop);
+
+    const maybe_remove_stub = make_stub();
+    override(pm_conversations.recent, "maybe_remove", maybe_remove_stub.f);
+    const update_private_messages_stub = make_stub();
+    override(pm_list, "update_private_messages", update_private_messages_stub.f);
+
+    dispatch({
+        type: "delete_message",
+        message_type: "private",
+        message_ids: [dm.id],
+    });
+
+    // We derive the conversation (excluding our own id, 20) from the
+    // deleted message and refresh the direct messages sidebar.
+    assert.equal(maybe_remove_stub.num_calls, 1);
+    const args = maybe_remove_stub.get_args("user_ids", "num_messages");
+    assert_same(args.user_ids, [user4.user_id]);
+    assert_same(args.num_messages, 1);
+    assert.equal(update_private_messages_stub.num_calls, 1);
+});
+
+run_test("delete_message_private_not_cached", ({override}) => {
+    // When none of the deleted messages are in our local cache, we can't
+    // identify the conversation, so we take no DM-specific action.
+    override(unread_ops, "process_read_messages_event", noop);
+    override(emoji_frequency, "update_emoji_frequency_on_messages_deletion", noop);
+    override(message_events, "remove_messages", noop);
+
+    const maybe_remove_stub = make_stub();
+    override(pm_conversations.recent, "maybe_remove", maybe_remove_stub.f, {
+        unused: false,
+    });
+
+    dispatch({
+        type: "delete_message",
+        message_type: "private",
+        message_ids: [99999],
+    });
+
+    assert.equal(maybe_remove_stub.num_calls, 0);
 });
 
 run_test("user_status", ({override}) => {

--- a/web/tests/echo.test.cjs
+++ b/web/tests/echo.test.cjs
@@ -87,6 +87,7 @@ message_lists.non_rendered_data = () => [];
 const echo = zrequire("echo");
 const echo_state = zrequire("echo_state");
 const people = zrequire("people");
+const pm_conversations = zrequire("pm_conversations");
 const {set_current_user} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
@@ -658,4 +659,54 @@ run_test("resend error on a message removed from the store doesn't crash", ({ove
     // The detached message was left untouched, since there was no stored entry
     // to mark as failed.
     assert.equal(message.failed_request, false);
+});
+
+run_test("reify_message_id counts a sent direct message", ({override}) => {
+    // A sent DM is counted only once acked (on reification), mirroring how
+    // stream messages are added to stream_topic_history there.
+    const local_id_float = 104.01;
+
+    const iago = {user_id: 123, full_name: "Iago", email: "iago@zulip.com"};
+    const cordelia = {user_id: 21, full_name: "Cordelia", email: "cordelia@zulip.com"};
+    override(current_user, "user_id", iago.user_id);
+    const people_params = {
+        realm_users: [iago, cordelia],
+        realm_non_active_users: [],
+        cross_realm_bots: [],
+    };
+    const user_group_params = {
+        realm_user_groups: [
+            make_user_group({is_system_group: true, members: [iago.user_id, cordelia.user_id]}),
+        ],
+    };
+    people.init();
+    people.initialize(current_user.user_id, people_params, user_group_params);
+
+    override(markdown, "render", noop);
+    override(markdown, "get_topic_links", () => []);
+    override(message_store, "reify_message_id", noop);
+    override(compose_notifications, "reify_message_id", noop);
+
+    const message_request = {
+        private_message_recipient: cordelia.email,
+        to_user_ids: cordelia.user_id.toString(),
+        type: "private",
+        sender_email: iago.email,
+        sender_full_name: iago.full_name,
+        sender_id: iago.user_id,
+    };
+    echo.insert_local_message(message_request, local_id_float, (message_data) => {
+        const messages = message_data.raw_messages;
+        messages.map((message) => echo.track_local_message(message));
+        return messages;
+    });
+
+    const increment_stub = make_stub();
+    override(pm_conversations.recent, "increment_local_message_count", increment_stub.f);
+
+    echo.reify_message_id(local_id_float.toString(), 120);
+
+    assert.equal(increment_stub.num_calls, 1);
+    const {user_ids} = increment_stub.get_args("user_ids");
+    assert.deepEqual(user_ids, [cordelia.user_id]);
 });

--- a/web/tests/message_store.test.cjs
+++ b/web/tests/message_store.test.cjs
@@ -278,7 +278,7 @@ test("errors", ({disallow_rewire}) => {
 
     // This should early return and not run pm_conversations.set_partner
     disallow_rewire(pm_conversations, "set_partner");
-    pm_conversations.process_message(message);
+    pm_conversations.process_message(message, false);
 });
 
 test("reify_message_id", () => {

--- a/web/tests/message_util.test.cjs
+++ b/web/tests/message_util.test.cjs
@@ -1,0 +1,84 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
+
+const channel = mock_esm("../src/channel");
+
+const message_util = zrequire("message_util");
+
+let reported_ids = [];
+function record_last_message_id(id) {
+    reported_ids.push(id);
+}
+
+function test(label, f) {
+    run_test(label, (helpers) => {
+        reported_ids = [];
+        f(helpers);
+    });
+}
+
+test("get_last_message_id_in_narrow builds the request from the narrow", () => {
+    let requested_opts;
+    channel.get = (opts) => {
+        requested_opts = opts;
+    };
+
+    const narrow = [
+        {operator: "channel", operand: 5},
+        {operator: "topic", operand: "topic"},
+    ];
+    message_util.get_last_message_id_in_narrow(narrow, noop, {allow_empty_topic_name: true});
+
+    assert.equal(requested_opts.url, "/json/messages");
+    assert.deepEqual(requested_opts.data, {
+        narrow: JSON.stringify(narrow),
+        anchor: "newest",
+        num_before: 1,
+        num_after: 0,
+        allow_empty_topic_name: true,
+    });
+});
+
+test("get_last_message_id_in_narrow reports the last message id on success", () => {
+    channel.get = (opts) => {
+        opts.success({messages: [{id: 987}]});
+    };
+
+    message_util.get_last_message_id_in_narrow(
+        [{operator: "dm", operand: [4]}],
+        record_last_message_id,
+    );
+
+    assert.deepEqual(reported_ids, [987]);
+});
+
+test("get_last_message_id_in_narrow ignores an empty result", () => {
+    channel.get = (opts) => {
+        opts.success({messages: []});
+    };
+
+    message_util.get_last_message_id_in_narrow(
+        [{operator: "dm", operand: [4]}],
+        record_last_message_id,
+    );
+
+    assert.deepEqual(reported_ids, []);
+});
+
+test("get_last_message_id_in_narrow ignores errors", () => {
+    channel.get = (opts) => {
+        opts.error();
+    };
+
+    // Should not throw or report a message id.
+    message_util.get_last_message_id_in_narrow(
+        [{operator: "dm", operand: [4]}],
+        record_last_message_id,
+    );
+
+    assert.deepEqual(reported_ids, []);
+});

--- a/web/tests/pm_conversations.test.cjs
+++ b/web/tests/pm_conversations.test.cjs
@@ -10,6 +10,7 @@ const user_topics = zrequire("user_topics");
 const muted_users = zrequire("muted_users");
 const people = zrequire("people");
 const pmc = zrequire("pm_conversations");
+const echo_state = zrequire("echo_state");
 const {set_current_user} = zrequire("state_data");
 
 const current_user = {};
@@ -59,6 +60,7 @@ function test(label, f) {
         pmc.clear_for_testing();
         user_topics.set_user_topics([]);
         muted_users.set_muted_users([]);
+        echo_state._patch_waiting_for_ack(new Map());
         people.initialize_current_user(me.user_id);
         f({override});
     });
@@ -80,11 +82,11 @@ test("insert_recent_private_message", () => {
 
     // Base data
     assert.deepEqual(pmc.recent.get(), [
-        {user_ids_string: "1", max_message_id: 100},
-        {user_ids_string: "3", max_message_id: 99},
-        {user_ids_string: "1,2", max_message_id: 98},
-        {user_ids_string: "1,2,3", max_message_id: 97},
-        {user_ids_string: "15", max_message_id: 96},
+        {user_ids_string: "1", max_message_id: 100, local_message_count: 0},
+        {user_ids_string: "3", max_message_id: 99, local_message_count: 0},
+        {user_ids_string: "1,2", max_message_id: 98, local_message_count: 0},
+        {user_ids_string: "1,2,3", max_message_id: 97, local_message_count: 0},
+        {user_ids_string: "15", max_message_id: 96, local_message_count: 0},
     ]);
 
     // Insert new messages (which should rearrange these entries).
@@ -97,11 +99,11 @@ test("insert_recent_private_message", () => {
     pmc.recent.insert([1], 555);
 
     assert.deepEqual(pmc.recent.get(), [
-        {user_ids_string: "1", max_message_id: 1000},
-        {user_ids_string: "1,2,3", max_message_id: 999},
-        {user_ids_string: "15", max_message_id: 101},
-        {user_ids_string: "3", max_message_id: 99},
-        {user_ids_string: "1,2", max_message_id: 98},
+        {user_ids_string: "1", max_message_id: 1000, local_message_count: 0},
+        {user_ids_string: "1,2,3", max_message_id: 999, local_message_count: 0},
+        {user_ids_string: "15", max_message_id: 101, local_message_count: 0},
+        {user_ids_string: "3", max_message_id: 99, local_message_count: 0},
+        {user_ids_string: "1,2", max_message_id: 98, local_message_count: 0},
     ]);
     assert.deepEqual(pmc.recent.get_strings(), ["1", "1,2,3", "15", "3", "1,2"]);
 });
@@ -141,11 +143,11 @@ test("muted_users", () => {
 
     // Base data
     assert.deepEqual(pmc.recent.get(), [
-        {user_ids_string: "1", max_message_id: 100},
-        {user_ids_string: "3", max_message_id: 99},
-        {user_ids_string: "1,2", max_message_id: 98},
-        {user_ids_string: "1,2,3", max_message_id: 97},
-        {user_ids_string: "15", max_message_id: 96},
+        {user_ids_string: "1", max_message_id: 100, local_message_count: 0},
+        {user_ids_string: "3", max_message_id: 99, local_message_count: 0},
+        {user_ids_string: "1,2", max_message_id: 98, local_message_count: 0},
+        {user_ids_string: "1,2,3", max_message_id: 97, local_message_count: 0},
+        {user_ids_string: "15", max_message_id: 96, local_message_count: 0},
     ]);
     assert.deepEqual(pmc.recent.get_strings(), ["1", "3", "1,2", "1,2,3", "15"]);
 
@@ -157,9 +159,9 @@ test("muted_users", () => {
     // 1:1 direct messages in which the other user hasn't been muted.
     // Direct message groups where there's at least one non-muted participant.
     assert.deepEqual(pmc.recent.get(), [
-        {user_ids_string: "3", max_message_id: 99},
-        {user_ids_string: "1,2,3", max_message_id: 97},
-        {user_ids_string: "15", max_message_id: 96},
+        {user_ids_string: "3", max_message_id: 99, local_message_count: 0},
+        {user_ids_string: "1,2,3", max_message_id: 97, local_message_count: 0},
+        {user_ids_string: "15", max_message_id: 96, local_message_count: 0},
     ]);
     assert.deepEqual(pmc.recent.get_strings(), ["3", "1,2,3", "15"]);
 });
@@ -183,4 +185,129 @@ test("has_conversation", ({override}) => {
     assert.ok(!pmc.recent.has_conversation("1,3"));
     assert.ok(!pmc.recent.has_conversation("2"));
     assert.ok(!pmc.recent.has_conversation("72"));
+});
+
+function local_message_count(user_ids_string) {
+    const conversation = pmc.recent.get().find((pm) => pm.user_ids_string === user_ids_string);
+    assert.ok(conversation !== undefined);
+    return conversation.local_message_count;
+}
+
+test("increment_local_message_count_and_remove", () => {
+    pmc.recent.initialize(params);
+
+    // initialize lists every conversation, each seeded with a zero count.
+    assert.deepEqual(pmc.recent.get_strings(), ["1", "3", "1,2", "1,2,3", "15"]);
+    assert.equal(local_message_count("1"), 0);
+    assert.equal(local_message_count("15"), 0);
+
+    // increment_local_message_count bumps the count of locally-known messages,
+    // without reordering the sidebar.
+    pmc.recent.increment_local_message_count([alice.user_id]);
+    pmc.recent.increment_local_message_count([alice.user_id]);
+    // The server sends [] for direct messages to oneself.
+    pmc.recent.increment_local_message_count([]);
+    assert.equal(local_message_count("1"), 2);
+    assert.equal(local_message_count("15"), 1);
+    assert.deepEqual(pmc.recent.get_strings(), ["1", "3", "1,2", "1,2,3", "15"]);
+
+    // remove drops a conversation from the sidebar regardless of its count.
+    pmc.recent.remove("3");
+    assert.ok(!pmc.recent.has_conversation("3"));
+    assert.deepEqual(pmc.recent.get_strings(), ["1", "1,2", "1,2,3", "15"]);
+
+    // Removing a conversation we don't have is a no-op.
+    pmc.recent.remove("999");
+    assert.deepEqual(pmc.recent.get_strings(), ["1", "1,2", "1,2,3", "15"]);
+});
+
+test("maybe_remove", () => {
+    pmc.recent.initialize(params);
+
+    const verified_conversations = [];
+    pmc.set_update_dm_last_message_id((user_ids_string) => {
+        verified_conversations.push(user_ids_string);
+    });
+
+    // Record two locally-known messages in Alice's 1:1 conversation.
+    pmc.recent.increment_local_message_count([alice.user_id]);
+    pmc.recent.increment_local_message_count([alice.user_id]);
+
+    // Deleting fewer messages than we know about proves the conversation is
+    // still non-empty, so we just decrement and never ask the server.
+    pmc.recent.maybe_remove([alice.user_id], 1);
+    assert.ok(pmc.recent.has_conversation(alice.user_id.toString()));
+    assert.deepEqual(verified_conversations, []);
+
+    // Deleting the rest leaves us with no locally-known messages, so we
+    // optimistically remove the conversation and verify with the server.
+    pmc.recent.maybe_remove([alice.user_id], 1);
+    assert.ok(!pmc.recent.has_conversation(alice.user_id.toString()));
+    assert.deepEqual(verified_conversations, [alice.user_id.toString()]);
+
+    // A self-DM (recipients sent as []) is keyed by our own user id.
+    pmc.recent.maybe_remove([], 1);
+    assert.ok(!pmc.recent.has_conversation(me.user_id.toString()));
+    assert.deepEqual(verified_conversations, [alice.user_id.toString(), me.user_id.toString()]);
+
+    // Deleting from a conversation we don't know about is a no-op.
+    pmc.recent.maybe_remove([alice.user_id], 1);
+    assert.deepEqual(verified_conversations, [alice.user_id.toString(), me.user_id.toString()]);
+});
+
+test("process_message counts only delivered messages", () => {
+    const key = alice.user_id.toString();
+    const dm = (id) => ({
+        type: "private",
+        id,
+        display_recipient: [{id: alice.user_id}, {id: me.user_id}],
+    });
+
+    // A delivered message (one received from the server, or one we sent
+    // once it is acked) creates the conversation and counts toward it.
+    pmc.process_message(dm(1001), true);
+    assert.ok(pmc.recent.has_conversation(key));
+    assert.equal(local_message_count(key), 1);
+
+    // A locally echoed message is recorded in the sidebar but not counted
+    // here; it is counted only once acked, in echo.reify_message_id, so a
+    // message we send is never counted twice.
+    pmc.process_message(dm(1002), false);
+    assert.equal(local_message_count(key), 1);
+
+    // A further delivered message bumps the count again.
+    pmc.process_message(dm(1003), true);
+    assert.equal(local_message_count(key), 2);
+});
+
+test("maybe_remove keeps a conversation with an unacked local echo", () => {
+    pmc.recent.initialize(params);
+
+    let server_checks = 0;
+    pmc.set_update_dm_last_message_id(() => {
+        server_checks += 1;
+    });
+
+    // One delivered message in Alice's DM, plus an unsent (e.g. failed)
+    // local echo that's still visible in the conversation.
+    pmc.recent.increment_local_message_count([alice.user_id]);
+    echo_state.set_message_waiting_for_ack("1.01", {
+        type: "private",
+        id: 1.01,
+        display_recipient: [{id: alice.user_id}, {id: me.user_id}],
+    });
+
+    // Deleting the delivered message drops the count to zero, but the
+    // pending echo keeps the row in the sidebar without a server check.
+    pmc.recent.maybe_remove([alice.user_id], 1);
+    assert.ok(pmc.recent.has_conversation(alice.user_id.toString()));
+    assert.equal(server_checks, 0);
+
+    // Once the echo is gone (the send succeeds or is cancelled), deleting
+    // again leaves no locally-known messages, so we remove the conversation
+    // and verify with the server after all.
+    echo_state._patch_waiting_for_ack(new Map());
+    pmc.recent.maybe_remove([alice.user_id], 1);
+    assert.ok(!pmc.recent.has_conversation(alice.user_id.toString()));
+    assert.equal(server_checks, 1);
 });

--- a/web/tests/pm_conversations_util.test.cjs
+++ b/web/tests/pm_conversations_util.test.cjs
@@ -1,0 +1,72 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {make_user} = require("./lib/example_user.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
+
+const channel = mock_esm("../src/channel");
+
+const people = zrequire("people");
+const pm_conversations = zrequire("pm_conversations");
+const pm_conversations_util = zrequire("pm_conversations_util");
+
+const alice = make_user({email: "alice@example.com", user_id: 4, full_name: "Alice"});
+const me = make_user({email: "me@example.com", user_id: 15, full_name: "Me"});
+people.add_active_user(alice);
+people.add_active_user(me);
+people.initialize_current_user(me.user_id);
+
+function test(label, f) {
+    run_test(label, (helpers) => {
+        pm_conversations.clear_for_testing();
+        f(helpers);
+    });
+}
+
+test("re-adds the conversation when the server reports a remaining message", () => {
+    let dom_updated = false;
+
+    channel.get = (opts) => {
+        assert.equal(opts.url, "/json/messages");
+        assert.deepEqual(JSON.parse(opts.data.narrow), [
+            {operator: "dm", operand: [alice.user_id]},
+        ]);
+        assert.equal(opts.data.anchor, "newest");
+        assert.equal(opts.data.num_before, 1);
+        assert.equal(opts.data.num_after, 0);
+        opts.success({messages: [{id: 555}]});
+    };
+
+    assert.ok(!pm_conversations.recent.has_conversation(alice.user_id.toString()));
+    pm_conversations_util.update_dm_last_message_id(alice.user_id.toString(), () => {
+        dom_updated = true;
+    });
+
+    assert.ok(pm_conversations.recent.has_conversation(alice.user_id.toString()));
+    assert.equal(pm_conversations.recent.get()[0].max_message_id, 555);
+    assert.ok(dom_updated);
+});
+
+test("leaves the conversation removed when the server reports it is empty", () => {
+    channel.get = (opts) => {
+        opts.success({messages: []});
+    };
+
+    // The conversation isn't re-added, so the dom-update callback (noop) is
+    // never invoked.
+    pm_conversations_util.update_dm_last_message_id(alice.user_id.toString(), noop);
+
+    assert.ok(!pm_conversations.recent.has_conversation(alice.user_id.toString()));
+});
+
+test("ignores errors", () => {
+    channel.get = (opts) => {
+        opts.error();
+    };
+
+    // Should not throw.
+    pm_conversations_util.update_dm_last_message_id(alice.user_id.toString(), noop);
+    assert.ok(!pm_conversations.recent.has_conversation(alice.user_id.toString()));
+});

--- a/web/tests/stream_topic_history.test.cjs
+++ b/web/tests/stream_topic_history.test.cjs
@@ -451,19 +451,16 @@ test("ask_server_for_latest_topic_data", () => {
     });
     const stream_id = 1080;
 
-    let success_callback;
-    let get_message_request_triggered = false;
-    channel.get = (opts) => {
-        get_message_request_triggered = true;
-        assert.equal(opts.url, "/json/messages");
-        assert.deepEqual(opts.data, {
-            anchor: "newest",
-            narrow: '[{"operator":"channel","operand":1080},{"operator":"topic","operand":"Topic1"}]',
-            num_after: 0,
-            num_before: 1,
-            allow_empty_topic_name: true,
-        });
-        success_callback = opts.success;
+    let report_last_message_id;
+    let last_message_request_triggered = false;
+    message_util.get_last_message_id_in_narrow = (narrow, on_success, extra_request_data) => {
+        last_message_request_triggered = true;
+        assert.deepEqual(narrow, [
+            {operator: "channel", operand: 1080},
+            {operator: "topic", operand: "Topic1"},
+        ]);
+        assert.deepEqual(extra_request_data, {allow_empty_topic_name: true});
+        report_last_message_id = on_success;
     };
 
     stream_topic_history.add_message({
@@ -477,36 +474,24 @@ test("ask_server_for_latest_topic_data", () => {
     assert.deepEqual(history, ["topic1"]);
     assert.deepEqual(max_message_id, 101);
 
-    // Remove all cached messages from the topic. This sends a request to the server
-    // to check for the latest message id in the topic.
+    // Remove all cached messages from the topic. This asks the server for the
+    // latest message id in the topic.
     stream_topic_history.remove_messages({
         stream_id,
         topic_name: "Topic1",
         num_messages: 1,
         max_removed_msg_id: 104,
     });
-    assert.equal(get_message_request_triggered, true);
-    get_message_request_triggered = false;
+    assert.equal(last_message_request_triggered, true);
 
     // Until we process the response from the server,
     // the topic is not available.
     history = stream_topic_history.get_recent_topic_names(stream_id);
     assert.deepEqual(history, []);
 
-    // Simulate the server responses.
-    // Topic is empty.
-    success_callback({
-        messages: [],
-    });
-    history = stream_topic_history.get_recent_topic_names(stream_id);
-    assert.deepEqual(history, []);
-
-    // Topic has a different max_message_id.
-    success_callback({
-        messages: [{id: 102}],
-    });
-
-    // The topic is now available.
+    // The server reports a remaining message, so the topic becomes available
+    // again with that message's id.
+    report_last_message_id(102);
     history = stream_topic_history.get_recent_topic_names(stream_id);
     max_message_id = stream_topic_history.get_max_message_id(stream_id);
     assert.deepEqual(history, ["Topic1"]);


### PR DESCRIPTION
Fixes #29275.

Deleting the last message in a DM conversation left a stale row in the left sidebar until reload, unlike topics, where deleting the last message removes the topic.

### Approach

This mirrors how `stream_topic_history` already handles topics: we track a count of locally-known messages per DM conversation. On a `delete_message` event we decrement it, and only when it reaches zero (so the conversation *might* be empty) do we optimistically remove the row and ask the server to confirm - re-adding it if messages actually remain. This also naturally handles a new message arriving while the request is in flight.

So in the common case (other messages are still loaded locally), removal is instant and there is no server request; the `/json/messages` check is a fallback only for the genuinely ambiguous case (e.g. the deleted message was the last one we'd loaded but older history exists server-side).

Counting matches the topic precedent: received/fetched messages are counted in `pm_conversations.process_message`, and a message you sent is counted when the server acks it, in `echo.reify_message_id` (a locally echoed message is never double-counted).

---

https://github.com/user-attachments/assets/d100196c-2a70-41fc-9ae2-bd767a431580

---
### Relationship to other PRs

- **#36233** attempted a local count but didn't account for all the paths messages enter/leave the cache; this handles fetched, received, and locally-sent messages, and falls back to the server whenever the local count is insufficient.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
