### PR TITLE
inbox: Hide DM unread info in header when not collapsed.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -615,14 +615,11 @@
 .inbox-container #inbox-pane .inbox-folder .unread_count {
     transition: none;
     cursor: default;
+    display: none;
 
     &:hover {
         outline: 0;
     }
-}
-
-.inbox-container #inbox-pane .inbox-folder:not(#inbox-dm-header) .unread_count {
-    display: none;
 }
 
 #inbox-pane #inbox-list .collapsible-button {
@@ -660,10 +657,7 @@
     #inbox-pane
     .inbox-folder.inbox-collapsed-state
     .unread_mention_info,
-.inbox-container
-    #inbox-pane
-    .inbox-folder.inbox-collapsed-state:not(#inbox-dm-header)
-    .unread_count {
+.inbox-container #inbox-pane .inbox-folder.inbox-collapsed-state .unread_count {
     display: inline;
 }
 


### PR DESCRIPTION
Discussed on CZO here:
https://chat.zulip.org/#narrow/channel/9-issues/topic/unread.20count.20summary.20for.20DMs.20in.20inbox.20view/near/2293833

![Kapture 2026-01-21 at 13 22 38](https://github.com/user-attachments/assets/4d15abf3-95ef-419f-8a83-02163ece1f69)
