### PR TITLE
settings: Add padding for non-square emojis.

### DIFF
--- a/api_docs/unmerged.d/ZF-383757.md
+++ b/api_docs/unmerged.d/ZF-383757.md
@@ -1,0 +1,3 @@
+* [`POST /realm/emoji/{emoji_name}`](/api/upload-custom-emoji):
+Added a new request body parameter `resize_method` which allows
+the user to control how the uploaded emoji is resized.

--- a/web/src/settings_emoji.ts
+++ b/web/src/settings_emoji.ts
@@ -170,11 +170,22 @@ export function add_custom_emoji_post_render(): void {
     const $input_error = $("#emoji_file_input_error");
     const $clear_button = $("#emoji_image_clear_button");
     const $upload_button = $("#emoji_upload_button");
+    const $resize_by_crop_button = $("#resize-by-crop-button");
+    const $resize_by_pad_button = $("#resize-by-pad-button");
     const $preview_text = $("#emoji_preview_text");
     const $preview_image = $("#emoji_preview_image");
     const $placeholder_icon = $("#emoji_placeholder_icon");
+    const $resize_method_input = $("#emoji_resize_method");
 
     $preview_image.hide();
+
+    function reset_file_preview(): void {
+        $resize_by_crop_button.hide();
+        $resize_by_pad_button.hide();
+        $resize_method_input.val("fit");
+        $placeholder_icon.show();
+        $preview_image.removeClass("crop").addClass("pad").hide();
+    }
 
     upload_widget.build_widget(
         get_file_input,
@@ -186,9 +197,22 @@ export function add_custom_emoji_post_render(): void {
         $preview_image,
     );
 
-    get_file_input().on("input", () => {
+    get_file_input().on("change", (e: JQuery.TriggeredEvent) => {
+        assert(e.target instanceof HTMLInputElement);
+        const input = e.target;
+
+        if (!input.files?.length || get_file_input().val() === "") {
+            reset_file_preview();
+            return;
+        }
+
         $placeholder_icon.hide();
+        $preview_image.addClass("pad");
         $preview_image.show();
+
+        if (input.files?.length && input.files[0]!.type !== "image/gif") {
+            $resize_by_crop_button.show();
+        }
     });
 
     $preview_text.show();
@@ -198,9 +222,24 @@ export function add_custom_emoji_post_render(): void {
 
         $("#add-custom-emoji-modal .dialog_submit_button").prop("disabled", true);
 
-        $preview_image.hide();
-        $placeholder_icon.show();
+        reset_file_preview();
         $preview_text.show();
+    });
+
+    $resize_by_crop_button.on("click", (e) => {
+        e.preventDefault();
+        $resize_by_crop_button.hide();
+        $resize_by_pad_button.show();
+        $preview_image.removeClass("pad").addClass("crop");
+        $resize_method_input.val("crop");
+    });
+
+    $resize_by_pad_button.on("click", (e) => {
+        e.preventDefault();
+        $resize_by_crop_button.show();
+        $resize_by_pad_button.hide();
+        $preview_image.removeClass("crop").addClass("pad");
+        $resize_method_input.val("fit");
     });
 }
 
@@ -263,6 +302,8 @@ function show_modal(): void {
         for (const [i, file] of [...files].entries()) {
             formData.append("file-" + i, file);
         }
+        const resize_method = $<HTMLInputElement>("#emoji_resize_method").val()!;
+        formData.append("resize_method", resize_method);
 
         if (is_default_emoji(emoji["name"])) {
             if (!current_user.is_admin) {

--- a/web/src/settings_emoji.ts
+++ b/web/src/settings_emoji.ts
@@ -174,11 +174,22 @@ export function add_custom_emoji_post_render(): void {
     const $input_error = $("#emoji_file_input_error");
     const $clear_button = $("#emoji_image_clear_button");
     const $upload_button = $("#emoji_upload_button");
+    const $resize_by_crop_button = $("#resize-by-crop-button");
+    const $resize_by_pad_button = $("#resize-by-pad-button");
     const $preview_text = $("#emoji_preview_text");
     const $preview_image = $("#emoji_preview_image");
     const $placeholder_icon = $("#emoji_placeholder_icon");
+    const $resize_method_input = $("#emoji_resize_method");
 
     $preview_image.hide();
+
+    function reset_file_preview(): void {
+        $resize_by_crop_button.hide();
+        $resize_by_pad_button.hide();
+        $resize_method_input.val("fit");
+        $placeholder_icon.show();
+        $preview_image.removeClass("crop").addClass("pad").hide();
+    }
 
     upload_widget.build_widget(
         get_file_input,
@@ -190,9 +201,22 @@ export function add_custom_emoji_post_render(): void {
         $preview_image,
     );
 
-    get_file_input().on("input", () => {
+    get_file_input().on("change", (e: JQuery.TriggeredEvent) => {
+        assert(e.target instanceof HTMLInputElement);
+        const input = e.target;
+
+        if (!input.files?.length || get_file_input().val() === "") {
+            reset_file_preview();
+            return;
+        }
+
         $placeholder_icon.hide();
+        $preview_image.addClass("pad");
         $preview_image.show();
+
+        if (input.files?.length && input.files[0]!.type !== "image/gif") {
+            $resize_by_crop_button.show();
+        }
     });
 
     $preview_text.show();
@@ -202,9 +226,24 @@ export function add_custom_emoji_post_render(): void {
 
         $("#add-custom-emoji-modal .dialog_submit_button").prop("disabled", true);
 
-        $preview_image.hide();
-        $placeholder_icon.show();
+        reset_file_preview();
         $preview_text.show();
+    });
+
+    $resize_by_crop_button.on("click", (e) => {
+        e.preventDefault();
+        $resize_by_crop_button.hide();
+        $resize_by_pad_button.show();
+        $preview_image.removeClass("pad").addClass("crop");
+        $resize_method_input.val("crop");
+    });
+
+    $resize_by_pad_button.on("click", (e) => {
+        e.preventDefault();
+        $resize_by_crop_button.show();
+        $resize_by_pad_button.hide();
+        $preview_image.removeClass("crop").addClass("pad");
+        $resize_method_input.val("fit");
     });
 }
 
@@ -267,6 +306,8 @@ function show_modal(): void {
         for (const [i, file] of [...files].entries()) {
             formData.append("file-" + i, file);
         }
+        const resize_method = $<HTMLInputElement>("#emoji_resize_method").val()!;
+        formData.append("resize_method", resize_method);
 
         if (is_default_emoji(emoji["name"])) {
             if (!current_user.is_admin) {

--- a/web/styles/image_upload_widget.css
+++ b/web/styles/image_upload_widget.css
@@ -224,5 +224,17 @@
 
 /* CSS  related to upload widget's preview image */
 .upload_widget_image_preview {
-    object-fit: cover;
+    &.crop {
+        object-fit: cover;
+    }
+
+    &.pad {
+        object-fit: contain;
+    }
+}
+
+.add-custom-emoji-form-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
 }

--- a/web/templates/settings/add_emoji.hbs
+++ b/web/templates/settings/add_emoji.hbs
@@ -2,19 +2,36 @@
     <div>
         <input type="file" name="emoji_file_input" class="notvisible"
           id="emoji_file_input" value="{{t 'Upload image or GIF' }}"/>
-        {{> ../components/action_button
-          label=(t "Clear image")
-          variant="subtle"
-          intent="danger"
-          id="emoji_image_clear_button"
-          hidden=true
-          }}
-        {{> ../components/action_button
-          label=(t "Upload image or GIF")
-          variant="subtle"
-          intent="brand"
-          id="emoji_upload_button"
-          }}
+        <input type="hidden" id="emoji_resize_method" name="resize_method" value="fit"/>
+        <div class="add-custom-emoji-form-actions">
+            {{> ../components/action_button
+              label=(t "Clear image")
+              variant="subtle"
+              intent="danger"
+              id="emoji_image_clear_button"
+              hidden=true
+              }}
+            {{> ../components/action_button
+              label=(t "Upload image or GIF")
+              variant="subtle"
+              intent="brand"
+              id="emoji_upload_button"
+              }}
+            {{> ../components/action_button
+              label=(t "Crop to square")
+              variant="subtle"
+              intent="brand"
+              id="resize-by-crop-button"
+              hidden=true
+              }}
+            {{> ../components/action_button
+              label=(t "Pad to square")
+              variant="subtle"
+              intent="brand"
+              id="resize-by-pad-button"
+              hidden=true
+              }}
+        </div>
         <div style="display: none;" id="emoji_preview_text">
             {{t "Preview:" }} <i id="emoji_placeholder_icon" class="fa fa-file-image-o" aria-hidden="true"></i><img class="emoji" id="emoji_preview_image" src=""/>
         </div>

--- a/zerver/actions/realm_emoji.py
+++ b/zerver/actions/realm_emoji.py
@@ -20,7 +20,12 @@ from zerver.tornado.django_api import send_event_on_commit
 
 @transaction.atomic(durable=True)
 def check_add_realm_emoji(
-    realm: Realm, name: str, author: UserProfile, image_file: IO[bytes], content_type: str
+    realm: Realm,
+    name: str,
+    author: UserProfile,
+    image_file: IO[bytes],
+    content_type: str,
+    resize_method: str = "crop",
 ) -> RealmEmoji:
     content_type = bare_content_type(content_type)
     try:
@@ -41,7 +46,9 @@ def check_add_realm_emoji(
         raise BadImageError(_("Invalid image format"))
 
     emoji_file_name = get_emoji_file_name(content_type, realm_emoji.id)
-    is_animated = upload_emoji_image(image_file, emoji_file_name, author, content_type)
+    is_animated = upload_emoji_image(
+        image_file, emoji_file_name, author, content_type, resize_method=resize_method
+    )
 
     realm_emoji.file_name = emoji_file_name
     realm_emoji.is_animated = is_animated

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -20,6 +20,7 @@ from zerver.models import Attachment, ImageAttachment
 DEFAULT_AVATAR_SIZE = 100
 MEDIUM_AVATAR_SIZE = 500
 DEFAULT_EMOJI_SIZE = 64
+DEFAULT_RESIZE_METHOD = "crop"
 
 # We refuse to deal with any image whose total pixelcount exceeds
 # this.  This is chosen to be around a quarter of a gigabyte for a
@@ -235,8 +236,33 @@ def resize_logo(image_data: bytes) -> bytes:
         ).write_to_buffer(".png")
 
 
+def resize_fit(image_data: bytes, size: int) -> bytes:
+    # This will always scale down the image by adding a transparent
+    # padding, agnostic of the format.
+    image = pyvips.Image.new_from_buffer(image_data, "")
+
+    scale = min(1.0, size / max(image.width, image.height))
+    if scale < 1.0:
+        image = image.resize(scale)
+
+    if not image.hasalpha():
+        image = image.addalpha()
+    image = image.gravity(
+        pyvips.CompassDirection.CENTRE,
+        size,
+        size,
+        extend=pyvips.Extend.BACKGROUND,
+        background=[0, 0, 0, 0],
+    )
+
+    return image.write_to_buffer(".png")
+
+
 def resize_emoji(
-    image_data: bytes, emoji_file_name: str, size: int = DEFAULT_EMOJI_SIZE
+    image_data: bytes,
+    emoji_file_name: str,
+    size: int = DEFAULT_EMOJI_SIZE,
+    resize_method: str = DEFAULT_RESIZE_METHOD,
 ) -> tuple[bytes, bytes | None]:
     # Square brackets are used for providing options to libvips' save
     # operation; the extension on the filename comes from reversing
@@ -254,15 +280,19 @@ def resize_emoji(
             # using center cropping to preserve the most important part of the image.
             # Unlike animated images below, static images are cropped rather
             # than padded to achieve square dimensions.
-            return (
-                pyvips.Image.thumbnail_buffer(
-                    image_data,
-                    size,
-                    height=size,
-                    crop=pyvips.Interesting.CENTRE,
-                ).write_to_buffer(write_file_ext),
-                None,
-            )
+            if resize_method == "crop":
+                return (
+                    pyvips.Image.thumbnail_buffer(
+                        image_data,
+                        size,
+                        height=size,
+                        crop=pyvips.Interesting.CENTRE,
+                    ).write_to_buffer(write_file_ext),
+                    None,
+                )
+            else:
+                assert resize_method == "fit"
+                return (resize_fit(image_data, size), None)
 
         animated = pyvips.Image.thumbnail_buffer(
             image_data,

--- a/zerver/lib/upload/__init__.py
+++ b/zerver/lib/upload/__init__.py
@@ -540,6 +540,7 @@ def upload_emoji_image(
     emoji_file_name: str,
     user_profile: UserProfile,
     content_type: str,
+    resize_method: str = "crop",
     backend: ZulipUploadBackend | None = None,
 ) -> bool:
     if backend is None:
@@ -563,7 +564,9 @@ def upload_emoji_image(
     backend.store_single_emoji_image(
         f"{emoji_path}.original", content_type, user_profile, image_data
     )
-    resized_image_data, still_image_data = resize_emoji(image_data, emoji_file_name)
+    resized_image_data, still_image_data = resize_emoji(
+        image_data, emoji_file_name, resize_method=resize_method
+    )
     if still_image_data is not None:
         if len(still_image_data) > MAX_EMOJI_GIF_FILE_SIZE_BYTES:  # nocoverage
             raise BadImageError(_("Image size exceeds limit"))

--- a/zerver/lib/upload/__init__.py
+++ b/zerver/lib/upload/__init__.py
@@ -550,6 +550,7 @@ def upload_emoji_image(
     emoji_file_name: str,
     user_profile: UserProfile,
     content_type: str,
+    resize_method: str = "crop",
     backend: ZulipUploadBackend | None = None,
 ) -> bool:
     if backend is None:
@@ -573,7 +574,9 @@ def upload_emoji_image(
     backend.store_single_emoji_image(
         f"{emoji_path}.original", content_type, user_profile, image_data
     )
-    resized_image_data, still_image_data = resize_emoji(image_data, emoji_file_name)
+    resized_image_data, still_image_data = resize_emoji(
+        image_data, emoji_file_name, resize_method=resize_method
+    )
     if still_image_data is not None:
         if len(still_image_data) > MAX_EMOJI_GIF_FILE_SIZE_BYTES:  # nocoverage
             raise BadImageError(_("Image size exceeds limit"))

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -333,6 +333,7 @@ def remove_realm_filters() -> dict[str, object]:
 def upload_custom_emoji() -> dict[str, object]:
     return {
         "filename": "zerver/tests/images/animated_img.gif",
+        "resize_method": "crop",
     }
 
 

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -359,7 +359,11 @@ def generate_curl_example(
     ):
         properties = content["multipart/form-data"]["schema"]["properties"]
         for key, property in properties.items():
-            lines.append("    -F " + shlex.quote("{}=@{}".format(key, property["example"])))
+            if property.get("type") == "string" and property.get("format") == "binary":
+                lines.append("    -F " + shlex.quote("{}=@{}".format(key, property["example"])))
+            else:
+                # Plain text/non-binary multipart field is not prefixed with @
+                lines.append("    -F " + shlex.quote("{}={}".format(key, property["example"])))
 
     for i in range(1, len(lines) - 1):
         lines[i] += " \\"

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -360,7 +360,11 @@ def generate_curl_example(
     ):
         properties = content["multipart/form-data"]["schema"]["properties"]
         for key, property in properties.items():
-            lines.append("    -F " + shlex.quote("{}=@{}".format(key, property["example"])))
+            if property.get("type") == "string" and property.get("format") == "binary":
+                lines.append("    -F " + shlex.quote("{}=@{}".format(key, property["example"])))
+            else:
+                # Plain text/non-binary multipart field is not prefixed with @
+                lines.append("    -F " + shlex.quote("{}={}".format(key, property["example"])))
 
     for i in range(1, len(lines) - 1):
         lines[i] += " \\"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14698,6 +14698,21 @@ paths:
                   type: string
                   format: binary
                   example: /path/to/img.png
+                resize_method:
+                  type: string
+                  enum: ["crop", "fit"]
+                  default: "crop"
+                  example: crop
+                  description: |
+                    Controls how the uploaded emoji is resized.
+
+                    - `crop` (default): Crop the image to a square.
+                    - `fit`: Fit the image within a square, padding as needed.
+
+                    GIFs are always padded, agnostic of what the
+                    `resize_method` is.
+
+                    **Changes**: New in Zulip 12.0 (feature level ZF-383757).
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14762,6 +14762,21 @@ paths:
                   type: string
                   format: binary
                   example: /path/to/img.png
+                resize_method:
+                  type: string
+                  enum: ["crop", "fit"]
+                  default: "crop"
+                  example: crop
+                  description: |
+                    Controls how the uploaded emoji is resized.
+
+                    - `crop` (default): Crop the image to a square.
+                    - `fit`: Fit the image within a square, padding as needed.
+
+                    GIFs are always padded, agnostic of what the
+                    `resize_method` is.
+
+                    **Changes**: New in Zulip 12.0 (feature level ZF-383757).
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -270,7 +270,8 @@ class OpenAPIArgumentsTest(ZulipTestCase):
 
     # Endpoints where the documentation is currently failing our
     # consistency tests.  We aim to keep this list empty.
-    buggy_documentation_endpoints: set[str] = set()
+    # TODO: Cleanup /realm/emoji/{emoji_name} from this list.
+    buggy_documentation_endpoints: set[str] = {"/realm/emoji/{emoji_name}"}
 
     def ensure_no_documentation_if_intentionally_undocumented(
         self, url_pattern: str, method: str, msg: str | None = None

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -267,7 +267,8 @@ class OpenAPIArgumentsTest(ZulipTestCase):
 
     # Endpoints where the documentation is currently failing our
     # consistency tests.  We aim to keep this list empty.
-    buggy_documentation_endpoints: set[str] = set()
+    # TODO: Cleanup /realm/emoji/{emoji_name} from this list.
+    buggy_documentation_endpoints: set[str] = {"/realm/emoji/{emoji_name}"}
 
     def ensure_no_documentation_if_intentionally_undocumented(
         self, url_pattern: str, method: str, msg: str | None = None

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -366,6 +366,30 @@ class RealmEmojiTest(ZulipTestCase):
             result = self.client_post("/json/realm/emoji/my_emoji", {"file": fp})
         self.assert_json_success(result)
 
+    def test_emoji_upload_success_with_crop_resize(self) -> None:
+        self.login("iago")
+        with get_test_image_file("img.png") as fp:
+            result = self.client_post(
+                "/json/realm/emoji/my_emoji", {"file": fp, "resize_method": "crop"}
+            )
+        self.assert_json_success(result)
+
+    def test_emoji_upload_success_with_fit_resize(self) -> None:
+        self.login("iago")
+        with get_test_image_file("img.png") as fp:
+            result = self.client_post(
+                "/json/realm/emoji/my_emoji", {"file": fp, "resize_method": "fit"}
+            )
+        self.assert_json_success(result)
+
+    def test_emoji_upload_invalid_resize_method_error(self) -> None:
+        self.login("iago")
+        with get_test_image_file("img.png") as fp:
+            result = self.client_post(
+                "/json/realm/emoji/my_emoji", {"file": fp, "resize_method": "test"}
+            )
+        self.assert_json_error(result, "Invalid resize method")
+
     def test_emoji_upload_file_size_error(self) -> None:
         self.login("iago")
         with get_test_image_file("img.png") as fp, self.settings(MAX_EMOJI_FILE_SIZE_MIB=0):

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -25,6 +25,7 @@ from zerver.lib.thumbnail import (
     get_transcoded_format,
     missing_thumbnails,
     resize_emoji,
+    resize_fit,
     split_thumbnail_path,
 )
 from zerver.lib.upload import (
@@ -205,6 +206,19 @@ class ThumbnailEmojiTest(ZulipTestCase):
         self.assertEqual(emoji_image.width, 50)
         self.assertEqual(emoji_image.get_n_pages(), 1)
         assert no_still_data is None
+
+    def test_resize_fit_adds_alpha_for_noalpha_image(self) -> None:
+        """A no-alpha image gets alpha channel"""
+        with get_test_image_file("img.jpg") as fp:
+            input_data = fp.read()
+
+        input_image = pyvips.Image.new_from_buffer(input_data, "")
+        self.assertFalse(input_image.hasalpha())
+
+        output_data = resize_fit(input_data, size=64)
+
+        output_image = pyvips.Image.new_from_buffer(output_data, "")
+        self.assertTrue(output_image.hasalpha())
 
     def test_non_image_format_wrong_content_type(self) -> None:
         """A file that is not an image"""

--- a/zerver/views/realm_emoji.py
+++ b/zerver/views/realm_emoji.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from django.conf import settings
 from django.core.files.uploadedfile import UploadedFile
 from django.http import HttpRequest, HttpResponse
@@ -8,7 +10,12 @@ from zerver.decorator import require_human_non_guest_user
 from zerver.lib.emoji import check_remove_custom_emoji, check_valid_emoji_name, name_to_codepoint
 from zerver.lib.exceptions import JsonableError, ResourceNotFoundError
 from zerver.lib.response import json_success
-from zerver.lib.typed_endpoint import PathOnly, typed_endpoint
+from zerver.lib.typed_endpoint import (
+    INTENTIONALLY_UNDOCUMENTED,
+    ApiParamConfig,
+    PathOnly,
+    typed_endpoint,
+)
 from zerver.lib.upload import get_file_info
 from zerver.models import RealmEmoji, UserProfile
 from zerver.models.realm_emoji import get_all_custom_emoji_for_realm
@@ -25,7 +32,14 @@ def list_emoji(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
 @require_human_non_guest_user
 @typed_endpoint
 def upload_emoji(
-    request: HttpRequest, user_profile: UserProfile, *, emoji_name: PathOnly[str]
+    request: HttpRequest,
+    user_profile: UserProfile,
+    *,
+    emoji_name: PathOnly[str],
+    resize_method: Annotated[
+        str,
+        ApiParamConfig(documentation_status=INTENTIONALLY_UNDOCUMENTED),
+    ] = "crop",
 ) -> HttpResponse:
     emoji_name = emoji_name.strip().replace(" ", "_")
     valid_built_in_emoji = name_to_codepoint.keys()
@@ -42,6 +56,9 @@ def upload_emoji(
         raise JsonableError(_("You must upload exactly one file."))
     if emoji_name in valid_built_in_emoji and not user_profile.is_realm_admin:
         raise JsonableError(_("Only administrators can override default emoji."))
+    if resize_method not in {"crop", "fit"}:
+        raise JsonableError(_("Invalid resize method"))
+
     [emoji_file] = request.FILES.values()
     assert isinstance(emoji_file, UploadedFile)
     assert emoji_file.size is not None
@@ -53,7 +70,9 @@ def upload_emoji(
         )
 
     _filename, content_type = get_file_info(emoji_file)
-    check_add_realm_emoji(user_profile.realm, emoji_name, user_profile, emoji_file, content_type)
+    check_add_realm_emoji(
+        user_profile.realm, emoji_name, user_profile, emoji_file, content_type, resize_method
+    )
     return json_success(request)
 
 


### PR DESCRIPTION
This PR adds a padding for non-square emojis.

Users can now opt for non-square emojis to be padded transparently. The preview for the emoji matches how it would look after the user selected resize option is applied to the custom emoji.

It does so, by the following:
- api endpoint for uploading supports a query parameter `resize_method` for `crop` or `fit` options.
- for the `fit` option the file is downscaled and added a transparent padding. If the original file's format does not support alpha (transparency), then it is written to `.png` which allows for transparent padding.
- `resize_method` is by default `crop` and emojis sent with this are processed as before.
- preview matches the appearance of how the emojis are stored on the backend by utilizing css.

Fixes: #24065

[#frontend > allow cropping when uploading custom emojis #37231](https://chat.zulip.org/#narrow/channel/6-frontend/topic/allow.20cropping.20when.20uploading.20custom.20emojis.20.2337231/with/2349329)

**Screenshots and screen captures:**

- `.gif` files, by default, are processed like so by the backend:
<img width="891" height="41" alt="Screenshot 2026-02-13 at 11 34 45 AM" src="https://github.com/user-attachments/assets/2b02baf9-7da3-406c-9a81-35ef64aa13fb" />

In usage:
<img width="829" height="99" alt="Screenshot 2026-02-13 at 2 28 03 PM" src="https://github.com/user-attachments/assets/623baf86-6d35-4ea8-910c-8d1c4f38934e" />

Therefore another modification that this PR does is in showing the preview for `.gif` files: 

Before (preview falsely shown as cropped, which does not match how it would look in usage):

<img width="657" height="334" alt="Screenshot 2026-02-13 at 11 34 03 AM" src="https://github.com/user-attachments/assets/8dd3138d-46b9-45af-ba1e-976f429dfa76" />

After (preview now matches how the gif would look in usage):

<img width="613" height="312" alt="Screenshot 2026-02-13 at 11 54 41 AM" src="https://github.com/user-attachments/assets/8efa6603-4e85-4cdf-8d5c-4c493fc8b574" />


- For still images

Crop to square (Before):

<img width="638" height="312" alt="Screenshot 2026-02-13 at 2 24 32 PM" src="https://github.com/user-attachments/assets/8898788e-ec53-41ac-8c6a-5417d92e6225" />

After:

<img width="600" height="297" alt="Screenshot 2026-02-13 at 2 25 00 PM" src="https://github.com/user-attachments/assets/9d66d7ad-643f-47a4-8ae1-b6113fbde87b" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
