### PR TITLE
refactor: Strict typing for message topics and reaction events

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -40,6 +40,7 @@ FILES_WITH_LEGACY_SUBJECT = {
     "zerver/tests/test_message_topics.py",
     # This is actually email subjects
     "zerver/lib/email_mirror_server.py",
+    "zerver/lib/types.py",
 }
 
 shebang_rules: list["Rule"] = [

--- a/zerver/actions/reactions.py
+++ b/zerver/actions/reactions.py
@@ -1,4 +1,4 @@
-from typing import Any
+
 
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.lib.emoji import check_emoji_request, get_emoji_data
@@ -12,6 +12,7 @@ from zerver.lib.message import (
 )
 from zerver.lib.message_cache import update_message_cache
 from zerver.lib.streams import access_stream_by_id
+from zerver.lib.types import ReactionEvent, ReactionUserDict
 from zerver.lib.user_message import create_historical_user_messages
 from zerver.models import Message, Reaction, UserProfile
 from zerver.tornado.django_api import send_event_on_commit
@@ -20,13 +21,13 @@ from zerver.tornado.django_api import send_event_on_commit
 def notify_reaction_update(
     user_profile: UserProfile, message: Message, reaction: Reaction, op: str
 ) -> None:
-    user_dict = {
+    user_dict: ReactionUserDict = {
         "user_id": user_profile.id,
         "email": user_profile.email,
         "full_name": user_profile.full_name,
     }
 
-    event: dict[str, Any] = {
+    event: ReactionEvent = {
         "type": "reaction",
         "op": op,
         "user_id": user_profile.id,

--- a/zerver/actions/reactions.py
+++ b/zerver/actions/reactions.py
@@ -1,5 +1,3 @@
-
-
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.lib.emoji import check_emoji_request, get_emoji_data
 from zerver.lib.exceptions import ReactionExistsError

--- a/zerver/lib/bot_lib.py
+++ b/zerver/lib/bot_lib.py
@@ -1,7 +1,7 @@
 import importlib
 import json
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 from django.conf import settings
 from django.utils.translation import gettext as _
@@ -22,6 +22,7 @@ from zerver.lib.bot_storage import (
 )
 from zerver.lib.integrations import EMBEDDED_BOTS
 from zerver.lib.topic import get_topic_from_message_info
+from zerver.lib.types import TopicMessageInfo
 from zerver.models import UserProfile
 from zerver.models.users import get_active_user
 
@@ -133,7 +134,7 @@ class EmbeddedBotHandler:
                 dict(
                     type="stream",
                     to=message["display_recipient"],
-                    topic=get_topic_from_message_info(message),
+                    topic=get_topic_from_message_info(cast(TopicMessageInfo, message)),
                     content=response,
                     sender_email=message["sender_email"],
                 )

--- a/zerver/lib/narrow_predicate.py
+++ b/zerver/lib/narrow_predicate.py
@@ -1,11 +1,12 @@
 from collections.abc import Collection
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.narrow_helpers import NeverNegatedNarrowTerm
 from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, get_topic_from_message_info
+from zerver.lib.types import TopicMessageInfo
 
 # "stream" is a legacy alias for "channel"
 channel_operators: list[str] = ["channel", "stream"]
@@ -47,7 +48,7 @@ def build_narrow_predicate(
             elif operator == "topic":
                 if message["type"] != "stream":
                     return False
-                topic_name = get_topic_from_message_info(message)
+                topic_name = get_topic_from_message_info(cast(TopicMessageInfo, message))
                 if operand.lower() != topic_name.lower():
                     return False
             elif operator == "sender":
@@ -69,7 +70,7 @@ def build_narrow_predicate(
             elif operator == "is" and operand == "resolved":
                 if message["type"] != "stream":
                     return False
-                topic_name = get_topic_from_message_info(message)
+                topic_name = get_topic_from_message_info(cast(TopicMessageInfo, message))
                 if not topic_name.startswith(RESOLVED_TOPIC_PREFIX):
                     return False
             return True

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -3,7 +3,7 @@ import json
 import logging
 from contextlib import suppress
 from time import perf_counter
-from typing import Any, AnyStr
+from typing import Any, AnyStr, cast
 
 import requests
 from django.conf import settings
@@ -18,6 +18,7 @@ from zerver.lib.message_cache import MessageDict
 from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.queue import retry_event
 from zerver.lib.topic import get_topic_from_message_info
+from zerver.lib.types import TopicMessageInfo
 from zerver.lib.url_encoding import message_link_url
 from zerver.lib.users import check_can_access_user, check_user_can_access_all_users
 from zerver.models import Realm, Service, UserProfile
@@ -196,7 +197,7 @@ def send_response_message(
     recipient_type_name = message_info["type"]
     display_recipient = message_info["display_recipient"]
     try:
-        topic_name: str | None = get_topic_from_message_info(message_info)
+        topic_name: str | None = get_topic_from_message_info(cast(TopicMessageInfo, message_info))
     except KeyError:
         topic_name = None
 

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -9,7 +9,7 @@ from django.db.models.functions import Cast
 from django.utils.translation import gettext as _
 from django.utils.translation import override as override_language
 
-from zerver.lib.types import EditHistoryEvent, StreamMessageEditRequest
+from zerver.lib.types import EditHistoryEvent, StreamMessageEditRequest, TopicMessageInfo
 from zerver.lib.utils import assert_is_not_none
 from zerver.models import Message, Reaction, UserMessage, UserProfile
 
@@ -32,7 +32,7 @@ where we'll want to support "subject" for a while.
 """
 
 
-def get_topic_from_message_info(message_info: dict[str, Any]) -> str:
+def get_topic_from_message_info(message_info: TopicMessageInfo) -> str:
     """
     Use this where you are getting dicts that are based off of messages
     that may come from the outside world, especially from third party

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -136,6 +136,11 @@ class FormattedEditHistoryEvent(TypedDict, total=False):
     content_html_diff: str
 
 
+class TopicMessageInfo(TypedDict, total=False):
+    topic: str
+    subject: str
+
+
 class UserTopicDict(TypedDict, total=False):
     """Dictionary containing fields fetched from the UserTopic model that
     are needed to encode the UserTopic object for the API.

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -138,7 +138,25 @@ class FormattedEditHistoryEvent(TypedDict, total=False):
 
 class TopicMessageInfo(TypedDict, total=False):
     topic: str
-    subject: str
+    subject: str  # Legacy key, required for compatibility.
+
+
+class ReactionUserDict(TypedDict):
+    user_id: int
+    email: str
+    full_name: str
+
+
+class ReactionEvent(TypedDict):
+    type: str
+    op: str
+    user_id: int
+    user: ReactionUserDict
+    message_id: int
+    emoji_name: str
+    emoji_code: str
+    reaction_type: str
+
 
 
 class UserTopicDict(TypedDict, total=False):

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -158,7 +158,6 @@ class ReactionEvent(TypedDict):
     reaction_type: str
 
 
-
 class UserTopicDict(TypedDict, total=False):
     """Dictionary containing fields fetched from the UserTopic model that
     are needed to encode the UserTopic object for the API.

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -1,13 +1,13 @@
 # See the Zulip URL spec at https://zulip.com/api/zulip-urls
 
 import urllib.parse
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlsplit
 
 import re2
 
 from zerver.lib.topic import get_topic_from_message_info
-from zerver.lib.types import UserDisplayRecipient
+from zerver.lib.types import TopicMessageInfo, UserDisplayRecipient
 from zerver.models import Realm, Stream, UserProfile
 
 hash_replacements = {
@@ -175,7 +175,7 @@ def stream_message_url(
     message_id = str(message["id"])
     stream_id = message["stream_id"]
     stream_name = message["display_recipient"]
-    topic_name = get_topic_from_message_info(message)
+    topic_name = get_topic_from_message_info(cast(TopicMessageInfo, message))
     encoded_topic_name = encode_hash_component(topic_name)
     encoded_stream = encode_channel(stream_id, stream_name)
 


### PR DESCRIPTION
**Summary:**
This PR improves type safety in two areas:
1. **Topics:** Replaces `Dict[str, Any]` with `TopicMessageInfo` TypedDict in `zerver/lib/topic.py` and callers.
2. **Reactions:** Replaces `Dict[str, Any]` with `ReactionEvent` TypedDict in `zerver/actions/reactions.py`.

**Why:**
Increases type safety, eliminates `Any`, and improves documentation for critical data structures (topics and reactions).

**Technical Notes:**
* **Linter Configuration:** Includes a whitelist update for `zerver/lib/types.py` in `tools/linter_lib/custom_check.py` because the `subject` key is strictly required for compatibility with legacy message dictionaries.

**Testing:**
* [x] `mypy` passed clean.
* [x] `test-backend` passed (`zerver/tests/test_subs.py` and `zerver/tests/test_reactions.py`).