### PR TITLE
settings: Default `PUSH_REGISTRATION_ENCRYPTION_KEYS` to empty dict.

### DIFF
--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -587,7 +587,6 @@ def do_register_remote_push_device(
 ) -> int:
     assert (realm is None) ^ (remote_realm is None)
 
-    assert settings.PUSH_REGISTRATION_ENCRYPTION_KEYS
     if bouncer_public_key not in settings.PUSH_REGISTRATION_ENCRYPTION_KEYS:
         raise InvalidBouncerPublicKeyError
 

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -101,7 +101,7 @@ ZULIP_ORG_KEY = get_secret("zulip_org_key")
 ZULIP_ORG_ID = get_secret("zulip_org_id")
 
 raw_keys: str | None = get_secret("push_registration_encryption_keys")
-PUSH_REGISTRATION_ENCRYPTION_KEYS: dict[str, str] | None = None
+PUSH_REGISTRATION_ENCRYPTION_KEYS: dict[str, str] = {}
 if raw_keys is not None:
     PUSH_REGISTRATION_ENCRYPTION_KEYS = json.loads(raw_keys)
 


### PR DESCRIPTION
When `PUSH_REGISTRATION_ENCRYPTION_KEYS` is not set on bouncer, it's cleaner for bouncer to return `InvalidBouncerPublicKeyError` to clients attempting to register push device instead of 500 error.

Afterall bouncer hasn't advertised any public key for clients yet.

This PR makes changes to implement the abovesaid behavior.



**How changes were tested:**

We already have test for `InvalidBouncerPublicKeyError`. And I think it's not worth adding a test for the case when this is not configured on bouncer b/c once set in the coming weeks the default value (empty dict) won't get ever used.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
