### PR TITLE
Adjust some rate limiting rules in development, and improve rate limit error pages

### DIFF
--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -42,7 +42,7 @@ from zerver.lib.exceptions import (
     RemoteBillingAuthenticationError,
     RemoteRealmServerMismatchError,
 )
-from zerver.lib.rate_limiter import rate_limit_request_by_ip
+from zerver.lib.rate_limiter import rate_limit_request_by_ip, readable_expiry_string_for_html
 from zerver.lib.remote_server import RealmDataForAnalytics, UserDataForRemoteBilling
 from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress, send_email
@@ -843,10 +843,11 @@ def check_rate_limits(
         # Our generic error response is good enough here, since this is
         # about the user's IP address, not their entire server.
         assert e.secs_to_freedom is not None
+        retry_after_string = readable_expiry_string_for_html(int(e.secs_to_freedom))
         return render(
             request,
             "zerver/portico_error_pages/rate_limit_exceeded.html",
-            context={"retry_after": int(e.secs_to_freedom)},
+            context={"retry_after_string": retry_after_string},
             status=429,
         )
 
@@ -857,10 +858,11 @@ def check_rate_limits(
         # that was exceeded, so we need to show an error page explaining
         # that specific situation.
         assert e.secs_to_freedom is not None
+        retry_after_string = readable_expiry_string_for_html(int(e.secs_to_freedom))
         return render(
             request,
             "corporate/billing/remote_server_rate_limit_exceeded.html",
-            context={"retry_after": int(e.secs_to_freedom)},
+            context={"retry_after_string": retry_after_string},
             status=429,
         )
 

--- a/templates/corporate/billing/remote_server_rate_limit_exceeded.html
+++ b/templates/corporate/billing/remote_server_rate_limit_exceeded.html
@@ -12,7 +12,7 @@
         <p>
             {% trans %}Your server has exceeded the limit for how
             often this action can be performed.{% endtrans %}
-            {% trans %}You can try again in {{retry_after}} seconds.{% endtrans %}
+            {% trans %}You can try again in {{retry_after_string}}.{% endtrans %}
         </p>
     </div>
 </div>

--- a/templates/zerver/portico_error_pages/rate_limit_exceeded.html
+++ b/templates/zerver/portico_error_pages/rate_limit_exceeded.html
@@ -12,7 +12,7 @@
         <p>
             {% trans %}You have exceeded the limit for how
             often a user can perform this action.{% endtrans %}
-            {% trans %}You can try again in {{retry_after}} seconds.{% endtrans %}
+            {% trans %}You can try again in {{retry_after_string}}.{% endtrans %}
         </p>
     </div>
 </div>

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -33,7 +33,12 @@ from zerver.lib.email_validation import (
 from zerver.lib.exceptions import JsonableError, RateLimitedError
 from zerver.lib.i18n import get_language_list
 from zerver.lib.name_restrictions import is_reserved_subdomain
-from zerver.lib.rate_limiter import RateLimitedObject, rate_limit_request_by_ip, should_rate_limit
+from zerver.lib.rate_limiter import (
+    RateLimitedObject,
+    rate_limit_request_by_ip,
+    readable_expiry_string_for_plaintext,
+    should_rate_limit,
+)
 from zerver.lib.subdomains import get_subdomain, is_root_domain_available
 from zerver.lib.users import check_full_name
 from zerver.models import PreregistrationRealm, Realm, UserProfile
@@ -627,12 +632,13 @@ class OurAuthenticationForm(AuthenticationForm):
             except RateLimitedError as e:
                 assert e.secs_to_freedom is not None
                 secs_to_freedom = int(e.secs_to_freedom)
+                retry_after_string = readable_expiry_string_for_plaintext(secs_to_freedom)
                 error_message = _(
                     "You're making too many attempts to sign in."
-                    " Try again in {seconds} seconds or contact your organization administrator"
+                    " Try again in {retry_after_string} or contact your organization administrator"
                     " for help."
                 )
-                raise ValidationError(error_message.format(seconds=secs_to_freedom))
+                raise ValidationError(error_message.format(retry_after_string=retry_after_string))
 
             if return_data.get("inactive_realm"):
                 raise AssertionError("Programming error: inactive realm in authentication form")

--- a/zerver/tests/test_rate_limiter.py
+++ b/zerver/tests/test_rate_limiter.py
@@ -12,6 +12,8 @@ from zerver.lib.rate_limiter import (
     RateLimiterBackend,
     RedisRateLimiterBackend,
     TornadoInMemoryRateLimiterBackend,
+    readable_expiry_string_for_html,
+    readable_expiry_string_for_plaintext,
 )
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import ratelimit_rule
@@ -339,6 +341,24 @@ class RateLimitedObjectsTest(ZulipTestCase):
                 "2001:0db8:13::8a2e:045f", domain=domain, ipv6_network_prefix=48
             ).key(),
         )
+
+
+class RateLimiterStringFormattingTest(ZulipTestCase):
+    def test_formatting_for_html(self) -> None:
+        self.assertEqual(readable_expiry_string_for_html(60), "60\xa0seconds")
+        self.assertEqual(readable_expiry_string_for_html(61), "1\xa0minute")
+        self.assertEqual(readable_expiry_string_for_html(90), "1\xa0minute")
+        self.assertEqual(readable_expiry_string_for_html(121), "2\xa0minutes")
+        self.assertEqual(readable_expiry_string_for_html(86400), "23\xa0hours, 59\xa0minutes")
+        self.assertEqual(readable_expiry_string_for_html(90000), "1\xa0day")
+
+    def test_formatting_for_plaintext(self) -> None:
+        self.assertEqual(readable_expiry_string_for_plaintext(60), "60 seconds")
+        self.assertEqual(readable_expiry_string_for_plaintext(61), "1 minute")
+        self.assertEqual(readable_expiry_string_for_plaintext(90), "1 minute")
+        self.assertEqual(readable_expiry_string_for_plaintext(121), "2 minutes")
+        self.assertEqual(readable_expiry_string_for_plaintext(86400), "23 hours, 59 minutes")
+        self.assertEqual(readable_expiry_string_for_plaintext(90000), "1 day")
 
 
 # Don't load the base class as a test: https://bugs.python.org/issue17519.

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -79,7 +79,7 @@ from zerver.lib.i18n import (
 )
 from zerver.lib.pysa import mark_sanitized
 from zerver.lib.queue import queue_json_publish_rollback_unsafe
-from zerver.lib.rate_limiter import rate_limit_request_by_ip
+from zerver.lib.rate_limiter import rate_limit_request_by_ip, readable_expiry_string_for_html
 from zerver.lib.response import json_success
 from zerver.lib.send_email import EmailNotDeliveredError, FromAddress, send_email
 from zerver.lib.sessions import get_expirable_session_var
@@ -1343,10 +1343,11 @@ def create_realm(request: HttpRequest, confirmation_key: str | None = None) -> H
                 rate_limit_request_by_ip(request, domain="sends_email_by_ip")
             except RateLimitedError as e:
                 assert e.secs_to_freedom is not None
+                retry_after_string = readable_expiry_string_for_html(int(e.secs_to_freedom))
                 return TemplateResponse(
                     request,
                     "zerver/portico_error_pages/rate_limit_exceeded.html",
-                    context={"retry_after": int(e.secs_to_freedom)},
+                    context={"retry_after_string": retry_after_string},
                     status=429,
                 )
 
@@ -1531,10 +1532,11 @@ def create_demo_organization(
                 rate_limit_request_by_ip(request, domain="demo_realm_creation_by_ip")
             except RateLimitedError as e:
                 assert e.secs_to_freedom is not None
+                retry_after_string = readable_expiry_string_for_html(int(e.secs_to_freedom))
                 return TemplateResponse(
                     request,
                     "zerver/portico_error_pages/rate_limit_exceeded.html",
-                    context={"retry_after": int(e.secs_to_freedom)},
+                    context={"retry_after_string": retry_after_string},
                     status=429,
                 )
 
@@ -1687,10 +1689,11 @@ def accounts_home(
                 rate_limit_request_by_ip(request, domain="sends_email_by_ip")
             except RateLimitedError as e:
                 assert e.secs_to_freedom is not None
+                retry_after_string = readable_expiry_string_for_html(int(e.secs_to_freedom))
                 return render(
                     request,
                     "zerver/portico_error_pages/rate_limit_exceeded.html",
-                    context={"retry_after": int(e.secs_to_freedom)},
+                    context={"retry_after_string": retry_after_string},
                     status=429,
                 )
 
@@ -1772,10 +1775,11 @@ def find_account(request: HttpRequest) -> HttpResponse:
                     rate_limit_request_by_ip(request, domain="sends_email_by_ip")
                 except RateLimitedError as e:
                     assert e.secs_to_freedom is not None
+                    retry_after_string = readable_expiry_string_for_html(int(e.secs_to_freedom))
                     return render(
                         request,
                         "zerver/portico_error_pages/rate_limit_exceeded.html",
-                        context={"retry_after": int(e.secs_to_freedom)},
+                        context={"retry_after_string": retry_after_string},
                         status=429,
                     )
 

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -50,7 +50,11 @@ from zerver.lib.exceptions import (
     UserDeactivatedError,
 )
 from zerver.lib.i18n import get_available_language_codes
-from zerver.lib.rate_limiter import RateLimitedUser, should_rate_limit
+from zerver.lib.rate_limiter import (
+    RateLimitedUser,
+    readable_expiry_string_for_plaintext,
+    should_rate_limit,
+)
 from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress, send_email
 from zerver.lib.sounds import get_available_notification_sounds
@@ -481,9 +485,10 @@ def json_change_settings(
         except RateLimitedError as e:
             assert e.secs_to_freedom is not None
             secs_to_freedom = int(e.secs_to_freedom)
+            retry_after_string = readable_expiry_string_for_plaintext(secs_to_freedom)
             raise JsonableError(
-                _("You're making too many attempts! Try again in {seconds} seconds.").format(
-                    seconds=secs_to_freedom
+                _("You're making too many attempts! Try again in {retry_after_string}.").format(
+                    retry_after_string=retry_after_string
                 ),
             )
 

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -241,9 +241,9 @@ RATE_LIMITING_RULES = {
     "sends_email_by_ip": [
         # This rule puts a limit on actions such as new organization creation,
         # which we sometimes need to test repeatedly in development.
-        (86400, 20),
+        (86400, 1000),
     ],
     "demo_realm_creation_by_ip": [
-        (86400, 20),
+        (86400, 1000),
     ],
 }


### PR DESCRIPTION
[#issues > rate limit for creating new orgs @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/rate.20limit.20for.20creating.20new.20orgs/near/2174657)

Error page with new, more reasonable string instead of "in 86400 seconds":
<img width="613" height="604" alt="Screenshot From 2026-01-22 20-59-19" src="https://github.com/user-attachments/assets/19701b5b-8880-4f0f-bc80-c429a754a3f6" />
