### PR TITLE
templates: Fix styles on reset_confirm template.

### DIFF
--- a/templates/zerver/reset_confirm.html
+++ b/templates/zerver/reset_confirm.html
@@ -7,18 +7,14 @@
 
 {% block portico_content %}
 
-<div class="password-container flex full-page new-style">
-
-    <!-- wrapper for flex content -->
-    <div>
-        <div class="get-started">
-            <h1>{{ _('Set a new password.') }}</h1>
+<div class="flex full-page new-style">
+    <div id="password-reset-confirm" >
+        <div class="registration-lead-section">
+            <h1 class="registration-lead-title">{{ _('Set a new password') }}</h1>
         </div>
-        <div class="password-reset white-box">
-            <!-- TODO: Ask about meta viewport 1:1 scaling -->
-
+        <div class="white-box">
             {% if validlink %}
-            <form method="post" id="password_reset" autocomplete="off">
+            <form class="form-inline" method="post" id="password_reset" autocomplete="off">
                 {{ csrf_input }}
                 <div class="input-box" id="email-section">
                     <label for="id_email">{{ _("Email") }}</label>
@@ -28,7 +24,7 @@
                 </div>
 
                 <div class="input-box password-div">
-                    <label for="id_new_password1" class="">{{ _('Password') }}</label>
+                    <label for="id_new_password1">{{ _('Password') }}</label>
                     <input id="id_new_password1" class="required" type="password" name="new_password1" autocomplete="new-password"
                       value="{% if form.new_password1.value() %}{{ form.new_password1.value() }}{% endif %}"
                       data-max-length="{{ password_max_length }}"
@@ -41,15 +37,12 @@
                         {% endfor %}
                     {% endif %}
                 </div>
-                <div class="input-box">
-                    <div class="">
-                        <div class="progress" id="pw_strength">
-                            <div class="bar bar-danger" style="width: 10%;"></div>
-                        </div>
-                    </div>
+                <div class="progress" id="pw_strength">
+                    <div class="bar bar-danger" style="width: 10%;"></div>
                 </div>
+
                 <div class="input-box password-div">
-                    <label for="id_new_password2" class="">{{ _('Confirm password') }}</label>
+                    <label for="id_new_password2">{{ _('Confirm password') }}</label>
                     <input id="id_new_password2" class="required" type="password" name="new_password2" autocomplete="off"
                       value="{% if form.new_password2.value() %}{{ form.new_password2.value() }}{% endif %}"
                       maxlength="100" required />
@@ -72,15 +65,13 @@
                 </div>
                 {% endif %}
 
-                <div class="input-box m-t-30">
-                    <div class="centered-button">
-                        <button type="submit" class="" value="Submit">Submit</button>
-                    </div>
+                <div class="input-box">
+                    <button type="submit" class="password-reset-button" value="Submit">Submit</button>
                 </div>
             </form>
 
             {% else %}
-            <p>{{ _('Sorry, the link you provided is invalid or has already been used.') }}</p>
+            <p class="password-reset-invalid">{{ _('Sorry, the link you provided is invalid or has already been used.') }}</p>
             {% endif %}
         </div>
     </div>

--- a/web/styles/portico/legacy_portico.css
+++ b/web/styles/portico/legacy_portico.css
@@ -837,56 +837,6 @@ input#terminal:checked ~ #tab-terminal {
     text-align: center;
 }
 
-/* -- password reset container -- */
-.password-reset {
-    display: inline-block;
-    text-align: left;
-    width: 328px;
-
-    & form {
-        margin: 0;
-    }
-
-    #pw_strength {
-        width: 328px;
-        margin-top: 20px;
-    }
-
-    .pitch {
-        width: auto;
-    }
-
-    .input-group {
-        margin: 15px 0;
-
-        & input[type="text"],
-        input[type="password"] {
-            width: calc(100% - 14px);
-        }
-
-        #pw_strength {
-            width: 100%;
-        }
-
-        &.m-t-30 {
-            margin-top: 30px;
-        }
-    }
-
-    & p {
-        margin: 0;
-    }
-
-    .progress {
-        margin: 0;
-    }
-
-    #email-section .fakecontrol {
-        display: inline-block;
-        margin: 0;
-    }
-}
-
 .input-group {
     .progress {
         margin: 0;
@@ -1174,12 +1124,6 @@ input#terminal:checked ~ #tab-terminal {
     .contributors-list {
         width: 100%;
         margin-left: 0;
-    }
-}
-
-@media (height <= 600px) {
-    .password-container {
-        margin-top: 10px;
     }
 }
 

--- a/web/styles/portico/marketing_page.css
+++ b/web/styles/portico/marketing_page.css
@@ -491,56 +491,6 @@ input#terminal:checked ~ #tab-terminal {
     text-align: center;
 }
 
-/* -- password reset container -- */
-.password-reset {
-    display: inline-block;
-    text-align: left;
-    width: 328px;
-
-    & form {
-        margin: 0;
-    }
-
-    #pw_strength {
-        width: 328px;
-        margin-top: 20px;
-    }
-
-    .pitch {
-        width: auto;
-    }
-
-    .input-group {
-        margin: 15px 0;
-
-        & input[type="text"],
-        input[type="password"] {
-            width: calc(100% - 14px);
-        }
-
-        #pw_strength {
-            width: 100%;
-        }
-
-        &.m-t-30 {
-            margin-top: 30px;
-        }
-    }
-
-    & p {
-        margin: 0;
-    }
-
-    .progress {
-        margin: 0;
-    }
-
-    #email-section .fakecontrol {
-        display: inline-block;
-        margin: 0;
-    }
-}
-
 .input-group {
     .progress {
         margin: 0;
@@ -824,12 +774,6 @@ input#terminal:checked ~ #tab-terminal {
     .contributors-list {
         width: 100%;
         margin-left: 0;
-    }
-}
-
-@media (height <= 600px) {
-    .password-container {
-        margin-top: 10px;
     }
 }
 

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -969,6 +969,7 @@ button#register_auth_button_gitlab {
     }
 }
 
+#password-reset-confirm,
 #realm-import-post-process,
 #realm-creation-form-slack-import,
 #account-deactivated-success-page-details,
@@ -1217,18 +1218,39 @@ button#register_auth_button_gitlab {
     }
 }
 
-#password_reset .input-group {
-    & label {
-        font-size: 1rem;
+#password-reset-confirm {
+    .white-box {
+        display: inline-block;
+        text-align: left;
+        width: 328px;
+    }
 
-        &.inline-block {
-            margin-top: -1px;
-        }
+    #pw_strength {
+        width: 328px;
+    }
 
-        &.marketing_emails_checkbox {
-            text-indent: -24px;
-            margin-left: 24px;
+    .password-reset-button {
+        margin-top: 10px;
+        width: 328px;
+    }
+
+    #password_reset .input-group {
+        & label {
+            font-size: 1rem;
+
+            &.inline-block {
+                margin-top: -1px;
+            }
+
+            &.marketing_emails_checkbox {
+                text-indent: -24px;
+                margin-left: 24px;
+            }
         }
+    }
+
+    .password-reset-invalid {
+        margin: 0;
     }
 }
 


### PR DESCRIPTION
CZO conversation: [#issues > password reset form spacing](https://chat.zulip.org/#narrow/channel/9-issues/topic/password.20reset.20form.20spacing/with/2345234)

**Notes**:
- Fixes the spacing between inputs, with the placement of the password strength bar, and with the submit button.
  - The screenshots are with the same zoom and placement on the page.
- Uses the new header styles that were added in #37405 for the new organization and demo organization creation pages.
  - Note that the header font size is slightly smaller in the updated version of the page.
  - Removed the period in the header line for consistency with other portico pages/forms. This will mean the string needs to be retranslated.
- Moves some of the in-use CSS from `legacy_portico.css` to `portico_signin.css`, and adds some named classes for rules that were previously set on HTML elements (e.g., `p` tag).
- Removes some legacy portico CSS that was no longer in use on the page. Also removes the matching CSS in the marketing portico CSS, which is also not being used.

**To manually test**:
- Log-in as Cordelia and go to reset password in settings, click the "forgot password" link and go through the dev emails to get to the page.
- For the invalid link, once you've set Cordelia's password, go back to the dev emails page and click the link again to reset the password.
- Create a demo organization via the button on the dev login page, and go through the process of adding an email to the account.
- To test/play with the password strength bar in dev, update `dev_settings.py` for the values below ...
  - PASSWORD_MIN_LENGTH = 6
  - PASSWORD_MIN_GUESSES = 10000

---

**Screenshots and screen captures:**

*REGULAR ORGANIZATION*
| Before | After |
| --- | --- |
| <img width="663" height="921" alt="Screenshot From 2026-01-19 19-26-17" src="https://github.com/user-attachments/assets/3abf00ea-46c4-4e7b-b215-160db4bd3f55" /> | <img width="663" height="921" alt="Screenshot From 2026-01-19 19-26-05" src="https://github.com/user-attachments/assets/0c4617a5-f20b-4b21-80f4-c6c7c9b87077" />

*DEMO ORGANIZATION OWNER*
| Before | After |
| --- | --- |
| <img width="663" height="921" alt="Screenshot From 2026-01-19 19-28-33" src="https://github.com/user-attachments/assets/2504a576-be26-4cf1-bcd1-4c5f6e52b5b1" /> | <img width="663" height="921" alt="Screenshot From 2026-01-19 19-28-16" src="https://github.com/user-attachments/assets/218afd11-32d7-421a-b316-8bf055b66c4c" />

*USED OR INVALID LINK*
| Before | After |
| --- | --- |
| <img width="663" height="423" alt="Screenshot From 2026-01-19 19-34-53" src="https://github.com/user-attachments/assets/6c1ddb80-6cdf-489f-af30-85228c172fae" /> | <img width="663" height="423" alt="Screenshot From 2026-01-19 19-35-04" src="https://github.com/user-attachments/assets/3ea43554-386f-4711-85d1-dc140d47888e" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
