### PR TITLE
compose: Fix local rendering of markdown preview.

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -1400,7 +1400,8 @@ export function render_and_show_preview(
             // wrong, users will see a brief flicker of the locally
             // echoed frontend rendering before receiving the
             // authoritative backend rendering from the server).
-            markdown.render(content);
+            const rendered_content = markdown.render(content).content;
+            show_preview(rendered_content);
         }
         void channel.post({
             url: "/json/messages/render",

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -821,6 +821,7 @@ test_ui("on_events", ({override, override_rewire}) => {
         override(markdown, "render", (raw_content) => {
             assert.equal(raw_content, "default message");
             render_called = true;
+            return {content: "Local: default message"};
         });
 
         fake_compose_box.click_on_markdown_preview_icon({


### PR DESCRIPTION
Previously, when previewing messages that don't require backend-only syntax, we called `markdown.render(content)` but discarded its return value, failing to display the locally rendered preview before the server response arrived. This meant users saw nothing while waiting for the server.

Now, the locally rendered content is immediately displayed via show_preview(), providing instant feedback for messages that can be rendered client-side.

This bug was introduced in commit [eb4635804f](https://github.com/zulip/zulip/commit/eb4635804f), which added show_preview() helper for /me message handling but forgot to use the same helper for local renders and all the commits made on top of it followed the same.

<!-- Describe your pull request here.-->

Fixes: [#issues > Preview delay and blank message before render](https://chat.zulip.org/#narrow/channel/9-issues/topic/Preview.20delay.20and.20blank.20message.20before.20render/with/2370389)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

I've tested by commenting out the server side render code and used a simple markdown that don't require backend-only syntax to ensure the client side show preview works correctly.

**Screenshots and screen captures:**

Local preview render:

![client-render](https://github.com/user-attachments/assets/0b531034-e2c7-4a29-8164-57c04fa47993)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
