### PR TITLE
ui: Use consistent @ symbol icons across app

### DIFF
--- a/templates/corporate/team.html
+++ b/templates/corporate/team.html
@@ -105,7 +105,7 @@ contributors, and 97+ people with 100+ commits." %}
                     <label for="api-clients"><i class="fa fa-code" aria-hidden="true"></i>&nbsp; Integrations</label>
 
                     <input id="devtools" type="radio" name="tabs" />
-                    <label for="devtools"><i class="fa fa-at" aria-hidden="true"></i>&nbsp; Devtools</label>
+                    <label for="devtools"><i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>&nbsp; Devtools</label>
                     <div id="tab-total" class="contributors">
                         <div class="contributors-grid"></div>
                     </div>

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -182,7 +182,7 @@
                     </a>
                 {{else}}
                     <a role="menuitem" class="popover-menu-link copy_mention_syntax" tabindex="0" data-clipboard-text="{{ user_mention_syntax }}">
-                        <i class="popover-menu-icon fa zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
+                        <i class="popover-menu-icon zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t "Copy mention syntax" }}</span>
                         {{#if is_sender_popover}}
                             {{popover_hotkey_hints "@"}}


### PR DESCRIPTION
Fixes #22816

**What I changed:**
Replaced FontAwesome @ icons (`fa-at`) with Zulip’s `zulip-icon-at-sign` to ensure a consistent @ symbol across the app.

Files updated:
- web/templates/popovers/user_card/user_card_popover.hbs
- templates/corporate/team.html

**How changes were tested:**
- Searched for remaining `fa-at` usages in the codebase.
- Verified icon classes were updated correctly.
- Confirmed no other @ icons remain inconsistent.
