### PR TITLE
left_sidebar: Move DM header into scroll list area.

### DIFF
--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -25,7 +25,6 @@ export function get_stream_filters_max_height(): number {
         Number.parseInt($("#left-sidebar").css("paddingTop"), 10) -
         (is_search_visible ? ($left_sidebar_search.outerHeight(true) ?? 0) : 0) -
         ($("#left-sidebar-navigation-area").not(".hidden-by-filters").outerHeight(true) ?? 0) -
-        ($("#direct-messages-section-header").not(".hidden-by-filters").outerHeight(true) ?? 0) -
         GAP;
 
     // Don't let us crush the stream sidebar completely out of view

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -40,28 +40,28 @@
     <a id="hide-more-direct-messages" class="trigger-click-on-enter" tabindex="0">
         <span class="hide-more-direct-messages-text"> {{t 'back to channels' }}</span>
     </a>
-    <div id="direct-messages-section-header" class="direct-messages-container hidden-for-spectators zoom-out zoom-in-sticky">
-        <i id="toggle-direct-messages-section-icon" class="zulip-icon zulip-icon-heading-triangle-right sidebar-heading-icon rotate-icon-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
-        <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{ LEFT_SIDEBAR_DIRECT_MESSAGES_TITLE }}</span></h4>
-        <div class="left-sidebar-controls">
-            <a class="show-all-direct-messages tippy-left-sidebar-tooltip-no-label-delay" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">
-                <i class="zulip-icon zulip-icon-all-messages" aria-label="{{t 'Direct message feed' }}"></i>
-            </a>
-            <span class="compose-new-direct-message tippy-left-sidebar-tooltip-no-label-delay auto-hide-left-sidebar-overlay" data-tooltip-template-id="new_direct_message_button_tooltip_template">
-                <i class="left-sidebar-new-direct-message-icon zulip-icon zulip-icon-square-plus" aria-label="{{t 'New direct message' }}"></i>
-            </span>
-        </div>
-        <div class="heading-markers-and-unreads">
-            <span class="unread_count"></span>
-        </div>
-        <div class="zoom-out-hide direct-messages-search-section left-sidebar-filter-input-container">
-            {{#> components/input_wrapper input_type="filter-input" icon="search" input_button_icon="close"}}
-                <input type="text" class="input-element direct-messages-list-filter" autocomplete="off" placeholder="{{t 'Filter direct messages' }}" />
-            {{/components/input_wrapper}}
-        </div>
-    </div>
     {{~!-- squash whitespace --~}}
     <div id="left_sidebar_scroll_container" class="scrolling_list" data-simplebar data-simplebar-tab-index="-1">
+        <div id="direct-messages-section-header" class="direct-messages-container hidden-for-spectators zoom-out zoom-in-sticky">
+            <i id="toggle-direct-messages-section-icon" class="zulip-icon zulip-icon-heading-triangle-right sidebar-heading-icon rotate-icon-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
+            <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{ LEFT_SIDEBAR_DIRECT_MESSAGES_TITLE }}</span></h4>
+            <div class="left-sidebar-controls">
+                <a class="show-all-direct-messages tippy-left-sidebar-tooltip-no-label-delay" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">
+                    <i class="zulip-icon zulip-icon-all-messages" aria-label="{{t 'Direct message feed' }}"></i>
+                </a>
+                <span class="compose-new-direct-message tippy-left-sidebar-tooltip-no-label-delay auto-hide-left-sidebar-overlay" data-tooltip-template-id="new_direct_message_button_tooltip_template">
+                    <i class="left-sidebar-new-direct-message-icon zulip-icon zulip-icon-square-plus" aria-label="{{t 'New direct message' }}"></i>
+                </span>
+            </div>
+            <div class="heading-markers-and-unreads">
+                <span class="unread_count"></span>
+            </div>
+            <div class="zoom-out-hide direct-messages-search-section left-sidebar-filter-input-container">
+                {{#> components/input_wrapper input_type="filter-input" icon="search" input_button_icon="close"}}
+                    <input type="text" class="input-element direct-messages-list-filter" autocomplete="off" placeholder="{{t 'Filter direct messages' }}" />
+                {{/components/input_wrapper}}
+            </div>
+        </div>
         <div class="direct-messages-container zoom-out hidden-for-spectators">
             <div id="direct-messages-list"></div>
         </div>


### PR DESCRIPTION
Prep from #37298

This should have no visual or functional changes, but should make sticky headers easier when adding a divider below the DM section.