### PR TITLE
settings: Convert name changes to group-based permission.

### DIFF
--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 479
+API_FEATURE_LEVEL = 480
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/admin.ts
+++ b/web/src/admin.ts
@@ -70,7 +70,6 @@ const admin_settings_label = {
 
     // Organization permissions
     realm_require_unique_names: $t({defaultMessage: "Require unique names"}),
-    realm_name_changes_disabled: $t({defaultMessage: "Prevent users from changing their name"}),
     realm_email_changes_disabled: $t({
         defaultMessage: "Prevent users from changing their email address",
     }),
@@ -169,7 +168,6 @@ export function build_page(): void {
         realm_inline_url_embed_preview: realm.realm_inline_url_embed_preview,
         server_inline_url_embed_preview: realm.server_inline_url_embed_preview,
         realm_authentication_methods: realm.realm_authentication_methods,
-        realm_name_changes_disabled: realm.realm_name_changes_disabled,
         server_name_changes_disabled: realm.server_name_changes_disabled,
         realm_require_unique_names: realm.realm_require_unique_names,
         realm_email_changes_disabled: realm.realm_email_changes_disabled,

--- a/web/src/group_permission_settings.ts
+++ b/web/src/group_permission_settings.ts
@@ -44,6 +44,7 @@ export function get_group_permission_settings(): GroupGroupSettingName[] {
 const realm_group_setting_names_supporting_anonymous_groups = [
     "can_add_custom_emoji_group",
     "can_add_subscribers_group",
+    "can_change_name_group",
     "can_create_groups",
     "can_create_bots_group",
     "can_create_public_channel_group",
@@ -71,6 +72,7 @@ export const realm_group_setting_name_schema = z.enum([
     ...realm_group_setting_names_supporting_anonymous_groups,
     "can_access_all_users_group",
     "can_create_web_public_channel_group",
+    "can_change_name_group",
 ]);
 export type RealmGroupSettingName = z.infer<typeof realm_group_setting_name_schema>;
 

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -872,6 +872,7 @@ export function check_realm_settings_property_changed(elem: HTMLElement): boolea
             break;
         case "realm_can_add_custom_emoji_group":
         case "realm_can_add_subscribers_group":
+        case "realm_can_change_name_group":
         case "realm_can_create_bots_group":
         case "realm_can_create_groups":
         case "realm_can_create_public_channel_group":
@@ -1098,6 +1099,11 @@ export function populate_data_for_realm_settings_request(
     const properties_elements = get_subsection_property_elements($subsection_elem);
     for (const input_elem of properties_elements) {
         const $input_elem = $(input_elem);
+
+        if ($input_elem.hasClass("dropdown-widget-button")) {
+            continue;
+        }
+
         if (check_realm_settings_property_changed(input_elem)) {
             const input_value = get_input_element_value(input_elem);
             if (input_value !== undefined && input_value !== null) {
@@ -1138,6 +1144,7 @@ export function populate_data_for_realm_settings_request(
                     "can_create_private_channel_group",
                     "can_create_public_channel_group",
                     "can_create_web_public_channel_group",
+                    "can_change_name_group",
                     "can_create_write_only_bots_group",
                     "can_manage_all_groups",
                     "can_manage_billing_group",

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -799,6 +799,9 @@ export const all_group_setting_labels = {
         can_access_all_users_group: $t({
             defaultMessage: "Who can view all other users in the organization",
         }),
+        can_change_name_group: $t({
+            defaultMessage: "Who can change their name",
+        }),
         can_summarize_topics_group: $t({defaultMessage: "Who can use AI summaries"}),
         can_create_write_only_bots_group: $t({
             defaultMessage: "Who can create bots that send messages into Zulip",
@@ -908,6 +911,11 @@ export const realm_group_permission_settings: {
         subsection_heading: $t({defaultMessage: "Guests"}),
         subsection_key: "org-guests-permissions",
         settings: ["can_access_all_users_group"],
+    },
+    {
+        subsection_heading: $t({defaultMessage: "User identity"}),
+        subsection_key: "org-user-identity",
+        settings: ["can_change_name_group"],
     },
     {
         subsection_heading: $t({defaultMessage: "Other permissions"}),

--- a/web/src/settings_data.ts
+++ b/web/src/settings_data.ts
@@ -24,10 +24,14 @@ export function user_can_change_name(): boolean {
     if (current_user.is_admin) {
         return true;
     }
-    if (realm.realm_name_changes_disabled || realm.server_name_changes_disabled) {
+    if (realm.server_name_changes_disabled) {
         return false;
     }
-    return true;
+    return user_has_permission_for_group_setting(
+        realm.realm_can_change_name_group,
+        "can_change_name_group",
+        "realm",
+    );
 }
 
 export function user_can_change_avatar(): boolean {

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -716,6 +716,7 @@ export function discard_realm_property_element_changes(elem: HTMLElement): void 
             break;
         case "realm_can_add_custom_emoji_group":
         case "realm_can_add_subscribers_group":
+        case "realm_can_change_name_group":
         case "realm_can_create_bots_group":
         case "realm_can_create_groups":
         case "realm_can_create_public_channel_group":

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -564,7 +564,7 @@ export const realm_schema = z.object({
     realm_moderation_request_channel_id: z.number(),
     realm_move_messages_between_streams_limit_seconds: z.nullable(z.number()),
     realm_move_messages_within_stream_limit_seconds: z.nullable(z.number()),
-    realm_name_changes_disabled: z.boolean(),
+    realm_can_change_name_group: group_setting_value_schema,
     realm_name: z.string(),
     realm_new_stream_announcements_stream_id: z.number(),
     realm_night_logo_source: z.string(),

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -311,12 +311,9 @@
                   is_checked=realm_require_unique_names
                   label=admin_settings_label.realm_require_unique_names}}
 
-                {{> settings_checkbox
-                  setting_name="realm_name_changes_disabled"
-                  prefix="id_"
-                  is_checked=(or realm_name_changes_disabled server_name_changes_disabled)
-                  label=admin_settings_label.realm_name_changes_disabled
-                  is_disabled=server_name_changes_disabled}}
+                {{> group_setting_value_pill_input
+                  setting_name="realm_can_change_name_group"
+                  label=group_setting_labels.can_change_name_group}}
 
                 {{> settings_checkbox
                   setting_name="realm_email_changes_disabled"

--- a/web/tests/settings_data.test.cjs
+++ b/web/tests/settings_data.test.cjs
@@ -144,17 +144,11 @@ run_test("user_can_change_name", ({override}) => {
     assert.equal(can_change_name(), true);
 
     override(current_user, "is_admin", false);
-    override(realm, "realm_name_changes_disabled", true);
-    override(realm, "server_name_changes_disabled", false);
-    assert.equal(can_change_name(), false);
-
-    override(realm, "realm_name_changes_disabled", false);
-    override(realm, "server_name_changes_disabled", false);
-    assert.equal(can_change_name(), true);
-
-    override(realm, "realm_name_changes_disabled", false);
     override(realm, "server_name_changes_disabled", true);
     assert.equal(can_change_name(), false);
+
+    override(realm, "server_name_changes_disabled", false);
+    test_realm_group_settings("realm_can_change_name_group", can_change_name);
 });
 
 run_test("user_can_change_avatar", ({override}) => {

--- a/web/tests/settings_org.test.cjs
+++ b/web/tests/settings_org.test.cjs
@@ -758,34 +758,6 @@ test("test combined_code_language_options", ({override}) => {
 test("misc", ({override}) => {
     override(current_user, "is_admin", false);
 
-    override(realm, "realm_name_changes_disabled", false);
-    override(realm, "server_name_changes_disabled", false);
-    settings_account.update_name_change_display();
-    assert.ok(!$("#full_name").prop("disabled"));
-    assert.ok(!$("#full_name_input_container").hasClass("disabled_setting_tooltip"));
-    assert.ok(!$("label[for='full_name']").hasClass("cursor-text"));
-
-    override(realm, "realm_name_changes_disabled", true);
-    override(realm, "server_name_changes_disabled", false);
-    settings_account.update_name_change_display();
-    assert.ok($("#full_name").prop("disabled"));
-    assert.ok($("#full_name_input_container").hasClass("disabled_setting_tooltip"));
-    assert.ok($("label[for='full_name']").hasClass("cursor-text"));
-
-    override(realm, "realm_name_changes_disabled", true);
-    override(realm, "server_name_changes_disabled", true);
-    settings_account.update_name_change_display();
-    assert.ok($("#full_name").prop("disabled"));
-    assert.ok($("#full_name_input_container").hasClass("disabled_setting_tooltip"));
-    assert.ok($("label[for='full_name']").hasClass("cursor-text"));
-
-    override(realm, "realm_name_changes_disabled", false);
-    override(realm, "server_name_changes_disabled", true);
-    settings_account.update_name_change_display();
-    assert.ok($("#full_name").prop("disabled"));
-    assert.ok($("#full_name_input_container").hasClass("disabled_setting_tooltip"));
-    assert.ok($("label[for='full_name']").hasClass("cursor-text"));
-
     override(realm, "realm_email_changes_disabled", false);
     settings_account.update_email_change_display();
     assert.ok(!$("#change_email_button").hasClass("hide"));
@@ -815,10 +787,6 @@ test("misc", ({override}) => {
 
     // If organization admin, these UI elements are never disabled.
     override(current_user, "is_admin", true);
-    settings_account.update_name_change_display();
-    assert.ok(!$("#full_name").prop("disabled"));
-    assert.ok(!$("#full_name_input_container").hasClass("disabled_setting_tooltip"));
-    assert.ok(!$("label[for='full_name']").hasClass("cursor-text"));
 
     settings_account.update_email_change_display();
     assert.ok(!$("#change_email_button").hasClass("hide"));

--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.db import transaction
 from django.db.models import F
 from django.utils.timezone import now as timezone_now
+from django.utils.translation import gettext as _
 
 from confirmation.models import Confirmation, create_confirmation_link
 from confirmation.settings import STATUS_REVOKED, STATUS_USED
@@ -19,12 +20,14 @@ from zerver.lib.cache import (
     user_profile_by_api_key_cache_key,
 )
 from zerver.lib.create_user import get_display_email_address
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.i18n import get_language_name
 from zerver.lib.queue import queue_event_on_commit
 from zerver.lib.send_email import FromAddress, clear_scheduled_emails, send_email
 from zerver.lib.timezone import canonicalize_timezone
 from zerver.lib.types import UserProfileChangeDict
 from zerver.lib.upload import delete_avatar_image
+from zerver.lib.user_groups import is_user_in_group
 from zerver.lib.users import (
     can_access_delivery_email,
     check_bot_name_available,
@@ -225,11 +228,29 @@ def do_change_password(user_profile: UserProfile, password: str, commit: bool = 
 
 @transaction.atomic(savepoint=False)
 def do_change_full_name(
-    user_profile: UserProfile, full_name: str, acting_user: UserProfile | None, notify: bool
+    user_profile: UserProfile,
+    full_name: str,
+    acting_user: UserProfile | None,
+    notify: bool = True,
+    *,
+    skip_permission_check: bool = False,
 ) -> None:
     old_name = user_profile.full_name
     if old_name == full_name:
         return
+
+    if (
+        not skip_permission_check
+        and acting_user is not None
+        and user_profile == acting_user
+        and not acting_user.is_realm_admin
+        and not is_user_in_group(
+            acting_user.realm.can_change_name_group_id,
+            acting_user,
+            direct_member_only=False,
+        )
+    ):
+        raise JsonableError(_("Insufficient permission"))
 
     user_profile.full_name = full_name
     user_profile.save(update_fields=["full_name"])
@@ -264,10 +285,10 @@ def do_change_full_name(
 def check_change_full_name(
     user_profile: UserProfile, full_name_raw: str, acting_user: UserProfile | None
 ) -> str:
-    """Verifies that the user's proposed full name is valid.  The caller
-    is responsible for checking check permissions.  Returns the new
-    full name, which may differ from what was passed in (because this
-    function strips whitespace)."""
+    """Verifies that the user's proposed full name is valid and that the user
+    has permission to change their name. Returns the new full name, which may
+    differ from what was passed in (because this function strips whitespace)."""
+
     new_full_name = check_full_name(
         full_name_raw=full_name_raw, user_profile=user_profile, realm=user_profile.realm
     )

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -508,11 +508,19 @@ def do_deactivate_user(
                 # The full name of spam user is changed to Deleted user.
                 if user_profile.full_name != "Deleted user" and not user_profile.is_bot:
                     do_change_full_name(
-                        user_profile, "Deleted user", acting_user=acting_user, notify=False
+                        user_profile,
+                        "Deleted user",
+                        acting_user=acting_user,
+                        notify=False,
+                        skip_permission_check=True,
                     )
                 elif user_profile.full_name != "Deactivated bot" and user_profile.is_bot:
                     do_change_full_name(
-                        user_profile, "Deactivated bot", acting_user=acting_user, notify=False
+                        user_profile,
+                        "Deactivated bot",
+                        acting_user=acting_user,
+                        notify=False,
+                        skip_permission_check=True,
                     )
 
                 # TODO: Change avatar image to that of an inaccessible user.

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -608,6 +608,7 @@ class GroupSettingUpdateData(GroupSettingUpdateDataCore):
     can_access_all_users_group: int | UserGroupMembersDict | None = None
     can_add_custom_emoji_group: int | UserGroupMembersDict | None = None
     can_add_subscribers_group: int | UserGroupMembersDict | None = None
+    can_change_name_group: int | UserGroupMembersDict | None = None
     can_create_bots_group: int | UserGroupMembersDict | None = None
     can_create_groups: int | UserGroupMembersDict | None = None
     can_create_public_channel_group: int | UserGroupMembersDict | None = None

--- a/zerver/migrations/0789__add_can_change_name_group.py
+++ b/zerver/migrations/0789__add_can_change_name_group.py
@@ -1,0 +1,66 @@
+import django.db.models.deletion
+from django.db import migrations, models
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+
+def set_can_change_name_group(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    """
+    Migrate existing realm_name_changes_disabled boolean to can_change_name_group.
+    - name_changes_disabled=True → role:administrators
+    - name_changes_disabled=False → role:everyone
+    """
+    Realm = apps.get_model("zerver", "Realm")
+    NamedUserGroup = apps.get_model("zerver", "NamedUserGroup")
+
+    for realm in Realm.objects.all().iterator():
+        if realm.name_changes_disabled:
+            # name_changes_disabled=True means only admins can change names
+            administrators_group = NamedUserGroup.objects.get(
+                name="role:administrators",
+                realm=realm,
+                is_system_group=True,
+            )
+            realm.can_change_name_group = administrators_group.usergroup_ptr
+        else:
+            # name_changes_disabled=False means everyone can change names
+            everyone_group = NamedUserGroup.objects.get(
+                name="role:everyone",
+                realm=realm,
+                is_system_group=True,
+            )
+            realm.can_change_name_group = everyone_group.usergroup_ptr
+        realm.save(update_fields=["can_change_name_group"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0788_realmfilter_alternative_url_templates"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="realm",
+            name="can_change_name_group",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.RESTRICT,
+                related_name="+",
+                to="zerver.usergroup",
+            ),
+        ),
+        migrations.RunPython(
+            set_can_change_name_group,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+        migrations.AlterField(
+            model_name="realm",
+            name="can_change_name_group",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.RESTRICT,
+                related_name="+",
+                to="zerver.usergroup",
+            ),
+        ),
+    ]

--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -338,6 +338,11 @@ class Realm(models.Model):
         "UserGroup", on_delete=models.RESTRICT, related_name="+"
     )
 
+    # UserGroup whose members are allowed to change their own name.
+    can_change_name_group = models.ForeignKey(
+        "UserGroup", on_delete=models.RESTRICT, related_name="+"
+    )
+
     # UserGroup whose members are allowed to invite other users to organization.
     can_invite_users_group = models.ForeignKey(
         "UserGroup", on_delete=models.RESTRICT, related_name="+"
@@ -776,7 +781,6 @@ class Realm(models.Model):
         move_messages_within_stream_limit_seconds=int | None,
         message_retention_days=int,
         name=str,
-        name_changes_disabled=bool,
         push_notifications_enabled=bool,
         require_e2ee_push_notifications=bool,
         require_unique_names=bool,
@@ -803,6 +807,11 @@ class Realm(models.Model):
             # Note that user_can_access_all_other_users in the web
             # app is relying on members always have access.
             allowed_system_groups=[SystemGroups.EVERYONE, SystemGroups.MEMBERS],
+        ),
+        can_change_name_group=GroupPermissionSetting(
+            allow_nobody_group=True,
+            allow_everyone_group=True,
+            default_group_name=SystemGroups.EVERYONE,
         ),
         can_add_subscribers_group=GroupPermissionSetting(
             allow_nobody_group=True,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5680,14 +5680,15 @@ paths:
                                       type: string
                                       description: |
                                         The name of the organization, used in login pages etc.
-                                    name_changes_disabled:
-                                      type: boolean
-                                      description: |
-                                        Indicates whether users are
-                                        [allowed to change](/help/restrict-name-and-email-changes) their name
-                                        via the Zulip UI in this organization. Typically disabled
-                                        in organizations syncing this type of account information from
-                                        an external user database like LDAP.
+                                    can_change_name_group:
+                                      allOf:
+                                        - description: |
+                                            A [group-setting value](/api/group-setting-values) defining the set of
+                                            users who have permission to change their own name in the organization.
+
+                                            **Changes**: New in Zulip 12.0 (feature level 480). Previously,
+                                            this was controlled by the `name_changes_disabled` boolean setting.
+                                        - $ref: "#/components/schemas/GroupSettingValue"
                                     night_logo_source:
                                       type: string
                                       description: |
@@ -19853,16 +19854,17 @@ paths:
 
                           **Changes**: New in Zulip 9.0 (feature level 246). Previously, the Zulip
                           server could not be configured to enforce unique names.
-                      realm_name_changes_disabled:
-                        type: boolean
-                        description: |
-                          Present if `realm` is present in `fetch_event_types`.
+                      realm_can_change_name_group:
+                        allOf:
+                          - description: |
+                              Present if `realm` is present in `fetch_event_types`.
 
-                          Indicates whether users are
-                          [allowed to change](/help/restrict-name-and-email-changes) their name
-                          via the Zulip UI in this organization. Typically disabled
-                          in organizations syncing this type of account information from
-                          an external user database like LDAP.
+                              A [group-setting value](/api/group-setting-values) defining the set of
+                              users who have permission to change their own name in the organization.
+
+                              **Changes**: New in Zulip 12.0 (feature level 480). Previously,
+                              this was controlled by the `realm_name_changes_disabled` boolean setting.
+                          - $ref: "#/components/schemas/GroupSettingValue"
                       realm_avatar_changes_disabled:
                         type: boolean
                         description: |

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -204,7 +204,7 @@ class HomeTest(ZulipTestCase):
         "realm_move_messages_between_streams_limit_seconds",
         "realm_move_messages_within_stream_limit_seconds",
         "realm_name",
-        "realm_name_changes_disabled",
+        "realm_can_change_name_group",
         "realm_new_stream_announcements_stream_id",
         "realm_night_logo_source",
         "realm_night_logo_url",

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -415,21 +415,24 @@ class RealmTest(ZulipTestCase):
         self.assert_json_error(result, "Must be an organization administrator")
 
     def test_unauthorized_name_change(self) -> None:
-        data = {"full_name": "Sir Hamlet"}
         user_profile = self.example_user("hamlet")
+        # Set name changes to administrators only
+        admin_group = NamedUserGroup.objects.get(
+            realm=user_profile.realm,
+            name=SystemGroups.ADMINISTRATORS,
+            is_system_group=True,
+        ).usergroup_ptr
+        do_change_realm_permission_group_setting(
+            user_profile.realm,
+            "can_change_name_group",
+            admin_group,
+            acting_user=None,
+        )
         self.login_user(user_profile)
-        do_set_realm_property(user_profile.realm, "name_changes_disabled", True, acting_user=None)
+        data = {"full_name": "Sir Hamlet"}
         url = "/json/settings"
         result = self.client_patch(url, data)
-        self.assertEqual(result.status_code, 200)
-        # Since the setting fails silently, no message is returned
-        self.assert_in_response("", result)
-        # Realm admins can change their name even setting is disabled.
-        data = {"full_name": "New Iago"}
-        self.login("iago")
-        url = "/json/settings"
-        result = self.client_patch(url, data)
-        self.assert_json_success(result)
+        self.assert_json_error(result, "Insufficient permission")
 
     def test_do_deactivate_realm_clears_user_realm_cache(self) -> None:
         """The main complicated thing about deactivating realm names is

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -192,7 +192,7 @@ def update_realm(
         ApiParamConfig("move_messages_within_stream_limit_seconds"),
     ] = None,
     name: Annotated[str | None, StringConstraints(max_length=Realm.MAX_REALM_NAME_LENGTH)] = None,
-    name_changes_disabled: Json[bool] | None = None,
+    can_change_name_group: Json[GroupSettingChangeRequest] | None = None,
     new_stream_announcements_stream_id: Json[int] | None = None,
     org_type: Json[OrgTypeEnum] | None = None,
     require_e2ee_push_notifications: Json[bool] | None = None,


### PR DESCRIPTION
Replace the boolean setting for disabling name changes with a group-based permission that controls who can change their own name in organization settings.

Existing organizations are migrated to preserve behavior: disabling name changes maps to administrators-only, while the default allows everyone including guests.

Fixes #30077.

<!-- Describe your pull request here.-->


**How changes were tested:**
Verified manually by changing the “Who can change their name” setting in organization permissions and confirming that users inside and outside the selected group could or could not change their name accordingly. Also verified that existing organizations retain the same behavior after migration.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<img width="702" height="388" alt="Screenshot 2026-02-27 at 21 23 27" src="https://github.com/user-attachments/assets/e5ae38a1-e12b-4322-9a36-2c2271f429b5" />

https://github.com/user-attachments/assets/644a4f38-fe95-4cb1-a606-c639bc95ed68




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
