### PR TITLE
[ai] Improve typeahead sorting.

### DIFF
--- a/web/src/recent_senders.ts
+++ b/web/src/recent_senders.ts
@@ -54,7 +54,7 @@ export function clear_for_testing(): void {
     topic_senders.clear();
 }
 
-function max_id_for_stream_topic_sender(opts: {
+export function max_id_for_stream_topic_sender(opts: {
     stream_id: number;
     topic: string;
     sender_id: number;
@@ -72,7 +72,7 @@ function max_id_for_stream_topic_sender(opts: {
     return id_tracker ? id_tracker.max_id() : -1;
 }
 
-function max_id_for_stream_sender(opts: {stream_id: number; sender_id: number}): number {
+export function max_id_for_stream_sender(opts: {stream_id: number; sender_id: number}): number {
     const {stream_id, sender_id} = opts;
     const sender_dict = stream_senders.get(stream_id);
     if (!sender_dict) {

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -249,7 +249,7 @@ function compare_by_direct_message_group(
         if (diff !== 0) {
             return diff;
         }
-        return typeahead_helper.compare_by_pms(person1, person2);
+        return typeahead_helper.compare_users_for_dms(person1, person2);
     };
 }
 
@@ -396,7 +396,7 @@ function make_people_getter(last: NarrowCanonicalTermSuggestion): () => User[] {
         }
 
         persons = people.get_people_for_search_bar(query);
-        persons.sort(typeahead_helper.compare_by_pms);
+        persons.sort(typeahead_helper.compare_users_for_dms);
         return persons;
     };
 }

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -259,127 +259,171 @@ export function sorter<T>(query: string, objs: T[], get_item: (x: T) => string):
     return [...results.matches, ...results.rest];
 }
 
-export function compare_by_pms(user_a: User, user_b: User): number {
-    const count_a = people.get_recipient_count(user_a);
-    const count_b = people.get_recipient_count(user_b);
+export function compare_users_for_streams(
+    user_a: User,
+    user_b: User,
+    current_stream_id: number,
+    current_topic: string,
+): number {
+    // Sort order: subscribers > recency in topic/stream > DM partners > alphabetical
+    const a_is_subscribed = stream_data.is_user_loaded_and_subscribed(
+        current_stream_id,
+        user_a.user_id,
+    );
+    const b_is_subscribed = stream_data.is_user_loaded_and_subscribed(
+        current_stream_id,
+        user_b.user_id,
+    );
+    if (a_is_subscribed !== b_is_subscribed) {
+        return a_is_subscribed ? -1 : 1;
+    }
 
-    if (count_a > count_b) {
-        return -1;
-    } else if (count_a < count_b) {
-        return 1;
+    const recency_comparison = recent_senders.compare_by_recency(
+        user_a,
+        user_b,
+        current_stream_id,
+        current_topic,
+    );
+    if (recency_comparison !== 0) {
+        return recency_comparison;
     }
 
     const a_is_partner = pm_conversations.is_partner(user_a.user_id);
     const b_is_partner = pm_conversations.is_partner(user_b.user_id);
+    if (a_is_partner !== b_is_partner) {
+        return a_is_partner ? -1 : 1;
+    }
+    return user_a.full_name.localeCompare(user_b.full_name);
+}
 
-    // This code will never run except in the rare case that one has no
-    // recent DM message history with a user, but does have some older
-    // message history that's outside the "recent messages only"
-    // data set powering people.get_recipient_count.
-    if (a_is_partner && !b_is_partner) {
-        return -1;
-    } else if (!a_is_partner && b_is_partner) {
-        return 1;
+export function compare_users_for_dms(user_a: User, user_b: User, query = ""): number {
+    // Sort order: DM partners > message count > shorter name (if query) > alphabetical
+    const a_is_partner = pm_conversations.is_partner(user_a.user_id);
+    const b_is_partner = pm_conversations.is_partner(user_b.user_id);
+    if (a_is_partner !== b_is_partner) {
+        return a_is_partner ? -1 : 1;
+    }
+    const count_a = people.get_recipient_count(user_a);
+    const count_b = people.get_recipient_count(user_b);
+    if (count_a !== count_b) {
+        return count_a > count_b ? -1 : 1;
+    }
+    // Only apply name length comparison when user has started typing
+    if (query.length > 0) {
+        const name_len_diff = user_a.full_name.length - user_b.full_name.length;
+        if (name_len_diff !== 0) {
+            return name_len_diff < 0 ? -1 : 1;
+        }
+    }
+    return user_a.full_name.localeCompare(user_b.full_name);
+}
+
+export function compare_user_with_wildcard(user: User, stream_id?: number, topic?: string): number {
+    if (stream_id === undefined || topic === undefined) {
+        return pm_conversations.is_partner(user.user_id) ? -1 : 1;
     }
 
-    // We use alpha sort as a tiebreaker, which might be helpful for
-    // new users.
-    return user_a.full_name.localeCompare(user_b.full_name);
+    const is_subscriber = stream_data.is_user_loaded_and_subscribed(stream_id, user.user_id);
+    if (is_subscriber) {
+        return -1;
+    }
+
+    const posted_in_topic =
+        recent_senders.max_id_for_stream_topic_sender({
+            stream_id,
+            topic,
+            sender_id: user.user_id,
+        }) > 0;
+    if (posted_in_topic) {
+        return -1;
+    }
+
+    const posted_in_stream =
+        recent_senders.max_id_for_stream_sender({
+            stream_id,
+            sender_id: user.user_id,
+        }) > 0;
+    if (posted_in_stream) {
+        return -1;
+    }
+
+    // A user with no connection to this channel still ranks above the
+    // wildcard mention if they're a DM partner, since a frequent DM
+    // contact is a more likely mention target than @all/@everyone for
+    // most users. Non-partners rank below the wildcard.
+    return pm_conversations.is_partner(user.user_id) ? -1 : 1;
 }
 
 export function compare_people_for_relevance(
     person_a: UserOrMentionPillData | UserPillData,
     person_b: UserOrMentionPillData | UserPillData,
-    compare_by_current_conversation?: (user_a: User, user_b: User) => number,
     current_stream_id?: number,
+    current_topic?: string,
+    query = "",
 ): number {
-    // give preference to "all", "everyone" or "stream"
-    if (compose_state.get_message_type() !== "private") {
-        if (person_a.type === "broadcast") {
-            if (person_b.type === "broadcast") {
-                return person_a.user.idx - person_b.user.idx;
-            }
-            return -1;
-        } else if (person_b.type === "broadcast") {
-            return 1;
-        }
-    } else {
-        if (person_a.type === "broadcast") {
-            if (person_b.type === "broadcast") {
-                return person_a.user.idx - person_b.user.idx;
-            }
-            return 1;
-        } else if (person_b.type === "broadcast") {
-            return -1;
-        }
-    }
-
-    // Now handle actual people users.
-    // give preference to subscribed users first
-    if (current_stream_id !== undefined) {
+    const view_is_stream = current_stream_id !== undefined;
+    if (view_is_stream && !peer_data.has_full_subscriber_data(current_stream_id)) {
         // Fetch subscriber data if we don't have it yet, but don't wait for it.
         // It's fine to use partial data for now, and hopefully on subsequent
         // keystrokes, we'll have the full data to show more subscribers at the
         // top of the list.
         //
         // (We will usually have it, since entering a channel triggers a fetch.)
-        if (!peer_data.has_full_subscriber_data(current_stream_id)) {
-            void peer_data.fetch_stream_subscribers(current_stream_id);
+        void peer_data.fetch_stream_subscribers(current_stream_id);
+    }
+    if (person_a.type === "user" && person_b.type === "user") {
+        if (view_is_stream) {
+            // Callers pass a stream's topic together with its id (the topic
+            // can be ""), so a selected stream always has a defined topic.
+            assert(current_topic !== undefined);
+            return compare_users_for_streams(
+                person_a.user,
+                person_b.user,
+                current_stream_id,
+                current_topic,
+            );
         }
-
-        // If the client does not yet have complete subscriber data,
-        // "unknown" and "not subscribed" are both represented as false here.
-        const a_is_sub = stream_data.is_user_loaded_and_subscribed(
-            current_stream_id,
-            person_a.user.user_id,
-        );
-        const b_is_sub = stream_data.is_user_loaded_and_subscribed(
-            current_stream_id,
-            person_b.user.user_id,
-        );
-
-        if (a_is_sub && !b_is_sub) {
-            return -1;
-        } else if (!a_is_sub && b_is_sub) {
-            return 1;
-        }
+        return compare_users_for_dms(person_a.user, person_b.user, query);
+    }
+    // User vs wildcard
+    if (person_a.type === "user") {
+        return compare_user_with_wildcard(person_a.user, current_stream_id, current_topic);
+    }
+    if (person_b.type === "user") {
+        return -compare_user_with_wildcard(person_b.user, current_stream_id, current_topic);
     }
 
-    if (compare_by_current_conversation !== undefined) {
-        const preference = compare_by_current_conversation(person_a.user, person_b.user);
-        if (preference !== 0) {
-            return preference;
-        }
-    }
-
-    return compare_by_pms(person_a.user, person_b.user);
+    // Both are wildcard mentions; `idx` preserves the order in which
+    // broadcast_mentions() lists them (e.g. @all before @topic).
+    return person_a.user.idx - person_b.user.idx;
 }
 
 export function sort_people_for_relevance<UserType extends UserOrMentionPillData | UserPillData>(
     objs: UserType[],
     current_stream_id?: number,
     current_topic?: string,
+    query = "",
 ): UserType[] {
     // If sorting for recipientbox typeahead and not viewing a stream / topic, then current_stream = ""
     const current_stream =
         current_stream_id !== undefined ? stream_data.get_sub_by_id(current_stream_id) : undefined;
     if (current_stream === undefined) {
-        objs.sort((person_a, person_b) => compare_people_for_relevance(person_a, person_b));
+        // Viewing PM conversations
+        objs.sort((person_a, person_b) =>
+            compare_people_for_relevance(person_a, person_b, undefined, undefined, query),
+        );
     } else {
         assert(current_stream_id !== undefined);
         assert(current_topic !== undefined);
+
+        // Viewing Stream messages
         objs.sort((person_a, person_b) =>
             compare_people_for_relevance(
                 person_a,
                 person_b,
-                (user_a, user_b) =>
-                    recent_senders.compare_by_recency(
-                        user_a,
-                        user_b,
-                        current_stream_id,
-                        current_topic,
-                    ),
                 current_stream_id,
+                current_topic,
+                query,
             ),
         );
     }
@@ -539,7 +583,7 @@ export let sort_recipients = <UserType extends UserOrMentionPillData | UserPillD
     max_num_items?: number | undefined;
 }): (UserType | UserGroupPillData)[] => {
     function sort_relevance(items: UserType[]): UserType[] {
-        return sort_people_for_relevance(items, current_stream_id, current_topic);
+        return sort_people_for_relevance(items, current_stream_id, current_topic, query);
     }
 
     function is_bot(user: UserType): boolean {

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -284,12 +284,7 @@ export function compare_by_pms(user_a: User, user_b: User): number {
 
     // We use alpha sort as a tiebreaker, which might be helpful for
     // new users.
-    if (user_a.full_name < user_b.full_name) {
-        return -1;
-    } else if (user_a === user_b) {
-        return 0;
-    }
-    return 1;
+    return user_a.full_name.localeCompare(user_b.full_name);
 }
 
 export function compare_people_for_relevance(
@@ -748,13 +743,7 @@ export function compare_group_setting_options(
         }
     }
 
-    if (option_a.user.full_name < option_b.user.full_name) {
-        return -1;
-    } else if (option_a.user.full_name === option_b.user.full_name) {
-        return 0;
-    }
-
-    return 1;
+    return option_a.user.full_name.localeCompare(option_b.user.full_name);
 }
 
 export const sort_users_and_groups_options = ({
@@ -941,13 +930,7 @@ export function compare_stream_or_group_members_options(
     assert(option_a.type === "user");
     assert(option_b.type === "user");
 
-    if (option_a.user.full_name < option_b.user.full_name) {
-        return -1;
-    } else if (option_a.user.full_name === option_b.user.full_name) {
-        return 0;
-    }
-
-    return 1;
+    return option_a.user.full_name.localeCompare(option_b.user.full_name);
 }
 
 export let sort_stream_or_group_members_options = ({

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -753,7 +753,9 @@ const make_emoji = (emoji_dict) => ({
     type: "emoji",
 });
 
-// Alphabetical tiebreaker in compare_by_pms sorts by full_name.
+// Empty query: compare_users_for_dms sorts alphabetically
+// by full_name (no recipient count, no partners, no name-length
+// tiebreaker without a query).
 const sorted_user_list = [
     ali_item, // Ali
     alice_item, // Alice
@@ -1482,8 +1484,8 @@ test("initialize", ({override, override_rewire, mock_template}) => {
             case $("#private_message_recipient")[0]: {
                 pill_items = [];
 
-                // Users sorted alphabetically by compare_by_pms
-                // tiebreaker, then groups, then welcome_bot.
+                // Empty query: alphabetical by full_name (no recipient
+                // count or PM partners), then groups, then bot.
                 let actual_value = options.source("");
                 let expected_value = [
                     ali_item, // Ali
@@ -2259,11 +2261,11 @@ test("begins_typeahead", ({override, override_rewire}) => {
     ]);
 
     const mention_all = broadcast_item(ct.broadcast_mentions()[0]);
-    // compose_state is "private" (from earlier test), so broadcasts
-    // sort after all users; bots alphabetical after non-bots.
+    // No stream context and no PM partners: broadcast sorts before
+    // all non-partner users; bots alphabetical by full_name.
     const users_and_all_mention = [
-        ...sorted_user_list,
         mention_all,
+        ...sorted_user_list,
         notification_bot_item, // Notification Bot
         welcome_bot_item, // Welcome Bot
     ];
@@ -2295,17 +2297,17 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals("@**", mentions_with_silent_marker(users_and_all_mention, false));
     assert_typeahead_equals("@_**", mentions_with_silent_marker(users_and_user_groups, true));
     // "o" is anywhere in each name; Othello starts with "o" so
-    // sorts first.  Remaining users alphabetical, then broadcasts
-    // (private mode), then bots alphabetical.
+    // sorts first.  Broadcast before non-partner users (no PM
+    // partners in test), then bots by name length (shorter first).
     assert_typeahead_equals(
         "test @**o",
         mentions_with_silent_marker(
             [
                 othello_item, // Othello starts with "o"
+                mention_everyone, // broadcast: before non-partner users
                 cordelia_item, // "Cordelia" contains "o"
-                mention_everyone, // broadcast: after users in private mode
-                notification_bot_item, // Notification Bot
                 welcome_bot_item, // Welcome Bot
+                notification_bot_item, // Notification Bot
             ],
             false,
         ),
@@ -2313,7 +2315,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals(
         "test @_**o",
         mentions_with_silent_marker(
-            [othello_item, cordelia_item, admins, members, notification_bot_item, welcome_bot_item],
+            [othello_item, cordelia_item, admins, members, welcome_bot_item, notification_bot_item],
             true,
         ),
     );
@@ -2323,28 +2325,28 @@ test("begins_typeahead", ({override, override_rewire}) => {
         mentions_with_silent_marker(
             [
                 othello_item,
-                cordelia_item,
                 mention_everyone,
-                notification_bot_item,
+                cordelia_item,
                 welcome_bot_item,
+                notification_bot_item,
             ],
             false,
         ),
     );
     // "k" matches: "King Hamlet" and "King Lear" start with "k"
-    // (best, alphabetical); "Mark Twin" x2 contain "k" (ok,
+    // (best, shorter name first); "Mark Twin" x2 contain "k" (ok,
     // word-boundary match); "backend" group also matches.
     assert_typeahead_equals(
         "test @_*k",
         mentions_with_silent_marker(
-            [hamlet_item, lear_item, twin1_item, twin2_item, backend],
+            [lear_item, hamlet_item, twin1_item, twin2_item, backend],
             true,
         ),
     );
     // "h": Harry starts with "h" (best); Earl Hal and King Hamlet
-    // have word-boundary match (ok, alphabetical); Cordelia and
+    // have word-boundary match (ok, shorter name first); Cordelia and
     // Othello contain "h" but no word-boundary match (worst,
-    // alphabetical).
+    // shorter name first).
     assert_typeahead_equals(
         "test @*h",
         mentions_with_silent_marker(
@@ -2370,20 +2372,21 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals("@** ", []);
     assert_typeahead_equals("@_** ", []);
     // "i" has no name-start match; all users whose name contains "i"
-    // are in the worst tier, sorted alphabetically by full_name.
+    // are in the worst tier, sorted by name length (shorter first);
+    // equal-length names alphabetical by full_name.
     assert_typeahead_equals(
         "test\n@i",
         mentions_with_silent_marker(
             [
-                ali_item, // Ali
-                alice_item, // Alice
-                cordelia_item, // Cordelia, Lear's daughter
-                gael_item, // Gaël Twin
-                hamlet_item, // King Hamlet
-                lear_item, // King Lear
-                twin1_item, // Mark Twin
-                twin2_item, // Mark Twin
-                othello_item, // Othello, the Moor of Venice
+                ali_item, // Ali (3)
+                alice_item, // Alice (5)
+                gael_item, // Gaël Twin (9)
+                lear_item, // King Lear (9)
+                twin1_item, // Mark Twin (9)
+                twin2_item, // Mark Twin (9)
+                hamlet_item, // King Hamlet (11)
+                cordelia_item, // Cordelia, Lear's daughter (25)
+                othello_item, // Othello, the Moor of Venice (28)
                 notification_bot_item, // Notification Bot (bot tier)
             ],
             false,
@@ -2396,38 +2399,37 @@ test("begins_typeahead", ({override, override_rewire}) => {
         "test\n@_i",
         mentions_with_silent_marker(
             [
-                ali_item, // Ali
-                alice_item, // Alice
-                cordelia_item, // Cordelia, Lear's daughter
-                gael_item, // Gaël Twin
-                hamlet_item, // King Hamlet
-                lear_item, // King Lear
-                twin1_item, // Mark Twin
-                twin2_item, // Mark Twin
-                othello_item, // Othello, the Moor of Venice
+                ali_item, // Ali (3)
+                alice_item, // Alice (5)
+                gael_item, // Gaël Twin (9)
+                lear_item, // King Lear (9)
+                twin1_item, // Mark Twin (9)
+                twin2_item, // Mark Twin (9)
+                hamlet_item, // King Hamlet (11)
+                cordelia_item, // Cordelia, Lear's daughter (25)
+                othello_item, // Othello, the Moor of Venice (28)
                 admins, // group: admins
                 notification_bot_item, // Notification Bot (bot tier)
             ],
             true,
         ),
     );
-    // "l": Cordelia and Lear have word-boundary match on "Lear"
-    // (best, alphabetical).  Others contain "l" with no word-boundary
-    // match (worst, alphabetical).  Broadcast after users (private
-    // mode), then bot.
+    // "l": King Lear and Cordelia have word-boundary match on "Lear"
+    // (best, shorter name first).  Broadcast before non-partner
+    // users (worst); remaining users by name length; then bot.
     assert_typeahead_equals(
         "test\n @l",
         mentions_with_silent_marker(
             [
-                cordelia_item, // Cordelia, *L*ear's daughter
-                lear_item, // King *L*ear
-                ali_item, // Ali
-                alice_item, // Alice
-                hal_item, // Earl Hal
-                gael_item, // Gaël Twin
-                hamlet_item, // King Hamlet
-                othello_item, // Othello, the Moor of Venice
-                mention_all, // broadcast "all" (after users)
+                lear_item, // King *L*ear (9)
+                cordelia_item, // Cordelia, *L*ear's daughter (25)
+                mention_all, // broadcast "all" (before non-partners)
+                ali_item, // Ali (3)
+                alice_item, // Alice (5)
+                hal_item, // Earl Hal (8)
+                gael_item, // Gaël Twin (9)
+                hamlet_item, // King Hamlet (11)
+                othello_item, // Othello, the Moor of Venice (28)
                 welcome_bot_item, // Welcome Bot (bot tier)
             ],
             false,
@@ -2437,8 +2439,8 @@ test("begins_typeahead", ({override, override_rewire}) => {
         "test\n @_l",
         mentions_with_silent_marker(
             [
-                cordelia_item,
                 lear_item,
+                cordelia_item,
                 ali_item,
                 alice_item,
                 hal_item,
@@ -2459,24 +2461,28 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals("@_ zuli", []);
     assert_typeahead_equals(" @zuli", []);
     assert_typeahead_equals(" @_zuli", []);
-    // Same ordering logic as @**o above.
+    // Same ordering logic as @**o above: name-start match first, then
+    // the broadcast mention before non-partner users, then remaining
+    // matches by name length (shorter first).
     assert_typeahead_equals(
         "test @o",
         mentions_with_silent_marker(
             [
-                othello_item,
-                cordelia_item,
-                mention_everyone,
-                notification_bot_item,
-                welcome_bot_item,
+                othello_item, // Othello starts with "o"
+                mention_everyone, // broadcast: before non-partner users
+                cordelia_item, // "Cordelia" contains "o"
+                welcome_bot_item, // Welcome Bot (11)
+                notification_bot_item, // Notification Bot (16)
             ],
             false,
         ),
     );
+    // Silent variant: user groups appear in place of the broadcast
+    // mention; bots still sort by name length (shorter first).
     assert_typeahead_equals(
         "test @_o",
         mentions_with_silent_marker(
-            [othello_item, cordelia_item, admins, members, notification_bot_item, welcome_bot_item],
+            [othello_item, cordelia_item, admins, members, welcome_bot_item, notification_bot_item],
             true,
         ),
     );
@@ -2960,8 +2966,8 @@ test("typeahead_results", ({override}) => {
     assert_mentions_matches("oor ", []);
     assert_mentions_matches("oor o", []);
     assert_mentions_matches("oor of venice", []);
-    // Both start with "King "; alphabetical: Hamlet < Lear.
-    assert_mentions_matches("King ", [not_silent(hamlet_item), not_silent(lear_item)]);
+    // Both start with "King "; shorter name first: Lear (9) < Hamlet (11).
+    assert_mentions_matches("King ", [not_silent(lear_item), not_silent(hamlet_item)]);
     assert_mentions_matches("King H", [not_silent(hamlet_item)]);
     assert_mentions_matches("King L", [not_silent(lear_item)]);
     assert_mentions_matches("delia lear", []);
@@ -2982,17 +2988,17 @@ test("typeahead_results", ({override}) => {
     const mention_everyone = not_silent(broadcast_item(ct.broadcast_mentions()[1]));
     // compose_state is "stream" here, so broadcasts sort before users.
     // "everyone" and Earl Hal start with "e" (best, broadcast first);
-    // remaining users contain "e" (worst, alphabetical); then groups
-    // and bots.
+    // remaining users contain "e" (worst, shorter name first); then
+    // groups and bots.
     assert_mentions_matches("e", [
         not_silent(mention_everyone), // broadcast: "everyone" starts with "e"
-        not_silent(hal_item), // Earl Hal starts with "e"
-        not_silent(alice_item), // Alice
-        not_silent(cordelia_item), // Cordelia, Lear's daughter
-        not_silent(gael_item), // Gaël Twin
-        not_silent(hamlet_item), // King Hamlet
-        not_silent(lear_item), // King Lear
-        not_silent(othello_item), // Othello, the Moor of Venice
+        not_silent(hal_item), // Earl Hal (8) starts with "e"
+        not_silent(alice_item), // Alice (5)
+        not_silent(gael_item), // Gaël Twin (9)
+        not_silent(lear_item), // King Lear (9)
+        not_silent(hamlet_item), // King Hamlet (11)
+        not_silent(cordelia_item), // Cordelia, Lear's daughter (25)
+        not_silent(othello_item), // Othello, the Moor of Venice (28)
         not_silent(hamletcharacters), // group
         not_silent(call_center), // group
         not_silent(welcome_bot_item), // Welcome Bot (bot tier)
@@ -3003,14 +3009,14 @@ test("typeahead_results", ({override}) => {
     const mention_topic = broadcast_item(ct.broadcast_mentions()[4]);
     // Othello starts with "o" (best); everyone/topic broadcasts and
     // Cordelia contain "o" (worst, broadcasts first in stream mode,
-    // then user); bots alphabetical.
+    // then user); bots by name length (shorter first).
     assert_mentions_matches("o", [
         not_silent(othello_item), // Othello starts with "o"
         not_silent(mention_everyone), // broadcast (stream mode: first)
         not_silent(mention_topic), // broadcast (stream mode: first)
         not_silent(cordelia_item), // "Cordelia" contains "o"
-        not_silent(notification_bot_item), // Notification Bot
         not_silent(welcome_bot_item), // Welcome Bot
+        not_silent(notification_bot_item), // Notification Bot
     ]);
 
     // Autocomplete by slash commands.

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -753,19 +753,19 @@ const make_emoji = (emoji_dict) => ({
     type: "emoji",
 });
 
-// Sorted by name
+// Alphabetical tiebreaker in compare_by_pms sorts by full_name.
 const sorted_user_list = [
-    ali_item,
-    alice_item,
-    cordelia_item,
-    hal_item, // Early Hal
-    gael_item,
-    harry_item,
+    ali_item, // Ali
+    alice_item, // Alice
+    cordelia_item, // Cordelia, Lear's daughter
+    hal_item, // Earl Hal
+    gael_item, // Gaël Twin
+    harry_item, // Harry
     hamlet_item, // King Hamlet
-    lear_item,
+    lear_item, // King Lear
     twin1_item, // Mark Twin
-    twin2_item,
-    othello_item,
+    twin2_item, // Mark Twin
+    othello_item, // Othello, the Moor of Venice
 ];
 
 function test(label, f) {
@@ -1482,20 +1482,21 @@ test("initialize", ({override, override_rewire, mock_template}) => {
             case $("#private_message_recipient")[0]: {
                 pill_items = [];
 
-                // This should match the users added at the beginning of this test file.
+                // Users sorted alphabetically by compare_by_pms
+                // tiebreaker, then groups, then welcome_bot.
                 let actual_value = options.source("");
                 let expected_value = [
-                    ali_item,
-                    alice_item,
-                    cordelia_item,
-                    hal_item,
-                    gael_item,
-                    harry_item,
-                    hamlet_item,
-                    lear_item,
-                    twin1_item,
-                    twin2_item,
-                    othello_item,
+                    ali_item, // Ali
+                    alice_item, // Alice
+                    cordelia_item, // Cordelia, Lear's daughter
+                    hal_item, // Earl Hal
+                    gael_item, // Gaël Twin
+                    harry_item, // Harry
+                    hamlet_item, // King Hamlet
+                    lear_item, // King Lear
+                    twin1_item, // Mark Twin
+                    twin2_item, // Mark Twin
+                    othello_item, // Othello, the Moor of Venice
                     hamletcharacters,
                     backend,
                     call_center,
@@ -2258,22 +2259,24 @@ test("begins_typeahead", ({override, override_rewire}) => {
     ]);
 
     const mention_all = broadcast_item(ct.broadcast_mentions()[0]);
+    // compose_state is "private" (from earlier test), so broadcasts
+    // sort after all users; bots alphabetical after non-bots.
     const users_and_all_mention = [
         ...sorted_user_list,
         mention_all,
-        notification_bot_item,
-        welcome_bot_item,
+        notification_bot_item, // Notification Bot
+        welcome_bot_item, // Welcome Bot
     ];
     const users_and_user_groups = [
         ...sorted_user_list,
-        // alphabetical
+        // Groups alphabetical by display name.
         hamletcharacters, // "Characters of Hamlet"
         backend,
-        call_center, // "folks working in support",
+        call_center, // "folks working in support"
         admins,
         members,
-        notification_bot_item,
-        welcome_bot_item,
+        notification_bot_item, // Notification Bot
+        welcome_bot_item, // Welcome Bot
     ];
     const mention_everyone = broadcast_item(ct.broadcast_mentions()[1]);
     function mentions_with_silent_marker(mentions, is_silent) {
@@ -2291,27 +2294,30 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals("@_*", mentions_with_silent_marker(users_and_user_groups, true));
     assert_typeahead_equals("@**", mentions_with_silent_marker(users_and_all_mention, false));
     assert_typeahead_equals("@_**", mentions_with_silent_marker(users_and_user_groups, true));
+    // "o" is anywhere in each name; Othello starts with "o" so
+    // sorts first.  Remaining users alphabetical, then broadcasts
+    // (private mode), then bots alphabetical.
     assert_typeahead_equals(
         "test @**o",
         mentions_with_silent_marker(
             [
-                othello_item,
-                cordelia_item,
-                mention_everyone,
-                notification_bot_item,
-                welcome_bot_item,
+                othello_item, // Othello starts with "o"
+                cordelia_item, // "Cordelia" contains "o"
+                mention_everyone, // broadcast: after users in private mode
+                notification_bot_item, // Notification Bot
+                welcome_bot_item, // Welcome Bot
             ],
             false,
         ),
     );
     assert_typeahead_equals(
         "test @_**o",
-
         mentions_with_silent_marker(
             [othello_item, cordelia_item, admins, members, notification_bot_item, welcome_bot_item],
             true,
         ),
     );
+    // Same as @**o above.
     assert_typeahead_equals(
         "test @*o",
         mentions_with_silent_marker(
@@ -2325,6 +2331,9 @@ test("begins_typeahead", ({override, override_rewire}) => {
             false,
         ),
     );
+    // "k" matches: "King Hamlet" and "King Lear" start with "k"
+    // (best, alphabetical); "Mark Twin" x2 contain "k" (ok,
+    // word-boundary match); "backend" group also matches.
     assert_typeahead_equals(
         "test @_*k",
         mentions_with_silent_marker(
@@ -2332,6 +2341,10 @@ test("begins_typeahead", ({override, override_rewire}) => {
             true,
         ),
     );
+    // "h": Harry starts with "h" (best); Earl Hal and King Hamlet
+    // have word-boundary match (ok, alphabetical); Cordelia and
+    // Othello contain "h" but no word-boundary match (worst,
+    // alphabetical).
     assert_typeahead_equals(
         "test @*h",
         mentions_with_silent_marker(
@@ -2356,57 +2369,66 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals("@_* ", []);
     assert_typeahead_equals("@** ", []);
     assert_typeahead_equals("@_** ", []);
+    // "i" has no name-start match; all users whose name contains "i"
+    // are in the worst tier, sorted alphabetically by full_name.
     assert_typeahead_equals(
         "test\n@i",
         mentions_with_silent_marker(
             [
-                ali_item,
-                alice_item,
-                cordelia_item,
-                gael_item,
-                hamlet_item,
-                lear_item,
-                twin1_item,
-                twin2_item,
-                othello_item,
-                notification_bot_item,
+                ali_item, // Ali
+                alice_item, // Alice
+                cordelia_item, // Cordelia, Lear's daughter
+                gael_item, // Gaël Twin
+                hamlet_item, // King Hamlet
+                lear_item, // King Lear
+                twin1_item, // Mark Twin
+                twin2_item, // Mark Twin
+                othello_item, // Othello, the Moor of Venice
+                notification_bot_item, // Notification Bot (bot tier)
             ],
             false,
         ),
     );
+    // Unlike the non-silent "@i" above, the silent "@_" typeahead offers
+    // every user group (not just those you're allowed to mention), so the
+    // "admins" group appears here; it's the only group whose name has "i".
     assert_typeahead_equals(
         "test\n@_i",
         mentions_with_silent_marker(
             [
-                ali_item,
-                alice_item,
-                cordelia_item,
-                gael_item,
-                hamlet_item,
-                lear_item,
-                twin1_item,
-                twin2_item,
-                othello_item,
-                admins,
-                notification_bot_item,
+                ali_item, // Ali
+                alice_item, // Alice
+                cordelia_item, // Cordelia, Lear's daughter
+                gael_item, // Gaël Twin
+                hamlet_item, // King Hamlet
+                lear_item, // King Lear
+                twin1_item, // Mark Twin
+                twin2_item, // Mark Twin
+                othello_item, // Othello, the Moor of Venice
+                admins, // group: admins
+                notification_bot_item, // Notification Bot (bot tier)
             ],
             true,
         ),
     );
+    // "l": Cordelia and Lear have word-boundary match on "Lear"
+    // (best, alphabetical).  Others contain "l" with no word-boundary
+    // match (worst, alphabetical).  Broadcast after users (private
+    // mode), then bot.
     assert_typeahead_equals(
         "test\n @l",
         mentions_with_silent_marker(
             [
-                cordelia_item,
-                lear_item,
-                ali_item,
-                alice_item,
-                hal_item,
-                gael_item,
-                hamlet_item,
-                othello_item,
-                mention_all,
-                welcome_bot_item,
+                cordelia_item, // Cordelia, *L*ear's daughter
+                lear_item, // King *L*ear
+                ali_item, // Ali
+                alice_item, // Alice
+                hal_item, // Earl Hal
+                gael_item, // Gaël Twin
+                hamlet_item, // King Hamlet
+                othello_item, // Othello, the Moor of Venice
+                mention_all, // broadcast "all" (after users)
+                welcome_bot_item, // Welcome Bot (bot tier)
             ],
             false,
         ),
@@ -2437,6 +2459,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals("@_ zuli", []);
     assert_typeahead_equals(" @zuli", []);
     assert_typeahead_equals(" @_zuli", []);
+    // Same ordering logic as @**o above.
     assert_typeahead_equals(
         "test @o",
         mentions_with_silent_marker(
@@ -2937,6 +2960,7 @@ test("typeahead_results", ({override}) => {
     assert_mentions_matches("oor ", []);
     assert_mentions_matches("oor o", []);
     assert_mentions_matches("oor of venice", []);
+    // Both start with "King "; alphabetical: Hamlet < Lear.
     assert_mentions_matches("King ", [not_silent(hamlet_item), not_silent(lear_item)]);
     assert_mentions_matches("King H", [not_silent(hamlet_item)]);
     assert_mentions_matches("King L", [not_silent(lear_item)]);
@@ -2956,33 +2980,37 @@ test("typeahead_results", ({override}) => {
     // Verify we suggest only the first matching stream wildcard mention,
     // irrespective of how many equivalent stream wildcard mentions match.
     const mention_everyone = not_silent(broadcast_item(ct.broadcast_mentions()[1]));
-    // Here, we suggest only "everyone" instead of both the matching
-    // "everyone" and "stream" wildcard mentions.
+    // compose_state is "stream" here, so broadcasts sort before users.
+    // "everyone" and Earl Hal start with "e" (best, broadcast first);
+    // remaining users contain "e" (worst, alphabetical); then groups
+    // and bots.
     assert_mentions_matches("e", [
-        not_silent(mention_everyone),
-        not_silent(hal_item),
-        not_silent(alice_item),
-        not_silent(cordelia_item),
-        not_silent(gael_item),
-        not_silent(hamlet_item),
-        not_silent(lear_item),
-        not_silent(othello_item),
-        not_silent(hamletcharacters),
-        not_silent(call_center),
-        not_silent(welcome_bot_item),
+        not_silent(mention_everyone), // broadcast: "everyone" starts with "e"
+        not_silent(hal_item), // Earl Hal starts with "e"
+        not_silent(alice_item), // Alice
+        not_silent(cordelia_item), // Cordelia, Lear's daughter
+        not_silent(gael_item), // Gaël Twin
+        not_silent(hamlet_item), // King Hamlet
+        not_silent(lear_item), // King Lear
+        not_silent(othello_item), // Othello, the Moor of Venice
+        not_silent(hamletcharacters), // group
+        not_silent(call_center), // group
+        not_silent(welcome_bot_item), // Welcome Bot (bot tier)
     ]);
 
     // Verify we suggest both 'the first matching stream wildcard' and
     // 'topic wildcard' mentions. Not only one matching wildcard mention.
     const mention_topic = broadcast_item(ct.broadcast_mentions()[4]);
-    // Here, we suggest both "everyone" and "topic".
+    // Othello starts with "o" (best); everyone/topic broadcasts and
+    // Cordelia contain "o" (worst, broadcasts first in stream mode,
+    // then user); bots alphabetical.
     assert_mentions_matches("o", [
-        not_silent(othello_item),
-        not_silent(mention_everyone),
-        not_silent(mention_topic),
-        not_silent(cordelia_item),
-        not_silent(notification_bot_item),
-        not_silent(welcome_bot_item),
+        not_silent(othello_item), // Othello starts with "o"
+        not_silent(mention_everyone), // broadcast (stream mode: first)
+        not_silent(mention_topic), // broadcast (stream mode: first)
+        not_silent(cordelia_item), // "Cordelia" contains "o"
+        not_silent(notification_bot_item), // Notification Bot
+        not_silent(welcome_bot_item), // Welcome Bot
     ]);
 
     // Autocomplete by slash commands.

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -165,13 +165,14 @@ test("get_is_suggestions_for_spectator", () => {
 test("dm_suggestions", ({override}) => {
     let query = "is:dm";
     let suggestions = get_suggestions(query);
+    // Sorted alphabetically by full_name (compare_by_pms tiebreaker).
     let expected = [
         "is:dm",
-        `dm:${alice.user_id}`,
-        `dm:${bob.user_id}`,
-        `dm:${jeff.user_id}`,
-        `dm:${me.user_id}`,
-        `dm:${ted.user_id}`,
+        `dm:${alice.user_id}`, // Alice Ignore
+        `dm:${bob.user_id}`, // Bob Roberts
+        `dm:${jeff.user_id}`, // Jeff Zoolipson
+        `dm:${me.user_id}`, // Me Myself
+        `dm:${ted.user_id}`, // Ted Smith
     ];
     assert.deepEqual(suggestions, expected);
 
@@ -197,14 +198,14 @@ test("dm_suggestions", ({override}) => {
 
     query = "is:private";
     suggestions = get_suggestions(query);
-    // Same search suggestions as for "is:dm"
+    // Same search suggestions and order as for "is:dm".
     expected = [
         "is:dm",
-        `dm:${alice.user_id}`,
-        `dm:${bob.user_id}`,
-        `dm:${jeff.user_id}`,
-        `dm:${me.user_id}`,
-        `dm:${ted.user_id}`,
+        `dm:${alice.user_id}`, // Alice Ignore
+        `dm:${bob.user_id}`, // Bob Roberts
+        `dm:${jeff.user_id}`, // Jeff Zoolipson
+        `dm:${me.user_id}`, // Me Myself
+        `dm:${ted.user_id}`, // Ted Smith
     ];
     assert.deepEqual(suggestions, expected);
 
@@ -1001,10 +1002,11 @@ test("people_suggestions", ({override}) => {
 
     let suggestions = get_suggestions(query);
 
+    // Both match "te"; alphabetical tiebreaker: Bob Térry < Ted Smith.
     let expected = [
         "te",
-        `dm:${bob.user_id}`, // bob térry
-        `dm:${ted.user_id}`,
+        `dm:${bob.user_id}`, // Bob Térry
+        `dm:${ted.user_id}`, // Ted Smith
         `sender:${bob.user_id}`,
         `sender:${ted.user_id}`,
         `dm-including:${bob.user_id}`,
@@ -1023,11 +1025,12 @@ test("people_suggestions", ({override}) => {
     people.add_active_user(accessible_user, "server_events");
     suggestions = get_suggestions(query);
 
+    // Same order with Test unknown user added last (alphabetical).
     expected = [
         "te",
-        `dm:${bob.user_id}`,
-        `dm:${ted.user_id}`,
-        `dm:${inaccessible_user.user_id}`,
+        `dm:${bob.user_id}`, // Bob Térry
+        `dm:${ted.user_id}`, // Ted Smith
+        `dm:${inaccessible_user.user_id}`, // Test unknown user
         `sender:${bob.user_id}`,
         `sender:${ted.user_id}`,
         `sender:${inaccessible_user.user_id}`,

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -165,7 +165,9 @@ test("get_is_suggestions_for_spectator", () => {
 test("dm_suggestions", ({override}) => {
     let query = "is:dm";
     let suggestions = get_suggestions(query);
-    // Sorted alphabetically by full_name (compare_by_pms tiebreaker).
+    // Empty query: compare_users_for_dms sorts alphabetically
+    // by full_name (no recipient count, no partners, no name-length
+    // tiebreaker without a query).
     let expected = [
         "is:dm",
         `dm:${alice.user_id}`, // Alice Ignore
@@ -1002,7 +1004,8 @@ test("people_suggestions", ({override}) => {
 
     let suggestions = get_suggestions(query);
 
-    // Both match "te"; alphabetical tiebreaker: Bob Térry < Ted Smith.
+    // Both match "te"; compare_users_for_dms called without query
+    // so no name-length tiebreaker — alphabetical by full_name.
     let expected = [
         "te",
         `dm:${bob.user_id}`, // Bob Térry
@@ -1025,7 +1028,7 @@ test("people_suggestions", ({override}) => {
     people.add_active_user(accessible_user, "server_events");
     suggestions = get_suggestions(query);
 
-    // Same order with Test unknown user added last (alphabetical).
+    // Same order with Test unknown user added (alphabetical).
     expected = [
         "te",
         `dm:${bob.user_id}`, // Bob Térry

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -545,34 +545,37 @@ function get_typeahead_result(query, current_stream_id, current_topic) {
 test("sort_recipients", () => {
     // Typeahead for recipientbox [query, "", undefined]
     assert.deepEqual(get_typeahead_result("b", ""), [
-        "b_user_1@zulip.net",
-        "b_user_2@zulip.net",
-        "b_user_3@zulip.net",
-        "b_bot@example.com",
-        "a_bot@zulip.com",
-        "a_user@zulip.org",
-        "zman@test.net",
+        "b_user_1@zulip.net", // Bob 1 (name prefix match)
+        "b_user_2@zulip.net", // Bob 2 (name prefix match)
+        "b_user_3@zulip.net", // Bob 3 (name prefix match)
+        "b_bot@example.com", // B bot (name prefix match, bot after humans)
+        "a_bot@zulip.com", // A Zulip test bot (matches "b" in "bot")
+        // "Zman" and "A Zulip user" match neither name nor email, so they
+        // tie on relevance; the non-empty query then orders them by name
+        // length, shorter first.
+        "zman@test.net", // Zman (4)
+        "a_user@zulip.org", // A Zulip user (12)
     ]);
 
     // Test match by email (To get coverage for ok_users and ok_bots)
     assert.deepEqual(get_typeahead_result("b_user_1@zulip.net", ""), [
         "b_user_1@zulip.net",
-        "a_user@zulip.org",
+        "zman@test.net",
         "b_user_2@zulip.net",
         "b_user_3@zulip.net",
-        "zman@test.net",
-        "a_bot@zulip.com",
+        "a_user@zulip.org",
         "b_bot@example.com",
+        "a_bot@zulip.com",
     ]);
 
     // Typeahead for direct message [query, "", ""]
     assert.deepEqual(get_typeahead_result("a", "", ""), [
         "a_user@zulip.org",
         "a_bot@zulip.com",
+        "zman@test.net",
         "b_user_1@zulip.net",
         "b_user_2@zulip.net",
         "b_user_3@zulip.net",
-        "zman@test.net",
         "b_bot@example.com",
     ]);
 
@@ -699,26 +702,31 @@ test("sort_recipients pm counts", () => {
 
     assert.deepEqual(get_typeahead_result("b", linux_sub.stream_id, "Linux topic"), [
         "b_user_3@zulip.net",
-        "b_user_2@zulip.net",
         "b_user_1@zulip.net",
+        "b_user_2@zulip.net",
         "b_bot@example.com",
         "a_bot@zulip.com",
         "a_user@zulip.org",
         "zman@test.net",
     ]);
 
-    /* istanbul ignore next */
-    function compare() {
-        throw new Error("We do not expect to need a tiebreaker here.");
-    }
-
     // get some line coverage
     assert.equal(
-        th.compare_people_for_relevance(b_user_1_item, b_user_3_item, compare, linux_sub.stream_id),
+        th.compare_people_for_relevance(
+            b_user_1_item,
+            b_user_3_item,
+            linux_sub.stream_id,
+            "Linux topic",
+        ),
         1,
     );
     assert.equal(
-        th.compare_people_for_relevance(b_user_3_item, b_user_1_item, compare, linux_sub.stream_id),
+        th.compare_people_for_relevance(
+            b_user_3_item,
+            b_user_1_item,
+            linux_sub.stream_id,
+            "Linux topic",
+        ),
         -1,
     );
 });
@@ -740,8 +748,8 @@ test("sort_recipients dup bots", () => {
         "b_bot@example.com",
         "a_bot@zulip.com",
         "a_bot@zulip.com",
-        "a_user@zulip.org",
         "zman@test.net",
+        "a_user@zulip.org",
     ];
     assert.deepEqual(recipients_email, expected);
 });
@@ -774,7 +782,7 @@ test("sort_recipients dup alls direct message", () => {
         query: "a",
     });
 
-    const expected = [a_user_item, all_obj_item];
+    const expected = [all_obj_item, a_user_item];
     assertSameEmails(recipients, expected);
 });
 
@@ -843,7 +851,7 @@ test("sort broadcast mentions for stream message type", () => {
     compose_state.set_message_type("stream");
     const mentions = ct.broadcast_mentions().toReversed();
     const broadcast_items = mentions.map((broadcast) => broadcast_item(broadcast));
-    const results = th.sort_people_for_relevance(broadcast_items, "", "");
+    const results = th.sort_people_for_relevance(broadcast_items, dev_sub.stream_id, "Dev topic");
 
     assert.deepEqual(
         results.map((r) => r.user.email),
@@ -852,7 +860,9 @@ test("sort broadcast mentions for stream message type", () => {
 
     // Reverse the list to test actual sorting
     // and ensure test coverage for the defensive
-    // code.  Also, add in some people users.
+    // code.  Also, add in some people users with
+    // no stream/topic relevance, who should sort
+    // after the wildcard mentions.
     const user_or_mention_items = [
         zman_item,
         ...ct
@@ -861,7 +871,11 @@ test("sort broadcast mentions for stream message type", () => {
             .toReversed(),
         a_user_item,
     ];
-    const results2 = th.sort_people_for_relevance(user_or_mention_items, "", "");
+    const results2 = th.sort_people_for_relevance(
+        user_or_mention_items,
+        dev_sub.stream_id,
+        "Dev topic",
+    );
 
     assert.deepEqual(
         results2.map((r) => r.user.email),
@@ -873,13 +887,15 @@ test("sort broadcast mentions for direct message type", () => {
     compose_state.set_message_type("private");
     const mentions = ct.broadcast_mentions().toReversed();
     const broadcast_items = mentions.map((broadcast) => broadcast_item(broadcast));
-    const results = th.sort_people_for_relevance(broadcast_items, "", "");
+    const results = th.sort_people_for_relevance(broadcast_items);
 
     assert.deepEqual(
         results.map((r) => r.user.email),
         ["all", "everyone"],
     );
 
+    // With no stream context and no DM partners, wildcard
+    // mentions sort before non-partner users.
     const user_or_mention_items = [
         zman_item,
         ...ct
@@ -888,35 +904,25 @@ test("sort broadcast mentions for direct message type", () => {
             .toReversed(),
         a_user_item,
     ];
-    const results2 = th.sort_people_for_relevance(user_or_mention_items, "", "");
+    const results2 = th.sort_people_for_relevance(user_or_mention_items);
 
     assert.deepEqual(
         results2.map((r) => r.user.email),
-        [a_user.email, zman.email, "all", "everyone"],
+        ["all", "everyone", a_user.email, zman.email],
     );
 });
 
-test("test compare directly for stream message type", () => {
+test("test compare directly for broadcast vs user", () => {
     // This is important for ensuring test coverage.
     // We don't technically need it now, but our test
     // coverage is subject to the whims of how JS sorts.
-    compose_state.set_message_type("stream");
     const all_obj = ct.broadcast_mentions()[0];
     const all_obj_item = broadcast_item(all_obj);
 
     assert.equal(th.compare_people_for_relevance(all_obj_item, all_obj_item), 0);
+    // Without stream context, broadcasts come before non-partner users.
     assert.equal(th.compare_people_for_relevance(all_obj_item, zman_item), -1);
     assert.equal(th.compare_people_for_relevance(zman_item, all_obj_item), 1);
-});
-
-test("test compare directly for direct message", () => {
-    compose_state.set_message_type("private");
-    const all_obj = ct.broadcast_mentions()[0];
-    const all_obj_item = broadcast_item(all_obj);
-
-    assert.equal(th.compare_people_for_relevance(all_obj_item, all_obj_item), 0);
-    assert.equal(th.compare_people_for_relevance(all_obj_item, zman_item), 1);
-    assert.equal(th.compare_people_for_relevance(zman_item, all_obj_item), -1);
 });
 
 test("render_person when emails hidden", ({mock_template, override}) => {
@@ -1122,37 +1128,37 @@ test("compare_language", () => {
     assert.equal(th.compare_language("custom_a", "custom_b"), util.strcmp("custom_a", "custom_b"));
 });
 
-test("compare_by_pms", () => {
+test("compare_users_for_dms", () => {
     // Same user should return 0
-    assert.equal(th.compare_by_pms(a_user, a_user), 0);
+    assert.equal(th.compare_users_for_dms(a_user, a_user), 0);
 
-    // Alphabetical fallback when PM counts and partner status are equal
+    // Alphabetical fallback when DM counts and partner status are equal
     assert.equal(
-        th.compare_by_pms(a_user, b_user_1),
+        th.compare_users_for_dms(a_user, b_user_1),
         util.strcmp(a_user.full_name, b_user_1.full_name),
     );
 
     // Reverse order should match strcmp behavior
     assert.equal(
-        th.compare_by_pms(b_user_1, a_user),
+        th.compare_users_for_dms(b_user_1, a_user),
         util.strcmp(b_user_1.full_name, a_user.full_name),
     );
 
     pm_conversations.set_partner(b_user_1.user_id);
 
-    // PM count takes priority over partner status
+    // Partner status takes priority over DM count: b_user_1 is a partner
+    // and wins even though a_user has the higher recipient count.
     people.set_recipient_count_for_testing(a_user.user_id, 10);
     people.set_recipient_count_for_testing(b_user_1.user_id, 5);
 
-    assert.equal(th.compare_by_pms(a_user, b_user_1), -1);
-    assert.equal(th.compare_by_pms(b_user_1, a_user), 1);
+    assert.equal(th.compare_users_for_dms(a_user, b_user_1), 1);
+    assert.equal(th.compare_users_for_dms(b_user_1, a_user), -1);
 
-    // Partner priority when counts are equal
-    people.set_recipient_count_for_testing(a_user.user_id, 0);
-    people.set_recipient_count_for_testing(b_user_1.user_id, 0);
+    // With matching partner status, higher recipient count wins.
+    pm_conversations.set_partner(a_user.user_id);
 
-    assert.equal(th.compare_by_pms(a_user, b_user_1), 1);
-    assert.equal(th.compare_by_pms(b_user_1, a_user), -1);
+    assert.equal(th.compare_users_for_dms(a_user, b_user_1), -1);
+    assert.equal(th.compare_users_for_dms(b_user_1, a_user), 1);
 });
 
 test("sort_group_setting_options", ({override_rewire}) => {

--- a/web/tests/typeahead_sorting_logic.test.cjs
+++ b/web/tests/typeahead_sorting_logic.test.cjs
@@ -1,0 +1,515 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const people = zrequire("people");
+const pm_conversations = zrequire("pm_conversations");
+const recent_senders = zrequire("recent_senders");
+const peer_data = zrequire("peer_data");
+const stream_data = zrequire("stream_data");
+const {set_current_user} = zrequire("state_data");
+const th = zrequire("typeahead_helper");
+
+const current_user = {is_guest: false, is_admin: false};
+set_current_user(current_user);
+people.initialize_current_user({user_id: 1, full_name: "Me"});
+
+// Test users
+const user1 = {
+    user_id: 2,
+    full_name: "Alice",
+    email: "alice@example.com",
+    is_bot: false,
+};
+
+const user2 = {
+    user_id: 3,
+    full_name: "Bob",
+    email: "bob@example.com",
+    is_bot: false,
+};
+
+const user3 = {
+    user_id: 4,
+    full_name: "Charlie",
+    email: "charlie@example.com",
+    is_bot: false,
+};
+
+const user4 = {
+    user_id: 5,
+    full_name: "David",
+    email: "david@example.com",
+    is_bot: false,
+};
+
+const user5 = {
+    user_id: 6,
+    full_name: "Eve",
+    email: "eve@example.com",
+    is_bot: false,
+};
+
+const bot_user = {
+    user_id: 7,
+    full_name: "Bot User",
+    email: "bot@example.com",
+    is_bot: true,
+};
+
+const short_name_user = {
+    user_id: 8,
+    full_name: "Al",
+    email: "al@example.com",
+    is_bot: false,
+};
+
+const long_name_user = {
+    user_id: 9,
+    full_name: "Alexander",
+    email: "alexander@example.com",
+    is_bot: false,
+};
+
+for (const user of [user1, user2, user3, user4, user5, bot_user, short_name_user, long_name_user]) {
+    people.add_active_user(user);
+}
+
+// Test streams
+const stream1 = {
+    name: "Dev",
+    stream_id: 101,
+    color: "blue",
+    subscriber_count: 0,
+};
+
+const stream2 = {
+    name: "General",
+    stream_id: 102,
+    color: "green",
+    subscriber_count: 0,
+};
+
+stream_data.create_streams([stream1, stream2]);
+stream_data.add_sub_for_tests(stream1);
+stream_data.add_sub_for_tests(stream2);
+
+function test(label, f) {
+    run_test(label, (helpers) => {
+        pm_conversations.clear_for_testing();
+        recent_senders.clear_for_testing();
+        peer_data.clear_for_testing();
+        people.clear_recipient_counts_for_testing();
+        peer_data.set_subscribers(stream1.stream_id, [], true);
+        peer_data.set_subscribers(stream2.stream_id, [], true);
+        f(helpers);
+    });
+}
+
+// ============================================================================
+// Tests for compare_users_for_streams
+// ============================================================================
+
+test("compare_users_for_streams: subscribers ranked before non-subscribers", () => {
+    const stream_id = stream1.stream_id;
+    const topic = "test topic";
+
+    // Make user1 a subscriber
+    peer_data.add_subscriber(stream_id, user1.user_id);
+
+    const result = th.compare_users_for_streams(user1, user2, stream_id, topic);
+    assert.ok(result < 0, "subscriber should come before non-subscriber");
+});
+
+test("compare_users_for_streams: both subscribers, recency decides", () => {
+    const stream_id = stream1.stream_id;
+    const topic = "test topic";
+
+    peer_data.add_subscriber(stream_id, user1.user_id);
+    peer_data.add_subscriber(stream_id, user2.user_id);
+
+    recent_senders.process_stream_message({
+        stream_id,
+        topic,
+        sender_id: user2.user_id,
+        id: 100,
+    });
+    recent_senders.process_stream_message({
+        stream_id,
+        topic,
+        sender_id: user1.user_id,
+        id: 200,
+    });
+
+    const result = th.compare_users_for_streams(user1, user2, stream_id, topic);
+    assert.ok(result < 0, "more recent user should come first");
+});
+
+test("compare_users_for_streams: same recency, DM partner comes first", () => {
+    const stream_id = stream1.stream_id;
+    const topic = "test topic";
+
+    peer_data.add_subscriber(stream_id, user1.user_id);
+    peer_data.add_subscriber(stream_id, user2.user_id);
+
+    // Make user1 a DM partner
+    pm_conversations.set_partner(user1.user_id);
+
+    const result = th.compare_users_for_streams(user1, user2, stream_id, topic);
+    assert.ok(result < 0, "DM partner should come first");
+});
+
+test("compare_users_for_streams: non-subscriber without recency, then DM partner", () => {
+    const stream_id = stream1.stream_id;
+    const topic = "test topic";
+
+    // Neither is a subscriber
+    pm_conversations.set_partner(user2.user_id);
+
+    const result = th.compare_users_for_streams(user1, user2, stream_id, topic);
+    assert.ok(result > 0, "user2 with DM partnership should come first");
+});
+
+// ============================================================================
+// Tests for compare_users_for_dms
+// ============================================================================
+// compare_users_for_dms is used when sorting DM recipients (no stream context).
+// Sort order: DM partners > message count > shorter name (if query) > alphabetical
+
+test("compare_users_for_dms: DM partners ranked before non-partners", () => {
+    pm_conversations.set_partner(user1.user_id);
+
+    const result = th.compare_users_for_dms(user1, user2);
+    assert.ok(result < 0, "DM partner should come before non-partner");
+});
+
+test("compare_users_for_dms: both partners, higher count comes first", () => {
+    pm_conversations.set_partner(user1.user_id);
+    pm_conversations.set_partner(user2.user_id);
+
+    people.set_recipient_count_for_testing(user1.user_id, 10);
+    people.set_recipient_count_for_testing(user2.user_id, 5);
+
+    const result = th.compare_users_for_dms(user1, user2);
+    assert.ok(result < 0, "higher message count should come first");
+});
+
+test("compare_users_for_dms: same count and partner status, shorter name comes first", () => {
+    // This test verifies the NEW behavior: when users have the same partner
+    // status and message count, shorter names are preferred.
+    // This rule ONLY applies when the user has started typing (query is non-empty).
+    pm_conversations.set_partner(short_name_user.user_id);
+    pm_conversations.set_partner(long_name_user.user_id);
+
+    people.set_recipient_count_for_testing(short_name_user.user_id, 5);
+    people.set_recipient_count_for_testing(long_name_user.user_id, 5);
+
+    const result = th.compare_users_for_dms(short_name_user, long_name_user, "a");
+    assert.ok(result < 0, "shorter name should come first");
+});
+
+test("compare_users_for_dms: same count and partner status, name length sorting only when query is non-empty", () => {
+    // This test verifies that name length comparison is ONLY applied when the
+    // user has started typing (query is non-empty). Without a query, users with
+    // equal DM partner status and message count fall through to alphabetical.
+    pm_conversations.set_partner(short_name_user.user_id);
+    pm_conversations.set_partner(long_name_user.user_id);
+
+    people.set_recipient_count_for_testing(short_name_user.user_id, 5);
+    people.set_recipient_count_for_testing(long_name_user.user_id, 5);
+
+    // With empty query, name length is skipped; alphabetical applies
+    const result_empty = th.compare_users_for_dms(short_name_user, long_name_user, "");
+    assert.ok(result_empty < 0, "alphabetical sort applies with empty query");
+
+    // With non-empty query, shorter name should come first
+    const result_with_query = th.compare_users_for_dms(short_name_user, long_name_user, "a");
+    assert.ok(result_with_query < 0, "shorter name should come first when query is not empty");
+});
+
+test("compare_users_for_dms: not partners but with different counts", () => {
+    // Neither is a partner
+    people.set_recipient_count_for_testing(user1.user_id, 10);
+    people.set_recipient_count_for_testing(user2.user_id, 5);
+
+    const result = th.compare_users_for_dms(user1, user2);
+    assert.ok(result < 0, "higher count should come first");
+});
+
+// ============================================================================
+// Tests for compare_user_with_wildcard (DM context)
+// ============================================================================
+
+test("compare_user_with_wildcard (DM): DM partner gets preference", () => {
+    pm_conversations.set_partner(user1.user_id);
+
+    const result = th.compare_user_with_wildcard(user1);
+    assert.ok(result < 0, "DM partner should have priority over wildcard");
+});
+
+test("compare_user_with_wildcard (DM): non-partner has less preference", () => {
+    // user2 is not a DM partner
+    const result = th.compare_user_with_wildcard(user2);
+    assert.ok(result > 0, "non-partner should have less priority than wildcard");
+});
+
+// ============================================================================
+// Tests for compare_user_with_wildcard (Stream context)
+// ============================================================================
+
+test("compare_user_with_wildcard (Stream): subscriber gets preference", () => {
+    const stream_id = stream1.stream_id;
+    const topic = "test topic";
+
+    peer_data.add_subscriber(stream_id, user1.user_id);
+
+    const result = th.compare_user_with_wildcard(user1, stream_id, topic);
+    assert.ok(result < 0, "subscriber should have priority over wildcard");
+});
+
+test("compare_user_with_wildcard (Stream): non-subscriber who posted in topic", () => {
+    const stream_id = stream1.stream_id;
+    const topic = "test topic";
+
+    recent_senders.process_stream_message({
+        stream_id,
+        topic,
+        sender_id: user1.user_id,
+        id: 110,
+    });
+
+    const result = th.compare_user_with_wildcard(user1, stream_id, topic);
+    assert.ok(result < 0, "topic participant should have priority over wildcard");
+});
+
+test("compare_user_with_wildcard (Stream): posted in stream but not topic", () => {
+    const stream_id = stream1.stream_id;
+    const topic = "test topic";
+
+    recent_senders.process_stream_message({
+        stream_id,
+        topic: "other topic",
+        sender_id: user1.user_id,
+        id: 120,
+    });
+
+    const result = th.compare_user_with_wildcard(user1, stream_id, topic);
+    assert.ok(result < 0, "stream participant should have priority over wildcard");
+});
+
+test("compare_user_with_wildcard (Stream): DM partner but nothing else", () => {
+    const stream_id = stream1.stream_id;
+    const topic = "test topic";
+
+    pm_conversations.set_partner(user1.user_id);
+
+    const result = th.compare_user_with_wildcard(user1, stream_id, topic);
+    assert.ok(result < 0, "DM partner should have priority over wildcard in stream context");
+});
+
+test("compare_user_with_wildcard (Stream): no relevance should have less priority", () => {
+    const stream_id = stream1.stream_id;
+    const topic = "test topic";
+
+    const result = th.compare_user_with_wildcard(user2, stream_id, topic);
+    assert.ok(result > 0, "user with no relevance should have less priority than wildcard");
+});
+
+// ============================================================================
+// Tests for compare_people_for_relevance (Stream context)
+// ============================================================================
+
+test("compare_people_for_relevance (Stream): two users both subscribers", () => {
+    const stream_id = stream1.stream_id;
+    const topic = "test topic";
+
+    peer_data.add_subscriber(stream_id, user1.user_id);
+    peer_data.add_subscriber(stream_id, user2.user_id);
+
+    const person_a = {type: "user", user: user1};
+    const person_b = {type: "user", user: user2};
+
+    const result = th.compare_people_for_relevance(person_a, person_b, stream_id, topic);
+    assert.ok(result < 0, "equal criteria, alphabetical tiebreaker: Alice < Bob");
+});
+
+test("compare_people_for_relevance (Stream): user vs wildcard (subscriber wins)", () => {
+    const stream_id = stream1.stream_id;
+    const topic = "test topic";
+
+    peer_data.add_subscriber(stream_id, user1.user_id);
+
+    const person_user = {type: "user", user: user1};
+    const person_wildcard = {type: "broadcast", user: {special_item_text: "@all", user_id: 0}};
+
+    const result = th.compare_people_for_relevance(person_user, person_wildcard, stream_id, topic);
+    assert.ok(result < 0, "subscriber should come before wildcard");
+});
+
+test("compare_people_for_relevance (Stream): wildcard vs user (non-subscriber)", () => {
+    const stream_id = stream1.stream_id;
+    const topic = "test topic";
+
+    const person_wildcard = {type: "broadcast", user: {special_item_text: "@all", user_id: 0}};
+    const person_user = {type: "user", user: user1};
+
+    const result = th.compare_people_for_relevance(person_wildcard, person_user, stream_id, topic);
+    assert.ok(result < 0, "wildcard should come before non-subscriber");
+});
+
+// ============================================================================
+// Tests for compare_people_for_relevance (DM context)
+// ============================================================================
+
+test("compare_people_for_relevance (DM): two users both DM partners", () => {
+    pm_conversations.set_partner(user1.user_id);
+    pm_conversations.set_partner(user2.user_id);
+
+    people.set_recipient_count_for_testing(user1.user_id, 10);
+    people.set_recipient_count_for_testing(user2.user_id, 5);
+
+    const person_a = {type: "user", user: user1};
+    const person_b = {type: "user", user: user2};
+
+    const result = th.compare_people_for_relevance(person_a, person_b);
+    assert.ok(result < 0, "user with higher count should come first in DM context");
+});
+
+test("compare_people_for_relevance (DM): user vs wildcard (partner wins)", () => {
+    pm_conversations.set_partner(user1.user_id);
+
+    const person_user = {type: "user", user: user1};
+    const person_wildcard = {type: "broadcast", user: {special_item_text: "@all", user_id: 0}};
+
+    const result = th.compare_people_for_relevance(person_user, person_wildcard);
+    assert.ok(result < 0, "DM partner should come before wildcard in DM context");
+});
+
+test("compare_people_for_relevance (DM): wildcard vs user (non-partner)", () => {
+    const person_wildcard = {type: "broadcast", user: {special_item_text: "@all", user_id: 0}};
+    const person_user = {type: "user", user: user1};
+
+    const result = th.compare_people_for_relevance(person_wildcard, person_user);
+    assert.ok(result < 0, "wildcard should come before non-partner in DM context");
+});
+
+test("compare_people_for_relevance (DM): two wildcards", () => {
+    const person_wildcard_a = {
+        type: "broadcast",
+        user: {special_item_text: "@all", user_id: 0, idx: 1},
+    };
+    const person_wildcard_b = {
+        type: "broadcast",
+        user: {special_item_text: "@everyone", user_id: 0, idx: 2},
+    };
+
+    const result = th.compare_people_for_relevance(person_wildcard_a, person_wildcard_b);
+    assert.ok(result < 0, "wildcards should be compared by idx");
+});
+
+// ============================================================================
+// Integration tests - Sorting multiple people
+// ============================================================================
+
+test("sort people for stream relevance - mixed users", () => {
+    const stream_id = stream1.stream_id;
+    const topic = "test topic";
+
+    peer_data.add_subscriber(stream_id, user1.user_id);
+    pm_conversations.set_partner(user2.user_id);
+
+    const people_list = [
+        {type: "user", user: user2},
+        {type: "user", user: user1},
+    ];
+
+    people_list.sort((a, b) => th.compare_people_for_relevance(a, b, stream_id, topic));
+
+    assert.equal(people_list[0].user.user_id, user1.user_id, "subscriber should come first");
+    assert.equal(people_list[1].user.user_id, user2.user_id, "DM partner should come second");
+});
+
+test("sort people for DM relevance - mixed users", () => {
+    pm_conversations.set_partner(user1.user_id);
+    people.set_recipient_count_for_testing(user1.user_id, 5);
+    people.set_recipient_count_for_testing(user2.user_id, 10);
+
+    const people_list = [
+        {type: "user", user: user2},
+        {type: "user", user: user1},
+    ];
+
+    people_list.sort((a, b) => th.compare_people_for_relevance(a, b));
+
+    assert.equal(people_list[0].user.user_id, user1.user_id, "DM partner should come first");
+    assert.equal(people_list[1].user.user_id, user2.user_id, "non-partner should come second");
+});
+
+test("sort users by name length - same other criteria", () => {
+    pm_conversations.set_partner(short_name_user.user_id);
+    pm_conversations.set_partner(long_name_user.user_id);
+    people.set_recipient_count_for_testing(short_name_user.user_id, 5);
+    people.set_recipient_count_for_testing(long_name_user.user_id, 5);
+
+    const people_list = [
+        {type: "user", user: long_name_user},
+        {type: "user", user: short_name_user},
+    ];
+
+    people_list.sort((a, b) => th.compare_people_for_relevance(a, b, undefined, undefined, "a"));
+
+    assert.equal(
+        people_list[0].user.user_id,
+        short_name_user.user_id,
+        "shorter name should come first",
+    );
+    assert.equal(
+        people_list[1].user.user_id,
+        long_name_user.user_id,
+        "longer name should come second",
+    );
+});
+
+test("stream sorting priority: subscriber > topic participant > stream participant > DM partner", () => {
+    const stream_id = stream1.stream_id;
+    const topic = "test topic";
+
+    // user1: subscriber
+    peer_data.add_subscriber(stream_id, user1.user_id);
+
+    // user2: not subscriber, but posted in topic
+    recent_senders.process_stream_message({
+        stream_id,
+        topic,
+        sender_id: user2.user_id,
+        id: 300,
+    });
+
+    // user3: posted in stream but not topic
+    recent_senders.process_stream_message({
+        stream_id,
+        topic: "other topic",
+        sender_id: user3.user_id,
+        id: 250,
+    });
+
+    // user4: not subscriber, no stream participation, DM partner
+    pm_conversations.set_partner(user4.user_id);
+
+    const people_list = [
+        {type: "user", user: user3},
+        {type: "user", user: user2},
+        {type: "user", user: user4},
+        {type: "user", user: user1},
+    ];
+
+    people_list.sort((a, b) => th.compare_people_for_relevance(a, b, stream_id, topic));
+
+    assert.equal(people_list[0].user.user_id, user1.user_id, "subscriber should be first");
+    assert.equal(people_list[1].user.user_id, user2.user_id, "topic participant should be second");
+    assert.equal(people_list[2].user.user_id, user3.user_id, "stream participant should be third");
+    assert.equal(people_list[3].user.user_id, user4.user_id, "DM partner should be fourth");
+});


### PR DESCRIPTION
discussion: [#design > mention typeahead](https://chat.zulip.org/#narrow/channel/101-design/topic/mention.20typeahead/with/1242409)

issue #26838

To make the changes easy to review, I had Claude write comments in each of the tests for why users were sorted the way they were so that changes to the user sort order are easy to understand.
