### PR TITLE
filter: Add navbar title for `-is:dm` search narrow.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -599,6 +599,7 @@ export class Filter {
             "is-alerted",
             "is-mentioned",
             "is-dm",
+            "not-is-dm",
             "is-starred",
             "is-unread",
             "is-resolved",
@@ -1260,6 +1261,8 @@ export class Filter {
                 }
                 case "is-dm":
                     return "/#narrow/is/dm";
+                case "not-is-dm":
+                    return "/#narrow/-is/dm";
                 case "is-starred":
                     return "/#narrow/is/starred";
                 case "is-mentioned":
@@ -1462,6 +1465,8 @@ export class Filter {
                     return $t({defaultMessage: "Mentions"});
                 case "is-dm":
                     return $t({defaultMessage: "Direct message feed"});
+                case "not-is-dm":
+                    return $t({defaultMessage: "Channel messages"});
                 case "is-resolved":
                     return $t({defaultMessage: "Resolved topics"});
                 case "is-followed":

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -2398,6 +2398,7 @@ test("navbar_helpers", ({override}) => {
     const in_all = [{operator: "in", operand: "all"}];
     const is_starred = [{operator: "is", operand: "starred"}];
     const is_dm = [{operator: "is", operand: "dm"}];
+    const not_is_dm = [{operator: "is", operand: "dm", negated: true}];
     const is_mentioned = [{operator: "is", operand: "mentioned"}];
     const is_resolved = [{operator: "is", operand: "resolved"}];
     const is_followed = [{operator: "is", operand: "followed"}];
@@ -2527,6 +2528,13 @@ test("navbar_helpers", ({override}) => {
             zulip_icon: "user",
             title: "translated: Direct message feed",
             redirect_url_with_search: "/#narrow/is/dm",
+        },
+        {
+            terms: not_is_dm,
+            is_common_narrow: true,
+            icon: undefined,
+            title: "translated: Channel messages",
+            redirect_url_with_search: "/#narrow/-is/dm",
         },
         {
             terms: is_mentioned,


### PR DESCRIPTION
In 0f19fda61007caab331d002a273a2671569a413f, not-is-dm was added in `single_term_type_returns_all_messages_of_conversation()` which in turn makes not-is-dm a common narrow. But we don't have a title defined for this narrow and so it throws an assertion error on `-is:dm` narrow.

We add a title for not-is-dm and also a redirect_url to keep it consistent with other `is_common_narrow` filters.

<!-- Describe your pull request here.-->

Fixes: [#issues > &#96;-is:dm&#96; assertion error @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.60-is.3Adm.60.20assertion.20error/near/2357629)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|**After**|
|-|
|<img width="818" height="259" alt="image" src="https://github.com/user-attachments/assets/ef044469-6e0c-40e4-bc4b-d6b296016a35" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
