### PR TITLE
Improve topic placeholder when new topics are disabled

### DIFF
--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -1016,8 +1016,12 @@ export async function build_move_topic_to_stream_popover(
         const has_input_focus = $topic_input.is(":focus");
 
         // reset
-        $topic_input.attr("placeholder",
-        stream_data.can_use_empty_topic(stream_widget_value) ? "" : $t({defaultMessage: "Topic"}),);
+        $topic_input.attr(
+            "placeholder",
+            stream_data.can_use_empty_topic(stream_widget_value)
+                ? ""
+                : $t({defaultMessage: "Topic"}),
+        );
         $topic_input.removeClass("empty-topic-display");
         $topic_not_mandatory_placeholder.removeClass("move-topic-new-topic-placeholder-visible");
         update_clear_move_topic_button_state();


### PR DESCRIPTION
This PR improves the topic input placeholder when users are not allowed to start new topics in a channel.

Previously, in this case, the topic field could appear empty, especially when focused, which made it unclear what users were expected to do. This change ensures that the placeholder "Topic" is always visible when new topics are disabled, making the behavior more consistent and less confusing.

Fixes: https://github.com/zulip/zulip/issues/37104

**How changes were tested:**

- Ran the development server locally.
- Opened the move topic modal in channels where creating new topics is not allowed.
- Checked that the "Topic" placeholder appears in both focused and unfocused states.
- Verified that existing behavior remains unchanged in channels where new topics are allowed.


<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and readability.
- [x] Followed the AI use policy.

- [x] Explained how this differs from the previous behavior.
- [x] Highlighted the main change and reasoning.
- [x] Considered possible edge cases.

- [x] Each commit represents a single, focused change.
- [x] Commit messages explain the intent clearly.

- [x] Manually verified the UI behavior.
- [x] Checked responsiveness and localization impact.
- [x] Tested relevant user flows and interactions.
- [x] Considered possible error scenarios.

</details>
