### PR TITLE
compose: Improve list editing with indentation support.

### DIFF
--- a/web/src/bulleted_numbered_list_util.ts
+++ b/web/src/bulleted_numbered_list_util.ts
@@ -3,22 +3,9 @@ export const get_last_line = (text: string): string => text.slice(text.lastIndex
 export const is_bulleted = (line: string): boolean =>
     line.startsWith("- ") || line.startsWith("* ") || line.startsWith("+ ");
 
-// Check if a line is an indented bulleted list item
-export const is_indented_bulleted = (line: string): boolean => {
-    const trimmed = line.trimStart();
-    return line.length > trimmed.length && is_bulleted(trimmed);
-};
-
 // testing against regex for string with numbered syntax, that is,
 // any string starting with digit/s followed by a period and space
 export const is_numbered = (line: string): boolean => /^\d+\. /.test(line);
-
-// Check if a line is an indented numbered list item
-export const is_indented_numbered = (line: string): boolean => {
-    const trimmed = line.trimStart();
-    return line.length > trimmed.length && is_numbered(trimmed);
-};
-
 // Get the indentation (leading spaces) from a line
 export const get_indentation = (line: string): string => {
     // Regex always matches since \s* can match zero characters

--- a/web/src/bulleted_numbered_list_util.ts
+++ b/web/src/bulleted_numbered_list_util.ts
@@ -3,9 +3,43 @@ export const get_last_line = (text: string): string => text.slice(text.lastIndex
 export const is_bulleted = (line: string): boolean =>
     line.startsWith("- ") || line.startsWith("* ") || line.startsWith("+ ");
 
+// Check if a line is an indented bulleted list item
+export const is_indented_bulleted = (line: string): boolean => {
+    const trimmed = line.trimStart();
+    return line.length > trimmed.length && is_bulleted(trimmed);
+};
+
 // testing against regex for string with numbered syntax, that is,
 // any string starting with digit/s followed by a period and space
 export const is_numbered = (line: string): boolean => /^\d+\. /.test(line);
+
+// Check if a line is an indented numbered list item
+export const is_indented_numbered = (line: string): boolean => {
+    const trimmed = line.trimStart();
+    return line.length > trimmed.length && is_numbered(trimmed);
+};
+
+// Get the indentation (leading spaces) from a line
+export const get_indentation = (line: string): string => {
+    // Regex always matches since \s* can match zero characters
+    const match = /^(\s*)/.exec(line);
+    return match![1]!;
+};
+
+// Get the bullet or number prefix with indentation
+export const get_list_item_prefix = (line: string): string => {
+    const indentation = get_indentation(line);
+    const trimmed = line.trimStart();
+
+    if (is_bulleted(trimmed)) {
+        return indentation + trimmed.slice(0, 2);
+    }
+    if (is_numbered(trimmed)) {
+        const end_of_number = trimmed.indexOf(" ");
+        return indentation + trimmed.slice(0, end_of_number + 1);
+    }
+    return "";
+};
 
 export const strip_bullet = (line: string): string => line.slice(2);
 

--- a/web/src/bulleted_numbered_list_util.ts
+++ b/web/src/bulleted_numbered_list_util.ts
@@ -26,21 +26,6 @@ export const get_indentation = (line: string): string => {
     return match![1]!;
 };
 
-// Get the bullet or number prefix with indentation
-export const get_list_item_prefix = (line: string): string => {
-    const indentation = get_indentation(line);
-    const trimmed = line.trimStart();
-
-    if (is_bulleted(trimmed)) {
-        return indentation + trimmed.slice(0, 2);
-    }
-    if (is_numbered(trimmed)) {
-        const end_of_number = trimmed.indexOf(" ");
-        return indentation + trimmed.slice(0, end_of_number + 1);
-    }
-    return "";
-};
-
 export const strip_bullet = (line: string): string => line.slice(2);
 
 export const strip_numbering = (line: string): string => line.slice(line.indexOf(" ") + 1);


### PR DESCRIPTION
Fixes: #37737

Add support for maintaining indentation levels when creating sublists with Shift+Enter. Pressing backspace on an empty indented list item now dedents one level at a time instead of deleting the entire line.

### Video Implementation
[creating_a_sub_list.webm](https://github.com/user-attachments/assets/92c7426c-383c-48f8-8ce0-7d486f2803c7)

[mix_list.webm](https://github.com/user-attachments/assets/f1b7fe24-084b-48e3-a058-15e12d105c63)

### What can be fixed ahead
Say, you're in a main list, and you want to create a sublist, for now, you have to hit spacebar 3 times, behind that '-' to create a sublist. It can also be created when hitting tab, which for now takes to next element in the page.

All tests have passed as well.

Thanks