### PR TITLE
demo-orgs: Generate realm name automatically for demo organizations.

### DIFF
--- a/templates/zerver/create_realm/create_realm.html
+++ b/templates/zerver/create_realm/create_realm.html
@@ -27,6 +27,7 @@
                   action="{{ current_url() }}" method="post">
                     {{ csrf_input }}
 
+                    {% include 'zerver/create_realm/realm_creation_name_form_field.html' %}
                     {% include 'zerver/create_realm/realm_creation_base_form_fields.html' %}
                     {% include 'zerver/create_realm/realm_creation_subdomain_form_field.html' %}
                     {% if is_realm_import_enabled %}

--- a/templates/zerver/create_realm/realm_creation_base_form_fields.html
+++ b/templates/zerver/create_realm/realm_creation_base_form_fields.html
@@ -1,25 +1,6 @@
 <div class="realm-creation-editable-inputs {% if user_registration_form and not form.realm_subdomain.errors %}hide{% endif %}">
     <div class="input-box">
         <div class="inline-block relative">
-            <input id="id_team_name" class="required" type="text"
-              value="{% if form.realm_name.value() %}{{ form.realm_name.value() }}{% endif %}"
-              name="realm_name" maxlength="{{ MAX_REALM_NAME_LENGTH }}" required {% if not user_registration_form %}autofocus{% endif %} />
-        </div>
-        <label for="id_team_name" class="inline-block label-title">
-            {{ _('Organization name') }}
-            <a href="/help/create-your-organization-profile" target="_blank" rel="noopener noreferrer">
-                <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-            </a>
-        </label>
-        {% if form.realm_name.errors %}
-            {% for error in form.realm_name.errors %}
-            <p class="help-inline text-error">{{ error }}</p>
-            {% endfor %}
-        {% endif %}
-    </div>
-
-    <div class="input-box">
-        <div class="inline-block relative">
             <select name="realm_type" id="realm_type" required>
                 <option disabled selected value>-- {{ _("Select one") }} --</option>
                 {% for realm_type in sorted_realm_types %}

--- a/templates/zerver/create_realm/realm_creation_name_form_field.html
+++ b/templates/zerver/create_realm/realm_creation_name_form_field.html
@@ -1,0 +1,20 @@
+<div class="realm-creation-editable-inputs {% if user_registration_form and not form.realm_subdomain.errors %}hide{% endif %}">
+    <div class="input-box">
+        <div class="inline-block relative">
+            <input id="id_team_name" class="required" type="text"
+              value="{% if form.realm_name.value() %}{{ form.realm_name.value() }}{% endif %}"
+              name="realm_name" maxlength="{{ MAX_REALM_NAME_LENGTH }}" required {% if not user_registration_form %}autofocus{% endif %} />
+        </div>
+        <label for="id_team_name" class="inline-block label-title">
+            {{ _('Organization name') }}
+            <a href="/help/create-your-organization-profile" target="_blank" rel="noopener noreferrer">
+                <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+            </a>
+        </label>
+        {% if form.realm_name.errors %}
+            {% for error in form.realm_name.errors %}
+            <p class="help-inline text-error">{{ error }}</p>
+            {% endfor %}
+        {% endif %}
+    </div>
+</div>

--- a/templates/zerver/create_user/register.html
+++ b/templates/zerver/create_user/register.html
@@ -40,6 +40,7 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
                 </legend>
                 {% with %}
                     {% set user_registration_form = "true" %}
+                    {% include 'zerver/create_realm/realm_creation_name_form_field.html' %}
                     {% include 'zerver/create_realm/realm_creation_base_form_fields.html' %}
                     {% include 'zerver/create_realm/realm_creation_subdomain_form_field.html' %}
                     {% if is_realm_import_enabled %}

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -228,7 +228,6 @@ class RegistrationForm(HowFoundZulipFormMixin, RealmDetailsForm):
 
 class DemoRegistrationForm(HowFoundZulipFormMixin, forms.Form):
     terms = forms.BooleanField(required=False)
-    realm_name = forms.CharField(max_length=Realm.MAX_REALM_NAME_LENGTH)
     realm_type = forms.TypedChoiceField(
         coerce=int, choices=[(t["id"], t["name"]) for t in Realm.ORG_TYPES.values()]
     )

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -979,14 +979,12 @@ Output:
 
     def submit_demo_creation_form(
         self,
-        demo_name: str,
         *,
         org_type: int = Realm.ORG_TYPES["business"]["id"],
         language: str = "en",
         captcha: str | None = None,
     ) -> "TestHttpResponse":
         payload = {
-            "realm_name": demo_name,
             "realm_type": org_type,
             "realm_default_language": language,
             "how_realm_creator_found_zulip": "ai_chatbot",

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3545,7 +3545,9 @@ class UserSignUpTest(ZulipTestCase):
         result = self.client_post("/devtools/register_demo_realm/")
         self.assertEqual(result.status_code, 302)
 
-        realm = Realm.objects.latest("date_created")
+        realm = Realm.objects.filter(
+            demo_organization_scheduled_deletion_date__isnull=False
+        ).latest("date_created")
         self.assertTrue(
             result["Location"].startswith(
                 f"http://{realm.string_id}.testserver/accounts/login/subdomain"
@@ -3573,7 +3575,6 @@ class UserSignUpTest(ZulipTestCase):
             days=settings.DEMO_ORG_DEADLINE_DAYS
         )
         self.assertEqual(realm.demo_organization_scheduled_deletion_date, expected_deletion_date)
-        self.assertIn("Demo organization", realm.name)
 
         # Make sure the correct Welcome Bot direct message is sent.
         welcome_msg = Message.objects.filter(

--- a/zerver/views/development/registration.py
+++ b/zerver/views/development/registration.py
@@ -90,12 +90,8 @@ def register_development_realm(request: HttpRequest) -> HttpResponse:
 
 @csrf_exempt
 def register_demo_development_realm(request: HttpRequest) -> HttpResponse:
-    count = (
-        Realm.objects.filter(demo_organization_scheduled_deletion_date__isnull=False).count() + 1
-    )
     user_profile = create_demo_helper(
         request,
-        realm_name=f"Demo organization {count}",
         realm_type=Realm.ORG_TYPES["education"]["id"],
         realm_default_language="en",
         how_realm_creator_found_zulip="existing_user",


### PR DESCRIPTION
Instead of asking users creating demo organizations to input a name for the organization, we generate the name from the same words that are used for the organization's string_id/subdomain.

**Notes**:
- The name of the demo organization is the adjective and noun used for the subdomain, capitalized. E.g., if the subdomain is `discreetly-far-upgrades`, then the realm name is `Far Upgrades`.
- Checks that the generated realm name does not exceed `Realm.MAX_REALM_NAME_LENGTH`.
- The changes in #37642 will conflict with these changes (due to the test helper `submit_demo_creation_form` no longer taking a realm name parameter), so depending on which is merged first, then the other should not be merged until it is updated.

---

**Screenshots and screen captures:**

*NEW DEMO ORGANIZATION FORM*
| Before | After |
| --- | --- |
| <img width="994" height="1440" alt="Screenshot From 2026-01-23 17-48-23" src="https://github.com/user-attachments/assets/c55a140d-f1ff-492d-876f-27966bf6f6e5" /> | <img width="994" height="1440" alt="Screenshot From 2026-01-23 17-49-58" src="https://github.com/user-attachments/assets/8b9ef5d6-fe43-46ec-a2c2-ced1a0168010" />

*NEW REGULAR ORGANIZATION FORM - no changes*
| Before | After |
| --- | --- |
| <img width="994" height="1440" alt="Screenshot From 2026-01-23 17-50-57" src="https://github.com/user-attachments/assets/ed352c02-2602-4fab-b478-32d170260edd" /> | <img width="994" height="1440" alt="Screenshot From 2026-01-23 17-51-17" src="https://github.com/user-attachments/assets/5a5d0b0e-20ec-4b8e-9216-31de6d9cc248" />

*NEW USER REGISTRATION FORM WITH ORG CREATION - no changes*
| Before | After |
| --- | --- |
| <img width="994" height="1440" alt="Screenshot From 2026-01-23 17-52-51" src="https://github.com/user-attachments/assets/8baf2cf7-fea3-46f5-998f-1f22973bf300" /> | <img width="994" height="1440" alt="Screenshot From 2026-01-23 17-53-15" src="https://github.com/user-attachments/assets/e7ef158e-cc78-4b76-894d-110ccb93ffcb" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
