### PR TITLE
user_profile: Fix channel/group tabs list container not scrollable.

### DIFF
--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -770,6 +770,7 @@ export function show_user_profile(user: User, default_tab_key = "profile-tab"): 
         callback(_name: string | undefined, key: string) {
             $(".tabcontent").hide();
             $(`#${CSS.escape(key)}`).show();
+            $("#user-profile-modal").removeClass("prevent-user-modal-content-scrolling");
             $("#user-profile-modal .manage-profile-tab-footer").removeClass(
                 "manage-profile-tab-active",
             );
@@ -782,10 +783,12 @@ export function show_user_profile(user: User, default_tab_key = "profile-tab"): 
                     break;
                 case "user-profile-groups-tab": {
                     render_or_update_user_groups_tab(user);
+                    $("#user-profile-modal").addClass("prevent-user-modal-content-scrolling");
                     break;
                 }
                 case "user-profile-streams-tab": {
                     void render_or_update_user_streams_tab(user);
+                    $("#user-profile-modal").addClass("prevent-user-modal-content-scrolling");
                     break;
                 }
                 case "manage-profile-tab":

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -368,6 +368,25 @@
         margin-bottom: var(--user-profile-modal-body-margin-bottom);
     }
 
+    &.prevent-user-modal-content-scrolling {
+        .modal__content {
+            flex-grow: 1;
+
+            .simplebar-content {
+                height: 100%;
+                box-sizing: border-box;
+            }
+        }
+
+        .tab-data {
+            height: calc(100% - var(--user-profile-modal-body-margin-bottom));
+        }
+
+        .tabcontent {
+            height: 100%;
+        }
+    }
+
     .group-tab-element-header,
     .stream-tab-element-header {
         margin: 0;
@@ -379,10 +398,6 @@
 
     #user-profile-groups-tab,
     #user-profile-streams-tab {
-        height: calc(
-            var(--user-profile-modal-body-height) -
-                var(--user-profile-modal-body-margin-bottom)
-        );
         display: grid;
         grid-template:
             "alert" auto


### PR DESCRIPTION
Currently the entire `#user-profile-streams-tab` and `#user-profile-groups-tab` is scrollable instead of just the intended streams/groups list container. We fix this by propagating the `modal__content` height to the tab content and preventing overflow for the tab content. The inner list container content however overflows and becomes scrollable.

Fixes: [#issues > Scrolling through channels list doesn't work with touchpad. @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/Scrolling.20through.20channels.20list.20doesn't.20work.20with.20touchpad.2E/near/2372535)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

|Before|After|
|-|-|
|<img width="618" height="749" alt="image" src="https://github.com/user-attachments/assets/a1a963fd-1571-45b4-869e-8e16936b898d" />|<img width="618" height="749" alt="Screenshot from 2026-02-10 00-11-07" src="https://github.com/user-attachments/assets/98e6b277-0bc3-43e7-b7ef-4f28e301a245" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
