### PR TITLE
gifs: Prevent stale network calls beacuse of debouncing.

### DIFF
--- a/web/src/gif_picker_ui.ts
+++ b/web/src/gif_picker_ui.ts
@@ -148,6 +148,11 @@ function render_featured_gifs(next_page: boolean): void {
 }
 
 function update_grid_with_search_term(search_term: string, next_page = false): void {
+    // The debounced version may call this after the picker is closed
+    // and the cleanup is done, so we add this guard.
+    if (popover_instance === undefined) {
+        return;
+    }
     if (
         network.is_loading_more_gifs() ||
         (search_term.trim() === current_search_term && !next_page)


### PR DESCRIPTION
In some cases, the debounced version of
update_grid_with_search_term called it after the picker was closed and the network wass "abandoned", which raised an assertion error in the following `ask_for_.*` calls.

Reproducer on `main`:
- Bump up the debounce timeout in:
```ts
                const debounced_search = _.debounce((search_term: string) => {
                    update_grid_with_search_term(search_term);
                }, 300);
```
- Open the GIF picker
- Enter text in the input, and then clear it. 
- Quickly close the picker.

Fixes: 
<img width="1047" height="1602" alt="image" src="https://github.com/user-attachments/assets/809978a7-9f82-4a5c-89b2-77033f3c79db" />


We add a guard check to prevent that from happening.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
