### PR TITLE
webhooks/github: Improve status emojis and fix missing commit error.

### DIFF
--- a/zerver/webhooks/github/fixtures/status__missing_commit.json
+++ b/zerver/webhooks/github/fixtures/status__missing_commit.json
@@ -1,0 +1,16 @@
+{
+    "state": "success",
+    "target_url": "https://example.com/build/1",
+    "description": "Build successful",
+    "context": "ci/build",
+    "sha": "abc1234",
+    "repository": {
+        "name": "zulip",
+        "full_name": "zulip/zulip",
+        "html_url": "https://github.com/zulip/zulip",
+        "private": false
+    },
+    "sender": {
+        "login": "github-actions"
+    }
+}

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -145,7 +145,7 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("deployment", TOPIC_DEPLOYMENT, expected_message)
 
     def test_deployment_status_msg(self) -> None:
-        expected_message = "Deployment changed status to success."
+        expected_message = ":check: Deployment changed status to success."
         self.check_webhook("deployment_status", TOPIC_DEPLOYMENT, expected_message)
 
     def test_fork_msg(self) -> None:
@@ -303,19 +303,17 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("pull_request__synchronized", TOPIC_PR, expected_message)
 
     def test_pull_request_closed_msg(self) -> None:
-        expected_message = "baxterthehacker closed without merge [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)."
+        expected_message = ":no_entry_sign: baxterthehacker closed without merge [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)."
         self.check_webhook("pull_request__closed", TOPIC_PR, expected_message)
 
     def test_pull_request_closed_msg_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic="notifications")
         expected_topic_name = "notifications"
-        expected_message = "baxterthehacker closed without merge [PR #1 Update the README with new information](https://github.com/baxterthehacker/public-repo/pull/1)."
+        expected_message = ":no_entry_sign: baxterthehacker closed without merge [PR #1 Update the README with new information](https://github.com/baxterthehacker/public-repo/pull/1)."
         self.check_webhook("pull_request__closed", expected_topic_name, expected_message)
 
     def test_pull_request_merged_msg(self) -> None:
-        expected_message = (
-            "baxterthehacker merged [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)."
-        )
+        expected_message = ":check: baxterthehacker merged [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)."
         self.check_webhook("pull_request__merged", TOPIC_PR, expected_message)
 
     def test_pull_request_merged_msg_private_repository_skipped(self) -> None:
@@ -370,35 +368,39 @@ class GitHubWebhookTest(WebhookTestCase):
 
     def test_page_build_msg(self) -> None:
         expected_message = (
-            "GitHub Pages build, triggered by baxterthehacker, has finished building."
+            ":check: GitHub Pages build, triggered by baxterthehacker, has finished building."
         )
         self.check_webhook("page_build", TOPIC_REPO, expected_message)
 
     def test_page_build_errored_msg(self) -> None:
-        expected_message = "GitHub Pages build, triggered by baxterthehacker, has failed: \n~~~ quote\nSomething went wrong.\n~~~."
+        expected_message = ":cross_mark: GitHub Pages build, triggered by baxterthehacker, has failed: \n~~~ quote\nSomething went wrong.\n~~~."
         self.check_webhook("page_build__errored", TOPIC_REPO, expected_message)
 
     def test_status_msg(self) -> None:
-        expected_message = "[9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to success."
+        expected_message = ":check: [9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to success."
         self.check_webhook("status", TOPIC_REPO, expected_message)
 
     def test_status_with_target_url_msg(self) -> None:
-        expected_message = "[9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to [success](https://example.com/build/status)."
+        expected_message = ":check: [9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to [success](https://example.com/build/status)."
         self.check_webhook("status__with_target_url", TOPIC_REPO, expected_message)
 
+    def test_status_missing_commit_msg(self) -> None:
+        expected_message = ":check: [abc1234](https://github.com/zulip/zulip/commit/abc1234) changed its status to [success](https://example.com/build/1)."
+        self.check_webhook("status__missing_commit", "zulip", expected_message)
+
     def test_pull_request_review_msg(self) -> None:
-        expected_message = "baxterthehacker submitted [PR review](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884):\n\n~~~ quote\nLooks great!\n~~~"
+        expected_message = ":thumbs_up: baxterthehacker submitted [PR review](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884):\n\n~~~ quote\nLooks great!\n~~~"
         self.check_webhook("pull_request_review", TOPIC_PR, expected_message)
 
     def test_pull_request_review_msg_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic="notifications")
         expected_topic_name = "notifications"
-        expected_message = "baxterthehacker submitted [PR review for #1 Update the README with new information](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884):\n\n~~~ quote\nLooks great!\n~~~"
+        expected_message = ":thumbs_up: baxterthehacker submitted [PR review for #1 Update the README with new information](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884):\n\n~~~ quote\nLooks great!\n~~~"
         self.check_webhook("pull_request_review", expected_topic_name, expected_message)
 
     def test_pull_request_review_msg_with_empty_body(self) -> None:
         expected_topic_name = "groonga / PR #1581 grn_db_value_lock: unlock GRN_TYPE obj..."
-        expected_message = "kou submitted [PR review](https://github.com/groonga/groonga/pull/1581#pullrequestreview-1483047907)."
+        expected_message = ":speech_balloon: kou submitted [PR review](https://github.com/groonga/groonga/pull/1581#pullrequestreview-1483047907)."
         self.check_webhook("pull_request_review__empty_body", expected_topic_name, expected_message)
 
     def test_pull_request_review_comment_msg(self) -> None:
@@ -553,7 +555,7 @@ class GitHubWebhookTest(WebhookTestCase):
     def test_check_run(self) -> None:
         expected_topic_name = "hello-world / checks"
         expected_message = """
-Check [randscape](http://github.com/github/hello-world/runs/4) completed (success). ([d6fde92930d](http://github.com/github/hello-world/commit/d6fde92930d4715a2b49857d24b940956b26d2d3))
+:check: Check [randscape](http://github.com/github/hello-world/runs/4) completed (success). ([d6fde92930d](http://github.com/github/hello-world/commit/d6fde92930d4715a2b49857d24b940956b26d2d3))
 """.strip()
         self.check_webhook("check_run__completed", expected_topic_name, expected_message)
 
@@ -692,7 +694,7 @@ A temporary team so that I can get some webhook fixtures!
         self.assertTrue(stack_info)
 
     def test_discussion_answered(self) -> None:
-        expected_message = "Niloth-p marked [comment #11460065](https://github.com/Niloth-p/webhook-tester/discussions/5#discussioncomment-11460065) as the answer:\n\n~~~ quote\nIf you're looking for a detailed explanation of the project structure, I'd recommend checking out our CONTRIBUTING.md file. It includes a breakdown of the different directories and files, as well as some guidelines for contributing to the project.\n~~~"
+        expected_message = ":check: Niloth-p marked [comment #11460065](https://github.com/Niloth-p/webhook-tester/discussions/5#discussioncomment-11460065) as the answer:\n\n~~~ quote\nIf you're looking for a detailed explanation of the project structure, I'd recommend checking out our CONTRIBUTING.md file. It includes a breakdown of the different directories and files, as well as some guidelines for contributing to the project.\n~~~"
         self.check_webhook("discussion__answered", TOPIC_DISCUSSION_ANSWERS, expected_message)
 
     def test_discussion_category_changed(self) -> None:
@@ -710,7 +712,7 @@ A temporary team so that I can get some webhook fixtures!
         self.check_webhook("discussion__created", TOPIC_DISCUSSION, expected_message)
 
     def test_discussion_closed(self) -> None:
-        expected_message = "Cordelia closed [discussion #3](https://github.com/Niloth-p/webhook-tester/discussions/3) as resolved."
+        expected_message = ":lock: Cordelia closed [discussion #3](https://github.com/Niloth-p/webhook-tester/discussions/3) as resolved."
         self.check_webhook("discussion__closed", TOPIC_DISCUSSION, expected_message)
 
     def test_discussion_deleted(self) -> None:
@@ -739,7 +741,7 @@ A temporary team so that I can get some webhook fixtures!
         self.check_webhook("discussion__pinned", TOPIC_DISCUSSION, expected_message)
 
     def test_discussion_reopened(self) -> None:
-        expected_message = "Niloth-p reopened [discussion #3](https://github.com/Niloth-p/webhook-tester/discussions/3)."
+        expected_message = ":recycle: Niloth-p reopened [discussion #3](https://github.com/Niloth-p/webhook-tester/discussions/3)."
         self.check_webhook("discussion__reopened", TOPIC_DISCUSSION, expected_message)
 
     def test_discussion_transferred(self) -> None:
@@ -759,7 +761,7 @@ A temporary team so that I can get some webhook fixtures!
         self.check_webhook("discussion__unpinned", TOPIC_DISCUSSION, expected_message)
 
     def test_discussion_unanswered(self) -> None:
-        expected_message = "Cordelia marked [comment #11460059](https://github.com/Niloth-p/webhook-tester/discussions/5#discussioncomment-11460059) as not the answer."
+        expected_message = ":grey_question: Cordelia marked [comment #11460059](https://github.com/Niloth-p/webhook-tester/discussions/5#discussioncomment-11460059) as not the answer."
         self.check_webhook("discussion__unanswered", TOPIC_DISCUSSION_ANSWERS, expected_message)
 
     def test_discussion_comment_msg(self) -> None:


### PR DESCRIPTION
Update emoji mappings for GitHub webhooks to provide better visual indicators:

Check Run Conclusion:
* success: :check:
* failure: :rotating_light:
* cancelled: :no_entry:
* skipped: :fast_forward:
* timed_out: :alarm_clock:
* action_required: :warning:
* neutral: :grey_question:
* stale: :zzz:

Deployment Status:
* success: :check:
* failure: :rotating_light:
* error: :cross_mark:
* pending: :time_ticking:

Status State:
* success: :check:
* failure: :rotating_light:
* error: :cross_mark:
* pending: :time_ticking:

Page Build Status:
* built: :check:
* errored: :cross_mark:
* building: :time_ticking:

PR Review State:
* approved: :thumbs_up:
* changes_requested: :memo:
* commented: :speech_balloon:

PR Close Action:
* merged: :check:
* closed without merge: :no_entry_sign:

Discussion Status:
* answered: :check:
* closed: :lock:
* reopened: :recycle:
* unanswered: :grey_question:

Additionally, fix an "Internal server error" that occurred when processing "status" events where the "commit" object was missing from the payload. The handler now gracefully handles this case.

Fixes #37250.

**How changes were tested:**
All scenarios were simulated using Postman to trigger the requests.

**Screenshots and screen captures:**
<img width="2642" height="2006" alt="image" src="https://github.com/user-attachments/assets/8e1a7399-3b4b-40c2-bf59-02c4fecd687d" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [X] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
