### PR TITLE
emails: Adjust borders in digest email to match web app styling

### DIFF
--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -32,7 +32,7 @@ table.layout {
     width: 100%;
 }
 
-table.layout > tbody > tr > td {
+table.layout>tbody>tr>td {
     font-family: sans-serif;
     font-size: 14px;
     vertical-align: top;
@@ -229,12 +229,15 @@ p.digest_paragraph,
 }
 
 .hot_convo_recipient_block {
-    border: 1px solid #000;
+    border: 1px solid #d6d6d6;
+    border-radius: 7px;
 }
 
 .hot_convo_recipient_header {
     background-color: #9ec9ff;
-    border-bottom: 1px solid #000;
+    border: 1px solid #e6e6e6;
+    border-bottom-color: #f2f2f2;
+    border-radius: 7px 7px 0 0;
     font-weight: bold;
     padding: 2px;
 }
@@ -313,6 +316,7 @@ p.digest_paragraph,
 }
 
 @media all {
+
     /* See https://templates.mailchimp.com/development/css/client-specific-styles/;
        ExternalClass is something Microsoft Outlook adds to emails. */
     .ExternalClass {


### PR DESCRIPTION
## Summary
This PR updates the digest email border styling to match the Zulip web app's modern, subtle design. The changes replace hard black borders with light gray borders and add rounded corners to both message containers and header bars.

## Changes Made

### Message Container (`.hot_convo_recipient_block`)
- Border color: `#000` → `#d6d6d6` (light gray)
- Added `border-radius: 7px` for rounded corners

### Header Bar (`.hot_convo_recipient_header`)
- Added full border: `border: 1px solid #e6e6e6` (all sides)
- Bottom border: `border-bottom-color: #f2f2f2` (lighter shade)
- Added `border-radius: 7px 7px 0 0` for rounded top corners
- Background color unchanged: `#9ec9ff` (to be addressed in #36685)

## Web App Styling Reference

The new border colors match the web app's CSS variables:
- Message list border: `--color-message-list-border` ≈ `#d6d6d6`
- Header border: `--color-message-header-contents-border` ≈ `#e6e6e6`
- Header bottom border: `--color-message-header-contents-border-bottom` ≈ `#f2f2f2`

Email clients don't support CSS variables, so hex color codes are used to approximate the web app's light mode styling.

## Testing

- CSS changes validated for email client compatibility
- Border styling matches web app's message list design
- Rounded corners applied consistently

Fixes #36687