### PR TITLE
Use avatars with presence in DM conversation header

### DIFF
--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -4,19 +4,32 @@ import assert from "minimalistic-assert";
 import render_inline_decorated_channel_name from "../templates/inline_decorated_channel_name.hbs";
 import render_message_view_header from "../templates/message_view_header.hbs";
 
+import * as buddy_data from "./buddy_data.ts";
 import type {Filter} from "./filter.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
 import * as inbox_util from "./inbox_util.ts";
+import * as muted_users from "./muted_users.ts";
 import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as peer_data from "./peer_data.ts";
+import * as people from "./people.ts";
 import * as recent_view_util from "./recent_view_util.ts";
 import * as rendered_markdown from "./rendered_markdown.ts";
 import * as search from "./search.ts";
 import {current_user} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import type {StreamSubscription} from "./sub_store.ts";
+import * as util from "./util.ts";
+
+let dm_avatars_resize_observer: ResizeObserver | undefined;
+
+type DmUserInfo = {
+    user_id: number;
+    avatar_url: string;
+    user_circle_class: string;
+    name: string;
+};
 
 type MessageViewHeaderContext = {
     title?: string | undefined;
@@ -30,6 +43,8 @@ type MessageViewHeaderContext = {
     is_admin?: boolean;
     stream?: StreamSubscription;
     stream_settings_link?: string;
+    is_dm_narrow?: boolean;
+    dm_users?: DmUserInfo[];
 } & (
     | {
           zulip_icon: string;
@@ -145,6 +160,34 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
         };
     }
 
+    if (filter.has_operator("dm")) {
+        const user_ids = filter.terms_with_operator("dm")[0]!.operand;
+        // Match the ordering logic used in the message recipient header.
+        const get_name_for_header_sort = (user_id: number): string =>
+            muted_users.is_user_muted(user_id)
+                ? $t({defaultMessage: "Muted user"})
+                : people.get_full_name(user_id);
+        const sorted_user_ids = user_ids.toSorted((a, b) =>
+            util.strcmp(get_name_for_header_sort(a), get_name_for_header_sort(b)),
+        );
+        const dm_users: DmUserInfo[] = sorted_user_ids.map((user_id) => {
+            const person = people.get_by_user_id(user_id);
+            return {
+                user_id: person.user_id,
+                avatar_url: people.small_avatar_url_for_person(person),
+                user_circle_class: buddy_data.get_user_circle_class(person.user_id),
+                name: person.full_name,
+            };
+        });
+        if (dm_users.length > 0) {
+            return {
+                ...context,
+                is_dm_narrow: true,
+                dm_users,
+            };
+        }
+    }
+
     return context;
 }
 
@@ -155,6 +198,40 @@ export function colorize_message_view_header(): void {
     }
     // selecting i instead of .fa because web public streams have custom icon.
     $("#message_view_header a.stream i").css("color", current_sub.color);
+}
+
+function update_dm_avatars_overflow(container: HTMLElement): void {
+    const has_overflow = container.scrollWidth > container.clientWidth;
+    $(container).toggleClass("dm-avatars-overflowing", has_overflow);
+}
+
+function setup_dm_avatars_overflow_detection(context: MessageViewHeaderContext): void {
+    // Clean up previous observer.
+    if (dm_avatars_resize_observer) {
+        dm_avatars_resize_observer.disconnect();
+        dm_avatars_resize_observer = undefined;
+    }
+
+    if (!context.is_dm_narrow || !context.dm_users || context.dm_users.length === 0) {
+        return;
+    }
+
+    const container = $(".navbar-dm-avatars")[0];
+    if (!container) {
+        return;
+    }
+
+    // Check overflow after the browser has completed layout so
+    // that scrollWidth / clientWidth are accurate.
+    requestAnimationFrame(() => {
+        update_dm_avatars_overflow(container);
+    });
+
+    // Re-check whenever the container is resized (e.g. window resize).
+    dm_avatars_resize_observer = new ResizeObserver(() => {
+        update_dm_avatars_overflow(container);
+    });
+    dm_avatars_resize_observer.observe(container);
 }
 
 function append_and_display_title_area(context: MessageViewHeaderContext): void {
@@ -169,12 +246,18 @@ function append_and_display_title_area(context: MessageViewHeaderContext): void 
         // Update syntax like stream names, emojis, mentions, timestamps.
         rendered_markdown.update_elements($content);
     }
+    setup_dm_avatars_overflow_detection(context);
 }
 
 function build_message_view_header(filter: Filter | undefined): void {
     // This makes sure we don't waste time appending
     // message_view_header on a template where it's never used
     if (filter && !filter.is_common_narrow()) {
+        // Clean up DM avatar observer when leaving a DM narrow.
+        if (dm_avatars_resize_observer) {
+            dm_avatars_resize_observer.disconnect();
+            dm_avatars_resize_observer = undefined;
+        }
         search.open_search_bar_and_close_narrow_description();
     } else {
         const context = get_message_view_header_context(filter);

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -209,6 +209,77 @@ export function initialize(): void {
         },
     });
 
+    // Individual DM avatar tooltip – shows the user's name when
+    // avatars fit without overflowing.  Suppressed when the
+    // container overflows so the container-level tooltip takes over.
+    tippy.delegate("body", {
+        target: ".navbar-dm-avatar",
+        appendTo: () => document.body,
+        onShow(instance) {
+            const container = instance.reference.closest(".navbar-dm-avatars");
+            if (container instanceof HTMLElement && container.scrollWidth > container.clientWidth) {
+                return false;
+            }
+            const content = instance.reference.getAttribute("data-tippy-content");
+            if (!content) {
+                return false;
+            }
+            instance.setContent(content);
+            return undefined;
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    // Container tooltip for overflowing DM avatars – lists every
+    // participant in the conversation.
+    tippy.delegate("body", {
+        target: ".navbar-dm-avatars",
+        appendTo: () => document.body,
+        placement: "bottom",
+        onShow(instance) {
+            const el = instance.reference;
+            assert(el instanceof HTMLElement);
+            if (el.scrollWidth <= el.clientWidth) {
+                return false;
+            }
+            const names: string[] = [];
+            for (const avatar of el.querySelectorAll<HTMLElement>(".navbar-dm-avatar")) {
+                const name = avatar.getAttribute("data-tippy-content");
+                if (name) {
+                    names.push(name);
+                }
+            }
+            if (names.length === 0) {
+                return false;
+            }
+            const tooltip_content = document.createElement("div");
+            tooltip_content.className = "dm-avatars-overflow-tooltip";
+
+            const tooltip_title = document.createElement("div");
+            tooltip_title.className = "dm-avatars-overflow-tooltip-title";
+            tooltip_title.textContent = $t({defaultMessage: "DM conversation with"});
+            tooltip_content.append(tooltip_title);
+
+            const names_list = document.createElement("div");
+            names_list.className = "dm-avatars-overflow-tooltip-list";
+            for (const name of names) {
+                const chip = document.createElement("span");
+                chip.className = "dm-avatars-overflow-tooltip-name";
+                chip.textContent = name;
+                names_list.append(chip);
+            }
+            tooltip_content.append(names_list);
+
+            instance.setContent(tooltip_content);
+            return undefined;
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
     // The below definitions are for specific tooltips that require
     // custom JavaScript code or configuration.  Note that since the
     // below specify the target directly, elements using those should

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -920,6 +920,15 @@ function register_click_handlers(): void {
         toggle_sidebar_user_card_popover($target);
     });
 
+    // Click on a DM avatar in the message view header navbar.
+    $("#message_view_header").on("click", ".navbar-dm-avatar", function (this: HTMLElement, e) {
+        e.preventDefault();
+        e.stopPropagation();
+        const user_id = Number.parseInt($(this).attr("data-user-id")!, 10);
+        const user = people.get_by_user_id(user_id);
+        toggle_user_card_popover(this, user);
+    });
+
     $("body").on("click", ".sidebar-popover-mute-user", function (e) {
         const user_id = elem_to_user_id($(this).parents("ul"));
         hide_all_user_card_popovers();

--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -139,6 +139,126 @@
     }
 }
 
+/* DM avatars in the navbar */
+.navbar-dm-avatars {
+    display: flex;
+    /* Adjusted margin/padding so that overflow: hidden
+       does not clip the presence dot (which extends ~1px
+       beyond the avatar box). */
+    margin-top: 4px;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 6px;
+    /* Allow this flex child to shrink below its content
+       width so that overflow: hidden clips at the visible
+       boundary instead of the full content edge. */
+    overflow: hidden;
+    min-width: 0;
+    /* Containing block for the ::after fade overlay. */
+    position: relative;
+
+    &.dm-avatars-overflowing::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: 30px;
+        background: linear-gradient(
+            to right,
+            transparent,
+            var(--color-background-navbar)
+        );
+        /* Let hover and click events pass through to the
+           avatars underneath. */
+        pointer-events: none;
+    }
+}
+
+.navbar-dm-avatar {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+    border-radius: 4px;
+
+    &:focus-visible {
+        outline: 2px solid var(--color-outline-focus);
+        outline-offset: -2px;
+    }
+
+    .navbar-dm-avatar-image {
+        width: 28px;
+        height: 28px;
+        border-radius: 4px;
+        overflow: hidden;
+
+        img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            display: block;
+        }
+    }
+
+    /* Availability dot — sized to match the right sidebar
+       with-avatar presence indicator (right_sidebar.css,
+       .user_sidebar_entry.with_avatar .user-circle).
+       line-height: 1 is required here because the navbar
+       sets line-height: var(--header-height) on the header,
+       which the span would otherwise inherit, stretching
+       the circle into an oval. */
+    .user-circle {
+        position: absolute;
+        /* 10px at 16px/1em */
+        font-size: 0.625em;
+        line-height: 1;
+        bottom: -0.5px;
+        right: -0.5px;
+        background-color: var(--color-background-navbar);
+        border: 1.5px solid var(--color-background-navbar);
+        border-radius: 50%;
+        pointer-events: none;
+
+        &.user-circle-offline {
+            display: none;
+        }
+    }
+
+    /* Adjust avatar corner when status dot is visible */
+    &:not(:has(.user-circle-offline)) .navbar-dm-avatar-image {
+        border-bottom-right-radius: 0.3875em;
+    }
+
+    &:hover .navbar-dm-avatar-image {
+        opacity: 0.85;
+    }
+}
+
+.dm-avatars-overflow-tooltip {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+}
+
+.dm-avatars-overflow-tooltip-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.dm-avatars-overflow-tooltip-name {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+    padding: 1px 6px;
+    background-color: hsl(0deg 0% 100% / 16%);
+    line-height: 1.3;
+}
+
 /* Media Queries */
 @media only screen and (width <= 620px) {
     .view-description-extended {

--- a/web/templates/navbar_icon_and_title.hbs
+++ b/web/templates/navbar_icon_and_title.hbs
@@ -1,3 +1,15 @@
+{{#if is_dm_narrow}}
+<div class="navbar-dm-avatars">
+    {{#each dm_users}}
+        <div class="navbar-dm-avatar" data-user-id="{{user_id}}" data-tippy-content="{{name}}" role="button" tabindex="0">
+            <div class="navbar-dm-avatar-image avatar-preload-background">
+                <img loading="lazy" src="{{avatar_url}}" alt="{{name}}" />
+            </div>
+            <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
+        </div>
+    {{/each}}
+</div>
+{{else}}
 {{#if zulip_icon}}
 <i class="navbar-icon zulip-icon zulip-icon-{{zulip_icon}}" aria-hidden="true"></i>
 {{else if icon}}
@@ -15,4 +27,5 @@
         <i class="archived-indicator">({{t 'archived' }})</i>
     </span>
     {{/if}}
+{{/if}}
 {{/if}}


### PR DESCRIPTION
Fixes #37078

## Relationship to previous work

This PR continues the work started in #37141, which implemented
avatars with presence indicators in the DM conversation header.

That PR has not progressed recently and did not reach a mergeable
state, so this PR continues the same design direction while rebasing
the implementation on the current `main` branch and addressing
outstanding issues and review feedback.

Key updates in this PR compared to #37141:

- Updated implementation to work with the current Zulip codebase.
- Resolved import cycles detected by ESLint.
- Implemented a fade-out effect when avatars overflow the navbar.
- Added an overflow tooltip showing DM participants based on
  design feedback.
- Ensured linting and CI checks pass cleanly.

Credit to @17AnuragMishra for the original implementation and
design direction.

---

This PR updates the direct message conversation header to use user
avatars instead of text names. Each avatar includes a presence
indicator, and clicking on an avatar opens the corresponding user
card, matching behavior used elsewhere in the Zulip UI.

## How changes were tested

- Ran the Zulip development server locally using `./tools/run-dev`
- Opened 1:1 and group direct message conversations
- Verified avatars appear in the DM header instead of names
- Confirmed presence indicators display correctly
- Verified clicking an avatar opens the user card
- Tested behavior across different window sizes and mobile-width layouts
- Verified fade and tooltip behavior during resize

## Screenshots and screen captures

<details>
<summary>Before</summary>

<img
  width="1911"
  height="821"
  alt="DM header showing text-based user names"
  src="https://github.com/user-attachments/assets/0c55d4bd-fb3c-44f4-bedb-a3e22b3e3c3f"
/>

</details>

<details>
<summary>After</summary>

<img
  width="1918"
  height="867"
  alt="DM header showing avatars with presence indicators"
  src="https://github.com/user-attachments/assets/ccc2ab97-39e2-4542-9ffd-010db0f491c9"
/>

### Avatar and presence indicators in group DM

https://github.com/user-attachments/assets/1ccd169c-6a16-45fc-a5ed-6be085cb7e5c

### Fade effect when avatars overflow (mobile view)

<img
  width="465"
  height="755"
  alt="Fade effect when avatars overflow"
  src="https://github.com/user-attachments/assets/60c1338f-55cb-4807-8602-f48e2a5fba66"
/>

### Tooltip behavior (overflow vs non-overflow)

https://github.com/user-attachments/assets/06e8f742-78bc-4e88-9ef4-c6645663e3e9

</details>

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Followed the AI use policy.
- [x] Explains differences from previous behavior.
- [x] Highlights technical choices and behavior changes.
- [x] Each commit represents a coherent change.
- [x] Commit messages explain the motivation for the changes.
- [x] Manually reviewed visual appearance.
- [x] Verified end-to-end functionality of interactions.

</details>