### PR TITLE
stream_events: Rerender inbox/recent views on channel updates.

### DIFF
--- a/web/src/inbox_util.ts
+++ b/web/src/inbox_util.ts
@@ -4,6 +4,7 @@ import assert from "minimalistic-assert";
 import type {Filter} from "./filter";
 import * as stream_color from "./stream_color.ts";
 import * as stream_data from "./stream_data.ts";
+import type {UpdatableStreamProperties} from "./stream_types.ts";
 
 export let filter: Filter | undefined;
 let is_inbox_visible = false;
@@ -37,6 +38,20 @@ export function set_visible(value: boolean): void {
 
 export function is_visible(): boolean {
     return is_inbox_visible;
+}
+
+const UPDATE_PROPERTIES_REQUIRING_COMPLETE_RERENDER = new Set<keyof UpdatableStreamProperties>([
+    "name",
+    "invite_only",
+    "is_archived",
+    "is_web_public",
+    "folder_id",
+]);
+
+export function should_complete_rerender_for_channel_property(
+    property: keyof UpdatableStreamProperties,
+): boolean {
+    return UPDATE_PROPERTIES_REQUIRING_COMPLETE_RERENDER.has(property);
 }
 
 export function update_stream_colors(): void {

--- a/web/src/recent_view_util.ts
+++ b/web/src/recent_view_util.ts
@@ -1,4 +1,5 @@
 import type {Message} from "./message_store.ts";
+import type {UpdatableStreamProperties} from "./stream_types.ts";
 
 let is_view_visible = false;
 
@@ -8,6 +9,19 @@ export function set_visible(value: boolean): void {
 
 export function is_visible(): boolean {
     return is_view_visible;
+}
+
+const UPDATE_PROPERTIES_REQUIRING_COMPLETE_RERENDER = new Set<keyof UpdatableStreamProperties>([
+    "name",
+    "invite_only",
+    "is_archived",
+    "is_web_public",
+]);
+
+export function should_complete_rerender_for_channel_property(
+    property: keyof UpdatableStreamProperties,
+): boolean {
+    return UPDATE_PROPERTIES_REQUIRING_COMPLETE_RERENDER.has(property);
 }
 
 export function get_topic_key(stream_id: number, topic: string): string {

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -24,6 +24,7 @@ import * as emoji_picker from "./emoji_picker.ts";
 import * as gear_menu from "./gear_menu.ts";
 import * as gif_state from "./gif_state.ts";
 import * as inbox_ui from "./inbox_ui.ts";
+import * as inbox_util from "./inbox_util.ts";
 import * as information_density from "./information_density.ts";
 import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area.ts";
 import * as linkifiers from "./linkifiers.ts";
@@ -49,6 +50,7 @@ import * as realm_logo from "./realm_logo.ts";
 import * as realm_playground from "./realm_playground.ts";
 import {realm_user_settings_defaults} from "./realm_user_settings_defaults.ts";
 import * as recent_view_ui from "./recent_view_ui.ts";
+import * as recent_view_util from "./recent_view_util.ts";
 import * as reload from "./reload.ts";
 import * as reminders_overlay_ui from "./reminders_overlay_ui.ts";
 import * as saved_snippets from "./saved_snippets.ts";
@@ -723,6 +725,16 @@ export function dispatch_normal_event(event) {
                         history_public_to_subscribers: event.history_public_to_subscribers,
                         is_web_public: event.is_web_public,
                     });
+                    if (inbox_util.should_complete_rerender_for_channel_property(event.property)) {
+                        inbox_ui.complete_rerender();
+                    }
+                    if (
+                        recent_view_util.should_complete_rerender_for_channel_property(
+                            event.property,
+                        )
+                    ) {
+                        recent_view_ui.complete_rerender();
+                    }
                     settings_streams.update_default_streams_table();
                     stream_list.update_subscribe_to_more_streams_link();
                     break;
@@ -769,6 +781,8 @@ export function dispatch_normal_event(event) {
                             stream_id,
                         );
                     }
+                    inbox_ui.complete_rerender();
+                    recent_view_ui.complete_rerender();
                     stream_list.update_subscribe_to_more_streams_link();
                     break;
                 default:

--- a/web/tests/dispatch_subs.test.cjs
+++ b/web/tests/dispatch_subs.test.cjs
@@ -15,8 +15,14 @@ const event_fixtures = events.fixtures;
 const test_user = events.test_user;
 
 const compose_recipient = mock_esm("../src/compose_recipient");
+mock_esm("../src/inbox_ui", {
+    complete_rerender: noop,
+});
 const message_events = mock_esm("../src/message_events");
 const overlays = mock_esm("../src/overlays");
+mock_esm("../src/recent_view_ui", {
+    complete_rerender: noop,
+});
 const settings_org = mock_esm("../src/settings_org");
 const settings_streams = mock_esm("../src/settings_streams");
 const stream_events = mock_esm("../src/stream_events");
@@ -185,6 +191,12 @@ test("stream update", ({override}) => {
     assert.equal(args.stream_id, event.stream_id);
     assert.equal(args.property, event.property);
     assert.equal(args.value, event.value);
+
+    // Dispatch a stream update with property "name" to exercise
+    // the complete_rerender calls for inbox and recent views.
+    const name_event = {...event, property: "name", value: "new_name"};
+    dispatch(name_event);
+    assert.equal(stub.num_calls, 2);
 });
 
 test("stream create", ({override}) => {


### PR DESCRIPTION
This ensures Recent and Inbox views refresh when a channel's name or privacy changes, keeping filters/sorting correct without requiring a page reload.


Fixes: https://github.com/zulip/zulip/issues/37704

**How changes were tested:**
Manually tested that channel name and privacy changes are reflected immediately.
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
