### PR TITLE
[ai] base_page_params: Handle tab restore with stale cached DOM.

### DIFF
--- a/web/src/base_page_params.ts
+++ b/web/src/base_page_params.ts
@@ -121,11 +121,44 @@ function take_params(): string {
     if (page_params_div === null) {
         throw new Error("Missing #page-params");
     }
+
     const params = page_params_div.getAttribute("data-params");
     if (params === null) {
-        throw new Error("Missing #page_params[data-params]");
+        // The div exists but data-params was already consumed.  This
+        // happens when Firefox restores a background tab from a cached
+        // DOM state (e.g. after tab discarding or BFCache restoration),
+        // since we remove the attribute below after extracting it.
+        //
+        // Force a single server reload to get fresh page params;
+        // sessionStorage persists across the reload so we can detect
+        // the second attempt and stop.  If sessionStorage is
+        // unavailable (crawlers, private browsing edge cases), we skip
+        // the reload to avoid a potential infinite loop and let the
+        // user reload manually.
+        try {
+            if (sessionStorage.getItem("reload_for_tab_restore") === null) {
+                sessionStorage.setItem("reload_for_tab_restore", "1");
+                window.location.reload();
+            }
+        } catch {
+            // sessionStorage unavailable; fall through to throw.
+        }
+        throw new Error("Missing #page-params data after tab restore");
     }
-    page_params_div.remove();
+
+    // Clear the reload guard on a successful load so it's ready
+    // for the next tab-restore event.
+    try {
+        sessionStorage.removeItem("reload_for_tab_restore");
+    } catch {
+        // Ignore; the stale flag just means the next tab-restore
+        // won't auto-reload, which is the safe default.
+    }
+
+    // Remove the attribute to free the (potentially multi-megabyte)
+    // JSON string from the DOM, but keep the div as a sentinel so
+    // we can distinguish tab-restore from a truly missing element.
+    page_params_div.removeAttribute("data-params");
     return params;
 }
 


### PR DESCRIPTION
In some cases, such as session restore after a browser restart, Firefox can restore a tab from a cached DOM state rather than fetching fresh HTML from the server.  When this happens, the #page-params div has already had its data-params attribute consumed and removed, so take_params() throws with no recovery path, leaving the user on a broken loading screen.  See #36094 for a screenshot of this failure mode.

Fix this by keeping the #page-params div in the DOM as a sentinel (replacing `div.remove()` with `div.removeAttribute("data-params")` to still free the multi-megabyte JSON string).  When a tab restore is detected -- the div exists but data-params is absent -- force a single server reload to get fresh page params.  A sessionStorage guard prevents an infinite reload loop; if sessionStorage is unavailable (crawlers, restricted browsing modes), we skip the reload entirely and let the user reload manually.

Fixes #36094.

[Implemented using Claude Code with considerable supervision]