### PR TITLE
message view: Remove legacy navbar_title span wrapper

### DIFF
--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -14,13 +14,7 @@
         display: none;
     }
 
-    /* TODO: Remove the `.navbar_title` span from the `message_view_header.hbs`
-       template. That span predates the use of flexbox, and makes it so that
-       elements like the `.narrow_description` have different line-height and
-       sizing contexts depending on whether it's a view or a narrow being shown. */
-
-    .message-header-stream-settings-button,
-    .navbar_title {
+    .message-header-stream-settings-button {
         padding: 0 2px 0 6px;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -46,7 +40,8 @@
         }
 
         @media (height < $short_navbar_cutoff_height) {
-            padding: 0 3.5px; /* based on having ~41.66% decrease */
+            padding: 0 3.5px;
+            /* based on having ~41.66% decrease */
         }
 
         .navbar-icon {
@@ -140,7 +135,7 @@
 }
 
 /* Media Queries */
-@media only screen and (width <= 620px) {
+@media only screen and (width <=620px) {
     .view-description-extended {
         padding-top: 0.5em !important;
     }

--- a/web/templates/message_view_header.hbs
+++ b/web/templates/message_view_header.hbs
@@ -1,5 +1,7 @@
 {{#if stream_settings_link}}
-<a class="message-header-stream-settings-button tippy-zulip-tooltip" data-tooltip-template-id="stream-details-tooltip-template" data-tippy-placement="bottom" href="{{stream_settings_link}}">
+<a class="message-header-stream-settings-button tippy-zulip-tooltip"
+  data-tooltip-template-id="stream-details-tooltip-template" data-tippy-placement="bottom"
+  href="{{stream_settings_link}}">
     {{> navbar_icon_and_title . }}
 </a>
 <template id="stream-details-tooltip-template">
@@ -24,16 +26,14 @@
     {{/if}}
 </span>
 {{else}}
-<span class="navbar_title">
-    {{> navbar_icon_and_title . }}
-</span>
+{{> navbar_icon_and_title . }}
 {{#if description}}
-    <span class="narrow_description rendered_markdown single-line-rendered-markdown">{{description}}
-        {{#if link}}
-        <a class="help_link_widget" href="{{link}}" target="_blank" rel="noopener noreferrer">
-            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-        </a>
-        {{/if}}
-    </span>
+<span class="narrow_description rendered_markdown single-line-rendered-markdown">{{description}}
+    {{#if link}}
+    <a class="help_link_widget" href="{{link}}" target="_blank" rel="noopener noreferrer">
+        <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+    </a>
+    {{/if}}
+</span>
 {{/if}}
 {{/if}}


### PR DESCRIPTION
The message view header still included a legacy wrapper element that predates Zulip’s use of flexbox. Keeping this extra wrapper introduced an additional sizing context, which led to inconsistent line-height and vertical alignment between stream views and narrows.

Removing the wrapper simplifies the header structure and ensures all elements participate in the same flexbox formatting context, resulting in consistent baseline alignment across view types.
