### PR TITLE
Fenced_code: Fallback to plain code when Pygments fails.

### DIFF
--- a/zerver/lib/markdown/fenced_code.py
+++ b/zerver/lib/markdown/fenced_code.py
@@ -76,6 +76,7 @@ Dependencies:
 
 """
 
+import logging
 import re
 from collections.abc import Callable, Iterable, Mapping, MutableSequence, Sequence
 from typing import Any
@@ -506,7 +507,11 @@ class FencedBlockPreprocessor(Preprocessor):
                 startinline=True,
             )
 
-            code = highliter.hilite().rstrip("\n")
+            try:
+                code = highliter.hilite().rstrip("\n")
+            except Exception:
+                logging.exception("Failed to highlight fenced code block")
+                code = CODE_WRAP.format(langclass, self._escape(text))
         else:
             code = CODE_WRAP.format(langclass, self._escape(text))
 

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -3751,3 +3751,22 @@ class MarkdownErrorTests(ZulipTestCase):
 
         result = processor.run(markdown_input)
         self.assertEqual(result, expected)
+
+    def test_fenced_code_with_pygments_exception(self) -> None:
+        """Fallback to plain code when Pygments raises an exception."""
+        with (
+            self.assertLogs(level="ERROR") as log,
+            mock.patch("zerver.lib.markdown.fenced_code.CodeHilite.hilite") as mocked_hilite,
+        ):
+            mocked_hilite.side_effect = Exception("pygments crashed")
+
+            markdown_text = "```python\nprint('pygments fallback test')\n```"
+            rendered_html = markdown_convert(
+                markdown_text,
+                self.example_user("hamlet"),
+            ).rendered_content
+
+        self.assertIn("<pre", rendered_html)
+        self.assertIn("print('pygments fallback test')", rendered_html)
+        mocked_hilite.assert_called()
+        self.assertIn("Failed to highlight fenced code block", log.output[0])


### PR DESCRIPTION
## Problem

When Pygments fails while rendering fenced code blocks, the markdown rendering process crashes and returns:

`{"result":"error","msg":"Unable to render message","code":"BAD_REQUEST"}`


This prevents messages containing certain code blocks from being displayed.

## Solution

1. Wrap the highliter.hilite() call in a try/except block.
2. Log the exception when Pygments crashes.
3. Fall back to rendering plain code (without syntax highlighting).

## Result

1. Code blocks render successfully even if Pygments fails.
2. No BAD_REQUEST error is returned.
3. Markdown messages always render correctly.

## Related issue

Fixes #22287


<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability  
  (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g. issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see commit discipline).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>

