### PR TITLE
changes in web

### DIFF
--- a/web/styles/blueslip.css
+++ b/web/styles/blueslip.css
@@ -35,6 +35,7 @@
     /* Subtract 5px to account for the bottom margin and another
        5px to account for the top. */
     max-height: calc(100vh - 10px);
+    max-height: calc(var(--full-height-dynamic-viewport) - 10px);
     overflow-y: auto;
     overscroll-behavior: contain;
     /* Set top padding to account for the translate-y motion of the

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -4,6 +4,7 @@
     background: var(--color-background-inbox);
     padding: 0;
     min-height: 100vh;
+    min-height: var(--full-height-dynamic-viewport);
 
     #inbox-pane {
         max-width: 100%;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -424,6 +424,7 @@ ul.popover-group-menu-member-list {
 
         width: 100vw;
         height: 100vh;
+        height: var(--full-height-dynamic-viewport);
 
         display: flex !important;
         justify-content: center;


### PR DESCRIPTION
This PR updates several layout constraints to use Zulip’s dynamic viewport CSS variables instead of static `vh`/`vw` units.

Static viewport units can cause content to be clipped on mobile browsers—particularly on iOS/iPadOS—when browser UI elements (such as the address bar) change size. By switching to dynamic viewport sizing with appropriate fallbacks, this change ensures modals, overlays, and full-height layouts render with consistent spacing and are not cut off at the bottom.

Fixes: #37366

**How changes were tested:**

- Ran Zulip locally and manually verified layout behavior.
- Opened settings and other overlays and confirmed content is no longer clipped at the bottom.
- Tested resizing the viewport and using mobile emulation to ensure dynamic viewport behavior works as expected.
- Verified no regressions on desktop layouts.
