### PR TITLE
message_delete: Send event to acting_user only if they have access.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 457**
+
+[`GET /events`](/api/get-events): `delete_message` events are now
+  sent to the user who deletes the message only if they have content
+  access to the messages' recipient, and the `message_ids` list only
+  includes IDs of the messages that they can access.
+
 **Feature level 456**
 
 * `PATCH /realm`, [`POST /register`](/api/register-queue),

--- a/version.py
+++ b/version.py
@@ -35,7 +35,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 456
+API_FEATURE_LEVEL = 457
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2142,23 +2142,35 @@ paths:
                               description: |
                                 Event sent when a message has been deleted.
 
-                                Sent to all users who currently are subscribed to the
-                                messages' recipient. May also be sent to additional users
-                                who had access to it, including, in particular, an
-                                administrator user deleting messages in a stream that they
-                                are not subscribed to.
+                                Sent to all users who currently are subscribed to the messages'
+                                recipient. May also be sent to additional users who had access to
+                                the deleted message, including, in particular, an administrator user
+                                deleting messages in a channel that they are not subscribed to, but
+                                have content access to. Clients can thus reliably remove the
+                                messages from whatever view the administrator was using to delete
+                                them.
 
-                                This means that clients can assume that they will always
-                                receive an event of this type for deletions that the
-                                client itself initiated.
+                                Clients will receive an event of this type for message deletions
+                                that the client itself initiated if and only if the user previously
+                                had access to the deleted messages. (Some moderation actions, such
+                                as deleting all messages sent by a user, allow deleting DMs or
+                                private channel messages that the acting user cannot themselves
+                                access. The user will not receive deletion events for such
+                                inaccessible messages).
 
                                 This event is also sent when the user loses access to a message,
                                 such as when it is [moved to a channel][message-move-channel] that
                                 the user does not [have permission to access][channel-access].
 
-                                **Changes**: Prior to Zulip 12.0 (feature level 452) messages
-                                deleted via a message retention policy incorrectly failed to
-                                generate `delete_message` events.
+                                **Changes**: Before Zulip 12.0 (feature level 457), an
+                                administrator who initiated the deletion of messages that they did
+                                not have permission to access could theoretically receive this event
+                                for inaccessible messages. However, no Zulip feature actually
+                                generated events of that type.
+
+                                Prior to Zulip 12.0 (feature level 452) messages deleted via a
+                                message retention policy incorrectly failed to generate
+                                `delete_message` events.
 
                                 Before Zulip 9.0 (feature level 274), this event was only sent to
                                 subscribers of the message's recipient.


### PR DESCRIPTION
Acting user should get the message deletion event only if they have access to the message location, i.e for DMs only if they are involved in the conversation and for streams only if they have content access to the stream. For private streams with protected history the acting user only gets the event with message_ids that they have UserMessage row for.

Extracted from #37563.