### PR TITLE
topic_link_util: Refactor to return unescaped links.

### DIFF
--- a/web/src/clipboard_handler.ts
+++ b/web/src/clipboard_handler.ts
@@ -38,14 +38,21 @@ export async function copy_link_to_clipboard(link: string): Promise<void> {
             } else {
                 const stream = stream_data.get_sub_by_id(stream_topic_details.stream_id);
                 assert(stream !== undefined);
-                const {text} = topic_link_util.get_topic_link_content_with_stream_name({
-                    stream_name: stream.name,
-                    topic_name: stream_topic_details.topic_name,
-                    message_id: stream_topic_details.message_id,
-                });
+                const {label_text_markdown} =
+                    topic_link_util.get_topic_link_content_with_stream_name({
+                        stream_name: stream.name,
+                        topic_name: stream_topic_details.topic_name,
+                        message_id: stream_topic_details.message_id,
+                    });
 
-                const copy_in_html_syntax = topic_link_util.as_html_link_syntax_unsafe(text, link);
-                const copy_in_markdown_syntax = topic_link_util.as_markdown_link_syntax(text, link);
+                const copy_in_html_syntax = topic_link_util.as_html_link_syntax_unsafe(
+                    label_text_markdown,
+                    link,
+                );
+                const copy_in_markdown_syntax = topic_link_util.as_markdown_link_syntax(
+                    label_text_markdown,
+                    link,
+                );
 
                 e.clipboardData?.setData("text/plain", link);
                 e.clipboardData?.setData("text/html", copy_in_html_syntax);

--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -61,7 +61,7 @@ export function get_topic_link_content_with_stream_name(opts: {
     stream_name: string;
     topic_name: string | undefined;
     message_id: string | undefined;
-}): {text: string; url: string} {
+}): {label_text_markdown: string; label_text_plain: string; url: string} {
     const stream = stream_data.get_sub(opts.stream_name);
     assert(stream !== undefined);
     return _get_topic_link_content({stream, ...opts});
@@ -71,7 +71,7 @@ export function get_topic_link_content_with_stream_id(opts: {
     stream_id: number;
     topic_name: string | undefined;
     message_id: string | undefined;
-}): {text: string; url: string} {
+}): {label_text_markdown: string; label_text_plain: string; url: string} {
     const stream = stream_data.get_sub_by_id(opts.stream_id);
     assert(stream !== undefined);
     return _get_topic_link_content({stream, ...opts});
@@ -81,7 +81,7 @@ function _get_topic_link_content(opts: {
     stream: StreamSubscription;
     topic_name: string | undefined;
     message_id: string | undefined;
-}): {text: string; url: string} {
+}): {label_text_markdown: string; label_text_plain: string; url: string} {
     const {stream, topic_name, message_id} = opts;
     const stream_name = stream.name;
     const stream_id = stream.stream_id;
@@ -91,17 +91,20 @@ function _get_topic_link_content(opts: {
         const topic_display_name = util.get_final_topic_display_name(topic_name);
         if (message_id !== undefined) {
             return {
-                text: `#${escape(stream_name)} > ${escape(topic_display_name)} @ 💬`,
+                label_text_markdown: `#${escape(stream_name)} > ${escape(topic_display_name)} @ 💬`,
+                label_text_plain: `#${stream_name} > ${topic_display_name} @ 💬`,
                 url: `${stream_topic_url}/near/${message_id}`,
             };
         }
         return {
-            text: `#${escape(stream_name)} > ${escape(topic_display_name)}`,
+            label_text_markdown: `#${escape(stream_name)} > ${escape(topic_display_name)}`,
+            label_text_plain: `#${stream_name} > ${topic_display_name}`,
             url: stream_topic_url,
         };
     }
     return {
-        text: `#${escape(stream_name)}`,
+        label_text_markdown: `#${escape(stream_name)}`,
+        label_text_plain: `#${stream_name}`,
         url: hash_util.channel_url_by_user_setting(stream_id),
     };
 }
@@ -126,12 +129,12 @@ export function get_fallback_markdown_link(
     // Generates the vanilla markdown link syntax for a stream/topic/message link, as
     // a fallback for cases where the nicer Zulip link syntax would not
     // render properly due to special characters in the channel or topic name.
-    const {text, url} = get_topic_link_content_with_stream_name({
+    const {label_text_markdown, url} = get_topic_link_content_with_stream_name({
         stream_name,
         topic_name,
         message_id,
     });
-    return as_markdown_link_syntax(text, url);
+    return as_markdown_link_syntax(label_text_markdown, url);
 }
 
 export function get_stream_topic_link_syntax(stream_name: string, topic_name: string): string {

--- a/web/tests/topic_link_util.test.cjs
+++ b/web/tests/topic_link_util.test.cjs
@@ -166,8 +166,22 @@ run_test("get_topic_link_content_with_stream_name", () => {
             message_id: 123,
         }),
         {
-            text: "#Sweden > abc @ 💬",
+            label_text_markdown: "#Sweden > abc @ 💬",
+            label_text_plain: "#Sweden > abc @ 💬",
             url: "#narrow/channel/1-Sweden/topic/abc/near/123",
+        },
+    );
+
+    assert.deepEqual(
+        topic_link_util.get_topic_link_content_with_stream_name({
+            stream_name: sweden_stream.name,
+            topic_name: "a![b](c)",
+            message_id: 123,
+        }),
+        {
+            label_text_markdown: "#Sweden > a!&#91;b&#93;(c) @ 💬",
+            label_text_plain: "#Sweden > a![b](c) @ 💬",
+            url: "#narrow/channel/1-Sweden/topic/a!.5Bb.5D.28c.29/near/123",
         },
     );
 });
@@ -180,8 +194,22 @@ run_test("get_topic_link_content_with_stream_id", () => {
             message_id: 123,
         }),
         {
-            text: "#Sweden > abc @ 💬",
+            label_text_markdown: "#Sweden > abc @ 💬",
+            label_text_plain: "#Sweden > abc @ 💬",
             url: "#narrow/channel/1-Sweden/topic/abc/near/123",
+        },
+    );
+
+    assert.deepEqual(
+        topic_link_util.get_topic_link_content_with_stream_id({
+            stream_id: sweden_stream.stream_id,
+            topic_name: "<abc>",
+            message_id: 123,
+        }),
+        {
+            label_text_markdown: "#Sweden > <abc&gt; @ 💬",
+            label_text_plain: "#Sweden > <abc> @ 💬",
+            url: "#narrow/channel/1-Sweden/topic/.3Cabc.3E/near/123",
         },
     );
 });


### PR DESCRIPTION
Prep for #36293 so that we can send unescaped links to left_sidebar_topic_links_popover to be rendered as fully escaped HTML there.

Further discussion here:
https://chat.zulip.org/#narrow/channel/6-frontend/topic/_get_topic_link_content.20escaping/near/2365437

I'm still not actually convinced this is the best solution, but putting it up so Tim can merge it if he likes it.