### PR TITLE
buddy_list: Use ::before for status circle to refactor status circle rendering.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -198,11 +198,37 @@
             font-size: 0.625em;
             bottom: -0.5px;
             right: -0.5px;
-            background-color: var(--color-background);
+
+            width: 1em;
+            height: 1em;
+            border-radius: 50%;
+
+            background-color: var(--color-background) !important;
             /* A 1.5px border provides better results than
                a 1px border, especially at smaller font sizes. */
             border: 1.5px solid var(--color-background);
-            border-radius: 50%;
+            box-sizing: content-box;
+
+            &::before {
+                content: "";
+                display: block;
+                width: 100%;
+                height: 100%;
+                border-radius: 50%;
+                background-color: currentcolor;
+            }
+
+            &.user-circle-online::before {
+                background-color: var(--color-user-status-online);
+            }
+
+            &.user-circle-busy::before {
+                background-color: var(--color-user-status-dnd);
+            }
+
+            &.user-circle-idle::before {
+                background: var(--gradient-user-circle-idle-avatar);
+            }
 
             &.user-circle-offline {
                 display: none;

--- a/web/templates/presence_row.hbs
+++ b/web/templates/presence_row.hbs
@@ -13,8 +13,8 @@
             <div class="user-profile-picture-container">
                 <div class="user-profile-picture avatar-preload-background">
                     <img loading="lazy" src="{{profile_picture}}"/>
-                    <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
                 </div>
+                <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
             </div>
             <a class="user-presence-link" href="{{href}}" draggable="false">
                 <div class="user-name-and-status-emoji">

--- a/web/tests/buddy_list.test.cjs
+++ b/web/tests/buddy_list.test.cjs
@@ -177,6 +177,48 @@ run_test("find_li", ({override}) => {
     assert.equal($li, $bob_li);
 });
 
+run_test("presence_row_template_structure", ({mock_template}) => {
+    const buddy_list = new BuddyList();
+    let rendered_html;
+
+    mock_template("presence_row.hbs", true, (_data, html) => {
+        rendered_html = html;
+        return html;
+    });
+
+    const data = {
+        name: "Iago",
+        user_id: 10,
+        user_list_style: {
+            WITH_AVATAR: true,
+            WITH_STATUS: false,
+        },
+        has_status_text: false,
+        user_circle_class: "user-circle-active",
+        profile_picture: "http://example.com/avatar.png",
+        href: "#user/10/Iago",
+        status_text: "",
+        num_unread: 0,
+    };
+
+    buddy_list.item_to_html({item: data});
+
+    assert.ok(rendered_html, "Should render presence row template");
+
+    const profile_pic_index = rendered_html.indexOf("user-profile-picture");
+    assert.ok(profile_pic_index !== -1, "Should render profile picture div");
+
+    const profile_pic_closing_tag_index = rendered_html.indexOf("</div>", profile_pic_index);
+
+    const status_circle_index = rendered_html.indexOf("user-circle");
+    assert.ok(status_circle_index !== -1, "Should render status circle");
+
+    assert.ok(
+        profile_pic_closing_tag_index < status_circle_index,
+        "The user-circle span must be outside (after) the user-profile-picture div.",
+    );
+});
+
 run_test("fill_screen_with_content early break on big list", ({override}) => {
     stub_buddy_list_elements();
     const buddy_list = new BuddyList();


### PR DESCRIPTION
Updates the right sidebar user entries to use the `::before` pseudo-element for rendering the status circle border. This aligns the implementation with the recent changes made to the Typeahead in #36490.

**Changes:**
* **Template (`presence_row.hbs`):** Moved the status circle span to be a sibling of the `user-profile-picture` container (instead of a child). This allows the status circle to overlap the avatar correctly without being hidden on the avatar container.

Fixes #37031.

**How changes were tested:**
 Verified that the status circle (Online, Idle, Busy) is correctly positioned on the bottom-right corner of the avatar.
 Verified that "Offline" users do not show a circle.
* **Automated Tests:**
    * Ran `node` tests: Added a specific test case in `web/tests/buddy_list.test.cjs` to assert that the `.user-circle` span renders after the closing `</div>` of the profile picture container.

**Screenshots and screen captures:**
Before:
<img width="657" height="201" alt="Screenshot From 2026-03-09 12-45-02" src="https://github.com/user-attachments/assets/bfc644ef-0e0b-4b4d-add9-6ea065afcf7b" />
<img width="657" height="201" alt="Screenshot From 2026-03-09 12-43-20" src="https://github.com/user-attachments/assets/e15b7e09-1b0c-4b7d-9c22-a9656c293a4a" />

After:
<img width="744" height="203" alt="Screenshot From 2026-03-09 11-57-51" src="https://github.com/user-attachments/assets/e7141032-3219-4eae-9b24-bbc8b3ae605e" />
<img width="657" height="201" alt="Screenshot From 2026-03-09 11-59-27" src="https://github.com/user-attachments/assets/2194f0fa-a32e-4d17-8a80-0310d68d22bb" />


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

