### PR TITLE
webhook: Improve wording for GitHub pull request messages.

### DIFF
--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -289,7 +289,7 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("pull_request__opened", expected_topic_name, expected_message)
 
     def test_pull_request_synchronized_msg(self) -> None:
-        expected_message = "baxterthehacker updated [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)."
+        expected_message = "baxterthehacker updated the code in [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)."
         self.check_webhook("pull_request__synchronized", TOPIC_PR, expected_message)
 
     def test_pull_request_closed_msg(self) -> None:
@@ -434,7 +434,7 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("pull_request__edited_with_body_change", TOPIC_PR, expected_message)
 
     def test_pull_request_synchronized_with_body(self) -> None:
-        expected_message = "baxterthehacker updated [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)."
+        expected_message = "baxterthehacker updated the code in [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)."
         self.check_webhook("pull_request__synchronized_with_body", TOPIC_PR, expected_message)
 
     def test_pull_request_assigned_msg(self) -> None:
@@ -459,7 +459,7 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("pull_request__unassigned", expected_topic_name, expected_message)
 
     def test_pull_request_ready_for_review_msg(self) -> None:
-        expected_message = "**Hypro999** has marked [PR #2](https://github.com/Hypro999/temp-test-github-webhook/pull/2) as ready for review."
+        expected_message = "Hypro999 marked [PR #2](https://github.com/Hypro999/temp-test-github-webhook/pull/2) as ready for review."
         self.check_webhook(
             "pull_request__ready_for_review",
             "temp-test-github-webhook / PR #2 Test",

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -80,7 +80,7 @@ def get_opened_or_update_pull_request_body(helper: Helper) -> str:
     pull_request = payload["pull_request"]
     action = payload["action"].tame(check_string)
     if action == "synchronize":
-        action = "updated"
+        action = "updated the code in"
     assignee = None
     if pull_request.get("assignee"):
         assignee = pull_request["assignee"]["login"].tame(check_string)
@@ -594,7 +594,7 @@ def get_pull_request_auto_merge_body(helper: Helper) -> str:
 def get_pull_request_ready_for_review_body(helper: Helper) -> str:
     payload = helper.payload
 
-    message = "**{sender}** has marked [PR #{pr_number}]({pr_url}) as ready for review."
+    message = "{sender} marked [PR #{pr_number}]({pr_url}) as ready for review."
     return message.format(
         sender=get_sender_name(payload),
         pr_number=payload["pull_request"]["number"].tame(check_int),


### PR DESCRIPTION
Summary :This PR improves the clarity and consistency of GitHub webhook messages for pull request events.

Changes:
              1.Clarified Synchronize Events: Changed the message for synchronize events from "updated" to "updated the code in".            
                 This makes it clear that new commits were pushed, distinguishing it from metadata updates (like label changes).
              2.Standardized "Ready for Review": Updated the "Ready for Review" message format to remove inconsistent bold   
                 styling and passive voice. Changed **User** has marked... to User marked... to match the style of other event  
                 messages (e.g., "User opened PR...").

Fixes: N/A(Improvement)

How changes were tested:
         1.Updated zerver/webhooks/github/tests.py
            to reflect the new message formats.
          2.Ran the full backend test suite for GitHub webhooks and verified all
             139 tests passed: ./tools/test-backendzerver/webhooks/github/tests.py

Screenshots and screen captures:N/A(text-only changes)


Communicate decisions, questions, and potential concerns.

- [ x] Explains differences from previous plans (e.g., issue description).
- [x ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x ] Each commit is a coherent idea.
- [ x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
