### PR TITLE
api docs: Replace BOT_EMAIL_ADDRESS with example email

### DIFF
--- a/api_docs/create-scheduled-message.md
+++ b/api_docs/create-scheduled-message.md
@@ -13,7 +13,7 @@
 ``` curl
 # Create a scheduled channel message
 curl -X POST {{ api_url }}/v1/scheduled_messages \
-    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
+    -u othello-bot@example.com:BOT_API_KEY \
     --data-urlencode type=stream \
     --data-urlencode to=9 \
     --data-urlencode topic=Hello \
@@ -22,7 +22,7 @@ curl -X POST {{ api_url }}/v1/scheduled_messages \
 
 # Create a scheduled direct message
 curl -X POST {{ api_url }}/v1/messages \
-    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
+    -u othello-bot@example.com:BOT_API_KEY \
     --data-urlencode type=direct \
     --data-urlencode 'to=[9, 10]' \
     --data-urlencode 'content=Can we meet on Monday?' \

--- a/api_docs/send-message.md
+++ b/api_docs/send-message.md
@@ -13,7 +13,7 @@
 ``` curl
 # For channel messages
 curl -X POST {{ api_url }}/v1/messages \
-    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
+    -u othello-bot@example.com:BOT_API_KEY \
     --data-urlencode type=stream \
     --data-urlencode 'to="Denmark"' \
     --data-urlencode topic=Castle \
@@ -21,7 +21,7 @@ curl -X POST {{ api_url }}/v1/messages \
 
 # For direct messages
 curl -X POST {{ api_url }}/v1/messages \
-    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
+    -u othello-bot@example.com:BOT_API_KEY \
     --data-urlencode type=direct \
     --data-urlencode 'to=[9]' \
     --data-urlencode 'content=With mirth and laughter let old wrinkles come.'


### PR DESCRIPTION
Replaces the unrealistic `BOT_EMAIL_ADDRESS` placeholder with `othello-bot@example.com` in the API documentation (`api_docs/send-message.md` and `api_docs/create-scheduled-message.md`).

**Reasoning:**
- **Consistency:** The documentation already uses `othello-bot` in other examples.
- **Standardization:** `example.com` is the standard reserved domain for documentation examples (RFC 2606).

Fixes #479

**How changes were tested:**
1. **Visual Verification:** Generated the documentation locally and verified that the new email address renders correctly in the modified files.
2. **Repository Search:** Ran a grep search for `BOT_EMAIL_ADDRESS` to ensure no other occurrences of this placeholder remain in the documentation.

**Screenshots and screen captures:**
<img width="1919" height="1079" alt="Screenshot 2026-02-14 121648" src="https://github.com/user-attachments/assets/86ee8317-336c-4d0a-b0db-a8315e9e500f" />
<img width="1919" height="1079" alt="Screenshot 2026-02-14 121754" src="https://github.com/user-attachments/assets/a4c4b6cb-61b9-45d8-ab90-65a94c3b3fa7" />


<details>
<summary>Self-review checklist</summary>

[x] Self-reviewed the changes for clarity and maintainability.
[x] Followed the AI use policy.

**Communicate decisions, questions, and potential concerns.**
[x] Explains differences from previous plans (e.g., issue description).
[ ] Highlights technical choices and bugs encountered.
[ ] Calls out remaining decisions and concerns.
[ ] Automated tests verify logic where appropriate.

**Individual commits are ready for review (see commit discipline).**
[x] Each commit is a coherent idea.
[x] Commit message(s) explain reasoning and motivation for changes.

**Completed manual review and testing of the following:**
[x] Visual appearance of the changes.
[ ] Responsiveness and internationalization.
[x] Strings and tooltips.
[ ] End-to-end functionality of buttons, interactions and flows.
[ ] Corner cases, error conditions, and easily imagined bugs.

</details>