### PR TITLE
Todo delete UI

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -347,3 +347,22 @@ input {
         cursor: not-allowed;
     }
 }
+
+.todo-task-delete {
+    background: none;
+    border: none;
+    padding: 4px;
+    margin-left: 6px;
+    cursor: pointer;
+    color: var(--color-text-default);
+    opacity: 0.6;
+}
+
+.todo-task-delete:hover {
+    opacity: 1;
+    color: var(--color-danger);
+}
+
+.todo-task-delete:focus:not(:focus-visible) {
+    outline: none;
+}

--- a/web/templates/widgets/todo_widget_tasks.hbs
+++ b/web/templates/widgets/todo_widget_tasks.hbs
@@ -2,14 +2,22 @@
     <li>
         <label class="checkbox">
             <span class="todo-checkbox">
-                <input type="checkbox" class="task" data-key="{{ key }}" {{#if completed}}checked{{/if}}/>
+                <input type="checkbox" class="task" data-key="{{ key }}" {{#if completed}}checked{{/if}} />
                 <span class="custom-checkbox"></span>
             </span>
             <span class="todo-task">
                 {{#if completed}}
-                <s><strong>{{ task }}</strong>{{#if desc }}: {{ desc }}{{/if}}</s>
+                <s>
+                    <strong>{{ task }}</strong>{{#if desc }}: {{ desc }}{{/if}}
+                    <button type="button" class="todo-task-delete" data-key="{{ key }}" aria-label="{{t 'Delete task'}}">
+                        <i class="zulip-icon zulip-icon-trash"></i>
+                    </button>
+                </s>
                 {{else}}
                 <strong>{{ task }}</strong>{{#if desc }}: {{ desc }}{{/if}}
+                <button type="button" class="todo-task-delete" data-key="{{ key }}" aria-label="{{t 'Delete task'}}">
+                    <i class="zulip-icon zulip-icon-trash"></i>
+                </button>
                 {{/if}}
             </span>
         </label>

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -559,6 +559,19 @@ def validate_todo_data(todo_data: object, is_widget_author: bool) -> None:
         checker("todo data", todo_data)
         return
 
+    if todo_data["type"] == "delete_task":
+        if not is_widget_author:
+            raise ValidationError("You can't delete tasks unless you are the author.")
+
+        checker = check_dict_only(
+            [
+                ("type", check_string),
+                ("key", check_string),
+            ]
+        )
+        checker("todo data", todo_data)
+        return
+
     raise ValidationError(f"Unknown type for todo data: {todo_data['type']}")
 
 


### PR DESCRIPTION
Add support for deleting individual tasks in /todo widgets.

This change adds a delete control for each task in the /todo widget UI and
implements the corresponding frontend and backend logic to remove a single
task. Deletion is restricted to the widget author and validated server-side.

Fixes #20213 (one part , will fix other's one by one )

How changes were tested:

Ran the Zulip development server locally using ./tools/run-dev
Manually created a /todo widget, added multiple tasks, and verified:
Clicking the delete button removes only the selected task
Other tasks remain unaffected
Deletions are reflected immediately via widget events
Backend accepts delete_task events without validation errors

Screenshots and screen captures:

| Before                                                                                                                | After                                                                                                                |
| --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
| <img src="https://github.com/user-attachments/assets/ce87d4ad-0260-40eb-b44a-bff59cf1d8ae" alt="before" width="480"/> | <img src="https://github.com/user-attachments/assets/ec581327-f838-451a-a223-dd9d2a9f0d14" alt="after" width="480"/> |



<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the AI use policy.

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see commit discipline).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>

