### PR TITLE
widgets: Add todo task reordering via drag-and-drop.

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -54,6 +54,19 @@
         position: static;
         min-height: 0;
 
+        .todo-drag-handle {
+            color: hsl(0deg 0% 75%);
+            cursor: grab;
+            display: inline-flex;
+            align-items: center;
+            user-select: none;
+            align-self: center;
+
+            &:active {
+                cursor: grabbing;
+            }
+        }
+
         & input[type="checkbox"] {
             ~ .custom-checkbox {
                 display: inline-block;

--- a/web/templates/widgets/todo_widget_tasks.hbs
+++ b/web/templates/widgets/todo_widget_tasks.hbs
@@ -1,8 +1,11 @@
 {{#each all_tasks}}
-    <li>
+    <li class="todo-task-row" draggable="true" data-key="{{ key }}">
         <label class="checkbox">
+            <span class="todo-drag-handle" draggable="true" data-key="{{ key }}" aria-label="{{t 'Reorder task'}}">
+                <i class="zulip-icon zulip-icon-grip-vertical" aria-hidden="true"></i>
+            </span>
             <span class="todo-checkbox">
-                <input type="checkbox" class="task" data-key="{{ key }}" {{#if completed}}checked{{/if}}/>
+                <input type="checkbox" class="task" data-key="{{ key }}" {{#if completed}}checked{{/if}} />
                 <span class="custom-checkbox"></span>
             </span>
             <span class="todo-task">

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -559,6 +559,19 @@ def validate_todo_data(todo_data: object, is_widget_author: bool) -> None:
         checker("todo data", todo_data)
         return
 
+    if todo_data["type"] == "reorder_tasks":
+        if not is_widget_author:
+            raise ValidationError("You can't reorder tasks unless you are the author.")
+
+        checker = check_dict_only(
+            [
+                ("type", check_string),
+                ("task_order", check_list(check_string)),
+            ]
+        )
+        checker("todo data", todo_data)
+        return
+
     raise ValidationError(f"Unknown type for todo data: {todo_data['type']}")
 
 


### PR DESCRIPTION
Allow message authors to manually reorder todo tasks by dragging and dropping them in the widget. 

Fixes #20213.

## How changes were tested:

Manually verified drag-and-drop reordering (including persistence and author-only behavior), ran ./tools/lint --fix , and added validator unit tests.

## Screenshots and screen captures:

https://github.com/user-attachments/assets/1f42b33f-b31c-400a-8e19-f9d54f32c6df

## Self-review checklist

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

### Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

### Individual commits are ready for review

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

### Completed manual review and testing

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.