### PR TITLE
views: Reset focus to first row on search.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -2334,6 +2334,8 @@ export function initialize({hide_other_views}: {hide_other_views: () => void}): 
         "input",
         "#inbox-search",
         _.debounce(() => {
+            // Reset focus to first row on new search.
+            row_focus = DEFAULT_ROW_FOCUS;
             search_and_update();
         }, 300),
     );

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1973,6 +1973,8 @@ export function initialize({
         "input",
         "#recent_view_search",
         _.debounce(() => {
+            // Reset focus to first row on new search.
+            row_focus = 0;
             update_filters_view();
             // Wait for user to go idle before initiating search.
         }, 300),


### PR DESCRIPTION
For inbox view and recent view, we reset focus to first row on search. Note that this doesn't restore focus when user clears search.

discussion: [#issues > reset scrolling when searching recent conversations](https://chat.zulip.org/#narrow/channel/9-issues/topic/reset.20scrolling.20when.20searching.20recent.20conversations/with/2282806)