### PR TITLE
message_edit: Fix missing convert pasted text to file banner.

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -297,12 +297,15 @@ export function show_convert_pasted_text_to_file_banner({
     show_paste_button,
     convert_to_file_cb,
     paste_to_compose_cb,
+    $textarea,
 }: {
     show_paste_button: boolean;
     convert_to_file_cb: () => void;
     paste_to_compose_cb: () => void;
+    $textarea: JQuery<HTMLTextAreaElement>;
 }): JQuery {
-    $(`#compose_banners .${CSS.escape(CLASSNAMES.convert_pasted_text_to_file)}`).remove();
+    const $banner_container = get_compose_banner_container($textarea);
+    $banner_container.find(CSS.escape(CLASSNAMES.convert_pasted_text_to_file)).remove();
     const $new_row = $(
         render_long_paste_options({
             banner_type: INFO,
@@ -312,6 +315,6 @@ export function show_convert_pasted_text_to_file_banner({
     );
     $new_row.on("click", ".main-view-banner-action-button.convert-to-file", convert_to_file_cb);
     $new_row.on("click", ".main-view-banner-action-button.paste-to-compose", paste_to_compose_cb);
-    append_compose_banner_to_banner_list($new_row, $("#compose_banners"));
+    append_compose_banner_to_banner_list($new_row, $banner_container);
     return $new_row;
 }

--- a/web/src/compose_paste.ts
+++ b/web/src/compose_paste.ts
@@ -763,9 +763,10 @@ export function paste_handler(
                 paste_to_compose_cb() {
                     do_paste_text(paste_html, paste_text, $textarea);
                 },
+                $textarea,
             });
             setTimeout(() => {
-                $("textarea#compose-textarea").one("input", () => {
+                $textarea.one("input", () => {
                     // The banner only displays until the user does
                     // some further input. This is both reasonable UI
                     // and also is required for undo, see above.


### PR DESCRIPTION
Previously, the convert pasted text to file banner was only shown in the compose area, while the conditional check applied to the message edit as well. This resulted in a no-op when the pasted text length was
>= MINIMUM_PASTE_SIZE_TO_AVOID_DIRECT_PASTE during message edit.

This PR modifies the show_convert_pasted_text_to_file_banner method to also work in the message edit section.

Fixes: [#issues > 🎯 pasting large text in message edit doesn't work](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20pasting.20large.20text.20in.20message.20edit.20doesn't.20work/with/2371516)

**How changes were tested:**
1. Check if banner is shown in the message edit area when `pasted_text_length >= MINIMUM_PASTE_SIZE_TO_AVOID_DIRECT_PASTE`.
2. Paste two different large texts in the compose and message edit and test for interference.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="926" height="277" alt="Screenshot 2026-02-05 at 8 38 21 PM" src="https://github.com/user-attachments/assets/ae35be2c-185e-4713-b35e-204faabaaf9d" />
<img width="926" height="277" alt="Screenshot 2026-02-05 at 8 42 48 PM" src="https://github.com/user-attachments/assets/8ee4ba0f-8a61-42f1-9421-e7ab6889206b" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
