### PR TITLE
compose: Prevent local echo and show banner for disallowed group mentions

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -6,6 +6,7 @@ import render_long_paste_options from "../templates/compose_banner/long_paste_op
 import render_stream_does_not_exist_error from "../templates/compose_banner/stream_does_not_exist_error.hbs";
 import render_topics_required_error_banner from "../templates/compose_banner/topics_required_error_banner.hbs";
 import render_unknown_zoom_user_error from "../templates/compose_banner/unknown_zoom_user_error.hbs";
+import render_user_group_mention_not_allowed_error from "../templates/compose_banner/user_group_mention_not_allowed_error.hbs";
 
 import {$t} from "./i18n.ts";
 import * as scroll_util from "./scroll_util.ts";
@@ -58,6 +59,7 @@ export const CLASSNAMES = {
     stream_does_not_exist: "stream_does_not_exist",
     missing_stream: "missing_stream",
     no_post_permissions: "no_post_permissions",
+    user_group_mention_not_allowed: "user_group_mention_not_allowed",
     cannot_send_direct_message: "cannot_send_direct_message",
     missing_private_message_recipient: "missing_private_message_recipient",
     invalid_recipient: "invalid_recipient",
@@ -244,6 +246,19 @@ export function show_stream_does_not_exist_error(stream_name: string): void {
 
     // Open stream select dropdown.
     $("#compose_select_recipient_widget").trigger("click");
+}
+
+export function show_user_group_mention_not_allowed_error(group_name: string): void {
+    // Remove any existing banners with this warning.
+    $(`#compose_banners .${CSS.escape(CLASSNAMES.user_group_mention_not_allowed)}`).remove();
+
+    const new_row_html = render_user_group_mention_not_allowed_error({
+        banner_type: ERROR,
+        classname: CLASSNAMES.user_group_mention_not_allowed,
+        group_name,
+    });
+    append_compose_banner_to_banner_list($(new_row_html), $("#compose_banners"));
+    hide_compose_spinner();
 }
 
 export function show_stream_not_subscribed_error(

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -20,6 +20,7 @@ import * as compose_state from "./compose_state.ts";
 import * as compose_ui from "./compose_ui.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
+import * as markdown from "./markdown.ts";
 import * as message_store from "./message_store.ts";
 import * as message_util from "./message_util.ts";
 import * as narrow_state from "./narrow_state.ts";
@@ -90,6 +91,9 @@ export const UPLOAD_IN_PROGRESS_ERROR_TOOLTIP_MESSAGE = $t({
 });
 export const WILDCARD_MENTION_ERROR_TOOLTIP_MESSAGE = $t({
     defaultMessage: "You do not have permission to use wildcard mentions in large streams.",
+});
+export const USER_GROUP_MENTION_ERROR_TOOLTIP_MESSAGE = $t({
+    defaultMessage: "You do not have permission to mention this group.",
 });
 export const CANNOT_CREATE_NEW_TOPIC_TOOLTIP_MESSAGE = $t({
     defaultMessage:
@@ -1238,6 +1242,19 @@ export let validate = (scheduling_message: boolean, show_banner = true): boolean
             disabled_send_tooltip_message_html = get_message_too_long_for_compose_error();
         }
         blueslip.debug("Invalid compose state: Message too long");
+        is_validating_compose_box = false;
+        return false;
+    }
+
+    const disallowed_group = markdown.get_first_disallowed_group_mention(message_content);
+    if (disallowed_group) {
+        if (show_banner) {
+            compose_banner.show_user_group_mention_not_allowed_error(disallowed_group);
+        }
+        if (is_validating_compose_box) {
+            disabled_send_tooltip_message_html = USER_GROUP_MENTION_ERROR_TOOLTIP_MESSAGE;
+        }
+        blueslip.debug("Invalid compose state: Disallowed group mention");
         is_validating_compose_box = false;
         return false;
     }

--- a/web/src/info_overlay.ts
+++ b/web/src/info_overlay.ts
@@ -208,7 +208,11 @@ export function set_up_toggler(): void {
             return 0;
         },
         get_user_group_from_name(name) {
-            return {id: 0, name};
+            return {
+                id: 0,
+                name,
+                can_mention_group: {direct_members: [current_user.user_id], direct_subgroups: []},
+            };
         },
         is_member_of_user_group() {
             return true;

--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -11,6 +11,8 @@ import type {ParseOptions, RegExpOrStub} from "../third/marked/lib/marked.cjs";
 
 import * as fenced_code from "./fenced_code.ts";
 import type {LinkifierMapValue} from "./linkifiers.ts";
+import type {GroupSettingValue} from "./state_data.ts";
+import * as user_groups from "./user_groups.ts";
 import * as util from "./util.ts";
 
 // This contains zulip's frontend Markdown implementation; see
@@ -74,7 +76,9 @@ export type MarkdownHelpers = {
     is_valid_user_id: (user_id: number) => boolean;
 
     // user groups
-    get_user_group_from_name: (name: string) => {id: number; name: string} | undefined;
+    get_user_group_from_name: (
+        name: string,
+    ) => {id: number; name: string; can_mention_group: GroupSettingValue} | undefined;
     is_member_of_user_group: (user_group_id: number, user_id: number) => boolean;
 
     // stream hashes
@@ -146,6 +150,23 @@ export function translate_emoticons_to_names({
     return translated;
 }
 
+export function get_first_disallowed_group_mention(content: string): string | null {
+    // Quick check: no @*...* syntax means no group mentions possible
+    if (!/@\*[^*]+\*/.test(content)) {
+        return null;
+    }
+
+    if (!web_app_helpers) {
+        return null;
+    }
+
+    const {disallowed_group_mentions} = parse({
+        raw_content: content,
+        helper_config: web_app_helpers,
+    });
+
+    return disallowed_group_mentions[0] ?? null;
+}
 function parse_with_options(
     raw_content: string,
     helper_config: MarkdownHelpers,
@@ -153,6 +174,7 @@ function parse_with_options(
 ): {
     content: string;
     flags: string[];
+    disallowed_group_mentions: string[];
 } {
     // Given the raw markdown content of a message (raw_content)
     // we return the HTML content (content) and flags.
@@ -164,6 +186,7 @@ function parse_with_options(
     let mentioned_group = false;
     let mentioned_stream_wildcard = false;
     let mentioned_topic_wildcard = false;
+    const disallowed_group_mentions: string[] = [];
 
     const marked_options = {
         ...options,
@@ -286,6 +309,16 @@ function parse_with_options(
         groupMentionHandler(name: string, silently: boolean): string | undefined {
             const group = helper_config.get_user_group_from_name(name);
             if (group !== undefined) {
+                if (
+                    !silently &&
+                    !user_groups.is_user_in_setting_group(
+                        group.can_mention_group,
+                        helper_config.my_user_id(),
+                    )
+                ) {
+                    disallowed_group_mentions.push(group.name);
+                }
+
                 let display_text;
                 let classes;
                 if (silently) {
@@ -358,7 +391,7 @@ function parse_with_options(
         flags.push("topic_wildcard_mentioned");
     }
 
-    return {content, flags};
+    return {content, flags, disallowed_group_mentions};
 }
 
 function is_x_between(x: number, start: number, length: number): boolean {
@@ -694,6 +727,7 @@ export function parse({
 }): {
     content: string;
     flags: string[];
+    disallowed_group_mentions: string[];
 } {
     function get_linkifier_regexes(): RE2JS[] {
         return [...helper_config.get_linkifier_map().keys()];

--- a/web/src/markdown_config.ts
+++ b/web/src/markdown_config.ts
@@ -3,6 +3,7 @@ import * as hash_util from "./hash_util.ts";
 import * as linkifiers from "./linkifiers.ts";
 import type {AbstractMap, MarkdownHelpers} from "./markdown.ts";
 import * as people from "./people.ts";
+import type {GroupSettingValue} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import type {Stream} from "./sub_store.ts";
 import * as user_groups from "./user_groups.ts";
@@ -51,7 +52,7 @@ function stream(obj: Stream | undefined): {stream_id: number; name: string} | un
 
 function user_group(
     obj: user_groups.UserGroup | undefined,
-): {id: number; name: string} | undefined {
+): {id: number; name: string; can_mention_group: GroupSettingValue} | undefined {
     if (obj === undefined) {
         return undefined;
     }
@@ -59,6 +60,7 @@ function user_group(
     return {
         id: obj.id,
         name: obj.name,
+        can_mention_group: obj.can_mention_group,
     };
 }
 

--- a/web/templates/compose_banner/user_group_mention_not_allowed_error.hbs
+++ b/web/templates/compose_banner/user_group_mention_not_allowed_error.hbs
@@ -1,0 +1,8 @@
+{{#> compose_banner . }}
+    <p class="banner_message">
+        {{#tr}}
+        You do not have permission to mention <z-highlight>@{group_name}</z-highlight>.
+        {{#*inline "z-highlight"}}<b class="highlighted-element">{{> @partial-block}}</b>{{/inline}}
+        {{/tr}}
+    </p>
+{{/compose_banner}}

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -41,7 +41,9 @@ const compose_fade = mock_esm("../src/compose_fade");
 const compose_notifications = mock_esm("../src/compose_notifications");
 const compose_pm_pill = mock_esm("../src/compose_pm_pill");
 const loading = mock_esm("../src/loading");
-const markdown = mock_esm("../src/markdown");
+const markdown = mock_esm("../src/markdown", {
+    get_first_disallowed_group_mention: () => null,
+});
 const narrow_state = mock_esm("../src/narrow_state");
 const rendered_markdown = mock_esm("../src/rendered_markdown");
 const resize = mock_esm("../src/resize");
@@ -511,6 +513,9 @@ test_ui("finish", ({override, override_rewire}) => {
     })();
 
     (function test_when_compose_validation_succeed() {
+        // Reset check to pass validation
+        override(markdown, "get_first_disallowed_group_mention", () => null);
+
         // Testing successfully sending of a message.
         fake_compose_box.show_message_preview();
         fake_compose_box.set_textarea_val("default message");

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -16,6 +16,9 @@ const blueslip = require("./lib/zblueslip.cjs");
 const $ = require("./lib/zjquery.cjs");
 
 const channel = mock_esm("../src/channel");
+const markdown = mock_esm("../src/markdown", {
+    get_first_disallowed_group_mention: () => null,
+});
 
 const compose_banner = zrequire("compose_banner");
 const compose_pm_pill = zrequire("compose_pm_pill");
@@ -336,6 +339,37 @@ test_ui("validate", ({mock_template, override}) => {
     compose_state.set_message_type("stream");
     assert.ok(!compose_validate.validate());
     assert.ok(!$("textarea#compose-textarea").prop("disabled"));
+
+    let disallowed_group_error_rendered = false;
+    mock_template("compose_banner/user_group_mention_not_allowed_error.hbs", false, (data) => {
+        assert.equal(data.classname, compose_banner.CLASSNAMES.user_group_mention_not_allowed);
+        assert.equal(data.group_name, "staff");
+        disallowed_group_error_rendered = true;
+        return "<banner-stub>";
+    });
+
+    override(markdown, "get_first_disallowed_group_mention", () => "staff");
+
+    denmark.subscribed = true;
+    denmark.can_send_message_group = everyone.id;
+    denmark.can_create_topic_group = everyone.id;
+    stream_data.add_sub_for_tests(denmark);
+
+    override(current_user, "user_id", me.user_id);
+
+    // We need to set a valid topic and non-empty content to reach the group validation
+    compose_state.topic("topic102");
+    compose_state.message_content("Hello @*staff*");
+    $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
+
+    assert.ok(!compose_validate.validate());
+    assert.ok(disallowed_group_error_rendered);
+    // The disabled Send button needs a tooltip message; otherwise
+    // hovering it logs "Compose send button incorrectly disabled."
+    assert.equal(
+        compose_validate.get_disabled_send_tooltip_html(),
+        compose_validate.USER_GROUP_MENTION_ERROR_TOOLTIP_MESSAGE,
+    );
 });
 
 test_ui("test_stream_wildcard_mention_allowed", ({override}) => {

--- a/web/tests/markdown.test.cjs
+++ b/web/tests/markdown.test.cjs
@@ -154,11 +154,14 @@ people.add_inaccessible_user(108);
 
 people.initialize_current_user(cordelia.user_id);
 
+const can_mention_group = {direct_members: [cordelia.user_id], direct_subgroups: []};
+
 const hamletcharacters = make_user_group({
     name: "hamletcharacters",
     id: 1,
     description: "Characters of Hamlet",
     members: [cordelia.user_id],
+    can_mention_group,
 });
 
 const backend = make_user_group({
@@ -166,6 +169,7 @@ const backend = make_user_group({
     id: 2,
     description: "Backend team",
     members: [],
+    can_mention_group,
 });
 
 const edgecase_group = make_user_group({
@@ -173,6 +177,7 @@ const edgecase_group = make_user_group({
     id: 3,
     description: "HTML syntax to check for Markdown edge cases.",
     members: [],
+    can_mention_group,
 });
 
 const amp_group = make_user_group({
@@ -180,6 +185,7 @@ const amp_group = make_user_group({
     id: 4,
     description: "Check ampersand escaping",
     members: [],
+    can_mention_group,
 });
 
 user_groups.add(hamletcharacters);
@@ -1088,4 +1094,88 @@ test("katex_throws_unexpected_exceptions", ({override}) => {
         name: "Error",
         message: "some-exception\nPlease report this to https://zulip.com/development-community/",
     });
+});
+
+test("get_first_disallowed_group_mention", () => {
+    const helpers = {
+        ...markdown_config.get_helpers(),
+        get_user_group_from_name(name) {
+            if (name === "allowed") {
+                // can_mention_group is group 1, which user 10 belongs to.
+                return {id: 1, name: "allowed", can_mention_group: 1};
+            }
+            if (name === "disallowed") {
+                // can_mention_group is group 3 (admins), which user 10 is not in.
+                return {id: 2, name: "disallowed", can_mention_group: 3};
+            }
+            return undefined;
+        },
+        my_user_id: () => 10,
+    };
+    markdown.initialize(helpers);
+
+    // Set up mock user_groups data
+    user_groups.init();
+
+    const allowed_group = {
+        name: "allowed",
+        id: 1,
+        description: "Allowed group",
+        members: [10],
+        can_mention_group: 1, // Self-mention allowed
+        direct_subgroup_ids: new Set(),
+    };
+    user_groups.add(allowed_group);
+
+    const disallowed_group = {
+        name: "disallowed",
+        id: 2,
+        description: "Disallowed group",
+        members: [99],
+        can_mention_group: 3, // Group 3 (admins) required
+        direct_subgroup_ids: new Set(),
+    };
+    user_groups.add(disallowed_group);
+
+    const admins_group = {
+        name: "admins",
+        id: 3,
+        description: "Admins",
+        members: [5], // User 10 is NOT in this group
+        can_mention_group: 3,
+        direct_subgroup_ids: new Set(),
+    };
+    user_groups.add(admins_group);
+
+    // User 10 is in 'allowed' group, but not in 'admins' (group 3).
+    // So mentioning 'allowed' should succeed, but 'disallowed' (requires admins) should fail.
+
+    // Test: Allowed group returns null
+    assert.equal(markdown.get_first_disallowed_group_mention("@*allowed*"), null);
+
+    // Test: Disallowed group returns the group name
+    assert.equal(markdown.get_first_disallowed_group_mention("@*disallowed*"), "disallowed");
+
+    // Test: Mixed content returns first disallowed group
+    assert.equal(
+        markdown.get_first_disallowed_group_mention("@*allowed* @*disallowed*"),
+        "disallowed",
+    );
+
+    // Test: No mentions returns null
+    assert.equal(markdown.get_first_disallowed_group_mention("hello world"), null);
+
+    // Test: Unknown groups are ignored
+    assert.equal(markdown.get_first_disallowed_group_mention("@*unknown*"), null);
+
+    // Test: Short-circuits after finding first disallowed mention
+    assert.equal(
+        markdown.get_first_disallowed_group_mention("@*disallowed* @*allowed*"),
+        "disallowed",
+    );
+
+    // Test: Uninitialized helpers returns null
+    markdown.initialize(undefined);
+    assert.equal(markdown.get_first_disallowed_group_mention("@*disallowed*"), null);
+    markdown.initialize(helpers);
 });

--- a/web/tests/markdown_parse.test.cjs
+++ b/web/tests/markdown_parse.test.cjs
@@ -48,6 +48,7 @@ function is_valid_user_id(user_id) {
 const staff_group = {
     id: 201,
     name: "Staff",
+    can_mention_group: {direct_members: [my_id], direct_subgroups: []},
 };
 
 const user_group_map = new Map([[staff_group.name, staff_group]]);


### PR DESCRIPTION
Fixes: #35304.

### Why

When a user mentions a group they don't have permission to mention, the
old behavior relied on server-side validation: the message would
local-echo and then fail, leaving a confusing "ghost message". This PR
catches the case on the client, so the send is blocked immediately and
the user is told exactly which group is restricted.

### What changed

- **`markdown.ts`**: while parsing a message we now record any
  non-silent group mention the sender lacks permission to use, exposed
  as a `disallowed_group_mentions` list on the parse result, with a
  `get_first_disallowed_group_mention` helper. The
  `get_user_group_from_name` Markdown helper now also returns
  `can_mention_group`, so the permission is evaluated without a second
  lookup into the user-groups store.
- **`compose_validate.ts`**: `validate()` now blocks sending when the
  message contains a disallowed group mention and shows an error banner
  naming the specific group. Because the send is blocked here, the
  message never local-echoes, so no separate `echo.ts` guard is needed.

### How was this tested

- [x] `./tools/test-js-with-node markdown echo compose compose_validate`
- [x] `./tools/run-tsc`
- [x] `./tools/lint` on the changed files
- [x] Manually verified: mentioning a restricted group blocks the send
      and shows the specific permission banner immediately.

### Screenshots

Previous behavior:
<img width="1580" height="362" alt="before" src="https://github.com/user-attachments/assets/bbe2c660-13d5-4add-8e36-3b90f75d7a93" />

Now the validation happens on the client, blocking the send and showing a specific permission banner:
<img width="1596" height="374" alt="after" src="https://github.com/user-attachments/assets/fa2a023f-9fc1-432c-95af-b468a383323a" />

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review.

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
