### PR TITLE
left_sidebar: Don't let direct messages header scroll out of view.

### DIFF
--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -130,7 +130,10 @@ export function update_private_messages(): void {
         !all_conversations_shown ||
         // If there is no search term, always show the header.
         !search_term;
-    $("#direct-messages-section-header").toggleClass("hidden-by-filters", !is_header_visible);
+    $("#left_sidebar_scroll_container").toggleClass(
+        "direct-messages-hidden-by-filters",
+        !is_header_visible,
+    );
 
     if (!is_dm_section_expanded) {
         // In the collapsed state, we will still display the current

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -269,11 +269,15 @@
 #direct-messages-section-header {
     cursor: pointer;
     white-space: nowrap;
-    border-radius: 4px;
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    background-color: var(--color-background);
 
     /* Prevent hover styles set on other rows when zoomed in. */
     &:not(.zoom-in):hover {
         background-color: var(--color-background-hover-narrow-filter);
+        border-radius: 4px;
         box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
 
         .left-sidebar-title,
@@ -396,8 +400,9 @@
     cursor: pointer;
     background-color: var(--color-background);
     position: sticky;
-    top: 0;
-    /* Must be more than .sidebar-topic-check and less than #left-sidebar-search */
+    top: var(--line-height-sidebar-row-prominent);
+    /* Must be more than .sidebar-topic-check and less than #left-sidebar-search
+       and #direct-messages-section-header */
     z-index: 2;
     color: var(--color-text-default);
     /* There seems to be a bug where when the header returns to normal position after
@@ -2338,7 +2343,16 @@ li.topic-list-item {
     display: none !important;
 }
 
-#left-sidebar-navigation-area.hidden-by-filters,
-#direct-messages-section-header.hidden-by-filters {
+#left-sidebar-navigation-area.hidden-by-filters {
     display: none;
+}
+
+#left_sidebar_scroll_container.direct-messages-hidden-by-filters {
+    #direct-messages-section-header {
+        display: none;
+    }
+
+    .stream-list-subsection-header {
+        top: 0;
+    }
 }


### PR DESCRIPTION

![Kapture 2026-02-10 at 10 53 49](https://github.com/user-attachments/assets/0fb054d3-4ab8-486f-9e08-0b9bc00df93b)


Fixes bug discussed here: [#issues > Direct Messages heading not sticky in dev @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/Direct.20Messages.20heading.20not.20sticky.20in.20dev/near/2375768)