### PR TITLE
invites: Store confirmation.id in REVOKED audit logs, instead of the key

### DIFF
--- a/zerver/actions/invites.py
+++ b/zerver/actions/invites.py
@@ -442,7 +442,7 @@ def do_revoke_user_invite(
         event_time=timezone_now(),
         acting_user=acting_user,
         extra_data={
-            "confirmation_key": confirmation.confirmation_key,
+            "confirmation_id": confirmation.id,
             "invitation_type": Confirmation.INVITATION,
             "invitation_object_id": prereg_user.id,
         },
@@ -474,7 +474,7 @@ def do_revoke_multi_use_invite(
         event_time=timezone_now(),
         acting_user=acting_user,
         extra_data={
-            "confirmation_key": confirmation.confirmation_key,
+            "confirmation_id": confirmation.id,
             "invitation_type": Confirmation.MULTIUSE_INVITE,
             "invitation_object_id": multiuse_invite.id,
         },

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -2559,7 +2559,7 @@ class InvitationsTestCase(InviteUserBase):
         self.assertDictEqual(
             extra_data,
             {
-                "confirmation_key": confirmation.confirmation_key,
+                "confirmation_id": confirmation.id,
                 "invitation_type": Confirmation.INVITATION,
                 "invitation_object_id": prereg_user.id,
             },
@@ -2682,6 +2682,7 @@ class InvitationsTestCase(InviteUserBase):
             multiuse_invite, Confirmation.MULTIUSE_INVITE, validity_in_minutes=validity_in_minutes
         )
         confirmation_key = confirmation_link.split("/")[-2]
+        confirmation = Confirmation.objects.get(confirmation_key=confirmation_key)
         result = self.client_delete("/json/invites/multiuse/" + str(multiuse_invite.id))
 
         audit_log = RealmAuditLog.objects.latest("id")
@@ -2691,7 +2692,7 @@ class InvitationsTestCase(InviteUserBase):
         self.assertDictEqual(
             extra_data,
             {
-                "confirmation_key": confirmation_key,
+                "confirmation_id": confirmation.id,
                 "invitation_type": Confirmation.MULTIUSE_INVITE,
                 "invitation_object_id": multiuse_invite.id,
             },


### PR DESCRIPTION
A quick tweak to #37680.

The confirmation key value might be sensitive under some circumstances and it might be undesirable for realm admins to be able to access it if they obtain insight into the RealmAuditLogs (via an export or some future feature that allows them to view audit logs directly). So it's safer to just record the id instead of the key, and not have to worry about whether keys are fine to reveal or not.
