### PR TITLE
email_notification: Remove extra spacing between sender blocks.

### DIFF
--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -263,10 +263,6 @@ p.digest_paragraph,
     color: #15c;
 }
 
-.missed_message {
-    padding-bottom: 10px;
-}
-
 .content_disabled_help_link {
     color: #15c;
 }


### PR DESCRIPTION
PR to fix: [#issues > email notifications - number of lines between senders @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/email.20notifications.20-.20number.20of.20lines.20between.20senders/near/2354342)

Bug was:
> one blank line between messages from the same sender and two between messages from a different sender.


**How changes were tested:**

Mail forwarded to Gmail client.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

Before | After |
|-------|------|
 | <img width="1115" height="249" alt="Screenshot 2026-02-10 at 6 58 06 PM" src="https://github.com/user-attachments/assets/c92e2d33-c545-45a7-887f-1c94b6e71120" /> |  <img width="1116" height="258" alt="Screenshot 2026-02-10 at 6 57 46 PM" src="https://github.com/user-attachments/assets/e61ed874-f5d3-4650-aa9d-9e6b9010be86" />
| <img width="993" height="310" alt="Screenshot 2026-02-10 at 7 25 47 PM" src="https://github.com/user-attachments/assets/5d733980-d462-4e71-a449-9ae84e38ccf8" /> | <img width="999" height="291" alt="Screenshot 2026-02-10 at 7 14 22 PM" src="https://github.com/user-attachments/assets/16049d89-fe69-44ac-8c6a-cfb8b11dccc7" />

Note there's a decrease in the spacing between "Message 4" and "__" too - which looks good to me. Let me know, if we think otherwise.
 


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
