### PR TITLE
email_mirror: Add subject to body when truncated

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -44,6 +44,7 @@ from zerver.models import (
     UserProfile,
 )
 from zerver.models.clients import get_client
+from zerver.models.constants import MAX_TOPIC_NAME_LENGTH
 from zerver.models.streams import StreamTopicsPolicyEnum, get_stream_by_id_in_realm
 from zerver.models.users import get_system_bot
 from zproject.backends import is_user_active
@@ -469,6 +470,9 @@ def process_stream_message(to: str, message: EmailMessage) -> None:
         topic = _("Email with no subject")
     else:
         topic = subject
+
+    if len(subject) > MAX_TOPIC_NAME_LENGTH:
+        options["subject_in_body"] = True
 
     body = construct_zulip_body(message, subject, realm, sender=sender, **options)
     send_zulip(sender, channel, topic, body)

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -47,11 +47,13 @@ from zerver.lib.email_mirror_helpers import (
 )
 from zerver.lib.email_mirror_server import ZulipMessageHandler, send_to_postmaster
 from zerver.lib.markdown.from_html import convert_html_to_markdown
+from zerver.lib.message import truncate_topic
 from zerver.lib.send_email import FromAddress
 from zerver.lib.streams import ensure_stream
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import most_recent_message, most_recent_usermessage
 from zerver.models import Attachment, Recipient, Stream, UserProfile
+from zerver.models.constants import MAX_TOPIC_NAME_LENGTH
 from zerver.models.groups import NamedUserGroup, SystemGroups
 from zerver.models.messages import Message
 from zerver.models.realms import get_realm
@@ -1825,6 +1827,59 @@ class TestStreamEmailMessagesSubjectStripping(ZulipTestCase):
         for subject in subject_list:
             stripped = strip_from_subject(subject["original_subject"])
             self.assertEqual(stripped, subject["stripped_subject"])
+
+    def test_subject_added_for_every_message(self) -> None:
+        hamlet = self.example_user("hamlet")
+        self.login_user(hamlet)
+        stream = self.subscribe(hamlet, "Denmark")
+
+        long_subject = "S" * (MAX_TOPIC_NAME_LENGTH + 10)
+        email_body = "TestStreamEmailMessages body"
+        email_token = get_channel_email_token(stream, creator=hamlet, sender=hamlet)
+        stream_to_address = encode_email_address(stream.name, email_token)
+        stream_to_address_with_sender = encode_email_address(
+            stream.name, email_token, show_sender=True
+        )
+
+        def get_incoming_valid_message(to: str, subject: str = long_subject) -> EmailMessage:
+            message = EmailMessage()
+            message.set_content(email_body)
+            message["Subject"] = subject
+            message["From"] = self.example_email("hamlet")
+            message["To"] = to
+            message["Reply-to"] = self.example_email("othello")
+            return message
+
+        process_message(get_incoming_valid_message(stream_to_address))
+        message = most_recent_message(hamlet)
+        self.assertEqual(truncate_topic(long_subject), message.topic_name())
+        self.assertEqual(
+            f"**Subject:** {long_subject}\n\n{email_body}",
+            message.content,
+        )
+
+        process_message(get_incoming_valid_message(stream_to_address_with_sender))
+        message = most_recent_message(hamlet)
+        self.assertEqual(truncate_topic(long_subject), message.topic_name())
+        self.assertEqual(
+            f"**From:** {hamlet.delivery_email}\n**Subject:** {long_subject}\n\n{email_body}",
+            message.content,
+        )
+
+        # Two different long subjects that truncate to the same topic name
+        # should each still show their full subject in the body.
+        subject_a = "S" * MAX_TOPIC_NAME_LENGTH + "AAAA"
+        subject_b = "S" * MAX_TOPIC_NAME_LENGTH + "BBBB"
+        self.assertEqual(truncate_topic(subject_a), truncate_topic(subject_b))
+
+        for full_subject in (subject_a, subject_b):
+            process_message(get_incoming_valid_message(stream_to_address, subject=full_subject))
+            message = most_recent_message(hamlet)
+            self.assertEqual(truncate_topic(full_subject), message.topic_name())
+            self.assertEqual(
+                f"**Subject:** {full_subject}\n\n{email_body}",
+                message.content,
+            )
 
 
 # If the Content-Type header didn't specify a charset, the text content


### PR DESCRIPTION
This PR ensures that if an email subject exceeds the maximum limit (60 characters), the full subject is inserted into the message body only if more than maximum limit.

Fixes #10539

**How changes were tested:**

- [x] add test for email_mirror

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="100%" height="300" alt="email-w1" src="https://github.com/user-attachments/assets/590fd9e3-66ff-48ae-8e69-a52071cfae0b" />

<img width="100%" height="300" alt="image" src="https://github.com/user-attachments/assets/1e1a2680-3967-4057-8db3-724d3a425558" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
