### PR TITLE
tools: Support renumbering migrations for other modules

### DIFF
--- a/tools/renumber-migrations
+++ b/tools/renumber-migrations
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import fileinput
 import glob
 import os
@@ -17,14 +18,18 @@ def validate_order(order: list[int], length: int) -> None:
             sys.exit(1)
 
 
-def renumber_migration(conflicts: list[str], order: list[int], last_correct_migration: str) -> None:
+def renumber_migration(
+    conflicts: list[str], order: list[int], last_correct_migration: str, migrations_dir: str
+) -> None:
     stack: list[str] = []
     for i in order:
         if conflicts[i - 1][0:4] not in stack:
             stack.append(conflicts[i - 1][0:4])
         else:
             # Replace dependencies with the last correct migration
-            with fileinput.FileInput("zerver/migrations/" + conflicts[i - 1], inplace=True) as file:
+            with fileinput.FileInput(
+                os.path.join(migrations_dir, conflicts[i - 1]), inplace=True
+            ) as file:
                 for line in file:
                     print(re.sub(r"[\d]+(_[a-z0-9]+)+", last_correct_migration, line), end="")
 
@@ -32,12 +37,15 @@ def renumber_migration(conflicts: list[str], order: list[int], last_correct_migr
             new_name = conflicts[i - 1].replace(
                 conflicts[i - 1][0:4], f"{int(last_correct_migration[0:4]) + 1:04}"
             )
-            os.rename("zerver/migrations/" + conflicts[i - 1], "zerver/migrations/" + new_name)
+            os.rename(
+                os.path.join(migrations_dir, conflicts[i - 1]),
+                os.path.join(migrations_dir, new_name),
+            )
 
             last_correct_migration = new_name.replace(".py", "")
 
 
-def resolve_conflicts(conflicts: list[str], files_list: list[str]) -> None:
+def resolve_conflicts(conflicts: list[str], files_list: list[str], migrations_dir: str) -> None:
     print("Conflicting migrations:")
     for i in range(len(conflicts)):
         print(str(i + 1) + ". " + conflicts[i])
@@ -49,15 +57,31 @@ def resolve_conflicts(conflicts: list[str], files_list: list[str]) -> None:
     last_correct_migration = conflicts[order[0] - 1]
 
     last_correct_migration = last_correct_migration.replace(".py", "")
-    renumber_migration(conflicts, order, last_correct_migration)
+    renumber_migration(conflicts, order, last_correct_migration, migrations_dir)
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Renumber migration files.")
+    parser.add_argument(
+        "app_label",
+        nargs="?",
+        default="zerver",
+        help="The Django app label to process (e.g. zerver, analytics)",
+    )
+    args = parser.parse_args()
+
+    migrations_dir = os.path.join(args.app_label, "migrations")
+    if not os.path.exists(migrations_dir):
+        print(f"Error: Directory '{migrations_dir}' does not exist.")
+        sys.exit(1)
+
     MIGRATIONS_TO_SKIP = {"0209", "0261", "0501", "0001"}
     while True:
         conflicts: list[str] = []
         stack: list[str] = []
-        files_list = [os.path.basename(path) for path in glob.glob("zerver/migrations/????_*.py")]
+        files_list = [
+            os.path.basename(path) for path in glob.glob(os.path.join(migrations_dir, "????_*.py"))
+        ]
         file_index = [file[0:4] for file in files_list]
 
         for file in file_index:
@@ -80,7 +104,7 @@ if __name__ == "__main__":
                 stack.append(migration_number)
 
         if len(conflicts) > 0:
-            resolve_conflicts(conflicts, files_list)
+            resolve_conflicts(conflicts, files_list, migrations_dir)
         else:
             break
 


### PR DESCRIPTION
Previously, the renumber-migrations tool was hardcoded to only work on the 'zerver' module

This commit adds an optional command-line argument to specify the module label (defaulting to 'zerver'), allowing the tool to be used for other modules like zilincer

*Explanation*
Previously, the script had `"zerver/migrations/"` hardcoded in multiple places. I have introduced `argparse` to allow passing an optional `app_label` argument.
*   If no argument is provided, it defaults to `zerver` (preserving backward compatibility).
*   If an argument is provided, it processes migrations for that app.

Fixes #20864.



**How changes were tested:**

1 it is tested  using command line 
2. `./tools/renumber-migrations` 
2../tools/renumber-migrations zilencer `



**Screenshots and screen captures:**

<img width="706" height="97" alt="image" src="https://github.com/user-attachments/assets/469fdc95-7179-4af4-bae5-88c44317f0e5" />


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
</details>