### PR TITLE
left-sidebar: Reduce max topics shown with and without unread messages.

### DIFF
--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -9,8 +9,8 @@ import * as unread from "./unread.ts";
 import * as user_topics from "./user_topics.ts";
 import * as util from "./util.ts";
 
-const max_topics = 8;
-const max_topics_with_unread = 12;
+const MAX_TOPICS = 6;
+const MAX_TOPICS_WITH_UNREAD = 10;
 
 export type TopicInfo = {
     stream_id: number;
@@ -69,7 +69,7 @@ function choose_topics(
                 // We always show the active topic.  Ideally, this
                 // logic would first check whether the active
                 // topic is in the set of those with unreads to
-                // avoid ending up with max_topics_with_unread + 1
+                // avoid ending up with MAX_TOPICS_WITH_UNREAD + 1
                 // total topics if the active topic comes after
                 // the first several topics with unread messages.
                 if (is_active_topic) {
@@ -83,16 +83,16 @@ function choose_topics(
                     return false;
                 }
 
-                // We include the most recent max_topics topics,
+                // We include the most recent MAX_TOPICS topics,
                 // even if there are no unread messages.
-                if (idx < max_topics && topics_selected < max_topics) {
+                if (idx < MAX_TOPICS && topics_selected < MAX_TOPICS) {
                     return true;
                 }
 
                 // We include older topics with unread messages up
-                // until max_topics_with_unread total topics have
+                // until MAX_TOPICS_WITH_UNREAD total topics have
                 // been included.
-                if (num_unread > 0 && topics_selected < max_topics_with_unread) {
+                if (num_unread > 0 && topics_selected < MAX_TOPICS_WITH_UNREAD) {
                     return true;
                 }
 

--- a/web/tests/topic_list_data.test.cjs
+++ b/web/tests/topic_list_data.test.cjs
@@ -155,7 +155,7 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
     override(narrow_state, "stream_id", () => 556);
 
     list_info = get_list_info();
-    assert.equal(list_info.items.length, 8);
+    assert.equal(list_info.items.length, 6);
     assert.equal(list_info.more_topics_unreads, 0);
     assert.equal(list_info.more_topics_have_unread_mention_messages, false);
     assert.equal(list_info.num_possible_topics, 11);
@@ -181,7 +181,7 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
     override(narrow_state, "topic", () => "topic 6");
 
     list_info = get_list_info();
-    assert.equal(list_info.items.length, 8);
+    assert.equal(list_info.items.length, 6);
     assert.equal(list_info.more_topics_unreads, 0);
     assert.equal(list_info.more_topics_have_unread_mention_messages, false);
     assert.equal(list_info.num_possible_topics, 10);
@@ -222,7 +222,7 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
     add_topic_message("", 2025);
 
     list_info = get_list_info();
-    assert.equal(list_info.items.length, 8);
+    assert.equal(list_info.items.length, 6);
     assert.equal(list_info.more_topics_unreads, 0);
     assert.equal(list_info.more_topics_have_unread_mention_messages, false);
     assert.equal(list_info.num_possible_topics, 11);
@@ -244,7 +244,7 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
     });
 
     // If we zoom in, our results are based on topic filter.
-    // If topic search input is empty, we show all 10 topics.
+    // If topic search input is empty, we show all topics.
     const zoomed = true;
     list_info = get_list_info(zoomed);
     assert.equal(list_info.items.length, 11);
@@ -336,11 +336,11 @@ test("get_list_info unreads", ({override}) => {
 
     /*
         We have 16 topics, but we only show up
-        to 12 topics, depending on how many have
-        unread counts.  We only show a max of 8
+        to 10 topics, depending on how many have
+        unread counts.  We only show a max of 6
         fully-read topics.
 
-        So first we'll get 10 topics, where 2 are
+        So first we'll get 8 topics, where 2 are
         unread.
     */
     add_unreads("topic 14", 1);
@@ -355,25 +355,14 @@ test("get_list_info unreads", ({override}) => {
     add_unreads_with_mention("topic 14", 1);
 
     list_info = get_list_info();
-    assert.equal(list_info.items.length, 10);
+    assert.equal(list_info.items.length, 8);
     assert.equal(list_info.more_topics_unreads, 0);
     assert.equal(list_info.more_topics_have_unread_mention_messages, false);
     assert.equal(list_info.num_possible_topics, 16);
 
     assert.deepEqual(
         list_info.items.map((li) => li.topic_name),
-        [
-            "topic 0",
-            "topic 1",
-            "topic 2",
-            "topic 3",
-            "topic 4",
-            "topic 5",
-            "topic 6",
-            "topic 7",
-            "topic 13",
-            "topic 14",
-        ],
+        ["topic 0", "topic 1", "topic 2", "topic 3", "topic 4", "topic 5", "topic 13", "topic 14"],
     );
 
     add_unreads("topic 12", 1);
@@ -381,7 +370,7 @@ test("get_list_info unreads", ({override}) => {
     add_unreads("topic 10", 1);
 
     list_info = get_list_info();
-    assert.equal(list_info.items.length, 12);
+    assert.equal(list_info.items.length, 10);
     assert.equal(list_info.more_topics_unreads, 2);
     assert.equal(list_info.more_topics_have_unread_mention_messages, true);
     assert.equal(list_info.num_possible_topics, 16);
@@ -395,8 +384,6 @@ test("get_list_info unreads", ({override}) => {
             "topic 3",
             "topic 4",
             "topic 5",
-            "topic 6",
-            "topic 7",
             "topic 10",
             "topic 11",
             "topic 12",
@@ -405,7 +392,6 @@ test("get_list_info unreads", ({override}) => {
     );
 
     add_unreads("topic 9", 1);
-    add_unreads("topic 8", 1);
 
     add_unreads("topic 4", 1);
     override(user_topics, "is_topic_muted", (stream_id, topic_name) => {
@@ -423,7 +409,7 @@ test("get_list_info unreads", ({override}) => {
     });
 
     list_info = get_list_info();
-    assert.equal(list_info.items.length, 12);
+    assert.equal(list_info.items.length, 10);
     assert.equal(list_info.more_topics_unreads, 3);
     assert.equal(list_info.more_topics_have_unread_mention_messages, true);
     assert.equal(list_info.num_possible_topics, 16);
@@ -438,8 +424,6 @@ test("get_list_info unreads", ({override}) => {
             "topic 2",
             "topic 3",
             "topic 6",
-            "topic 7",
-            "topic 8",
             "topic 9",
             "topic 10",
             "topic 11",
@@ -447,13 +431,13 @@ test("get_list_info unreads", ({override}) => {
         ],
     );
 
-    // Now test with topics 4/8/9, all the ones with unreads, being muted.
+    // Now test with topics 4/9/10, all the ones with unreads, being muted.
     override(user_topics, "is_topic_muted", (stream_id, topic_name) => {
         assert.equal(stream_id, general.stream_id);
-        return ["topic 4", "topic 8", "topic 9"].includes(topic_name);
+        return ["topic 4", "topic 9", "topic 10"].includes(topic_name);
     });
     list_info = get_list_info();
-    assert.equal(list_info.items.length, 12);
+    assert.equal(list_info.items.length, 10);
     assert.equal(list_info.more_topics_unreads, 3);
     // Topic 14 now makes it above the "show all topics" fold.
     assert.equal(list_info.more_topics_have_unread_mention_messages, false);
@@ -468,8 +452,6 @@ test("get_list_info unreads", ({override}) => {
             "topic 2",
             "topic 3",
             "topic 6",
-            "topic 7",
-            "topic 10",
             "topic 11",
             "topic 12",
             "topic 13",
@@ -477,9 +459,9 @@ test("get_list_info unreads", ({override}) => {
         ],
     );
 
-    add_unreads_with_mention("topic 8", 1);
+    add_unreads_with_mention("topic 9", 1);
     list_info = get_list_info();
-    assert.equal(list_info.items.length, 12);
+    assert.equal(list_info.items.length, 10);
     assert.equal(list_info.more_topics_unreads, 4);
     // Topic 8's new mention gets counted here.
     assert.equal(list_info.more_topics_have_unread_mention_messages, true);
@@ -494,8 +476,6 @@ test("get_list_info unreads", ({override}) => {
             "topic 2",
             "topic 3",
             "topic 6",
-            "topic 7",
-            "topic 10",
             "topic 11",
             "topic 12",
             "topic 13",
@@ -507,7 +487,7 @@ test("get_list_info unreads", ({override}) => {
     // result in just the unmuted unreads being counted.
     add_unreads("topic 15", 15);
     list_info = get_list_info();
-    assert.equal(list_info.items.length, 12);
+    assert.equal(list_info.items.length, 10);
     assert.equal(list_info.more_topics_unreads, 15);
     assert.equal(list_info.more_topics_have_unread_mention_messages, true);
     assert.equal(list_info.num_possible_topics, 16);
@@ -521,8 +501,6 @@ test("get_list_info unreads", ({override}) => {
             "topic 2",
             "topic 3",
             "topic 6",
-            "topic 7",
-            "topic 10",
             "topic 11",
             "topic 12",
             "topic 13",


### PR DESCRIPTION
Changes the max topics shown in the left sidebar:
- with unread messages = 10
- without unread messages = 6.

Part of #36199.

---

**Screenshots and screen captures:**

*NO UNREAD MESSAGES IN CHANNEL - OLDER TOPIC - MOSTLY ONE LINE TOPICS*
| Before | After |
| --- | --- |
| <img width="469" height="973" alt="Screenshot From 2026-01-27 19-41-28" src="https://github.com/user-attachments/assets/23c0bd40-07ed-483c-8b89-7e9b9903b055" /> | <img width="469" height="973" alt="Screenshot From 2026-01-27 19-41-37" src="https://github.com/user-attachments/assets/7df79833-d019-4b30-b1bf-286a43e2c612" />

*UNREAD MESSAGES IN CHANNEL - NEWER TOPIC - ALL TWO LINE TOPICS*
| Before | After |
| --- | --- |
| <img width="477" height="1356" alt="Screenshot From 2026-01-27 19-59-26" src="https://github.com/user-attachments/assets/667bd369-91f5-43be-8443-c36547fee9d5" /> | <img width="477" height="1356" alt="Screenshot From 2026-01-27 19-59-38" src="https://github.com/user-attachments/assets/11387f35-2fbe-45e9-aee8-6e6cefad2ff1" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
