### PR TITLE
   buddy list: Use ::before for status circle

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -160,13 +160,20 @@
         }
     }
 
-    .user-circle {
-        grid-area: starting-anchor-element;
-        place-self: center center;
-        /* Tighten the line-height to match the icon's size... */
-        line-height: 1;
-        /* ...which is approximately 8px at 15px/1em in Vlad's design. */
-        font-size: 0.5333em;
+    .selectable_sidebar_block.user-circle {
+        &::before {
+            grid-area: starting-anchor-element;
+            place-self: center center;
+            position: static;
+            /* Override zulip-icon absolute positioning for grid layout */
+            top: auto;
+            left: auto;
+            transform: none;
+            /* Tighten the line-height to match the icon's size... */
+            line-height: 1;
+            /* ...which is approximately 8px at 15px/1em in Vlad's design. */
+            font-size: 0.5333em;
+        }
     }
 
     .user_sidebar_entry.with_avatar {
@@ -177,7 +184,7 @@
                .selectable_sidebar_block. */
             margin-right: var(--right-sidebar-avatar-right-margin);
 
-            &:not(:has(.user-circle-offline)) .user-profile-picture {
+            .user-profile-picture:not(.user-circle-offline) {
                 /* The over-avatar user circle width is 15.5px at 20px/1em;
                    we adjust the border radius here to avoid any pixels
                    from the avatar bleeding through. */
@@ -192,19 +199,27 @@
             margin-right: 0;
         }
 
-        .user-circle {
-            position: absolute;
-            /* 10px at 16px/1em */
-            font-size: 0.625em;
-            bottom: -0.5px;
-            right: -0.5px;
-            background-color: var(--color-background);
-            /* A 1.5px border provides better results than
-               a 1px border, especially at smaller font sizes. */
-            border: 1.5px solid var(--color-background);
-            border-radius: 50%;
+        .user-profile-picture.user-circle {
+            position: relative;
 
-            &.user-circle-offline {
+            &::before {
+                position: absolute;
+                /* 10px at 16px/1em */
+                font-size: 0.625em;
+                bottom: -0.5px;
+                right: -0.5px;
+                background-color: var(--color-background);
+                /* A 1.5px border provides better results than
+                   a 1px border, especially at smaller font sizes. */
+                border: 1.5px solid var(--color-background);
+                border-radius: 50%;
+                /* Override zulip-icon centering for absolute positioning */
+                top: auto;
+                left: auto;
+                transform: none;
+            }
+
+            &.user-circle-offline::before {
                 display: none;
             }
         }

--- a/web/templates/presence_row.hbs
+++ b/web/templates/presence_row.hbs
@@ -1,7 +1,6 @@
-<li data-user-id="{{user_id}}" data-name="{{name}}" class="user_sidebar_entry {{#if user_list_style.WITH_AVATAR}}with_avatar{{/if}} {{#if has_status_text}}with_status{{/if}} {{#if is_current_user}}user_sidebar_entry_me {{/if}} narrow-filter {{#if faded}} user-fade {{/if}}">
-    <div class="selectable_sidebar_block">
+<li ...>
+    <div class="selectable_sidebar_block {{#unless user_list_style.WITH_AVATAR}}user-circle zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}}{{/unless}}">
         {{#if user_list_style.WITH_STATUS}}
-            <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
             <a class="user-presence-link" href="{{href}}" draggable="false">
                 <div class="user-name-and-status-emoji">
                     {{> user_full_name .}}
@@ -11,9 +10,8 @@
             </a>
         {{else if user_list_style.WITH_AVATAR}}
             <div class="user-profile-picture-container">
-                <div class="user-profile-picture avatar-preload-background">
+                <div class="user-profile-picture avatar-preload-background user-circle zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}}">
                     <img loading="lazy" src="{{profile_picture}}"/>
-                    <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
                 </div>
             </div>
             <a class="user-presence-link" href="{{href}}" draggable="false">
@@ -24,7 +22,6 @@
                 <span class="status-text">{{status_text}}</span>
             </a>
         {{else}}
-            <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
             <a class="user-presence-link" href="{{href}}" draggable="false">
                 <div class="user-name-and-status-emoji">
                     {{> user_full_name .}}


### PR DESCRIPTION
   Fixes #[issue_number]
   
   Changed status circle rendering from `<span>` elements to CSS `::before` pseudo-element in the buddy list.
   
   - Updated `presence_row.hbs` template to remove `<span class="user-circle">` elements
   - Added `::before` styling in `right_sidebar.css` for both avatar and non-avatar cases
