### PR TITLE
recent_conversations: Highlight filter text on return.

### DIFF
--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1430,7 +1430,18 @@ export function show(): void {
         is_recent_view: true,
         is_visible: recent_view_util.is_visible,
         set_visible: recent_view_util.set_visible,
-        complete_rerender,
+        complete_rerender(coming_from_other_views = false) {
+            complete_rerender(coming_from_other_views);
+            // If the user was searching for something, we want to restore focus
+            // to the search box and select the text so they can easily type over it.
+            // We only do this if the user has typed something in the search box.
+            const search_val = $<HTMLInputElement>("#recent_view_search").val();
+            if (search_val) {
+                setTimeout(() => {
+                    $("#recent_view_search").trigger("focus").trigger("select");
+                }, 0);
+            }
+        },
     });
     last_scroll_offset = undefined;
 


### PR DESCRIPTION
When returning to the "Recent conversations" view with an active search filter, automatically focus and select the search input. This allows the user to immediately type to modify the filter without requiring a manual click, improving the navigation workflow.

What I have done is added logic to `show()` function in `recent_view_ui.ts` that check if the search box has text. If it does, we refocus it and highlights the text.

Added `setTimout` for extra safety while re-rendering.

Fixes #17941

**How changes were tested:**

- Automated test done using Ai agents.
- Manually tested on web app.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**


| Before |
| :---: | 
| ![Before](https://github.com/user-attachments/assets/4546124c-eb86-4f4a-a08c-a89f842c7391)
| After |
![After](https://github.com/user-attachments/assets/e9804a68-b940-4ab1-af7d-c707d78c7552) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
