### PR TITLE
inbox: Potential fix user jumping to top when scrolling.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -415,6 +415,10 @@ export function hide(): void {
     });
 
     inbox_util.set_filter(undefined);
+    // Clear the inbox HTML as we rebuild it from scratch.
+    // Note that `requestAnimationFrame` waits for next paint to render,
+    // which can cause user scrolling if we don't clear the HTML here.
+    $("#inbox-pane").empty();
 }
 
 function get_topic_key(stream_id: number, topic: string): string {


### PR DESCRIPTION
When user scrolls immediately after render, it is possible for user to be scrolled back to top when the rendering in `requestAnimationFrame` is complete.

What might be happening is when we show inbox view, previous cached inbox view is displayed, then user scrolls and then we render with updated data causing user to scroll jump.

Clearing the previous cached HTML can avoid this bug as there will be nothing for user to scroll in this case.

discussion: [#issues > 🎯 view jumping to the top unexpectedly](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20view.20jumping.20to.20the.20top.20unexpectedly/with/2169440)