### PR TITLE
[ai] message_events: Fix back button skipping after topic resolve.

### DIFF
--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -735,7 +735,7 @@ export function update_messages(events: UpdateMessageEvent[]): void {
                     message_list_data_cache.remove(new_filter);
                     const terms = new_filter.terms();
                     const opts = {
-                        trigger: "stream/topic change",
+                        trigger: "retarget topic location",
                         then_select_id: current_selected_id,
                     };
                     message_view.show(terms, opts);


### PR DESCRIPTION
When resolving a topic while viewing it, the update_messages handler called message_view.show() with trigger
"stream/topic change", which flows to changehash() and uses pushState — creating a new history entry with the old (stale) topic URL rather than replacing the current one.

This caused a "dead" back button press: navigating back to the stale entry would silently adjust to the current (resolved) topic via try_adjusting_for_moved_with_target(), and
try_rendering_locally_for_same_narrow() would detect it matched the current view, resulting in no visible change. The user would need to press back twice to actually go back one step.

Fix this by using the "retarget topic location" trigger, which maps to replaceState in changehash(). This is the same trigger already used for the analogous post-fetch topic adjustment at message_view.ts line 798.

The second call site at line 769 ("messages moved INTO current narrow") intentionally keeps "stream/topic change" because set_hash()'s dedup check makes it a no-op when the hash hasn't changed.

  ## Test plan

  - [x] Wrote a Puppeteer test that reproduces the bug (history length
    grows after resolve, second back press is a dead no-op)
  - [x] Verified the test **fails** without the fix and **passes** with it
  - [x] `./tools/lint web/src/message_events.ts` passes
  - [x] `./tools/test-js-with-puppeteer navigation` passes
  - [x] Audited all consumers of the trigger string — no code checks
    for `"stream/topic change"` or `"retarget topic location"` beyond
    `changehash()`
  - [x] The second call site at line 769 is intentionally unchanged
    (it re-narrows to the same hash, so `set_hash()`'s dedup check
    makes it a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
