### PR TITLE
forms: Move check for marketing emails checkbox to template.

### DIFF
--- a/templates/zerver/reset_confirm.html
+++ b/templates/zerver/reset_confirm.html
@@ -61,7 +61,8 @@
                     {% endif %}
                 </div>
 
-                {% if form.show_enable_marketing_emails %}
+                {% if corporate_enabled and form.user.realm.demo_organization_scheduled_deletion_date %}
+                {% if not form.user.enable_marketing_emails and (form.user.realm.get_first_human_user() == form.user) %}
                 <div class="input-group">
                     <label for="id_enable_marketing_emails_demo_creator" class="inline-block checkbox marketing_emails_checkbox">
                         <input id="id_enable_marketing_emails_demo_creator" type="checkbox" name="enable_marketing_emails"
@@ -70,6 +71,7 @@
                         {% trans %}Subscribe me to Zulip's low-traffic newsletter (a few emails a year).{% endtrans %}
                     </label>
                 </div>
+                {% endif %}
                 {% endif %}
 
                 <div class="input-box m-t-30">

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -483,16 +483,6 @@ class LoggingSetPasswordForm(SetPasswordForm[UserProfile]):
     )
     enable_marketing_emails = forms.BooleanField(required=False)
 
-    def __init__(self, user: UserProfile, *args: Any, **kwargs: Any) -> None:
-        super().__init__(user, *args, **kwargs)
-        self.show_enable_marketing_emails = False
-        if (
-            settings.CORPORATE_ENABLED
-            and user.realm.demo_organization_scheduled_deletion_date is not None
-            and not user.enable_marketing_emails
-        ):
-            self.show_enable_marketing_emails = user.realm.get_first_human_user() == user
-
     def clean_new_password1(self) -> str:
         new_password = self.cleaned_data["new_password1"]
         if not check_password_strength(new_password):


### PR DESCRIPTION
In Django's `PasswordResetConfirmView` class, if the link is invalid, then it is possible for the user set on the form to be `None`.

[Relevant Django code link](https://github.com/django/django/blob/9814676ea75bfe5c5d5244c50ccfe1f652a2f058/django/contrib/auth/views.py#L267-L306)

Moves the check for the demo organization creator case to the template where we know "validlink" is true via the context dict.

**Screenshots and screen captures:**

| Not demo creator | Demo creator |
| --- | --- |
| <img width="696" height="798" alt="Screenshot From 2026-01-20 21-38-29" src="https://github.com/user-attachments/assets/31cda243-6425-4405-bc2e-60a2c5754b2d" /> | <img width="696" height="897" alt="Screenshot From 2026-01-20 21-39-17" src="https://github.com/user-attachments/assets/357d802b-276e-4d5c-96d1-7b165636ee14" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
