### PR TITLE
css: Fix channel-folder selector padding and row height

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2201,7 +2201,7 @@ body:not(.spectator-view) {
         /* Sync with `max-height` in dropdown_widget. */
         max-height: 210px;
         /* 200px/14px */
-        min-width: 14.285em;
+        min-width: max-content;
 
         .dropdown-list {
             list-style: none;
@@ -2238,7 +2238,7 @@ body:not(.spectator-view) {
     .no-dropdown-items {
         color: hsl(0deg 0% 60%);
         display: none;
-        padding: 3px 10px 3px 8px;
+        padding: 3px 10px;
         font-weight: 400;
         line-height: 20px;
         white-space: normal;
@@ -2254,13 +2254,15 @@ body:not(.spectator-view) {
             )
             minmax(0, 1fr);
         color: var(--color-dropdown-item);
-        padding: 3px 10px 3px 8px;
+        padding: 3px 10px;
         font-weight: 400;
         white-space: normal;
         /* Keep the line-height stable, instead of using the
            user-set line-height, so that the icon is always
            vertically centered properly. */
         line-height: 1.214;
+        min-height: 2.125em;
+        align-content: center;
 
         .channel-privacy-type-icon,
         .zulip-icon-deactivated-circle {


### PR DESCRIPTION
This PR fixes styling issues in the channel-folder selector dropdown:

- Increase left padding to match right side spacing (8px → 10px)
- Add min-height (2.125em / 34px) to ensure "None" row matches other single-line folder rows
- Add `align-content: center` for proper vertical text alignment

Fixes: #37647 

**How changes were tested:**
- Opened the channel settings page in the development environment
- Verified the "None" row height now matches other folder rows (34px)
- Verified left padding matches the right side spacing


https://github.com/user-attachments/assets/c83eee91-f19e-478f-acf5-9702e58d3844



