### PR TITLE
templates: Forbid testing a number with {{#if}}, {{#unless}}

### DIFF
--- a/web/src/templates.ts
+++ b/web/src/templates.ts
@@ -12,6 +12,10 @@ const orig_escape_expression = Handlebars.Utils.escapeExpression;
 const orig_is_empty = Handlebars.Utils.isEmpty;
 const orig_each = Handlebars.helpers["each"];
 assert(orig_each !== undefined);
+const orig_if = Handlebars.helpers["if"];
+assert(orig_if !== undefined);
+const orig_unless = Handlebars.helpers["unless"];
+assert(orig_unless !== undefined);
 
 Handlebars.Utils.escapeExpression = (value: unknown): string => {
     /* istanbul ignore if */
@@ -52,6 +56,26 @@ Handlebars.helpers["each"] = function (context, options): unknown {
         );
     }
     return orig_each.call(this, context, options);
+};
+
+Handlebars.helpers["if"] = function (conditional, options): unknown {
+    /* istanbul ignore if */
+    if (typeof conditional === "number") {
+        blueslip.error(
+            `Cannot test a value of type ${typeof conditional} in a Zulip Handlebars template`,
+        );
+    }
+    return orig_if.call(this, conditional, options);
+};
+
+Handlebars.helpers["unless"] = function (conditional, options): unknown {
+    /* istanbul ignore if */
+    if (typeof conditional === "number") {
+        blueslip.error(
+            `Cannot test a value of type ${typeof conditional} in a Zulip Handlebars template`,
+        );
+    }
+    return orig_unless.call(this, conditional, options);
 };
 
 // Below, we register Zulip-specific extensions to the Handlebars API.

--- a/web/templates/components/banner.hbs
+++ b/web/templates/components/banner.hbs
@@ -8,7 +8,7 @@
             {{/if}}
         </span>
         {{#unless (eq buttons undefined)}}
-            {{#if buttons.length}}
+            {{#unless (eq buttons.length 0)}}
             <span class="banner-action-buttons">
                 {{!-- squash whitespace so :empty selector works when no buttons --}}
                 {{~!-- squash whitespace --~}}
@@ -21,7 +21,7 @@
                 {{/each}}
                 {{~!-- squash whitespace --~}}
             </span>
-            {{/if}}
+            {{/unless}}
         {{/unless}}
     </span>
     {{#if close_button}}

--- a/web/templates/compose_banner/compose_banner.hbs
+++ b/web/templates/compose_banner/compose_banner.hbs
@@ -1,7 +1,7 @@
 <div
   class="main-view-banner {{banner_type}} {{classname}}"
-  {{#if user_id}}data-user-id="{{user_id}}"{{/if}}
-  {{#if stream_id}}data-stream-id="{{stream_id}}"{{/if}}
+  {{#unless (eq user_id undefined)}}data-user-id="{{user_id}}"{{/unless}}
+  {{#unless (eq stream_id undefined)}}data-stream-id="{{stream_id}}"{{/unless}}
   {{#if (or topic_name is_empty_string_topic)}}data-topic-name="{{topic_name}}"{{/if}}>
     <div class="main-view-banner-elements-wrapper">
         {{#if banner_text}}

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -30,7 +30,7 @@
             <a role="button" class="compose_control_button compose-gif-icon zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0></a>
         </div>
     {{/if}}
-    {{#if message_id}}
+    {{#unless (eq message_id undefined)}}
     <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tooltip-template-id="add-saved-snippet-tooltip">
         <a role="button" class="saved_snippets_widget saved-snippets-message-edit-widget compose_control_button zulip-icon zulip-icon-message-square-text" aria-label="{{t 'Add saved snippet' }}" data-message-id="{{message_id}}" tabindex=0></a>
     </div>
@@ -38,7 +38,7 @@
     <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tooltip-template-id="add-saved-snippet-tooltip">
         <a role="button" class="saved_snippets_widget saved-snippets-composebox-widget compose_control_button zulip-icon zulip-icon-message-square-text" aria-label="{{t 'Add saved snippet' }}" tabindex=0></a>
     </div>
-    {{/if}}
+    {{/unless}}
     <div class="divider"></div>
     <div class="compose-control-buttons-container preview_mode_disabled">
         <a role="button" data-format-type="link" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-link formatting_button" aria-label="{{t 'Link' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="link-tooltip" data-tippy-maxWidth="none"></a>
@@ -57,13 +57,13 @@
         <a role="button" data-format-type="latex" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-math formatting_button" aria-label="{{t 'Math (LaTeX)' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Math (LaTeX)' }}"></a>
     </div>
     <div class="divider"></div>
-    {{#unless message_id}}
+    {{#if (eq message_id undefined)}}
     <div class="compose_control_button_container preview_mode_disabled needs-empty-compose compose_button_tooltip" data-tooltip-template-id="add-poll-tooltip" data-tippy-maxWidth="none">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-poll add-poll" aria-label="{{t 'Add poll' }}" tabindex=0></a>
     </div>
     <div class="compose_control_button_container preview_mode_disabled needs-empty-compose compose_button_tooltip" data-tooltip-template-id="add-todo-tooltip" data-tippy-maxWidth="none">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-todo-list add-todo-list" aria-label="{{t 'Add to-do list' }}" tabindex=0></a>
     </div>
-    {{/unless}}
+    {{/if}}
     <a role="button" class="compose_control_button compose_help_button zulip-icon zulip-icon-question compose_button_tooltip" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>
 </div>

--- a/web/templates/confirm_dialog/confirm_deactivate_user.hbs
+++ b/web/templates/confirm_dialog/confirm_deactivate_user.hbs
@@ -12,7 +12,7 @@
         {{/tr}}
     {{/if}}
 </p>
-{{#if bots_owned_by_user.length}}
+{{#unless (eq bots_owned_by_user.length 0)}}
     <p>
         {{t "They administer the following bots:"}}
     </p>
@@ -21,7 +21,7 @@
             <li>{{this.full_name}}</li>
         {{/each}}
     </ul>
-{{/if}}
+{{/unless}}
 <label class="checkbox">
     <input type="checkbox" class="send_email" />
     <span class="rendered-checkbox"></span>

--- a/web/templates/creator_details.hbs
+++ b/web/templates/creator_details.hbs
@@ -18,13 +18,13 @@
         {{#*inline "z-date-created"}}{{date_created_string}}{{/inline}}
     {{/tr}}
 {{/if}}
-{{#if stream_id}}
+{{#unless (eq stream_id undefined)}}
 {{# tr}}
     &nbsp;Channel ID: {stream_id}.
 {{/tr}}
-{{/if}}
-{{#if group_id}}
+{{/unless}}
+{{#unless (eq group_id undefined)}}
 {{# tr}}
     &nbsp;Group ID: {group_id}.
 {{/tr}}
-{{/if}}
+{{/unless}}

--- a/web/templates/edited_notice.hbs
+++ b/web/templates/edited_notice.hbs
@@ -1,6 +1,6 @@
 <div class="edit-notifications"></div>
 {{#if modified}}
-    {{#if msg/local_edit_timestamp}}
+    {{#unless (eq msg/local_edit_timestamp undefined)}}
         <div class="message_edit_notice">
             {{t "SAVING"}}
         </div>
@@ -12,5 +12,5 @@
         <div class="message_edit_notice">
             {{t "MOVED"}}
         </div>
-    {{/if}}
+    {{/unless}}
 {{/if}}

--- a/web/templates/export_modal_warning_notes.hbs
+++ b/web/templates/export_modal_warning_notes.hbs
@@ -1,4 +1,4 @@
-{{#if unusable_user_count}}
+{{#unless (eq unusable_user_count 0)}}
     <p>
         {{#tr}}
             You don't have permission to <z-help-link>access</z-help-link> the
@@ -19,7 +19,7 @@
         {{/tr}}
     </p>
 
-    {{#if unusable_admin_user_count}}
+    {{#unless (eq unusable_admin_user_count 0)}}
         <p>
             {{#tr}}
                 The following {unusable_admin_user_count, plural, one
@@ -39,5 +39,5 @@
                 {{/inline}}
             {{/tr}}
         </p>
-    {{/if}}
-{{/if}}
+    {{/unless}}
+{{/unless}}

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -33,7 +33,7 @@
                         <span class="unread_mention_info tippy-zulip-tooltip
                           {{#unless mention_in_unread}}hidden{{/unless}}"
                           data-tippy-content="{{t 'You have unread mentions'}}">@</span>
-                        {{#if unread_count}}
+                        {{#unless (or (eq unread_count undefined) (eq unread_count 0))}}
                         <div class="unread-count-focus-outline" tabindex="0" data-col-index="{{ column_indexes.UNREAD_COUNT }}">
                             <span class="unread_count tippy-zulip-tooltip on_hover_topic_read"
                               data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}"
@@ -41,7 +41,7 @@
                                 {{unread_count}}
                             </span>
                         </div>
-                        {{/if}}
+                        {{/unless}}
                     {{/if}}
                 </div>
             </div>

--- a/web/templates/input_pill.hbs
+++ b/web/templates/input_pill.hbs
@@ -1,7 +1,7 @@
 <div class='pill {{#if deactivated}} deactivated-pill {{/if~}}'
-  {{~#if user_id}}data-user-id="{{user_id}}"{{/if~}}
-  {{~#if group_id}}data-user-group-id="{{group_id}}"{{/if~}}
-  {{~#if stream_id}}data-stream-id="{{stream_id}}"{{/if~}}
+  {{~#unless (eq user_id undefined)}}data-user-id="{{user_id}}"{{/unless~}}
+  {{~#unless (eq group_id undefined)}}data-user-group-id="{{group_id}}"{{/unless~}}
+  {{~#unless (eq stream_id undefined)}}data-stream-id="{{stream_id}}"{{/unless~}}
   {{~#if data_syntax}}data-syntax="{{data_syntax}}"{{/if}} tabindex=0>
     {{#if has_image}}
     <img class="pill-image" src="{{img_src}}" />

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -104,7 +104,7 @@
     {{/if}}
     {{#if is_admin}}
     <div class="input-group">
-        {{#if default_welcome_message_custom_text.length}}
+        {{#if default_welcome_message_custom_text}}
         <label class="checkbox display-block modal-field-label">
             <input type="checkbox" id="send_default_realm_welcome_message_custom_text" checked="checked"/>
             <span class="rendered-checkbox"></span>

--- a/web/templates/left_sidebar_expanded_view_item.hbs
+++ b/web/templates/left_sidebar_expanded_view_item.hbs
@@ -5,10 +5,10 @@
         </span>
         {{~!-- squash whitespace --~}}
         <span class="left-sidebar-navigation-label">{{name}}</span>
-        <span class="unread_count {{unread_count_type}}{{#unless unread_count}} hide{{/unless}}">
-            {{#if unread_count}}
+        <span class="unread_count {{unread_count_type}}{{#if (or (eq unread_count undefined) (eq unread_count 0))}} hide{{/if}}">
+            {{#unless (or (eq unread_count undefined) (eq unread_count 0))}}
                 {{unread_count}}
-            {{/if}}
+            {{/unless}}
         </span>
         {{#if supports_masked_unread}}
         <span class="masked_unread_count">

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -75,10 +75,10 @@
 
 <div class="message_length_controller"></div>
 
-{{#if (and (not is_hidden) msg.message_reactions.length)}}
+{{#unless (or is_hidden (eq msg.message_reactions.length 0))}}
     {{> message_reactions . }}
-{{/if}}
+{{/unless}}
 
-{{#if msg.reminders.length}}
+{{#unless (eq msg.reminders.length 0)}}
     {{> message_reminders . }}
-{{/if}}
+{{/unless}}

--- a/web/templates/more_pms.hbs
+++ b/web/templates/more_pms.hbs
@@ -1,6 +1,6 @@
-<li id="show-more-direct-messages" class="dm-list-item dm-box bottom_left_row {{#unless more_conversations_unread_count}}zero-dm-unreads{{/unless}}">
+<li id="show-more-direct-messages" class="dm-list-item dm-box bottom_left_row {{#if (eq more_conversations_unread_count 0)}}zero-dm-unreads{{/if}}">
     <a class="dm-name trigger-click-on-enter" tabindex="0">{{t "more conversations" }}</a>
-    <span class="unread_count {{#unless more_conversations_unread_count}}zero_count{{/unless}}">
+    <span class="unread_count {{#if (eq more_conversations_unread_count 0)}}zero_count{{/if}}">
         {{more_conversations_unread_count}}
     </span>
 </li>

--- a/web/templates/more_topics.hbs
+++ b/web/templates/more_topics.hbs
@@ -1,5 +1,5 @@
 <li class="topic-list-item show-more-topics bottom_left_row
-  {{#unless more_topics_unreads}}zero-topic-unreads{{/unless}}
+  {{#if (eq more_topics_unreads 0)}}zero-topic-unreads{{/if}}
   {{#if more_topics_unread_count_muted}}more_topic_unreads_muted_only{{/if}}">
     <div class="topic-box">
         <a href="" class="sidebar-topic-action-heading" tabindex="0">{{t "Show all topics" }}</a>
@@ -9,7 +9,7 @@
                     @
                 </span>
             {{/if}}
-            <span class="unread_count normal-count {{#unless more_topics_unreads}}zero_count{{/unless}}">
+            <span class="unread_count normal-count {{#if (eq more_topics_unreads 0)}}zero_count{{/if}}">
                 {{more_topics_unreads}}
             </span>
         </div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_view_popover_item.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_view_popover_item.hbs
@@ -4,7 +4,7 @@
         {{#if has_unread_count}}
         <span class="label-and-unread-wrapper">
             <span class="popover-menu-label">{{name}}</span>
-            <span class="unread_count {{unread_count_type}}">{{#if unread_count}}{{unread_count}}{{/if}}</span>
+            <span class="unread_count {{unread_count_type}}">{{#unless (eq unread_count 0)}}{{unread_count}}{{/unless}}</span>
             {{#if supports_masked_unread}}
             <span class="masked_unread_count">
                 <i class="zulip-icon zulip-icon-masked-unread"></i>

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -11,7 +11,7 @@
                 {{/if}}
             </div>
         </li>
-        {{#if (or displayed_members.length displayed_subgroups.length)}}
+        {{#unless (and (eq displayed_members.length 0) (eq displayed_subgroups.length 0))}}
             {{#if user_can_access_all_other_users}}
                 <li role="none" class="popover-menu-list-item text-item italic">
                     {{#tr}}
@@ -19,7 +19,7 @@
                     {{/tr}}
                 </li>
             {{/if}}
-        {{/if}}
+        {{/unless}}
         {{#if deactivated}}
             <li role="none" class="popover-menu-list-item text-item italic hidden-for-spectators">
                 <span class="popover-menu-label">{{t "This group has been deactivated." }}</span>
@@ -27,7 +27,7 @@
         {{/if}}
         <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="popover-menu-list-item">
-            {{#if (or displayed_members.length displayed_subgroups.length)}}
+            {{#unless (and (eq displayed_members.length 0) (eq displayed_subgroups.length 0))}}
                 <ul class="popover-menu-list popover-group-menu-member-list" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
                     {{#each displayed_subgroups}}
                         <li class="popover-group-menu-member">
@@ -71,7 +71,7 @@
                 </ul>
             {{else}}
                 <span class="popover-group-menu-placeholder"><i>{{t 'This group has no members.'}}</i></span>
-            {{/if}}
+            {{/unless}}
         </li>
         {{#unless (or is_guest is_system_group)}}
             <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>

--- a/web/templates/presence_row.hbs
+++ b/web/templates/presence_row.hbs
@@ -32,7 +32,7 @@
                 </div>
             </a>
         {{/if}}
-        <span class="unread_count {{#unless num_unread}}hide{{/unless}}">{{#if num_unread}}{{num_unread}}{{/if}}</span>
+        <span class="unread_count {{#if (eq num_unread 0)}}hide{{/if}}">{{#unless (eq num_unread 0)}}{{num_unread}}{{/unless}}</span>
     </div>
     {{#unless user_list_style.WITH_AVATAR}}
     <span class="sidebar-menu-icon user-list-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -1,4 +1,4 @@
-<tr id="recent_conversation:{{conversation_key}}" class="{{#if unread_count}}unread_topic{{/if}} {{#if is_private}}private_conversation_row{{/if}}">
+<tr id="recent_conversation:{{conversation_key}}" class="{{#unless (eq unread_count 0)}}unread_topic{{/unless}} {{#if is_private}}private_conversation_row{{/if}}">
     <td class="recent_topic_stream">
         <div class="flex_container flex_container_pm">
             <div class="left_part recent_view_focusable" data-col-index="{{ column_indexes.stream }}">
@@ -43,7 +43,7 @@
                   data-tippy-content="{{t 'You have unread mentions' }}">@</span>
                 <div class="recent_topic_actions">
                     <div class="recent_view_focusable" data-col-index="{{ column_indexes.read }}">
-                        <span class="unread_count unread_count_pm recent-view-table-unread-count {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-user-ids-string="{{user_ids_string}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
+                        <span class="unread_count unread_count_pm recent-view-table-unread-count {{#if (eq unread_count 0)}}unread_hidden{{/if}} tippy-zulip-tooltip on_hover_topic_read" data-user-ids-string="{{user_ids_string}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
                     </div>
                 </div>
                 <div class="recent_topic_actions dummy_action_button">
@@ -57,7 +57,7 @@
                   data-tippy-content="{{t 'You have unread mentions'}}">@</span>
                 <div class="recent_topic_actions">
                     <div class="recent_view_focusable hidden-for-spectators" data-col-index="{{ column_indexes.read }}">
-                        <span class="unread_count recent-view-table-unread-count {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
+                        <span class="unread_count recent-view-table-unread-count {{#if (eq unread_count 0)}}unread_hidden{{/if}} tippy-zulip-tooltip on_hover_topic_read" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
                     </div>
                 </div>
                 <div class="recent_topic_actions">
@@ -83,12 +83,12 @@
     </td>
     <td class='recent_topic_users'>
         <ul class="recent_view_participants">
-            {{#if other_senders_count}}
+            {{#unless (eq other_senders_count 0)}}
             <li class="recent_view_participant_item tippy-zulip-tooltip" data-tooltip-template-id="recent_view_participant_overflow_tooltip:{{conversation_key}}">
                 <span class="recent_view_participant_overflow">+{{other_senders_count}}</span>
             </li>
             <template id="recent_view_participant_overflow_tooltip:{{conversation_key}}">{{{other_sender_names_html}}}</template>
-            {{/if}}
+            {{/unless}}
             {{#each senders}}
                 {{#if this.is_muted}}
                 <li class="recent_view_participant_item participant_profile tippy-zulip-tooltip" data-tippy-content="{{t 'Muted user'}}" data-user-id="{{this.user_id}}">

--- a/web/templates/settings/uploaded_files_list.hbs
+++ b/web/templates/settings/uploaded_files_list.hbs
@@ -7,7 +7,7 @@
     </td>
     <td>{{ create_time_str }}</td>
     <td>
-        {{#if messages.length}}
+        {{#unless (eq messages.length 0)}}
         <div class="attachment-messages">
             {{#each messages}}
                 <a class="ind-message" href="/#narrow/id/{{ this.id }}">
@@ -15,7 +15,7 @@
                 </a>
             {{/each}}
         </div>
-        {{/if}}
+        {{/unless}}
     </td>
     <td class="upload-size" >{{ size_str }}</td>
     <td class="actions">

--- a/web/templates/stream_settings/stream_subscription_request_result.hbs
+++ b/web/templates/stream_settings/stream_subscription_request_result.hbs
@@ -7,34 +7,34 @@
         {{t "All users were already subscribed."}}
     {{else}}
         {{#if (not is_total_subscriber_more_than_five) }}
-            {{#if subscribed_users_count}}
+            {{#unless (eq subscribed_users_count 0)}}
                 {{t "Subscribed:" }} {{> user_links users=subscribed_users}}.
-            {{/if}}
-            {{#if already_subscribed_users_count}}
+            {{/unless}}
+            {{#unless (eq already_subscribed_users_count 0)}}
                 {{t "Already a subscriber:" }} {{> user_links users=already_subscribed_users}}.
-            {{/if}}
-            {{#if ignored_deactivated_users_count}}
+            {{/unless}}
+            {{#unless (eq ignored_deactivated_users_count 0)}}
                 {{t "Ignored deactivated users:" }} {{> user_links users=ignored_deactivated_users}}.
-            {{/if}}
+            {{/unless}}
         {{else}}
-            {{#if subscribed_users_count}}
+            {{#unless (eq subscribed_users_count 0)}}
                 {{t "{subscribed_users_count, plural,
                   one {Subscribed: {subscribed_users_count} user.}
                 other {Subscribed: {subscribed_users_count} users.}
             }"}}
-            {{/if}}
-            {{#if already_subscribed_users_count}}
+            {{/unless}}
+            {{#unless (eq already_subscribed_users_count 0)}}
                 {{t "{already_subscribed_users_count, plural,
                   one {Already subscribed: {already_subscribed_users_count} user.}
                     other {Already subscribed: {already_subscribed_users_count} users.}
                 }"}}
-            {{/if}}
-            {{#if ignored_deactivated_users_count}}
+            {{/unless}}
+            {{#unless (eq ignored_deactivated_users_count 0)}}
                 {{t "{ignored_deactivated_users_count, plural,
                   one {Ignored deactivated: {ignored_deactivated_users_count} user.}
                 other {Ignored deactivated: {ignored_deactivated_users_count} users.}
             }"}}
-            {{/if}}
+            {{/unless}}
         {{/if}}
     {{/if}}
 {{/if}}

--- a/web/templates/subscribe_to_more_streams.hbs
+++ b/web/templates/subscribe_to_more_streams.hbs
@@ -3,7 +3,7 @@
         <i class="subscribe-more-icon zulip-icon zulip-icon-browse-channels" aria-hidden="true" ></i>
         <span class="subscribe-more-label">{{~t "BROWSE 1 MORE CHANNEL" ~}}</span>
     </a>
-{{else if can_subscribe_stream_count}}
+{{else unless (eq can_subscribe_stream_count 0)}}
     <a class="subscribe-more-link" href="#channels/available">
         <i class="subscribe-more-icon zulip-icon zulip-icon-browse-channels" aria-hidden="true" ></i>
         <span class="subscribe-more-label">{{~t "BROWSE {can_subscribe_stream_count} MORE CHANNELS" ~}}</span>

--- a/web/templates/user_group_settings/group_permission_settings.hbs
+++ b/web/templates/user_group_settings/group_permission_settings.hbs
@@ -3,7 +3,7 @@
         <h3>{{t "Organization permissions"}}</h3>
 
         {{#each group_assigned_realm_permissions}}
-            <div class="settings-subsection-parent {{subsection_key}} {{#unless assigned_permissions.length}}hide{{/unless}}">
+            <div class="settings-subsection-parent {{subsection_key}} {{#if (eq assigned_permissions.length 0)}}hide{{/if}}">
                 <div class="subsection-header">
                     <h3>{{subsection_heading}}</h3>
                     {{> ../settings/settings_save_discard_widget show_only_indicator=false }}
@@ -24,7 +24,7 @@
         {{/each}}
     </div>
 
-    <div class="channel-group-permissions group-permissions-section {{#unless group_assigned_stream_permissions.length}}hide{{/unless}}">
+    <div class="channel-group-permissions group-permissions-section {{#if (eq group_assigned_stream_permissions.length 0)}}hide{{/if}}">
         <h3>{{t "Channel permissions"}}</h3>
 
         {{#each group_assigned_stream_permissions}}
@@ -37,7 +37,7 @@
         {{/each}}
     </div>
 
-    <div class="user-group-permissions group-permissions-section {{#unless group_assigned_user_group_permissions.length}}hide{{/unless}}">
+    <div class="user-group-permissions group-permissions-section {{#if (eq group_assigned_user_group_permissions.length 0)}}hide{{/if}}">
         <h3>{{t "User group permissions"}}</h3>
 
         {{#each group_assigned_user_group_permissions}}

--- a/web/templates/user_group_settings/user_group_membership_request_result.hbs
+++ b/web/templates/user_group_settings/user_group_membership_request_result.hbs
@@ -2,58 +2,58 @@
     {{error_message}}
 {{else}}
     {{#if (and (eq newly_added_member_count 0) (eq ignored_deactivated_member_count 0))}}
-        {{#if (and already_added_user_count already_added_subgroups_count)}}
+        {{#unless (or (eq already_added_user_count 0) (eq already_added_subgroups_count 0))}}
             {{t "All users and groups were already members."}}
-        {{else if already_added_user_count}}
+        {{else unless (eq already_added_user_count 0)}}
             {{t "All users were already members."}}
         {{else}}
             {{t "All groups were already members."}}
-        {{/if}}
+        {{/unless}}
     {{else}}
         {{#if (not total_member_count_exceeds_five)}}
-            {{#if newly_added_member_count}}
+            {{#unless (eq newly_added_member_count 0)}}
                 {{t "Added:" }} {{> member_links members=additions.newly_added_members}}.&nbsp;
-            {{/if}}
-            {{#if already_added_member_count}}
+            {{/unless}}
+            {{#unless (eq already_added_member_count 0)}}
                 {{t "Already a member:"}} {{> member_links members=additions.already_added_members}}.
-            {{/if}}
-            {{#if ignored_deactivated_users_count}}
+            {{/unless}}
+            {{#unless (eq ignored_deactivated_users_count 0)}}
                 {{t "Ignored deactivated users:"}} {{> member_links members=additions.ignored_deactivated_users}}.
-            {{/if}}
-            {{#if ignored_deactivated_groups_count}}
+            {{/unless}}
+            {{#unless (eq ignored_deactivated_groups_count 0)}}
                 {{t "Ignored deactivated groups:"}} {{> member_links members=additions.ignored_deactivated_groups}}.
-            {{/if}}
+            {{/unless}}
         {{else}}
-            {{#if newly_added_member_count}}
+            {{#unless (eq newly_added_member_count 0)}}
                 {{t "Added:"}}
-                {{#if (and newly_added_user_count newly_added_subgroups_count)}}
+                {{#unless (or (eq newly_added_user_count 0) (eq newly_added_subgroups_count 0))}}
                     {{t "{newly_added_user_count, plural, one {# user} other {# users}} and {newly_added_subgroups_count, plural, one {# group.} other {# groups.}}"}}
-                {{else if newly_added_user_count}}
+                {{else unless (eq newly_added_user_count 0)}}
                     {{t "{newly_added_user_count, plural, one {# user.} other {# users.}}"}}
-                {{else if newly_added_subgroups_count}}
+                {{else unless (eq newly_added_subgroups_count 0)}}
                     {{t "{newly_added_subgroups_count, plural, one {# group.} other {# groups.}}"}}
-                {{/if}}
-            {{/if}}
-            {{#if already_added_member_count}}
+                {{/unless}}
+            {{/unless}}
+            {{#unless (eq already_added_member_count 0)}}
                 {{t "Already a member:"}}
-                {{#if (and already_added_user_count already_added_subgroups_count)}}
+                {{#unless (or (eq already_added_user_count 0) (eq already_added_subgroups_count 0))}}
                     {{t "{already_added_user_count, plural, one {# user} other {# users}} and {already_added_subgroups_count, plural, one {# group.} other {# groups.}}"}}
-                {{else if already_added_user_count}}
+                {{else unless (eq already_added_user_count 0)}}
                     {{t "{already_added_user_count, plural, one {# user.} other {# users.}}"}}
-                {{else if already_added_subgroups_count}}
+                {{else unless (eq already_added_subgroups_count 0)}}
                     {{t "{already_added_subgroups_count, plural, one {# group.} other {# groups.}}"}}
-                {{/if}}
-            {{/if}}
-            {{#if ignored_deactivated_member_count}}
+                {{/unless}}
+            {{/unless}}
+            {{#unless (eq ignored_deactivated_member_count 0)}}
                 {{t "Ignored deactivated:"}}
-                {{#if (and ignored_deactivated_users_count ignored_deactivated_groups_count)}}
+                {{#unless (or (eq ignored_deactivated_users_count 0) (eq ignored_deactivated_groups_count 0))}}
                     {{t "{ignored_deactivated_users_count, plural, one {# user} other {# users}} and {ignored_deactivated_groups_count, plural, one {# group.} other {# groups.}}"}}
-                {{else if ignored_deactivated_users_count}}
+                {{else unless (eq ignored_deactivated_users_count 0)}}
                     {{t "{ignored_deactivated_users_count, plural, one {# user.} other {# users.}}"}}
-                {{else if ignored_deactivated_groups_count}}
+                {{else unless (eq ignored_deactivated_groups_count 0)}}
                     {{t "{ignored_deactivated_groups_count, plural, one {# group.} other {# groups.}}"}}
-                {{/if}}
-            {{/if}}
+                {{/unless}}
+            {{/unless}}
         {{/if}}
     {{/if}}
 {{/if}}


### PR DESCRIPTION
In order to safely translate Handlebars `{{#if x}}content{{/if}}` to JSX `{x && <>content</>}` (rather than the more verbose `{x ? <>content</> : <></>}`), we need to rely on `x` not being the number `0`.

- Followup to #37578.