### PR TITLE
emoji_picker: Improve loading time by 15x with large custom emojis. 

### DIFF
--- a/web/e2e-tests/user-status.test.ts
+++ b/web/e2e-tests/user-status.test.ts
@@ -34,20 +34,20 @@ async function test_user_status(page: Page): Promise<void> {
 
     // Manually adding everything.
     await page.type(".user-status", "Busy");
-    const tada_emoji_selector = ".emoji-1f389";
+    const laughing_emoji_selector = ".emoji-1f606";
     await page.click(".status-emoji-wrapper .smiley-icon");
     // Wait until emoji popover is opened.
-    await page.waitForSelector(`.emoji-popover ${tada_emoji_selector}`, {visible: true});
-    await page.click(`.emoji-popover ${tada_emoji_selector}`);
+    await page.waitForSelector(`.emoji-popover ${laughing_emoji_selector}`, {visible: true});
+    await page.click(`.emoji-popover  ${laughing_emoji_selector}`);
     await page.waitForSelector(".emoji-picker-popover", {hidden: true});
-    await page.waitForSelector(`.selected-emoji${tada_emoji_selector}`);
+    await page.waitForSelector(`.selected-emoji${laughing_emoji_selector}`);
 
     await page.click("#set-user-status-modal .dialog_submit_button");
     // It should close the modal after saving.
     await page.waitForSelector("#set-user-status-modal", {hidden: true});
 
     // Check if the emoji is added in user presence list.
-    await page.waitForSelector(`.user-presence-link .status-emoji${tada_emoji_selector}`);
+    await page.waitForSelector(`.user-presence-link .status-emoji${laughing_emoji_selector}`);
 }
 
 async function user_status_test(page: Page): Promise<void> {

--- a/web/templates/popovers/emoji/emoji_popover_emoji.hbs
+++ b/web/templates/popovers/emoji/emoji_popover_emoji.hbs
@@ -1,7 +1,7 @@
 {{#with emoji_dict}}
 <div class="emoji-popover-emoji {{#if has_reacted}}reacted{{/if}}" data-emoji-name="{{#if emoji_name}}{{emoji_name}}{{else}}{{name}}{{/if}}" tabindex="0" data-emoji-id="{{../type}},{{../section}},{{../index}}">
     {{#if is_realm_emoji}}
-    <img src="{{url}}" class="emoji"/>
+    <img src="{{url}}" loading="lazy" class="emoji"/>
     {{else}}
     <div class="emoji emoji-{{emoji_code}}"></div>
     {{/if}}


### PR DESCRIPTION
By dynamically rendering the emoji sections as the user scrolls,
and lazy loading images inside a section.

The performance was the most noticeable on Safari,
from ~500ms to ~30ms.
On Chrome and Firefox, from 50ms to 5ms.

<details><summary>Patch for measurement</summary>
<p>
<code>patch
diff --git a/web/src/emoji_picker.ts b/web/src/emoji_picker.ts
index 9cea4de203..a2398f36ed 100644
--- a/web/src/emoji_picker.ts
+++ b/web/src/emoji_picker.ts
@@ -805,6 +805,7 @@ function get_default_emoji_popover_options(
             ],
         },
         onCreate(instance: tippy.Instance) {
             emoji_popover_instance = instance;
             const $popover = $(instance.popper);
             $popover.addClass("emoji-popover-root");
@@ -815,13 +816,17 @@ function get_default_emoji_popover_options(
                 section: 0,
                 index: 0,
             };
         },
         onShow(instance: tippy.Instance) {
             const $reference = $(instance.reference);
             $reference.addClass("active-emoji-picker-reference");
             $reference.parent().addClass("active-emoji-picker-reference");
         },
         onMount(instance: tippy.Instance) {
+            let start = performance.now();
             const $popover = $(instance.popper);
             // Render the emojis after simplebar has been initialized which
             // saves us ~30% time rendering them.
@@ -912,6 +917,7 @@ function get_default_emoji_popover_options(
             if (!util.is_mobile()) {
                 change_focus_to_filter();
             }
+            console.log(`Emoji popover onMount took ${performance.now() - start} ms`);
         },
         onHidden() {
             hide_emoji_popover();
</code></p>
</details> 

The test is also included to reproduce but I don't think going to be kept, so let's enjoy the rabbits statically:
<img width="301" height="406" alt="image" src="https://github.com/user-attachments/assets/91518dbf-451c-4f00-9204-183b7cec9b4f" />
The dangling test commit https://github.com/zulip/zulip/pull/37569/changes/58d865eca13eaa3cd6901cf51f8a04ede0c7d4ae

CZO discussion: [#issues > slow emoji reactions picker](https://chat.zulip.org/#narrow/channel/9-issues/topic/slow.20emoji.20reactions.20picker/with/2358274)
