### PR TITLE
demo-orgs: Revert setting deletion_delay_days for demo conversion.

### DIFF
--- a/zerver/actions/create_realm.py
+++ b/zerver/actions/create_realm.py
@@ -94,19 +94,11 @@ def do_change_realm_subdomain(
     # it's deactivated redirect to new_subdomain so that we can tell the users that
     # the realm has been moved to a new subdomain.
     if add_deactivated_redirect:
-        scheduled_deletion_days = None
-        if was_demo_organization:
-            # For converted demo organizations, we schedule the placeholder realm to be
-            # deleted/scrubbed after a set number of days, so that our finite possible
-            # options for demo organization subdomains don't get used up over time.
-            scheduled_deletion_days = settings.DEMO_ORG_DEADLINE_DAYS
-
         placeholder_realm = do_create_realm(old_subdomain, realm.name)
         do_deactivate_realm(
             placeholder_realm,
             acting_user=None,
             deactivation_reason="subdomain_change",
-            deletion_delay_days=scheduled_deletion_days,
             email_owners=False,
         )
         do_add_deactivated_redirect(placeholder_realm, realm.url)

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -340,7 +340,6 @@ class RealmTest(ZulipTestCase):
         placeholder_realm = get_realm("zulip")
         self.assertTrue(placeholder_realm.deactivated)
         self.assertEqual(placeholder_realm.deactivated_redirect, realm.url)
-        self.assertIsNotNone(placeholder_realm.scheduled_deletion_date)
 
     def test_realm_name_length(self) -> None:
         new_name = "A" * (Realm.MAX_REALM_NAME_LENGTH + 1)
@@ -420,7 +419,6 @@ class RealmTest(ZulipTestCase):
         placeholder_realm = get_realm("zulip")
         self.assertTrue(placeholder_realm.deactivated)
         self.assertEqual(placeholder_realm.deactivated_redirect, user.realm.url)
-        self.assertIsNone(placeholder_realm.scheduled_deletion_date)
 
         realm_audit_log = RealmAuditLog.objects.filter(
             event_type=AuditLogEventType.REALM_SUBDOMAIN_CHANGED, acting_user=iago


### PR DESCRIPTION
Reverts the changes from #37486, which set `deletion_delay_days` for converted demo organization placeholder realms. Scrubbing these realms is a noop and does not remove the redirect or free up the string_id/subdomain of the placeholder realm.

CZO discussion: [#backend > demo organizations: when converted to permanent orgs](https://chat.zulip.org/#narrow/channel/3-backend/topic/demo.20organizations.3A.20when.20converted.20to.20permanent.20orgs/with/2359434)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
