### PR TITLE
channel: Show channel privacy icon in change channel info modal.

### DIFF
--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -113,14 +113,23 @@ export function open_stream_edit_modal(stream_id: number): void {
         max_stream_name_length: realm.max_stream_name_length,
         max_stream_description_length: realm.max_stream_description_length,
     };
+    const stream_name_with_privacy_symbol_html = render_decorated_channel_name({
+        inline_with_text: true,
+        stream,
+    });
     const change_stream_info_modal = render_change_stream_info_modal(template_data);
 
     const heading = is_archived
         ? $t_html(
-              {defaultMessage: "Edit #{channel_name} (<i>archived</i>)"},
-              {channel_name: stream.name},
+              {defaultMessage: "Edit <z-link></z-link> (<i>archived</i>)"},
+              {
+                  "z-link": () => stream_name_with_privacy_symbol_html,
+              },
           )
-        : $t_html({defaultMessage: "Edit #{channel_name}"}, {channel_name: stream.name});
+        : $t_html(
+              {defaultMessage: "Edit <z-link></z-link>"},
+              {"z-link": () => stream_name_with_privacy_symbol_html},
+          );
     dialog_widget.launch({
         modal_title_html: heading,
         modal_content_html: change_stream_info_modal,


### PR DESCRIPTION
Follow-up work carried out from PR #36723

Earlier, we showed a `#` for every channel, irrespective of the channel icon. This PR updates the modal to show the corresponding channel icon in the modal heading.

Fixes a part of: [#issues > small bugs in settings/popovers?](https://chat.zulip.org/#narrow/channel/9-issues/topic/small.20bugs.20in.20settings.2Fpopovers.3F/with/2305069).
<details>
<summary>Screenshots and screen captures</summary>

### Channel privacy icon in the stream info modal.

| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/5d09eafc-45d7-45cf-9b72-aa91eae5ea94) | ![image-after](https://github.com/user-attachments/assets/b80ee0b7-9733-4070-b7a0-5d5c95790cc1)
| ![image-before](https://github.com/user-attachments/assets/617b12e3-4a01-4252-8c64-b4b5cb0bae10) | ![image-after](https://github.com/user-attachments/assets/9d4cd450-b7ef-406c-8d7d-4fdd4ac6809a)
| ![image-before](https://github.com/user-attachments/assets/b73fe8f4-5588-4074-a68e-1cedb41961a0) | ![image-after](https://github.com/user-attachments/assets/0760b59a-4549-4c1d-96c7-83500094ea58)




</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
