### PR TITLE
Typeahead: Add gradient fade at bottom when scrollable.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -274,6 +274,9 @@ export class Typeahead<ItemType extends string | object> {
     // Used for adding a custom classname to the typeahead link.
     getCustomItemClassname: ((item: ItemType) => string) | undefined;
 
+    // intersection observer to watch last item visibility
+    private lastItemObserver?: IntersectionObserver;
+
     constructor(input_element: TypeaheadInputElement, options: TypeaheadOptions<ItemType>) {
         this.input_element = input_element;
         if (this.input_element.type === "contenteditable") {
@@ -595,8 +598,49 @@ export class Typeahead<ItemType extends string | object> {
         }
         // Getting scroll element ensures simplebar has processed the element
         // before we render it.
+
         scroll_util.get_scroll_element(this.$menu);
-        scroll_util.get_content_element(this.$menu).empty().append($items);
+        const $content = scroll_util.get_content_element(this.$menu);
+        $content.empty().append($items);
+
+        // intersection observer watching the  last element to add and remove fade 
+        // overlay at the bottom depending on last list element visbility.
+
+        const lastItem = $items.at(-1)?.[0];
+        const rootElement = this.$menu[0];
+
+        if (lastItem && rootElement) {
+            this.$menu.addClass("fade-bottom");
+
+            this.lastItemObserver?.disconnect();
+
+            this.lastItemObserver = new IntersectionObserver(
+                (entries: IntersectionObserverEntry[]) => {
+                    const entry = entries[0];
+                    if (!entry) {
+                        return;
+                    }
+
+                    const lastItemBottom = entry.boundingClientRect.bottom;
+                    const containerBottom = entry.rootBounds?.bottom ?? Infinity;
+
+                    if (lastItemBottom <= containerBottom + 1) {
+                        this.$menu.removeClass("fade-bottom");
+                    } else {
+                        if (!this.$menu.hasClass("fade-bottom")) {
+                            this.$menu.addClass("fade-bottom");
+                        }
+                    }
+                },
+                {
+                    root: rootElement,
+                    threshold: Array.from({length: 101}, (_, i) => i / 100),
+                },
+            );
+
+            this.lastItemObserver.observe(lastItem);
+        }
+
         return this;
     }
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2342,6 +2342,12 @@
         var(--grey-400)
     );
 
+    /* bottom fade gradients for typeahead dropdowns */
+    --color-dropdown-bottom-gradient: light-dark(
+        hsl(0deg 0% 100%),
+        hsl(0deg 0% 0% / 35%)
+    );
+
     /* Shared button CSS variables */
     --color-outline-button-focus: light-dark(
         hsl(0deg 0% 0%),

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -145,6 +145,7 @@
         margin: 4px 0;
         max-height: min(248px, 95vh);
         overflow-y: auto;
+        margin-bottom: 0;
     }
 
     .typeahead-footer {
@@ -174,6 +175,27 @@
             margin-right: 3px;
         }
     }
+}
+
+.typeahead-menu.fade-bottom {
+    position: relative;
+}
+
+.typeahead-menu.fade-bottom::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 20px;
+    pointer-events: none;
+    border-radius: 5px;
+    background: linear-gradient(
+        to bottom,
+        transparent,
+        var(--color-dropdown-bottom-gradient)
+    );
+    z-index: 10;
 }
 
 .typeahead-option-label-container {


### PR DESCRIPTION
Fixes: <!-- Issue link, or clear description.-->
https://github.com/zulip/zulip/issues/34478

- This PR adds a gradient at the bottom of typeaheads to signal that scroll is possible.
- The gradient appears and disappears based on the visibility of the last list element.
- Intersection observer is added to achieve the effect based on the feedback given in the previous PR at https://github.com/zulip/zulip/pull/35992

**How changes were tested:**
**Manual testing:** 

- The shadow disappears correctly when at the bottom of the elements.
- The gradient reappears when the typeahead is scrollable.

| Before     | After    |
|-------------|--------------|
| <img width="1422" height="178" alt="image" src="https://github.com/user-attachments/assets/ae0a7e47-683e-4e55-860f-fabf9268834c" />  | <img width="667" height="120" alt="image" src="https://github.com/user-attachments/assets/647214d5-e5d5-4fda-8a6a-73ed35c66bd6" /> |
| <img width="1046" height="236" alt="image" src="https://github.com/user-attachments/assets/94f36948-606e-4133-9b9c-45a838d635b2" />  | <img width="769" height="329" alt="image" src="https://github.com/user-attachments/assets/7cd0640a-1e8f-49e4-b83d-1c06154370af" />  |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ x] Visual appearance of the changes.
- [ x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
