### PR TITLE
i18n: Fix \xa0 character in a string for translation.

### DIFF
--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.http import HttpRequest
 from django.utils.timesince import timeuntil
 from django.utils.timezone import now as timezone_now
-from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 from typing_extensions import override
 
 from zerver.lib import redis_utils
@@ -663,7 +663,11 @@ def readable_expiry_string_for_html(seconds_till_expiry: int) -> str:
         # We use \xa0 as the whitespace to be consistent with
         # timeuntil.
         # If you want the regular " ", see readable_expiry_string_for_plaintext.
-        return _("{secs}\xa0seconds").format(secs=seconds_till_expiry)
+        return ngettext(
+            "{secs}{nbsp}second",
+            "{secs}{nbsp}seconds",
+            seconds_till_expiry,
+        ).format(secs=seconds_till_expiry, nbsp="\xa0")
 
     return timeuntil(expires_in_datetime)
 


### PR DESCRIPTION
https://github.com/zulip/zulip/pull/37636#discussion_r2766498219

Having `\xa0` in the string doesn't work for our translation system:
```
$ ./manage.py makemessages --locale=en
./zerver/lib/rate_limiter.py:666: invalid multibyte sequence
./zerver/lib/rate_limiter.py:666: invalid multibyte sequence
processing locale en
[frontend] processing locale en
$ grep -A4 'rate_limiter\.py:666' locale/en/LC_MESSAGES/django.po
msgid "{secs}seconds"
msgstr ""
```

We can instead insert this character via `.format`. Additionally we switch to using `ngettext` to support pluralization.
