### PR TITLE
[ai] emoji: Add "native" emojiset option.

### DIFF
--- a/api_docs/unmerged.d/ZF-e6bf89.md
+++ b/api_docs/unmerged.d/ZF-e6bf89.md
@@ -1,0 +1,4 @@
+* [`PATCH /settings`](/api/update-settings),
+  [`POST /register`](/api/register-queue),
+  [`GET /server_settings`](/api/get-server-settings): Added
+  `"native"` as a new option for the `emojiset` setting.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "handlebars-loader": "^1.7.1",
     "html-webpack-plugin": "^5.3.2",
     "intl-messageformat": "^11.0.7",
+    "is-emoji-supported": "^0.0.5",
     "is-url": "^1.2.4",
     "jquery": "^3.6.3",
     "jquery-caret-plugin": "^1.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       intl-messageformat:
         specifier: ^11.0.7
         version: 11.0.9
+      is-emoji-supported:
+        specifier: ^0.0.5
+        version: 0.0.5
       is-url:
         specifier: ^1.2.4
         version: 1.2.4
@@ -5773,6 +5776,9 @@ packages:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
+
+  is-emoji-supported@0.0.5:
+    resolution: {integrity: sha512-WOlXUhDDHxYqcSmFZis+xWhhqXiK2SU0iYiqmth5Ip0FHLZQAt9rKL5ahnilE8/86WH8tZ3bmNNNC+bTzamqlw==}
 
   is-empty@1.2.0:
     resolution: {integrity: sha512-F2FnH/otLNJv0J6wc73A5Xo7oHLNnqplYqZhUu01tD54DIPvxIRSTSLkrUB/M0nHO4vo1O9PDfN4KoTxCzLh/w==}
@@ -16076,6 +16082,8 @@ snapshots:
   is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
+
+  is-emoji-supported@0.0.5: {}
 
   is-empty@1.2.0: {}
 

--- a/web/src/emoji_picker.ts
+++ b/web/src/emoji_picker.ts
@@ -135,7 +135,12 @@ class UserStatusSession {
             emoji_alt_code: user_settings.emojiset === "text",
         };
         if (!emoji_info.emoji_alt_code) {
-            emoji_info = {...emoji_info, ...emoji.get_emoji_details_by_name(emoji_name)};
+            const details = emoji.get_emoji_details_by_name(emoji_name);
+            emoji_info = {
+                ...emoji_info,
+                ...details,
+                ...emoji.get_native_emoji_info(details),
+            };
         }
         user_status_ui.set_selected_emoji_info(emoji_info);
         user_status_ui.update_button();

--- a/web/src/emojisets.ts
+++ b/web/src/emojisets.ts
@@ -21,9 +21,10 @@ const emojisets = new Map<string, EmojiSet>([
     ["twitter", {css: twitter_css, sheet: twitter_sheet}],
 ]);
 
-// For `text` emoji set we fallback to `google` emoji set
+// For `text` and `native` emoji sets we fallback to `google` emoji set
 // for displaying emojis in emoji picker and typeahead.
 emojisets.set("text", emojisets.get("google")!);
+emojisets.set("native", emojisets.get("google")!);
 
 let current_emojiset: EmojiSet | undefined;
 

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -155,6 +155,7 @@ export type MessageCleanReaction = {
     label: string;
     local_id: string;
     reaction_type: "zulip_extra_emoji" | "realm_emoji" | "unicode_emoji";
+    unicode_emoji?: string;
     user_ids: number[];
     vote_text: string;
 };

--- a/web/src/reactions.ts
+++ b/web/src/reactions.ts
@@ -380,6 +380,7 @@ export let insert_new_reaction = (
         label: new_label,
         local_id: get_local_reaction_id(clean_reaction_object),
         emoji_alt_code: user_settings.emojiset === "text",
+        ...emoji.get_native_emoji_info(emoji_details),
         is_realm_emoji,
         vote_text: "", // Updated below
         class: reaction_class,
@@ -626,6 +627,7 @@ function make_clean_reaction({
         user_ids,
         ...emoji_details,
         emoji_alt_code,
+        ...emoji.get_native_emoji_info(emoji_details),
         is_realm_emoji,
         ...build_reaction_data(user_ids, emoji_name, should_display_reactors),
     };

--- a/web/src/user_pill.ts
+++ b/web/src/user_pill.ts
@@ -26,7 +26,9 @@ export type UserPill = {
     full_name: string;
     img_src?: string;
     deactivated?: boolean;
-    status_emoji_info?: (EmojiRenderingDetails & {emoji_alt_code?: boolean}) | undefined; // TODO: Move this in user_status.js
+    status_emoji_info?:
+        | (EmojiRenderingDetails & {emoji_alt_code?: boolean; unicode_emoji?: string})
+        | undefined; // TODO: Move this in user_status.js
     should_add_guest_user_indicator?: boolean;
     is_bot?: boolean;
 };

--- a/web/src/user_status.ts
+++ b/web/src/user_status.ts
@@ -10,6 +10,7 @@ import {user_status_schema} from "./user_status_types.ts";
 export type UserStatus = z.infer<typeof user_status_schema>;
 export type UserStatusEmojiInfo = EmojiRenderingDetails & {
     emoji_alt_code?: boolean;
+    unicode_emoji?: string;
 };
 
 const user_status_event_schema = z.intersection(
@@ -94,13 +95,16 @@ export function set_status_emoji(event: UserStatusEvent): void {
         return;
     }
 
+    const emoji_details = emoji.get_emoji_details_for_rendering({
+        emoji_name: opts.emoji_name,
+        emoji_code: opts.emoji_code,
+        reaction_type: opts.reaction_type,
+    });
+
     user_status_emoji_info.set(opts.user_id, {
         emoji_alt_code: user_settings.emojiset === "text",
-        ...emoji.get_emoji_details_for_rendering({
-            emoji_name: opts.emoji_name,
-            emoji_code: opts.emoji_code,
-            reaction_type: opts.reaction_type,
-        }),
+        ...emoji.get_native_emoji_info(emoji_details),
+        ...emoji_details,
     });
 }
 

--- a/web/src/user_status_ui.ts
+++ b/web/src/user_status_ui.ts
@@ -13,7 +13,10 @@ import * as user_status from "./user_status.ts";
 import type {UserStatusEmojiInfo} from "./user_status.ts";
 
 let selected_emoji_info: Partial<UserStatusEmojiInfo> = {};
-let default_status_messages_and_emoji_info: {status_text: string; emoji: EmojiRenderingDetails}[];
+let default_status_messages_and_emoji_info: {
+    status_text: string;
+    emoji: EmojiRenderingDetails & {unicode_emoji?: string};
+}[];
 
 export function set_selected_emoji_info(emoji_info: Partial<UserStatusEmojiInfo>): void {
     selected_emoji_info = {...emoji_info};
@@ -185,35 +188,42 @@ function user_status_post_render(): void {
     });
 }
 
+function get_emoji_with_native_info(
+    emoji_name: string,
+): EmojiRenderingDetails & {unicode_emoji?: string} {
+    const details = emoji.get_emoji_details_by_name(emoji_name);
+    return {...details, ...emoji.get_native_emoji_info(details)};
+}
+
 export function initialize(): void {
     default_status_messages_and_emoji_info = [
         {
             status_text: $t({defaultMessage: "Busy"}),
-            emoji: emoji.get_emoji_details_by_name("working_on_it"),
+            emoji: get_emoji_with_native_info("working_on_it"),
         },
         {
             status_text: $t({defaultMessage: "In a meeting"}),
-            emoji: emoji.get_emoji_details_by_name("calendar"),
+            emoji: get_emoji_with_native_info("calendar"),
         },
         {
             status_text: $t({defaultMessage: "Commuting"}),
-            emoji: emoji.get_emoji_details_by_name("bus"),
+            emoji: get_emoji_with_native_info("bus"),
         },
         {
             status_text: $t({defaultMessage: "Out sick"}),
-            emoji: emoji.get_emoji_details_by_name("hurt"),
+            emoji: get_emoji_with_native_info("hurt"),
         },
         {
             status_text: $t({defaultMessage: "Vacationing"}),
-            emoji: emoji.get_emoji_details_by_name("palm_tree"),
+            emoji: get_emoji_with_native_info("palm_tree"),
         },
         {
             status_text: $t({defaultMessage: "Working remotely"}),
-            emoji: emoji.get_emoji_details_by_name("house"),
+            emoji: get_emoji_with_native_info("house"),
         },
         {
             status_text: $t({defaultMessage: "At the office"}),
-            emoji: emoji.get_emoji_details_by_name("office"),
+            emoji: get_emoji_with_native_info("office"),
         },
     ];
 }

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -417,6 +417,10 @@
     /* Box shadow for overlays across the web app */
     --box-shadow-overlay: none;
 
+    /* Font family for rendering native Unicode emoji. */
+    --font-family-native-emoji:
+        "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+
     /* Shared sidebar typography and effects values. */
     --font-weight-sidebar-heading: 600;
     --font-weight-sidebar-action-heading: 370;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1384,6 +1384,11 @@ label.preferences-radio-choice-label {
     margin-right: 1px;
 }
 
+.emoji-native-preview {
+    font-family: var(--font-family-native-emoji);
+    font-size: 1.2em;
+}
+
 .download_bot_zuliprc,
 .copy_zuliprc,
 .open_bots_subscribed_streams,

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1450,6 +1450,16 @@ div.topic_edit_spinner .loading_indicator_spinner {
     align-self: center;
 }
 
+/* Native emoji rendering: override sprite sheet properties
+   so that the Unicode character is shown directly. */
+.emoji-native {
+    background: none !important;
+    text-indent: 0 !important;
+    overflow: visible !important;
+    font-family: var(--font-family-native-emoji);
+    text-align: center;
+}
+
 .status-emoji {
     /* 16px at 14px/1em */
     height: 1.1429em;

--- a/web/templates/message_reaction.hbs
+++ b/web/templates/message_reaction.hbs
@@ -2,6 +2,8 @@
     <div class="{{this.class}} {{#if is_archived}}disabled{{/if}}" aria-label="{{this.label}}" data-reaction-id="{{this.local_id}}">
         {{#if this.emoji_alt_code}}
             <div class="emoji_alt_code">&nbsp;:{{this.emoji_name}}:</div>
+        {{else if this.unicode_emoji}}
+            <div class="emoji emoji-native">{{this.unicode_emoji}}</div>
         {{else if this.is_realm_emoji}}
             <img src="{{this.url}}" class="emoji" />
         {{else}}

--- a/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
@@ -22,6 +22,8 @@
                         {{#if status_emoji_info}}
                             {{#if status_emoji_info.emoji_alt_code}}
                             <span class="emoji_alt_code">&nbsp;:{{status_emoji_info.emoji_name}}:</span>
+                            {{else if status_emoji_info.unicode_emoji}}
+                            <span class="emoji status_emoji emoji-native">{{status_emoji_info.unicode_emoji}}</span>
                             {{else if status_emoji_info.url}}
                             <img src="{{status_emoji_info.url}}" class="emoji status_emoji" />
                             {{else}}

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -40,6 +40,8 @@
                     {{#if status_emoji_info}}
                         {{#if status_emoji_info.emoji_alt_code}}
                             <span class="emoji_alt_code">&nbsp;:{{status_emoji_info.emoji_name}}:</span>
+                        {{else if status_emoji_info.unicode_emoji}}
+                            <span class="emoji status_emoji emoji-native" data-tippy-content=":{{status_emoji_info.emoji_name}}:">{{status_emoji_info.unicode_emoji}}</span>
                         {{else if status_emoji_info.url}}
                             <img src="{{status_emoji_info.url}}" class="emoji status_emoji" data-tippy-content=":{{status_emoji_info.emoji_name}}:"/>
                         {{else}}

--- a/web/templates/set_status_overlay.hbs
+++ b/web/templates/set_status_overlay.hbs
@@ -13,6 +13,8 @@
             <a class="modal-option-content trigger-click-on-enter user-status-value" tabindex="0">
                 {{#if emoji.emoji_alt_code}}
                     <div class="emoji_alt_code">&nbsp;:{{emoji.emoji_name}}:</div>
+                {{else if emoji.unicode_emoji}}
+                    <div class="emoji status-emoji emoji-native">{{emoji.unicode_emoji}}</div>
                 {{else if emoji.url}}
                     <img src="{{emoji.url}}" class="emoji status-emoji" />
                 {{else}}

--- a/web/templates/settings/preferences_emoji.hbs
+++ b/web/templates/settings/preferences_emoji.hbs
@@ -21,6 +21,8 @@
                     <span class="right">
                         {{#if (eq this.key "text") }}
                         <span class="emoji_alt_code">&nbsp;:relaxed:</span>
+                        {{else if (eq this.key "native") }}
+                        <span class="emoji-native-preview">&nbsp;&#x1f604;&#x1f44d;&#x1f680;&#x1f389;</span>
                         {{else}}
                         <img class="emoji" src="/static/generated/emoji/images-{{this.key}}-64/1f604.png" />
                         <img class="emoji" src="/static/generated/emoji/images-{{this.key}}-64/1f44d.png" />

--- a/web/templates/status_emoji.hbs
+++ b/web/templates/status_emoji.hbs
@@ -1,6 +1,8 @@
 {{~#if . ~}}
 {{~#if emoji_alt_code ~}}
 <span class="emoji_alt_code">&nbsp;:{{emoji_name}}:</span>
+{{~else if unicode_emoji ~}}
+<span class="emoji status-emoji status-emoji-name emoji-native" data-tippy-content=":{{emoji_name}}:">{{unicode_emoji}}</span>
 {{~else if still_url ~}}
 <img src="{{still_url}}" class="emoji status-emoji status-emoji-name" data-animated-url="{{url}}" data-still-url="{{still_url}}" data-tippy-content=":{{emoji_name}}:" />
 {{~else if url ~}}

--- a/web/templates/status_emoji_selector.hbs
+++ b/web/templates/status_emoji_selector.hbs
@@ -1,6 +1,8 @@
 {{#if selected_emoji}}
     {{#if selected_emoji.emoji_alt_code}}
         <div class="emoji_alt_code">&nbsp;:{{selected_emoji.emoji_name}}:</div>
+    {{else if selected_emoji.unicode_emoji}}
+        <div class="emoji selected-emoji emoji-native">{{selected_emoji.unicode_emoji}}</div>
     {{else if selected_emoji.url}}
         <img src="{{selected_emoji.url}}" class="emoji selected-emoji" />
     {{else}}

--- a/web/tests/emoji.test.cjs
+++ b/web/tests/emoji.test.cjs
@@ -3,13 +3,22 @@
 const assert = require("node:assert/strict");
 
 const events = require("./lib/events.cjs");
-const {zrequire} = require("./lib/namespace.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
 
+let is_emoji_supported_result = true;
+mock_esm("is-emoji-supported", {
+    isEmojiSupported: () => is_emoji_supported_result,
+});
+
 const emoji_codes = zrequire("../../static/generated/emoji/emoji_codes.json");
+const {initialize_user_settings} = zrequire("user_settings");
 
 const emoji = zrequire("emoji");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 const realm_emoji = events.test_realm_emojis;
 
@@ -130,4 +139,79 @@ run_test("get_emoji_details_by_name", () => {
             message: "Bad emoji name: unknown-emoji",
         },
     );
+});
+
+run_test("get_native_emoji_info", ({override}) => {
+    // get_native_emoji_info returns {unicode_emoji: char} when the emojiset
+    // is "native" and the emoji is a supported Unicode emoji.
+
+    const smile_details = {
+        emoji_name: "smile",
+        emoji_code: "1f604",
+        reaction_type: "unicode_emoji",
+    };
+
+    // With emojiset="native" and a supported Unicode emoji, it should
+    // return the Unicode character.
+    override(user_settings, "emojiset", "native");
+    is_emoji_supported_result = true;
+    let result = emoji.get_native_emoji_info(smile_details);
+    assert.deepEqual(result, {unicode_emoji: "\uD83D\uDE04"});
+
+    // With emojiset="google" (non-native), it should return an empty object
+    // even for a supported Unicode emoji.
+    override(user_settings, "emojiset", "google");
+    result = emoji.get_native_emoji_info(smile_details);
+    assert.deepEqual(result, {});
+
+    // With emojiset="text", it should return an empty object.
+    override(user_settings, "emojiset", "text");
+    result = emoji.get_native_emoji_info(smile_details);
+    assert.deepEqual(result, {});
+
+    // With emojiset="twitter", it should return an empty object.
+    override(user_settings, "emojiset", "twitter");
+    result = emoji.get_native_emoji_info(smile_details);
+    assert.deepEqual(result, {});
+
+    // With emojiset="native" but an unsupported emoji, it should return
+    // an empty object.
+    override(user_settings, "emojiset", "native");
+    is_emoji_supported_result = false;
+    result = emoji.get_native_emoji_info(smile_details);
+    assert.deepEqual(result, {});
+
+    // With emojiset="native" and a realm emoji (not unicode_emoji),
+    // it should return an empty object regardless of support.
+    is_emoji_supported_result = true;
+    const realm_emoji_details = {
+        emoji_name: "spain",
+        emoji_code: "101",
+        reaction_type: "realm_emoji",
+        url: "/some/path/to/spain.gif",
+    };
+    result = emoji.get_native_emoji_info(realm_emoji_details);
+    assert.deepEqual(result, {});
+
+    // With emojiset="native" and a zulip_extra_emoji, it should
+    // return an empty object.
+    const zulip_emoji_details = {
+        emoji_name: "zulip",
+        emoji_code: "zulip",
+        reaction_type: "zulip_extra_emoji",
+        url: "/static/generated/emoji/images/emoji/unicode/zulip.png",
+    };
+    result = emoji.get_native_emoji_info(zulip_emoji_details);
+    assert.deepEqual(result, {});
+
+    // Multi-codepoint emoji (e.g., flags with dash-separated hex codes)
+    // should produce the correct joined Unicode character.
+    is_emoji_supported_result = true;
+    const flag_details = {
+        emoji_name: "united_states",
+        emoji_code: "1f1fa-1f1f8",
+        reaction_type: "unicode_emoji",
+    };
+    result = emoji.get_native_emoji_info(flag_details);
+    assert.deepEqual(result, {unicode_emoji: "\uD83C\uDDFA\uD83C\uDDF8"});
 });

--- a/zerver/migrations/0753_remove_google_blob_emojiset.py
+++ b/zerver/migrations/0753_remove_google_blob_emojiset.py
@@ -24,7 +24,12 @@ class Migration(migrations.Migration):
             model_name="realmuserdefault",
             name="emojiset",
             field=models.CharField(
-                choices=[("google", "Google"), ("twitter", "Twitter"), ("text", "Plain text")],
+                choices=[
+                    ("google", "Google"),
+                    ("twitter", "Twitter"),
+                    ("native", "Native"),
+                    ("text", "Plain text"),
+                ],
                 default="google",
                 max_length=20,
             ),
@@ -33,7 +38,12 @@ class Migration(migrations.Migration):
             model_name="userprofile",
             name="emojiset",
             field=models.CharField(
-                choices=[("google", "Google"), ("twitter", "Twitter"), ("text", "Plain text")],
+                choices=[
+                    ("google", "Google"),
+                    ("twitter", "Twitter"),
+                    ("native", "Native"),
+                    ("text", "Plain text"),
+                ],
                 default="google",
                 max_length=20,
             ),

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -154,11 +154,13 @@ class UserBaseSettings(models.Model):
 
     # Emoji sets
     GOOGLE_EMOJISET = "google"
+    NATIVE_EMOJISET = "native"
     TEXT_EMOJISET = "text"
     TWITTER_EMOJISET = "twitter"
     EMOJISET_CHOICES = (
         (GOOGLE_EMOJISET, "Google"),
         (TWITTER_EMOJISET, "Twitter"),
+        (NATIVE_EMOJISET, "Native"),
         (TEXT_EMOJISET, "Plain text"),
     )
     emojiset = models.CharField(default=GOOGLE_EMOJISET, choices=EMOJISET_CHOICES, max_length=20)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14232,7 +14232,11 @@ paths:
 
                     - "google" - Google
                     - "twitter" - Twitter
+                    - "native" - Native
                     - "text" - Plain text
+
+                    **Changes**: New `"native"` option added in Zulip 12.0
+                    (feature level ZF-e6bf89).
                   type: string
                   example: "google"
                 demote_inactive_streams:
@@ -17974,7 +17978,11 @@ paths:
 
                               - "google" - Google modern
                               - "twitter" - Twitter
+                              - "native" - Native
                               - "text" - Plain text
+
+                              **Changes**: New `"native"` option added in Zulip 12.0
+                              (feature level ZF-e6bf89).
                           demote_inactive_streams:
                             type: integer
                             description: |
@@ -20292,7 +20300,11 @@ paths:
 
                               - "google" - Google modern
                               - "twitter" - Twitter
+                              - "native" - Native
                               - "text" - Plain text
+
+                              **Changes**: New `"native"` option added in Zulip 12.0
+                              (feature level ZF-e6bf89).
                           demote_inactive_streams:
                             type: integer
                             description: |
@@ -21621,9 +21633,13 @@ paths:
 
                     - "google" - Google modern
                     - "twitter" - Twitter
+                    - "native" - Native
                     - "text" - Plain text
 
-                    **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
+                    **Changes**: New `"native"` option added in Zulip 12.0
+                    (feature level ZF-e6bf89).
+
+                    Before Zulip 5.0 (feature level 80), this setting was managed by
                     the `PATCH /settings/display` endpoint.
 
                     Unnecessary JSON-encoding of this parameter was removed in Zulip 4.0 (feature level 64).

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -531,7 +531,7 @@ class ChangeSettingsTest(ZulipTestCase):
     def test_emojiset(self) -> None:
         """Test banned emoji sets are not accepted."""
         banned_emojisets = ["apple", "emojione", "google-blob"]
-        valid_emojisets = ["google", "text", "twitter"]
+        valid_emojisets = ["google", "native", "text", "twitter"]
 
         for emojiset in banned_emojisets:
             result = self.do_change_emojiset(emojiset)


### PR DESCRIPTION
Add a new "native" emoji theme that renders Unicode emoji using the OS/browser's native color emoji font instead of bundled sprite sheets.

On the web, each Unicode emoji is checked at render time using the is-emoji-supported library, which detects whether the OS can render it as a color glyph. Unsupported emoji (e.g., newer Unicode additions on older OSes, or flags on Windows) gracefully fall back to Google sprites. Custom and realm emoji are always rendered as images regardless of the emojiset setting.

In notification emails, the native and text emojisets both use Unicode characters directly rather than image tags. This also fixes a pre-existing bug where the "text" emojiset generated broken image URLs pointing to nonexistent "images-text-64/" sprites.

Fixes #37564.

[PR authored via asking Claude Code to work on the issue with significant supervision; I've not reviewed it yet properly myself]