### PR TITLE
bot settings: Enable bot avatar uploads backend API (#29766)

### DIFF
--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -122,6 +122,7 @@ RoleParamType: TypeAlias = Annotated[
 
 AVATAR_CHANGES_DISABLED_ERROR = gettext_lazy("Avatar changes are disabled in this organization.")
 
+
 def check_last_owner(user_profile: UserProfile) -> bool:
     owners = set(user_profile.realm.get_human_owner_users())
     return user_profile.is_realm_owner and not user_profile.is_bot and len(owners) == 1
@@ -600,9 +601,12 @@ def patch_bot_backend(
 
     return json_success(request, data=json_result)
 
-@require_member_or_admin
+
+@require_human_non_guest_user
 @typed_endpoint
-def set_bot_avatar_backend(request: HttpRequest, user_profile: UserProfile, *, bot_id: PathOnly[int]) -> HttpResponse:
+def set_bot_avatar_backend(
+    request: HttpRequest, user_profile: UserProfile, *, bot_id: PathOnly[int]
+) -> HttpResponse:
     if len(request.FILES) != 1:
         raise JsonableError(_("You must upload exactly one avatar."))
 
@@ -629,25 +633,26 @@ def set_bot_avatar_backend(request: HttpRequest, user_profile: UserProfile, *, b
     )
     return json_success(request, data=json_result)
 
-@require_member_or_admin
+
+@require_human_non_guest_user
 @typed_endpoint
-def delete_bot_avatar_backend(request: HttpRequest, user_profile: UserProfile, *, bot_id: PathOnly[int]) -> HttpResponse:
+def delete_bot_avatar_backend(
+    request: HttpRequest, user_profile: UserProfile, *, bot_id: PathOnly[int]
+) -> HttpResponse:
     if avatar_changes_disabled(user_profile.realm) and not user_profile.is_realm_admin:
         raise JsonableError(str(AVATAR_CHANGES_DISABLED_ERROR))
 
-    bot = access_bot_by_id(user_profile,bot_id)
+    bot = access_bot_by_id(user_profile, bot_id)
 
     if bot.avatar_source == UserProfile.AVATAR_FROM_USER:
-        do_change_avatar_fields(
-            bot, UserProfile.AVATAR_FROM_GRAVATAR, acting_user=user_profile
-        )
-
+        do_change_avatar_fields(bot, UserProfile.AVATAR_FROM_GRAVATAR, acting_user=user_profile)
 
     gravatar_url = avatar_url(bot)
     json_result = dict(
         avatar_url=gravatar_url,
     )
     return json_success(request, data=json_result)
+
 
 @require_human_non_guest_user
 @typed_endpoint_without_parameters

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -253,6 +253,7 @@ from zerver.views.users import (
     deactivate_bot_backend,
     deactivate_user_backend,
     deactivate_user_own_backend,
+    delete_bot_avatar_backend,
     get_bots_backend,
     get_member_backend,
     get_members_backend,
@@ -261,10 +262,9 @@ from zerver.views.users import (
     get_subscription_backend,
     get_user_by_email,
     patch_bot_backend,
-    set_bot_avatar_backend,
-    delete_bot_avatar_backend,
     reactivate_user_backend,
     regenerate_bot_api_key,
+    set_bot_avatar_backend,
     update_user_by_email_api,
     update_user_by_id_api,
 )
@@ -372,7 +372,11 @@ v1_api_and_json_patterns = [
     rest_path("bots", GET=get_bots_backend, POST=add_bot_backend),
     rest_path("bots/<int:bot_id>/api_key/regenerate", POST=regenerate_bot_api_key),
     rest_path("bots/<int:bot_id>", PATCH=patch_bot_backend, DELETE=deactivate_bot_backend),
-    rest_path("bots/<int:bot_id>/avatar", POST=set_bot_avatar_backend, DELETE=delete_bot_avatar_backend),
+    rest_path(
+        "bots/<int:bot_id>/avatar",
+        POST=(set_bot_avatar_backend, {"intentionally_undocumented"}),
+        DELETE=(delete_bot_avatar_backend, {"intentionally_undocumented"}),
+    ),
     # invites -> zerver.views.invite
     rest_path("invites", GET=get_user_invites, POST=invite_users_backend),
     rest_path("invites/<int:invite_id>", DELETE=revoke_user_invite),


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR introduces two new backend API endpoints to support independent upload and deletion of bot avatars:
- POST /json/bots/{bot_id}/avatar
- DELETE /json/bots/{bot_id}/avatar

These dedicated endpoints are required for modernization of the "Edit Bot" UI (issue #29766) to suppo
instant avatar uploads/cropping. Repurposing the existing `patch_bot_backend` was rejected as it is 
designed for bulk updates, involves unnecessary parameter validation for this use case, and returns a
overly broad response object.

## Implementation Plan
- [x] **Backend:** Add `set_bot_avatar_backend` and `delete_bot_avatar_backend` functions.
- [x] **Routing:** Add URL endpoints in `zproject/urls.py` (`POST` and `DELETE`).
- [x] **Tests:** Add backend tests in `zerver/tests/test_users.py`.
- [ ] **Frontend:** Update the "Edit Bot" UI to use these new endpoints.

Fixes: #29766 <!-- Issue link, or clear description.-->

**How changes were tested:**
- Manual verification of these new endpoints will be performed once URL routing is configured.
- Automated tests will be added in a subsequent commit/PR

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
N/A (Backend changes only)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
