### PR TITLE
peer_data: Ignore subscriber fetch errors with ready_state 0.

### DIFF
--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -145,11 +145,15 @@ async function fetch_stream_subscribers_from_server(
                         error_json: xhr.responseJSON,
                     });
                     resolve(false);
+                } else if (xhr.readyState === 0) {
+                    // This means that something in client-side code cancelled the request.
+                    // We've seen this happen, only occasionally, and decided to ignore and
+                    // potentially retry.
+                    resolve(null);
                 } else {
                     blueslip.error("Failure fetching channel subscribers", {
                         stream_id,
                         error_json: xhr.responseJSON,
-                        xhr_ready_state: xhr.readyState,
                     });
                     resolve(null);
                 }

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -350,6 +350,16 @@ test("maybe_fetch_stream_subscribers", async () => {
 
     peer_data.clear_for_testing();
     mock_channel_get(channel, (opts) => {
+        opts.error({readyState: 0});
+    });
+    // null because there was an error, but no blueslip error for readystate 0
+    assert.deepEqual(
+        await peer_data.get_subscribers_with_possible_fetch(india.stream_id, false),
+        null,
+    );
+
+    peer_data.clear_for_testing();
+    mock_channel_get(channel, (opts) => {
         opts.error({status: 500, responseJSON: ""});
     });
     blueslip.expect("error", "Failure fetching channel subscribers");


### PR DESCRIPTION
More context: https://chat.zulip.org/#narrow/channel/464-kandra-js-errors/topic/Error.3A.20Failure.20fetching.20channel.20subscribers/with/2374137
