### PR TITLE
Allow @-prefix for adding user groups.

### DIFF
--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -295,6 +295,16 @@ export function set_up_combined(
             }
 
             if (include_user_groups) {
+                if (query.startsWith("@")) {
+                    // If query starts with @ we expect only user group
+                    // suggestions so we simply return user group source.
+                    if (opts.user_group_source !== undefined) {
+                        return opts
+                            .user_group_source()
+                            .map((user_group) => ({type: "user_group", ...user_group}));
+                    }
+                    return user_group_pill.typeahead_source(pills);
+                }
                 if (opts.user_group_source !== undefined) {
                     const groups: UserGroupPillData[] = opts
                         .user_group_source()
@@ -345,9 +355,17 @@ export function set_up_combined(
                 return item.name.toLowerCase().includes(query);
             }
 
+            if (include_user_groups && query.startsWith("@")) {
+                if (item.type === "user_group") {
+                    const normalized_query = query.slice(1);
+                    return group_matcher(normalized_query, item);
+                }
+                return false;
+            }
+
             let matches = false;
             if (include_user_groups && item.type === "user_group") {
-                matches = matches || group_matcher(query, item);
+                matches = group_matcher(query, item);
             }
 
             if (include_users && item.type === "user") {
@@ -383,9 +401,10 @@ export function set_up_combined(
                 }
             }
 
+            const normalized_query = query.startsWith("@") ? query.slice(1) : query;
             return typeahead_helper.sort_stream_or_group_members_options({
                 users,
-                query,
+                query: normalized_query,
                 groups,
                 for_stream_subscribers: opts.for_stream_subscribers,
             });

--- a/web/tests/pill_typeahead.test.cjs
+++ b/web/tests/pill_typeahead.test.cjs
@@ -54,7 +54,8 @@ function override_typeahead_helper({mock_template, override_rewire}) {
     override_rewire(typeahead_helper, "sort_streams", () => {
         sort_streams_called = true;
     });
-    override_rewire(typeahead_helper, "sort_stream_or_group_members_options", ({users}) => {
+    override_rewire(typeahead_helper, "sort_stream_or_group_members_options", ({users, query}) => {
+        assert.ok(!query.startsWith("@"));
         sort_stream_or_group_members_options_called = true;
         return users;
     });
@@ -528,6 +529,14 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
                 // person query with wrong item.
                 result = config.matcher(jill_item, person_query);
                 assert.ok(!result);
+                // @-prefixed query matches groups only.
+                result = config.matcher(testers_item, "@" + group_query);
+                assert.ok(result);
+                result = config.matcher(admins_item, "@admins");
+                assert.ok(result);
+                // @-prefixed query must NOT match users.
+                result = config.matcher(me_item, "@" + person_query);
+                assert.ok(!result);
             }
             if (opts.user_group && !opts.user) {
                 result = config.matcher(testers_item, group_query);
@@ -554,6 +563,11 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
                 sort_stream_or_group_members_options_called = false;
                 config.sorter([testers_item], group_query);
                 assert.ok(!sort_recipients_called);
+                assert.ok(sort_stream_or_group_members_options_called);
+
+                // Ensure @-prefixed queries use normalized query in sorter.
+                sort_stream_or_group_members_options_called = false;
+                config.sorter([testers_item], "@" + group_query);
                 assert.ok(sort_stream_or_group_members_options_called);
             }
             if (opts.user) {
@@ -611,6 +625,13 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
                 })
                 .filter(Boolean);
             assert.deepEqual(actual_result, expected_result);
+
+            if (opts.user_group) {
+                const result = config.source("@" + group_query);
+                assert.ok(result.length > 0);
+                // Source returns only user groups for @-prefixed queries.
+                assert.ok(result.every((item) => item.type === "user_group"));
+            }
         })();
 
         (function test_updater() {


### PR DESCRIPTION
Fixes #22448.

This PR fixes an issue where typing `@admins` or other group names with an `@` prefix failed to return results in the subscriber typeahead.

Note on Sorting: The issue also requested that groups appear above users. I confirmed this is already handled by `compare_stream_or_group_members_options` in `typeahead_helper.ts`. No additional sorting logic was needed; groups automatically sort to the top.


## Screenshots

### Case 1: During stream creation
| Before | After |
| --- | --- |
| <img width="450" alt="before" src="https://github.com/user-attachments/assets/66e24a05-0dc4-4da7-8311-5d36c2b87a63" /> | <img width="450" alt="after" src="https://github.com/user-attachments/assets/a421dc4b-0db0-4115-9a43-8193ded1b339" /> |

### Case 2: During stream editing 
| Before | After |
| --- | --- |
| <img width="450" alt="before" src="https://github.com/user-attachments/assets/a0409c71-df59-4222-a3c5-98f90ab9c00b" /> | <img width="450" alt="after" src="https://github.com/user-attachments/assets/00de7164-54d1-489c-8a44-bf93cf16d604" /> |

### Case 3: Stream editing and stream creation without the initial @ 
| | |
| --- | --- |
| <img width="450" alt="screenshot1" src="https://github.com/user-attachments/assets/e6b99932-3a6b-41f6-a6c7-bf0953734686" /> | <img width="450" alt="screenshot2" src="https://github.com/user-attachments/assets/76726daf-0173-4bde-bfd2-0b1ffc22558e" /> |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
