### PR TITLE
Remove outdated Google Code-in references from documentation

### DIFF
--- a/docs/development/request-remote.md
+++ b/docs/development/request-remote.md
@@ -5,7 +5,8 @@ orphan: true
 # How to request a remote Zulip development instance
 
 Under specific circumstances, typically during sprints, hackathons, and
-Google Code-in, Zulip can provide you with a virtual machine with the
+other mentorship events (like GSoC application periods or Outreachy
+internships), Zulip can provide you with a virtual machine with the
 development environment already set up.
 
 The machines (droplets) are being generously provided by

--- a/docs/outreach/overview.md
+++ b/docs/outreach/overview.md
@@ -42,8 +42,8 @@ post](https://blog.zulip.com/2021/04/28/why-zulip-is-on-github-sponsors/)!
 Zulip has been a [GSoC](https://summerofcode.withgoogle.com/) mentoring
 organization since 2016, and we accept 12-20 GSoC participants each summer. We
 have also mentored several interns through the
-[Outreachy](https://www.outreachy.org/) program, and hundreds of Google Code-In
-participants.
+[Outreachy](https://www.outreachy.org/) program, and, while the program was
+active, hundreds of Google Code-in participants.
 
 Zulip operates under a **group mentorship** model. While you will have an
 assigned mentor, you will also get lots of feedback from other members of the


### PR DESCRIPTION
This PR updates two documentation files to avoid confusion for new contributors:

In docs/development/request-remote.md, references to Google Code-in as a current pathway for requesting remote development instances have been removed. The text now highlights active mentorship events such as GSoC, Outreachy, and community sprints.

In docs/outreach/overview.md, the mention of Google Code-in is clarified as historical, so newcomers are directed toward current programs like GSoC and Outreachy.