### PR TITLE
Fix visual jitter in subscription list

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1886,7 +1886,7 @@ label.preferences-radio-choice-label {
     opacity: var(--opacity-readonly-modal-input);
 }
 
-@media (width < $lg_min) {
+@media (width < 768px) {
     .settings-email-column {
         display: none;
     }
@@ -1915,7 +1915,7 @@ label.preferences-radio-choice-label {
 
 /* We should eventually consolidate some of these styles with the styles
    in subscriptions.css, using shared classnames. */
-@container settings-overlay (width < $settings_overlay_sidebar_collapse_breakpoint) {
+@container settings-overlay (width < 600px) {
     .profile-settings-form {
         .user-avatar-section {
             flex: 100%;
@@ -2005,7 +2005,7 @@ label.preferences-radio-choice-label {
     }
 }
 
-@container (width > $settings_overlay_sidebar_collapse_breakpoint) {
+@container (width > 600px) {
     #attachments-settings .upload-file-name {
         min-width: 10em;
     }
@@ -2038,7 +2038,7 @@ label.preferences-radio-choice-label {
     }
 }
 
-@media (width < $sm_min) {
+@media (width < 768px) {
     #admin-user-list,
     #admin-bot-list {
         .user_row,
@@ -2104,7 +2104,7 @@ label.preferences-radio-choice-label {
     }
 }
 
-@media (width < $ml_min) {
+@media (width < 600px) {
     #api_key_buttons,
     #download_zuliprc {
         flex-direction: column;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -284,7 +284,7 @@ h4.user_group_setting_subsection_title {
         max-width: 160px;
     }
 
-    @media (max-width: $ms_min) {
+    @media (width <= 600px) {
         float: none;
         display: flex;
         justify-content: flex-start;
@@ -786,14 +786,18 @@ h4.user_group_setting_subsection_title {
     align-items: center;
 
     .check {
-        width: 1.5625em; /* 25px at 16px font size */
-        height: 1.5625em; /* 25px at 16px font size */
-        margin-right: 0.75em; /* 12px at 16px font size */
+        /* UPDATED: Fixed width of 28px to prevent visual jitter */
+        width: 28px;
+        height: 1.5625em; /* Keep height consistent */
+        margin-right: 0.75em;
         background-size: 60% auto;
         background-repeat: no-repeat;
         background-position: center center;
-        display: flex;
-        justify-content: center;
+
+        /* UPDATED: Use inline-block/text-align per your fix */
+        display: inline-block;
+        text-align: center;
+        flex-shrink: 0;
 
         & .sub-unsub-icon {
             display: flex;
@@ -1042,7 +1046,7 @@ h4.user_group_setting_subsection_title {
             border-top: 1px solid var(--color-border-modal-bar);
         }
 
-        @container settings-overlay (width > $settings_overlay_sidebar_collapse_breakpoint) {
+        @container settings-overlay (width > 600px) {
             .settings-sticky-footer {
                 border-radius: 0 0 6px;
             }
@@ -1434,7 +1438,7 @@ h4.user_group_setting_subsection_title {
     }
 }
 
-@media (width < $lg_min) {
+@media (width <= 1200px) {
     .two-pane-settings-container {
         max-width: 95%;
     }
@@ -1442,7 +1446,7 @@ h4.user_group_setting_subsection_title {
 
 /* This ensures the left-border is tall enough. We can't keep this style for
     narrow screens because `right` is absolutely positioned on narrow screens. */
-@container settings-overlay (width >= $settings_overlay_sidebar_collapse_breakpoint) {
+@container settings-overlay (width >= 900px) {
     .two-pane-settings-container .right {
         height: 100%;
     }
@@ -1450,7 +1454,7 @@ h4.user_group_setting_subsection_title {
 
 /* We should eventually consolidate some of these styles with the styles
    in settings.css, using shared classnames. */
-@container settings-overlay (width < $settings_overlay_sidebar_collapse_breakpoint) {
+@container settings-overlay (width < 900px) {
     .two-pane-settings-container {
         position: relative;
         overflow: hidden;
@@ -1492,7 +1496,7 @@ h4.user_group_setting_subsection_title {
     }
 }
 
-@media (width < $sm_min) {
+@media (width <= 600px) {
     #groups_overlay .user_group_settings_wrapper,
     #subscription_overlay .subscription_settings {
         .button-group {
@@ -1587,7 +1591,7 @@ h4.user_group_setting_subsection_title {
     }
 }
 
-@media (width < $lg_min) {
+@media (width <= 1200px) {
     #stream_members_list,
     #user_group_settings .member-list,
     #stream_creation_form .subscriber-list,


### PR DESCRIPTION
**Description**
This PR fixes a visual issue in the "Manage channels" list where the channel name text would shift horizontally ("jitter") when subscribing or unsubscribing.

The issue was caused by the container for the toggle button changing width depending on whether the "Plus" (+) or "Check" (✓) icon was displayed.

**Changes**
*   Updated `web/styles/subscriptions.css`.
*   Applied a fixed width (`28px`), `display: inline-block`, and `text-align: center` to the `.sub_unsub_button` class.
*   This forces the button container to maintain a consistent size regardless of the icon state, preventing the adjacent text from shifting.

**Fixes**
Fixes the visual regression reported on CZO.
("Fixes : #33250(https://github.com/zulip/zulip/issues/33250)").

https://github.com/user-attachments/assets/def24528-2213-436c-a32b-c4001745a9bc


**How changes were tested:**
1. Open the "Manage channels" modal (Settings -> Manage channels).
2. Locate a channel (e.g., "announce" or "chris-public-test").
3. Rapidly toggle the "Subscribe" / "Unsubscribe" button.
4. **Observation:** The channel name text now remains perfectly stationary and does not jump left or right.


**Screenshots**
See attached videos in the comments below.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
