### PR TITLE
url_preview: Fix YouTube link previews by replacing pyoembed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "micromodal": "^0.6.1",
     "mini-css-extract-plugin": "^2.2.2",
     "minimalistic-assert": "^1.0.1",
+    "oembed-providers": "^1.0.20260222",
     "panzoom": "^9.4.2",
     "plotly.js": "^3.0.0",
     "postcss": "^8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       minimalistic-assert:
         specifier: ^1.0.1
         version: 1.0.1
+      oembed-providers:
+        specifier: ^1.0.20260222
+        version: 1.0.20260222
       panzoom:
         specifier: ^9.4.2
         version: 9.4.4
@@ -7109,6 +7112,9 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  oembed-providers@1.0.20260222:
+    resolution: {integrity: sha512-HXCvPxSgeI8aymDquSq6Uhz+64nZq9knJmeFKgZfAWL+0iv68N1yvmandA3wQfdbnwhDRSw0uZpcFYVOZtgLtA==}
 
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
@@ -17873,6 +17879,8 @@ snapshots:
   obuf@1.1.2: {}
 
   obug@2.1.1: {}
+
+  oembed-providers@1.0.20260222: {}
 
   ofetch@1.5.1:
     dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ prod = [
 
   # Needed for link preview
   "beautifulsoup4",
-  "pyoembed",
   "python-magic",
 
   # The Zulip API bindings, from its own repository.
@@ -446,7 +445,6 @@ module = [
     "ldap.*", # https://github.com/python-ldap/python-ldap/issues/368
     "onelogin.*",
     "pyinotify.*",
-    "pyoembed.*",
     "pyuca.*",
     "pyvips.*",
     "scim2_filter_parser.attr_paths",

--- a/static/.gitignore
+++ b/static/.gitignore
@@ -9,3 +9,5 @@
 /generated/integrations/
 # From emoji
 /generated/emoji
+# Copied from the oembed-providers npm package
+/generated/oembed-providers.json

--- a/tools/lib/provision_inner.py
+++ b/tools/lib/provision_inner.py
@@ -78,6 +78,14 @@ def build_timezones_data_paths() -> list[str]:
     return paths
 
 
+def build_oembed_providers_paths() -> list[str]:
+    paths = [
+        "tools/setup/build_oembed_providers",
+        "pnpm-lock.yaml",
+    ]
+    return paths
+
+
 def build_landing_page_images_paths() -> list[str]:
     paths = ["tools/setup/generate_landing_page_images.py"]
     paths += glob.glob("static/images/landing-page/hello/original/*")
@@ -218,6 +226,16 @@ def need_to_run_build_timezone_data() -> bool:
     )
 
 
+def need_to_run_build_oembed_providers() -> bool:
+    if not os.path.exists("static/generated/oembed-providers.json"):
+        return True
+
+    return is_digest_obsolete(
+        "build_oembed_providers_hash",
+        build_oembed_providers_paths(),
+    )
+
+
 def need_to_regenerate_landing_page_images() -> bool:
     if not os.path.exists("static/images/landing-page/hello/generated"):
         return True
@@ -298,6 +316,15 @@ def main(options: argparse.Namespace) -> int:
         )
     else:
         print("No need to run `tools/setup/build_timezone_values`.")
+
+    if options.is_force or need_to_run_build_oembed_providers():
+        run(["tools/setup/build_oembed_providers"])
+        write_new_digest(
+            "build_oembed_providers_hash",
+            build_oembed_providers_paths(),
+        )
+    else:
+        print("No need to run `tools/setup/build_oembed_providers`.")
 
     if options.is_force or need_to_regenerate_landing_page_images():
         run(["tools/setup/generate_landing_page_images.py"])

--- a/tools/setup/build_oembed_providers
+++ b/tools/setup/build_oembed_providers
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+import os
+import shutil
+
+ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
+SRC_PATH = os.path.join(ZULIP_PATH, "node_modules", "oembed-providers", "providers.json")
+OUT_PATH = os.path.join(ZULIP_PATH, "static", "generated", "oembed-providers.json")
+
+os.makedirs(os.path.dirname(OUT_PATH), exist_ok=True)
+shutil.copyfile(SRC_PATH, OUT_PATH)

--- a/tools/update-prod-static
+++ b/tools/update-prod-static
@@ -42,6 +42,9 @@ run(["./tools/setup/build_pygments_data"])
 # Build time zone data
 run(["./tools/setup/build_timezone_values"])
 
+# Copy over the oEmbed providers list from the oembed-providers npm package
+run(["./tools/setup/build_oembed_providers"])
+
 # Generate supported browser regex used during initial load
 run(["node", "./tools/setup/build_supported_browser_regex.ts"])
 

--- a/uv.lock
+++ b/uv.lock
@@ -3999,17 +3999,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyoembed"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "lxml" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/32/11/7b9549660ae130668cabc886e4012572745508d381cd0005239b082129a8/pyoembed-0.1.2.tar.gz", hash = "sha256:0f755c8308039f1e49238e95ea94ef16aa08add9f32075ba13ab9b65f32ff582", size = 12502, upload-time = "2017-11-17T11:51:21.083Z" }
-
-[[package]]
 name = "pyopenssl"
 version = "26.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6350,7 +6339,6 @@ dev = [
     { name = "pyjwt" },
     { name = "pymongo" },
     { name = "pynacl" },
-    { name = "pyoembed" },
     { name = "python-binary-memcached" },
     { name = "python-bsonstream" },
     { name = "python-dateutil" },
@@ -6481,7 +6469,6 @@ prod = [
     { name = "pyjwt" },
     { name = "pymongo" },
     { name = "pynacl" },
-    { name = "pyoembed" },
     { name = "python-binary-memcached" },
     { name = "python-bsonstream" },
     { name = "python-dateutil" },
@@ -6596,7 +6583,6 @@ dev = [
     { name = "pyjwt" },
     { name = "pymongo" },
     { name = "pynacl" },
-    { name = "pyoembed" },
     { name = "python-binary-memcached" },
     { name = "python-bsonstream", specifier = ">=0.1.4" },
     { name = "python-dateutil" },
@@ -6729,7 +6715,6 @@ prod = [
     { name = "pyjwt" },
     { name = "pymongo" },
     { name = "pynacl" },
-    { name = "pyoembed" },
     { name = "python-binary-memcached" },
     { name = "python-bsonstream", specifier = ">=0.1.4" },
     { name = "python-dateutil" },

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 502
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (378, 1)  # bumped to add oembed-providers dependency
+PROVISION_VERSION = (379, 0)  # bumped 2026-05-08 to remove pyoembed dependency

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 502
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (378, 0)  # bumped 2026-05-07 to remove litellm
+PROVISION_VERSION = (378, 1)  # bumped to add oembed-providers dependency

--- a/zerver/lib/url_preview/oembed.py
+++ b/zerver/lib/url_preview/oembed.py
@@ -1,15 +1,115 @@
 import json
+import re
+from typing import Any, cast
+from urllib.parse import urlsplit, urlunsplit
 
+import orjson
 import requests
-from pyoembed import PyOembedException, oEmbed
 
+from zerver.lib.storage import static_path
 from zerver.lib.url_preview.types import UrlEmbedData, UrlOEmbedData
 
 
-def get_oembed_data(url: str, maxwidth: int = 640, maxheight: int = 480) -> UrlEmbedData | None:
+def load_oembed_providers() -> list[dict[str, Any]]:
+    # Load the list of the official providers from https://oembed.com/providers.json,
+    # as maintained in the `oembed-providers` npm package.
+    with open(static_path("generated/oembed-providers.json"), "rb") as f:
+        return cast(list[dict[str, Any]], orjson.loads(f.read()))
+
+
+def scheme_to_regex(scheme: str) -> str:
+    # The provider list uses `*` as a wildcard, and a leading `://*.` to mean
+    # "with or without a leading subdomain".  Schemes are written with a
+    # single protocol, but oEmbed traffic may use either http or https, so
+    # accept both.
+    host_variants = [scheme]
+    if "://*." in scheme:
+        host_variants.append(scheme.replace("://*.", "://", 1))
+
+    variants: list[str] = []
+    for variant in host_variants:
+        variants.append(variant)
+        if variant.startswith("https://"):
+            variants.append("http://" + variant[len("https://") :])
+        elif variant.startswith("http://"):
+            variants.append("https://" + variant[len("http://") :])
+
+    patterns = []
+    for variant in variants:
+        pattern = re.escape(variant).replace(r"\*", ".*")
+        if not variant.endswith("*"):
+            pattern += "$"
+        patterns.append(pattern)
+
+    return "(?:" + "|".join(patterns) + ")"
+
+
+def compile_oembed_providers(providers: list[dict[str, Any]]) -> dict[re.Pattern[str], str]:
+    endpoint_map: dict[re.Pattern[str], str] = {}
+
+    for provider in providers:
+        for endpoint in provider.get("endpoints", []):
+            schemes = endpoint.get("schemes", [])
+            endpoint_url = endpoint.get("url")
+
+            if not schemes or not endpoint_url:
+                continue
+
+            formatted_endpoint = endpoint_url.replace("{format}", "json")
+            joined_patterns = "|".join(scheme_to_regex(s) for s in schemes)
+            regex_str = f"(?:{joined_patterns})"
+
+            compiled_regex = re.compile(regex_str)
+            endpoint_map[compiled_regex] = formatted_endpoint
+
+    return endpoint_map
+
+
+OEMBED_PROVIDERS = load_oembed_providers()
+OEMBED_ENDPOINT_MAP = compile_oembed_providers(OEMBED_PROVIDERS)
+
+
+def get_oembed_endpoint(url: str) -> str | None:
+    # Lowercase the scheme and host so that e.g. HTTPS://YOUTUBE.COM/... still
+    # matches, but leave the path and query alone so that case-sensitive
+    # tokens like literal `?v=` query keys in provider schemes are respected.
+    parsed = urlsplit(url)
+    normalized_url = urlunsplit(
+        parsed._replace(scheme=parsed.scheme.lower(), netloc=parsed.netloc.lower())
+    )
+    for compiled_regex, endpoint_url in OEMBED_ENDPOINT_MAP.items():
+        if compiled_regex.match(normalized_url):
+            return endpoint_url
+    return None
+
+
+def get_oembed_data(
+    url: str,
+    maxwidth: int = 640,
+    maxheight: int = 480,
+    session: requests.Session | None = None,
+) -> UrlEmbedData | None:
+    endpoint = get_oembed_endpoint(url)
+    if endpoint is None:
+        return None
+
+    if session is None:
+        from zerver.lib.url_preview.preview import PreviewSession
+
+        session = PreviewSession()
+
+    params: dict[str, str | int] = {
+        "url": url,
+        "maxwidth": maxwidth,
+        "maxheight": maxheight,
+    }
+
     try:
-        data = oEmbed(url, maxwidth=maxwidth, maxheight=maxheight)
-    except (PyOembedException, json.decoder.JSONDecodeError, requests.exceptions.ConnectionError):
+        response = session.get(endpoint, params=params)
+        if not response.ok:
+            return None
+        data = response.json()
+    except (requests.RequestException, json.JSONDecodeError):
         return None
 
     oembed_resource_type = data.get("type", "")
@@ -32,9 +132,8 @@ def get_oembed_data(url: str, maxwidth: int = 640, maxheight: int = 480) -> UrlE
             title=data.get("title"),
             description=data.get("description"),
         )
-
-    # Otherwise, use the title/description from pyembed as the basis
-    # for our other parsers
+    # For unsupported oEmbed types (e.g. "link"),
+    # return basic metadata to seed the merge.
     return UrlEmbedData(
         title=data.get("title"),
         description=data.get("description"),

--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -32,7 +32,6 @@ ZULIP_URL_PREVIEW_USER_AGENT = (
     f"Mozilla/5.0 (compatible; ZulipURLPreview/{ZULIP_VERSION}; +{settings.ROOT_DOMAIN_URI})"
 )
 
-# FIXME: This header and timeout are not used by pyoembed, when trying to autodiscover!
 HEADERS = {"User-Agent": ZULIP_URL_PREVIEW_USER_AGENT}
 TIMEOUT = 15
 
@@ -91,10 +90,6 @@ def get_link_embed_data(url: str, maxwidth: int = 640, maxheight: int = 480) -> 
     if not valid_content_type(url):
         return None
 
-    # The oembed data from pyoembed may be complete enough to return
-    # as-is; if so, we use it.  Otherwise, we use it as a _base_ for
-    # the other, less sophisticated techniques which we apply as
-    # successive fallbacks.
     data = get_oembed_data(url, maxwidth=maxwidth, maxheight=maxheight)
     if data is not None and isinstance(data, UrlOEmbedData):
         return data

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -1,13 +1,12 @@
 import re
 from collections import OrderedDict
-from typing import Any
+from typing import Any, cast
 from unittest import mock
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from urllib.parse import urlencode
 
 import responses
 from django.test import override_settings
 from django.utils.html import escape
-from pyoembed.providers import get_provider
 from requests.exceptions import ConnectionError
 from typing_extensions import override
 
@@ -17,7 +16,13 @@ from zerver.lib.camo import get_camo_url
 from zerver.lib.queue import queue_json_publish_rollback_unsafe
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import mock_queue_publish
-from zerver.lib.url_preview.oembed import get_oembed_data, strip_cdata
+from zerver.lib.url_preview.oembed import (
+    compile_oembed_providers,
+    get_oembed_data,
+    get_oembed_endpoint,
+    scheme_to_regex,
+    strip_cdata,
+)
 from zerver.lib.url_preview.parsers import GenericParser, OpenGraphParser
 from zerver.lib.url_preview.preview import get_link_embed_data
 from zerver.lib.url_preview.types import UrlEmbedData, UrlOEmbedData
@@ -25,143 +30,129 @@ from zerver.models import Message, Realm, UserMessage, UserProfile
 from zerver.worker.embed_links import FetchLinksEmbedData
 
 
-def reconstruct_url(url: str, maxwidth: int = 640, maxheight: int = 480) -> str:
-    # The following code is taken from
-    # https://github.com/rafaelmartins/pyoembed/blob/master/pyoembed/__init__.py.
-    # This is a helper function which will be indirectly use to mock the HTTP responses.
-    provider = get_provider(str(url))
-    oembed_url = provider.oembed_url(url)
-    scheme, netloc, path, query_string, fragment = urlsplit(oembed_url)
-
-    query_params = OrderedDict(parse_qsl(query_string))
+def get_oembed_api_url(endpoint: str, url: str, maxwidth: int = 640, maxheight: int = 480) -> str:
+    # Build the oEmbed API URL for a given endpoint and content URL.
+    query_params = OrderedDict()
+    query_params["url"] = url
     query_params["maxwidth"] = str(maxwidth)
     query_params["maxheight"] = str(maxheight)
-    final_url = urlunsplit((scheme, netloc, path, urlencode(query_params, True), fragment))
-    return final_url
+
+    return endpoint + "?" + urlencode(query_params, True)
 
 
 @override_settings(INLINE_URL_EMBED_PREVIEW=True)
 class OembedTestCase(ZulipTestCase):
     @responses.activate
-    def test_present_provider(self) -> None:
+    def test_unsupported_resource_type(self) -> None:
         response_data = {
             "type": "rich",
-            "thumbnail_url": "https://scontent.cdninstagram.com/t51.2885-15/n.jpg",
-            "thumbnail_width": 640,
-            "thumbnail_height": 426,
             "title": "NASA",
             "html": "<p>test</p>",
             "version": "1.0",
             "width": 658,
             "height": 400,
         }
-        url = "http://instagram.com/p/BLtI2WdAymy"
-        reconstructed_url = reconstruct_url(url)
-        responses.add(
-            responses.GET,
-            reconstructed_url,
-            json=response_data,
-            status=200,
-        )
+        url = "https://www.youtube.com/watch?v=BLtI2WdAymy"
+        api_url = get_oembed_api_url("https://www.youtube.com/oembed", url)
+        responses.add(responses.GET, api_url, json=response_data, status=200)
 
         data = get_oembed_data(url)
         assert data is not None
         self.assertIsInstance(data, UrlEmbedData)
-        self.assertEqual(data.title, response_data["title"])
+        self.assertEqual(data.title, "NASA")
 
     @responses.activate
-    def test_photo_provider(self) -> None:
-        response_data = {
-            "type": "photo",
-            "thumbnail_url": "https://scontent.cdninstagram.com/t51.2885-15/n.jpg",
-            "url": "https://scontent.cdninstagram.com/t51.2885-15/n.jpg",
-            "thumbnail_width": 640,
-            "thumbnail_height": 426,
-            "title": "NASA",
-            "html": "<p>test</p>",
-            "version": "1.0",
-            "width": 658,
-            "height": 400,
-        }
-        # pyoembed.providers.imgur only works with http:// URLs, not https:// (!)
-        url = "http://imgur.com/photo/158727223"
-        reconstructed_url = reconstruct_url(url)
-        responses.add(
-            responses.GET,
-            reconstructed_url,
-            json=response_data,
-            status=200,
-        )
+    def test_supported_photo_and_video_resource_types(self) -> None:
+        test_cases: list[dict[str, Any]] = [
+            {
+                "name": "photo",
+                "url": "https://www.flickr.com/photos/bees/2341623661/",
+                "response_data": {
+                    "type": "photo",
+                    "url": "https://live.staticflickr.com/3123/2341623661_7c99f48bbf_b.jpg",
+                    "thumbnail_width": 640,
+                    "thumbnail_height": 426,
+                    "title": "Flickr Test Image",
+                    "version": "1.0",
+                    "width": 658,
+                    "height": 400,
+                },
+                "expected_title": "Flickr Test Image",
+                "expected_type": "photo",
+                "expected_image": "https://live.staticflickr.com/3123/2341623661_7c99f48bbf_b.jpg",
+                "expected_html": None,
+            },
+            {
+                "name": "video",
+                "url": "https://vimeo.com/158727223",
+                "response_data": {
+                    "type": "video",
+                    "thumbnail_url": "https://i.vimeocdn.com/video/590587169-640x360.jpg",
+                    "thumbnail_width": 480,
+                    "thumbnail_height": 360,
+                    "title": "Vimeo Test Video",
+                    "html": '<![CDATA[<iframe src="https://player.vimeo.com/video/158727223" width="480" height="270" frameborder="0"></iframe>]]>',
+                    "version": "1.0",
+                    "width": 480,
+                    "height": 270,
+                },
+                "expected_title": "Vimeo Test Video",
+                "expected_type": "video",
+                "expected_image": "https://i.vimeocdn.com/video/590587169-640x360.jpg",
+                "expected_html": '<iframe src="https://player.vimeo.com/video/158727223" width="480" height="270" frameborder="0"></iframe>',
+            },
+        ]
 
-        data = get_oembed_data(url)
-        assert data is not None
-        self.assertIsInstance(data, UrlOEmbedData)
-        self.assertEqual(data.title, response_data["title"])
+        for case in test_cases:
+            with self.subTest(case_name=case["name"]):
+                responses.reset()
+                url = cast(str, case["url"])
+                response_data = cast(dict[str, Any], case["response_data"])
+                expected_type = cast(str, case["expected_type"])
+                expected_title = cast(str, case["expected_title"])
+                expected_image = cast(str, case["expected_image"])
+                expected_html = cast(str | None, case["expected_html"])
 
-    @responses.activate
-    def test_video_provider(self) -> None:
-        response_data = {
-            "type": "video",
-            "thumbnail_url": "https://scontent.cdninstagram.com/t51.2885-15/n.jpg",
-            "thumbnail_width": 640,
-            "thumbnail_height": 426,
-            "title": "NASA",
-            "html": "<p>test</p>",
-            "version": "1.0",
-            "width": 658,
-            "height": 400,
-        }
-        url = "http://blip.tv/video/158727223"
-        reconstructed_url = reconstruct_url(url)
-        responses.add(
-            responses.GET,
-            reconstructed_url,
-            json=response_data,
-            status=200,
-        )
+                endpoint = get_oembed_endpoint(url)
+                assert endpoint is not None
+                api_url = get_oembed_api_url(endpoint, url)
+                responses.add(responses.GET, api_url, json=response_data, status=200)
 
-        data = get_oembed_data(url)
-        assert data is not None
-        self.assertIsInstance(data, UrlOEmbedData)
-        self.assertEqual(data.title, response_data["title"])
-
-    @responses.activate
-    def test_connect_error_request(self) -> None:
-        url = "http://instagram.com/p/BLtI2WdAymy"
-        reconstructed_url = reconstruct_url(url)
-        responses.add(responses.GET, reconstructed_url, body=ConnectionError())
-        data = get_oembed_data(url)
-        self.assertIsNone(data)
-
-    @responses.activate
-    def test_400_error_request(self) -> None:
-        url = "http://instagram.com/p/BLtI2WdAymy"
-        reconstructed_url = reconstruct_url(url)
-        responses.add(responses.GET, reconstructed_url, status=400)
-        data = get_oembed_data(url)
-        self.assertIsNone(data)
+                data = get_oembed_data(url)
+                assert data is not None
+                self.assertIsInstance(data, UrlOEmbedData)
+                self.assertEqual(data.type, expected_type)
+                self.assertEqual(data.title, expected_title)
+                self.assertEqual(data.image, expected_image)
+                self.assertEqual(data.html, expected_html)
 
     @responses.activate
-    def test_500_error_request(self) -> None:
-        url = "http://instagram.com/p/BLtI2WdAymy"
-        reconstructed_url = reconstruct_url(url)
-        responses.add(responses.GET, reconstructed_url, status=500)
-        data = get_oembed_data(url)
-        self.assertIsNone(data)
+    def test_request_error_responses(self) -> None:
+        url = "https://www.youtube.com/watch?v=BLtI2WdAymy"
+        api_url = get_oembed_api_url("https://www.youtube.com/oembed", url)
+
+        error_cases: list[tuple[str, dict[str, Any]]] = [
+            ("connection_error", {"body": ConnectionError()}),
+            ("status_400", {"status": 400}),
+            ("status_500", {"status": 500}),
+            (
+                "invalid_json",
+                {
+                    "body": "{invalid json}",
+                    "content_type": "application/json",
+                    "status": 200,
+                },
+            ),
+        ]
+
+        for case_name, response_kwargs in error_cases:
+            with self.subTest(case_name=case_name):
+                responses.reset()
+                responses.add(responses.GET, api_url, **response_kwargs)
+                data = get_oembed_data(url)
+                self.assertIsNone(data)
 
     @responses.activate
-    def test_invalid_json_in_response(self) -> None:
-        url = "http://instagram.com/p/BLtI2WdAymy"
-        reconstructed_url = reconstruct_url(url)
-        responses.add(
-            responses.GET,
-            reconstructed_url,
-            json="{invalid json}",
-            status=200,
-        )
-        data = get_oembed_data(url)
-        self.assertIsNone(data)
-
     def test_oembed_html(self) -> None:
         html = '<iframe src="//www.instagram.com/embed.js"></iframe>'
         stripped_html = strip_cdata(html)
@@ -172,6 +163,267 @@ class OembedTestCase(ZulipTestCase):
         html = f"<![CDATA[{iframe_content}]]>"
         stripped_html = strip_cdata(html)
         self.assertEqual(iframe_content, stripped_html)
+
+    def test_scheme_to_regex(self) -> None:
+        test_cases: list[dict[str, Any]] = [
+            {
+                "name": "wildcard_subdomain",
+                "scheme": "https://*.youtube.com/watch*",
+                "match_urls": [
+                    "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                    "https://m.youtube.com/watch?v=dQw4w9WgXcQ",
+                    "https://youtube.com/watch?v=dQw4w9WgXcQ",
+                    "http://youtube.com/watch?v=dQw4w9WgXcQ",
+                ],
+                "non_match_urls": ["https://youtube.com/v/dQw4w9WgXcQ"],
+            },
+            {
+                "name": "literal_plus_in_query",
+                "scheme": "https://example.com/watch?v=*&list=+",
+                "match_urls": ["https://example.com/watch?v=abc&list=+"],
+                "non_match_urls": ["https://example.com/watch?v=abc&list=something"],
+            },
+            {
+                "name": "anchors_non_wildcard_path",
+                "scheme": "https://example.com/watch",
+                "match_urls": ["https://example.com/watch", "http://example.com/watch"],
+                "non_match_urls": ["https://example.com/watch/extra"],
+            },
+            {
+                "name": "case_sensitive_path",
+                "scheme": "https://example.com/watch?v=*",
+                "match_urls": ["https://example.com/watch?v=abc"],
+                "non_match_urls": ["https://example.com/watch?V=abc"],
+            },
+        ]
+
+        for case in test_cases:
+            with self.subTest(case_name=case["name"]):
+                regex = scheme_to_regex(cast(str, case["scheme"]))
+                for url in cast(list[str], case["match_urls"]):
+                    self.assertIsNotNone(re.match(regex, url))
+                for url in cast(list[str], case["non_match_urls"]):
+                    self.assertIsNone(re.match(regex, url))
+
+    def test_oembed_endpoint_with_existing_query_param(self) -> None:
+        # hearthis.at's endpoint already contains ?format=json.
+        # Verify that session.get(endpoint, params=params) appends additional
+        # parameters with & instead of ?, producing a valid URL.
+        endpoint = get_oembed_endpoint("https://hearthis.at/some-artist/some-track/")
+        assert endpoint is not None
+        self.assertIn("?", endpoint)
+
+        url = "https://hearthis.at/some-artist/some-track/"
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.GET,
+                "https://hearthis.at/oembed/",
+                json={"type": "rich", "title": "Test Track", "version": "1.0"},
+                status=200,
+            )
+            get_oembed_data(url)
+            self.assert_length(rsps.calls, 1)
+            called_url = rsps.calls[0].request.url
+            assert called_url is not None
+            self.assertEqual(called_url.count("?"), 1)
+            self.assertIn("url=", called_url)
+            self.assertIn("maxwidth=", called_url)
+
+    def test_unknown_provider_returns_none(self) -> None:
+        url = "https://unknown-site.example.com/page"
+        data = get_oembed_data(url)
+        self.assertIsNone(data)
+
+    def test_compile_oembed_providers_missing_endpoint(self) -> None:
+        mock_providers: list[dict[str, Any]] = [
+            {
+                "provider_name": "TestProvider",
+                "endpoints": [
+                    {
+                        "schemes": [
+                            "https://*.example.com/watch*",
+                            "https://example.com/watch?v=*&list=+",
+                        ],
+                        "url": "https://example.com/oembed",
+                    }
+                ],
+            },
+            {"provider_name": "MissingEndpoints"},
+            {
+                "provider_name": "MissingSchemes",
+                "endpoints": [{"url": "https://invalid.example.com/oembed"}],
+            },
+            {
+                "provider_name": "MissingEndpointUrl",
+                "endpoints": [{"schemes": ["https://missing-url.example.com/*"]}],
+            },
+        ]
+
+        endpoint_map = compile_oembed_providers(mock_providers)
+        self.assert_length(endpoint_map, 1)
+        [(compiled_regex, endpoint_url)] = endpoint_map.items()
+        self.assertEqual(endpoint_url, "https://example.com/oembed")
+
+        regex_match_cases = [
+            ("https://www.example.com/watch?v=123", True),
+            ("https://example.com/watch?v=123&list=+", True),
+            ("https://example.com/v/123", False),
+        ]
+        for url, should_match in regex_match_cases:
+            with self.subTest(url=url):
+                self.assertEqual(compiled_regex.match(url) is not None, should_match)
+
+    def test_compile_oembed_providers_format_and_http_normalization(self) -> None:
+        mock_providers: list[dict[str, Any]] = [
+            {
+                "provider_name": "FormatAndSchemeVariants",
+                "endpoints": [
+                    {
+                        "schemes": ["https://example.com/watch/*"],
+                        "url": "https://example.com/oembed.{format}",
+                    }
+                ],
+            }
+        ]
+
+        mock_map = compile_oembed_providers(mock_providers)
+
+        with mock.patch("zerver.lib.url_preview.oembed.OEMBED_ENDPOINT_MAP", mock_map):
+            test_cases = [
+                ("https://example.com/watch/123", "https://example.com/oembed.json"),
+                ("http://example.com/watch/123", "https://example.com/oembed.json"),
+            ]
+            for url, expected_endpoint in test_cases:
+                with self.subTest(url=url):
+                    self.assertEqual(get_oembed_endpoint(url), expected_endpoint)
+
+    def test_compile_oembed_providers_wildcard_matches_bare_domain(self) -> None:
+        mock_providers: list[dict[str, Any]] = [
+            {
+                "provider_name": "WildcardSubdomain",
+                "endpoints": [
+                    {
+                        "schemes": ["https://*.example.com/watch/*"],
+                        "url": "https://example.com/oembed",
+                    }
+                ],
+            }
+        ]
+
+        mock_map = compile_oembed_providers(mock_providers)
+
+        with mock.patch("zerver.lib.url_preview.oembed.OEMBED_ENDPOINT_MAP", mock_map):
+            self.assertEqual(
+                get_oembed_endpoint("https://media.example.com/watch/123"),
+                "https://example.com/oembed",
+            )
+            self.assertEqual(
+                get_oembed_endpoint("https://example.com/watch/123"),
+                "https://example.com/oembed",
+            )
+
+    def test_get_oembed_endpoint_provider_matches(self) -> None:
+        test_cases = [
+            ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", "https://www.youtube.com/oembed"),
+            ("http://www.youtube.com/watch?v=dQw4w9WgXcQ", "https://www.youtube.com/oembed"),
+            ("HTTPS://YOUTUBE.COM/watch?v=dQw4w9WgXcQ", "https://www.youtube.com/oembed"),
+            ("https://youtube.com/watch?v=dQw4w9WgXcQ", "https://www.youtube.com/oembed"),
+            ("https://youtu.be/dQw4w9WgXcQ", "https://www.youtube.com/oembed"),
+            ("https://www.youtube.com/v/dQw4w9WgXcQ", "https://www.youtube.com/oembed"),
+            ("https://www.youtube.com/embed/dQw4w9WgXcQ", "https://www.youtube.com/oembed"),
+            ("https://www.youtube.com/shorts/dQw4w9WgXcQ", "https://www.youtube.com/oembed"),
+            ("https://vimeo.com/123456789", "https://vimeo.com/api/oembed.json"),
+            ("http://vimeo.com/123456789", "https://vimeo.com/api/oembed.json"),
+            ("https://open.spotify.com/track/abc123", "https://open.spotify.com/oembed"),
+            ("http://open.spotify.com/track/abc123", "https://open.spotify.com/oembed"),
+            ("https://soundcloud.com/artist/track", "https://soundcloud.com/oembed"),
+            ("http://soundcloud.com/artist/track", "https://soundcloud.com/oembed"),
+        ]
+        for url, expected_endpoint in test_cases:
+            with self.subTest(url=url):
+                self.assertEqual(get_oembed_endpoint(url), expected_endpoint)
+
+    def test_get_oembed_endpoint_case_sensitivity(self) -> None:
+        mock_providers: list[dict[str, Any]] = [
+            {
+                "provider_name": "TestProvider",
+                "endpoints": [
+                    {
+                        "schemes": ["https://*.example.com/watch?v=*"],
+                        "url": "https://example.com/oembed",
+                    }
+                ],
+            }
+        ]
+        mock_map = compile_oembed_providers(mock_providers)
+
+        with mock.patch("zerver.lib.url_preview.oembed.OEMBED_ENDPOINT_MAP", mock_map):
+            self.assertEqual(
+                get_oembed_endpoint("HTTPS://WWW.EXAMPLE.COM/watch?v=dQw4w9WgXcQ"),
+                "https://example.com/oembed",
+            )
+            self.assertIsNone(get_oembed_endpoint("https://example.com/watch?V=dQw4w9WgXcQ"))
+
+    def test_get_oembed_endpoint_matches_first_provider(self) -> None:
+        # When two providers match the same URL, the first one registered is preferred.
+        mock_providers: list[dict[str, Any]] = [
+            {
+                "provider_name": "GenericProvider",
+                "endpoints": [
+                    {
+                        "schemes": ["https://example.com/*"],
+                        "url": "https://generic.example.com/oembed",
+                    }
+                ],
+            },
+            {
+                "provider_name": "SpecificProvider",
+                "endpoints": [
+                    {
+                        "schemes": ["https://example.com/video/*"],
+                        "url": "https://specific.example.com/oembed",
+                    }
+                ],
+            },
+        ]
+
+        mock_map = compile_oembed_providers(mock_providers)
+
+        with mock.patch("zerver.lib.url_preview.oembed.OEMBED_ENDPOINT_MAP", mock_map):
+            self.assertEqual(
+                get_oembed_endpoint("https://example.com/video/123"),
+                "https://generic.example.com/oembed",
+            )
+
+    def test_get_oembed_endpoint_skips_malformed_provider(self) -> None:
+        mock_providers: list[dict[str, Any]] = [
+            {"provider_name": "MissingEndpoints"},
+            {
+                "provider_name": "MissingSchemes",
+                "endpoints": [{"url": "https://invalid.example.com/oembed"}],
+            },
+            {
+                "provider_name": "EmptySchemes",
+                "endpoints": [{"schemes": [], "url": "https://invalid.example.com/oembed"}],
+            },
+            {
+                "provider_name": "Valid",
+                "endpoints": [
+                    {
+                        "schemes": ["https://example.com/video/*"],
+                        "url": "https://specific.example.com/oembed",
+                    }
+                ],
+            },
+        ]
+
+        mock_map = compile_oembed_providers(mock_providers)
+
+        with mock.patch("zerver.lib.url_preview.oembed.OEMBED_ENDPOINT_MAP", mock_map):
+            self.assertEqual(
+                get_oembed_endpoint("https://example.com/video/123"),
+                "https://specific.example.com/oembed",
+            )
 
 
 class OpenGraphParserTestCase(ZulipTestCase):


### PR DESCRIPTION
YouTube's bot detection blocks the request from cloud provider IPs, causing the autodiscover request to fail and return incorrect metadata.

Fixes: #31891

Replace pyoembed with a custom implementation that directly calls oEmbed endpoints using a list of providers (`oembed_providers.json`).

- URLs not in the provider list return `None` from `get_oembed_data()`, falling back to OpenGraph/meta tag parsing (same as before for unknown providers)

**How changes were tested:**
- Tested on AWS CloudShell to verify the fix works on cloud provider IPs

**Screenshots and screen captures:**

**AWS CloudShell test output:**
<img width="909" height="872" alt="Screenshot 2026-02-06 125503" src="https://github.com/user-attachments/assets/ac19f35e-94cd-423d-80c6-b2857a666469" />

**Local test output:**
<img width="917" height="712" alt="Screenshot 2026-02-06 125143" src="https://github.com/user-attachments/assets/761f5951-888d-4724-8b25-01255d9973c8" />

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:
- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>