### PR TITLE
search: Add "topic_contains" operator for substring topic matching.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -171,6 +171,13 @@ function message_matches_search_term(message: Message, term: NarrowTerm): boolea
 
             return message.topic.toLowerCase() === term.operand.toLowerCase();
 
+        case "topic-contains":
+            if (message.type !== "stream") {
+                return false;
+            }
+
+            return message.topic.toLowerCase().includes(term.operand.toLowerCase());
+
         case "sender":
             return people.id_matches_email_operand(message.sender_id, term.operand);
 
@@ -265,6 +272,8 @@ export class Filter {
                 break;
             case "topic":
                 break;
+            case "topic-contains":
+                break;
             case "sender":
             case "dm":
                 narrow_term.operand = narrow_term.operand.toLowerCase();
@@ -296,7 +305,7 @@ export class Filter {
         message: Message,
     ): NarrowTerm[] | undefined {
         // In presence of `with` term without channel or topic terms in the narrow, the
-        // narrow is populated with the channel and toipic terms through this operation,
+        // narrow is populated with the channel and topic terms through this operation,
         // so that `with` can be used as a standalone operator to target conversation.
         const contains_with_operator = orig_terms.some((term) => term.operator === "with");
 
@@ -514,6 +523,8 @@ export class Filter {
                 return channels_operands.has(term.operand);
             case "topic":
                 return true;
+            case "topic-contains":
+                return true;
             case "sender":
             case "dm":
             case "dm-including":
@@ -656,6 +667,9 @@ export class Filter {
 
             case "topic":
                 return verb + "topic";
+
+            case "topic-contains":
+                return verb + "topic contains";
 
             case "sender":
                 return verb + "sent by";

--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -137,6 +137,7 @@ export const allowed_web_public_narrow_operators = [
     "streams",
     "stream",
     "topic",
+    "topic-contains",
     "sender",
     "has",
     "search",

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -48,6 +48,7 @@ export const narrow_canonical_operator_schema = z.enum([
     "search",
     "sender",
     "topic",
+    "topic-contains",
     "with",
 ]);
 export type NarrowCanonicalOperator = z.output<typeof narrow_canonical_operator_schema>;
@@ -115,6 +116,11 @@ export const narrow_canonical_term_schema = z.discriminatedUnion("operator", [
     }),
     z.object({
         operator: z.literal("topic"),
+        operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("topic-contains"),
         operand: z.string(),
         negated: z.optional(z.boolean()),
     }),

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1160,6 +1160,14 @@ test("predicate_basics", ({override}) => {
     predicate = get_predicate([["topic", "Bar"]]);
     assert.ok(!predicate({type: direct_message}));
 
+    predicate = get_predicate([["topic-contains", "bug"]]);
+    assert.ok(predicate({type: stream_message, topic: "Bug fixes"}));
+    assert.ok(predicate({type: stream_message, topic: "debugging"}));
+    assert.ok(predicate({type: stream_message, topic: "BUG REPORT"}));
+    assert.ok(predicate({type: stream_message, topic: "a]bug[b"}));
+    assert.ok(!predicate({type: stream_message, topic: "feature request"}));
+    assert.ok(!predicate({type: direct_message}));
+
     predicate = get_predicate([["is", "dm"]]);
     assert.ok(predicate({type: direct_message}));
     assert.ok(!predicate({type: stream_message}));
@@ -1900,6 +1908,18 @@ test("describe", ({mock_template, override}) => {
     terms = [{operator: "dm-including", operand: ""}];
     string = "direct messages including";
     assert.equal(Filter.search_description_as_html(terms, true), string);
+
+    terms = [{operator: "topic-contains", operand: ""}];
+    string = "topic contains";
+    assert.equal(Filter.search_description_as_html(terms, true), string);
+
+    terms = [{operator: "topic-contains", operand: "bug"}];
+    string = "topic contains bug";
+    assert.equal(Filter.search_description_as_html(terms, false), string);
+
+    terms = [{operator: "topic-contains", operand: "bug", negated: true}];
+    string = "exclude topic contains bug";
+    assert.equal(Filter.search_description_as_html(terms, false), string);
 });
 
 test("can_bucket_by", () => {
@@ -2110,6 +2130,7 @@ test("convert_suggestion_to_term", () => {
         ["channels:public", true],
         ["channels:private", false],
         ["topic:GhostTown", true],
+        ["topic-contains:bug", true],
         ["dm-including:alice@example.com", true],
         ["sender:ghost@zulip.com", false],
         ["sender:me", true],

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -338,6 +338,16 @@ class NarrowBuilderTest(ZulipTestCase):
             term, "WHERE NOT (upper(subject) = upper(%(param_1)s) AND is_channel_message)"
         )
 
+    def test_add_term_using_topic_contains_operator(self) -> None:
+        term = NarrowParameter(operator="topic-contains", operand="lunch")
+        self._do_add_term_test(term, "WHERE subject ILIKE %(subject_1)s AND is_channel_message")
+
+    def test_add_term_using_topic_contains_operator_negated(self) -> None:  # NEGATED
+        term = NarrowParameter(operator="topic-contains", operand="lunch", negated=True)
+        self._do_add_term_test(
+            term, "WHERE NOT (subject ILIKE %(subject_1)s AND is_channel_message)"
+        )
+
     def test_add_term_using_sender_operator(self) -> None:
         term = NarrowParameter(operator="sender", operand=self.othello_email)
         self._do_add_term_test(term, "WHERE sender_id = %(param_1)s")


### PR DESCRIPTION
Add a new search filter `topic-contains:` that matches topics containing a substring (case-insensitive), unlike the existing `topic:` operator which requires an exact match.

Fixes: #12328

This PR differs from the previous approach in  open PR #34841 which proposed changing `topic:` to partial match and adding `topic-exact:` for exact match. 

**Performance concern**
For this query, I'm using ILIKE with wildcards on both sides (%pattern%). My understanding is that standard B-tree indexes cannot be used in this case, requiring a sequential scan of matching rows. As mentioned in the previous PR, this could become a performance issue.

I am considering some potential solutions:

- Scope the search to a specific channel - This would be a UX change, but limiting topic-contains searches to a channel/stream context could significantly reduce the search space. However, this would also limit the usefulness of the operator.
- pg_trgm (trigram indexes): Could help with pattern matching queries like this, though the index size may be considerably larger.
- tsvector for full-text search: Would provide word-based matching instead of substring matching.

I'd appreciate your thoughts on how to approach this. Do you have any preferences or concerns about these options, or alternative approaches I should consider?

The changes were manually tested in a vagrant development environment.

**Screenshots and screen captures:**

[Screencast_20260123_202133.webm](https://github.com/user-attachments/assets/555743ed-6595-4753-a344-9647cbb99bdc)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
