### PR TITLE
webpack: Fix misordered bootstrap.app.css in dev assets webpack.

### DIFF
--- a/web/webpack.dev-assets.json
+++ b/web/webpack.dev-assets.json
@@ -8,10 +8,8 @@
         "./src/channel.ts"
     ],
     "dev-email-log": [
-        "./src/bundles/common.ts",
+        "./src/bundles/legacy_portico_bundle.ts",
         "./src/portico/email_log.ts",
-        "./src/portico/portico_modals.ts",
-        "./styles/portico/legacy_portico_styles_bundle.css",
         "./styles/portico/email_log.css",
         "./src/reload_state.ts",
         "./src/channel.ts"


### PR DESCRIPTION
This PR fixes a bug where the the bootstrap.app.css was taking precedence over the legacy_portico_styles_bundle.css, following the changes in commit 847a7f8f9c0723edf1a947749fd4138908d092ca.

While this commit fixes the issue by importing legacy_portico_bundle.ts instead of trying to fix the order sequence of legacy_portico_styles_bundle.css, similar to the approach in commits ead2f2d2540e62c5d8bc6faa5185ab571f373e70 and c6dcfbc4808287954021bb9131bffbf0e54164b9, the actual cause of this bug remains unknown at the time of the PR.


Fixes: [#issues > legacy portico regressions in dev](https://chat.zulip.org/#narrow/channel/9-issues/topic/legacy.20portico.20regressions.20in.20dev/with/2370681)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| <img width="312" height="266" alt="Screenshot 2026-02-04 at 11 30 39 PM" src="https://github.com/user-attachments/assets/a855b418-0696-47e1-8a32-e60a6ccdff00" /> | <img width="312" height="266" alt="Screenshot 2026-02-04 at 11 27 36 PM" src="https://github.com/user-attachments/assets/687d821c-51a7-4a48-b7ec-f8dad6d106ec" /> |
| <img width="1195" height="521" alt="Screenshot 2026-02-04 at 11 33 27 PM" src="https://github.com/user-attachments/assets/e8f2bcc6-7655-4007-b4fe-e991aa892bf3" /> | <img width="1195" height="521" alt="Screenshot 2026-02-04 at 11 31 48 PM" src="https://github.com/user-attachments/assets/f27148e0-cc50-4bd2-836f-63ce038a1ab8" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
