### PR TITLE
Fix autolinking of URLs preceded by multibyte characters

### DIFF
--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -1467,6 +1467,31 @@
       "New logic with trailing dot: Go to https://podcasts.google.com?feed=abc.",
       "<p>New logic with trailing dot: Go to <a href=\"https://podcasts.google.com?feed=abc\">https://podcasts.google.com?feed=abc</a>.</p>",
       "Go to https://podcasts.google.com?feed=abc."
+    ],
+    [
+      "日本語http://example.com/",
+      "<p>日本語%s</p>",
+      "http://example.com/"
+    ],
+    [
+      "日本語https://example.com/path",
+      "<p>日本語%s</p>",
+      "https://example.com/path"
+    ],
+    [
+      "中文http://test.com/",
+      "<p>中文%s</p>",
+      "http://test.com/"
+    ],
+    [
+      "Тестhttps://example.org/",
+      "<p>Тест%s</p>",
+      "https://example.org/"
+    ],
+    [
+      "test日本語http://example.com/",
+      "<p>test日本語%s</p>",
+      "http://example.com/"
     ]
   ]
 }


### PR DESCRIPTION

This pull request updates the URL detection logic in the Markdown parser to improve handling of URLs adjacent to multibyte (non-ASCII) characters, such as those found in Japanese, Chinese, and Cyrillic text. The primary change is a refinement of the regular expression used to match web links, ensuring that URLs are correctly recognized when they follow multibyte characters. Corresponding test cases have been added to verify this improved behavior.

Improvements to URL detection:

* Updated the URL-matching regular expression in `zerver/lib/markdown/__init__.py` to allow URLs with explicit protocols (e.g., `http://`, `https://`) to be detected even when preceded by multibyte characters, by using a negative lookbehind for ASCII alphanumerics.

Test coverage enhancements:

* Added new test cases to `zerver/tests/fixtures/markdown_test_cases.json` to confirm correct URL recognition in text containing Japanese, Chinese, and Cyrillic characters.