### PR TITLE
billing: Rename link to show all invoices.

### DIFF
--- a/templates/corporate/billing/billing.html
+++ b/templates/corporate/billing/billing.html
@@ -320,7 +320,7 @@
                     <h2 class="billing-section-title">Invoices</h2>
                     <div class="billing-section-content">
                         <a href="{{ billing_base_url }}/invoices/">
-                            View past invoices
+                            View invoices
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
This will help users find pending invoices and not confuse this link to only include paid invoices.

| before | after |
| --- | --- |
| <img width="266" height="105" alt="Screenshot from 2026-02-06 09-46-23" src="https://github.com/user-attachments/assets/37ae0882-01bf-4b14-bc3a-ef39bb998f21" /> | <img width="266" height="105" alt="Screenshot from 2026-02-06 09-46-12" src="https://github.com/user-attachments/assets/067186f8-225f-47bc-808d-f1b3db8c07af" /> |
