### PR TITLE
keyboard_ui: Fix overscroll on long drafts during keyboard navigation. #35038

### DIFF
--- a/web/src/scroll_util.ts
+++ b/web/src/scroll_util.ts
@@ -5,6 +5,58 @@ import * as util from "./util.ts";
 
 // This type is helpful for testing, where we may have a dummy object instead of an actual jquery object.
 type JQueryOrZJQuery = {__zjquery?: true} & JQuery;
+type OffsetLike = {top: number};
+
+function has_numeric_length(value: unknown): value is {length: number} {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        typeof Reflect.get(value, "length") === "number"
+    );
+}
+
+function has_get_bounding_client_rect(
+    value: unknown,
+): value is {getBoundingClientRect: () => DOMRect} {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        typeof Reflect.get(value, "getBoundingClientRect") === "function"
+    );
+}
+
+function has_contains(value: unknown): value is {contains: (node: Node) => boolean} {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        typeof Reflect.get(value, "contains") === "function"
+    );
+}
+
+function has_offset_element(
+    value: unknown,
+): value is {offset: () => OffsetLike | undefined; innerHeight: () => number | undefined} {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        typeof Reflect.get(value, "offset") === "function" &&
+        typeof Reflect.get(value, "innerHeight") === "function"
+    );
+}
+
+function has_offset_container(value: unknown): value is {
+    offset: () => OffsetLike | undefined;
+    height: () => number | undefined;
+    scrollTop: (arg?: number) => number | JQueryOrZJQuery;
+} {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        typeof Reflect.get(value, "offset") === "function" &&
+        typeof Reflect.get(value, "height") === "function" &&
+        typeof Reflect.get(value, "scrollTop") === "function"
+    );
+}
 
 export function get_content_element($element: JQuery): JQuery {
     const element = util.the($element);
@@ -31,6 +83,10 @@ export function get_scroll_element($element: JQueryOrZJQuery): JQuery {
         return $(new SimpleBar(element, {tabIndex: -1}).getScrollElement()!);
     }
     return $element;
+}
+
+export function get_left_sidebar_scroll_container(): JQuery {
+    return get_scroll_element($("#left_sidebar_scroll_container"));
 }
 
 export function reset_scrollbar($element: JQuery): void {
@@ -72,37 +128,82 @@ export function scroll_element_into_container(
     $container: JQuery,
     sticky_header_height = 0,
 ): void {
-    // This does the minimum amount of scrolling that is needed to make
-    // the element visible.  It doesn't try to center the element, so
-    // this will be non-intrusive to users when they already have
-    // the element visible.
     $container = get_scroll_element($container);
+    const elem = has_numeric_length($elem) ? util.the($elem) : $elem;
+    const container = has_numeric_length($container) ? util.the($container) : $container;
 
-    // To correctly compute the offset of the element's scroll
-    // position within our scroll container, we need to subtract the
-    // scroll container's own offset within the document.
-    const elem_offset = $elem.offset()?.top ?? 0;
-    const container_offset = $container.offset()?.top ?? 0;
+    const can_use_dom_rect =
+        has_get_bounding_client_rect(elem) && has_get_bounding_client_rect(container);
+    const can_use_offsets = has_offset_element($elem) && has_offset_container($container);
 
-    const elem_top = elem_offset - container_offset - sticky_header_height;
-    const elem_bottom = elem_top + ($elem.innerHeight() ?? 0);
-    const container_height = ($container.height() ?? 0) - sticky_header_height;
-
-    const opts = {
-        elem_top,
-        elem_bottom,
-        container_height,
-    };
-
-    const delta = scroll_delta(opts);
-
-    if (delta === 0) {
+    if (!can_use_dom_rect && can_use_offsets) {
+        // Fallback for tests or non-DOM stubs.
+        const elem_offset = $elem.offset()?.top ?? 0;
+        const container_offset = $container.offset()?.top ?? 0;
+        const elem_top = elem_offset - container_offset - sticky_header_height;
+        const elem_bottom = elem_top + ($elem.innerHeight() ?? 0);
+        const container_height = ($container.height() ?? 0) - sticky_header_height;
+        const delta = scroll_delta({
+            elem_top,
+            elem_bottom,
+            container_height,
+        });
+        if (delta !== 0) {
+            $container.scrollTop(($container.scrollTop() ?? 0) + delta);
+        }
         return;
     }
 
-    $container.scrollTop(($container.scrollTop() ?? 0) + delta);
-}
+    if (!can_use_dom_rect) {
+        return;
+    }
 
-export function get_left_sidebar_scroll_container(): JQuery {
-    return get_scroll_element($("#left_sidebar_scroll_container"));
+    const elem_rect = elem.getBoundingClientRect();
+    const container_rect = container.getBoundingClientRect();
+    const view_top = container_rect.top + sticky_header_height;
+    const view_bottom = container_rect.bottom;
+    const selection = window.getSelection();
+    let caret_rect = null;
+
+    if (selection && selection.rangeCount > 0) {
+        const range = selection.getRangeAt(0);
+        const anchor_node = selection.anchorNode;
+        const caret_in_container =
+            anchor_node && has_contains(container) && container.contains(anchor_node);
+        if (caret_in_container) {
+            caret_rect = range.getBoundingClientRect();
+        }
+    }
+
+    let delta = 0;
+    const PADDING = 30;
+    const view_height = view_bottom - view_top;
+    const is_tall_element = elem_rect.height > view_height;
+    if (caret_rect && caret_rect.height > 0) {
+        if (caret_rect.top < view_top) {
+            delta = caret_rect.top - view_top - PADDING;
+        } else if (caret_rect.bottom > view_bottom) {
+            delta = caret_rect.bottom - view_bottom + PADDING;
+        }
+    }
+    if (delta === 0) {
+        if (is_tall_element) {
+            delta = elem_rect.top - view_top - PADDING;
+        } else if (elem_rect.top < view_top) {
+            delta = elem_rect.top - view_top - PADDING;
+        } else if (elem_rect.bottom > view_bottom) {
+            delta = elem_rect.bottom - view_bottom + PADDING;
+        }
+    }
+    if (Math.abs(delta) < 2) {
+        return;
+    }
+
+    const prefers_reduced_motion =
+        window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    const behavior: ScrollBehavior = prefers_reduced_motion ? "auto" : "smooth";
+    container.scrollBy({
+        top: delta,
+        behavior,
+    });
 }


### PR DESCRIPTION

### This PR fixes overscroll and jump issues in the draft overlay by improving keyboard navigation and scrolling behavior.

It rewires draft overlay scrolling to be smoother and symmetric (Up/Down) and improves the core scroll helper so that long items and caret position are handled without sudden jumps. This fixes the “jump to top/bottom” behavior and makes keyboard navigation feel natural and predictable. 
fixes #35038

**Summary of Changes in ` messages_overlay_ui.ts`**

**Focus-aware Up/Down arrow handling**
- Navigation is now state-aware instead of always jumping to the next/previous row.
- When the overlay is not focused, the current row is focused and aligned first.
- When focused, navigation decides whether to scroll within the current row or move between rows.
- Prevents jumpy behavior when entering navigation and keeps movement consistent in both directions.
 
**New helper: `scroll_list_by_arrow()`**
- Scrolls the list by ~10% of the container height per key press.
- Respects prefers-reduced-motion
- Allows smooth scrolling through long drafts instead of snapping between rows.

 **Upgraded  `scroll_to_element()`**
- Uses scroll_util.get_scroll_element() for SimpleBar compatibility.
- Applies smooth scrolling when appropriate. 
- Fixes alignment when switching between #drafts-from-conversation and #other-drafts.

**Summary of Changes in`scroll_util.ts`**

- Switches to geometry-based scrolling using `getBoundingClientRect()`.
- Adds caret-aware scrolling inside long paragraphs.
- Improves handling of oversized elements.
- Adds padding and smooth scrolling with reduced-motion support.
- Makes scrolling more reliable and natural across containers. 
 
**Net Improvements**

- Eliminates jump-to-top/bottom behavior on long drafts.
- Makes Up/Down navigation symmetrical and predictable.
- Ensures section switches start at the top of the new section.
- Enables smooth, controlled navigation within long drafts.
- Improves overall keyboard accessibility and usability.

### How Changes Were Tested

- Manually tested keyboard navigation on short and long drafts and schedule message.
- Verified behavior when entering overlays without prior focus.
- Tested scrolling inside oversized rows.
- Checked transitions between Drafts and Other Drafts sections.
- Confirmed caret-based scrolling inside long paragraphs.
- Verified reduced-motion preferences are respected.




 **SCREEN RECORDING AFTER FIXING :**

https://github.com/user-attachments/assets/20aca9ce-6d0a-4173-8628-df55d901cb7c


https://github.com/user-attachments/assets/c081a63f-7f85-4e45-a47e-2cd36fc5b820









<details>

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>


