### PR TITLE
feat(mobile): show reaction details on long-tap

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -53,7 +53,7 @@ export function initialize(): void {
             current_target: undefined,
         };
 
-        $("#main_div").on("touchstart", ".messagebox", function () {
+        $("#main_div").on("touchstart", ".messagebox, .message_reaction", function () {
             meta.touchdown = true;
             meta.invalid = false;
             const id = rows.id($(this).closest(".message_row"));
@@ -77,16 +77,24 @@ export function initialize(): void {
             }, MS_DELAY);
         });
 
-        $("#main_div").on("touchend", ".messagebox", () => {
+        $("#main_div").on("touchend", ".messagebox, .message_reaction", () => {
             meta.touchdown = false;
         });
 
-        $("#main_div").on("touchmove", ".messagebox", () => {
+        $("#main_div").on("touchmove", ".messagebox, .message_reaction", () => {
             meta.invalid = true;
         });
 
-        $("#main_div").on("contextmenu", ".messagebox", (e) => {
+        $("#main_div").on("contextmenu", ".messagebox, .message_reaction", (e) => {
             e.preventDefault();
+        });
+
+        $("#main_div").on("longtap", ".message_reaction", function (e) {
+            e.preventDefault();
+            $(this).data("longtap-triggered", true);
+            const local_id = $(this).attr("data-reaction-id")!;
+            const message_id = rows.get_message_id(this);
+            reactions.show_reaction_popover(this, message_id, local_id);
         });
     }
 
@@ -257,6 +265,11 @@ export function initialize(): void {
 
     $("#main_div").on("click", ".message_reaction", function (this: HTMLElement, e) {
         e.stopPropagation();
+
+        if ($(this).data("longtap-triggered")) {
+            $(this).removeData("longtap-triggered");
+            return;
+        }
 
         if (page_params.is_spectator) {
             spectators.login_to_access();

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1568,3 +1568,26 @@ ul.popover-menu-list {
     flex: 1;
     min-width: 0;
 }
+
+ul.reaction-popover-users {
+    list-style: none;
+    margin: 0;
+    padding: 5px;
+
+    li {
+        display: flex;
+        align-items: center;
+        margin-bottom: 5px;
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+
+        .reaction-popover-avatar {
+            width: 20px;
+            height: 20px;
+            border-radius: 3px;
+            margin-right: 8px;
+        }
+    }
+}


### PR DESCRIPTION
This PR implements a long-press generic interaction for message reactions on mobile web.

**Changes:**
- Extended `longtap` detection in `web/src/click_handlers.ts` to support `.message_reaction`.
- Added a `longtap` event listener that prevents the default click behavior (toggling the reaction) and instead triggers a popover.
- Implemented `show_reaction_popover` in `web/src/reactions.ts` to display a list of users who reacted, using Tippy.js.
- Added necessary styles in `web/styles/popovers.css`.

**Fixes:** #15364