### PR TITLE
docs: clarify WSL 2 usage in recommended setup

### DIFF
--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -12,7 +12,7 @@ internet connection throughout the entire installation processes.** You can
 [configure a proxy][configure-proxy] if you need one.
 
 ## Recommended setup
- 
+
 **For first-time contributors, we recommend using the
 [Vagrant development environment][install-vagrant]** on
 macOS and Linux based OS and [WSL 2 setup][install-via-wsl] on Windows.


### PR DESCRIPTION
This change clarifies that Windows users running Ubuntu via WSL 2 can use the
WSL 2 setup directly without Vagrant, following the Linux development
environment instructions.

This aims to reduce uncertainty for first-time contributors choosing between
Vagrant and WSL-based setups.
