### PR TITLE
help: Fix emoji vertical alignment in keyboard shortcuts overlay.

### DIFF
--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -67,6 +67,11 @@
         text-align: right;
     }
 
+    & td.definition .emoji-1f44d {
+        vertical-align: middle;
+        margin-bottom: 0.6em;
+    }
+
     .hotkey {
         font-weight: normal;
     }

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -447,7 +447,7 @@
                     <td class="definition rendered_markdown">
                         {{t 'React to selected message with' }}
                         <img alt=":thumbs_up:"
-                          class="emoji"
+                          class="emoji emoji-1f44d"
                           src="../../static/generated/emoji/images/emoji/unicode/1f44d.png"
                           title=":thumbs_up:"/>
                     </td>


### PR DESCRIPTION
**Changes:**
- Fixed vertical alignment of thumbs-up emoji in the "React to selected message with 👍" keyboard shortcut
- Added CSS properties `vertical-align: middle` and `margin-bottom: 0.5rem` to emoji elements within table definitions in the help modal

**Problem:**
The thumbs-up emoji in the keyboard shortcuts overlay was appearing too low relative to the adjacent text, causing visual misalignment.

**Solution:**
Modified `web/styles/informational_overlays.css` to apply proper vertical alignment to emoji images within the keyboard shortcuts table.

Fixes: #30781

<hr>

**Screenshots and screen captures:**

**Zoomed view**

![3rd](https://github.com/user-attachments/assets/7ece37c3-3873-40bb-bd59-b2354caefa70)


**GIFs with different font sizes(using Zulip's font size feature. https://zulip.com/help/font-size).**

**Font size 16px**

![ezgif com-animated-gif-maker](https://github.com/user-attachments/assets/7cba860c-6535-4756-a420-c6585617099d)


**Font size 18px**

![ezgif com-animated-gif-maker 2nd](https://github.com/user-attachments/assets/fce3c297-e5f9-4a94-a195-c21f667ad3bb)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
