### PR TITLE
nginx: Hardcode a Host: header to uwsgi when making health checks.

### DIFF
--- a/puppet/zulip/templates/nginx/healthcheck.conf.template.erb
+++ b/puppet/zulip/templates/nginx/healthcheck.conf.template.erb
@@ -9,4 +9,13 @@ location /health {
     deny all;
 
     include uwsgi_params;
+
+    # Healthchecks may not supply a Host header; but also nothing in
+    # the response is host-specific, as the Django processes
+    # themselves are what are being healthchecked.  we hardcode a Host
+    # that we know is in ALLOWED_HOSTS.  The alternative is injecting
+    # a new Django middleware before
+    # `django.middleware.security.SecurityMiddleware` which only kicks
+    # in for this one specific path.
+    uwsgi_param HTTP_HOST "127.0.0.1";
 }


### PR DESCRIPTION
Fixes: #37805.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
