### PR TITLE
refactor: Use modern URL API in Jitsi call generation.

### DIFF
--- a/web/src/compose_call.ts
+++ b/web/src/compose_call.ts
@@ -3,8 +3,16 @@ import {realm} from "./state_data.ts";
 export const zoom_token_callbacks = new Map();
 export const video_call_xhrs = new Map<string, JQuery.jqXHR<unknown>>();
 
-export function get_jitsi_server_url(): string | null {
-    return realm.realm_jitsi_server_url ?? realm.server_jitsi_server_url;
+export function get_jitsi_server_url(video_call_id?: string): URL | null {
+    const base_url = realm.realm_jitsi_server_url ?? realm.server_jitsi_server_url;
+    if (!base_url) {
+        return null;
+    }
+    const url = new URL(base_url);
+    if (video_call_id !== undefined) {
+        url.pathname = `/${video_call_id}`;
+    }
+    return url;
 }
 
 export function abort_video_callbacks(edit_message_id = ""): void {

--- a/web/src/compose_call_ui.ts
+++ b/web/src/compose_call_ui.ts
@@ -141,32 +141,32 @@ export function generate_and_insert_audio_or_video_call_link(
             },
         });
     } else {
-        // TODO: Use `new URL` to generate the URLs here.
         const video_call_id = util.random_int(100000000000000, 999999999999999);
-        const video_call_link = compose_call.get_jitsi_server_url() + "/" + video_call_id;
-        if (is_audio_call) {
-            insert_audio_call_url(
-                video_call_link + "#config.startWithVideoMuted=true",
-                $target_textarea,
-            );
-        } else {
-            /* Because Jitsi remembers what last call type you joined
-               in browser local storage, we need to specify that video
-               should not be muted in the video call case, or your
-               next call will also join without video after joining an
-               audio-only call.
+        const video_call_url = compose_call.get_jitsi_server_url(video_call_id.toString());
+        if (video_call_url === null) {
+            return;
+        }
+        /*  Because Jitsi remembers what last call type you joined
+            in browser local storage, we need to specify that video
+            should not be muted in the video call case, or your
+            next call will also join without video after joining an
+            audio-only call.
 
-               This has the annoying downside that it requires users
-               who have a personal preference to disable video every
-               time, but Jitsi's UI makes that very easy to do, and
-               that inconvenience is probably less important than letting
-               the person organizing a call specify their intended
-               call type (video vs audio).
-           */
-            insert_video_call_url(
-                video_call_link + "#config.startWithVideoMuted=false",
-                $target_textarea,
-            );
+            This has the annoying downside that it requires users
+            who have a personal preference to disable video every
+            time, but Jitsi's UI makes that very easy to do, and
+            that inconvenience is probably less important than letting
+            the person organizing a call specify their intended
+            call type (video vs audio).
+        */
+        const video_muted = is_audio_call ? "true" : "false";
+        video_call_url.hash = `config.startWithVideoMuted=${video_muted}`;
+        const video_call_link = video_call_url.toString();
+
+        if (is_audio_call) {
+            insert_audio_call_url(video_call_link, $target_textarea);
+        } else {
+            insert_video_call_url(video_call_link, $target_textarea);
         }
     }
 }


### PR DESCRIPTION
The previous implementation used string concatenation for Jitsi meeting URLs and configuration fragments. This replaces that logic with the modern `new URL` API for better readability and maintainability.

<!-- Describe your pull request here.-->
Changes included:

- Replaced manual string concatenation in `web/src/compose_call_ui.ts` with the modern `new URL()` API.

- Refactored the configuration fragment logic to use `url.hash` for better readability.

- Deduplicated the URL generation logic by using a ternary operator for the `startWithVideoMuted` parameter.

- Preserved the existing technical comments regarding Jitsi's local storage behavior.

Fixes: <!-- Issue link, or clear description.-->
Addresses the `TODO` in `web/src/compose_call_ui.ts` regarding `new URL` migration.

**How changes were tested:**
- Manual Test: Verified in a local development environment that clicking the "Video Call" and "Audio Call" icons correctly generates links in the compose box.

- Functionality Test: Confirmed that clicking the generated links opens Jitsi with the correct parameters (e.g., `#config.startWithVideoMuted=true` for audio calls).

- Linter: Ran `./tools/lint` and `./tools/prettier` to ensure compliance with Zulip's style guide.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
The following screenshots show correct link generation and functioning:

#### 1. New URL generation with different `startWithVideoMuted` parameter.
<img width="940" height="165" alt="Generated Jitsi link in compose box showing modern URL structure" src="https://github.com/user-attachments/assets/aa6c00cb-a0bb-40e4-8ee9-6907dacb8809" />


#### 2. Successful connection to the Jitsi meeting with the camera correctly enabled for video call
<img width="940" height="485" alt="Jitsi video call interface with camera active" src="https://github.com/user-attachments/assets/dc1e55bb-906a-48ac-b11a-abd01c478f16" />


#### 3. Successful connection to the Jitsi meeting with the camera correctly disabled for audio call
<img width="940" height="484" alt="Jitsi audio call interface with camera disabled by default" src="https://github.com/user-attachments/assets/110d001c-729e-45f4-9912-186c0091be06" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
