### PR TITLE
compose: fix multiline formatting for inline syntax

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -971,16 +971,68 @@ export let format_text = (
             inline_syntax_markers.has(syntax_start)
         ) {
             const lines = selected_text.split("\n");
+
+            // Check if every non-empty line is already formatted
+            const all_lines_formatted = lines.every((line) => {
+                if (line.trim() === "") {
+                    return true;
+                }
+
+                const trimmed = line.trimStart();
+                const numbering_match = /^\d+\.\s*/.exec(trimmed);
+
+                let content = trimmed;
+
+                if (bulleted_numbered_list_util.is_bulleted(trimmed)) {
+                    content = bulleted_numbered_list_util.strip_bullet(trimmed);
+                } else if (numbering_match) {
+                    content = trimmed.slice(numbering_match[0].length);
+                }
+
+                return content.startsWith(syntax_start) && content.endsWith(syntax_end);
+            });
+
             const formatted_lines = lines.map((line) => {
                 // Skip empty lines.
                 if (line.trim() === "") {
                     return line;
                 }
 
-                if (line.startsWith(syntax_start) && line.endsWith(syntax_end)) {
-                    return line.slice(syntax_start.length, line.length - syntax_end.length);
+                const trimmed = line.trimStart();
+                const indent = line.slice(0, line.length - trimmed.length);
+
+                // For list items, apply formatting only to the content
+                // after the list prefix (e.g., "- " or "1. ").
+
+                // To detect numbered list
+                const numbering_match = /^\d+\.\s*/.exec(trimmed);
+
+                let prefix = indent;
+                let content = trimmed;
+
+                if (bulleted_numbered_list_util.is_bulleted(trimmed)) {
+                    prefix += trimmed.slice(0, 2);
+                    content = bulleted_numbered_list_util.strip_bullet(trimmed);
+                } else if (numbering_match) {
+                    const numbering = numbering_match[0];
+                    prefix += numbering;
+                    content = trimmed.slice(numbering.length);
                 }
-                return `${syntax_start}${line}${syntax_end}`;
+
+                // If all lines are formatted, unformat every line
+                if (all_lines_formatted) {
+                    return (
+                        prefix +
+                        content.slice(syntax_start.length, content.length - syntax_end.length)
+                    );
+                }
+
+                // If line is already formatted, leave it as is
+                if (content.startsWith(syntax_start) && content.endsWith(syntax_end)) {
+                    return prefix + content;
+                }
+
+                return `${prefix}${syntax_start}${content}${syntax_end}`;
             });
 
             const result = formatted_lines.join("\n");

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -948,6 +948,10 @@ export let format_text = (
         }
     };
 
+    // Inline formatting syntax markers that should be applied
+    // independently to each line in a multiline selection.
+    const inline_syntax_markers = new Set(["*", "**", "***", "~~"]);
+
     const format = (syntax_start: string, syntax_end = syntax_start): boolean => {
         let linebreak_start = "";
         let linebreak_end = "";
@@ -957,6 +961,35 @@ export let format_text = (
         if (syntax_end.endsWith("\n")) {
             linebreak_end = "\n";
         }
+
+        // For multiline selections with inline syntax (bold, italic,
+        // strikethrough), apply formatting to each line independently
+        // rather than wrapping the entire block.
+        if (
+            selected_text.includes("\n") &&
+            syntax_start === syntax_end &&
+            inline_syntax_markers.has(syntax_start)
+        ) {
+            const lines = selected_text.split("\n");
+            const formatted_lines = lines.map((line) => {
+                // Skip empty lines.
+                if (line.trim() === "") {
+                    return line;
+                }
+
+                if (line.startsWith(syntax_start) && line.endsWith(syntax_end)) {
+                    return line.slice(syntax_start.length, line.length - syntax_end.length);
+                }
+                return `${syntax_start}${line}${syntax_end}`;
+            });
+
+            const result = formatted_lines.join("\n");
+            text = text.slice(0, range.start) + result + text.slice(range.end);
+            insert_and_scroll_into_view(text, $textarea, true);
+            field.setSelectionRange(range.start, range.start + result.length);
+            return true;
+        }
+
         if (is_selection_formatted(syntax_start, syntax_end)) {
             text =
                 text.slice(0, range.start - syntax_start.length) +
@@ -1269,6 +1302,13 @@ export let format_text = (
             // **foo**, toggling italics should add italics, since in
             // fact it's just bold syntax, even though with *foo* and
             // ***foo*** should remove italics.
+
+            // For multiline selections, the format helper already
+            // handles per-line toggling correctly.
+            if (selected_text.includes("\n")) {
+                format(italic_syntax);
+                break;
+            }
 
             // If the text is already italic, we remove the italic_syntax from text.
             if (range.start >= 1 && text.length - range.end >= italic_syntax.length) {

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -751,6 +751,36 @@ run_test("format_text - bold and italic", ({override, override_rewire}) => {
     compose_ui.format_text($textarea, "bold");
     assert.equal(get_textarea_state(), "before <abc\ndef\nghi> after");
 
+    // Bold multiline numbered list
+    init_textarea_state("<1. abc\n2. def\n3. ghi>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<1. **abc**\n2. **def**\n3. **ghi**>");
+
+    // Undo bold multiline numbered list
+    init_textarea_state("<1. **abc**\n2. **def**\n3. **ghi**>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<1. abc\n2. def\n3. ghi>");
+
+    // Bold multiline bulleted list (- style)
+    init_textarea_state("<- abc\n- def\n- ghi>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<- **abc**\n- **def**\n- **ghi**>");
+
+    // Undo bold multiline bulleted list (- style)
+    init_textarea_state("<- **abc**\n- **def**\n- **ghi**>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<- abc\n- def\n- ghi>");
+
+    // Bold multiline bulleted list (* style)
+    init_textarea_state("<* abc\n* def\n* ghi>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<* **abc**\n* **def**\n* **ghi**>");
+
+    // Bold multiline bulleted list (+ style)
+    init_textarea_state("<+ abc\n+ def\n+ ghi>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<+ **abc**\n+ **def**\n+ **ghi**>");
+
     // Italic selected text
     init_textarea_state("before <abc> after");
     compose_ui.format_text($textarea, "italic");
@@ -779,6 +809,16 @@ run_test("format_text - bold and italic", ({override, override_rewire}) => {
     init_textarea_state("before <*abc*\n*def*\n*ghi*> after");
     compose_ui.format_text($textarea, "italic");
     assert.equal(get_textarea_state(), "before <abc\ndef\nghi> after");
+
+    // Italic multiline numbered list
+    init_textarea_state("<1. abc\n2. def>");
+    compose_ui.format_text($textarea, "italic");
+    assert.equal(get_textarea_state(), "<1. *abc*\n2. *def*>");
+
+    // Undo italic multiline numbered list
+    init_textarea_state("<1. *abc*\n2. *def*>");
+    compose_ui.format_text($textarea, "italic");
+    assert.equal(get_textarea_state(), "<1. abc\n2. def>");
 
     // Undo bold selected text, text is both italic and bold, syntax not selected.
     init_textarea_state("before ***<abc>*** after");
@@ -922,6 +962,16 @@ run_test("format_text - strikethrough", ({override, override_rewire}) => {
     init_textarea_state("before <~~abc~~\n~~def~~\n~~ghi~~> after");
     compose_ui.format_text($textarea, "strikethrough");
     assert.equal(get_textarea_state(), "before <abc\ndef\nghi> after");
+
+    // Strikethrough multiline bulleted list
+    init_textarea_state("<- abc\n- def>");
+    compose_ui.format_text($textarea, "strikethrough");
+    assert.equal(get_textarea_state(), "<- ~~abc~~\n- ~~def~~>");
+
+    // Undo strikethrough multiline bulleted list
+    init_textarea_state("<- ~~abc~~\n- ~~def~~>");
+    compose_ui.format_text($textarea, "strikethrough");
+    assert.equal(get_textarea_state(), "<- abc\n- def>");
 });
 
 run_test("format_text - latex", ({override, override_rewire}) => {

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -736,6 +736,21 @@ run_test("format_text - bold and italic", ({override, override_rewire}) => {
     compose_ui.format_text($textarea, "bold");
     assert.equal(get_textarea_state(), "before <abc> after");
 
+    // Bold multiline selected text
+    init_textarea_state("before <abc\ndef\nghi> after");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "before <**abc**\n**def**\n**ghi**> after");
+
+    // Bold multiline selected text with empty line preserved
+    init_textarea_state("<abc\n\ndef>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<**abc**\n\n**def**>");
+
+    // Undo bold multiline selected text
+    init_textarea_state("before <**abc**\n**def**\n**ghi**> after");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "before <abc\ndef\nghi> after");
+
     // Italic selected text
     init_textarea_state("before <abc> after");
     compose_ui.format_text($textarea, "italic");
@@ -754,6 +769,16 @@ run_test("format_text - bold and italic", ({override, override_rewire}) => {
     init_textarea_state("before <*abc*> after");
     compose_ui.format_text($textarea, "italic");
     assert.equal(get_textarea_state(), "before <abc> after");
+
+    // Italic multiline selected text
+    init_textarea_state("before <abc\ndef\nghi> after");
+    compose_ui.format_text($textarea, "italic");
+    assert.equal(get_textarea_state(), "before <*abc*\n*def*\n*ghi*> after");
+
+    // Undo italic multiline selected text
+    init_textarea_state("before <*abc*\n*def*\n*ghi*> after");
+    compose_ui.format_text($textarea, "italic");
+    assert.equal(get_textarea_state(), "before <abc\ndef\nghi> after");
 
     // Undo bold selected text, text is both italic and bold, syntax not selected.
     init_textarea_state("before ***<abc>*** after");
@@ -887,6 +912,16 @@ run_test("format_text - strikethrough", ({override, override_rewire}) => {
     init_textarea_state("before <~~abc~~> after");
     compose_ui.format_text($textarea, "strikethrough");
     assert.equal(get_textarea_state(), "before <abc> after");
+
+    // Strikethrough multiline selected text
+    init_textarea_state("before <abc\ndef\nghi> after");
+    compose_ui.format_text($textarea, "strikethrough");
+    assert.equal(get_textarea_state(), "before <~~abc~~\n~~def~~\n~~ghi~~> after");
+
+    // Undo strikethrough multiline selected text
+    init_textarea_state("before <~~abc~~\n~~def~~\n~~ghi~~> after");
+    compose_ui.format_text($textarea, "strikethrough");
+    assert.equal(get_textarea_state(), "before <abc\ndef\nghi> after");
 });
 
 run_test("format_text - latex", ({override, override_rewire}) => {


### PR DESCRIPTION
**Description:**
This PR fixes an issue where applying formatting (bold, italic, strikethrough) via compose hotkeys or compose buttons to a multi-paragraph selection only wrapped the entire selection, producing invalid Markdown.
It also makes sure that formatting interacts well with numbered and bulleted lists.


**Details**

**Frontend Logic Changes**

• Made changes in format helper function to format multiple paragraph text correctly for inline syntax(bold, italic and strikethrough). These changes include -

1.) Detecting inline syntax, by checking if syntax is italic, bold, both or strikethrough.

2.) Adding an if block for the case where the text is multi paragraph and syntax is inline, then enveloping each '/n' separated line of the text with the syntax instead of the enveloping the whole text(this is the current behaviour) for this case.

3.) When the syntax was italic, format function wasn't called after the detection of italic syntax. So, I changed the code to call it(format function) when text is multi-line, since the format function is working fine for multi-line italic.

4.) Added logic for only formatting the contents of such list items and not list prefixes("- ", "1.", "2." .etc)

**Testing Changes**
• Added/updated unit tests for multi-paragraph formatting behavior in italic, bold and strikethrough section of file web/tests/compose_ui.test.cjs

**Related Issues**
• Does not change Markdown rendering behavior (tracked separately in #23138)

Fixes: #37614 

**How changes were tested:**
• Visual - The behavior was visibly changed
• Ran tools/test-js-with-node to verify frontend compose formatting logic


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/ea818795-057d-40ab-8662-e5185d33bd54

https://github.com/user-attachments/assets/31342a74-cfb0-4d7c-8e7c-b2adfbcdaf30



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>