### PR TITLE
copy_messages: Improve end_id detection in analyze_selection.

### DIFF
--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -407,7 +407,7 @@ export function analyze_selection(selection: Selection): {
 }
 
 function get_end_tr_from_endc($endc: JQuery<Node>): JQuery {
-    if ($endc.attr("id") === "bottom_whitespace" || $endc.attr("id") === "compose_close") {
+    if ($endc.attr("id") === "bottom_whitespace" || $endc.closest("#compose").length > 0) {
         // If the selection ends in the bottom whitespace, we should
         // act as though the selection ends on the final message.
         // This handles the issue that Chrome seems to like selecting


### PR DESCRIPTION
A selection ending in the compose recipient buttons falsely reported the `end_id` as undefined, which
is fixed here.

Tested on Chrome and Firefox.
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
