### PR TITLE
Fix 404 when LOCAL_UPLOADS_DIR is changed (fixes #37691)

### DIFF
--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -127,6 +127,13 @@ class zulip::app_frontend_base {
     notify  => Service['nginx'],
   }
 
+  $local_uploads_dir_raw = get_django_setting_slow('LOCAL_UPLOADS_DIR')
+  $local_uploads_dir = $local_uploads_dir_raw ? {
+    undef   => '/home/zulip/uploads',
+    ''      => '/home/zulip/uploads',
+    'None'  => '/home/zulip/uploads',
+    default => $local_uploads_dir_raw,
+  }
   file { '/etc/nginx/zulip-include/app.d/uploads-internal.conf':
     ensure  => file,
     require => Package[$zulip::common::nginx],
@@ -134,7 +141,7 @@ class zulip::app_frontend_base {
     group   => 'root',
     mode    => '0644',
     notify  => Service['nginx'],
-    source  => 'puppet:///modules/zulip/nginx/zulip-include-frontend/uploads-internal.conf',
+    content => template('zulip/nginx/uploads-internal.conf.template.erb'),
   }
 
   # This determines whether we run queue processors multithreaded or

--- a/puppet/zulip/templates/nginx/uploads-internal.conf.template.erb
+++ b/puppet/zulip/templates/nginx/uploads-internal.conf.template.erb
@@ -1,0 +1,88 @@
+# Handle redirects to S3
+location ~ ^/internal/s3/(?<s3_hostname>[^/]+)/(?<s3_path>.*) {
+    internal;
+    include /etc/nginx/zulip-include/headers;
+    add_header Content-Security-Policy "default-src 'none'; media-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'self'; plugin-types application/pdf;";
+
+    # The components of this path are originally double-URI-escaped
+    # (see zerver/view/upload.py).  "location" matches are on
+    # unescaped values, which fills $s3_path with a properly
+    # single-escaped path to pass to the upstream server.
+    # (see associated commit message for more details)
+    set $download_url https://$s3_hostname/$s3_path;
+    proxy_set_header Host $s3_hostname;
+    proxy_ssl_name $s3_hostname;
+    proxy_ssl_server_name on;
+
+    # Strip off X-amz-cf-id header, which otherwise the request has to
+    # have been signed over, leading to signature mismatches.
+    proxy_set_header x-amz-cf-id "";
+
+    # Strip off any auth request headers which the Zulip client might
+    # have sent, as they will not work for S3, and will report an error due
+    # to the signed auth header we also provide.
+    proxy_set_header Authorization "";
+    proxy_set_header x-amz-security-token "";
+
+    # These headers are only valid if there is a body, but better to
+    # strip them to be safe.
+    proxy_set_header Content-Length "";
+    proxy_set_header Content-Type "";
+    proxy_set_header Content-MD5 "";
+    proxy_set_header x-amz-content-sha256 "";
+    proxy_set_header Expect "";
+
+    # Ensure that we only get _one_ of these response headers: the one
+    # that Django added, not the one from S3.
+    proxy_hide_header Cache-Control;
+    proxy_hide_header Expires;
+    proxy_hide_header Set-Cookie;
+    # We are _leaving_ S3 to provide Content-Type,
+    # Content-Disposition, and Accept-Ranges headers, which are the
+    # three remaining headers which nginx would also pass through from
+    # the first response.  Django explicitly unsets the first, and
+    # does not set the latter two.
+
+    # We slice the content into 5M chunks; this means that the client
+    # doesn't need to wait for nginx to download and cache the full
+    # content if the client just requested a small range (e.g. for
+    # showing a thumbnail of a large video).  5M is chosen to be
+    # enough for videos to be able to thumbnail in one slice, but not
+    # take overly long to retrieve from S3, or cause overwhelming
+    # numbers of cache entries for large files.
+    slice 5m;
+    proxy_set_header Range $slice_range;
+
+    proxy_pass $download_url$is_args$args;
+    proxy_cache uploads;
+    # If the S3 response doesn't contain Cache-Control headers (which
+    # we don't expect it to) then we assume they are valid for a very
+    # long time.  The size of the cache is controlled by
+    # `s3_disk_cache_size` and read frequency, set via
+    # `s3_cache_inactive_time`.
+    proxy_cache_valid 200 206 1y;
+
+    # We only include the requested content-disposition (and range
+    # slice) in the cache key, so that we cache "Content-Disposition:
+    # attachment" separately from the inline version.
+    proxy_cache_key $download_url$s3_disposition_cache_key$slice_range;
+}
+
+# Internal file-serving
+location /internal/local/uploads {
+    internal;
+    include /etc/nginx/zulip-include/headers;
+    add_header Content-Security-Policy "default-src 'none'; media-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'self'; plugin-types application/pdf;";
+
+    # Django handles setting Content-Type, Content-Disposition, and Cache-Control.
+
+    alias <%= @local_uploads_dir %>/files;
+}
+
+location /internal/local/user_avatars {
+    internal;
+    include /etc/nginx/zulip-include/headers;
+    add_header Content-Security-Policy "default-src 'none' img-src 'self'";
+    include /etc/nginx/zulip-include/uploads.types;
+    alias <%= @local_uploads_dir %>/avatars;
+}

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -802,10 +802,6 @@ SOCIAL_AUTH_SAML_SUPPORT_CONTACT = {
 ##
 ##   https://zulip.readthedocs.io/en/latest/production/upload-backends.html
 ##
-## If you change LOCAL_UPLOADS_DIR to a different path, you will also
-## need to manually edit Zulip's nginx configuration to use the new
-## path.  For that reason, we recommend replacing /home/zulip/uploads
-## with a symlink instead of changing LOCAL_UPLOADS_DIR.
 LOCAL_UPLOADS_DIR = "/home/zulip/uploads"
 # S3_AUTH_UPLOADS_BUCKET = ""
 # S3_AVATAR_BUCKET = ""


### PR DESCRIPTION

# Fix 404 when LOCAL_UPLOADS_DIR is changed (fixes #37691)

## Summary

Changing `LOCAL_UPLOADS_DIR` to a non-default path and reconfiguring caused uploads to succeed but viewing images to return 404. The nginx config used a hardcoded `/home/zulip/uploads` path, while Django wrote to the new `LOCAL_UPLOADS_DIR`. Nginx and Django are now aligned by templating the uploads-internal config from `LOCAL_UPLOADS_DIR` via Puppet.

## Problem

- User changes `LOCAL_UPLOADS_DIR` (e.g. in `/etc/zulip/settings.py`), reconfigures, and restarts.
- Uploads work and files are stored in the new directory.
- Viewing uploaded images returns **404** because nginx still serves from `/home/zulip/uploads`.
- Workaround was a symlink: `/home/zulip/uploads` → `$LOCAL_UPLOADS_DIR`.

## Solution

- Add `puppet/zulip/templates/nginx/uploads-internal.conf.template.erb` that uses `<%= @local_uploads_dir %>` for the `alias` directives (`.../files` and `.../avatars`) instead of hardcoded paths.
- In `app_frontend_base.pp`, read `LOCAL_UPLOADS_DIR` via `get_django_setting_slow('LOCAL_UPLOADS_DIR')`, default to `/home/zulip/uploads` when unset/empty/`None`, and generate the uploads-internal config from the template.
- Remove the old "use a symlink" guidance from `prod_settings_template.py`; changing `LOCAL_UPLOADS_DIR` and reconfiguring is now supported without symlinks.

## Changes

| File | Change |
|------|--------|
| `puppet/zulip/templates/nginx/uploads-internal.conf.template.erb` | **New.** ERB template; alias paths use `@local_uploads_dir`. S3 block unchanged. |
| `puppet/zulip/manifests/app_frontend_base.pp` | Switch uploads-internal from `source` to `content => template(...)`; add `$local_uploads_dir` from Django with fallback. |
| `zproject/prod_settings_template.py` | Remove comment recommending symlink when changing `LOCAL_UPLOADS_DIR`. |

## Testing

- After changing `LOCAL_UPLOADS_DIR`, run `scripts/zulip-puppet-apply` (or your install's reconfigure), restart nginx, then upload and view an image. It should load instead of 404.
- Default installs and S3-only setups unchanged; fallback path used when `LOCAL_UPLOADS_DIR` is missing.

## Checklist

- [x] Fix addresses the root cause (nginx path vs Django path mismatch).
- [x] Minimal change: template + manifest + prod_settings comment only; no Django or URL changes.
- [x] Default and S3-only behavior preserved.