### PR TITLE
Fix: Add scrollbar width adjustment to message feed container

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -3,6 +3,10 @@ html {
     overscroll-behavior-y: none;
     width: calc(100% - var(--disabled-scrollbar-width));
 }
+.message_feed_container {
+    width: calc(100% - var(--disabled-scrollbar-width));
+}
+
 
 body,
 html {


### PR DESCRIPTION
## Problem
The message feed shifts horizontally when modals open because the scrollbar is hidden.

## Root Cause
The `.message_feed_container` element wasn't included in the CSS width adjustment
that accounts for the hidden scrollbar.

## Solution
Added the same scrollbar-width CSS adjustment to `.message_feed_container`:
```css
width: calc(100% - var(--disabled-scrollbar-width));


- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
