### PR TITLE
slack_integration_doc: Document caveats.

### DIFF
--- a/zerver/webhooks/slack/doc.md
+++ b/zerver/webhooks/slack/doc.md
@@ -98,6 +98,27 @@ If you are looking to quickly move your Slack integrations to Zulip, check out
   Slack's [users.info](https://api.slack.com/methods/users.info) endpoint. This
   is used to get the name of the Slack message's sender.
 
+### Caveats
+
+- Mentions in messages are not converted to Zulip mentions.
+
+- Notifications will be delayed by a few seconds.
+
+- Some emojis exported from Slack will display as `:emojiname:`, if
+  the emoji name is not present in the emoji database used by Zulip.
+
+- Threads will appear in the main topic instead of in separate topics.
+
+The following data is not included:
+
+- Custom emoji
+
+- Message attachments
+
+- Message edit history
+
+- Message reactions
+
 ### Related documentation
 
 - [Forward messages Slack <-> Zulip][6] (both directions)


### PR DESCRIPTION
We currently don't document the Slack integration's caveats

CZO: [#integrations > slack bridge @ 💬](https://chat.zulip.org/#narrow/channel/127-integrations/topic/slack.20bridge/near/2368080)

**Screenshots and screen captures:**

(Updated on February, 4 2026)
<img width="978" height="491" alt="image" src="https://github.com/user-attachments/assets/be65f11d-b10b-4e8d-801a-c3f3f606ed45" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
