### PR TITLE
markdown: Add inline preview support for .mov video files

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,14 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 495**
+
+* [Message formatting](/api/message-formatting): Uploaded videos with
+  the `video/quicktime` MIME type (i.e., `.mov` files) are now rendered
+  inline using the existing `message_inline_video` format. Clients that
+  cannot play the format should detect a playback error and hide the
+  preview; the download link remains in the surrounding `a` tag.
+
 **Feature level 494**
 
 * [`PUT /bot_storage`](/api/update-bot-storage),

--- a/api_docs/message-formatting.md
+++ b/api_docs/message-formatting.md
@@ -418,7 +418,12 @@ available.
 ## Video embeddings and previews
 
 When a Zulip message is sent linking to an uploaded video, Zulip may
-generate a video preview element with the following format.
+generate a video preview element with the following format. Supported
+MIME types are `video/mp4`, `video/quicktime` (i.e., `.mov` files), and
+`video/webm`. Because `video/quicktime` is not supported in every
+browser, the preview element is hidden at render time when the browser
+reports that it cannot play the video; the download link in the
+surrounding `a` tag remains available.
 
 
 ``` html

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 494
+API_FEATURE_LEVEL = 495
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -245,7 +245,7 @@ export function canonical_url_of_media(media: HTMLMediaElement | HTMLImageElemen
 export function render_lightbox_media_list(): void {
     if (!is_open) {
         const message_media_list = $<HTMLMediaElement | HTMLImageElement>(
-            ".focused-message-list .message-media-inline-image img, .focused-message-list .message-media-preview-image img, .focused-message-list .message_inline_video video",
+            ".focused-message-list .message-media-inline-image img, .focused-message-list .message-media-preview-image img, .focused-message-list .message_inline_video:not(.video-format-unsupported) video",
         ).toArray();
         const $lightbox_media_list = $("#lightbox_overlay .image-list").empty();
         for (const media of message_media_list) {
@@ -421,7 +421,7 @@ export function show_from_selected_message(): void {
     let $message = $message_selected;
     // This is a function to satisfy eslint unicorn/no-array-callback-reference
     const media_classes = (): string =>
-        ".message-media-inline-image img, .message-media-preview-image img, .message-media-preview-video video";
+        ".message-media-inline-image img, .message-media-preview-image img, .message-media-preview-video:not(.video-format-unsupported) video";
     let $media = $message.find<HTMLMediaElement | HTMLImageElement>(media_classes());
     let $prev_traverse = false;
 

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -133,6 +133,14 @@ export const update_elements = ($content: JQuery): void => {
         });
     }
 
+    // Hide video preview for browsers that cannot play the format.
+    // The download link remains available.
+    $content.find<HTMLMediaElement>(".message_inline_video video").each((_index, video) => {
+        $(video).on("error", () => {
+            $(video).closest(".message_inline_video").addClass("video-format-unsupported");
+        });
+    });
+
     // personal and stream wildcard mentions
     $content.find(".user-mention").each(function (): void {
         const user_id = get_user_id_for_mention_button(this);

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -729,6 +729,10 @@
         }
     }
 
+    .message_inline_video.video-format-unsupported {
+        display: none;
+    }
+
     .youtube-video .media-anchor-element {
         /* We display the youtube-video anchor
            as a grid, not inline grid, to avoid

--- a/web/tests/rendered_markdown.test.cjs
+++ b/web/tests/rendered_markdown.test.cjs
@@ -188,10 +188,14 @@ run_test("message_inline_video", () => {
     };
 
     $content.set_find_results(".message_inline_video video", $elem);
+
+    assert.equal(window.GestureEvent, undefined);
     window.GestureEvent = true;
     rm.update_elements($content);
     assert.equal(load_called, true);
-    window.GestureEvent = false;
+    // Delete so "GestureEvent" in window — and thus is_client_safari() —
+    // returns false for other tests.
+    delete window.GestureEvent;
 });
 
 run_test("user-mention", ({override}) => {

--- a/web/tests/rendered_markdown.test.cjs
+++ b/web/tests/rendered_markdown.test.cjs
@@ -198,6 +198,25 @@ run_test("message_inline_video", () => {
     delete window.GestureEvent;
 });
 
+run_test("message_inline_video_unsupported_format", () => {
+    const $content = get_content_element();
+    const $video = $.create("video_element");
+    const $video_container = $.create("message_inline_video_container");
+
+    $video.set_closest_results(".message_inline_video", $video_container);
+    $content.set_find_results(".message_inline_video video", $video);
+
+    rm.update_elements($content);
+
+    // Without a playback error, the preview container is not hidden.
+    assert.ok(!$video_container.hasClass("video-format-unsupported"));
+
+    // Simulate video error (browser cannot play the format).
+    $video.trigger("error");
+
+    assert.ok($video_container.hasClass("video-format-unsupported"));
+});
+
 run_test("user-mention", ({override}) => {
     // Setup
     const $content = get_content_element();

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1043,10 +1043,12 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
             return False
 
         url_type = guess_type(url)[0]
-        # Support only video formats (containers) that are supported cross-browser and cross-device. As per
+        # Video container formats broadly supported across browsers; see
         # https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers#index_of_media_container_formats_file_types
-        # MP4 and WebM are the only formats that are widely supported.
-        supported_mimetypes = ["video/mp4", "video/webm"]
+        # Whether a specific file actually plays depends on the codecs
+        # inside the container; the frontend hides the preview on a
+        # playback error and falls back to the download link.
+        supported_mimetypes = ["video/mp4", "video/quicktime", "video/webm"]
         return url_type in supported_mimetypes
 
     def add_video(

--- a/zerver/lib/mime_types.py
+++ b/zerver/lib/mime_types.py
@@ -10,6 +10,7 @@ EXTRA_MIME_TYPES = [
     ("audio/wav", ".wav"),
     ("audio/webm", ".weba"),
     ("image/apng", ".apng"),
+    ("video/quicktime", ".mov"),
 ]
 
 if sys.version_info < (3, 11):  # nocoverage
@@ -45,6 +46,7 @@ INLINE_MIME_TYPES = [
     "image/webp",
     "text/plain",
     "video/mp4",
+    "video/quicktime",
     "video/webm",
     # To avoid cross-site scripting attacks, DO NOT add types such
     # as application/xhtml+xml, application/x-shockwave-flash,

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1207,6 +1207,19 @@ class MarkdownEmbedsTest(ZulipTestCase):
 <div class="message_inline_image message_inline_video"><a href="https://www.dropbox.com/scl/fi/x8z01rodq1n6pgyznt1kh/SampleVideo_1280x720_1mb.mp4?rlkey=fiibsgnu06tms041vfzfopmos&amp;st=kjtkea8h&amp;dl=0&amp;raw=1"><video preload="metadata" src="https://external-content.zulipcdn.net/external_content/eca04355025c60f40334c9a03d220c3298d4df47/68747470733a2f2f7777772e64726f70626f782e636f6d2f73636c2f66692f78387a3031726f6471316e367067797a6e74316b682f53616d706c65566964656f5f31323830783732305f316d622e6d70343f726c6b65793d6669696273676e753036746d7330343176667a666f706d6f732673743d6b6a746b6561386826646c3d30267261773d31"></video></a></div>""",
         )
 
+    def test_inline_mov_video(self) -> None:
+        msg = "Check out: https://example.com/video.mov"
+        converted = markdown_convert_wrapper(msg)
+        self.assertEqual(
+            converted,
+            '<p>Check out: <a href="https://example.com/video.mov">https://example.com/video.mov</a></p>\n'
+            '<div class="message_inline_image message_inline_video">'
+            '<a href="https://example.com/video.mov">'
+            '<video preload="metadata" '
+            'src="https://external-content.zulipcdn.net/external_content/63ae0235541edb2aaebc4f2e6cd63c6f0c1447ed/68747470733a2f2f6578616d706c652e636f6d2f766964656f2e6d6f76">'
+            "</video></a></div>",
+        )
+
     def test_inline_dropbox_preview(self) -> None:
         # Test photo album previews
         msg = "https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5"


### PR DESCRIPTION
## Summary

Add `video/quicktime` MIME type to supported video formats, enabling inline preview for `.mov` (QuickTime) files.

**Changes:**
- Added `video/quicktime` to `supported_mimetypes` in markdown processing
- Added `video/quicktime` to `INLINE_MIME_TYPES` for inline display
- Added error-based graceful degradation for browsers that cannot play the format
- Added CSS rule to hide video preview when format is unsupported
- Added tests for .mov inline video preview

Fixes #29728.

## Test plan

- [x] Upload a `.mov` file to a Zulip message
- [x] Verify preview appears in supported browsers
- [x] Verify clicking the link downloads/plays the file