### PR TITLE
[ai] performance: Minor query and code quality improvements.

### DIFF
--- a/zerver/actions/default_streams.py
+++ b/zerver/actions/default_streams.py
@@ -37,16 +37,20 @@ def check_default_stream_group_name(group_name: str) -> None:
 def lookup_default_stream_groups(
     default_stream_group_names: list[str], realm: Realm
 ) -> list[DefaultStreamGroup]:
-    default_stream_groups = []
+    groups_by_name = {
+        group.name: group
+        for group in DefaultStreamGroup.objects.filter(
+            realm=realm, name__in=default_stream_group_names
+        )
+    }
+    result = []
     for group_name in default_stream_group_names:
-        try:
-            default_stream_group = DefaultStreamGroup.objects.get(name=group_name, realm=realm)
-        except DefaultStreamGroup.DoesNotExist:
+        if group_name not in groups_by_name:
             raise JsonableError(
                 _("Invalid default channel group {group_name}").format(group_name=group_name)
             )
-        default_stream_groups.append(default_stream_group)
-    return default_stream_groups
+        result.append(groups_by_name[group_name])
+    return result
 
 
 def notify_default_streams(realm: Realm) -> None:

--- a/zerver/actions/user_activity.py
+++ b/zerver/actions/user_activity.py
@@ -10,18 +10,15 @@ def do_update_user_activity_interval(user_profile: UserProfile, log_time: dateti
     # This code isn't perfect, because with various races we might end
     # up creating two overlapping intervals, but that shouldn't happen
     # often, and can be corrected for in post-processing
-    try:
-        last = UserActivityInterval.objects.filter(user_profile=user_profile).order_by("-end")[0]
-        # Two intervals overlap iff each interval ends after the other
-        # begins.  In this case, we just extend the old interval to
-        # include the new interval.
-        if log_time <= last.end and effective_end >= last.start:
-            last.end = max(last.end, effective_end)
-            last.start = min(last.start, log_time)
-            last.save(update_fields=["start", "end"])
-            return
-    except IndexError:
-        pass
+    last = UserActivityInterval.objects.filter(user_profile=user_profile).order_by("-end").first()
+    # Two intervals overlap iff each interval ends after the other
+    # begins.  In this case, we just extend the old interval to
+    # include the new interval.
+    if last is not None and log_time <= last.end and effective_end >= last.start:
+        last.end = max(last.end, effective_end)
+        last.start = min(last.start, log_time)
+        last.save(update_fields=["start", "end"])
+        return
 
     # Otherwise, the intervals don't overlap, so we should make a new one
     UserActivityInterval.objects.create(

--- a/zerver/lib/bot_storage.py
+++ b/zerver/lib/bot_storage.py
@@ -54,7 +54,7 @@ def set_bot_storage(bot_profile: UserProfile, entries: list[tuple[str, str]]) ->
 
 def remove_bot_storage(bot_profile: UserProfile, keys: list[str]) -> None:
     queryset = BotStorageData.objects.filter(bot_profile=bot_profile, key__in=keys)
-    if len(queryset) < len(keys):
+    if queryset.count() < len(keys):
         raise StateError("Key does not exist.")
     queryset.delete()
 

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -393,13 +393,16 @@ def include_realm_name_in_missedmessage_emails_subject(user_profile: UserProfile
         user_profile.realm_name_in_email_notifications_policy
         == UserProfile.REALM_NAME_IN_EMAIL_NOTIFICATIONS_POLICY_AUTOMATIC
     ):
-        realms_count = UserProfile.objects.filter(
-            delivery_email=user_profile.delivery_email,
-            is_active=True,
-            is_bot=False,
-            realm__deactivated=False,
-        ).count()
-        return realms_count > 1
+        return (
+            UserProfile.objects.filter(
+                delivery_email=user_profile.delivery_email,
+                is_active=True,
+                is_bot=False,
+                realm__deactivated=False,
+            )
+            .exclude(id=user_profile.id)
+            .exists()
+        )
     return (
         user_profile.realm_name_in_email_notifications_policy
         == UserProfile.REALM_NAME_IN_EMAIL_NOTIFICATIONS_POLICY_ALWAYS

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1301,34 +1301,26 @@ def apply_event(
                                 subscriber_key = (
                                     "subscribers" if "subscribers" in sub else "partial_subscribers"
                                 )
-                                sub[subscriber_key] = [
-                                    user_id
-                                    for user_id in sub[subscriber_key]
-                                    if user_id != person_user_id
-                                ]
+                                if person_user_id in sub[subscriber_key]:
+                                    sub[subscriber_key].remove(person_user_id)
 
                     for user_group in state["realm_user_groups"]:
-                        user_group["members"] = [
-                            user_id
-                            for user_id in user_group["members"]
-                            if user_id != person_user_id
-                        ]
+                        if person_user_id in user_group["members"]:
+                            user_group["members"].remove(person_user_id)
 
                     for setting_name in Realm.REALM_PERMISSION_GROUP_SETTINGS:
-                        if not isinstance(state["realm_" + setting_name], int):
-                            state["realm_" + setting_name]["direct_members"] = [
-                                user_id
-                                for user_id in state["realm_" + setting_name]["direct_members"]
-                                if user_id != person_user_id
-                            ]
+                        if (
+                            not isinstance(state["realm_" + setting_name], int)
+                            and person_user_id in state["realm_" + setting_name]["direct_members"]
+                        ):
+                            state["realm_" + setting_name]["direct_members"].remove(person_user_id)
                     for group in state["realm_user_groups"]:
                         for setting_name in NamedUserGroup.GROUP_PERMISSION_SETTINGS:
-                            if not isinstance(group[setting_name], int):
-                                group[setting_name]["direct_members"] = [
-                                    user_id
-                                    for user_id in group[setting_name]["direct_members"]
-                                    if user_id != person_user_id
-                                ]
+                            if (
+                                not isinstance(group[setting_name], int)
+                                and person_user_id in group[setting_name]["direct_members"]
+                            ):
+                                group[setting_name]["direct_members"].remove(person_user_id)
         elif event["op"] == "remove":
             if person_user_id in state["raw_users"]:
                 if user_list_incomplete:

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1722,8 +1722,9 @@ def apply_event(
                             subscriber_key = (
                                 "subscribers" if "subscribers" in sub else "partial_subscribers"
                             )
-                            subscribers = set(sub[subscriber_key]) - user_ids
-                            sub[subscriber_key] = sorted(subscribers)
+                            sub[subscriber_key] = [
+                                uid for uid in sub[subscriber_key] if uid not in user_ids
+                            ]
         else:
             raise AssertionError("Unexpected event type {type}/{op}".format(**event))
     elif event["type"] == "presence":

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -618,22 +618,19 @@ class NarrowBuilder:
         return query.where(maybe_negate(cond))
 
     def _get_direct_message_group_recipients(self, other_user: UserProfile) -> set[int]:
-        self_recipient_ids = [
-            recipient_tuple["recipient_id"]
-            for recipient_tuple in Subscription.objects.filter(
+        self_recipient_ids = set(
+            Subscription.objects.filter(
                 user_profile=self.user_profile,
                 recipient__type=Recipient.DIRECT_MESSAGE_GROUP,
-            ).values("recipient_id")
-        ]
-        narrow_recipient_ids = [
-            recipient_tuple["recipient_id"]
-            for recipient_tuple in Subscription.objects.filter(
+            ).values_list("recipient_id", flat=True)
+        )
+        narrow_recipient_ids = set(
+            Subscription.objects.filter(
                 user_profile=other_user,
                 recipient__type=Recipient.DIRECT_MESSAGE_GROUP,
-            ).values("recipient_id")
-        ]
-
-        return set(self_recipient_ids) & set(narrow_recipient_ids)
+            ).values_list("recipient_id", flat=True)
+        )
+        return self_recipient_ids & narrow_recipient_ids
 
     def by_dm_including(
         self, query: Select, operand: str | int, maybe_negate: ConditionTransform

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -926,7 +926,7 @@ def update_narrow_terms_containing_with_operator(
     if narrow is None:
         return narrow
 
-    with_operator_terms = list(filter(lambda term: term.operator == "with", narrow))
+    with_operator_terms = [term for term in narrow if term.operator == "with"]
     can_user_access_target_message = True
 
     if len(with_operator_terms) > 1:

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -494,7 +494,7 @@ class NarrowBuilder:
         else:
             raise BadNarrowOperatorError("unknown channels operand " + operand)
 
-        recipient_ids = recipient_queryset.values_list("recipient_id", flat=True).order_by("id")
+        recipient_ids = recipient_queryset.values_list("recipient_id", flat=True)
         cond = column("recipient_id", Integer).in_(recipient_ids)
         return query.where(maybe_negate(cond))
 

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -1436,15 +1436,25 @@ def post_process_limited_query(
 
     rows_limited = len(visible_rows) != len(rows)
 
+    before_rows: list[MessageRowT]
+    anchor_rows: list[MessageRowT]
+    after_rows: list[MessageRowT]
     if anchored_to_right:
         num_after = 0
-        before_rows = visible_rows[:]
+        before_rows = list(visible_rows)
         anchor_rows = []
         after_rows = []
     else:
-        before_rows = [r for r in visible_rows if r[0] < anchor]
-        anchor_rows = [r for r in visible_rows if r[0] == anchor]
-        after_rows = [r for r in visible_rows if r[0] > anchor]
+        before_rows = []
+        anchor_rows = []
+        after_rows = []
+        for r in visible_rows:
+            if r[0] < anchor:
+                before_rows.append(r)
+            elif r[0] == anchor:
+                anchor_rows.append(r)
+            else:
+                after_rows.append(r)
 
     if num_before:
         before_rows = before_rows[-1 * num_before :]

--- a/zerver/lib/onboarding_steps.py
+++ b/zerver/lib/onboarding_steps.py
@@ -89,9 +89,14 @@ def get_next_onboarding_steps(user: UserProfile) -> list[dict[str, Any]]:
 
 
 def copy_onboarding_steps(source_profile: UserProfile, target_profile: UserProfile) -> None:
-    for onboarding_step in frozenset(OnboardingStep.objects.filter(user=source_profile)):
-        OnboardingStep.objects.create(
-            user=target_profile,
-            onboarding_step=onboarding_step.onboarding_step,
-            timestamp=onboarding_step.timestamp,
-        )
+    source_steps = OnboardingStep.objects.filter(user=source_profile)
+    OnboardingStep.objects.bulk_create(
+        [
+            OnboardingStep(
+                user=target_profile,
+                onboarding_step=step.onboarding_step,
+                timestamp=step.timestamp,
+            )
+            for step in source_steps
+        ]
+    )

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -543,12 +543,16 @@ def validate_user_custom_profile_data(
     realm_id: int, profile_data: list[ProfileDataElementUpdateDict], acting_user: UserProfile
 ) -> None:
     # This function validate all custom field values according to their field type.
+    field_ids = [item["id"] for item in profile_data]
+    fields_by_id = {
+        field.id: field
+        for field in CustomProfileField.objects.filter(realm_id=realm_id, id__in=field_ids)
+    }
     for item in profile_data:
         field_id = item["id"]
-        try:
-            field = CustomProfileField.objects.get(realm_id=realm_id, id=field_id)
-        except CustomProfileField.DoesNotExist:
+        if field_id not in fields_by_id:
             raise JsonableError(_("Field id {id} not found.").format(id=field_id))
+        field = fields_by_id[field_id]
 
         if not acting_user.is_realm_admin and not field.editable_by_user:
             raise JsonableError(

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -2039,10 +2039,8 @@ class GetOldMessagesTest(ZulipTestCase):
         query_ids["othello_id"] = othello_user.id
         query_ids["hamlet_recipient"] = hamlet_user.recipient_id
         query_ids["othello_recipient"] = othello_user.recipient_id
-        recipients = (
-            get_public_streams_queryset(hamlet_user.realm)
-            .values_list("recipient_id", flat=True)
-            .order_by("id")
+        recipients = get_public_streams_queryset(hamlet_user.realm).values_list(
+            "recipient_id", flat=True
         )
         query_ids["public_channels_recipients"] = ", ".join(str(r) for r in recipients)
         return query_ids


### PR DESCRIPTION
## Summary                                                             
- Fix N+1 query patterns in `default_streams` and `users` by batching  
  lookups into single queries                                          
- Use `.count()` instead of `len(queryset)` in `bot_storage` to avoid  
  fetching all rows just to count them                                 
- Use `.exists()` instead of `.count()` in `email_notifications` to    
  short-circuit after the first match                                  
- Remove unnecessary `ORDER BY` and simplify set operations in `narrow`
  (hot path for message fetches)                                       
- Use `.first()` instead of `[0]` indexing in `user_activity` for      
  idiomatic Django                                                     
- Use `bulk_create` instead of N individual inserts in                 
  `onboarding_steps`                                                   
- Avoid unnecessary list rebuilding and re-sorting in `events`         

Generated with Claude Code starting with asking it to audit the codebase for performance issues that are easy to fix. I've not yet hand-reviewed the code myself.