### PR TITLE
Support Ctrl+N/P part-1 (search bar) on macOS

### DIFF
--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -206,6 +206,7 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
         helpOnEmptyStrings: true,
         stopAdvance: true,
         requireHighlight: false,
+        enableMacCtrlNPNavigation: true,
         item_html(item: string, query: string): string {
             const obj = search_map.get(item);
             assert(obj !== undefined);


### PR DESCRIPTION
Adds macOS-style Ctrl+N / Ctrl+P keyboard navigation to the search bar typeahead, so users can move through suggestions using common readline/macOS conventions (Ctrl+N = Down, Ctrl+P = Up). The behavior is implemented behind a typeahead option so other typeaheads are unaffected.

Fixes: https://github.com/zulip/zulip/issues/10884

**How changes were tested:**
- `tools/test-js-with-node`
- Manual testing (before/after) on the search bar typeahead:
  - With the search box focused and typeahead open, Ctrl+N moves highlight down, Ctrl+P moves highlight up.

**Screenshots and screen captures:**





- Before: 

https://github.com/user-attachments/assets/cf55f29e-56a3-498b-87e5-dd9d8a13454c

<!-- attach/drag video here -->
- After: 

https://github.com/user-attachments/assets/aaa32329-9584-4d94-882f-64e0b2b0a298

 <!-- attach/drag video here -->

</details>

<details>
<summary>Implementation notes</summary>

- Added a `enableMacCtrlNPNavigation` option to `Typeahead` and used it to normalize key handling.
- Enabled the option only for the search bar typeahead in `web/src/search.ts` to keep the fix minimal and avoid changing behavior in compose/topic/other typeaheads.

</details>

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
      <!-- I used AI assistance for guidance on locating relevant code paths and drafting a minimal change. I reviewed and verified the final code and behavior myself. -->

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>


