### PR TITLE
Fix channel folder selector layout

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2200,8 +2200,9 @@ body:not(.spectator-view) {
     .dropdown-list-wrapper {
         /* Sync with `max-height` in dropdown_widget. */
         max-height: 210px;
-        /* 200px/14px */
-        min-width: max-content;
+        /* Ensure adequate width for content while allowing responsive sizing. */
+        min-width: 14.285em; /* 200px at 14px/em */
+        max-width: min(100vw - 2em, 25em);
 
         .dropdown-list {
             list-style: none;
@@ -2214,7 +2215,20 @@ body:not(.spectator-view) {
     }
 
     &.folder_id-dropdown-list-container {
+        /* Set reasonable width for folder selector. */
         width: calc(var(--modal-input-width) * 0.75);
+
+        .dropdown-list .dropdown-list-item-common-styles {
+            /* Match left padding to right spacing (10px base + 7px scrollbar). */
+            padding-left: 17px;
+
+            /* Ensure consistent 34px row height: 1.75em (28px) + 3px top + 3px bottom = 34px
+               for both rows with buttons and "None" rows. */
+            grid-template-rows: minmax(1.75em, min-content) minmax(
+                    0,
+                    min-content
+                );
+        }
 
         /* Alignment adjustments on channel-folder selector. */
         .dropdown-list-item-name:has(.dropdown-list-buttons) {
@@ -2254,6 +2268,7 @@ body:not(.spectator-view) {
             )
             minmax(0, 1fr);
         color: var(--color-dropdown-item);
+        /* Use symmetric 10px padding; folder selector overrides left to 17px. */
         padding: 3px 10px;
         font-weight: 400;
         white-space: normal;
@@ -2261,7 +2276,7 @@ body:not(.spectator-view) {
            user-set line-height, so that the icon is always
            vertically centered properly. */
         line-height: 1.214;
-        min-height: 2.125em;
+        /* Remove min-height; let grid-template-rows control height consistency. */
         align-content: center;
 
         .channel-privacy-type-icon,


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR addresses a few layout issues in the channel-folder selector:

Increased the space to the left of the channel name to match the right-hand space with icons, ensuring proper alignment even with scrollbars.

Adjusted the height of the "None" row to match other single-line folder rows (34px at 16px/1em) and ensured the text sits correctly in the vertical space.

> Note: The "likely difficult" improvement regarding dropdown width adjustment has not been addressed in this PR.

These changes improve visual consistency and usability of the channel-folder selector.

Fixes #37647

###Before
<img width="1048" height="591" alt="localhost_9991_" src="https://github.com/user-attachments/assets/a2c5e58b-80a2-45ad-945e-faaacd3153f8" />

###After 
<img width="2076" height="1690" alt="localhost_9991_" src="https://github.com/user-attachments/assets/eb2c6e7e-5277-4b9f-8586-8bca8db9083b" />

This PR builds on the work in #37655, which appears inactive for ~1 week, and addresses the remaining issues called out in the design feedback.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
