### PR TITLE
webhooks/notion: Add Page events.

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -14,6 +14,7 @@ from django_stubs_ext import StrPromise
 from typing_extensions import override
 
 from zerver.lib.storage import static_path
+from zerver.lib.validator import check_string
 from zerver.lib.webhooks.common import PresetUrlOption, WebhookConfigOption, WebhookUrlOption
 from zerver.webhooks import fixtureless_integrations
 
@@ -790,7 +791,17 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
         [WebhookScreenshotConfig("incident_activated_new_default_payload.json")],
         display_name="New Relic",
     ),
-    IncomingWebhookIntegration("notion", ["productivity", "project-management"]),
+    IncomingWebhookIntegration(
+        "notion",
+        ["productivity", "project-management"],
+        config_options=[
+            WebhookConfigOption(
+                name="notion_token",
+                label="Notion API integration token",
+                validator=check_string,
+            ),
+        ],
+    ),
     IncomingWebhookIntegration(
         "opencollective",
         ["financial"],

--- a/zerver/webhooks/notion/fixtures/notion_page_info_api_response.json
+++ b/zerver/webhooks/notion/fixtures/notion_page_info_api_response.json
@@ -1,0 +1,76 @@
+{
+  "object": "page",
+  "id": "337e31d6-4eb9-80fa-b299-c93680d85322",
+  "created_time": "2026-04-03T18:04:00.000Z",
+  "last_edited_time": "2026-04-03T18:07:00.000Z",
+  "created_by": {
+    "object": "user",
+    "id": "1d6d872b-594c-8129-818d-000250c7f19f"
+  },
+  "last_edited_by": {
+    "object": "user",
+    "id": "1d6d872b-594c-8129-818d-000250c7f19f"
+  },
+  "cover": null,
+  "icon": null,
+  "parent": {
+    "type": "page_id",
+    "page_id": "2f1e31d6-4eb9-80c7-8250-f8a76132adc2"
+  },
+  "in_trash": false,
+  "is_archived": false,
+  "is_locked": false,
+  "properties": {
+    "title": {
+      "id": "title",
+      "type": "title",
+      "title": [
+        {
+          "type": "text",
+          "text": {
+            "content": "Zulip Notion Test",
+            "link": null
+          },
+          "annotations": {
+            "bold": false,
+            "italic": false,
+            "strikethrough": false,
+            "underline": false,
+            "code": false,
+            "color": "default"
+          },
+          "plain_text": "Zulip Notion Test",
+          "href": null
+        }
+      ]
+    },
+    "Status": {
+      "id": "XGe%40",
+      "type": "select",
+      "select": {
+        "name": "In Progress"
+      }
+    },
+    "Priority": {
+      "id": "bDf%5B",
+      "type": "select",
+      "select": {
+        "name": "High"
+      }
+    },
+    "Deadline": {
+      "id": "DbAu",
+      "type": "formula",
+      "formula": {
+        "type": "date",
+        "date": {
+          "start": "2026-02-01"
+        }
+      }
+    }
+  },
+  "url": "https://www.notion.so/Zulip-Notion-Test-337e31d64eb980fab299c93680d85322",
+  "public_url": null,
+  "archived": false,
+  "request_id": "cbc1ec1c-f0c9-4b3c-852d-5c95353c21dd"
+}

--- a/zerver/webhooks/notion/fixtures/notion_user_info_api_response.json
+++ b/zerver/webhooks/notion/fixtures/notion_user_info_api_response.json
@@ -1,0 +1,11 @@
+{
+    "object": "user",
+    "id": "1d6d872b-594c-8129-818d-000250c7f19f",
+    "name": "Sathwik Shetty",
+    "avatar_url": null,
+    "type": "person",
+    "person": {
+        "email": "sathwikshetty1234@gmail.com"
+    },
+    "request_id": "42e7b910-0f84-46da-8f27-21c8f20587aa"
+}

--- a/zerver/webhooks/notion/fixtures/page_content_updated.json
+++ b/zerver/webhooks/notion/fixtures/page_content_updated.json
@@ -1,0 +1,42 @@
+{
+  "id": "56c3e00c-4f0c-4566-9676-4b058a50a03d",
+  "timestamp": "2024-12-05T19:49:36.997Z",
+  "workspace_id": "13950b26-c203-4f3b-b97d-93ec06319565",
+  "workspace_name": "Quantify Labs",
+  "subscription_id": "29d75c0d-5546-4414-8459-7b7a92f1fc4b",
+  "integration_id": "0ef2e755-4912-8096-91c1-00376a88a5ca",
+  "type": "page.content_updated",
+  "authors": [
+    {
+      "id": "1d6d872b-594c-8129-818d-000250c7f19f",
+      "type": "person"
+    }
+  ],
+  "accessible_by": [
+    {
+      "id": "556a1abf-4f08-40c6-878a-75890d2a88ba",
+      "type": "person"
+    },
+    {
+      "id": "1edc05f6-2702-81b5-8408-00279347f034",
+      "type": "bot"
+    }
+  ],
+  "attempt_number": 1,
+  "entity": {
+    "id": "337e31d6-4eb9-80fa-b299-c93680d85322",
+    "type": "page"
+  },
+  "data": {
+    "updated_blocks": [
+      {
+        "id": "153104cd-477e-80ec-a87d-f7ff0236d35c",
+        "type": "block"
+      }
+    ],
+    "parent": {
+      "id": "0ef104cd-477e-80e1-8571-cfd10e92339a",
+      "type": "page"
+    }
+  }
+}

--- a/zerver/webhooks/notion/fixtures/page_created.json
+++ b/zerver/webhooks/notion/fixtures/page_created.json
@@ -1,0 +1,36 @@
+{
+  "id": "367cba44-b6f3-4c92-81e7-6a2e9659efd4",
+  "timestamp": "2024-12-05T23:55:34.285Z",
+  "workspace_id": "13950b26-c203-4f3b-b97d-93ec06319565",
+  "workspace_name": "Quantify Labs",
+  "subscription_id": "29d75c0d-5546-4414-8459-7b7a92f1fc4b",
+  "integration_id": "0ef2e755-4912-8096-91c1-00376a88a5ca",
+  "type": "page.created",
+  "authors": [
+    {
+      "id": "1d6d872b-594c-8129-818d-000250c7f19f",
+      "type": "person"
+    }
+  ],
+  "accessible_by": [
+    {
+      "id": "556a1abf-4f08-40c6-878a-75890d2a88ba",
+      "type": "person"
+    },
+    {
+      "id": "1edc05f6-2702-81b5-8408-00279347f034",
+      "type": "bot"
+    }
+  ],
+  "attempt_number": 1,
+  "entity": {
+    "id": "337e31d6-4eb9-80fa-b299-c93680d85322",
+    "type": "page"
+  },
+  "data": {
+    "parent": {
+      "id": "0ef104cd-477e-80e1-8571-cfd10e92339a",
+      "type": "page"
+    }
+  }
+}

--- a/zerver/webhooks/notion/fixtures/page_deleted.json
+++ b/zerver/webhooks/notion/fixtures/page_deleted.json
@@ -1,0 +1,36 @@
+{
+  "id": "ea6b8136-1db6-4f2e-b157-84a532437f62",
+  "timestamp": "2024-12-05T23:59:31.215Z",
+  "workspace_id": "13950b26-c203-4f3b-b97d-93ec06319565",
+  "workspace_name": "Quantify Labs",
+  "subscription_id": "29d75c0d-5546-4414-8459-7b7a92f1fc4b",
+  "integration_id": "0ef2e755-4912-8096-91c1-00376a88a5ca",
+  "type": "page.deleted",
+  "authors": [
+    {
+      "id": "1d6d872b-594c-8129-818d-000250c7f19f",
+      "type": "person"
+    }
+  ],
+  "accessible_by": [
+    {
+      "id": "556a1abf-4f08-40c6-878a-75890d2a88ba",
+      "type": "person"
+    },
+    {
+      "id": "1edc05f6-2702-81b5-8408-00279347f034",
+      "type": "bot"
+    }
+  ],
+  "attempt_number": 1,
+  "entity": {
+    "id": "337e31d6-4eb9-80fa-b299-c93680d85322",
+    "type": "page"
+  },
+  "data": {
+    "parent": {
+      "id": "0ef104cd-477e-80e1-8571-cfd10e92339a",
+      "type": "page"
+    }
+  }
+}

--- a/zerver/webhooks/notion/fixtures/page_locked.json
+++ b/zerver/webhooks/notion/fixtures/page_locked.json
@@ -1,0 +1,36 @@
+{
+  "id": "e2a3092c-5af0-442f-9d11-b813145edb72",
+  "timestamp": "2024-12-06T00:00:56.480Z",
+  "workspace_id": "13950b26-c203-4f3b-b97d-93ec06319565",
+  "workspace_name": "Quantify Labs",
+  "subscription_id": "29d75c0d-5546-4414-8459-7b7a92f1fc4b",
+  "integration_id": "0ef2e755-4912-8096-91c1-00376a88a5ca",
+  "type": "page.locked",
+  "authors": [
+    {
+      "id": "1d6d872b-594c-8129-818d-000250c7f19f",
+      "type": "person"
+    }
+  ],
+  "accessible_by": [
+    {
+      "id": "556a1abf-4f08-40c6-878a-75890d2a88ba",
+      "type": "person"
+    },
+    {
+      "id": "1edc05f6-2702-81b5-8408-00279347f034",
+      "type": "bot"
+    }
+  ],
+  "attempt_number": 1,
+  "entity": {
+    "id": "337e31d6-4eb9-80fa-b299-c93680d85322",
+    "type": "page"
+  },
+  "data": {
+    "parent": {
+      "id": "0ef104cd-477e-80e1-8571-cfd10e92339a",
+      "type": "page"
+    }
+  }
+}

--- a/zerver/webhooks/notion/fixtures/page_moved.json
+++ b/zerver/webhooks/notion/fixtures/page_moved.json
@@ -1,0 +1,36 @@
+{
+  "id": "7de99a6f-2edd-4116-bf59-2d09407bddec",
+  "timestamp": "2024-12-11T05:43:14.383Z",
+  "workspace_id": "13950b26-c203-4f3b-b97d-93ec06319565",
+  "workspace_name": "Quantify Labs",
+  "subscription_id": "29d75c0d-5546-4414-8459-7b7a92f1fc4b",
+  "integration_id": "0ef2e755-4912-8096-91c1-00376a88a5ca",
+  "type": "page.moved",
+  "authors": [
+    {
+      "id": "1d6d872b-594c-8129-818d-000250c7f19f",
+      "type": "person"
+    }
+  ],
+  "accessible_by": [
+    {
+      "id": "556a1abf-4f08-40c6-878a-75890d2a88ba",
+      "type": "person"
+    },
+    {
+      "id": "1edc05f6-2702-81b5-8408-00279347f034",
+      "type": "bot"
+    }
+  ],
+  "attempt_number": 1,
+  "entity": {
+    "id": "337e31d6-4eb9-80fa-b299-c93680d85322",
+    "type": "page"
+  },
+  "data": {
+    "parent": {
+      "id": "0ef104cd-477e-80e1-8571-cfd10e92339a",
+      "type": "page"
+    }
+  }
+}

--- a/zerver/webhooks/notion/fixtures/page_properties_updated.json
+++ b/zerver/webhooks/notion/fixtures/page_properties_updated.json
@@ -1,0 +1,41 @@
+{
+  "id": "1782edd6-a853-4d4a-b02c-9c8c16f28e53",
+  "timestamp": "2024-12-05T23:57:05.379Z",
+  "workspace_id": "13950b26-c203-4f3b-b97d-93ec06319565",
+  "workspace_name": "Quantify Labs",
+  "subscription_id": "29d75c0d-5546-4414-8459-7b7a92f1fc4b",
+  "integration_id": "0ef2e755-4912-8096-91c1-00376a88a5ca",
+  "type": "page.properties_updated",
+  "authors": [
+    {
+      "id": "1d6d872b-594c-8129-818d-000250c7f19f",
+      "type": "person"
+    }
+  ],
+  "accessible_by": [
+    {
+      "id": "556a1abf-4f08-40c6-878a-75890d2a88ba",
+      "type": "person"
+    },
+    {
+      "id": "1edc05f6-2702-81b5-8408-00279347f034",
+      "type": "bot"
+    }
+  ],
+  "attempt_number": 1,
+  "entity": {
+    "id": "337e31d6-4eb9-80fa-b299-c93680d85322",
+    "type": "page"
+  },
+  "data": {
+    "parent": {
+      "id": "13950b26-c203-4f3b-b97d-93ec06319565",
+      "type": "space"
+    },
+    "updated_properties": [
+      "XGe%40",
+      "bDf%5B",
+      "DbAu"
+    ]
+  }
+}

--- a/zerver/webhooks/notion/fixtures/page_undeleted.json
+++ b/zerver/webhooks/notion/fixtures/page_undeleted.json
@@ -1,0 +1,36 @@
+{
+  "id": "ec37232c-a17b-4f02-bb7c-8d8e1f5f2250",
+  "timestamp": "2024-12-06T00:00:03.356Z",
+  "workspace_id": "13950b26-c203-4f3b-b97d-93ec06319565",
+  "workspace_name": "Quantify Labs",
+  "subscription_id": "29d75c0d-5546-4414-8459-7b7a92f1fc4b",
+  "integration_id": "0ef2e755-4912-8096-91c1-00376a88a5ca",
+  "type": "page.undeleted",
+  "authors": [
+    {
+      "id": "1d6d872b-594c-8129-818d-000250c7f19f",
+      "type": "person"
+    }
+  ],
+  "accessible_by": [
+    {
+      "id": "556a1abf-4f08-40c6-878a-75890d2a88ba",
+      "type": "person"
+    },
+    {
+      "id": "1edc05f6-2702-81b5-8408-00279347f034",
+      "type": "bot"
+    }
+  ],
+  "attempt_number": 1,
+  "entity": {
+    "id": "337e31d6-4eb9-80fa-b299-c93680d85322",
+    "type": "page"
+  },
+  "data": {
+    "parent": {
+      "id": "0ef104cd-477e-80e1-8571-cfd10e92339a",
+      "type": "page"
+    }
+  }
+}

--- a/zerver/webhooks/notion/fixtures/page_unlocked.json
+++ b/zerver/webhooks/notion/fixtures/page_unlocked.json
@@ -1,0 +1,36 @@
+{
+  "id": "e2a3092c-5af0-442f-9d11-b813145edb72",
+  "timestamp": "2024-12-06T00:00:56.480Z",
+  "workspace_id": "13950b26-c203-4f3b-b97d-93ec06319565",
+  "workspace_name": "Quantify Labs",
+  "subscription_id": "29d75c0d-5546-4414-8459-7b7a92f1fc4b",
+  "integration_id": "0ef2e755-4912-8096-91c1-00376a88a5ca",
+  "type": "page.unlocked",
+  "authors": [
+    {
+      "id": "1d6d872b-594c-8129-818d-000250c7f19f",
+      "type": "person"
+    }
+  ],
+  "accessible_by": [
+    {
+      "id": "556a1abf-4f08-40c6-878a-75890d2a88ba",
+      "type": "person"
+    },
+    {
+      "id": "1edc05f6-2702-81b5-8408-00279347f034",
+      "type": "bot"
+    }
+  ],
+  "attempt_number": 1,
+  "entity": {
+    "id": "337e31d6-4eb9-80fa-b299-c93680d85322",
+    "type": "page"
+  },
+  "data": {
+    "parent": {
+      "id": "0ef104cd-477e-80e1-8571-cfd10e92339a",
+      "type": "page"
+    }
+  }
+}

--- a/zerver/webhooks/notion/tests.py
+++ b/zerver/webhooks/notion/tests.py
@@ -1,4 +1,55 @@
+import copy
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, Concatenate
+
+import orjson
+import requests
+import responses
+from typing_extensions import ParamSpec
+
+from zerver.lib.bot_config import set_bot_config
 from zerver.lib.test_classes import WebhookTestCase
+from zerver.lib.validator import to_wild_value
+from zerver.webhooks.notion.view import (
+    extract_page_title,
+    extract_property_value,
+    get_author_name,
+    get_notion_api_headers,
+    get_notion_data,
+)
+
+ParamT = ParamSpec("ParamT")
+
+USER_NAME = "Sathwik Shetty"
+PAGE_TITLE = "Zulip Notion Test"
+AUTHOR_ID = "1d6d872b-594c-8129-818d-000250c7f19f"
+PAGE_ID = "337e31d6-4eb9-80fa-b299-c93680d85322"
+
+NOTION_USERS_URL = f"https://api.notion.com/v1/users/{AUTHOR_ID}"
+NOTION_PAGES_URL = f"https://api.notion.com/v1/pages/{PAGE_ID}"
+
+
+def mock_notion_api_calls(
+    test_func: Callable[Concatenate["NotionWebhookTest", ParamT], None],
+) -> Callable[Concatenate["NotionWebhookTest", ParamT], None]:
+    @wraps(test_func)
+    @responses.activate
+    def _wrapped(self: "NotionWebhookTest", /, *args: ParamT.args, **kwargs: ParamT.kwargs) -> None:
+        set_bot_config(self.test_user, "notion_token", "test_notion_token")
+        responses.add(
+            responses.GET,
+            NOTION_USERS_URL,
+            self.webhook_fixture_data("notion", "notion_user_info_api_response"),
+        )
+        responses.add(
+            responses.GET,
+            NOTION_PAGES_URL,
+            self.webhook_fixture_data("notion", "notion_page_info_api_response"),
+        )
+        test_func(self, *args, **kwargs)
+
+    return _wrapped
 
 
 class NotionWebhookTest(WebhookTestCase):
@@ -10,3 +61,337 @@ Your verification token is: `secret_tMrlL1qK5vuQAh1b6cZGhFChZTSYJlce98V0pYn7yBl`
 Please copy this token and paste it into your Notion webhook configuration to complete the setup.
 """.strip()
         self.check_webhook("verification", expected_topic, expected_message)
+
+    @mock_notion_api_calls
+    def test_page_created(self) -> None:
+        expected_topic = f"Page: {PAGE_TITLE}"
+        expected_message = f"Page **{PAGE_TITLE}** was created by **{USER_NAME}**."
+        self.check_webhook("page_created", expected_topic, expected_message)
+
+    @mock_notion_api_calls
+    def test_page_content_updated(self) -> None:
+        expected_topic = f"Page: {PAGE_TITLE}"
+        expected_message = f"Page **{PAGE_TITLE}**'s content was updated by **{USER_NAME}**."
+        self.check_webhook("page_content_updated", expected_topic, expected_message)
+
+    @mock_notion_api_calls
+    def test_page_properties_updated(self) -> None:
+        expected_topic = f"Page: {PAGE_TITLE}"
+        expected_message = (
+            f"Page **{PAGE_TITLE}**'s properties were updated by **{USER_NAME}**"
+            " with the following:\n"
+            "- Status set to In Progress\n"
+            "- Priority set to High\n"
+            "- Deadline set to 2026-02-01"
+        )
+
+        payload_data = orjson.loads(self.webhook_fixture_data("notion", "page_properties_updated"))
+        self.check_webhook("page_properties_updated", expected_topic, expected_message)
+
+        modified = copy.deepcopy(payload_data)
+        modified["data"]["updated_properties"] = modified["data"]["updated_properties"][:1]
+
+        self.subscribe(self.test_user, self.channel_name)
+        msg = self.send_webhook_payload(
+            self.test_user,
+            self.url,
+            orjson.dumps(modified).decode(),
+            content_type="application/json",
+        )
+
+        self.assert_channel_message(
+            message=msg,
+            channel_name=self.channel_name,
+            topic_name=f"Page: {PAGE_TITLE}",
+            content=f"Page **{PAGE_TITLE}**'s property was updated by **{USER_NAME}** with Status set to In Progress.",
+        )
+
+    @mock_notion_api_calls
+    def test_page_moved(self) -> None:
+        expected_topic = f"Page: {PAGE_TITLE}"
+        expected_message = f"Page **{PAGE_TITLE}** was moved by **{USER_NAME}**."
+        self.check_webhook("page_moved", expected_topic, expected_message)
+
+    @mock_notion_api_calls
+    def test_page_deleted(self) -> None:
+        expected_topic = f"Page: {PAGE_TITLE}"
+        expected_message = f"Page **{PAGE_TITLE}** was moved to trash by **{USER_NAME}**."
+        self.check_webhook("page_deleted", expected_topic, expected_message)
+
+    @mock_notion_api_calls
+    def test_page_undeleted(self) -> None:
+        expected_topic = f"Page: {PAGE_TITLE}"
+        expected_message = f"Page **{PAGE_TITLE}** was restored from trash by **{USER_NAME}**."
+        self.check_webhook("page_undeleted", expected_topic, expected_message)
+
+    @mock_notion_api_calls
+    def test_page_locked(self) -> None:
+        expected_topic = f"Page: {PAGE_TITLE}"
+        expected_message = f"Page **{PAGE_TITLE}** was locked by **{USER_NAME}**."
+        self.check_webhook("page_locked", expected_topic, expected_message)
+
+    @mock_notion_api_calls
+    def test_page_unlocked(self) -> None:
+        expected_topic = f"Page: {PAGE_TITLE}"
+        expected_message = f"Page **{PAGE_TITLE}** was unlocked by **{USER_NAME}**."
+        self.check_webhook("page_unlocked", expected_topic, expected_message)
+
+    def test_get_notion_api_headers(self) -> None:
+        headers = get_notion_api_headers("test_token")
+        self.assertEqual(headers["Authorization"], "Bearer test_token")
+        self.assertEqual(headers["Notion-Version"], "2025-09-03")
+        self.assertEqual(headers["Content-Type"], "application/json")
+
+    def test_extract_page_title(self) -> None:
+        page_data = orjson.loads(
+            self.webhook_fixture_data("notion", "notion_page_info_api_response")
+        )
+
+        # Test for null title field.
+        page_data_with_null_title = copy.deepcopy(page_data)
+        page_data_with_null_title["properties"]["title"]["title"] = []
+        self.assertEqual(extract_page_title(page_data_with_null_title), "Untitled Page")
+
+        # Test for missing title field.
+        page_data_without_title = copy.deepcopy(page_data)
+        page_data_without_title["properties"].pop("title")
+        self.assertRaises(AssertionError, extract_page_title, page_data_without_title)
+
+    @mock_notion_api_calls
+    def test_get_author_name(self) -> None:
+        payload_data = orjson.loads(self.webhook_fixture_data("notion", "page_created"))
+
+        # Test for successful retrieval.
+        self.assertEqual(
+            get_author_name(to_wild_value("payload", orjson.dumps(payload_data).decode()), "token"),
+            USER_NAME,
+        )
+
+        # Test for empty authors list.
+        payload_no_authors = copy.deepcopy(payload_data)
+        payload_no_authors["authors"] = []
+        self.assertIsNone(
+            get_author_name(
+                to_wild_value("payload", orjson.dumps(payload_no_authors).decode()), "token"
+            )
+        )
+
+        # Test for multiple authors.
+        payload_multiple = copy.deepcopy(payload_data)
+        payload_multiple["authors"].append({"id": "user2", "type": "person"})
+        self.assertEqual(
+            get_author_name(
+                to_wild_value("payload", orjson.dumps(payload_multiple).decode()), "token"
+            ),
+            f"{USER_NAME} (+1 other)",
+        )
+
+        # Test for many authors.
+        payload_many = copy.deepcopy(payload_data)
+        payload_many["authors"].extend(
+            [{"id": "user2", "type": "person"}, {"id": "user3", "type": "person"}]
+        )
+        self.assertEqual(
+            get_author_name(to_wild_value("payload", orjson.dumps(payload_many).decode()), "token"),
+            f"{USER_NAME} (+2 others)",
+        )
+
+        # Test for failed user API response.
+        UNKNOWN_USER_ID = "unknown_user_id"
+        NOTION_UNKNOWN_USER_URL = f"https://api.notion.com/v1/users/{UNKNOWN_USER_ID}"
+        responses.add(
+            responses.GET,
+            NOTION_UNKNOWN_USER_URL,
+            json={"object": "error", "status": 404, "message": "Not found"},
+            status=404,
+        )
+        payload_failed_author = copy.deepcopy(payload_data)
+        payload_failed_author["authors"] = [{"id": UNKNOWN_USER_ID, "type": "person"}]
+        with self.assertLogs("zerver.lib.webhooks.common", level="WARNING") as warn_logs:
+            self.assertIsNone(
+                get_author_name(
+                    to_wild_value("payload", orjson.dumps(payload_failed_author).decode()), "token"
+                )
+            )
+        self.assertEqual(
+            warn_logs.output,
+            [
+                f"WARNING:zerver.lib.webhooks.common:Failed to fetch data from {NOTION_UNKNOWN_USER_URL}"
+                f" for Notion integration: 404 Client Error: Not Found for url: {NOTION_UNKNOWN_USER_URL}"
+            ],
+        )
+
+    def test_extract_property_value(self) -> None:
+        cases: list[tuple[str, dict[str, Any], str]] = [
+            ("None value", {"type": "url", "url": None}, "empty"),
+            (
+                "rich_text",
+                {"type": "rich_text", "rich_text": [{"plain_text": "Test Page"}]},
+                "Test Page",
+            ),
+            ("checkbox", {"type": "checkbox", "checkbox": True}, "true"),
+            (
+                "multi_select",
+                {
+                    "type": "multi_select",
+                    "multi_select": [{"name": "Option 1"}, {"name": "Option 2"}],
+                },
+                "Option 1, Option 2",
+            ),
+            (
+                "formula number",
+                {"type": "formula", "formula": {"type": "number", "number": 123}},
+                "123",
+            ),
+            (
+                "relation",
+                {"type": "relation", "relation": [{"id": "123"}, {"id": "456"}]},
+                "2 linked page(s)",
+            ),
+            ("unique_id", {"type": "unique_id", "unique_id": {"number": 123}}, "123"),
+        ]
+        for label, prop, expected in cases:
+            with self.subTest(label):
+                self.assertEqual(extract_property_value(prop), expected)
+
+    @responses.activate
+    def test_get_notion_data(self) -> None:
+        # Test for missing token.
+        self.assertIsNone(get_notion_data("", "users", AUTHOR_ID))
+
+        # Test for successful retrieval.
+        responses.add(
+            responses.GET,
+            NOTION_USERS_URL,
+            self.webhook_fixture_data("notion", "notion_user_info_api_response"),
+        )
+        result = get_notion_data("token", "users", AUTHOR_ID)
+        assert result is not None
+        self.assertEqual(result["name"], USER_NAME)
+
+        # Test for API failure.
+        responses.add(
+            responses.GET,
+            NOTION_PAGES_URL,
+            json={"object": "error", "status": 500, "message": "Internal error"},
+            status=500,
+        )
+
+        with self.assertLogs("zerver.lib.webhooks.common", level="WARNING") as warn_logs:
+            self.assertIsNone(get_notion_data("token", "pages", PAGE_ID))
+        self.assertEqual(
+            warn_logs.output,
+            [
+                f"WARNING:zerver.lib.webhooks.common:Failed to fetch data from {NOTION_PAGES_URL}"
+                f" for Notion integration: 500 Server Error: Internal Server Error for url: {NOTION_PAGES_URL}"
+            ],
+        )
+
+        # Test for invalid JSON.
+        INVALID_URL = "https://api.notion.com/v1/pages/invalid-json"
+        responses.add(
+            responses.GET,
+            INVALID_URL,
+            body="invalid json",
+            status=200,
+        )
+        self.assertIsNone(get_notion_data("token", "pages", "invalid-json"))
+
+        # Test for RequestException (network failure).
+        EXCEPTION_URL = "https://api.notion.com/v1/pages/network-error"
+        responses.add(
+            responses.GET,
+            EXCEPTION_URL,
+            body=requests.RequestException("Connection error"),
+        )
+
+        with self.assertLogs("zerver.lib.webhooks.common", level="WARNING") as warn_logs:
+            self.assertIsNone(get_notion_data("token", "pages", "network-error"))
+        self.assertEqual(
+            warn_logs.output,
+            [
+                f"WARNING:zerver.lib.webhooks.common:Failed to fetch data from {EXCEPTION_URL}"
+                " for Notion integration: Connection error"
+            ],
+        )
+
+    @responses.activate
+    def test_event_with_author_retrieval_failure(self) -> None:
+        set_bot_config(self.test_user, "notion_token", "test_notion_token")
+        responses.add(
+            responses.GET,
+            NOTION_USERS_URL,
+            json={"object": "error", "status": 404, "message": "Not found"},
+            status=404,
+        )
+        responses.add(
+            responses.GET,
+            NOTION_PAGES_URL,
+            self.webhook_fixture_data("notion", "notion_page_info_api_response"),
+        )
+
+        expected_topic = f"Page: {PAGE_TITLE}"
+        expected_message = f"Page **{PAGE_TITLE}** was created."
+        with self.assertLogs("zerver.lib.webhooks.common", level="WARNING") as warn_logs:
+            self.check_webhook("page_created", expected_topic, expected_message)
+        self.assertEqual(
+            warn_logs.output,
+            [
+                f"WARNING:zerver.lib.webhooks.common:Failed to fetch data from {NOTION_USERS_URL}"
+                f" for Notion integration: 404 Client Error: Not Found for url: {NOTION_USERS_URL}"
+            ],
+        )
+
+    @responses.activate
+    def test_event_with_title_retrieval_failure(self) -> None:
+        set_bot_config(self.test_user, "notion_token", "test_notion_token")
+        responses.add(
+            responses.GET,
+            NOTION_USERS_URL,
+            self.webhook_fixture_data("notion", "notion_user_info_api_response"),
+        )
+        responses.add(
+            responses.GET,
+            NOTION_PAGES_URL,
+            json={"object": "error", "status": 404, "message": "Not found"},
+            status=404,
+        )
+
+        expected_topic = "Page"
+        expected_message = f"Page was created by **{USER_NAME}**."
+        with self.assertLogs("zerver.lib.webhooks.common", level="WARNING") as warn_logs:
+            self.check_webhook("page_created", expected_topic, expected_message)
+        self.assertEqual(
+            warn_logs.output,
+            [
+                f"WARNING:zerver.lib.webhooks.common:Failed to fetch data from {NOTION_PAGES_URL}"
+                f" for Notion integration: 404 Client Error: Not Found for url: {NOTION_PAGES_URL}"
+            ],
+        )
+
+    @responses.activate
+    def test_property_updated_without_page_data(self) -> None:
+        set_bot_config(self.test_user, "notion_token", "test_notion_token")
+        responses.add(
+            responses.GET,
+            NOTION_USERS_URL,
+            self.webhook_fixture_data("notion", "notion_user_info_api_response"),
+        )
+        responses.add(
+            responses.GET,
+            NOTION_PAGES_URL,
+            json={"object": "error", "status": 404, "message": "Not found"},
+            status=404,
+        )
+
+        expected_topic = "Page"
+        expected_message = f"Page's properties were updated by **{USER_NAME}**."
+        with self.assertLogs("zerver.lib.webhooks.common", level="WARNING") as warn_logs:
+            self.check_webhook("page_properties_updated", expected_topic, expected_message)
+        self.assertEqual(
+            warn_logs.output,
+            [
+                f"WARNING:zerver.lib.webhooks.common:Failed to fetch data from {NOTION_PAGES_URL}"
+                f" for Notion integration: 404 Client Error: Not Found for url: {NOTION_PAGES_URL}"
+            ],
+        )

--- a/zerver/webhooks/notion/view.py
+++ b/zerver/webhooks/notion/view.py
@@ -1,14 +1,22 @@
 from collections.abc import Callable
+from typing import Any
 
+import requests
 from django.http import HttpRequest
 from django.http.response import HttpResponse
 
 from zerver.decorator import webhook_view
+from zerver.lib.bot_config import ConfigError, get_bot_config
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError
+from zerver.lib.partial import partial
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
-from zerver.lib.validator import WildValue, check_none_or, check_string
-from zerver.lib.webhooks.common import check_send_webhook_message, get_setup_webhook_message
+from zerver.lib.validator import WildValue, check_dict, check_list, check_none_or, check_string
+from zerver.lib.webhooks.common import (
+    check_send_webhook_message,
+    get_service_api_data,
+    get_setup_webhook_message,
+)
 from zerver.models import UserProfile
 
 NOTION_VERIFICATION_TOKEN_MESSAGE = """
@@ -18,7 +26,160 @@ Please copy this token and paste it into your Notion webhook configuration to co
 """.strip()
 
 
-def handle_verification_request(payload: WildValue) -> tuple[str, str]:
+def get_entity_topic_name(entity_type: str, entity_name: str | None) -> str:
+    return f"{entity_type}: {entity_name}" if entity_name else entity_type
+
+
+def extract_page_title(page_data: dict[str, Any]) -> str:
+    title_prop = next(
+        (v["title"] for v in page_data["properties"].values() if v["type"] == "title"), None
+    )
+    if title_prop is None:
+        raise AssertionError("Page data must contain a title property")
+    return title_prop[0]["plain_text"] if title_prop else "Untitled Page"
+
+
+def extract_property_value(prop_value: dict[str, Any]) -> str:
+    prop_type = prop_value["type"]
+    value = prop_value[prop_type]
+
+    if value is None:
+        return "empty"
+
+    match prop_type:
+        case "rich_text" | "title":
+            return value[0]["plain_text"] if value else "empty"
+        case "select" | "status" | "place":
+            return value["name"]
+        case "date":
+            return value["start"]
+        case "checkbox":
+            return str(value).lower()
+        case "files" | "people" | "multi_select":
+            return ", ".join(f["name"] for f in value) if value else "empty"
+        case "formula" | "rollup":
+            return extract_property_value(value)
+        case "relation":
+            return f"{len(value)} linked page(s)" if value else "empty"
+        case "unique_id":
+            return str(value["number"])
+        case _:
+            return str(value)
+
+
+def extract_property_updates(page_data: dict[str, Any], property_ids: list[str]) -> list[str]:
+    return [
+        f"{name} set to {extract_property_value(val)}"
+        for name, val in page_data["properties"].items()
+        if val["id"] in property_ids
+    ]
+
+
+def get_notion_api_headers(notion_token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {notion_token}",
+        "Notion-Version": "2025-09-03",
+        "Content-Type": "application/json",
+    }
+
+
+def get_notion_data(notion_token: str, entity_type: str, entity_id: str) -> dict[str, Any] | None:
+    if not notion_token:
+        return None
+
+    url = f"https://api.notion.com/v1/{entity_type}/{entity_id}"
+    headers = get_notion_api_headers(notion_token)
+
+    try:
+        response = get_service_api_data(url, integration_name="Notion", headers=headers)
+        return response.json()
+
+    except (requests.RequestException, ValueError):
+        return None
+
+
+def get_author_name(payload: WildValue, notion_token: str) -> str | None:
+    authors = payload["authors"].tame(check_list(check_dict([("id", check_string)])))
+    if not authors:
+        return None
+
+    primary_name = (get_notion_data(notion_token, "users", str(authors[0]["id"])) or {}).get("name")
+    if not primary_name:
+        return None
+
+    others_count = len(authors) - 1
+    if others_count == 0:
+        return primary_name
+
+    suffix = "other" if others_count == 1 else "others"
+    return f"{primary_name} (+{others_count} {suffix})"
+
+
+def format_message(
+    entity_type: str,
+    entity_name: str | None,
+    action: str,
+    suffix: str | None,
+    author_name: str | None,
+    properties: list[str] | None = None,
+) -> str:
+    entity_display = entity_type
+
+    if entity_name:
+        entity_display += f" **{entity_name}**"
+
+    if suffix:
+        entity_display += f"'s {suffix}"
+
+    message_parts = [entity_display]
+    message_parts.append(f"{'were' if suffix == 'properties' else 'was'} {action}")
+
+    if author_name:
+        message_parts.append(f"by **{author_name}**")
+
+    if properties:
+        if len(properties) == 1:
+            message_parts.append(f"with {properties[0]}")
+        else:
+            bullet_list = "\n".join(f"- {prop}" for prop in properties)
+            message_parts.append(f"with the following:\n{bullet_list}")
+
+    message = " ".join(message_parts)
+    return message if properties and len(properties) > 1 else message + "."
+
+
+def get_message(
+    event_descriptor: str, entity_type: str, payload: WildValue, notion_token: str
+) -> tuple[str, str]:
+    entity_id = payload["entity"]["id"].tame(check_string)
+    entity_data = get_notion_data(notion_token, "pages", entity_id)
+    author_name = get_author_name(payload, notion_token)
+    entity_title = extract_page_title(entity_data) if entity_data else None
+
+    match event_descriptor:
+        case "content":
+            body = format_message(
+                entity_type, entity_title, "updated", event_descriptor, author_name
+            )
+        case "properties":
+            updated_property_ids = payload["data"]["updated_properties"].tame(
+                check_list(check_string)
+            )
+            properties_list = (
+                extract_property_updates(entity_data, updated_property_ids) if entity_data else None
+            )
+            suffix = "properties" if len(updated_property_ids) > 1 else "property"
+            body = format_message(
+                entity_type, entity_title, "updated", suffix, author_name, properties_list
+            )
+        case _:
+            body = format_message(entity_type, entity_title, event_descriptor, None, author_name)
+
+    topic = get_entity_topic_name(entity_type, entity_title)
+    return (topic, body)
+
+
+def handle_verification_request(payload: WildValue, notion_token: str) -> tuple[str, str]:
     verification_token = payload["verification_token"].tame(check_string)
     setup_message = get_setup_webhook_message("Notion")
     body = NOTION_VERIFICATION_TOKEN_MESSAGE.format(
@@ -27,8 +188,16 @@ def handle_verification_request(payload: WildValue) -> tuple[str, str]:
     return ("Verification", body)
 
 
-EVENT_TO_FUNCTION_MAPPER: dict[str, Callable[[WildValue], tuple[str, str]]] = {
+EVENT_TO_FUNCTION_MAPPER: dict[str, Callable[[WildValue, str], tuple[str, str]]] = {
     "verification": handle_verification_request,
+    "page.created": partial(get_message, "created", "Page"),
+    "page.deleted": partial(get_message, "moved to trash", "Page"),
+    "page.undeleted": partial(get_message, "restored from trash", "Page"),
+    "page.moved": partial(get_message, "moved", "Page"),
+    "page.locked": partial(get_message, "locked", "Page"),
+    "page.unlocked": partial(get_message, "unlocked", "Page"),
+    "page.content_updated": partial(get_message, "content", "Page"),
+    "page.properties_updated": partial(get_message, "properties", "Page"),
 }
 
 
@@ -47,15 +216,21 @@ def api_notion_webhook(
     *,
     payload: JsonBodyPayload[WildValue],
 ) -> HttpResponse:
+    try:
+        config = get_bot_config(user_profile)
+        notion_token = config.get("notion_token", "")
+    except ConfigError:
+        notion_token = ""
+
     if is_verification(payload):
         event_type = "verification"
     else:
-        event_type = payload.get("type").tame(check_string)  # nocoverage
+        event_type = payload.get("type").tame(check_string)
 
     handler = EVENT_TO_FUNCTION_MAPPER.get(event_type)
     if handler is None:
         raise UnsupportedWebhookEventTypeError(event_type)
-    topic_name, body = handler(payload)
+    topic_name, body = handler(payload, notion_token)
 
     check_send_webhook_message(request, user_profile, topic_name, body, event_type)
     return json_success(request)


### PR DESCRIPTION
This pr adds support for incoming webhooks from Notion, previously notion webhooks were supported by zapier integration which just supports a [subset ](https://zapier.com/apps/notion/integrations#triggers-and-actions)of triggers from notion. But Notion natively supports [webhooks](https://developers.notion.com/reference/webhooks).

Fixes part of: #37278
CZO Thread [#integrations > Notion webhook integration](https://chat.zulip.org/#narrow/channel/127-integrations/topic/Notion.20webhook.20integration/with/2369796)

This pr has blocker, until we have support to store `config_options` for incoming webhook bots this cannot be merged.
The pr adds support for these notion webhooks events:
* `page.created`
* `page.deleted`
* `page.undeleted`
* `page.moved`
* `page.locked`
* `page.unlocked`
* `page.content_updated`
* `page.properties_updated`

The pr contains Fixtures and related views and tests for the same.
The fixtures were taken from documentation of [Notion](https://developers.notion.com/reference/webhooks-events-delivery) and have tested manually for the correctness of these.

The pr also introduces a config_options `notion_token` - The notion webhook payloads just the ID's of page/datasource/users which are not human readable, so we need this token to fetch from the Notion API.
For tests that involves fetched data(i.e page_data, user_data) fetched from Notion api, have used real fixtures from Notion API.
**How changes were tested:**
The changes were tested by running `./tools/test-backend zerver.webhooks.notion` and added 20 unit tese and these have  tests passed.
Manually verified by trigeering events from Notion.
**Screenshots and screen captures:**

<img width="1108" height="443" alt="image" src="https://github.com/user-attachments/assets/be038bbf-611a-4e98-9476-317a002178d3" />


`page.properties_updated` with single property.

<img width="1097" height="72" alt="image" src="https://github.com/user-attachments/assets/0f3b933f-18c3-4d8c-b68c-81961b4b2dac" />


`page.properties_updated` with multiple properties.

<img width="1102" height="131" alt="image" src="https://github.com/user-attachments/assets/3a0db36e-03ce-4bbf-84ee-2bcac89385bb" />




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>