### PR TITLE
click: Revert getSelection() check to determine link selection.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -965,13 +965,10 @@ export function initialize(): void {
         if (compose_state.composing() && $(e.target).parents("#compose").length === 0) {
             const is_click_within_link = $(e.target).closest("a").length > 0;
             if (is_click_within_link || $(e.target).closest(".copy_codeblock").length > 0) {
-                const is_selecting_link_text =
-                    is_click_within_link &&
-                    (mouse_drag.is_drag(e) || document.getSelection()?.type === "Range");
+                const is_selecting_link_text = is_click_within_link && mouse_drag.is_drag(e);
                 if (is_selecting_link_text) {
                     // Avoid triggering the click handler for a link
-                    // when just dragging over it to select the text or
-                    // double/triple clicking it to select link text.
+                    // when just dragging over it to select the text.
                     e.preventDefault();
                     return;
                 }


### PR DESCRIPTION
This reverts commit 1a8cbf6e645c9815f07025a3344dbbc48c18b14a. It introduced an annoying bug wherein trying to click on any normal link(with no dedicated click handlers that run before the main composebox handler) with the composebox open and some text selected would make that click a
no-op because of this check:

if (is_selecting_link_text) {
    // Avoid triggering the click handler for a link
    // when just dragging over it to select the text or
    // double/triple clicking it to select link text.
    e.preventDefault();
    return;
}

This happens because the previous `is_selecting_link_text` was incorrectly set to `true` on clicking
any link with some text selected.

This bug didn't affect the channel or topic links in the left sidebar because of their click handlers, which were triggered before the main click handler and also stop propagation.

Fixes: https://chat.zulip.org/#narrow/channel/9-issues/topic/Clicking.20links.20does.20nothing.20on.20selecting.20something.2E/with/2367421

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
