### PR TITLE
demo-orgs: Update relative "new/demo/" links to go to main Zulip site.

### DIFF
--- a/starlight_help/src/content/docs/trying-out-zulip.mdx
+++ b/starlight_help/src/content/docs/trying-out-zulip.mdx
@@ -17,9 +17,9 @@ It's also easy to try out Zulip for yourself.
        where hundreds of participants collaborate to improve Zulip. Many parts of
        the community are open for [public access](/help/public-access-option), so
        you can start exploring without creating an account.
-     * [Create a demo organization](/new/demo/) — no email required when you
-       register. It only takes a minute, and is a great way to explore Zulip even
-       if you plan to [self-host](https://zulip.com/self-hosting/).
+     * [Create a demo organization](https://zulip.com/new/demo/) — no email required
+       when you register. It only takes a minute, and is a great way to explore Zulip
+       even if you plan to [self-host](https://zulip.com/self-hosting/).
      * [See how Zulip is being used](https://zulip.com/communities/) in open
        organizations that have opted in to be listed in the [Zulip communities
        directory](/help/communities-directory).

--- a/starlight_help/src/content/include/_CreateADemoOrganization.mdx
+++ b/starlight_help/src/content/include/_CreateADemoOrganization.mdx
@@ -1,5 +1,5 @@
 import {Steps} from "@astrojs/starlight/components";
 
 <Steps>
-  1. Fill out [a brief form](/new/demo/), and click **Try Zulip**.
+  1. Fill out [a brief form](https://zulip.com/new/demo/), and click **Try Zulip**.
 </Steps>


### PR DESCRIPTION
Since demo organizations are live on Zulip Cloud, we can update the relative links for the demo organization form in the help center to go directly to the main zulip website.

**Notes**:
- Marked this PR as closing the main issue tracking the demo organization feature since the points there have been taken care of and any follow-ups can be tracked via separate issues.

Fixes #19523.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
