### PR TITLE
templates: Do not use arrays for truthiness check.

### DIFF
--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -788,7 +788,7 @@ export class MessageListView {
         for (const message of messages) {
             const message_reactions = reactions.get_message_reactions(message);
             message.message_reactions = message_reactions;
-            message.reminders = message_reminder.get_reminders(message.id);
+            message.reminders = message_reminder.get_reminders(message.id) ?? [];
 
             // These will be used to build the message container
             let include_recipient = false;
@@ -1083,7 +1083,8 @@ export class MessageListView {
     _get_message_template(message_container: MessageContainer): string {
         const msg_reactions = reactions.get_message_reactions(message_container.msg);
         message_container.msg.message_reactions = msg_reactions;
-        message_container.msg.reminders = message_reminder.get_reminders(message_container.msg.id);
+        message_container.msg.reminders =
+            message_reminder.get_reminders(message_container.msg.id) ?? [];
         let invite_only;
         let is_web_public;
         let is_archived;

--- a/web/templates/confirm_dialog/confirm_deactivate_user.hbs
+++ b/web/templates/confirm_dialog/confirm_deactivate_user.hbs
@@ -12,7 +12,7 @@
         {{/tr}}
     {{/if}}
 </p>
-{{#if bots_owned_by_user}}
+{{#if bots_owned_by_user.length}}
     <p>
         {{t "They administer the following bots:"}}
     </p>

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -79,6 +79,6 @@
     {{> message_reactions . }}
 {{/if}}
 
-{{#if msg.reminders}}
+{{#if msg.reminders.length}}
     {{> message_reminders . }}
 {{/if}}

--- a/web/templates/stream_settings/stream_subscription_request_result.hbs
+++ b/web/templates/stream_settings/stream_subscription_request_result.hbs
@@ -7,29 +7,29 @@
         {{t "All users were already subscribed."}}
     {{else}}
         {{#if (not is_total_subscriber_more_than_five) }}
-            {{#if subscribed_users}}
+            {{#if subscribed_users_count}}
                 {{t "Subscribed:" }} {{> user_links users=subscribed_users}}.
             {{/if}}
-            {{#if already_subscribed_users}}
+            {{#if already_subscribed_users_count}}
                 {{t "Already a subscriber:" }} {{> user_links users=already_subscribed_users}}.
             {{/if}}
-            {{#if ignored_deactivated_users}}
+            {{#if ignored_deactivated_users_count}}
                 {{t "Ignored deactivated users:" }} {{> user_links users=ignored_deactivated_users}}.
             {{/if}}
         {{else}}
-            {{#if subscribed_users}}
+            {{#if subscribed_users_count}}
                 {{t "{subscribed_users_count, plural,
                   one {Subscribed: {subscribed_users_count} user.}
                 other {Subscribed: {subscribed_users_count} users.}
             }"}}
             {{/if}}
-            {{#if already_subscribed_users}}
+            {{#if already_subscribed_users_count}}
                 {{t "{already_subscribed_users_count, plural,
                   one {Already subscribed: {already_subscribed_users_count} user.}
                     other {Already subscribed: {already_subscribed_users_count} users.}
                 }"}}
             {{/if}}
-            {{#if ignored_deactivated_users}}
+            {{#if ignored_deactivated_users_count}}
                 {{t "{ignored_deactivated_users_count, plural,
                   one {Ignored deactivated: {ignored_deactivated_users_count} user.}
                 other {Ignored deactivated: {ignored_deactivated_users_count} users.}

--- a/web/templates/user_group_settings/user_group_membership_request_result.hbs
+++ b/web/templates/user_group_settings/user_group_membership_request_result.hbs
@@ -11,16 +11,16 @@
         {{/if}}
     {{else}}
         {{#if (not total_member_count_exceeds_five)}}
-            {{#if additions.newly_added_members}}
+            {{#if newly_added_member_count}}
                 {{t "Added:" }} {{> member_links members=additions.newly_added_members}}.&nbsp;
             {{/if}}
-            {{#if additions.already_added_members}}
+            {{#if already_added_member_count}}
                 {{t "Already a member:"}} {{> member_links members=additions.already_added_members}}.
             {{/if}}
-            {{#if additions.ignored_deactivated_users}}
+            {{#if ignored_deactivated_users_count}}
                 {{t "Ignored deactivated users:"}} {{> member_links members=additions.ignored_deactivated_users}}.
             {{/if}}
-            {{#if additions.ignored_deactivated_groups}}
+            {{#if ignored_deactivated_groups_count}}
                 {{t "Ignored deactivated groups:"}} {{> member_links members=additions.ignored_deactivated_groups}}.
             {{/if}}
         {{else}}


### PR DESCRIPTION
After changes in ea3cbd5, arrays cannot be used directly for truthiness check in if block, we should always use
array length.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->



<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
