### PR TITLE
notifications: Skip profile update notifications for deactivated users.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -2217,7 +2217,10 @@ def send_user_profile_update_notification(
     acting_user: UserProfile | None,
     changes: list[UserProfileChangeDict],
 ) -> None:
-    if (acting_user is not None and acting_user.id == user_profile.id) or user_profile.is_bot:
+    if not user_profile.is_active or user_profile.is_bot:
+        return
+
+    if acting_user is not None and acting_user.id == user_profile.id:
         return
 
     notification_bot = get_system_bot(settings.NOTIFICATION_BOT, user_profile.realm_id)


### PR DESCRIPTION
Fixes a regression from #36208 (for #23641) where deactivating a user account causes an exception when the system attempts to send a profile update notification to the now-deactivated user.

Reported by Alex Vandiver here: https://chat.zulip.org/#narrow/channel/9-issues/topic/Notify.20of.20changed.20accounts.20breaks.20for.20account.20disabling/with/2358752



**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
