### PR TITLE
[ai] filter: Optimize _build_predicate with per-term compilation.

### DIFF
--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1121,6 +1121,28 @@ test("predicate_basics", ({override}) => {
     assert.ok(!predicate({type: stream_message, stream_id: 9999999}));
     assert.ok(!predicate({type: direct_message}));
 
+    // Three or more terms: channel + topic + is:starred.
+    predicate = get_predicate([
+        ["channel", foo_stream_id.toString()],
+        ["topic", "Bar"],
+        ["is", "starred"],
+    ]);
+    assert.ok(
+        predicate({type: stream_message, stream_id: foo_stream_id, topic: "bar", starred: true}),
+    );
+    assert.ok(
+        !predicate({type: stream_message, stream_id: foo_stream_id, topic: "bar", starred: false}),
+    );
+    assert.ok(
+        !predicate({
+            type: stream_message,
+            stream_id: foo_stream_id,
+            topic: "whatever",
+            starred: true,
+        }),
+    );
+    assert.ok(!predicate({type: direct_message, starred: true}));
+
     // For old channels that we are no longer subscribed to, we may not have
     // a subscription, but these should still match by channel name.
     const old_sub_id = new_stream_id();


### PR DESCRIPTION
Replace message_matches_search_term, which re-evaluated operator matching on every message, with build_term_predicate, which compiles each narrow term into a closure once at filter creation time.  This avoids per-message work like string-to-number conversions, toLowerCase() on operands, and
people.sorted_other_user_ids() lookups.

No-op operators (near, with, in:all) return null and are filtered out before composition.  For the common 1- and 2-predicate narrows, the composed predicate uses direct calls rather than .every(), avoiding its per-element closure overhead.

Benchmarks on 5000 messages show ~2x throughput for most narrows (e.g. channel+topic: 14.6M -> 30.0M msgs/sec).

Fixes #31135.

[Created using Claude Code with significant supervision]