### PR TITLE
alert_words: Highlight and notify for alert words in channel/topic li…

### DIFF
--- a/web/src/alert_words.ts
+++ b/web/src/alert_words.ts
@@ -1,9 +1,9 @@
 import _ from "lodash";
 
-import type {Message} from "./message_store.ts";
+import type { Message } from "./message_store.ts";
 import * as message_store from "./message_store.ts";
 import * as people from "./people.ts";
-import type {StateData} from "./state_data.ts";
+import type { StateData } from "./state_data.ts";
 
 // For simplicity, we use a list for our internal
 // data, since that matches what the server sends us.
@@ -18,12 +18,12 @@ export function set_words(words: string[]): void {
     my_alert_words.sort((a, b) => b.length - a.length);
 }
 
-export function get_word_list(): {word: string}[] {
+export function get_word_list(): { word: string }[] {
     // Returns a array of objects
     // (with each alert_word as value and 'word' as key to the object.)
     const words = [];
     for (const word of my_alert_words) {
-        words.push({word});
+        words.push({ word });
     }
     return words;
 }
@@ -53,8 +53,8 @@ export function process_message(message: Message): void {
             /["&'<>]/g,
             (c) => alert_regex_replacements.get(c)!,
         );
-        const before_punctuation = "\\s|^|>|[\\(\\\".,';\\[]";
-        const after_punctuation = "(?=\\s)|$|<|[\\)\\\"\\?!:.,';\\]!]";
+        const before_punctuation = "\\s|^|>|[\\(\\\".,';\\[#@*`]";
+        const after_punctuation = "(?=\\s)|$|<|[\\)\\\"\\?!:.,';\\]!*`]";
 
         const regex = new RegExp(`(${before_punctuation})(${clean})(${after_punctuation})`, "ig");
         const updated_content = message.content.replace(

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1941,7 +1941,7 @@ def possible_linked_topics(content: str) -> set[ChannelTopicInfo]:
 
 
 class AlertWordNotificationProcessor(markdown.preprocessors.Preprocessor):
-    allowed_before_punctuation = {" ", "\n", "(", '"', ".", ",", "'", ";", "[", "*", "`", ">"}
+    allowed_before_punctuation = {" ", "\n", "(", '"', ".", ",", "'", ";", "[", "*", "`", ">", "#", "@"}
     allowed_after_punctuation = {
         " ",
         "\n",


### PR DESCRIPTION
Problem
Currently, alert words are not highlighted or matched for notifications when they appear inside channel links (e.g., #**GSoC**) or stream-topic links (e.g., #**GSoC > project ideas**). This is because the # character was not included in the "allowed before punctuation" set for alert word boundaries. Similarly, alert words used at the start of a mention (e.g., via @) were not being caught.

Solution
This PR updates the alert word boundary logic in both the frontend and backend:

Frontend Highlighting (
web/src/alert_words.ts
):
Added #, @, *, and ` to before_punctuation.
Added * and ` to after_punctuation to maintain consistency with the server-side logic.
This ensures that when a message is rendered, alert words within channel/topic links are correctly wrapped in <span class='alert-word'>.
Backend Notifications (
zerver/lib/markdown/
init
.py
):
Added # and @ to allowed_before_punctuation in the 
AlertWordNotificationProcessor
.
This ensures that the server correctly identifies alert words in the raw Markdown and triggers the appropriate notifications for users.
Testing
Verified the logic using standalone scripts for both Python and Javascript to ensure that:

Alert words match when preceded by # or @.
Alert words do not match when they are part of a larger alphanumeric word (e.g., myGSoC).
Highlighting does not occur inside HTML attributes (e.g., <a title="#GSoC">).
