### PR TITLE
composebox_typeahead: Unmark slash command names for translation

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -552,13 +552,13 @@ function should_show_custom_query(query: string, items: string[]): boolean {
 
 export const dev_only_slash_commands = [
     {
-        text: $t({defaultMessage: "/dark"}),
+        text: "/dark",
         name: "dark",
         aliases: "night",
         info: $t({defaultMessage: "Switch to the dark theme"}),
     },
     {
-        text: $t({defaultMessage: "/light"}),
+        text: "/light",
         name: "light",
         aliases: "day",
         info: $t({defaultMessage: "Switch to light theme"}),
@@ -567,21 +567,21 @@ export const dev_only_slash_commands = [
 
 export const slash_commands = [
     {
-        text: $t({defaultMessage: "/me"}),
+        text: "/me",
         name: "me",
         aliases: "",
         placeholder: $t({defaultMessage: "is …"}),
         info: $t({defaultMessage: "Action message"}),
     },
     {
-        text: $t({defaultMessage: "/poll"}),
+        text: "/poll",
         name: "poll",
         aliases: "",
         placeholder: $t({defaultMessage: "Question"}),
         info: $t({defaultMessage: "Create a poll"}),
     },
     {
-        text: $t({defaultMessage: "/todo"}),
+        text: "/todo",
         name: "todo",
         aliases: "",
         placeholder: $t({defaultMessage: "Task list"}),

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -255,7 +255,7 @@ const emojis_by_name = new Map(
 const me_command = {
     name: "me",
     aliases: "",
-    text: "translated: /me",
+    text: "/me",
     placeholder: "translated: is …",
     info: "translated: Action message",
 };
@@ -264,13 +264,13 @@ const me_command_item = slash_item(me_command);
 const my_command_item = slash_item({
     name: "my",
     aliases: "",
-    text: "translated: /my (Test)",
+    text: "/my (Test)",
 });
 
 const dark_command = {
     name: "dark",
     aliases: "night",
-    text: "translated: /dark",
+    text: "/dark",
     info: "translated: Switch to the dark theme",
 };
 const dark_command_item = slash_item(dark_command);
@@ -278,7 +278,7 @@ const dark_command_item = slash_item(dark_command);
 const light_command = {
     name: "light",
     aliases: "day",
-    text: "translated: /light",
+    text: "/light",
     info: "translated: Switch to light theme",
 };
 const light_command_item = slash_item(light_command);
@@ -2158,7 +2158,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals("test no#o", []);
 
     const poll_command = {
-        text: "translated: /poll",
+        text: "/poll",
         name: "poll",
         info: "translated: Create a poll",
         aliases: "",
@@ -2166,7 +2166,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
         type: "slash",
     };
     const todo_command = {
-        text: "translated: /todo",
+        text: "/todo",
         name: "todo",
         info: "translated: Create a collaborative to-do list",
         aliases: "",


### PR DESCRIPTION
These are not translated when interpreted on the backend, so we shouldn’t pretend they’re translated during typeahead.