### PR TITLE
compose: Make typeahead hint more semantic.

### DIFF
--- a/web/templates/topic_typeahead_hint.hbs
+++ b/web/templates/topic_typeahead_hint.hbs
@@ -6,12 +6,12 @@
     {{/if}}
 {{else if (eq contains_dm "some")}}
     {{#if can_create_new_topics_in_stream}}
-    <em>{{t 'Start or select a topic, or switch to DM.' }}</em>
+    <em>{{t 'Start or continue a topic, or switch to DM.' }}</em>
     {{else}}
-    <em>{{t 'Select a topic, or switch to DM.' }}</em>
+    <em>{{t 'Continue a conversation or switch to DM.' }}</em>
     {{/if}}
 {{else if can_create_new_topics_in_stream}}
-    <em>{{t 'Start a new topic or select one from the list.' }}</em>
+    <em>{{t 'Start a new topic or continue a conversation.' }}</em>
 {{else}}
-    <em>{{t 'Select a topic from the list.' }}</em>
+    <em>{{t 'Continue a conversation.' }}</em>
 {{/if}}


### PR DESCRIPTION
Discussed in [#translation > Have clearer instructions when you input the topic / title](https://chat.zulip.org/#narrow/channel/58-translation/topic/Have.20clearer.20instructions.20when.20you.20input.20the.20topic.20.2F.20title/with/2364589).

Most common string:

<img width="418" height="247" alt="Screenshot 2026-02-05 at 15 31 04" src="https://github.com/user-attachments/assets/183de868-3a60-4a39-99a1-9951aba85a35" />

## Alternatives considered
The closest analogue for the string that mentions existing topics, new topics, and DMs is rather long, so I decided to shorten.

### In this PR:

<img width="411" height="209" alt="Screenshot 2026-02-05 at 15 42 35" src="https://github.com/user-attachments/assets/840b2fa4-b344-4f4b-820c-bacb0111246a" />


#### Considered:
<img width="421" height="184" alt="Screenshot 2026-02-05 at 15 31 54" src="https://github.com/user-attachments/assets/033a0395-2a42-4b89-8b8e-3115f8d59c46" />
