### PR TITLE
Typeahead: Prioritize exact diacritic-prefix matches over normalized matches

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -207,15 +207,17 @@ export function topics_seen_for(stream_id?: number): string[] {
 }
 
 export function get_language_matcher(query: string): (language: string) => boolean {
-    query = query.toLowerCase();
+    // Filtering is diacritics-agnostic: strip diacritics from both the query
+    // and the language name so ASCII and diacritic spellings match each other.
+    query = typeahead.remove_diacritics(query.toLowerCase());
     return function (language: string): boolean {
-        return language.includes(query);
+        return typeahead.remove_diacritics(language.toLowerCase()).includes(query);
     };
 }
 
 export function get_stream_matcher(query: string): (stream: StreamPillData) => boolean {
     // Case-insensitive.
-    query = typeahead.clean_query_lowercase(query, false);
+    query = typeahead.clean_query_lowercase(query);
     const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
     return function (stream: StreamPillData) {
@@ -224,7 +226,7 @@ export function get_stream_matcher(query: string): (stream: StreamPillData) => b
 }
 
 export function get_slash_matcher(query: string): (item: SlashCommand) => boolean {
-    query = typeahead.clean_query_lowercase(query, false);
+    query = typeahead.clean_query_lowercase(query);
     const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
     return function (item: SlashCommand) {
@@ -246,7 +248,7 @@ export function get_slash_matcher(query: string): (item: SlashCommand) => boolea
 }
 
 function get_topic_matcher(query: string): (topic: string) => boolean {
-    query = typeahead.clean_query_lowercase(query, false);
+    query = typeahead.clean_query_lowercase(query);
     const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
     return function (topic: string): boolean {
@@ -712,7 +714,7 @@ function filter_persons<T>(
 }
 
 export function get_person_suggestion_for_topic_typeahead(query: string): UserPillData[] {
-    query = typeahead.clean_query_lowercase(query, false);
+    query = typeahead.clean_query_lowercase(query);
 
     const filterer = (person_items: UserPillData[]): UserPillData[] =>
         person_items.filter((item) =>
@@ -783,7 +785,7 @@ export function get_person_suggestions(
     opts: PersonSuggestionOpts,
     exclude_non_welcome_bots = false,
 ): (UserOrMentionPillData | UserGroupPillData)[] {
-    query = typeahead.clean_query_lowercase(query, false);
+    query = typeahead.clean_query_lowercase(query);
 
     let groups: UserGroup[];
     if (opts.filter_groups_for_mention) {

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -713,11 +713,10 @@ function filter_persons<T>(
 
 export function get_person_suggestion_for_topic_typeahead(query: string): UserPillData[] {
     query = typeahead.clean_query_lowercase(query, false);
-    const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
     const filterer = (person_items: UserPillData[]): UserPillData[] =>
         person_items.filter((item) =>
-            typeahead_helper.query_matches_person_name(query, item, should_remove_diacritics, true),
+            typeahead_helper.query_matches_person_name(query, item, true),
         );
 
     const current_narrow_participant_ids = message_lists.current?.data.participants.visible();
@@ -785,7 +784,6 @@ export function get_person_suggestions(
     exclude_non_welcome_bots = false,
 ): (UserOrMentionPillData | UserGroupPillData)[] {
     query = typeahead.clean_query_lowercase(query, false);
-    const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
     let groups: UserGroup[];
     if (opts.filter_groups_for_mention) {
@@ -824,7 +822,7 @@ export function get_person_suggestions(
     }));
 
     const filtered_groups = group_pill_data.filter((item) =>
-        typeahead_helper.query_matches_group_name(query, item, should_remove_diacritics),
+        typeahead_helper.query_matches_group_name(query, item),
     );
 
     const user = people.get_from_unique_full_name(query);
@@ -881,7 +879,6 @@ export function get_person_suggestions(
             typeahead_helper.query_matches_person(
                 query,
                 item,
-                should_remove_diacritics,
                 undefined,
                 opts.allow_custom_profile_field_matching,
             ),
@@ -1279,9 +1276,8 @@ export function get_candidates(
 }
 
 export function content_item_html(
-    query: string,
+    _query: string,
 ): (item: TypeaheadSuggestion) => string | undefined {
-    const should_remove_diacritics = !typeahead.contains_diacritics(query);
     return function (item: TypeaheadSuggestion): string | undefined {
         switch (item.type) {
             case "emoji":
@@ -1291,7 +1287,6 @@ export function content_item_html(
             case "broadcast":
                 return typeahead_helper.render_person_or_user_group(item, {
                     query: token,
-                    should_remove_diacritics,
                 });
             case "slash":
                 return typeahead_helper.render_typeahead_item({

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -713,11 +713,10 @@ function filter_persons<T>(
 
 export function get_person_suggestion_for_topic_typeahead(query: string): UserPillData[] {
     query = typeahead.clean_query_lowercase(query, false);
-    const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
     const filterer = (person_items: UserPillData[]): UserPillData[] =>
         person_items.filter((item) =>
-            typeahead_helper.query_matches_person_name(query, item, should_remove_diacritics, true),
+            typeahead_helper.query_matches_person_name(query, item, true),
         );
 
     const current_narrow_participant_ids = message_lists.current?.data.participants.visible();
@@ -785,7 +784,6 @@ export function get_person_suggestions(
     exclude_non_welcome_bots = false,
 ): (UserOrMentionPillData | UserGroupPillData)[] {
     query = typeahead.clean_query_lowercase(query, false);
-    const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
     let groups: UserGroup[];
     if (opts.filter_groups_for_mention) {
@@ -824,7 +822,7 @@ export function get_person_suggestions(
     }));
 
     const filtered_groups = group_pill_data.filter((item) =>
-        typeahead_helper.query_matches_group_name(query, item, should_remove_diacritics),
+        typeahead_helper.query_matches_group_name(query, item),
     );
 
     const user = people.get_from_unique_full_name(query);
@@ -881,7 +879,6 @@ export function get_person_suggestions(
             typeahead_helper.query_matches_person(
                 query,
                 item,
-                should_remove_diacritics,
                 undefined,
                 opts.allow_custom_profile_field_matching,
             ),

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -16,23 +16,15 @@ import type {UserGroup} from "./user_groups.ts";
 import * as user_pill from "./user_pill.ts";
 import type {UserPillData, UserPillWidget} from "./user_pill.ts";
 
-function person_matcher(
-    query: string,
-    item: UserPillData,
-    should_remove_diacritics: boolean,
-): boolean {
+function person_matcher(query: string, item: UserPillData): boolean {
     return (
         people.is_known_user_id(item.user.user_id) &&
-        typeahead_helper.query_matches_person(query, item, should_remove_diacritics)
+        typeahead_helper.query_matches_person(query, item)
     );
 }
 
-function group_matcher(
-    query: string,
-    item: UserGroupPillData,
-    should_remove_diacritics: boolean,
-): boolean {
-    return typeahead_helper.query_matches_group_name(query, item, should_remove_diacritics);
+function group_matcher(query: string, item: UserGroupPillData): boolean {
+    return typeahead_helper.query_matches_group_name(query, item);
 }
 
 type TypeaheadItem = UserGroupPillData | StreamPillData | UserPillData;
@@ -60,8 +52,7 @@ export function set_up_user(
         },
         matcher(query: string): (item: UserPillData) => boolean {
             query = typeahead.clean_query_lowercase(query, false);
-            const should_remove_diacritics = !typeahead.contains_diacritics(query);
-            return (item: UserPillData) => person_matcher(query, item, should_remove_diacritics);
+            return (item: UserPillData) => person_matcher(query, item);
         },
         sorter(matches: UserPillData[], query: string): UserPillData[] {
             const users = matches.filter((match) => people.is_known_user_id(match.user.user_id));
@@ -156,10 +147,7 @@ export function set_up_user_group(
         },
         matcher(query: string): (item: UserGroupPillData) => boolean {
             query = typeahead.clean_query_lowercase(query, false);
-            const should_remove_diacritics = !typeahead.contains_diacritics(query);
-
-            return (item: UserGroupPillData) =>
-                group_matcher(query, item, should_remove_diacritics);
+            return (item: UserGroupPillData) => group_matcher(query, item);
         },
         sorter(matches: UserGroupPillData[], query: string): UserGroupPillData[] {
             return typeahead_helper.sort_user_groups(matches, query);
@@ -207,14 +195,13 @@ export function set_up_group_setting_typeahead(
         },
         matcher(query: string): (item: GroupSettingTypeaheadItem) => boolean {
             query = typeahead.clean_query_lowercase(query, false);
-            const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
             return (item: GroupSettingTypeaheadItem): boolean => {
                 let matches = false;
                 if (item.type === "user_group") {
-                    matches ||= group_matcher(query, item, should_remove_diacritics);
+                    matches ||= group_matcher(query, item);
                 } else if (item.type === "user") {
-                    matches ||= person_matcher(query, item, should_remove_diacritics);
+                    matches ||= person_matcher(query, item);
                 }
                 return matches;
             };
@@ -352,7 +339,6 @@ export function set_up_combined(
         },
         matcher(query: string): (item: TypeaheadItem) => boolean {
             query = typeahead.clean_query_lowercase(query, false);
-            const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
             return (item: TypeaheadItem): boolean => {
                 if (include_streams(query) && item.type === "stream") {
@@ -363,18 +349,18 @@ export function set_up_combined(
                 if (include_user_groups && query.startsWith("@")) {
                     if (item.type === "user_group") {
                         const normalized_query = query.slice(1);
-                        return group_matcher(normalized_query, item, should_remove_diacritics);
+                        return group_matcher(normalized_query, item);
                     }
                     return false;
                 }
 
                 let matches = false;
                 if (include_user_groups && item.type === "user_group") {
-                    matches = group_matcher(query, item, should_remove_diacritics);
+                    matches = group_matcher(query, item);
                 }
 
                 if (include_users && item.type === "user") {
-                    matches ||= person_matcher(query, item, should_remove_diacritics);
+                    matches ||= person_matcher(query, item);
                 }
                 return matches;
             };

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -51,7 +51,7 @@ export function set_up_user(
             return (item: UserPillData) => typeahead_helper.render_person(item);
         },
         matcher(query: string): (item: UserPillData) => boolean {
-            query = typeahead.clean_query_lowercase(query, false);
+            query = typeahead.clean_query_lowercase(query);
             return (item: UserPillData) => person_matcher(query, item);
         },
         sorter(matches: UserPillData[], query: string): UserPillData[] {
@@ -146,7 +146,7 @@ export function set_up_user_group(
             return (item: UserGroupPillData) => typeahead_helper.render_user_group(item);
         },
         matcher(query: string): (item: UserGroupPillData) => boolean {
-            query = typeahead.clean_query_lowercase(query, false);
+            query = typeahead.clean_query_lowercase(query);
             return (item: UserGroupPillData) => group_matcher(query, item);
         },
         sorter(matches: UserGroupPillData[], query: string): UserGroupPillData[] {
@@ -194,7 +194,7 @@ export function set_up_group_setting_typeahead(
             };
         },
         matcher(query: string): (item: GroupSettingTypeaheadItem) => boolean {
-            query = typeahead.clean_query_lowercase(query, false);
+            query = typeahead.clean_query_lowercase(query);
 
             return (item: GroupSettingTypeaheadItem): boolean => {
                 let matches = false;
@@ -338,7 +338,7 @@ export function set_up_combined(
             };
         },
         matcher(query: string): (item: TypeaheadItem) => boolean {
-            query = typeahead.clean_query_lowercase(query, false);
+            query = typeahead.clean_query_lowercase(query);
 
             return (item: TypeaheadItem): boolean => {
                 if (include_streams(query) && item.type === "stream") {

--- a/web/src/realm_playground.ts
+++ b/web/src/realm_playground.ts
@@ -74,6 +74,8 @@ export function get_pygments_typeahead_list_for_settings(query: string): Map<str
 
     // Adds a typeahead that allows selecting a custom language, by adding a
     // "Custom language" label in the first position of the typeahead list.
+    // Selecting this option registers the query as typed, diacritics
+    // included; the matcher strips diacritics on both sides instead.
     const clean_query = typeahead.clean_query_lowercase(query);
     if (clean_query !== "") {
         language_labels.set(

--- a/web/src/settings_playgrounds.ts
+++ b/web/src/settings_playgrounds.ts
@@ -192,7 +192,7 @@ function build_page(): void {
                 exact_matches,
                 begins_with_case_sensitive_matches,
                 begins_with_case_insensitive_matches,
-            } = typeahead.triage_raw_with_multiple_items(q, items, (item) => [
+            } = typeahead.triage_raw(q, items, (item) => [
                 item,
                 ...realm_playground.get_aliases_for_pretty_name(item),
             ]);

--- a/web/src/settings_playgrounds.ts
+++ b/web/src/settings_playgrounds.ts
@@ -190,6 +190,7 @@ function build_page(): void {
 
             const {
                 exact_matches,
+                begins_with_case_insensitive_diacritic_matches,
                 begins_with_case_sensitive_matches,
                 begins_with_case_insensitive_matches,
             } = typeahead.triage_raw(q, items, (item) => [
@@ -199,6 +200,7 @@ function build_page(): void {
 
             const begins_with = [
                 ...exact_matches,
+                ...begins_with_case_insensitive_diacritic_matches,
                 ...begins_with_case_sensitive_matches,
                 ...begins_with_case_insensitive_matches,
             ];

--- a/web/src/settings_playgrounds.ts
+++ b/web/src/settings_playgrounds.ts
@@ -169,17 +169,22 @@ function build_page(): void {
             return (item: string) => render_typeahead_item({primary: language_labels.get(item)});
         },
         matcher(query: string): (item: string) => boolean {
-            const q = query.trim().toLowerCase();
+            // Filtering is diacritics-agnostic: strip diacritics from both the query
+            // and the language name so ASCII and diacritic spellings match each other.
+            const q = typeahead.remove_diacritics(query.trim().toLowerCase());
 
             if (q === "") {
                 return () => true;
             }
 
+            const begins_with_query = (name: string): boolean =>
+                typeahead.remove_diacritics(name.toLowerCase()).startsWith(q);
+
             return (item: string) =>
-                item.toLowerCase().startsWith(q) ||
+                begins_with_query(item) ||
                 realm_playground
                     .get_aliases_for_pretty_name(item)
-                    .some((alias) => alias.toLowerCase().startsWith(q));
+                    .some((alias) => begins_with_query(alias));
         },
         sorter(items: string[], query: string): string[] {
             const q = query.trim().toLowerCase();

--- a/web/src/typeahead.ts
+++ b/web/src/typeahead.ts
@@ -253,7 +253,7 @@ export function get_emoji_matcher(query: string): (emoji: EmojiSuggestion) => bo
 // from BEFORE_MENTION_ALLOWED_REGEX in zerver/lib/mention.py later.
 export const word_boundary_chars = " _/-";
 
-export function triage_raw_with_multiple_items<T>(
+export function triage_raw<T>(
     query: string,
     objs: T[],
     get_items: (x: T) => string[],
@@ -264,6 +264,17 @@ export function triage_raw_with_multiple_items<T>(
     word_boundary_matches: T[];
     no_matches: T[];
 } {
+    /*
+        We split objs into five groups:
+
+            - entire string exact match
+            - match prefix exactly with `query`
+            - match prefix case-insensitively
+            - match word boundary prefix case-insensitively
+            - other
+
+        and return an object of these.
+    */
     const exact_matches = [];
     const begins_with_case_sensitive_matches = [];
     const begins_with_case_insensitive_matches = [];
@@ -302,63 +313,6 @@ export function triage_raw_with_multiple_items<T>(
     };
 }
 
-export function triage_raw<T>(
-    query: string,
-    objs: T[],
-    get_item: (x: T) => string,
-): {
-    exact_matches: T[];
-    begins_with_case_sensitive_matches: T[];
-    begins_with_case_insensitive_matches: T[];
-    word_boundary_matches: T[];
-    no_matches: T[];
-} {
-    /*
-        We split objs into five groups:
-
-            - entire string exact match
-            - match prefix exactly with `query`
-            - match prefix case-insensitively
-            - match word boundary prefix case-insensitively
-            - other
-
-        and return an object of these.
-    */
-    const exact_matches = [];
-    const begins_with_case_sensitive_matches = [];
-    const begins_with_case_insensitive_matches = [];
-    const word_boundary_matches = [];
-    const no_matches = [];
-    const lower_query = query ? query.toLowerCase() : "";
-
-    for (const obj of objs) {
-        const item = get_item(obj);
-        const lower_item = item.toLowerCase();
-
-        if (lower_item === lower_query) {
-            exact_matches.push(obj);
-        } else if (item.startsWith(query)) {
-            begins_with_case_sensitive_matches.push(obj);
-        } else if (lower_item.startsWith(lower_query)) {
-            begins_with_case_insensitive_matches.push(obj);
-        } else if (
-            new RegExp(`[${word_boundary_chars}]${_.escapeRegExp(lower_query)}`).test(lower_item)
-        ) {
-            word_boundary_matches.push(obj);
-        } else {
-            no_matches.push(obj);
-        }
-    }
-
-    return {
-        exact_matches,
-        begins_with_case_sensitive_matches,
-        begins_with_case_insensitive_matches,
-        word_boundary_matches,
-        no_matches,
-    };
-}
-
 export function triage<T>(
     query: string,
     objs: T[],
@@ -371,7 +325,7 @@ export function triage<T>(
         begins_with_case_insensitive_matches,
         word_boundary_matches,
         no_matches,
-    } = triage_raw(query, objs, get_item);
+    } = triage_raw(query, objs, (x) => [get_item(x)]);
 
     if (sorting_comparator) {
         const beginning_matches_sorted = [

--- a/web/src/typeahead.ts
+++ b/web/src/typeahead.ts
@@ -259,31 +259,46 @@ export function triage_raw<T>(
     get_items: (x: T) => string[],
 ): {
     exact_matches: T[];
+    // Only populated when the query itself contains diacritics; holds items
+    // whose lowercased form starts with the lowercased query (diacritics intact).
+    begins_with_case_insensitive_diacritic_matches: T[];
     begins_with_case_sensitive_matches: T[];
     begins_with_case_insensitive_matches: T[];
     word_boundary_matches: T[];
     no_matches: T[];
 } {
     /*
-        We split objs into five groups:
+        We split objs into six groups:
 
             - entire string exact match
-            - match prefix exactly with `query`
-            - match prefix case-insensitively
-            - match word boundary prefix case-insensitively
+            - case-insensitive prefix match preserving diacritics in the query
+            - prefix match with `query` exactly (case-sensitive)
+            - prefix match case-insensitively
+            - word-boundary prefix match case-insensitively
             - other
 
         and return an object of these.
+
+        A query with diacritics also matches after stripping diacritics from
+        both sides, so "gaë" matches "Gael" but ranks below "Gaël". A query
+        without diacritics gets no such fallback, so "a" doesn't prefix-match
+        "Ądam".
     */
     const exact_matches = [];
+    const begins_with_case_insensitive_diacritic_matches = [];
     const begins_with_case_sensitive_matches = [];
     const begins_with_case_insensitive_matches = [];
     const word_boundary_matches = [];
     const no_matches = [];
     const lower_query = query ? query.toLowerCase() : "";
+    const diacritic_stripped_query = remove_diacritics(lower_query);
+    const query_has_diacritics = lower_query !== diacritic_stripped_query;
 
-    const word_boundary_match_regex = new RegExp(
+    const lower_word_boundary_regex = new RegExp(
         `[${word_boundary_chars}]${_.escapeRegExp(lower_query)}`,
+    );
+    const diacritic_stripped_word_boundary_regex = new RegExp(
+        `[${word_boundary_chars}]${_.escapeRegExp(diacritic_stripped_query)}`,
     );
 
     for (const obj of objs) {
@@ -293,11 +308,28 @@ export function triage_raw<T>(
 
         if (lower_items.includes(lower_query)) {
             exact_matches.push(obj);
+        } else if (
+            query_has_diacritics &&
+            lower_items.some((item) => item.startsWith(lower_query))
+        ) {
+            begins_with_case_insensitive_diacritic_matches.push(obj);
         } else if (items.some((item) => item.startsWith(query))) {
             begins_with_case_sensitive_matches.push(obj);
         } else if (lower_items.some((item) => item.startsWith(lower_query))) {
             begins_with_case_insensitive_matches.push(obj);
-        } else if (lower_items.some((item) => word_boundary_match_regex.test(item))) {
+        } else if (
+            query_has_diacritics &&
+            lower_items.some((item) => remove_diacritics(item).startsWith(diacritic_stripped_query))
+        ) {
+            begins_with_case_insensitive_matches.push(obj);
+        } else if (lower_items.some((item) => lower_word_boundary_regex.test(item))) {
+            word_boundary_matches.push(obj);
+        } else if (
+            query_has_diacritics &&
+            lower_items.some((item) =>
+                diacritic_stripped_word_boundary_regex.test(remove_diacritics(item)),
+            )
+        ) {
             word_boundary_matches.push(obj);
         } else {
             no_matches.push(obj);
@@ -306,6 +338,7 @@ export function triage_raw<T>(
 
     return {
         exact_matches,
+        begins_with_case_insensitive_diacritic_matches,
         begins_with_case_sensitive_matches,
         begins_with_case_insensitive_matches,
         word_boundary_matches,
@@ -321,6 +354,7 @@ export function triage<T>(
 ): {matches: T[]; rest: T[]} {
     const {
         exact_matches,
+        begins_with_case_insensitive_diacritic_matches,
         begins_with_case_sensitive_matches,
         begins_with_case_insensitive_matches,
         word_boundary_matches,
@@ -335,6 +369,7 @@ export function triage<T>(
         return {
             matches: [
                 ...exact_matches.toSorted(sorting_comparator),
+                ...begins_with_case_insensitive_diacritic_matches.toSorted(sorting_comparator),
                 ...beginning_matches_sorted,
                 ...word_boundary_matches.toSorted(sorting_comparator),
             ],
@@ -345,6 +380,7 @@ export function triage<T>(
     return {
         matches: [
             ...exact_matches,
+            ...begins_with_case_insensitive_diacritic_matches,
             ...begins_with_case_sensitive_matches,
             ...begins_with_case_insensitive_matches,
             ...word_boundary_matches,

--- a/web/src/typeahead.ts
+++ b/web/src/typeahead.ts
@@ -205,10 +205,7 @@ export function query_matches_string_in_any_order(
     return true;
 }
 
-function clean_query(query: string, should_remove_diacritics: boolean): string {
-    if (should_remove_diacritics) {
-        query = remove_diacritics(query);
-    }
+function clean_query(query: string): string {
     // When `abc ` with a space at the end is typed in
     // a content-editable widget such as the composebox
     // direct message section, the space at the end was
@@ -219,9 +216,9 @@ function clean_query(query: string, should_remove_diacritics: boolean): string {
     return query;
 }
 
-export function clean_query_lowercase(query: string, remove_diacritics = true): string {
+export function clean_query_lowercase(query: string): string {
     query = query.toLowerCase();
-    query = clean_query(query, remove_diacritics);
+    query = clean_query(query);
     return query;
 }
 
@@ -234,7 +231,7 @@ export const parse_unicode_emoji_code = (code: string): string =>
 export function get_emoji_matcher(query: string): (emoji: EmojiSuggestion) => boolean {
     // replace spaces with underscores for emoji matching
     query = query.replaceAll(" ", "_");
-    query = clean_query_lowercase(query, false);
+    query = clean_query_lowercase(query);
     const should_remove_diacritics = !contains_diacritics(query);
 
     return function (emoji) {

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -96,7 +96,6 @@ export let render_person = (
     person: UserPillData | UserOrMentionPillData,
     opts?: {
         query: string;
-        should_remove_diacritics: boolean;
     },
 ): string => {
     if (person.type === "broadcast") {
@@ -123,11 +122,14 @@ export let render_person = (
     let secondary_text = user_email;
 
     if (opts) {
+        // Strip diacritics as query_matches_person does, so the email or
+        // field that made this user match is the one we show.
+        const diacritic_stripped_query = typeahead.remove_diacritics(opts.query);
         const email_matches = typeahead.query_matches_string_in_order(
-            opts.query,
+            diacritic_stripped_query,
             user_email ?? "",
             "",
-            opts.should_remove_diacritics,
+            true,
         );
         let matched_custom_field;
 
@@ -140,10 +142,10 @@ export let render_person = (
 
             if (
                 typeahead.query_matches_string_in_order(
-                    opts.query,
+                    diacritic_stripped_query,
                     value ?? "",
                     "",
-                    opts.should_remove_diacritics,
+                    true,
                 )
             ) {
                 matched_custom_field = value;
@@ -205,7 +207,6 @@ export function render_person_or_user_group(
     item: UserGroupPillData | UserPillData | UserOrMentionPillData,
     opts?: {
         query: string;
-        should_remove_diacritics: boolean;
     },
 ): string {
     if (item.type === "user_group") {
@@ -542,11 +543,6 @@ const get_user_matches_with_quality = <UserType extends UserOrMentionPillData | 
     worst_users: () => UserType[];
 } => {
     const users_name_results = typeahead.triage_raw(query, users, (p) => [p.user.full_name]);
-    const users_name_good_matches = [
-        ...users_name_results.exact_matches,
-        ...users_name_results.begins_with_case_sensitive_matches,
-        ...users_name_results.begins_with_case_insensitive_matches,
-    ];
     const users_name_okay_matches = [...users_name_results.word_boundary_matches];
 
     const email_results = typeahead.triage_raw(query, users_name_results.no_matches, (p) => [
@@ -554,14 +550,42 @@ const get_user_matches_with_quality = <UserType extends UserOrMentionPillData | 
     ]);
     const email_good_matches = [
         ...email_results.exact_matches,
+        ...email_results.begins_with_case_insensitive_diacritic_matches,
         ...email_results.begins_with_case_sensitive_matches,
         ...email_results.begins_with_case_insensitive_matches,
     ];
     const email_okay_matches = [...email_results.word_boundary_matches];
-    const best_users = (): UserType[] => [
-        ...sort_relevance(users_name_good_matches),
-        ...sort_relevance(users_name_okay_matches),
-    ];
+    const query_has_diacritics = typeahead.contains_diacritics(query);
+    const best_users = (): UserType[] => {
+        if (query_has_diacritics) {
+            // Sort exact and diacritic-prefix matches together as one tier, and
+            // case-sensitive + case-insensitive (including the diacritic-stripped
+            // fallback) as a second tier. The separate sort calls ensure relevance
+            // sorting within the second tier can't bubble a diacritic-stripped
+            // fallback above a diacritic prefix match.
+            return [
+                ...sort_relevance([
+                    ...users_name_results.exact_matches,
+                    ...users_name_results.begins_with_case_insensitive_diacritic_matches,
+                ]),
+                ...sort_relevance([
+                    ...users_name_results.begins_with_case_sensitive_matches,
+                    ...users_name_results.begins_with_case_insensitive_matches,
+                ]),
+                ...sort_relevance(users_name_okay_matches),
+            ];
+        }
+
+        const users_name_good_matches = [
+            ...users_name_results.exact_matches,
+            ...users_name_results.begins_with_case_sensitive_matches,
+            ...users_name_results.begins_with_case_insensitive_matches,
+        ];
+        return [
+            ...sort_relevance(users_name_good_matches),
+            ...sort_relevance(users_name_okay_matches),
+        ];
+    };
     const ok_users = (): UserType[] => [
         ...sort_relevance(email_good_matches),
         ...sort_relevance(email_okay_matches),
@@ -619,6 +643,7 @@ export let sort_recipients = <UserType extends UserOrMentionPillData | UserPillD
     });
     const groups_good_matches = [
         ...groups_results.exact_matches,
+        ...groups_results.begins_with_case_insensitive_diacritic_matches,
         ...groups_results.begins_with_case_sensitive_matches,
         ...groups_results.begins_with_case_insensitive_matches,
     ];
@@ -843,6 +868,9 @@ export const sort_users_and_groups_options = ({
     ]);
 
     const prefix_matches = sort_items([
+        ...groups_results.begins_with_case_insensitive_diacritic_matches,
+        ...users_name_results.begins_with_case_insensitive_diacritic_matches,
+        ...email_results.begins_with_case_insensitive_diacritic_matches,
         ...groups_results.begins_with_case_sensitive_matches,
         ...groups_results.begins_with_case_insensitive_matches,
         ...users_name_results.begins_with_case_sensitive_matches,
@@ -1146,19 +1174,19 @@ export function rewire_sort_user_groups(value: typeof sort_user_groups): void {
 export function query_matches_person_name(
     query: string,
     person: UserPillData,
-    should_remove_diacritics: boolean,
     match_prefix?: boolean,
 ): boolean {
-    query = query.toLowerCase();
-
-    const full_name = people.maybe_remove_diacritics_from_name(
-        person.user,
-        should_remove_diacritics,
-    );
-
+    // Filtering is diacritics-agnostic: we strip diacritics from both the query
+    // and the name so ASCII and diacritic spellings match each other. Ranking is
+    // not -- triage_raw/sort_recipients keep exact diacritic-prefix matches above
+    // the diacritic-stripped ones.
+    const diacritic_stripped_query = typeahead.remove_diacritics(query.toLowerCase());
+    const diacritic_stripped_name = people
+        .maybe_remove_diacritics_from_name(person.user, true)
+        .toLowerCase();
     return typeahead.query_matches_string_in_order_assume_canonicalized(
-        query,
-        full_name.toLowerCase(),
+        diacritic_stripped_query,
+        diacritic_stripped_name,
         " ",
         match_prefix,
     );
@@ -1167,24 +1195,18 @@ export function query_matches_person_name(
 export function query_matches_person(
     query: string,
     person: UserPillData | UserOrMentionPillData,
-    should_remove_diacritics: boolean,
     match_prefix?: boolean,
     allow_custom_profile_field_matching = false,
 ): boolean {
     if (
         person.type === "broadcast" &&
-        typeahead.query_matches_string_in_order(
-            query,
-            person.user.full_name,
-            " ",
-            should_remove_diacritics,
-        )
+        typeahead.query_matches_string_in_order(query, person.user.full_name, " ", true)
     ) {
         return true;
     }
 
     if (person.type === "user") {
-        if (query_matches_person_name(query, person, should_remove_diacritics, match_prefix)) {
+        if (query_matches_person_name(query, person, match_prefix)) {
             return true;
         }
 
@@ -1196,10 +1218,10 @@ export function query_matches_person(
                         people.get_custom_profile_data(person.user.user_id, field.id)?.value ?? "";
                     if (
                         typeahead.query_matches_string_in_order(
-                            query,
+                            typeahead.remove_diacritics(query),
                             field_value,
                             " ",
-                            should_remove_diacritics,
+                            true,
                         )
                     ) {
                         return true;
@@ -1210,10 +1232,10 @@ export function query_matches_person(
 
         if (person.user.delivery_email) {
             return typeahead.query_matches_string_in_order(
-                query,
+                typeahead.remove_diacritics(query),
                 people.get_visible_email(person.user),
                 " ",
-                should_remove_diacritics,
+                true,
             );
         }
     }
@@ -1233,31 +1255,23 @@ export function query_matches_stream_name(
     );
 }
 
-export function query_matches_group_name(
-    query: string,
-    user_group: UserGroupPillData,
-    should_remove_diacritics: boolean,
-): boolean {
+export function query_matches_group_name(query: string, user_group: UserGroupPillData): boolean {
+    // Filtering is diacritics-agnostic, like query_matches_person_name: we
+    // strip diacritics from both the query and the group name so ASCII and
+    // diacritic spellings match each other. Ranking (sort_recipients) stays
+    // diacritic-aware.
+    const diacritic_stripped_query = typeahead.remove_diacritics(query.toLowerCase());
+    const matches_group_name = (group_name: string): boolean =>
+        typeahead.query_matches_string_in_order_assume_canonicalized(
+            diacritic_stripped_query,
+            typeahead.remove_diacritics(group_name.toLowerCase()),
+            "",
+        );
     if (user_group.name === "role:members") {
         return (
-            typeahead.query_matches_string_in_order(
-                query,
-                user_groups.get_display_group_name(user_group.name),
-                "",
-                should_remove_diacritics,
-            ) ||
-            typeahead.query_matches_string_in_order(
-                query,
-                settings_config.alternate_members_group_typeahead_matching_name,
-                "",
-                should_remove_diacritics,
-            )
+            matches_group_name(user_groups.get_display_group_name(user_group.name)) ||
+            matches_group_name(settings_config.alternate_members_group_typeahead_matching_name)
         );
     }
-    return typeahead.query_matches_string_in_order(
-        query,
-        user_groups.get_display_group_name(user_group.name),
-        "",
-        should_remove_diacritics,
-    );
+    return matches_group_name(user_groups.get_display_group_name(user_group.name));
 }

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -541,7 +541,7 @@ const get_user_matches_with_quality = <UserType extends UserOrMentionPillData | 
     ok_users: () => UserType[];
     worst_users: () => UserType[];
 } => {
-    const users_name_results = typeahead.triage_raw(query, users, (p) => p.user.full_name);
+    const users_name_results = typeahead.triage_raw(query, users, (p) => [p.user.full_name]);
     const users_name_good_matches = [
         ...users_name_results.exact_matches,
         ...users_name_results.begins_with_case_sensitive_matches,
@@ -549,11 +549,9 @@ const get_user_matches_with_quality = <UserType extends UserOrMentionPillData | 
     ];
     const users_name_okay_matches = [...users_name_results.word_boundary_matches];
 
-    const email_results = typeahead.triage_raw(
-        query,
-        users_name_results.no_matches,
-        (p) => p.user.email,
-    );
+    const email_results = typeahead.triage_raw(query, users_name_results.no_matches, (p) => [
+        p.user.email,
+    ]);
     const email_good_matches = [
         ...email_results.exact_matches,
         ...email_results.begins_with_case_sensitive_matches,
@@ -610,7 +608,7 @@ export let sort_recipients = <UserType extends UserOrMentionPillData | UserPillD
         worst_users: worst_bots,
     } = get_user_matches_with_quality(bots, query, sort_relevance);
 
-    const groups_results = typeahead.triage_raw_with_multiple_items(query, groups, (g) => {
+    const groups_results = typeahead.triage_raw(query, groups, (g) => {
         if (g.name === "role:members") {
             return [
                 user_groups.get_display_group_name(g.name),
@@ -824,13 +822,11 @@ export const sort_users_and_groups_options = ({
         return objs;
     }
 
-    const users_name_results = typeahead.triage_raw(query, users, (p) => p.user.full_name);
-    const email_results = typeahead.triage_raw(
-        query,
-        users_name_results.no_matches,
-        (p) => p.user.email,
-    );
-    const groups_results = typeahead.triage_raw_with_multiple_items(query, groups, (g) => {
+    const users_name_results = typeahead.triage_raw(query, users, (p) => [p.user.full_name]);
+    const email_results = typeahead.triage_raw(query, users_name_results.no_matches, (p) => [
+        p.user.email,
+    ]);
+    const groups_results = typeahead.triage_raw(query, groups, (g) => {
         if (g.name === "role:members") {
             return [
                 user_groups.get_display_group_name(g.name),

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -542,11 +542,6 @@ const get_user_matches_with_quality = <UserType extends UserOrMentionPillData | 
     worst_users: () => UserType[];
 } => {
     const users_name_results = typeahead.triage_raw(query, users, (p) => [p.user.full_name]);
-    const users_name_good_matches = [
-        ...users_name_results.exact_matches,
-        ...users_name_results.begins_with_case_sensitive_matches,
-        ...users_name_results.begins_with_case_insensitive_matches,
-    ];
     const users_name_okay_matches = [...users_name_results.word_boundary_matches];
 
     const email_results = typeahead.triage_raw(query, users_name_results.no_matches, (p) => [
@@ -554,14 +549,42 @@ const get_user_matches_with_quality = <UserType extends UserOrMentionPillData | 
     ]);
     const email_good_matches = [
         ...email_results.exact_matches,
+        ...email_results.begins_with_case_insensitive_diacritic_matches,
         ...email_results.begins_with_case_sensitive_matches,
         ...email_results.begins_with_case_insensitive_matches,
     ];
     const email_okay_matches = [...email_results.word_boundary_matches];
-    const best_users = (): UserType[] => [
-        ...sort_relevance(users_name_good_matches),
-        ...sort_relevance(users_name_okay_matches),
-    ];
+    const query_has_diacritics = typeahead.contains_diacritics(query);
+    const best_users = (): UserType[] => {
+        if (query_has_diacritics) {
+            // Sort exact and diacritic-prefix matches together as one tier, and
+            // case-sensitive + case-insensitive (including the diacritic-stripped
+            // fallback) as a second tier. The separate sort calls ensure relevance
+            // sorting within the second tier can't bubble a diacritic-stripped
+            // fallback above a diacritic prefix match.
+            return [
+                ...sort_relevance([
+                    ...users_name_results.exact_matches,
+                    ...users_name_results.begins_with_case_insensitive_diacritic_matches,
+                ]),
+                ...sort_relevance([
+                    ...users_name_results.begins_with_case_sensitive_matches,
+                    ...users_name_results.begins_with_case_insensitive_matches,
+                ]),
+                ...sort_relevance(users_name_okay_matches),
+            ];
+        }
+
+        const users_name_good_matches = [
+            ...users_name_results.exact_matches,
+            ...users_name_results.begins_with_case_sensitive_matches,
+            ...users_name_results.begins_with_case_insensitive_matches,
+        ];
+        return [
+            ...sort_relevance(users_name_good_matches),
+            ...sort_relevance(users_name_okay_matches),
+        ];
+    };
     const ok_users = (): UserType[] => [
         ...sort_relevance(email_good_matches),
         ...sort_relevance(email_okay_matches),
@@ -619,6 +642,7 @@ export let sort_recipients = <UserType extends UserOrMentionPillData | UserPillD
     });
     const groups_good_matches = [
         ...groups_results.exact_matches,
+        ...groups_results.begins_with_case_insensitive_diacritic_matches,
         ...groups_results.begins_with_case_sensitive_matches,
         ...groups_results.begins_with_case_insensitive_matches,
     ];
@@ -843,6 +867,9 @@ export const sort_users_and_groups_options = ({
     ]);
 
     const prefix_matches = sort_items([
+        ...groups_results.begins_with_case_insensitive_diacritic_matches,
+        ...users_name_results.begins_with_case_insensitive_diacritic_matches,
+        ...email_results.begins_with_case_insensitive_diacritic_matches,
         ...groups_results.begins_with_case_sensitive_matches,
         ...groups_results.begins_with_case_insensitive_matches,
         ...users_name_results.begins_with_case_sensitive_matches,
@@ -1146,19 +1173,19 @@ export function rewire_sort_user_groups(value: typeof sort_user_groups): void {
 export function query_matches_person_name(
     query: string,
     person: UserPillData,
-    should_remove_diacritics: boolean,
     match_prefix?: boolean,
 ): boolean {
-    query = query.toLowerCase();
-
-    const full_name = people.maybe_remove_diacritics_from_name(
-        person.user,
-        should_remove_diacritics,
-    );
-
+    // Filtering is diacritics-agnostic: we strip diacritics from both the query
+    // and the name so ASCII and diacritic spellings match each other. Ranking is
+    // not -- triage_raw/sort_recipients keep exact diacritic-prefix matches above
+    // the diacritic-stripped ones.
+    const diacritic_stripped_query = typeahead.remove_diacritics(query.toLowerCase());
+    const diacritic_stripped_name = people
+        .maybe_remove_diacritics_from_name(person.user, true)
+        .toLowerCase();
     return typeahead.query_matches_string_in_order_assume_canonicalized(
-        query,
-        full_name.toLowerCase(),
+        diacritic_stripped_query,
+        diacritic_stripped_name,
         " ",
         match_prefix,
     );
@@ -1167,24 +1194,18 @@ export function query_matches_person_name(
 export function query_matches_person(
     query: string,
     person: UserPillData | UserOrMentionPillData,
-    should_remove_diacritics: boolean,
     match_prefix?: boolean,
     allow_custom_profile_field_matching = false,
 ): boolean {
     if (
         person.type === "broadcast" &&
-        typeahead.query_matches_string_in_order(
-            query,
-            person.user.full_name,
-            " ",
-            should_remove_diacritics,
-        )
+        typeahead.query_matches_string_in_order(query, person.user.full_name, " ", true)
     ) {
         return true;
     }
 
     if (person.type === "user") {
-        if (query_matches_person_name(query, person, should_remove_diacritics, match_prefix)) {
+        if (query_matches_person_name(query, person, match_prefix)) {
             return true;
         }
 
@@ -1196,10 +1217,10 @@ export function query_matches_person(
                         people.get_custom_profile_data(person.user.user_id, field.id)?.value ?? "";
                     if (
                         typeahead.query_matches_string_in_order(
-                            query,
+                            typeahead.remove_diacritics(query),
                             field_value,
                             " ",
-                            should_remove_diacritics,
+                            true,
                         )
                     ) {
                         return true;
@@ -1210,10 +1231,10 @@ export function query_matches_person(
 
         if (person.user.delivery_email) {
             return typeahead.query_matches_string_in_order(
-                query,
+                typeahead.remove_diacritics(query),
                 people.get_visible_email(person.user),
                 " ",
-                should_remove_diacritics,
+                true,
             );
         }
     }
@@ -1233,31 +1254,23 @@ export function query_matches_stream_name(
     );
 }
 
-export function query_matches_group_name(
-    query: string,
-    user_group: UserGroupPillData,
-    should_remove_diacritics: boolean,
-): boolean {
+export function query_matches_group_name(query: string, user_group: UserGroupPillData): boolean {
+    // Filtering is diacritics-agnostic, like query_matches_person_name: we
+    // strip diacritics from both the query and the group name so ASCII and
+    // diacritic spellings match each other. Ranking (sort_recipients) stays
+    // diacritic-aware.
+    const diacritic_stripped_query = typeahead.remove_diacritics(query.toLowerCase());
+    const matches_group_name = (group_name: string): boolean =>
+        typeahead.query_matches_string_in_order_assume_canonicalized(
+            diacritic_stripped_query,
+            typeahead.remove_diacritics(group_name.toLowerCase()),
+            "",
+        );
     if (user_group.name === "role:members") {
         return (
-            typeahead.query_matches_string_in_order(
-                query,
-                user_groups.get_display_group_name(user_group.name),
-                "",
-                should_remove_diacritics,
-            ) ||
-            typeahead.query_matches_string_in_order(
-                query,
-                settings_config.alternate_members_group_typeahead_matching_name,
-                "",
-                should_remove_diacritics,
-            )
+            matches_group_name(user_groups.get_display_group_name(user_group.name)) ||
+            matches_group_name(settings_config.alternate_members_group_typeahead_matching_name)
         );
     }
-    return typeahead.query_matches_string_in_order(
-        query,
-        user_groups.get_display_group_name(user_group.name),
-        "",
-        should_remove_diacritics,
-    );
+    return matches_group_name(user_groups.get_display_group_name(user_group.name));
 }

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1602,7 +1602,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 assert.deepEqual(actual_value, expected_value);
 
                 function matcher(query, person) {
-                    query = typeahead.clean_query_lowercase(query, false);
+                    query = typeahead.clean_query_lowercase(query);
                     return typeahead_helper.query_matches_person(query, person);
                 }
 
@@ -1803,6 +1803,13 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 matcher = ct.get_language_matcher("py");
                 assert.equal(matcher("python"), true);
                 assert.equal(matcher("javascript"), false);
+
+                // Language matching is diacritics-agnostic: a diacritic query
+                // matches an ASCII language name and vice versa.
+                matcher = ct.get_language_matcher("café");
+                assert.equal(matcher("cafe"), true);
+                matcher = ct.get_language_matcher("cafe");
+                assert.equal(matcher("café"), true);
 
                 // options.sorter()
                 actual_value = typeahead.sort_emojis(

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1603,12 +1603,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
 
                 function matcher(query, person) {
                     query = typeahead.clean_query_lowercase(query, false);
-                    const should_remove_diacritics = !typeahead.contains_diacritics(query);
-                    return typeahead_helper.query_matches_person(
-                        query,
-                        person,
-                        should_remove_diacritics,
-                    );
+                    return typeahead_helper.query_matches_person(query, person);
                 }
 
                 let query;
@@ -2272,6 +2267,33 @@ test("get_person_suggestion_for_topic_typeahead respects DM permissions", ({over
     });
     results = ct.get_person_suggestion_for_topic_typeahead("lear");
     assert.deepEqual(results, []);
+});
+
+test("get_person_suggestion_for_topic_typeahead: diacritic query prioritizes exact diacritic matches", ({
+    override,
+}) => {
+    // "Gael" has the shorter name, so the within-bucket tiebreaker would rank
+    // it above "Gaël Twin" -- only the diacritic-prefix bucket puts "Gaël
+    // Twin" first.
+    const gael_ascii = make_user({
+        full_name: "Gael",
+        user_id: 112,
+        email: "gael@zulip.com",
+    });
+    people.add_active_user(gael_ascii);
+
+    message_lists.current = undefined;
+    override(pm_conversations, "get_partners", () => [
+        gael.user_id,
+        gael_ascii.user_id,
+        lear.user_id,
+    ]);
+
+    const results = ct.get_person_suggestion_for_topic_typeahead("gaë");
+    assert.deepEqual(
+        results.map((result) => result.user.user_id),
+        [gael.user_id, gael_ascii.user_id],
+    );
 });
 
 test("begins_typeahead", ({override, override_rewire}) => {

--- a/web/tests/realm_playground.test.cjs
+++ b/web/tests/realm_playground.test.cjs
@@ -118,4 +118,12 @@ run_test("get_pygments_typeahead_list_for_settings", () => {
     assert.equal(iterator.next().value[1], "Text only (text, text)");
     assert.equal(iterator.next().value[1], "quote (quote, quote)");
     assert.equal(iterator.next().value[1], "spoiler (spoiler, spoiler)");
+
+    // Test typing a query with diacritics. The "Custom language" option keeps them.
+    candidates = realm_playground.get_pygments_typeahead_list_for_settings("Français");
+    iterator = candidates.entries();
+    assert.deepEqual(iterator.next().value, [
+        "français",
+        $t({defaultMessage: "Custom language: {query}"}, {query: "français"}),
+    ]);
 });

--- a/web/tests/typeahead.test.cjs
+++ b/web/tests/typeahead.test.cjs
@@ -208,6 +208,84 @@ run_test("triage: prioritise word boundary matches to arbitrary substring matche
     );
 });
 
+run_test("triage: prioritize exact diacritic matches over diacritic-stripped matches", () => {
+    const exact_a = {name: "a"};
+    const exact_diacritic = {name: "ą"};
+    const aaron = {name: "aaron"};
+    const aa = {name: "Aa"};
+    const adam_diacritic = {name: "Ądam"};
+    const john_a = {name: "John a"};
+    const zoe = {name: "Zoe"};
+
+    const users = [exact_a, exact_diacritic, aaron, aa, adam_diacritic, john_a, zoe];
+
+    assert.deepEqual(
+        typeahead.triage("a", users, (r) => r.name),
+        {
+            matches: [exact_a, aaron, aa, john_a],
+            rest: [exact_diacritic, adam_diacritic, zoe],
+        },
+    );
+
+    assert.deepEqual(
+        typeahead.triage("A", users, (r) => r.name),
+        {
+            matches: [exact_a, aa, aaron, john_a],
+            rest: [exact_diacritic, adam_diacritic, zoe],
+        },
+    );
+
+    assert.deepEqual(
+        typeahead.triage("ą", users, (r) => r.name),
+        {
+            matches: [exact_diacritic, adam_diacritic, exact_a, aaron, aa, john_a],
+            rest: [zoe],
+        },
+    );
+
+    assert.deepEqual(
+        typeahead.triage("Ą", users, (r) => r.name),
+        {
+            matches: [exact_diacritic, adam_diacritic, exact_a, aaron, aa, john_a],
+            rest: [zoe],
+        },
+    );
+});
+
+run_test("triage: ASCII query matches diacritic item via word boundary", () => {
+    const luke_adam = {name: "Łuke adam"};
+    const zoe = {name: "Zoe"};
+    const users = [luke_adam, zoe];
+
+    assert.deepEqual(
+        typeahead.triage("a", users, (r) => r.name),
+        {
+            matches: [luke_adam],
+            rest: [zoe],
+        },
+    );
+});
+
+run_test("triage_raw: diacritic-prefix and diacritic-stripped fallback", () => {
+    const adam_diacritic = {names: ["Ądam"]};
+    const joe_ascii = {names: ["Joe Maria"]};
+    const alex_joe = {names: ["Alex joe"]};
+    const zoe = {names: ["Zoe"]};
+    const items = [adam_diacritic, joe_ascii, alex_joe, zoe];
+
+    const diacritic_result = typeahead.triage_raw("ą", items, (item) => item.names);
+    assert.deepEqual(diacritic_result.begins_with_case_insensitive_diacritic_matches, [
+        adam_diacritic,
+    ]);
+    // The query has diacritics, so the diacritic-stripped fallback still lets an
+    // ASCII candidate ("Alex joe") land in the case-insensitive bucket.
+    assert.deepEqual(diacritic_result.begins_with_case_insensitive_matches, [alex_joe]);
+
+    const fallback_result = typeahead.triage_raw("joé", items, (item) => item.names);
+    assert.deepEqual(fallback_result.begins_with_case_insensitive_matches, [joe_ascii]);
+    assert.deepEqual(fallback_result.word_boundary_matches, [alex_joe]);
+});
+
 function sort_emojis(emojis, query) {
     return typeahead.sort_emojis(emojis, query).map((emoji) => emoji.emoji_name);
 }

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -1904,6 +1904,25 @@ test("render_person with matching custom profile field but email hidden", ({
     assert.ok(rendered);
 });
 
+test("query_matches_person_name keeps diacritics when the query has them", () => {
+    // When should_remove_diacritics is false (used when the query itself has
+    // diacritics), the name keeps its diacritics, so a diacritic query matches
+    // a name with the same diacritics but not its ASCII counterpart.
+    const adam_diacritic = make_user({
+        email: "adam_name_diacritic@zulip.com",
+        full_name: "Ądam",
+        user_id: 101,
+    });
+    const adam_ascii = make_user({
+        email: "adam_name_ascii@zulip.com",
+        full_name: "adam",
+        user_id: 102,
+    });
+
+    assert.equal(th.query_matches_person_name("ądam", user_item(adam_diacritic), false), true);
+    assert.equal(th.query_matches_person_name("ądam", user_item(adam_ascii), false), false);
+});
+
 test("query_matches_person matches custom profile fields when they are enabled for user matching ", ({
     override,
 }) => {

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -1904,10 +1904,10 @@ test("render_person with matching custom profile field but email hidden", ({
     assert.ok(rendered);
 });
 
-test("query_matches_person_name keeps diacritics when the query has them", () => {
-    // When should_remove_diacritics is false (used when the query itself has
-    // diacritics), the name keeps its diacritics, so a diacritic query matches
-    // a name with the same diacritics but not its ASCII counterpart.
+test("query_matches_person_name strips diacritics from both query and name", () => {
+    // query_matches_person_name now always strips diacritics from both sides,
+    // so a diacritic query matches an ASCII name and an ASCII query matches a
+    // name with diacritics.
     const adam_diacritic = make_user({
         email: "adam_name_diacritic@zulip.com",
         full_name: "Ądam",
@@ -1919,8 +1919,37 @@ test("query_matches_person_name keeps diacritics when the query has them", () =>
         user_id: 102,
     });
 
-    assert.equal(th.query_matches_person_name("ądam", user_item(adam_diacritic), false), true);
-    assert.equal(th.query_matches_person_name("ądam", user_item(adam_ascii), false), false);
+    assert.equal(th.query_matches_person_name("ądam", user_item(adam_diacritic)), true);
+    assert.equal(th.query_matches_person_name("ądam", user_item(adam_ascii)), true);
+    assert.equal(th.query_matches_person_name("adam", user_item(adam_diacritic)), true);
+    assert.equal(th.query_matches_person_name("zoe", user_item(adam_ascii)), false);
+});
+
+test("query_matches_group_name strips diacritics from both query and name", () => {
+    // Like query_matches_person_name, group-name filtering is
+    // diacritics-agnostic: a diacritic query matches an ASCII group name
+    // and an ASCII query matches a group name with diacritics.
+    const diacritic_group = make_user_group({
+        id: 200,
+        name: "Ągents",
+        description: "",
+        members: new Set([b_user_2.user_id]),
+        is_system_group: false,
+    });
+    const ascii_group = make_user_group({
+        id: 201,
+        name: "agents",
+        description: "",
+        members: new Set([b_user_2.user_id]),
+        is_system_group: false,
+    });
+    user_groups.add(diacritic_group);
+    user_groups.add(ascii_group);
+
+    assert.equal(th.query_matches_group_name("ągents", user_group_item(diacritic_group)), true);
+    assert.equal(th.query_matches_group_name("ągents", user_group_item(ascii_group)), true);
+    assert.equal(th.query_matches_group_name("agents", user_group_item(diacritic_group)), true);
+    assert.equal(th.query_matches_group_name("zoe", user_group_item(ascii_group)), false);
 });
 
 test("query_matches_person matches custom profile fields when they are enabled for user matching ", ({
@@ -1956,6 +1985,113 @@ test("query_matches_person matches custom profile fields when they are enabled f
         value: "Beta",
     });
 
-    assert.equal(th.query_matches_person("alpha", a_user_item, undefined, undefined, true), true);
-    assert.equal(th.query_matches_person("beta", a_user_item, undefined, undefined, true), false);
+    assert.equal(th.query_matches_person("alpha", a_user_item, undefined, true), true);
+    assert.equal(th.query_matches_person("beta", a_user_item, undefined, true), false);
+});
+
+test("sort_recipients prioritizes exact diacritic matches", () => {
+    const aaron_item = {
+        type: "user",
+        user: {full_name: "aaron", email: "aaron@zulip.com", is_bot: false},
+    };
+
+    const aaron_diacritic_item = {
+        type: "user",
+        user: {full_name: "Ąaron", email: "aaron_diacritic@zulip.com", is_bot: false},
+    };
+
+    const users = [aaron_item, aaron_diacritic_item];
+
+    const result = th.sort_recipients({
+        users,
+        query: "ą",
+        groups: [],
+        max_num_items: 10,
+    });
+
+    assert.deepEqual(result, [aaron_diacritic_item, aaron_item]);
+});
+
+test("sort_recipients: diacritic query allows diacritic-stripped ASCII fallback", () => {
+    const adam_item = {
+        type: "user",
+        user: {full_name: "adam", email: "adam@zulip.com", is_bot: false},
+    };
+    const zoe_item = {
+        type: "user",
+        user: {full_name: "zoe", email: "zoe@zulip.com", is_bot: false},
+    };
+
+    const result = th.sort_recipients({
+        users: [adam_item, zoe_item],
+        query: "ą",
+        groups: [],
+        max_num_items: 10,
+    });
+
+    assert.deepEqual(result, [adam_item, zoe_item]);
+});
+
+test("sort_recipients: plain ASCII query ranks diacritic names below matches", () => {
+    const adam_item = {
+        type: "user",
+        user: {full_name: "adam", email: "adam@zulip.com", is_bot: false},
+    };
+    const adam_diacritic_item = {
+        type: "user",
+        user: {full_name: "Ądam", email: "adam_diacritic@zulip.com", is_bot: false},
+    };
+
+    const result = th.sort_recipients({
+        users: [adam_item, adam_diacritic_item],
+        query: "a",
+        groups: [],
+        max_num_items: 10,
+    });
+
+    assert.deepEqual(result, [adam_item, adam_diacritic_item]);
+});
+
+test("sort_recipients: diacritic query matches via word boundary (diacritic-stripped)", () => {
+    const john_adam_item = {
+        type: "user",
+        user: {full_name: "John adam", email: "johnadam@zulip.com", is_bot: false},
+    };
+    const zoe_item = {
+        type: "user",
+        user: {full_name: "zoe", email: "zoe@zulip.com", is_bot: false},
+    };
+
+    const result = th.sort_recipients({
+        users: [john_adam_item, zoe_item],
+        query: "ą",
+        groups: [],
+        max_num_items: 10,
+    });
+
+    assert.deepEqual(result, [john_adam_item, zoe_item]);
+});
+
+test("sort_recipients surfaces groups whose names match a diacritic query", () => {
+    // Regression test: a group whose display name begins with a
+    // diacritic query lands in the diacritic-prefix bucket, which
+    // sort_recipients must still surface rather than drop.
+    const diacritic_group = make_user_group({
+        id: 100,
+        name: "Ągents",
+        description: "",
+        members: new Set([b_user_2.user_id]),
+        is_system_group: false,
+    });
+    user_groups.add(diacritic_group);
+
+    const result = th.sort_recipients({
+        users: [],
+        query: "ą",
+        groups: [user_group_item(diacritic_group)],
+        max_num_items: 10,
+    });
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, diacritic_group.id);
 });

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -1781,10 +1781,7 @@ test("render_person shows value of custom profile fields in secondary", ({
         return "typeahead-item-stub";
     });
 
-    assert.equal(
-        th.render_person(a_user_item, {query: "Alpha", should_remove_diacritics: true}),
-        "typeahead-item-stub",
-    );
+    assert.equal(th.render_person(a_user_item, {query: "Alpha"}), "typeahead-item-stub");
     assert.ok(rendered);
 });
 
@@ -1818,10 +1815,43 @@ test("render_person shows both email and custom profile fields as secondary if b
         return "typeahead-item-stub";
     });
 
-    assert.equal(
-        th.render_person(a_user_item, {query: "a_user", should_remove_diacritics: true}),
-        "typeahead-item-stub",
-    );
+    assert.equal(th.render_person(a_user_item, {query: "a_user"}), "typeahead-item-stub");
+    assert.ok(rendered);
+});
+
+test("render_person shows the email and custom profile field a diacritic query matched", ({
+    mock_template,
+    override,
+}) => {
+    // "a_usèr" matches this user's email and field once diacritics are
+    // stripped, so the secondary line has to show both rather than hide them.
+    override(realm, "custom_profile_field_types", {
+        SHORT_TEXT: {id: 1, name: "Short text"},
+        PRONOUNS: {id: 3, name: "Pronouns"},
+    });
+
+    override(realm, "custom_profile_fields", [
+        {
+            id: 1,
+            name: "Alpha field",
+            type: realm.custom_profile_field_types.SHORT_TEXT.id,
+            use_for_user_matching: true,
+        },
+    ]);
+
+    people.set_custom_profile_field_data(a_user.user_id, {
+        id: 1,
+        value: "a_user",
+    });
+
+    let rendered = false;
+    mock_template("typeahead_list_item.hbs", false, (args) => {
+        assert.equal(args.secondary, "a_user_delivery@zulip.org, a_user");
+        rendered = true;
+        return "typeahead-item-stub";
+    });
+
+    assert.equal(th.render_person(a_user_item, {query: "a_usèr"}), "typeahead-item-stub");
     assert.ok(rendered);
 });
 
@@ -1856,10 +1886,7 @@ test("render_person skips custom profile fields not used for user matching", ({
         return "typeahead-item-stub";
     });
 
-    assert.equal(
-        th.render_person(a_user_item, {query: "Alpha", should_remove_diacritics: true}),
-        "typeahead-item-stub",
-    );
+    assert.equal(th.render_person(a_user_item, {query: "Alpha"}), "typeahead-item-stub");
     assert.ok(rendered);
 });
 
@@ -1897,17 +1924,14 @@ test("render_person with matching custom profile field but email hidden", ({
         return "typeahead-item-stub";
     });
 
-    assert.equal(
-        th.render_person(b_user_1_item, {query: "", should_remove_diacritics: true}),
-        "typeahead-item-stub",
-    );
+    assert.equal(th.render_person(b_user_1_item, {query: ""}), "typeahead-item-stub");
     assert.ok(rendered);
 });
 
-test("query_matches_person_name keeps diacritics when the query has them", () => {
-    // When should_remove_diacritics is false (used when the query itself has
-    // diacritics), the name keeps its diacritics, so a diacritic query matches
-    // a name with the same diacritics but not its ASCII counterpart.
+test("query_matches_person_name strips diacritics from both query and name", () => {
+    // query_matches_person_name now always strips diacritics from both sides,
+    // so a diacritic query matches an ASCII name and an ASCII query matches a
+    // name with diacritics.
     const adam_diacritic = make_user({
         email: "adam_name_diacritic@zulip.com",
         full_name: "Ądam",
@@ -1919,8 +1943,37 @@ test("query_matches_person_name keeps diacritics when the query has them", () =>
         user_id: 102,
     });
 
-    assert.equal(th.query_matches_person_name("ądam", user_item(adam_diacritic), false), true);
-    assert.equal(th.query_matches_person_name("ądam", user_item(adam_ascii), false), false);
+    assert.equal(th.query_matches_person_name("ądam", user_item(adam_diacritic)), true);
+    assert.equal(th.query_matches_person_name("ądam", user_item(adam_ascii)), true);
+    assert.equal(th.query_matches_person_name("adam", user_item(adam_diacritic)), true);
+    assert.equal(th.query_matches_person_name("zoe", user_item(adam_ascii)), false);
+});
+
+test("query_matches_group_name strips diacritics from both query and name", () => {
+    // Like query_matches_person_name, group-name filtering is
+    // diacritics-agnostic: a diacritic query matches an ASCII group name
+    // and an ASCII query matches a group name with diacritics.
+    const diacritic_group = make_user_group({
+        id: 200,
+        name: "Ągents",
+        description: "",
+        members: new Set([b_user_2.user_id]),
+        is_system_group: false,
+    });
+    const ascii_group = make_user_group({
+        id: 201,
+        name: "agents",
+        description: "",
+        members: new Set([b_user_2.user_id]),
+        is_system_group: false,
+    });
+    user_groups.add(diacritic_group);
+    user_groups.add(ascii_group);
+
+    assert.equal(th.query_matches_group_name("ągents", user_group_item(diacritic_group)), true);
+    assert.equal(th.query_matches_group_name("ągents", user_group_item(ascii_group)), true);
+    assert.equal(th.query_matches_group_name("agents", user_group_item(diacritic_group)), true);
+    assert.equal(th.query_matches_group_name("zoe", user_group_item(ascii_group)), false);
 });
 
 test("query_matches_person matches custom profile fields when they are enabled for user matching ", ({
@@ -1956,6 +2009,113 @@ test("query_matches_person matches custom profile fields when they are enabled f
         value: "Beta",
     });
 
-    assert.equal(th.query_matches_person("alpha", a_user_item, undefined, undefined, true), true);
-    assert.equal(th.query_matches_person("beta", a_user_item, undefined, undefined, true), false);
+    assert.equal(th.query_matches_person("alpha", a_user_item, undefined, true), true);
+    assert.equal(th.query_matches_person("beta", a_user_item, undefined, true), false);
+});
+
+test("sort_recipients prioritizes exact diacritic matches", () => {
+    const aaron_item = {
+        type: "user",
+        user: {full_name: "aaron", email: "aaron@zulip.com", is_bot: false},
+    };
+
+    const aaron_diacritic_item = {
+        type: "user",
+        user: {full_name: "Ąaron", email: "aaron_diacritic@zulip.com", is_bot: false},
+    };
+
+    const users = [aaron_item, aaron_diacritic_item];
+
+    const result = th.sort_recipients({
+        users,
+        query: "ą",
+        groups: [],
+        max_num_items: 10,
+    });
+
+    assert.deepEqual(result, [aaron_diacritic_item, aaron_item]);
+});
+
+test("sort_recipients: diacritic query allows diacritic-stripped ASCII fallback", () => {
+    const adam_item = {
+        type: "user",
+        user: {full_name: "adam", email: "adam@zulip.com", is_bot: false},
+    };
+    const zoe_item = {
+        type: "user",
+        user: {full_name: "zoe", email: "zoe@zulip.com", is_bot: false},
+    };
+
+    const result = th.sort_recipients({
+        users: [adam_item, zoe_item],
+        query: "ą",
+        groups: [],
+        max_num_items: 10,
+    });
+
+    assert.deepEqual(result, [adam_item, zoe_item]);
+});
+
+test("sort_recipients: plain ASCII query ranks diacritic names below matches", () => {
+    const adam_item = {
+        type: "user",
+        user: {full_name: "adam", email: "adam@zulip.com", is_bot: false},
+    };
+    const adam_diacritic_item = {
+        type: "user",
+        user: {full_name: "Ądam", email: "adam_diacritic@zulip.com", is_bot: false},
+    };
+
+    const result = th.sort_recipients({
+        users: [adam_item, adam_diacritic_item],
+        query: "a",
+        groups: [],
+        max_num_items: 10,
+    });
+
+    assert.deepEqual(result, [adam_item, adam_diacritic_item]);
+});
+
+test("sort_recipients: diacritic query matches via word boundary (diacritic-stripped)", () => {
+    const john_adam_item = {
+        type: "user",
+        user: {full_name: "John adam", email: "johnadam@zulip.com", is_bot: false},
+    };
+    const zoe_item = {
+        type: "user",
+        user: {full_name: "zoe", email: "zoe@zulip.com", is_bot: false},
+    };
+
+    const result = th.sort_recipients({
+        users: [john_adam_item, zoe_item],
+        query: "ą",
+        groups: [],
+        max_num_items: 10,
+    });
+
+    assert.deepEqual(result, [john_adam_item, zoe_item]);
+});
+
+test("sort_recipients surfaces groups whose names match a diacritic query", () => {
+    // Regression test: a group whose display name begins with a
+    // diacritic query lands in the diacritic-prefix bucket, which
+    // sort_recipients must still surface rather than drop.
+    const diacritic_group = make_user_group({
+        id: 100,
+        name: "Ągents",
+        description: "",
+        members: new Set([b_user_2.user_id]),
+        is_system_group: false,
+    });
+    user_groups.add(diacritic_group);
+
+    const result = th.sort_recipients({
+        users: [],
+        query: "ą",
+        groups: [user_group_item(diacritic_group)],
+        max_num_items: 10,
+    });
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, diacritic_group.id);
 });


### PR DESCRIPTION
Fixes #32634.

Typeahead queries now preserve diacritics in the query string, so typing "ą" matches names containing "ą"/"Ą" directly. However, this left two problems: exact diacritic-prefix matches like "Ądam" ranked no higher than normalized matches in the same bucket, and ASCII users were excluded entirely from diacritic queries.

This PR adds a `diacritic_prefix_matches` bucket to `triage_raw` to rank exact diacritic-prefix matches above normalized ones, and restores ASCII users as lower-priority candidates via a normalized fallback.

ASCII queries (e.g. `@a`) are unaffected - behavior and ordering are unchanged.
## Screenshots 

Screenshots taken in a self-DM as Desdemona.

### CASE 1: Query `@a`

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="432" height="392" alt="image" src="https://github.com/user-attachments/assets/966c3cad-b6c1-4212-8c5b-f651d490c700" />

</td>
<td>
<img width="425" height="396" alt="image" src="https://github.com/user-attachments/assets/b53ce513-60df-4e89-b41c-902e74e20406" />

</td>
</tr>
</table>

### CASE 2: Query `@A`

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="432" height="392" alt="image" src="https://github.com/user-attachments/assets/6d15477a-ecc4-44fb-adf5-ecefafb01fa8" />

</td>
<td>
<img width="398" height="395" alt="image" src="https://github.com/user-attachments/assets/c6404d21-2a92-4ec8-a111-945cb3a6308a" />

</td>
</tr>
</table>

### CASE 3: Query `@ą`

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="266" height="148" alt="image" src="https://github.com/user-attachments/assets/436980bf-72f3-42f4-99ad-a71b99cae6a7" />

</td>
<td>
<img width="399" height="321" alt="image" src="https://github.com/user-attachments/assets/3b93d03f-b4e1-4bd3-a9d2-1c0d87bb8604" />

</td>
</tr>
</table>

### CASE 4: Query `@Ą`

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="270" height="147" alt="image" src="https://github.com/user-attachments/assets/7f1fe697-b000-488e-b9ce-cc53f1272a04" />

</td>
<td>
<img width="401" height="326" alt="image" src="https://github.com/user-attachments/assets/ba5fa7d0-a888-4ba4-9853-c7f278b85653" />

</td>
</tr>
</table>


### Relationship to other PRs

This addresses the same issue as #33260, but uses an independent implementation.
I did, however, incorporate feedback from that discussion -- in particular,
adding explicit test coverage and screenshots covering all four query cases
(`a`, `A`, `ą`, `Ą`).

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
