### PR TITLE
settings: Fix banners shown on adding users to stream and groups.

### DIFF
--- a/web/templates/stream_settings/stream_subscription_request_result.hbs
+++ b/web/templates/stream_settings/stream_subscription_request_result.hbs
@@ -8,13 +8,13 @@
     {{else}}
         {{#if (not is_total_subscriber_more_than_five) }}
             {{#if subscribed_users}}
-                {{t "Subscribed:" }} {{> user_links subscribed_users}}.
+                {{t "Subscribed:" }} {{> user_links users=subscribed_users}}.
             {{/if}}
             {{#if already_subscribed_users}}
-                {{t "Already a subscriber:" }} {{> user_links already_subscribed_users}}.
+                {{t "Already a subscriber:" }} {{> user_links users=already_subscribed_users}}.
             {{/if}}
             {{#if ignored_deactivated_users}}
-                {{t "Ignored deactivated users:" }} {{> user_links ignored_deactivated_users}}.
+                {{t "Ignored deactivated users:" }} {{> user_links users=ignored_deactivated_users}}.
             {{/if}}
         {{else}}
             {{#if subscribed_users}}

--- a/web/templates/user_group_settings/user_group_membership_request_result.hbs
+++ b/web/templates/user_group_settings/user_group_membership_request_result.hbs
@@ -12,16 +12,16 @@
     {{else}}
         {{#if (not total_member_count_exceeds_five)}}
             {{#if additions.newly_added_members}}
-                {{t "Added:" }} {{> member_links additions.newly_added_members}}.&nbsp;
+                {{t "Added:" }} {{> member_links members=additions.newly_added_members}}.&nbsp;
             {{/if}}
             {{#if additions.already_added_members}}
-                {{t "Already a member:"}} {{> member_links additions.already_added_members}}.
+                {{t "Already a member:"}} {{> member_links members=additions.already_added_members}}.
             {{/if}}
             {{#if additions.ignored_deactivated_users}}
-                {{t "Ignored deactivated users:"}} {{> member_links additions.ignored_deactivated_users}}.
+                {{t "Ignored deactivated users:"}} {{> member_links members=additions.ignored_deactivated_users}}.
             {{/if}}
             {{#if additions.ignored_deactivated_groups}}
-                {{t "Ignored deactivated groups:"}} {{> member_links additions.ignored_deactivated_groups}}.
+                {{t "Ignored deactivated groups:"}} {{> member_links members=additions.ignored_deactivated_groups}}.
             {{/if}}
         {{else}}
             {{#if newly_added_member_count}}


### PR DESCRIPTION
User and user group names were shown in the result banner when adding subscribers to streams and when adding members to groups.

This was happening after changes in 61dd5fb and 3a6db7a missed using correct variable names when passing users list.

**Screenshots and screen captures:**

|| Before | After |
|------ | ------ | ------ |
| Channels UI | <img width="709" height="147" alt="image" src="https://github.com/user-attachments/assets/c89f0433-0be3-41bf-a0dc-a4a8eca54a63" /> |<img width="709" height="147" alt="image" src="https://github.com/user-attachments/assets/0fd01a6b-5f8a-43a7-916c-9a5b783cd528" /> |
| Groups UI |<img width="709" height="147" alt="image" src="https://github.com/user-attachments/assets/256e3653-5479-4fc4-91fc-0565b2bc3fca" /> | <img width="709" height="147" alt="image" src="https://github.com/user-attachments/assets/d4c2c2eb-7a9a-4ae7-a0c4-e07857fcf669" /> |

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
