### PR TITLE
composebox_typeahead: Change string for wildcard mention suggestion.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -490,9 +490,9 @@ function get_wildcard_string(mention: string): string {
         return $t({defaultMessage: "Notify recipients"});
     }
     if (mention === "topic") {
-        return $t({defaultMessage: "Notify topic"});
+        return $t({defaultMessage: "Notify participants in this conversation"});
     }
-    return $t({defaultMessage: "Notify channel"});
+    return $t({defaultMessage: "Notify all channel subscribers"});
 }
 
 export function broadcast_mentions(): PseudoMentionUser[] {

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -138,15 +138,18 @@ run_test("verify wildcard mentions typeahead for stream message", () => {
     assert.equal(mention_topic.full_name, "topic");
 
     assert.equal(mention_all.special_item_text, "all");
-    assert.equal(mention_all.secondary_text, "translated: Notify channel");
+    assert.equal(mention_all.secondary_text, "translated: Notify all channel subscribers");
     assert.equal(mention_everyone.special_item_text, "everyone");
-    assert.equal(mention_everyone.secondary_text, "translated: Notify channel");
+    assert.equal(mention_everyone.secondary_text, "translated: Notify all channel subscribers");
     assert.equal(mention_stream.special_item_text, "stream");
-    assert.equal(mention_stream.secondary_text, "translated: Notify channel");
+    assert.equal(mention_stream.secondary_text, "translated: Notify all channel subscribers");
     assert.equal(mention_channel.special_item_text, "channel");
-    assert.equal(mention_channel.secondary_text, "translated: Notify channel");
+    assert.equal(mention_channel.secondary_text, "translated: Notify all channel subscribers");
     assert.equal(mention_topic.special_item_text, "topic");
-    assert.equal(mention_topic.secondary_text, "translated: Notify topic");
+    assert.equal(
+        mention_topic.secondary_text,
+        "translated: Notify participants in this conversation",
+    );
 
     compose_validate.stream_wildcard_mention_allowed = () => false;
     compose_validate.topic_wildcard_mention_allowed = () => true;


### PR DESCRIPTION
We change wildcard mention typeahead suggestion string for "channel" and "topic".

<!-- Describe your pull request here.-->

Fixes: [#translation > Suggestion to change the "Notify topic" string @ 💬](https://chat.zulip.org/#narrow/channel/58-translation/topic/Suggestion.20to.20change.20the.20.22Notify.20topic.22.20string/near/2362071)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

|Before|After|
|-|-|
|<img width="370" height="273" alt="image" src="https://github.com/user-attachments/assets/a840b16d-4a4a-4a2b-9962-2c8105ea2797" />|<img width="370" height="273" alt="image" src="https://github.com/user-attachments/assets/97cdc806-a344-413f-81d4-e972a17aafab" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
