### PR TITLE
read-receipt: Convert read-receipt modal to popover.

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -893,10 +893,6 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
 
     // `list_util` will process the event in send later modal.
     if (is_any_modal_active && active_modal !== "#send_later_modal") {
-        if (event_name === "toggle_read_receipts" && active_modal === "#read_receipts_modal") {
-            read_receipts.hide_user_list();
-            return true;
-        }
         return false;
     }
 
@@ -1508,7 +1504,7 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
             return true;
         }
         case "toggle_read_receipts": {
-            read_receipts.show_user_list(msg.id);
+            read_receipts.toggle_read_receipts(msg.id);
             return true;
         }
         case "zoom_to_message_near": {

--- a/web/src/message_actions_popover.ts
+++ b/web/src/message_actions_popover.ts
@@ -206,10 +206,10 @@ export function initialize({
 
             $popper.one("click", ".view_read_receipts", (e) => {
                 const message_id = Number($(e.currentTarget).attr("data-message-id"));
-                read_receipts.show_user_list(message_id);
+                popover_menus.hide_current_popover_if_visible(instance);
+                read_receipts.open_read_receipt_popover(message_id, instance.reference);
                 e.preventDefault();
                 e.stopPropagation();
-                popover_menus.hide_current_popover_if_visible(instance);
             });
 
             $popper.one("click", ".delete_message", (e) => {

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -39,7 +39,9 @@ type PopoverName =
     | "show_folders_sidebar"
     | "show_folders_inbox"
     | "folder_actions"
-    | "send_later_options";
+    | "send_later_options"
+    | "show_channels_sidebar"
+    | "read_receipt_popover";
 
 export const popover_instances: Record<PopoverName, tippy.Instance | null> = {
     compose_control_buttons: null,
@@ -66,6 +68,8 @@ export const popover_instances: Record<PopoverName, tippy.Instance | null> = {
     show_folders_inbox: null,
     folder_actions: null,
     send_later_options: null,
+    show_channels_sidebar: null,
+    read_receipt_popover: null,
 };
 
 // Font size in em for popover derived from popover font size being

--- a/web/src/read_receipts.ts
+++ b/web/src/read_receipts.ts
@@ -1,6 +1,6 @@
 import $ from "jquery";
 import assert from "minimalistic-assert";
-import SimpleBar from "simplebar";
+import type * as tippy from "tippy.js";
 import * as z from "zod/mini";
 
 import render_read_receipts from "../templates/read_receipts.hbs";
@@ -10,10 +10,11 @@ import * as channel from "./channel.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as loading from "./loading.ts";
 import * as message_store from "./message_store.ts";
-import * as modals from "./modals.ts";
 import * as people from "./people.ts";
+import * as popover_menus from "./popover_menus.ts";
 import {realm} from "./state_data.ts";
 import * as ui_report from "./ui_report.ts";
+import {parse_html} from "./ui_util.ts";
 import * as util from "./util.ts";
 
 const read_receipts_polling_interval_ms = 60 * 1000;
@@ -29,12 +30,12 @@ export function fetch_read_receipts(message_id: number): void {
     assert(message !== undefined, "message is undefined");
 
     if (message.sender_email === "notification-bot@zulip.com") {
-        $("#read_receipts_modal .read_receipts_info").text(
+        $("#read-receipts-popover .read_receipts_info").text(
             $t({
                 defaultMessage: "Read receipts are not available for Notification Bot messages.",
             }),
         );
-        $("#read_receipts_modal .modal__content").addClass("compact");
+        $("#read-receipts-popover .read-receipt-content").addClass("compact");
         return;
     }
     if (!realm.realm_enable_read_receipts) {
@@ -43,13 +44,13 @@ export function fetch_read_receipts(message_id: number): void {
                 defaultMessage: "Read receipts are disabled for this organization.",
             }),
             undefined,
-            $("#read_receipts_modal #read_receipts_error"),
+            $("#read-receipts-popover #read_receipts_error"),
         );
         return;
     }
 
     if (!has_initial_data) {
-        loading.make_indicator($("#read_receipts_modal .loading_indicator"), {
+        loading.make_indicator($("#read-receipts-popover .loading_indicator"), {
             abs_positioned: true,
         });
     }
@@ -57,7 +58,7 @@ export function fetch_read_receipts(message_id: number): void {
     void channel.get({
         url: `/json/messages/${message_id}/read_receipts`,
         success(raw_data) {
-            const $modal = $("#read_receipts_modal").filter(`[data-message-id=${message_id}]`);
+            const $modal = $("#read-receipts-popover").filter(`[data-message-id=${message_id}]`);
             // If the read receipts modal for the selected message ID is closed
             // by the time we receive the response, return immediately.
             if ($modal.length === 0) {
@@ -65,7 +66,7 @@ export function fetch_read_receipts(message_id: number): void {
             }
 
             has_initial_data = true;
-            $("#read_receipts_modal .read_receipts_error").removeClass("show");
+            $("#read-receipts-popover .read_receipts_error").removeClass("show");
             const data = read_receipts_api_response_schema.parse(raw_data);
             const users = data.user_ids.map((id) => people.get_user_by_id_assert_valid(id));
             users.sort(people.compare_by_name);
@@ -79,16 +80,16 @@ export function fetch_read_receipts(message_id: number): void {
             };
 
             if (users.length === 0) {
-                $("#read_receipts_modal .read_receipts_info").text(
+                $("#read-receipts-popover .read_receipts_info").text(
                     $t({defaultMessage: "No one has read this message yet."}),
                 );
                 $modal.find(".read_receipts_list").hide();
             } else {
-                $("#read_receipts_modal .read_receipts_info").html(
+                $("#read-receipts-popover .read_receipts_info").html(
                     $t_html(
                         {
                             defaultMessage:
-                                "{num_of_people, plural, one {This message has been <z-link>read</z-link> by {num_of_people} person:} other {This message has been <z-link>read</z-link> by {num_of_people} people:}}",
+                                "{num_of_people, plural, one {Message <z-link>read</z-link> by {num_of_people} person:} other {Message <z-link>read</z-link> by {num_of_people} people:}}",
                         },
                         {
                             num_of_people: users.length,
@@ -100,36 +101,59 @@ export function fetch_read_receipts(message_id: number): void {
                     ),
                 );
                 $modal.find(".read_receipts_list").html(render_read_receipts(context)).show();
-                $("#read_receipts_modal .modal__container").addClass("showing_read_receipts_list");
-                new SimpleBar(util.the($("#read_receipts_modal .modal__content")), {
-                    tabIndex: -1,
-                });
+                $("#read-receipts-popover .read-receipt-container").addClass(
+                    "showing_read_receipts_list",
+                );
             }
-            loading.destroy_indicator($("#read_receipts_modal .loading_indicator"));
+            loading.destroy_indicator($("#read-receipts-popover .loading_indicator"));
         },
         error(xhr) {
             ui_report.error(
                 $t({defaultMessage: "Failed to load read receipts."}),
                 xhr,
-                $("#read_receipts_modal #read_receipts_error"),
+                $("#read-receipts-popover #read_receipts_error"),
             );
-            loading.destroy_indicator($("#read_receipts_modal .loading_indicator"));
+            loading.destroy_indicator($("#read-receipts-popover .loading_indicator"));
         },
     });
 }
 
-export function show_user_list(message_id: number): void {
-    $("#read-receipts-modal-container").html(render_read_receipts_modal({message_id}));
-    modals.open("read_receipts_modal", {
-        autoremove: true,
-        on_shown() {
+export function open_read_receipt_popover(
+    message_id: number,
+    target: tippy.ReferenceElement,
+): void {
+    popover_menus.toggle_popover_menu(target, {
+        theme: "popover-menu",
+        placement: "bottom",
+        popperOptions: {
+            modifiers: [
+                {
+                    // The placement is set to bottom, but if that placement does not fit,
+                    // the opposite top placement will be used.
+                    name: "flip",
+                    options: {
+                        fallbackPlacements: ["top", "left"],
+                    },
+                },
+            ],
+        },
+        onShow(instance) {
+            instance.setContent(parse_html(render_read_receipts_modal({message_id})));
+            popover_menus.popover_instances.read_receipt_popover = instance;
+            const $row = $(instance.reference).closest(".message_row");
+            $row.addClass("has_actions_popover");
             has_initial_data = false;
             fetch_read_receipts(message_id);
             interval_id = window.setInterval(() => {
                 fetch_read_receipts(message_id);
             }, read_receipts_polling_interval_ms);
         },
-        on_hidden() {
+        onHidden(instance) {
+            const $row = $(instance.reference).closest(".message_row");
+            $row.removeClass("has_actions_popover");
+            instance.destroy();
+            popover_menus.popover_instances.read_receipt_popover = null;
+
             if (interval_id !== null) {
                 clearInterval(interval_id);
                 interval_id = null;
@@ -138,6 +162,17 @@ export function show_user_list(message_id: number): void {
     });
 }
 
-export function hide_user_list(): void {
-    modals.close_if_open("read_receipts_modal");
+export function toggle_read_receipts(message_id: number): void {
+    const popover = popover_menus.popover_instances.read_receipt_popover;
+
+    if (popover) {
+        popover.hide();
+        return;
+    }
+
+    const $button = $(
+        `.message_row[data-message-id="${message_id}"] .actions_hover .message-actions-menu-button`,
+    );
+
+    open_read_receipt_popover(message_id, util.the($button));
 }

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -416,6 +416,8 @@
     /* Tippy popover related values */
     --navbar-popover-menu-min-width: 230px;
     --message-actions-popover-min-width: 230px;
+    --read-receipts-popover-min-width: 240px;
+    --read-receipts-popover-max-height: 315px;
     --user-group-info-popover-min-width: 16.4285em; /* 230px / 14px em */
     --topic-actions-popover-min-width: 200px;
     --user-card-popover-min-width: 200px;

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -1213,6 +1213,14 @@ ul.modal-options-list {
     width: 100%;
 }
 
+.read_receipts_user_avatar {
+    display: inline-block;
+    height: 1.25em; /* 20px at 16px font-size at 14px em */
+    width: 1.25em; /* 20px at 16px font-size at 14px em */
+    position: relative;
+    border-radius: 4px;
+}
+
 #change_group_info_modal .user-group-info-modal-fields {
     display: flex;
     flex-direction: column;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -306,6 +306,13 @@
     width: max-content;
 }
 
+#read_recepients_info_container {
+    padding: 0;
+    margin-top: 4px;
+    min-height: min-content;
+}
+
+.read-receipt-container,
 .popover-group-menu-info {
     display: flex;
     flex-direction: column;
@@ -324,6 +331,10 @@
     line-height: 1.1111em;
     color: var(--color-text-full-name);
     overflow-wrap: anywhere;
+}
+
+.popover-group-menu-name-container .popover-group-menu-name {
+    padding-top: 5px;
 }
 
 .popover-group-menu-description {
@@ -1152,12 +1163,27 @@ ul.popover-group-menu-member-list {
     }
 }
 
+#read-receipts-popover,
 #message-actions-menu-dropdown {
     /* 350px at 15px/1em */
     --popover-menu-max-width: 23.3333em;
 
     .simplebar-content {
         min-width: var(--message-actions-popover-min-width);
+    }
+}
+
+#read-receipts-popover {
+    max-height: var(--read-receipts-popover-max-height);
+
+    .simplebar-content {
+        min-width: var(--read-receipts-popover-min-width);
+    }
+
+    .popover-menu-label {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
     }
 }
 
@@ -1337,6 +1363,16 @@ ul.popover-menu-list {
     li.popover-menu-separator {
         margin: 4px 0;
         border-bottom: solid 1px var(--color-border-popover-menu-separator);
+    }
+}
+
+.read_receipts_list {
+    .popover-menu-list {
+        padding-top: 0;
+
+        .popover-menu-list-item .popover-menu-link {
+            padding-left: 0;
+        }
     }
 }
 

--- a/web/templates/read_receipts.hbs
+++ b/web/templates/read_receipts.hbs
@@ -1,6 +1,10 @@
-{{#each users}}
-    <li class="view_user_profile" data-user-id="{{user_id}}" tabindex="0" role="button">
-        <img class="read_receipts_user_avatar" src="{{avatar_url}}" />
-        <span>{{full_name}}</span>
-    </li>
-{{/each}}
+<ul role="menu" class="popover-menu-list">
+    {{#each users}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="view_user_profile popover-menu-link" data-user-id="{{user_id}}" tabindex="0">
+                <img class="read_receipts_user_avatar" src="{{avatar_url}}" />
+                <span class="popover-menu-label">{{full_name}}</span>
+            </a>
+        </li>
+    {{/each}}
+</ul>

--- a/web/templates/read_receipts_modal.hbs
+++ b/web/templates/read_receipts_modal.hbs
@@ -1,21 +1,12 @@
-<div class="micromodal" id="read_receipts_modal" aria-hidden="true" data-message-id="{{message_id}}">
-    <div class="modal__overlay" tabindex="-1">
-        <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="read_receipts_modal_label">
-            <header class="modal__header">
-                <div class="modal__header-content">
-                    <h1 class="modal__title" id="read_receipts_modal_label">
-                        {{t "Read receipts" }}
-                    </h1>
-                </div>
-                {{> components/icon_button icon="close" intent="neutral" custom_classes="modal__close" aria-label=(t 'Close modal') data-micromodal-close=true }}
-            </header>
-            <main class="modal__content">
-                <div class="alert" id="read_receipts_error"></div>
-                <div class="read_receipts_info">
-                </div>
-                <div class="loading_indicator"></div>
-                <ul class="read_receipts_list"></ul>
-            </main>
+<div class="popover-menu" id="read-receipts-popover" data-simplebar data-simplebar-tab-index="-1" data-message-id="{{message_id}}">
+    <div class="read-receipt-container">
+        <div role="none" class="popover-menu-list-item read_receipts_info_container text-item" id="read_recepients_info_container">
+            <span class="read_receipts_info"></span>
+        </div>
+        <div class="read-receipt-content">
+            <div class="alert" id="read_receipts_error"></div>
+            <div class="loading_indicator"></div>
+            <div class="read_receipts_list"></div>
         </div>
     </div>
 </div>

--- a/web/tests/hotkey.test.cjs
+++ b/web/tests/hotkey.test.cjs
@@ -558,11 +558,7 @@ test_while_not_editing_text("misc", ({override}) => {
     override(message_edit, "can_move_message", () => false);
     assert_unmapped("m");
 
-    assert_mapping("V", read_receipts, "show_user_list", true);
-
-    override(modals, "any_active", () => true);
-    override(modals, "active_modal", () => "#read_receipts_modal");
-    assert_mapping("V", read_receipts, "hide_user_list", true);
+    assert_mapping("V", read_receipts, "toggle_read_receipts", true);
 });
 
 test_while_not_editing_text("lightbox overlay open", ({override}) => {


### PR DESCRIPTION
This PR completes the conversion of the read-receipts UI from a modal to a popover. It builds on the groundwork laid in #35112, which implemented most of the popover-based UI.

Work done in this PR:
- `show_user_list` and `hide_user_list` has been cleaned up from `hotkey.js`
- `toggle_read_receipts` now handles toggling read-receipt
- Minor styling changes in the popover

Fixes: #35004

**Screenshots and screen captures:**

Before:

<img width="454" height="220" alt="Screenshot 2026-01-26 at 3 59 13 PM" src="https://github.com/user-attachments/assets/f3200dc8-3263-47e3-966b-fc41525e667f" />

<img width="452" height="567" alt="Screenshot 2026-01-26 at 3 58 18 PM" src="https://github.com/user-attachments/assets/10f1ebde-982a-47b4-917a-96a9127725d6" />

After:

<img width="263" height="333" alt="Screenshot 2026-03-27 at 7 16 28 PM" src="https://github.com/user-attachments/assets/34a17bff-3693-4292-a944-43b937834d74" />
<img width="241" height="73" alt="Screenshot 2026-03-27 at 7 16 45 PM" src="https://github.com/user-attachments/assets/1fee70b9-60c4-4965-b585-6351f0e442b0" />
<img width="265" height="80" alt="Screenshot 2026-03-27 at 7 20 44 PM" src="https://github.com/user-attachments/assets/9c4c4d53-fbe3-4040-9005-145d67ad1a08" />




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
