### PR TITLE
portico: Fix case studies menu overflow on low-height screens.

### DIFF
--- a/web/styles/portico/navbar.css
+++ b/web/styles/portico/navbar.css
@@ -1,3 +1,10 @@
+:root {
+    /* Navbar height is important to avoid case studies
+       items from overflowing at the bottom. Hence, keep
+       it in sync with the current value. */
+    --navbar-height: 60px;
+}
+
 details summary::-webkit-details-marker {
     /* Hide the default arrow on Safari. */
     display: none;
@@ -312,6 +319,8 @@ details summary::-webkit-details-marker {
 .top-menu-tab-input:checked ~ .top-menu-submenu {
     opacity: 1;
     visibility: visible;
+    max-height: calc(100vh - var(--navbar-height));
+    overflow-y: auto;
 }
 
 .top-menu-submenu-column {


### PR DESCRIPTION
Now, the case studies menu in the top navbar allows scroll on overflow on low-height screens ensuring all items remain accessible.

This PR addresses the remaining feedback on the work done in #37121 by  @sania-2912

Fixes: #37091

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Before (Manually resizing window to mimic lower height screens):
<img width="1461" height="733" alt="Screenshot 2026-02-09 at 8 43 58 PM" src="https://github.com/user-attachments/assets/5b06d1fe-76ef-4441-a7f6-2b56ad8f903c" />

Content gets cut off.

After (Manually resizing window to mimic lower height screens):
<img width="1469" height="717" alt="Screenshot 2026-02-09 at 8 44 19 PM" src="https://github.com/user-attachments/assets/3be12c24-4e1b-480e-a0b3-ecfe944eae5d" />

I am able to scroll to the bottom to view all the items in the menu.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
