### PR TITLE
peer_data: Log xhr ready state to aid debugging.

### DIFF
--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -149,6 +149,7 @@ async function fetch_stream_subscribers_from_server(
                     blueslip.error("Failure fetching channel subscribers", {
                         stream_id,
                         error_json: xhr.responseJSON,
+                        xhr_ready_state: xhr.readyState,
                     });
                     resolve(null);
                 }


### PR DESCRIPTION
As discussed here: [#kandra js errors > Error: Failure fetching channel subscribers @ 💬](https://chat.zulip.org/#narrow/channel/464-kandra-js-errors/topic/Error.3A.20Failure.20fetching.20channel.20subscribers/near/2363838)