### PR TITLE
webhooks: Add test event handler to Dropbox Sign.

### DIFF
--- a/zerver/webhooks/dropboxsign/fixtures/callback_test.json
+++ b/zerver/webhooks/dropboxsign/fixtures/callback_test.json
@@ -1,0 +1,10 @@
+{
+    "event": {
+        "event_time": "1729521679",
+        "event_type": "callback_test",
+        "event_hash": "1abb1c65915585ab5afgec6f62c479b2917a889605f7ee867f64cbb313666f8f",
+        "event_metadata": {
+            "reported_for_account_id": "7ca5011f9071abc48c498f10a5692ea36f9534e3"
+        }
+    }
+}

--- a/zerver/webhooks/dropboxsign/tests.py
+++ b/zerver/webhooks/dropboxsign/tests.py
@@ -64,6 +64,13 @@ class DropboxSignHookTests(WebhookTestCase):
             topic=expected_topic_name,
         )
 
+    def test_callback_test(self) -> None:
+        expected_topic_name = "Dropbox Sign"
+        expected_message = "Dropbox Sign webhook has been successfully configured."
+        self.check_webhook(
+            "callback_test", expected_topic_name, expected_message, content_type=None
+        )
+
     @override
     def get_payload(self, fixture_name: str) -> dict[str, str]:
         return {"json": self.webhook_fixture_data("dropboxsign", fixture_name, file_type="json")}

--- a/zerver/webhooks/dropboxsign/view.py
+++ b/zerver/webhooks/dropboxsign/view.py
@@ -7,7 +7,7 @@ from zerver.decorator import webhook_view
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import ApiParamConfig, typed_endpoint
 from zerver.lib.validator import WildValue, check_string
-from zerver.lib.webhooks.common import check_send_webhook_message
+from zerver.lib.webhooks.common import check_send_webhook_message, get_setup_webhook_message
 from zerver.models import UserProfile
 
 IS_AWAITING_SIGNATURE = "is awaiting the signature of {awaiting_recipients}"
@@ -67,6 +67,10 @@ def api_dropboxsign_webhook(
     if "signature_request" in payload:
         body = get_message_body(payload)
         topic_name = payload["signature_request"]["title"].tame(check_string)
+        check_send_webhook_message(request, user_profile, topic_name, body)
+    elif payload["event"]["event_type"].tame(check_string) == "callback_test":
+        body = get_setup_webhook_message("Dropbox Sign")
+        topic_name = "Dropbox Sign"
         check_send_webhook_message(request, user_profile, topic_name, body)
 
     return json_success(request, data={"msg": "Hello API Event Received"})


### PR DESCRIPTION
This was a commit part of #32084 and was planned to be part of the Dropbox Sign changes after #37577, but since the Dropbox Sign commit was merged as part of that PR, this one's now a separate PR.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
