### PR TITLE
import: Fix missing avatar thumbnails.

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -928,9 +928,8 @@ def process_avatars(record: dict[str, Any]) -> None:
             # same realm ID from a previous iteration).
             os.remove(medium_file_path)
     try:
+        ensure_avatar_image(user_profile=user_profile)
         ensure_avatar_image(user_profile=user_profile, medium=True)
-        if record.get("importer_should_thumbnail"):
-            ensure_avatar_image(user_profile=user_profile)
     except BadImageError:
         logging.warning(
             "Could not thumbnail avatar image for user %s; ignoring",


### PR DESCRIPTION
Fixes #37601.

When the Zulip export comes from a server using s3 upload, only the .original avatar files are included, as it is expected for the import process to generate thumbnails when needed.

The `ensure_avatar_image` call being gated behind
`if record.get("importer_should_thumbnail")`
is incorrect, as that flag doesn't have any meaningful use anymore. This is actually the only place in the code where `importer_should_thumbnail` is still mentioned.

