### PR TITLE
banner: Warn users via navbar banner when too many messages are muted.

### DIFF
--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -20,6 +20,7 @@ import {raw_message_schema} from "./message_store.ts";
 import * as message_util from "./message_util.ts";
 import * as message_viewport from "./message_viewport.ts";
 import * as narrow_banner from "./narrow_banner.ts";
+import * as navbar_alerts from "./navbar_alerts.ts";
 import {page_params} from "./page_params.ts";
 import * as popup_banners from "./popup_banners.ts";
 import {recent_view_messages_data} from "./recent_view_messages_data.ts";
@@ -686,6 +687,12 @@ export function set_initial_pointer_and_offset({
     initial_narrow_offset = narrow_offset;
 }
 
+function post_initial_backfill_for_all_messages_done(): void {
+    initial_backfill_for_all_messages_done = true;
+    emoji_frequency.initialize_frequently_used_emojis();
+    navbar_alerts.check_and_show_muted_messages_banner();
+}
+
 export function initialize(finished_initial_fetch: () => void): void {
     const fetch_target_day_timestamp =
         Date.now() / 1000 - consts.target_days_of_history * 24 * 60 * 60;
@@ -700,8 +707,7 @@ export function initialize(finished_initial_fetch: () => void): void {
         }
 
         if (data.found_oldest) {
-            initial_backfill_for_all_messages_done = true;
-            emoji_frequency.initialize_frequently_used_emojis();
+            post_initial_backfill_for_all_messages_done();
             return;
         }
 
@@ -714,14 +720,12 @@ export function initialize(finished_initial_fetch: () => void): void {
             recent_view_messages_data.num_items() >= consts.minimum_initial_backfill_size &&
             latest_message.timestamp < fetch_target_day_timestamp
         ) {
-            initial_backfill_for_all_messages_done = true;
-            emoji_frequency.initialize_frequently_used_emojis();
+            post_initial_backfill_for_all_messages_done();
             return;
         }
 
         if (recent_view_messages_data.num_items() >= consts.maximum_initial_backfill_size) {
-            initial_backfill_for_all_messages_done = true;
-            emoji_frequency.initialize_frequently_used_emojis();
+            post_initial_backfill_for_all_messages_done();
             return;
         }
 

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -15,15 +15,18 @@ import * as feedback_widget from "./feedback_widget.ts";
 import {$t} from "./i18n.ts";
 import type {LocalStorage} from "./localstorage.ts";
 import {localstorage} from "./localstorage.ts";
+import * as muted_users from "./muted_users.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as popover_menus from "./popover_menus.ts";
+import {recent_view_messages_data} from "./recent_view_messages_data.ts";
 import {current_user, realm} from "./state_data.ts";
 import * as timerender from "./timerender.ts";
 import * as ui_util from "./ui_util.ts";
 import * as unread from "./unread.ts";
 import * as unread_ops from "./unread_ops.ts";
 import {user_settings} from "./user_settings.ts";
+import * as user_topics from "./user_topics.ts";
 import * as util from "./util.ts";
 
 function open_navbar_banner_and_resize(banner: AlertBanner): void {
@@ -431,6 +434,87 @@ const time_zone_update_offer_banner = (): AlertBanner => {
     };
 };
 
+const majority_messages_muted_banner = (percent_muted_messages: number): AlertBanner => {
+    const truncated_percent_muted_messages = Math.trunc(percent_muted_messages);
+    return {
+        process: "too-many-muted-messages",
+        intent: "warning",
+        label: $t(
+            {
+                defaultMessage:
+                    "{truncated_percent_muted_messages}% of your recent messages are muted, which may slow down the app.",
+            },
+            {
+                truncated_percent_muted_messages,
+            },
+        ),
+        buttons: [
+            {
+                variant: "subtle",
+                label: $t({defaultMessage: "Learn more"}),
+                custom_classes: "managing-muted-channels",
+            },
+            {
+                variant: "text",
+                label: $t({defaultMessage: "Dismiss for 3 months"}),
+                custom_classes: "dismiss-majority-messages-muted-banner",
+            },
+        ],
+        close_button: true,
+        custom_classes: "navbar-alert-banner",
+    };
+};
+
+export function check_and_show_muted_messages_banner(): void {
+    const ls = localstorage();
+    if (
+        localstorage.supported() &&
+        ls.get("majority_muted_messages_banner_dismissal_date") !== undefined
+    ) {
+        const last_dismissal_date = ls.get("majority_muted_messages_banner_dismissal_date");
+        assert(typeof last_dismissal_date === "number");
+        const today = Date.now();
+
+        if (
+            differenceInCalendarDays(last_dismissal_date, today, {in: timerender.display_tz}) <= 90
+        ) {
+            // If the user had previously dismissed the banner,
+            // wait for 3 months before showing the banner again.
+            return;
+        }
+    }
+
+    if (recent_view_messages_data.empty()) {
+        // If recent_view_messages_data is empty, even after the initial
+        // backfill for recent_view_messages_data is done, then there are
+        // no messages to check and the ratio calculation below
+        // would result in a division by zero.
+        return;
+    }
+
+    // We use all_messages_after_mute_filtering() here because
+    // recent_view_messages_data is initialized with muting disabled
+    // (excludes_muted_topics: false, excludes_muted_users: false).
+    // Therefore, this method returns all messages, effectively ignoring muting.
+    const messages = recent_view_messages_data.all_messages_after_mute_filtering();
+
+    const muted_messages = messages.filter(
+        (message) =>
+            muted_users.is_user_muted(message.sender_id) ||
+            (message.type === "stream" &&
+                !user_topics.is_topic_visible_in_home(message.stream_id, message.topic)),
+    );
+
+    const percent_muted_messages = (muted_messages.length / messages.length) * 100;
+    if (muted_messages.length >= 5000 && percent_muted_messages > 50) {
+        // If more than 50% of the loaded messages are muted, and that quantity exceeds
+        // at least 5000 messages, show the banner. We use an absolute number threshold
+        // to avoid showing the banner when there are very few messages loaded to have
+        // any impact on the performance.
+        open_navbar_banner_and_resize(majority_messages_muted_banner(percent_muted_messages));
+    }
+}
+
 export function initialize(): void {
     const ls = localstorage();
     const browser_time_zone = timerender.browser_time_zone();
@@ -525,6 +609,8 @@ export function initialize(): void {
         demo_organizations_ui.show_convert_demo_organization_modal();
     });
 
+    // NOTE: The `window.open()` click handlers are required over here since the
+    // the buttons component framework doesn't support link buttons as of now.
     $("#navbar_alerts_wrapper").on("click", ".demo-organizations-help", () => {
         window.open("https://zulip.com/help/demo-organizations", "_blank", "noopener,noreferrer");
     });
@@ -560,6 +646,26 @@ export function initialize(): void {
     $("#navbar_alerts_wrapper").on("click", ".unsupported-browser-learn-more", () => {
         window.open("/help/supported-browsers", "_blank", "noopener,noreferrer");
     });
+
+    $("#navbar_alerts_wrapper").on("click", ".managing-muted-channels", () => {
+        window.open(
+            "/help/mute-a-channel#managing-muted-channels",
+            "_blank",
+            "noopener,noreferrer",
+        );
+    });
+
+    $("#navbar_alerts_wrapper").on(
+        "click",
+        ".dismiss-majority-messages-muted-banner",
+        function (this: HTMLElement) {
+            const $banner = $(this).closest(".banner");
+            close_navbar_banner_and_resize($banner);
+            if (localstorage.supported()) {
+                ls.set("majority_muted_messages_banner_dismissal_date", Date.now());
+            }
+        },
+    );
 
     $("#navbar_alerts_wrapper").on(
         "click",


### PR DESCRIPTION
The Combined Feed's central cache (`all_messages_data`) fetches all message history to avoid expensive recalculations. However, when a high percentage of those messages are muted, this approach becomes inefficient and impacts performance.

This PR introduces a navbar warning banner that triggers when >90% of cached messages are muted.

Fixes: #31607 

CZO discussion re:threshold: [#design > Warn when too many messages are muted #31607 / PR #37588](https://chat.zulip.org/#narrow/channel/101-design/topic/Warn.20when.20too.20many.20messages.20are.20muted.20.2331607.20.2F.20PR.20.2337588/with/2359436)

**How changes were tested:**
1. Run `./manage.py populate_db -n #` to initialize an org with roughly `#` messages.
2. Add messages to make the total number of messages to be exactly `#`.
3. Mute topics/users/channels such that that `muted messages` / `#` > 0.9.
4. Check is navbar banner was shown.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="1228" height="125" alt="Screenshot 2026-01-20 at 8 50 13 PM" src="https://github.com/user-attachments/assets/a05cc6f6-d48e-4885-921e-0a95ec1d3e93" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
