### PR TITLE
typeahead: Use CSS Grid for item layout.

### DIFF
--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -68,10 +68,11 @@
             }
 
             .typeahead-content {
-                display: flex;
+                display: grid;
+                grid-template-columns: max-content minmax(0, 1fr);
                 align-items: center;
-                overflow: hidden;
                 gap: 0.3571em;
+                width: 100%;
             }
 
             .typeahead-text-container {


### PR DESCRIPTION
This PR refactors the `.typeahead-content` class to use **CSS Grid** layout instead of the previous `flexbox` and `vertical-align` implementation.

Previously, relying on `vertical-align: middle` caused minor inconsistencies in alignment between the avatar and text, particularly when font sizes varied or usernames were long. Switching to CSS Grid allows us to:
1. Keep the avatar in a fixed-width column (`max-content`).
2. Allow the text to fill the remaining space (`minmax(0, 1fr)`).
3. Ensure perfect vertical centering using `align-items: center`.

**Screenshots**
<img width="790" height="415" alt="Screenshot 2026-01-25 220641" src="https://github.com/user-attachments/assets/e54008b9-3482-4114-9838-e78d9a2c53b9" />


**Testing**
* **Manual Verification:** Verified in the browser that the typeahead menu opens correctly and items are perfectly aligned. Checked that long usernames truncate properly without breaking the layout.
* **Automated Tests:** Ran the Puppeteer frontend tests locally.
    * `tools/test-js-with-puppeteer compose` → **PASSED**

**Fixes**
Fixes #37030