### PR TITLE
tests: add brief explanations to # type: ignore occurrences for clari…

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -469,7 +469,7 @@ class AuthBackendTest(ZulipTestCase):
             with self.artificial_transaction_savepoint():
                 return orig_authenticate(*args, **kwargs)
 
-        backend.authenticate = wrapped_authenticate  # type: ignore[method-assign]
+        backend.authenticate = wrapped_authenticate  # type: ignore[method-assign]  # assignment for test wrapper
 
         # Test LDAP auth fails when LDAP server rejects password
         self.assertIsNone(

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -156,7 +156,7 @@ class MissedMessageHookTest(ZulipTestCase):
     def destroy_event_queue(self, user: UserProfile, queue_id: str) -> None:
         # Ignore this when running mypy, since mypy expects queue_id to be specified when calling the function
         # but it is actually extracted from the request body using the typed_endpoint decorator.
-        result = self.tornado_call(cleanup_event_queue, user, {"queue_id": queue_id})  # type: ignore[arg-type]
+        result = self.tornado_call(cleanup_event_queue, user, {"queue_id": queue_id})  # type: ignore[arg-type]  # arg extracted from request body via typed_endpoint
         self.assert_json_success(result)
 
     def assert_maybe_enqueue_notifications_call_args(

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -2474,7 +2474,7 @@ class RealmImportExportTest(ExportFile):
                 "last_realmauditlog_id": 0,
             }
 
-            def mock_send_to_push_bouncer_response(  # type: ignore[return]
+            def mock_send_to_push_bouncer_response(  # type: ignore[return]  # stub may return None or dict; mypy false positive
                 method: str, *args: Any
             ) -> dict[str, int] | None:
                 if method == "GET":

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -266,7 +266,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
             # We intentionally provide the _wrong_ charset on this, so
             # that we verify that the charset detection code is not
             # overriding the value that the user claims.
-            uploaded_file.content_type = "text/plain; test-key=test_value; charset=big5"  # type: ignore[attr-defined]
+            uploaded_file.content_type = "text/plain; test-key=test_value; charset=big5"  # type: ignore[attr-defined]  # NamedTemporaryFile stub lacks content_type attr
 
             result = self.api_post(
                 self.example_user("hamlet"), "/api/v1/user_uploads", {"file": uploaded_file}


### PR DESCRIPTION
…ty and lint rules

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
