### PR TITLE
letsencrypt : Enable strict shell mode for email server restart.

### DIFF
--- a/puppet/zulip/files/letsencrypt/055-email-server.sh
+++ b/puppet/zulip/files/letsencrypt/055-email-server.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 supervisorctl restart zulip-email-server


### PR DESCRIPTION
Add strict shell options to the email server restart script.

This script is a single command wrapper with no variables or pipelines,
so enabling strict mode is unambiguous and safe.

This is a small follow up to #37463, applying the same strict mode pattern
to an additional script.

Fixes part of #20748.

**How changes were tested:**
- Ran `bash -n` and `shellcheck` on the script.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
