### PR TITLE
stream_list: Filter all (cached) topics.

### DIFF
--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -545,12 +545,20 @@ function all_rows(): JQuery {
         "#streams_list.is_searching .stream-list-toggle-inactive-or-muted-channels.bottom_left_row",
     );
 
-    return $all_rows
+    const $filtered_rows = $all_rows
         .not($inactive_or_muted_rows)
         .not($collapsed_views)
         .not($collapsed_channels)
         .not($hidden_topic_rows)
         .not($toggle_inactive_or_muted_channels_row);
+
+    // With a "topic:" prefix search, keyboard navigation only lands on
+    // topic rows, not channel header rows.
+    if (ui_util.is_topic_search()) {
+        return $filtered_rows.not("#stream_filters .channel-header.bottom_left_row");
+    }
+
+    return $filtered_rows;
 }
 
 class LeftSidebarListCursor extends ListCursor<JQuery> {

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -545,12 +545,19 @@ function all_rows(): JQuery {
         "#streams_list.is_searching .stream-list-toggle-inactive-or-muted-channels.bottom_left_row",
     );
 
+    // Exclude the topic-search hint row when it's hidden; when shown,
+    // it should be a navigable row.
+    const $hidden_topic_search_hint_row = $(
+        "#left-sidebar-topic-search-hint.hidden .left-sidebar-topic-search-hint-link",
+    );
+
     const $filtered_rows = $all_rows
         .not($inactive_or_muted_rows)
         .not($collapsed_views)
         .not($collapsed_channels)
         .not($hidden_topic_rows)
-        .not($toggle_inactive_or_muted_channels_row);
+        .not($toggle_inactive_or_muted_channels_row)
+        .not($hidden_topic_search_hint_row);
 
     // With a "topic:" prefix search, keyboard navigation only lands on
     // topic rows, not channel header rows.
@@ -559,6 +566,25 @@ function all_rows(): JQuery {
     }
 
     return $filtered_rows;
+}
+
+const TOPIC_SEARCH_HINT_MIN_LENGTH = 2;
+
+function should_show_topic_search_hint(search_term: string): boolean {
+    // Once the user is already searching with the "topic:" prefix,
+    // topic-search results are visible and the hint is no longer
+    // useful. Otherwise, surface the hint as soon as the user has
+    // typed enough that they might want to expand the search.
+    return search_term.length >= TOPIC_SEARCH_HINT_MIN_LENGTH && !ui_util.is_topic_search();
+}
+
+function initiate_topic_search(): void {
+    const $search_input = $<HTMLInputElement>("input.left-sidebar-search-input").expectOne();
+    const current_value = ($search_input.val() ?? "").trim();
+    const new_value = ui_util.TOPIC_SEARCH_PREFIX + " " + current_value;
+    $search_input.val(new_value);
+    util.the($search_input).setSelectionRange(new_value.length, new_value.length);
+    $search_input.trigger("focus").trigger("input");
 }
 
 class LeftSidebarListCursor extends ListCursor<JQuery> {
@@ -584,6 +610,14 @@ export function initialize_left_sidebar_cursor(): void {
                     return undefined;
                 }
                 const $non_header_rows = $all_rows.not($(get_header_rows_selectors()));
+                // Prefer landing on a real result row first; fall
+                // back to the topic-search hint only when there are
+                // no other matches, so the hint never steals initial
+                // highlight from matching channels or topics.
+                const $non_hint_rows = $non_header_rows.not(".left-sidebar-topic-search-hint-link");
+                if ($non_hint_rows.length > 0) {
+                    return $non_hint_rows.first();
+                }
                 return $non_header_rows.first();
             },
             next_key($key) {
@@ -642,6 +676,13 @@ function actually_update_left_sidebar_for_search(): void {
     stream_list.update_streams_sidebar();
 
     resize.resize_page_components();
+    const show_topic_search_hint = should_show_topic_search_hint(search_value);
+    if (show_topic_search_hint) {
+        $(".left-sidebar-topic-search-hint-label").text(
+            $t({defaultMessage: "Search all topics for ‘{query}’"}, {query: search_value}),
+        );
+    }
+    $("#left-sidebar-topic-search-hint").toggleClass("hidden", !show_topic_search_hint);
     left_sidebar_cursor.reset();
     $("#left-sidebar-empty-list-message").toggleClass(
         "hidden",
@@ -806,6 +847,11 @@ export function set_event_handlers(): void {
             return;
         }
 
+        if ($row.hasClass("left-sidebar-topic-search-hint-link")) {
+            initiate_topic_search();
+            return;
+        }
+
         if ($row[0]!.id === "views-label-container") {
             $row.find("#toggle-top-left-navigation-area-icon").trigger("click");
             return;
@@ -874,6 +920,12 @@ export function set_event_handlers(): void {
     // Handle arrow key navigation when a sidebar element has Tab
     // focus, so that Tab and arrow key navigation stay in sync.
     $("#left-sidebar").on("keydown", handle_left_sidebar_arrow_navigation);
+
+    $("body").on("click", ".left-sidebar-topic-search-hint-link", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        initiate_topic_search();
+    });
 }
 
 export function initiate_search(): void {

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -433,10 +433,9 @@ export function build_stream_list(force_rerender: boolean): void {
     //
     // The main logic to build the list is in stream_list_sort.ts
     const streams = stream_data.subscribed_stream_ids();
-    const stream_groups = stream_list_sort.sort_groups(
-        streams,
-        ui_util.get_left_sidebar_search_term(),
-    );
+    const search_term =
+        ui_util.get_left_sidebar_topic_search_term() ?? ui_util.get_left_sidebar_search_term();
+    const stream_groups = stream_list_sort.sort_groups(streams, search_term);
 
     if (stream_groups.same_as_before && !force_rerender) {
         return;
@@ -942,6 +941,17 @@ export let update_streams_sidebar = (force_rerender = false): void => {
 
     const filter = narrow_state.filter();
     if (!filter) {
+        // The narrow-specific update path below (which handles both
+        // the topic-search rebuild and its cleanup) doesn't run when
+        // there's no narrow, e.g. in Recent Conversations, so do both
+        // here directly. We can't rely on build_stream_list() above to
+        // clear topics, since it skips that when the channel list is
+        // unchanged.
+        if (ui_util.is_topic_search()) {
+            update_stream_sidebar_for_topic_search();
+        } else {
+            clear_topics();
+        }
         return;
     }
 
@@ -1209,6 +1219,29 @@ function deselect_stream_items(): void {
     $("ul#stream_filters li").removeClass("active-filter stream-expanded");
 }
 
+export function update_stream_sidebar_for_topic_search(): void {
+    // In "topic:" search mode the sidebar renders only the channels
+    // whose topics matched the search. get_stream_ids() returns the
+    // currently rendered rows, so we build topic lists for exactly
+    // those, rather than walking every subscription — most of which
+    // have no visible row and no matching topics.
+    for (const stream_id of stream_list_sort.get_stream_ids()) {
+        const row = stream_sidebar.get_row(stream_id);
+        assert(row !== undefined);
+        topic_list.rebuild_left_sidebar(row.get_li(), stream_id, true);
+    }
+}
+
+// Skip topic clearing when we're in topic-search mode — otherwise we'd wipe
+// the topic lists that update_stream_sidebar_for_topic_search() just populated
+// across all channels.
+function clear_topics_if_not_searching(): void {
+    const rerender_topics_for_search = ui_util.is_topic_search();
+    if (!rerender_topics_for_search) {
+        clear_topics();
+    }
+}
+
 export function update_stream_sidebar_for_narrow(filter: Filter): JQuery | undefined {
     const info = get_sidebar_stream_topic_info(filter);
 
@@ -1216,17 +1249,26 @@ export function update_stream_sidebar_for_narrow(filter: Filter): JQuery | undef
 
     const stream_id = info.stream_id;
 
+    // If we're currently searching for topics across all channels
+    // (via the "topic:" prefix), show all topic lists, each filtered
+    // by the search term. Otherwise we'll only show the topic list for
+    // the current narrow.
+    const rerender_topics_for_search = ui_util.is_topic_search();
+    if (rerender_topics_for_search) {
+        update_stream_sidebar_for_topic_search();
+    }
+
     if (!stream_id) {
-        clear_topics();
+        clear_topics_if_not_searching();
         return undefined;
     }
 
     const $stream_li = get_stream_li(stream_id);
 
+    // When zoomed into a channel's topic list, only the
+    // zoomed-in channel has a row in the sidebar.
     if (!$stream_li) {
-        // When zoomed into a channel's topic list, only the
-        // zoomed-in channel has a row in the sidebar.
-        clear_topics();
+        clear_topics_if_not_searching();
         return undefined;
     }
 
@@ -1240,13 +1282,15 @@ export function update_stream_sidebar_for_narrow(filter: Filter): JQuery | undef
     $stream_li.addClass("stream-expanded");
 
     if (stream_id !== topic_list.active_stream_id()) {
-        clear_topics();
+        clear_topics_if_not_searching();
     }
 
     // We want to update channel view for inbox for the same reasons
     // we want to the topics list here.
     update_inbox_channel_view_callback(stream_id);
-    topic_list.rebuild_left_sidebar($stream_li, stream_id);
+    if (!rerender_topics_for_search) {
+        topic_list.rebuild_left_sidebar($stream_li, stream_id);
+    }
     topic_list.topic_state_typeahead?.lookup(true);
 
     // If we're updating a view for a highlighted stream, it's possible

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -9,6 +9,7 @@ import * as sub_store from "./sub_store.ts";
 import type {StreamSubscription} from "./sub_store.ts";
 import * as topic_list_data from "./topic_list_data.ts";
 import * as typeahead from "./typeahead.ts";
+import * as ui_util from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
 import * as user_topics from "./user_topics.ts";
 import * as util from "./util.ts";
@@ -140,10 +141,20 @@ export function sort_groups(
     };
     const NORMAL_SECTION_TITLE_WITH_OTHER_FOLDERS = $t({defaultMessage: "OTHER"});
 
-    const show_all_channels = util.prefix_match({value: normal_section.section_title, search_term});
+    // With a "topic:" prefix search, we only match on topic names, not
+    // channel names, folder names, or section titles.
+    const is_topic_search = ui_util.is_topic_search();
+    // When the user types a prefix of a section title (e.g. "chan" for
+    // "CHANNELS"), treat it as "unfilter that section" and show every
+    // channel in it, rather than filtering by name. User-defined
+    // folder names get analogous treatment below.
+    const show_all_channels =
+        !is_topic_search && util.prefix_match({value: normal_section.section_title, search_term});
     const include_all_pinned_channels =
-        show_all_channels || util.prefix_match({value: pinned_section.section_title, search_term});
+        show_all_channels ||
+        (!is_topic_search && util.prefix_match({value: pinned_section.section_title, search_term}));
     const search_term_prefix_matches_other_section_title =
+        !is_topic_search &&
         search_term &&
         other_section_visible_without_search_term &&
         util.prefix_match({value: NORMAL_SECTION_TITLE_WITH_OTHER_FOLDERS, search_term});
@@ -152,49 +163,58 @@ export function sort_groups(
     const normalize = (s: string): string => s.replaceAll(/[:/_-]+/g, " ");
     const normalized_query = normalize(search_term);
     // Use -, _, : and / as word separators apart from the default space character
-    let matching_stream_ids = show_all_channels
-        ? all_subscribed_stream_ids
-        : all_subscribed_stream_ids.filter((stream_id) => {
-              const normalized_name = normalize(stream_id_to_name(stream_id));
+    let matching_stream_ids: number[];
+    if (is_topic_search) {
+        matching_stream_ids = [];
+    } else if (show_all_channels) {
+        matching_stream_ids = all_subscribed_stream_ids;
+    } else {
+        matching_stream_ids = all_subscribed_stream_ids.filter((stream_id) => {
+            const normalized_name = normalize(stream_id_to_name(stream_id));
 
-              return typeahead.query_matches_string_in_any_order(
-                  normalized_query,
-                  normalized_name,
-                  " ",
-              );
-          });
+            return typeahead.query_matches_string_in_any_order(
+                normalized_query,
+                normalized_name,
+                " ",
+            );
+        });
+    }
 
     const current_channel_id = narrow_state.stream_id(narrow_state.filter(), true);
     const current_topic_name = narrow_state.topic()?.toLowerCase();
-    if (
-        current_channel_id !== undefined &&
-        stream_data.is_subscribed(current_channel_id) &&
-        !matching_stream_ids.includes(current_channel_id)
-    ) {
+
+    let channels_to_check_topic_matches: number[] = [];
+    if (is_topic_search) {
+        channels_to_check_topic_matches = all_subscribed_stream_ids;
+    } else if (current_channel_id !== undefined && stream_data.is_subscribed(current_channel_id)) {
+        channels_to_check_topic_matches = [current_channel_id];
+    }
+
+    for (const stream_id of channels_to_check_topic_matches) {
+        if (matching_stream_ids.includes(stream_id)) {
+            continue;
+        }
         // If any of the unmuted topics of the channel match the search
         // term, or a muted topic matches the current topic, we include
         // the channel in the list of matches.
-        const topics = topic_list_data.get_filtered_topic_names(current_channel_id, (topic_names) =>
-            topic_list_data.filter_topics_by_search_term(
-                current_channel_id,
-                topic_names,
-                search_term,
-            ),
+        const topics = topic_list_data.get_filtered_topic_names(stream_id, (topic_names) =>
+            topic_list_data.filter_topics_by_search_term(stream_id, topic_names, search_term),
         );
         if (
             topics.some(
                 (topic) =>
-                    topic.toLowerCase() === current_topic_name ||
-                    !user_topics.is_topic_muted(current_channel_id, topic),
+                    (current_channel_id === stream_id &&
+                        topic.toLowerCase() === current_topic_name) ||
+                    !user_topics.is_topic_muted(stream_id, topic),
             )
         ) {
-            matching_stream_ids.push(current_channel_id);
+            matching_stream_ids.push(stream_id);
         }
     }
 
     // If the channel folder matches the search term, include all channels
     // of that folder.
-    if (user_settings.web_left_sidebar_show_channel_folders && search_term) {
+    if (!is_topic_search && user_settings.web_left_sidebar_show_channel_folders && search_term) {
         matching_stream_ids = [
             ...new Set([
                 ...matching_stream_ids,

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -447,17 +447,13 @@ export class TopicListWidget {
     }
 }
 
-function filter_topics_left_sidebar(topic_names: string[]): string[] {
+function filter_topics_left_sidebar(topic_names: string[], stream_id: number): string[] {
     // This runs both for the zoomed-in topic list and the inline
     // topic lists under streams, so we read the search term from
     // whichever input is in use.
     const search_term = zoomed
         ? get_zoomed_topic_search_term()
-        : ui_util.get_left_sidebar_search_term();
-    const stream_id = active_stream_id();
-    if (stream_id === undefined) {
-        return topic_names;
-    }
+        : (ui_util.get_left_sidebar_topic_search_term() ?? ui_util.get_left_sidebar_search_term());
     return topic_list_data.filter_topics_by_search_term(
         stream_id,
         topic_names,
@@ -468,7 +464,9 @@ function filter_topics_left_sidebar(topic_names: string[]): string[] {
 
 export class LeftSidebarTopicListWidget extends TopicListWidget {
     constructor($stream_li: JQuery, my_stream_id: number, for_modal: boolean) {
-        super($stream_li, my_stream_id, for_modal, filter_topics_left_sidebar);
+        super($stream_li, my_stream_id, for_modal, (topic_names) =>
+            filter_topics_left_sidebar(topic_names, my_stream_id),
+        );
     }
 
     override build(spinner = false): void {
@@ -524,7 +522,11 @@ export function get_stream_li(): JQuery | undefined {
     return $stream_li;
 }
 
-export function rebuild_left_sidebar($stream_li: JQuery, stream_id: number): void {
+export function rebuild_left_sidebar(
+    $stream_li: JQuery,
+    stream_id: number,
+    for_search = false,
+): void {
     if (zoomed) {
         if (zoomed_in_widget?.my_stream_id !== stream_id) {
             clear_zoomed();
@@ -535,14 +537,23 @@ export function rebuild_left_sidebar($stream_li: JQuery, stream_id: number): voi
     }
 
     zoomed_in_widget?.remove();
+
+    // Only search should have more than one channel widget open
+    if (!for_search && active_widgets.size > 1) {
+        clear();
+    }
     const active_widget = active_widgets.get(stream_id);
 
+    // Rebuild existing channel widget
     if (active_widget) {
         active_widget.build();
         return;
     }
 
-    clear();
+    // Create new channel widget
+    if (!for_search) {
+        clear();
+    }
     const widget = new LeftSidebarTopicListWidget($stream_li, stream_id, false);
     widget.build();
 

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -337,11 +337,31 @@ export function enable_element_and_remove_tooltip($element: JQuery): void {
     }
 }
 
-export function get_left_sidebar_search_term(): string {
+export let get_left_sidebar_search_term = function (): string {
     const $search_box = $<HTMLInputElement>("input.left-sidebar-search-input").expectOne();
     const search_term = $search_box.val();
     assert(search_term !== undefined);
     return search_term.trim();
+};
+
+export function rewire_get_left_sidebar_search_term(
+    value: typeof get_left_sidebar_search_term,
+): void {
+    get_left_sidebar_search_term = value;
+}
+
+const TOPIC_SEARCH_PREFIX = "topic:";
+
+export function get_left_sidebar_topic_search_term(): string | undefined {
+    const search_term = get_left_sidebar_search_term();
+    if (search_term.toLowerCase().startsWith(TOPIC_SEARCH_PREFIX)) {
+        return search_term.slice(TOPIC_SEARCH_PREFIX.length).trim();
+    }
+    return undefined;
+}
+
+export function is_topic_search(): boolean {
+    return get_left_sidebar_topic_search_term() !== undefined;
 }
 
 export function disable_left_sidebar_search(): void {

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -350,7 +350,7 @@ export function rewire_get_left_sidebar_search_term(
     get_left_sidebar_search_term = value;
 }
 
-const TOPIC_SEARCH_PREFIX = "topic:";
+export const TOPIC_SEARCH_PREFIX = "topic:";
 
 export function get_left_sidebar_topic_search_term(): string | undefined {
     const search_term = get_left_sidebar_search_term();

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -940,6 +940,60 @@
     }
 }
 
+#left-sidebar-topic-search-hint {
+    /* Match the outer spacing used by #subscribe-to-more-streams so
+       icon and label align with that row's icon and label. */
+    margin-right: var(--left-sidebar-right-margin);
+}
+
+.left-sidebar-topic-search-hint-link {
+    /* Padding on the link (which fills the row) keeps the focus ring
+       spanning the full row width. */
+    padding-left: var(--left-sidebar-toggle-width-offset);
+    display: grid;
+    grid-template:
+        "icon . text" minmax(var(--line-height-sidebar-row-prominent), auto)
+        / var(--left-sidebar-icon-column-width)
+        var(--left-sidebar-icon-content-gap)
+        minmax(0, 1fr);
+    align-items: center;
+    border-radius: 4px;
+    cursor: pointer;
+
+    /* Override the global a:hover / a:focus rule in zulip.css that
+       adds underline and changes the color to the generic link color. */
+    &,
+    &:hover,
+    &:focus {
+        color: var(--color-text-sidebar-row);
+        text-decoration: none;
+    }
+
+    &:hover {
+        background-color: var(--color-background-hover-narrow-filter);
+    }
+
+    /* Match the inset outline used by .highlighted_row so Tab and
+       arrow key focus look identical and don't clip outside the row. */
+    &:focus-visible {
+        outline: 2px solid var(--color-outline-focus);
+        outline-offset: -2px;
+    }
+
+    .zulip-icon {
+        grid-area: icon;
+        justify-self: center;
+        opacity: 0.7;
+    }
+
+    .left-sidebar-topic-search-hint-label {
+        grid-area: text;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+}
+
 #stream_filters .narrow-filter,
 #direct-messages-list .bottom_left_row {
     a.stream-name:focus,

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -15,6 +15,12 @@
           empty_list_message=(t "No matches.")
           }}
     </ul>
+    <div id="left-sidebar-topic-search-hint" class="hidden">
+        <a tabindex="0" role="button" class="bottom_left_row left-sidebar-topic-search-hint-link">
+            <i class="zulip-icon zulip-icon-search" aria-hidden="true"></i>
+            <span class="left-sidebar-topic-search-hint-label"></span>
+        </a>
+    </div>
     <div id="left-sidebar-navigation-area" class="left-sidebar-navigation-area">
         <div id="views-label-container" class="left-sidebar-section-header showing-expanded-navigation{{#if is_spectator}} remove-pointer-for-spectator{{/if}}">
             <i id="toggle-top-left-navigation-area-icon" class="zulip-icon zulip-icon-heading-triangle-right sidebar-heading-icon rotate-icon-down views-tooltip-target hidden-for-spectators" aria-hidden="true" tabindex="0" role="button"></i>

--- a/web/tests/stream_list_sort.test.cjs
+++ b/web/tests/stream_list_sort.test.cjs
@@ -17,6 +17,7 @@ const settings_config = zrequire("settings_config");
 const stream_topic_history = zrequire("stream_topic_history");
 const message_lists = zrequire("message_lists");
 const channel_folders = zrequire("channel_folders");
+const ui_util = zrequire("ui_util");
 const {initialize_user_settings} = zrequire("user_settings");
 
 state_data.set_realm(
@@ -483,7 +484,7 @@ test("current_section_id_for_stream", ({override}) => {
     ]);
 });
 
-test("left_sidebar_search", ({override}) => {
+test("left_sidebar_search", ({override, override_rewire}) => {
     // If a topic in the current channel matches the search query,
     // the channel should appear in its corresponding section in the result.
     add_all_subs();
@@ -494,10 +495,7 @@ test("left_sidebar_search", ({override}) => {
         );
         const history = stream_topic_history.find_or_create(stream.stream_id);
         history.add_or_update("an important topic", 1);
-        return stream_list_sort.sort_groups(
-            stream_data.subscribed_stream_ids().filter((id) => id !== stream.stream_id),
-            "import",
-        ).sections;
+        return stream_list_sort.sort_groups(stream_data.subscribed_stream_ids(), "import").sections;
     }
     let sorted_sections = setup_search_around_stream(scalene);
     // The topic matches the search query, so the stream appears in the search result.
@@ -506,7 +504,7 @@ test("left_sidebar_search", ({override}) => {
     assert.deepEqual(sorted_sections[0].default_visible_streams, [scalene.stream_id]);
 
     sorted_sections = stream_list_sort.sort_groups(
-        stream_data.subscribed_stream_ids().filter((id) => id !== scalene.stream_id),
+        stream_data.subscribed_stream_ids(),
         "any",
     ).sections;
     assert.deepEqual(sorted_sections.length, 2);
@@ -521,8 +519,41 @@ test("left_sidebar_search", ({override}) => {
     assert.deepEqual(sorted_sections.length, 3);
     assert.deepEqual(sorted_sections[1].folder_id, fast_tortoise.folder_id);
     assert.deepEqual(sorted_sections[1].default_visible_streams, [fast_tortoise.stream_id]);
+    // No topic match on "import", since it isn't the current narrow stream.
     assert.deepEqual(sorted_sections[0].default_visible_streams, []);
     assert.deepEqual(sorted_sections[2].default_visible_streams, []);
+
+    // If the current channel already matches by name, the topic check
+    // skips it (it's already included).
+    const history = stream_topic_history.find_or_create(scalene.stream_id);
+    history.add_or_update("scalene topic", 1);
+    message_lists.set_current(
+        make_message_list([{operator: "stream", operand: scalene.stream_id.toString()}]),
+    );
+    sorted_sections = stream_list_sort.sort_groups(
+        stream_data.subscribed_stream_ids(),
+        "scalene",
+    ).sections;
+    assert.deepEqual(sorted_sections[0].default_visible_streams, [scalene.stream_id]);
+
+    // If the search string starts with topic: then we do include it
+    override_rewire(ui_util, "get_left_sidebar_search_term", () => "topic:import");
+    sorted_sections = setup_search_around_stream(fast_tortoise);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, [scalene.stream_id]);
+
+    // A topic: search does not match channel names. "tortoise" matches
+    // the fast_tortoise channel name, but no topic matches it, so no
+    // channels are included.
+    override_rewire(ui_util, "get_left_sidebar_search_term", () => "topic:tortoise");
+    sorted_sections = stream_list_sort.sort_groups(
+        stream_data.subscribed_stream_ids(),
+        "tortoise",
+    ).sections;
+    // No matching streams, so no folder sections are built — just the
+    // pinned and normal sections remain.
+    assert.deepEqual(sorted_sections.length, 2);
+    assert.deepEqual(sorted_sections[0].default_visible_streams, []);
+    assert.deepEqual(sorted_sections[1].default_visible_streams, []);
 });
 
 test("filter inactives", ({override}) => {

--- a/web/tests/ui_util.test.cjs
+++ b/web/tests/ui_util.test.cjs
@@ -70,6 +70,44 @@ run_test("potentially_collapse_quotes", ({override_rewire}) => {
     );
 });
 
+run_test("topic search term parsing", ({override_rewire}) => {
+    // get_left_sidebar_search_term() already trims, so each value
+    // here stands in for an already-trimmed search input.
+    function set_search_term(term) {
+        override_rewire(ui_util, "get_left_sidebar_search_term", () => term);
+    }
+
+    // Without the "topic:" prefix, there is no topic search.
+    set_search_term("foo");
+    assert.equal(ui_util.get_left_sidebar_topic_search_term(), undefined);
+    assert.equal(ui_util.is_topic_search(), false);
+
+    // The "topic:" prefix yields the rest of the term as the query.
+    set_search_term("topic:foo");
+    assert.equal(ui_util.get_left_sidebar_topic_search_term(), "foo");
+    assert.equal(ui_util.is_topic_search(), true);
+
+    // Whitespace after the prefix is trimmed off the query.
+    set_search_term("topic:   important");
+    assert.equal(ui_util.get_left_sidebar_topic_search_term(), "important");
+
+    // The prefix match is case-insensitive; the query keeps its case.
+    set_search_term("TOPIC:Foo");
+    assert.equal(ui_util.get_left_sidebar_topic_search_term(), "Foo");
+    assert.equal(ui_util.is_topic_search(), true);
+
+    // The prefix alone, with an empty query, still counts as a topic
+    // search (so the sidebar switches to topic-filtering mode).
+    set_search_term("topic:");
+    assert.equal(ui_util.get_left_sidebar_topic_search_term(), "");
+    assert.equal(ui_util.is_topic_search(), true);
+
+    // "topic:" only counts as a prefix, not when it appears mid-term.
+    set_search_term("mytopic:foo");
+    assert.equal(ui_util.get_left_sidebar_topic_search_term(), undefined);
+    assert.equal(ui_util.is_topic_search(), false);
+});
+
 run_test("replace_emoji_name_with_emoji_unicode", () => {
     const $emoji = $.create("span").attr("class", "emoji emoji-1f419");
     $emoji.set_matches("img", false);


### PR DESCRIPTION
Fixes #36886.

<img width="200" alt="image" src="https://github.com/user-attachments/assets/79bfd893-31bb-41c7-b845-aaf24369ffbd" />

Test cases I manually tested:

* Channels that match query
* Topics that match query under channels that don't match query (both channel name and topic name shows up)
* Multiple topics matching query in a single channel
* Searching while in a topic narrow and also while outside of one (e.g. Inbox)
* Transitioning from filtered topics to no filter (topics from channels the user isn't viewing go away)

I'm pretty sure this only shows cached topics, or at least topics that would show if you clicked into a channel, not all topics from the "all topics" views, because it's sharing the code for displaying that initial sidebar view and not the "all topics" view.
