### PR TITLE
typeahead: Use window width for mobile detection instead of touchscreen.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -428,6 +428,17 @@ export class Typeahead<ItemType extends string | object> {
                 offset({placement, reference}) {
                     // Gap separates the typeahead and caret by 2px vertically.
                     const gap = 2;
+                    // Use window width for mobile detection instead of touchscreen.
+                    const isMobileWidth = window.innerWidth < 768;
+
+                    if (isMobileWidth) {
+                        // On narrow screens the input is near the right edge, so
+                        // the dropdown would overflow and get clipped.  Shift it
+                        // left so its left edge aligns with the viewport's left edge,
+                        // giving it the full screen width.
+                        const inputRect = the(input_element.$element).getBoundingClientRect();
+                        return [-inputRect.left, gap];
+                    }
 
                     if (input_element.type === "textarea") {
                         const caret = getCaretCoordinates(


### PR DESCRIPTION
Previously the typeahead used touchscreen detection for mobile
positioning, which doesn't work in DevTools mobile view, as
DevTools doesn't simulate a touchscreen by default.  On narrow
screens the input element is near the right edge of the viewport,
so the dropdown overflowed and user names got clipped.

Changed the `offset` callback in `show()` in
`bootstrap_typeahead.ts` to check `window.innerWidth < 768`
instead of touchscreen detection.  On mobile widths the dropdown
is shifted left so its left edge aligns with the viewport edge,
giving it the full screen width.

Fixes: https://chat.zulip.org/#narrow/channel/9-issues/topic/DM.20compose.3A.20User.20names.20cut.20off.20in.20recipient.20selection/with/2357825

**How changes were tested:**
Tested in DevTools mobile view (iPhone 12, 375px width). Desktop
typeahead positioning is unchanged. Linter passes.

**Screenshots and screen captures:**
Before :
<img width="322" height="674" alt="image" src="https://github.com/user-attachments/assets/f084bddb-2587-44f9-95ae-7e4ab22edc5b" />

After:
<img width="328" height="683" alt="image" src="https://github.com/user-attachments/assets/84546ec6-f2e8-4bd6-8194-9e6707dbc460" />

Self-review checklist
- [x] Self-reviewed the changes for clarity and maintainability
- [x] Followed the AI use policy. Communicate decisions, questions, and potential concerns.
- [ ] Explains differences from previous plans
- [ ] Highlights technical choices and bugs encountered
- [ ] Calls out remaining decisions and concerns
- [ ] Automated tests verify logic where appropriate
- [x] Each commit is a coherent idea
- [x] Commit message explain reasoning and motivation for changes
- [x] Visual appearance of the changes
- [x] Responsiveness and internationalization
- [ ] Strings and tooltips
- [x] End-to-end functionality of buttons, interactions and flows
- [ ] Corner cases, error conditions, and easily imagined bugs
</details>