### PR TITLE
hotkeys: Refactor tab and shift_tab keys to use document.activeElement.

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -802,8 +802,13 @@ export function process_shift_tab_key(): boolean {
     // Returns true if we handled it, false if the browser should.
     // TODO: See if browsers like Safari can now handle tabbing correctly
     // without our intervention.
+    const focused_element = document.activeElement;
 
-    if ($("#compose-send-button").is(":focus")) {
+    if (!(focused_element instanceof HTMLElement)) {
+        return false;
+    }
+
+    if (focused_element.id === "compose-send-button") {
         // Shift-Tab: go back to content textarea and restore
         // cursor position.
         compose_textarea.restore_compose_cursor();


### PR DESCRIPTION
this PR is a refactoring step to use document.activeElement in `tab` and `shift_tab` keys for the issue #36663.

related PR :- https://github.com/zulip/zulip/pull/36675