### PR TITLE
overlays: Add lightbox support for images in overlays.

### DIFF
--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -410,22 +410,39 @@ export function initialize(): void {
         },
     );
 
-    $("body").on("click", "#message-history-overlay .message_edit_history_content", (e) => {
-        const $img = $(e.target).closest("img");
-        if ($img.length > 0) {
+    // Handle clicks on image links (anchor tags wrapping images) to prevent download
+    $("body").on(
+        "click",
+        "#message-history-overlay .message_edit_history_content a:has(img)",
+        (e) => {
             e.stopPropagation();
             e.preventDefault();
+            const $img = $(e.currentTarget).find<HTMLImageElement>("img");
+            if ($img.length > 0) {
+                overlays.close_overlay("message_edit_history");
+                lightbox.handle_inline_media_element_click($img, true);
+            }
+        },
+    );
+
+    // Handle clicks on images (for images not wrapped in anchor tags)
+    $("body").on("click", "#message-history-overlay .message_edit_history_content img", (e) => {
+        // Only handle if not already handled by the anchor handler
+        if ($(e.currentTarget).parent("a").length === 0) {
+            e.stopPropagation();
+            e.preventDefault();
+            const $img = $(e.currentTarget);
             overlays.close_overlay("message_edit_history");
             lightbox.handle_inline_media_element_click($img, true);
-            return;
         }
+    });
 
-        const $video = $(e.target).closest("video");
-        if ($video.length > 0) {
-            e.stopPropagation();
-            e.preventDefault();
-            overlays.close_overlay("message_edit_history");
-            lightbox.handle_inline_media_element_click($video, true);
-        }
+    // Handle video clicks
+    $("body").on("click", "#message-history-overlay .message_edit_history_content video", (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        const $video = $(e.currentTarget);
+        overlays.close_overlay("message_edit_history");
+        lightbox.handle_inline_media_element_click($video, true);
     });
 }

--- a/web/src/reminders_overlay_ui.ts
+++ b/web/src/reminders_overlay_ui.ts
@@ -5,6 +5,7 @@ import render_reminder_list from "../templates/reminder_list.hbs";
 import render_reminders_overlay from "../templates/reminders_overlay.hbs";
 
 import * as browser_history from "./browser_history.ts";
+import * as lightbox from "./lightbox.ts";
 import * as message_reminder from "./message_reminder.ts";
 import type {Reminder} from "./message_reminder.ts";
 import * as messages_overlay_ui from "./messages_overlay_ui.ts";
@@ -129,6 +130,30 @@ export function remove_reminder_id(reminder_id: number): void {
 }
 
 export function initialize(): void {
+    // Handle image clicks in reminder message content - using same selectors as lightbox.ts
+    $("body").on(
+        "click",
+        ".reminder-row .message-media-inline-image a, .reminder-row .message-media-preview-image:not(.message_inline_video) a, .reminder-row .message_inline_animated_image_still",
+        function (e) {
+            e.preventDefault();
+            e.stopPropagation();
+            const $img = $(this).find<HTMLImageElement>("img");
+            if ($img.length > 0) {
+                overlays.close_overlay("reminders");
+                lightbox.handle_inline_media_element_click($img, true);
+            }
+        },
+    );
+
+    // Handle video clicks in reminder message content - using same selector as lightbox.ts
+    $("body").on("click", ".reminder-row .message_inline_video", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const $video = $(e.currentTarget).find<HTMLMediaElement>("video");
+        overlays.close_overlay("reminders");
+        lightbox.handle_inline_media_element_click($video, true);
+    });
+
     $("body").on("click", ".reminder-row .delete-overlay-message", (e) => {
         const scheduled_msg_id = $(e.currentTarget)
             .closest(".reminder-row")

--- a/web/src/scheduled_messages_overlay_ui.ts
+++ b/web/src/scheduled_messages_overlay_ui.ts
@@ -173,28 +173,37 @@ export function remove_scheduled_message_id(scheduled_msg_id: number): void {
 }
 
 export function initialize(): void {
+    // Handle image clicks in scheduled message content - using same selectors as lightbox.ts
+    $("body").on(
+        "click",
+        ".scheduled-message-row .message-media-inline-image a, .scheduled-message-row .message-media-preview-image:not(.message_inline_video) a, .scheduled-message-row .message_inline_animated_image_still",
+        function (e) {
+            e.preventDefault();
+            e.stopPropagation();
+            const $img = $(this).find<HTMLImageElement>("img");
+            if ($img.length > 0) {
+                overlays.close_overlay("scheduled");
+                lightbox.handle_inline_media_element_click($img, true);
+            }
+        },
+    );
+
+    // Handle video clicks in scheduled message content - using same selector as lightbox.ts
+    $("body").on("click", ".scheduled-message-row .message_inline_video", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const $video = $(e.currentTarget).find<HTMLMediaElement>("video");
+        overlays.close_overlay("scheduled");
+        lightbox.handle_inline_media_element_click($video, true);
+    });
+
+    // Handle restore/edit scheduled message - images/videos are handled above
     $("body").on("click", ".scheduled-message-row .restore-overlay-message", (e) => {
         if (mouse_drag.is_drag(e)) {
             return;
         }
-        const $img = $(e.target).closest("img");
-        if ($img.length > 0) {
-            e.stopPropagation();
-            e.preventDefault();
-            overlays.close_overlay("scheduled");
-            lightbox.handle_inline_media_element_click($img, true);
-            return;
-        }
-
-        const $video = $(e.target).closest("video");
-        if ($video.length > 0) {
-            e.stopPropagation();
-            e.preventDefault();
-            overlays.close_overlay("scheduled");
-            lightbox.handle_inline_media_element_click($video, true);
-            return;
-        }
-
+        // Images and videos are handled by their own handlers above,
+        // so we only need to handle the restore action here.
         const scheduled_msg_id = Number.parseInt(
             $(e.currentTarget).closest(".scheduled-message-row").attr("data-scheduled-message-id")!,
             10,


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip/issues/35313

Problem
Previously, images displayed within several overlay components—specifically Message Edit History, Reminders, and Scheduled Messages—did not support the native Zulip lightbox. Instead of a fullscreen viewing experience, clicking these images would trigger default browser behaviors, such as opening the image in a new tab or initiating a download.

Solution
This PR integrates the lightbox module into these specific overlay contexts:

web/src/message_edit_history.ts: Added logic to capture click events on images within the edit history and route them to the lightbox.

web/src/reminders_overlay_ui.ts: Implemented click handlers for image attachments in the reminders overlay.

web/src/scheduled_messages_overlay_ui.ts: Enabled lightbox support for images in scheduled messages.

This ensures that users have a consistent and immersive fullscreen viewing experience for images regardless of whether they are in the main message feed or an overlay.

Fixes
Fixes the inconsistent image handling behavior in overlay-based UI components.

How changes were tested
I performed manual end-to-end testing in the development environment:

Edit History: Opened the "Edit History" for a message containing an image, clicked the image, and verified it opened in the lightbox.

Reminders: Set a reminder for a message with an image and verified the lightbox triggers correctly from the reminders overlay.

Scheduled Messages: Verified that clicking an image in a scheduled message opens the lightbox fullscreen as expected.

Navigation: Confirmed that closing the lightbox returns focus to the active overlay without dismissing the overlay itself.

https://github.com/user-attachments/assets/aceb78eb-8e0b-4588-889e-20d8dac6a2f1




