### PR TITLE
Fix message attachment deletion

### DIFF
--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -711,24 +711,20 @@ def do_add_deactivated_redirect(realm: Realm, redirect_url: str) -> None:
     realm.save(update_fields=["deactivated_redirect"])
 
 
-def do_delete_all_realm_attachments(realm: Realm, *, batch_size: int = 1000) -> None:
+def do_delete_all_realm_attachments(realm: Realm) -> None:
     # Delete attachment files from the storage backend, so that we
     # don't leave them dangling.
-    for obj_class in Attachment, ArchivedAttachment:
-        last_id = 0
-        while True:
+    with delete_message_attachments(delete_from=(ImageAttachment,)) as delete_one:
+        for obj_class in Attachment, ArchivedAttachment:
             to_delete = (
-                obj_class._default_manager.filter(realm_id=realm.id, pk__gt=last_id)
+                obj_class._default_manager.filter(realm_id=realm.id)
                 .order_by("pk")
-                .values_list("pk", "path_id")[:batch_size]
+                .select_for_update()
+                .values_list("path_id", flat=True)
             )
-            if len(to_delete) > 0:
-                delete_message_attachments([row[1] for row in to_delete])
-                last_id = to_delete[len(to_delete) - 1][0]
-                ImageAttachment.objects.filter(path_id__in=[row[1] for row in to_delete]).delete()
-            if len(to_delete) < batch_size:
-                break
-        obj_class._default_manager.filter(realm=realm).delete()
+            for path_id in to_delete.iterator():
+                delete_one(path_id)
+            obj_class._default_manager.filter(realm_id=realm.id).delete()
 
 
 @transaction.atomic(durable=True)

--- a/zerver/lib/upload/local.py
+++ b/zerver/lib/upload/local.py
@@ -118,10 +118,11 @@ class LocalUploadBackend(ZulipUploadBackend):
         )
 
     @override
-    def delete_message_attachment(self, path_id: str) -> None:
+    def delete_message_attachment(self, path_id: str, *, raw_path: bool = False) -> None:
         delete_local_file("files", path_id)
-        delete_local_file("files", f"{path_id}.info")
-        delete_local_file("files", f"thumbnail/{path_id}/", directory=True)
+        if not raw_path:
+            delete_local_file("files", f"{path_id}.info")
+            delete_local_file("files", f"thumbnail/{path_id}/", directory=True)
 
     @override
     def all_message_attachments(

--- a/zerver/tests/test_upload_local.py
+++ b/zerver/tests/test_upload_local.py
@@ -1,6 +1,7 @@
 import os
 import re
 from io import BytesIO
+from pathlib import Path
 from urllib.parse import urlsplit
 
 import pyvips
@@ -127,6 +128,9 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
         assert settings.LOCAL_UPLOADS_DIR is not None
         assert settings.LOCAL_FILES_DIR is not None
 
+        file_list = list(Path(settings.LOCAL_FILES_DIR).rglob("*"))
+        self.assertEqual(sum(1 for item in file_list if item.is_file()), 0)
+
         user_profile = self.example_user("hamlet")
         path_ids = []
         for n in range(1, 1005):
@@ -138,10 +142,21 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
             file_path = os.path.join(settings.LOCAL_FILES_DIR, path_id)
             self.assertTrue(os.path.isfile(file_path))
 
-        delete_message_attachments(path_ids)
-        for path_id in path_ids:
-            file_path = os.path.join(settings.LOCAL_FILES_DIR, path_id)
-            self.assertFalse(os.path.isfile(file_path))
+            # Make synthetic .info files and thumbnail files, to ensure those are cleaned up
+            with open(file_path + ".info", "w") as fh:
+                fh.write("{}")
+            os.makedirs(os.path.join(settings.LOCAL_FILES_DIR, "thumbnail", path_id))
+            with open(
+                os.path.join(settings.LOCAL_FILES_DIR, "thumbnail", path_id, "100x100.webp"), "w"
+            ) as fh:
+                fh.write("...")
+
+        with delete_message_attachments() as delete_one:
+            for path_id in path_ids:
+                delete_one(path_id)
+
+        file_list = list(Path(settings.LOCAL_FILES_DIR).rglob("*"))
+        self.assertEqual(sum(1 for item in file_list if item.is_file()), 0)
 
     def test_all_message_attachments(self) -> None:
         write_local_file("files", "foo", b"content")

--- a/zerver/tests/test_upload_s3.py
+++ b/zerver/tests/test_upload_s3.py
@@ -191,7 +191,9 @@ class S3Test(ZulipTestCase):
             path_ids.append(path_id)
 
         with patch.object(S3UploadBackend, "delete_message_attachment") as single_delete:
-            delete_message_attachments(path_ids)
+            with delete_message_attachments() as delete_one:
+                for path_id in path_ids:
+                    delete_one(path_id)
             single_delete.assert_not_called()
         for path_id in path_ids:
             with self.assertRaises(botocore.exceptions.ClientError):


### PR DESCRIPTION
Fixes: do_delete_old_unclaimed_attachments fails with an S3 backend due to it trying to delete more than 1000 files per batch.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
