### PR TITLE
bots: Update bot email in zuliprc after editing short name.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 461**
+
+* [`GET /events`](/api/get-events): `realm_bot` update events are
+  now sent when a bot's Zulip display email address is changed.
+
 **Feature level 460**
 
 * [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 460
+API_FEATURE_LEVEL = 461
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -134,6 +134,15 @@ def do_change_user_delivery_email(
 
     send_event_on_commit(user_profile.realm, event, delivery_email_visible_user_ids)
 
+    if user_profile.is_bot:
+        bot_payload = dict(user_id=user_profile.id, email=new_email)
+        bot_event = dict(type="realm_bot", op="update", bot=bot_payload)
+        send_event_on_commit(
+            user_profile.realm,
+            bot_event,
+            bot_owner_user_ids(user_profile),
+        )
+
     if user_profile.avatar_source == UserProfile.AVATAR_FROM_GRAVATAR:
         # If the user is using Gravatar to manage their email address,
         # their Gravatar just changed, and we need to notify other

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -25713,6 +25713,13 @@ components:
             owner_id:
               nullable: true
             services: {}
+            email:
+              type: string
+              description: |
+                The Zulip display email address of the bot, used for authentication.
+
+                **Changes**: New in Zulip 12.0 (feature level 461). Previously,
+                only `realm_user` events were sent when updating a bot’s email.
             is_active:
               type: boolean
               description: |


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: When we edit the bot email , its gets updated in the UI but when we download or copy 
the zuliprc , it still uses the old email.
 [issues > Bot email is not updated in zuliprc file after edit](https://chat.zulip.org/#narrow/channel/9-issues)
 
Updated the `bot_data` from `realm_user` events
**How changes were tested:**
Manually tested the working. Before editing the email downloaded the zuliprc file. After updating the email verified if the change is reflected immediately in zuliprc file and the copy button. The email is correctly getting updated.Did'nt see any regression.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
