### PR TITLE
Typeahead: Add gradient fade at bottom when scrollable.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2488,6 +2488,13 @@
         var(--grey-400)
     );
 
+    /* bottom fade mask for typeahead dropdowns */
+    --mask-dropdown-bottom-fade: linear-gradient(
+        to bottom,
+        hsl(0deg 0% 0%) calc(100% - 20px),
+        transparent 100%
+    );
+
     /* Shared button CSS variables */
     --color-outline-button-focus: light-dark(
         hsl(0deg 0% 0%),

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -145,6 +145,11 @@
         margin: 4px 0;
         max-height: min(248px, 95vh);
         overflow-y: auto;
+        margin-bottom: 0;
+
+        /* Mask image to fade out the bottom of the menu when it is scrollable. */
+        padding-bottom: 10px;
+        mask-image: var(--mask-dropdown-bottom-fade);
     }
 
     .typeahead-footer {


### PR DESCRIPTION
Fixes: #34478

- This PR adds a gradient at the bottom of typeaheads to signal that scroll is possible.
- The gradient appears and disappears based on the visibility of the last list element.
- This implementation uses a pure CSS mask-image approach instead of an intersection observer and scroll listener to make it lighter. 



**How changes were tested:**
**Manual testing:** 

- The shadow disappears correctly when at the bottom of the elements.
- The gradient reappears when the typeahead is scrollable.

| Before     | After    |
|-------------|--------------|
| <img width="1046" height="178" alt="image" src="https://github.com/user-attachments/assets/ae0a7e47-683e-4e55-860f-fabf9268834c" />  | <img width="452" height="71" alt="image" src="https://github.com/user-attachments/assets/c5b69afe-4d19-4925-ac33-f454e9adb618" />|
| <img width="1046" height="336" alt="image" src="https://github.com/user-attachments/assets/94f36948-606e-4133-9b9c-45a838d635b2" />  | <img width="731" height="101" alt="image" src="https://github.com/user-attachments/assets/2b7efa3e-9949-45cd-aca4-e8d75d9c1d72" /> |
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>