### PR TITLE
people: Rename `is_active_user_for_popover` helper.

### DIFF
--- a/web/src/buddy_list_presence.ts
+++ b/web/src/buddy_list_presence.ts
@@ -7,7 +7,7 @@ import * as people from "./people.ts";
 export function update_indicators(): void {
     $("[data-presence-indicator-user-id]").each(function () {
         const user_id = Number.parseInt($(this).attr("data-presence-indicator-user-id") ?? "", 10);
-        const is_deactivated = !people.is_active_user_for_popover(user_id || 0);
+        const is_deactivated = !people.is_active_user_or_system_bot(user_id || 0);
         assert(!Number.isNaN(user_id));
         const user_circle_class = buddy_data.get_user_circle_class(user_id, is_deactivated);
         const user_circle_class_with_icon = `${user_circle_class} zulip-icon-${user_circle_class}`;

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -482,7 +482,7 @@ function format_dm(
     let is_bot = false;
     if (recipient_ids.length === 1 && recipient_ids[0] !== undefined) {
         const user_id = recipient_ids[0];
-        const is_deactivated = !people.is_active_user_for_popover(user_id);
+        const is_deactivated = !people.is_active_user_or_system_bot(user_id);
         is_bot = people.get_by_user_id(user_id).is_bot;
         user_circle_class = is_bot
             ? false

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -892,7 +892,7 @@ export function sender_is_guest(message: Message): boolean {
 export function sender_is_deactivated(message: Message): boolean {
     const sender_id = message.sender_id;
     if (sender_id) {
-        return !is_active_user_for_popover(message.sender_id);
+        return !is_active_user_or_system_bot(message.sender_id);
     }
     return false;
 }
@@ -1109,7 +1109,7 @@ export function is_valid_bulk_user_ids_for_compose(user_ids: number[]): boolean 
     });
 }
 
-export function is_active_user_for_popover(user_id: number): boolean {
+export function is_active_user_or_system_bot(user_id: number): boolean {
     // For popover menus, we include cross-realm bots as active
     // users.
 

--- a/web/src/pm_list_data.ts
+++ b/web/src/pm_list_data.ts
@@ -84,7 +84,7 @@ export function get_conversations(search_string = ""): DisplayObject[] {
         const is_group = user_ids_string.includes(",");
         const is_active = user_ids_string === active_user_ids_string;
         const includes_deactivated_user = user_ids.some(
-            (id) => !people.is_active_user_for_popover(id),
+            (id) => !people.is_active_user_or_system_bot(id),
         );
 
         let user_circle_class: string | undefined;

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -338,7 +338,7 @@ export function get_personal_menu_content_context(): PersonalMenuContext {
 
         // user information
         user_avatar: current_user.avatar_url_medium,
-        is_active: people.is_active_user_for_popover(my_user_id),
+        is_active: people.is_active_user_or_system_bot(my_user_id),
         user_circle_class: buddy_data.get_user_circle_class(my_user_id),
         user_last_seen_time_status: buddy_data.user_last_seen_time_status(my_user_id),
         user_full_name: current_user.full_name,

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -735,7 +735,7 @@ function format_conversation(conversation_data: ConversationData): ConversationC
         let user_circle_class;
         if (!is_group) {
             const user_id = Number.parseInt(last_msg.to_user_ids, 10);
-            const is_deactivated = !people.is_active_user_for_popover(user_id);
+            const is_deactivated = !people.is_active_user_or_system_bot(user_id);
             const user = people.get_by_user_id(user_id);
             if (user.is_bot) {
                 // We display the bot icon rather than a user circle for bots.

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -243,7 +243,7 @@ export let fetch_presence_for_popover = (user_id: number): void => {
         return;
     }
 
-    if (!people.is_active_user_for_popover(user_id) || people.get_by_user_id(user_id).is_bot) {
+    if (!people.is_active_user_or_system_bot(user_id) || people.get_by_user_id(user_id).is_bot) {
         return;
     }
 
@@ -311,7 +311,7 @@ function get_user_card_popover_data(
         invisible_mode = !user_settings.presence_enabled;
     }
 
-    const is_active = people.is_active_user_for_popover(user.user_id);
+    const is_active = people.is_active_user_or_system_bot(user.user_id);
     const is_system_bot = user.is_system_bot;
     const status_text = user_status.get_status_text(user.user_id);
     const status_emoji_info = user_status.get_status_emoji(user.user_id);
@@ -846,7 +846,7 @@ function register_click_handlers(): void {
         }
         const user_id = elem_to_user_id($(this).parents("ul"));
         const name = people.get_by_user_id(user_id).full_name;
-        const is_active = people.is_active_user_for_popover(user_id);
+        const is_active = people.is_active_user_or_system_bot(user_id);
         const mention = people.get_mention_syntax(name, user_id, !is_active);
         compose_ui.insert_syntax_and_focus(mention);
         message_user_card.hide();

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -107,7 +107,7 @@ export function toggle_user_group_info_popover(
                     group.is_system_group &&
                     all_individual_members.some((member_id) => {
                         const member = people.get_user_by_id_assert_valid(member_id);
-                        return people.is_active_user_for_popover(member.user_id) && member.is_bot;
+                        return people.is_active_user_or_system_bot(member.user_id) && member.is_bot;
                     });
                 const displayed_subgroups = subgroups.slice(0, MAX_ROWS_IN_POPOVER);
                 const displayed_members =
@@ -211,7 +211,7 @@ function fetch_group_members(member_ids: number[]): PopoverGroupMember[] {
             // Inaccessible or unknown users should not appear in displayed_members.
             .filter(
                 (m: User) =>
-                    people.is_active_user_for_popover(m.user_id) && !m.is_inaccessible_user,
+                    people.is_active_user_or_system_bot(m.user_id) && !m.is_inaccessible_user,
             )
             .map((p: User) => ({
                 ...p,

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -999,7 +999,7 @@ run_test("realm_user", ({override}) => {
     // manipulation
     assert.deepEqual(added_person, event.person);
 
-    assert.ok(people.is_active_user_for_popover(event.person.user_id));
+    assert.ok(people.is_active_user_or_system_bot(event.person.user_id));
 
     event = event_fixtures.realm_user__update;
     const stub = make_stub();

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -362,7 +362,7 @@ run_test("basics", ({override}) => {
 
     const active_user_ids = people.get_active_user_ids().toSorted();
     assert.deepEqual(active_user_ids, [me.user_id, isaac.user_id]);
-    assert.equal(people.is_active_user_for_popover(isaac.user_id), true);
+    assert.equal(people.is_active_user_or_system_bot(isaac.user_id), true);
     assert.ok(people.is_valid_email_for_compose(isaac.email));
     assert.ok(people.is_valid_user_id_for_compose(isaac.user_id));
 
@@ -374,12 +374,12 @@ run_test("basics", ({override}) => {
     assert.equal(people.get_non_active_human_ids().length, 1);
     assert.equal(people.get_non_active_user_ids_count([isaac.user_id]), 1);
     assert.equal(people.get_active_human_count(), 1);
-    assert.equal(people.is_active_user_for_popover(isaac.user_id), false);
+    assert.equal(people.is_active_user_or_system_bot(isaac.user_id), false);
     assert.equal(people.is_valid_email_for_compose(isaac.email), true);
     assert.equal(people.is_valid_user_id_for_compose(isaac.user_id), true);
 
     people.add_active_user(bot_botson);
-    assert.equal(people.is_active_user_for_popover(bot_botson.user_id), true);
+    assert.equal(people.is_active_user_or_system_bot(bot_botson.user_id), true);
     bot_user_ids = people.get_bot_ids();
     assert.deepEqual(bot_user_ids, [bot_botson.user_id]);
 
@@ -427,10 +427,10 @@ run_test("basics", ({override}) => {
 
     // Invalid user ID returns true and warns.
     blueslip.expect("warn", "Unexpectedly invalid user_id in user popover query");
-    assert.equal(people.is_active_user_for_popover(123412), true);
+    assert.equal(people.is_active_user_or_system_bot(123412), true);
 
     unknown_user.is_inaccessible_user = true;
-    assert.equal(people.is_active_user_for_popover(unknown_user.user_id), true);
+    assert.equal(people.is_active_user_or_system_bot(unknown_user.user_id), true);
     unknown_user.is_inaccessible_user = false;
 
     // We can still get their info for non-realm needs.
@@ -1449,7 +1449,7 @@ run_test("initialize", () => {
 
     people.initialize(current_user.user_id, params, user_group_params);
 
-    assert.equal(people.is_active_user_for_popover(17), true);
+    assert.equal(people.is_active_user_or_system_bot(17), true);
     assert.ok(people.is_cross_realm_email("bot@example.com"));
     assert.ok(people.is_valid_email_for_compose("bot@example.com"));
     assert.ok(people.is_valid_user_id_for_compose(test_bot.user_id));


### PR DESCRIPTION
Follow up to #35563.

According to [Tim's comment](https://github.com/zulip/zulip/pull/35563#discussion_r2500783155), we are renaming `is_active_user_for_popover` helper to `is_active_user_or_system_bot` to better reflect its purpose as we are no longer using that helper function only for popover.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
