### PR TITLE
contributor docs: Improve how new guide is linked up.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -442,9 +442,9 @@ to keep in mind.
 - Submitting carefully tested code. See our [detailed guide on how to review
   code](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code)
   (yours or someone else's).
-- Following our guide for clearly [presenting visual changes][presenting-visual-changes].
 - Working to [make your pull requests easy to
-  review](https://zulip.readthedocs.io/en/latest/contributing/reviewable-prs.html).
+  review](https://zulip.readthedocs.io/en/latest/contributing/reviewable-prs.html),
+  including following our [guide on how to present visual changes][presenting-visual-changes].
 - Clearly describing what you have implemented and why. For example, if your
   implementation differs from the issue description in some way or is a partial
   step towards the requirements described in the issue, be sure to call
@@ -455,7 +455,7 @@ to keep in mind.
 - Being helpful and friendly on the [Zulip community
   server](https://zulip.com/development-community/).
 
-[presenting-visual-changes]: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.md
+[presenting-visual-changes]: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
 [great-questions]: https://zulip.readthedocs.io/en/latest/contributing/asking-great-questions.html
 
 ## Submitting a pull request


### PR DESCRIPTION
Also fix to use .html URL.

<img width="700" height="97" alt="Screenshot 2026-01-21 at 16 40 56" src="https://github.com/user-attachments/assets/3299583e-5f94-4fdb-a4e6-753d6e1c6ff9" />
