### PR TITLE
stream_type_icon: Render stream privacy icons in message references

### DIFF
--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -5,6 +5,7 @@ import assert from "minimalistic-assert";
 
 import render_channel_message_link from "../templates/channel_message_link.hbs";
 import code_buttons_container from "../templates/code_buttons_container.hbs";
+import render_decorated_channel_name from "../templates/decorated_channel_name.hbs";
 import render_markdown_audio from "../templates/markdown_audio.hbs";
 import render_markdown_timestamp from "../templates/markdown_timestamp.hbs";
 import render_mention_content_wrapper from "../templates/mention_content_wrapper.hbs";
@@ -227,12 +228,12 @@ export const update_elements = ($content: JQuery): void => {
         if (stream_id && $(this).find(".highlight").length === 0) {
             // Display the current name for stream if it is not
             // being displayed in search highlight.
-            const stream_name = sub_store.maybe_get_stream_name(stream_id);
-            if (stream_name !== undefined) {
-                // If the stream has been deleted,
-                // sub_store.maybe_get_stream_name might return
-                // undefined.  Otherwise, display the current stream name.
-                $(this).text("#" + stream_name);
+            const sub = sub_store.get(stream_id);
+            if (sub !== undefined) {
+                // If the stream has been deleted, sub_store.get
+                // might return undefined.  Otherwise, display the
+                // current stream name.
+                $(this).html(render_decorated_channel_name({stream: sub, inline_with_text: true}));
             }
         }
     });
@@ -242,8 +243,8 @@ export const update_elements = ($content: JQuery): void => {
         assert(narrow_url !== undefined);
         const channel_topic = hash_util.decode_stream_topic_from_url(narrow_url);
         assert(channel_topic !== null);
-        const channel_name = sub_store.maybe_get_stream_name(channel_topic.stream_id);
-        if (channel_name !== undefined && $(this).find(".highlight").length === 0) {
+        const sub = sub_store.get(channel_topic.stream_id);
+        if (sub !== undefined && $(this).find(".highlight").length === 0) {
             // Display the current channel name if it hasn't been deleted
             // and not being displayed in search highlight.
             // TODO: Ideally, we should NOT skip this if only topic is highlighted,
@@ -252,7 +253,7 @@ export const update_elements = ($content: JQuery): void => {
             assert(topic_name !== undefined);
             const topic_display_name = util.get_final_topic_display_name(topic_name);
             const context = {
-                channel_name,
+                channel_name: sub.name,
                 topic_display_name,
                 is_empty_string_topic: topic_name === "",
                 href: narrow_url,
@@ -260,6 +261,7 @@ export const update_elements = ($content: JQuery): void => {
             if ($(this).hasClass("stream-topic")) {
                 const topic_link_html = render_topic_link({
                     channel_id: channel_topic.stream_id,
+                    stream: sub,
                     ...context,
                 });
                 $(this).replaceWith($(topic_link_html));

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -334,8 +334,11 @@
     }
 
     .stream-topic {
-        /* Display whitespace within topics. */
-        white-space: pre-wrap;
+        /* Display whitespace within channel and topic names. */
+        .stream-topic-inner,
+        .decorated-channel-name {
+            white-space: pre;
+        }
     }
 
     .user-group-mention {

--- a/web/templates/topic_link.hbs
+++ b/web/templates/topic_link.hbs
@@ -1,13 +1,21 @@
 {{#if is_empty_string_topic}}
 <a class="stream-topic" data-stream-id="{{channel_id}}" href="{{href}}">
     {{~!-- squash whitespace --~}}
-    #{{channel_name}} &gt; <span class="empty-topic-display">{{topic_display_name}}</span>
+    {{#if stream~}}
+    {{~> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}
+    {{~else~}}
+    #{{channel_name}}
+    {{~/if}} &gt; <span class="empty-topic-display">{{topic_display_name}}</span>
     {{~!-- squash whitespace --~}}
 </a>
 {{~else}}
 <a class="stream-topic" data-stream-id="{{channel_id}}" href="{{href}}">
     {{~!-- squash whitespace --~}}
-    #{{channel_name}} &gt; {{topic_display_name}}
+    {{#if stream~}}
+    {{~> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}
+    {{~else~}}
+    #{{channel_name}}
+    {{~/if}} &gt; {{topic_display_name}}
     {{~!-- squash whitespace --~}}
 </a>
 {{~/if}}

--- a/web/tests/rendered_markdown.test.cjs
+++ b/web/tests/rendered_markdown.test.cjs
@@ -415,6 +415,12 @@ run_test("stream-links", ({mock_template}) => {
     $content.set_find_results("a.stream", $stream);
     $content.set_find_results("a.stream-topic, a.message-link", $stream_topic);
 
+    let stream_name_context;
+    mock_template("decorated_channel_name.hbs", true, (data, html) => {
+        stream_name_context = data;
+        return html;
+    });
+
     let topic_link_context;
     let topic_link_rendered_html;
     mock_template("topic_link.hbs", true, (data, html) => {
@@ -429,10 +435,14 @@ run_test("stream-links", ({mock_template}) => {
 
     rm.update_elements($content);
 
-    // Final asserts
-    assert.equal($stream.text(), `#${stream.name}`);
+    // Verify decorated_channel_name was called with the correct stream.
+    assert.ok(stream_name_context, "decorated_channel_name should be called");
+    assert.equal(stream_name_context.stream.stream_id, stream.stream_id);
+    assert.equal(stream_name_context.stream.name, stream.name);
+
     assert.deepEqual(topic_link_context, {
         channel_id: stream.stream_id,
+        stream,
         channel_name: stream.name,
         topic_display_name: "topic name > still the topic name",
         is_empty_string_topic: false,
@@ -468,6 +478,7 @@ run_test("topic-link (empty string topic)", ({mock_template}) => {
     // Final assert
     assert.deepEqual(topic_link_context, {
         channel_id: stream.stream_id,
+        stream,
         channel_name: stream.name,
         topic_display_name: `translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}`,
         is_empty_string_topic: true,
@@ -804,6 +815,153 @@ run_test("code playground multiple", ({override, mock_template}) => {
     assert.equal($view_code.attr("data-tippy-content"), "translated: View in playground");
     assert.equal($view_code.attr("aria-label"), "translated: View in playground");
     assert.equal($view_code.attr("aria-haspopup"), "true");
+});
+
+run_test("stream-private", ({mock_template}) => {
+    // Setup
+    const private_stream = {
+        stream_id: 88,
+        name: "secret-stream",
+        invite_only: true,
+        is_web_public: false,
+        is_archived: false,
+    };
+    stream_data.add_sub_for_tests(private_stream);
+
+    const $content = get_content_element();
+    const $stream = $.create("a.stream");
+    $stream.attr("data-stream-id", private_stream.stream_id);
+    $stream.set_find_results(".highlight", []);
+
+    const $topic = $.create("a.stream-topic");
+    $topic.attr("href", `/#narrow/channel/${private_stream.stream_id}-secret-stream/topic/test`);
+    $topic.set_find_results(".highlight", []);
+    $topic.addClass("stream-topic");
+    $topic[0].replaceWith = noop;
+
+    $content.set_find_results("a.stream", $stream);
+    $content.set_find_results("a.stream-topic, a.message-link", $topic);
+
+    let stream_name_context;
+    mock_template("decorated_channel_name.hbs", true, (data, html) => {
+        stream_name_context = data;
+        return html;
+    });
+
+    let topic_link_context;
+    mock_template("topic_link.hbs", true, (data, html) => {
+        topic_link_context = data;
+        return html;
+    });
+
+    rm.update_elements($content);
+
+    // Verify decorated_channel_name was called with the private stream.
+    assert.ok(stream_name_context, "decorated_channel_name should be called");
+    assert.ok(stream_name_context.stream.invite_only, "Stream should be private");
+
+    // Verify topic_link was called with the private stream.
+    assert.ok(topic_link_context, "topic_link should be called");
+    assert.ok(topic_link_context.stream.invite_only, "Topic stream should be private");
+});
+
+run_test("stream-web-public", ({mock_template}) => {
+    // Setup
+    const web_public_stream = {
+        stream_id: 99,
+        name: "web-public-stream",
+        invite_only: false,
+        is_web_public: true,
+        is_archived: false,
+    };
+    stream_data.add_sub_for_tests(web_public_stream);
+
+    const $content = get_content_element();
+    const $stream = $.create("a.stream");
+    $stream.attr("data-stream-id", web_public_stream.stream_id);
+    $stream.set_find_results(".highlight", []);
+
+    const $topic = $.create("a.stream-topic");
+    $topic.attr(
+        "href",
+        `/#narrow/channel/${web_public_stream.stream_id}-web-public-stream/topic/test`,
+    );
+    $topic.set_find_results(".highlight", []);
+    $topic.addClass("stream-topic");
+    $topic[0].replaceWith = noop;
+
+    $content.set_find_results("a.stream", $stream);
+    $content.set_find_results("a.stream-topic, a.message-link", $topic);
+
+    let stream_name_context;
+    mock_template("decorated_channel_name.hbs", true, (data, html) => {
+        stream_name_context = data;
+        return html;
+    });
+
+    let topic_link_context;
+    mock_template("topic_link.hbs", true, (data, html) => {
+        topic_link_context = data;
+        return html;
+    });
+
+    rm.update_elements($content);
+
+    // Verify decorated_channel_name was called with the web-public stream.
+    assert.ok(stream_name_context, "decorated_channel_name should be called");
+    assert.ok(stream_name_context.stream.is_web_public, "Stream should be web-public");
+
+    // Verify topic_link was called with the web-public stream.
+    assert.ok(topic_link_context, "topic_link should be called");
+    assert.ok(topic_link_context.stream.is_web_public, "Topic stream should be web-public");
+});
+
+run_test("stream-archived", ({mock_template}) => {
+    // Setup
+    const archived_stream = {
+        stream_id: 77,
+        name: "old-stream",
+        invite_only: false,
+        is_web_public: false,
+        is_archived: true,
+    };
+    stream_data.add_sub_for_tests(archived_stream);
+
+    const $content = get_content_element();
+    const $stream = $.create("a.stream");
+    $stream.attr("data-stream-id", archived_stream.stream_id);
+    $stream.set_find_results(".highlight", []);
+
+    const $topic = $.create("a.stream-topic");
+    $topic.attr("href", `/#narrow/channel/${archived_stream.stream_id}-old-stream/topic/test`);
+    $topic.set_find_results(".highlight", []);
+    $topic.addClass("stream-topic");
+    $topic[0].replaceWith = noop;
+
+    $content.set_find_results("a.stream", $stream);
+    $content.set_find_results("a.stream-topic, a.message-link", $topic);
+
+    let stream_name_context;
+    mock_template("decorated_channel_name.hbs", true, (data, html) => {
+        stream_name_context = data;
+        return html;
+    });
+
+    let topic_link_context;
+    mock_template("topic_link.hbs", true, (data, html) => {
+        topic_link_context = data;
+        return html;
+    });
+
+    rm.update_elements($content);
+
+    // Verify decorated_channel_name was called with the archived stream.
+    assert.ok(stream_name_context, "decorated_channel_name should be called");
+    assert.ok(stream_name_context.stream.is_archived, "Stream should be archived");
+
+    // Verify topic_link was called with the archived stream.
+    assert.ok(topic_link_context, "topic_link should be called");
+    assert.ok(topic_link_context.stream.is_archived, "Topic stream should be archived");
 });
 
 run_test("rtl", () => {


### PR DESCRIPTION
Fixes #19058.

This updates the rendering of stream and topic mentions in messages to display the correct privacy icon (Lock, Globe, Archived or Hash) instead of a generic `#`. This aligns the in-message references with the left sidebar, giving users immediate visual context about the stream's privacy.

Tests cover public, private, web-public and archived streams.

- Note: Links to specific messages retain the standard # prefix for now.

## Screenshots

### Public Stream - default font size
| Before | After |
|--------|-------|
|<img width="2560" height="1600" alt="public stream before" src="https://github.com/user-attachments/assets/7ff4cfef-6e7c-4d68-985a-4077e7270037" />|<img width="2560" height="1600" alt="Public stream - after" src="https://github.com/user-attachments/assets/ac8f122b-bc58-4335-8e90-fe6a20389770" />|

---

### Private Stream - default font size
| Before | After |
|--------|-------|
|<img width="2560" height="1600" alt="pvt stream before" src="https://github.com/user-attachments/assets/d70cf92c-594f-403b-afc6-1b1ac785ef49" />|<img width="2560" height="1600" alt="Private stream - after" src="https://github.com/user-attachments/assets/ea7f89f1-e290-42d8-81fa-b986173523a5" />|

---

### Web-public Stream - default font size
| Before | After |
|--------|-------|
|<img width="2560" height="1600" alt="web public before" src="https://github.com/user-attachments/assets/7291d3c6-b26f-477f-9259-74cbc16256f0" />|<img width="2560" height="1600" alt="web public stream - after" src="https://github.com/user-attachments/assets/4c92b7e3-2110-466c-b8cf-2ef8a2fde84a" />|

---

### Archived Stream - default font size
| Before | After |
|--------|-------|
|<img width="2560" height="1600" alt="archived stream before" src="https://github.com/user-attachments/assets/ed53e3a0-4bd1-487f-9aee-53e9e13bb653" />| <img width="2560" height="1600" alt="archived stream - after" src="https://github.com/user-attachments/assets/8b8b23f5-bea8-43c2-8f1f-59b2723a2482" />|

---

## Screenshots for different font sizes 

### Private stream - minimum font size 
| Before | After |
|--------|-------|
|<img width="2560" height="1600" alt="pvt stream before min font size" src="https://github.com/user-attachments/assets/6c163847-d80e-40ae-a211-dbbbd93d53a9" />|<img width="2560" height="1600" alt="private stream min font size - after" src="https://github.com/user-attachments/assets/5ac24c84-d237-4489-9e2a-5d8e528c5c45" />|

---

### Private stream - default font size 
| Before | After |
|--------|-------|
| <img width="2560" height="1600" alt="pvt stream before default font size" src="https://github.com/user-attachments/assets/c534efef-de33-4211-bc0f-f6f0700b250e" /> |<img width="2560" height="1600" alt="private stream default font size - after" src="https://github.com/user-attachments/assets/4173cabd-d87f-48e0-97fe-02a68be0d9f8" />|

---

### Private stream - maximum font size 
| Before | After |
|--------|-------|
| <img width="2560" height="1600" alt="pvt stream before max font size" src="https://github.com/user-attachments/assets/04022576-a305-40f9-bfdc-494ff9fd2cbd" />| <img width="2560" height="1600" alt="Private stream max font size - after" src="https://github.com/user-attachments/assets/e217e776-7868-4fab-ab24-6e2ee333d46c" />|

---

## Screenshots with inline text 

### Minimum font size 
<img width="2560" height="1600" alt="inline text min font size" src="https://github.com/user-attachments/assets/07b78fcd-e56e-440d-b229-ddf36e6e8c8e" />

---

### Default font size 
<img width="2560" height="1600" alt="inline text default font size" src="https://github.com/user-attachments/assets/e717aa0a-837b-4d38-b2f5-32ae81aa868b" />


---

### Maximum font size
<img width="2560" height="1600" alt="inline text max font size" src="https://github.com/user-attachments/assets/e21c76e1-bdd6-4544-a89b-e3eb602b5e15" />


---


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
