### PR TITLE
message_sending: Do not show retry/cancel while message is still sending

### DIFF
--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -217,10 +217,11 @@
     <div>
         <div>{{t "Dismiss failed message" }}</div>
         <div class="italic tooltip-inner-content">
-            {{t "This content remains saved in your drafts." }}
+            {{t "If the message is not sent successfully, it will be saved as a draft." }}
         </div>
     </div>
 </template>
+
 <template id="slow-send-spinner-tooltip-template">
     <div>
         <div>{{t "Sending…" }}</div>


### PR DESCRIPTION
Fixes #29100.

This change prevents Cancel and Retry buttons from appearing while a
message is still sending (before receiving a server response), avoiding
confusing UI states.

Verified locally by sending messages while offline and confirming that
only the sending spinner is shown until an actual failure occurs.
