### PR TITLE
left-sidebar: Prioritize followed topics with unread messages.

### DIFF
--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -44,10 +44,10 @@ function build_topic_info_item(
     topic_name: string,
     num_unread: number,
     is_topic_muted: boolean,
+    is_topic_followed: boolean,
     is_active_topic: boolean,
     contains_unread_mention: boolean,
 ): TopicInfo {
-    const is_topic_followed = user_topics.is_topic_followed(stream_id, topic_name);
     const is_topic_unmuted_or_followed = user_topics.is_topic_unmuted_or_followed(
         stream_id,
         topic_name,
@@ -80,6 +80,7 @@ function show_all_topics(
         const num_unread = unread.num_unread_for_topic(stream_id, topic_name);
         const is_active_topic = topic_choice_state.active_topic === topic_name.toLowerCase();
         const is_topic_muted = user_topics.is_topic_muted(stream_id, topic_name);
+        const is_topic_followed = user_topics.is_topic_followed(stream_id, topic_name);
         // Important: Topics are lower-case in this set.
         const contains_unread_mention = topic_choice_state.topics_with_unread_mentions.has(
             topic_name.toLowerCase(),
@@ -89,6 +90,7 @@ function show_all_topics(
             topic_name,
             num_unread,
             is_topic_muted,
+            is_topic_followed,
             is_active_topic,
             contains_unread_mention,
         );
@@ -230,6 +232,7 @@ function choose_topics(
             selected_topic.topic_name,
             selected_topic.num_unread,
             selected_topic.is_muted,
+            selected_topic.is_followed,
             selected_topic.is_active_topic,
             selected_topic.contains_unread_mention,
         );

--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -96,85 +96,142 @@ function show_all_topics(
     }
 }
 
+type TopicBaseInfo = {
+    contains_unread_mention: boolean;
+    is_active_topic: boolean;
+    is_followed: boolean;
+    is_muted: boolean;
+    num_unread: number;
+    position: number;
+    topic_name: string;
+};
+
 function choose_topics(
     stream_id: number,
     topic_names: string[],
     topic_choice_state: TopicChoiceState,
 ): void {
-    for (const topic_name of topic_names) {
+    const selected_topics: TopicBaseInfo[] = [];
+    const additional_followed_topics_with_unreads: TopicBaseInfo[] = [];
+    const additional_topics_with_unreads: TopicBaseInfo[] = [];
+
+    // Select most recent, unmuted MAX_TOPICS topics and the
+    // active topic. Build sets for additional followed and
+    // unmuted topics with unread messages. And update
+    // TopicChoiceState for topics with unread messages that
+    // are not selected for any of the above sets.
+    for (const [idx, topic_name] of topic_names.entries()) {
         const num_unread = unread.num_unread_for_topic(stream_id, topic_name);
         const is_active_topic = topic_choice_state.active_topic === topic_name.toLowerCase();
-        const is_topic_muted = user_topics.is_topic_muted(stream_id, topic_name);
+
+        // If we've already found the most recent MAX_TOPICS,
+        // then we only need to consider topics with unread
+        // messages and the active topic.
+        if (selected_topics.length >= MAX_TOPICS && !is_active_topic && num_unread === 0) {
+            continue;
+        }
+
+        const is_muted = user_topics.is_topic_muted(stream_id, topic_name);
         // Important: Topics are lower-case in this set.
         const contains_unread_mention = topic_choice_state.topics_with_unread_mentions.has(
             topic_name.toLowerCase(),
         );
 
-        function should_show_topic(topics_selected: number): boolean {
-            // This function exists just for readability, to
-            // avoid long chained conditionals to determine
-            // which topics to include.
-
-            // We always show the active topic.  Ideally, this
-            // logic would first check whether the active
-            // topic is in the set of those with unreads to
-            // avoid ending up with MAX_TOPICS_WITH_UNREAD + 1
-            // total topics if the active topic comes after
-            // the first several topics with unread messages.
-            if (is_active_topic) {
-                return true;
-            }
-
-            // We unconditionally skip showing muted topics
-            // when not zoomed, even if they have unread
-            // messages.
-            if (is_topic_muted) {
-                return false;
-            }
-
-            // We include the most recent unmuted MAX_TOPICS topics,
-            // even if there are no unread messages.
-            if (topics_selected < MAX_TOPICS) {
-                return true;
-            }
-
-            // We include older topics with unread messages up
-            // until MAX_TOPICS_WITH_UNREAD total topics have
-            // been included.
-            if (num_unread > 0 && topics_selected < MAX_TOPICS_WITH_UNREAD) {
-                return true;
-            }
-
-            // Otherwise, we don't show the topic in the
-            // unzoomed view.  We might display its unread
-            // count in "show all topics" if it is not muted.
-            return false;
-        }
-
-        const show_topic = should_show_topic(topic_choice_state.topics_selected);
-        if (!show_topic) {
-            if (!is_topic_muted) {
-                topic_choice_state.more_topics_unmuted_unreads += num_unread;
-                if (contains_unread_mention) {
-                    topic_choice_state.more_topics_have_unread_mention_messages = true;
-                }
-            } else {
-                topic_choice_state.more_topics_muted_unreads += num_unread;
-                if (contains_unread_mention) {
-                    topic_choice_state.more_topics_have_muted_unread_mention_messages = true;
-                }
+        // We don't show muted topics, unless it's the active topic,
+        // so we just update the TopicChoiceState here.
+        if (!is_active_topic && is_muted) {
+            topic_choice_state.more_topics_muted_unreads += num_unread;
+            if (contains_unread_mention) {
+                topic_choice_state.more_topics_have_muted_unread_mention_messages = true;
             }
             continue;
         }
+
+        const topic_base_info: TopicBaseInfo = {
+            contains_unread_mention,
+            is_active_topic,
+            is_followed: user_topics.is_topic_followed(stream_id, topic_name),
+            is_muted,
+            num_unread,
+            position: idx,
+            topic_name,
+        };
+
+        if (selected_topics.length < MAX_TOPICS) {
+            selected_topics.push(topic_base_info);
+            continue;
+        }
+
+        if (topic_base_info.num_unread > 0) {
+            if (
+                topic_base_info.is_followed &&
+                additional_followed_topics_with_unreads.length < MAX_TOPICS_WITH_UNREAD
+            ) {
+                additional_followed_topics_with_unreads.push(topic_base_info);
+                continue;
+            }
+
+            if (additional_topics_with_unreads.length < MAX_TOPICS_WITH_UNREAD) {
+                additional_topics_with_unreads.push(topic_base_info);
+                continue;
+            }
+
+            if (!topic_base_info.is_active_topic) {
+                topic_choice_state.more_topics_unmuted_unreads += topic_base_info.num_unread;
+                if (topic_base_info.contains_unread_mention) {
+                    topic_choice_state.more_topics_have_unread_mention_messages = true;
+                }
+                continue;
+            }
+        }
+
+        // We always show the active topic, even if it's older and
+        // has no unread messages.
+        if (topic_base_info.is_active_topic) {
+            selected_topics.push(topic_base_info);
+        }
+    }
+
+    // Select followed topics with unread messages up to MAX_TOPICS_WITH_UNREAD.
+    // Update TopicChoiceState for topics that are not selected.
+    for (const topic_base_info of additional_followed_topics_with_unreads) {
+        if (selected_topics.length < MAX_TOPICS_WITH_UNREAD) {
+            selected_topics.push(topic_base_info);
+        } else {
+            topic_choice_state.more_topics_unmuted_unreads += topic_base_info.num_unread;
+            if (topic_base_info.contains_unread_mention) {
+                topic_choice_state.more_topics_have_unread_mention_messages = true;
+            }
+        }
+    }
+
+    // Select additional topics with unread messages up to MAX_TOPICS_WITH_UNREAD.
+    // Update TopicChoiceState for topics that are not selected.
+    for (const topic_base_info of additional_topics_with_unreads) {
+        if (selected_topics.length < MAX_TOPICS_WITH_UNREAD) {
+            selected_topics.push(topic_base_info);
+        } else {
+            topic_choice_state.more_topics_unmuted_unreads += topic_base_info.num_unread;
+            if (topic_base_info.contains_unread_mention) {
+                topic_choice_state.more_topics_have_unread_mention_messages = true;
+            }
+        }
+    }
+
+    // Sort selected topics by original position in topic_names list
+    // and build TopicInfo items for topic list data.
+    for (const selected_topic of selected_topics.toSorted(
+        (a: TopicBaseInfo, b: TopicBaseInfo) => a.position - b.position,
+    )) {
         topic_choice_state.topics_selected += 1;
 
         const topic_info = build_topic_info_item(
             stream_id,
-            topic_name,
-            num_unread,
-            is_topic_muted,
-            is_active_topic,
-            contains_unread_mention,
+            selected_topic.topic_name,
+            selected_topic.num_unread,
+            selected_topic.is_muted,
+            selected_topic.is_active_topic,
+            selected_topic.contains_unread_mention,
         );
         topic_choice_state.items.push(topic_info);
     }

--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -101,7 +101,7 @@ function choose_topics(
     topic_names: string[],
     topic_choice_state: TopicChoiceState,
 ): void {
-    for (const [idx, topic_name] of topic_names.entries()) {
+    for (const topic_name of topic_names) {
         const num_unread = unread.num_unread_for_topic(stream_id, topic_name);
         const is_active_topic = topic_choice_state.active_topic === topic_name.toLowerCase();
         const is_topic_muted = user_topics.is_topic_muted(stream_id, topic_name);
@@ -132,9 +132,9 @@ function choose_topics(
                 return false;
             }
 
-            // We include the most recent MAX_TOPICS topics,
+            // We include the most recent unmuted MAX_TOPICS topics,
             // even if there are no unread messages.
-            if (idx < MAX_TOPICS && topics_selected < MAX_TOPICS) {
+            if (topics_selected < MAX_TOPICS) {
                 return true;
             }
 
@@ -284,12 +284,11 @@ export function get_list_info(
         const unmuted_or_followed_topics = topic_names.filter((topic) =>
             user_topics.is_topic_unmuted_or_followed(stream_id, topic),
         );
-        choose_topics(stream_id, unmuted_or_followed_topics, topic_choice_state);
-
         const other_topics = topic_names.filter(
             (topic) => !user_topics.is_topic_unmuted_or_followed(stream_id, topic),
         );
-        choose_topics(stream_id, other_topics, topic_choice_state);
+        const reordered_topics = [...unmuted_or_followed_topics, ...other_topics];
+        choose_topics(stream_id, reordered_topics, topic_choice_state);
     } else {
         choose_topics(stream_id, topic_names, topic_choice_state);
     }

--- a/web/tests/topic_list_data.test.cjs
+++ b/web/tests/topic_list_data.test.cjs
@@ -391,6 +391,35 @@ test("get_list_info unreads", ({override}) => {
         ],
     );
 
+    // If there is an active topic, then it's shown, even
+    // if it's an older topic with no unread messages.
+    override(narrow_state, "stream_id", () => 556);
+    override(narrow_state, "topic", () => "topic 15");
+    list_info = get_list_info();
+    assert.equal(list_info.items.length, 11);
+    assert.equal(list_info.more_topics_unreads, 2);
+    assert.equal(list_info.more_topics_have_unread_mention_messages, true);
+    assert.equal(list_info.num_possible_topics, 16);
+
+    assert.deepEqual(
+        list_info.items.map((li) => li.topic_name),
+        [
+            "topic 0",
+            "topic 1",
+            "topic 2",
+            "topic 3",
+            "topic 4",
+            "topic 5",
+            "topic 10",
+            "topic 11",
+            "topic 12",
+            "topic 13",
+            "topic 15",
+        ],
+    );
+
+    override(narrow_state, "topic", () => {});
+
     add_unreads("topic 9", 1);
 
     add_unreads("topic 4", 1);

--- a/web/tests/topic_list_data.test.cjs
+++ b/web/tests/topic_list_data.test.cjs
@@ -421,15 +421,41 @@ test("get_list_info unreads", ({override}) => {
     override(narrow_state, "topic", () => {});
 
     add_unreads("topic 9", 1);
-
-    add_unreads("topic 4", 1);
+    add_unreads("topic 4", 2);
     override(user_topics, "is_topic_muted", (stream_id, topic_name) => {
         assert.equal(stream_id, general.stream_id);
         return topic_name === "topic 4";
     });
 
-    // muting the stream and unmuting the topic 5
-    // this should make topic 5 at top in items array
+    // Muting topic 4 removes it from the list, and topic 6
+    // is added to the list even though it doesn't have any
+    // unread messages.
+    list_info = get_list_info();
+    assert.equal(list_info.items.length, 10);
+    // The unread messages in topic 4 are not added to the
+    // unread count, but the unread message in topic 9 is.
+    assert.equal(list_info.more_topics_unreads, 3);
+    assert.equal(list_info.more_topics_have_unread_mention_messages, true);
+    assert.equal(list_info.num_possible_topics, 16);
+
+    assert.deepEqual(
+        list_info.items.map((li) => li.topic_name),
+        [
+            "topic 0",
+            "topic 1",
+            "topic 2",
+            "topic 3",
+            "topic 5",
+            "topic 6",
+            "topic 9",
+            "topic 10",
+            "topic 11",
+            "topic 12",
+        ],
+    );
+
+    // Muting the stream and unmuting the topic 5
+    // means it moves to the top of the items array.
     general.is_muted = true;
     add_unreads("topic 5", 1);
     override(user_topics, "is_topic_unmuted_or_followed", (stream_id, topic_name) => {
@@ -439,6 +465,8 @@ test("get_list_info unreads", ({override}) => {
 
     list_info = get_list_info();
     assert.equal(list_info.items.length, 10);
+    // We still show the count for unread messages in
+    // unmuted topics.
     assert.equal(list_info.more_topics_unreads, 3);
     assert.equal(list_info.more_topics_have_unread_mention_messages, true);
     assert.equal(list_info.num_possible_topics, 16);
@@ -467,7 +495,7 @@ test("get_list_info unreads", ({override}) => {
     });
     list_info = get_list_info();
     assert.equal(list_info.items.length, 10);
-    assert.equal(list_info.more_topics_unreads, 3);
+    assert.equal(list_info.more_topics_unreads, 4);
     // Topic 14 now makes it above the "show all topics" fold.
     assert.equal(list_info.more_topics_have_unread_mention_messages, false);
     assert.equal(list_info.num_possible_topics, 16);
@@ -491,8 +519,8 @@ test("get_list_info unreads", ({override}) => {
     add_unreads_with_mention("topic 9", 1);
     list_info = get_list_info();
     assert.equal(list_info.items.length, 10);
-    assert.equal(list_info.more_topics_unreads, 4);
-    // Topic 8's new mention gets counted here.
+    assert.equal(list_info.more_topics_unreads, 5);
+    // Topic 9's new mention gets counted here.
     assert.equal(list_info.more_topics_have_unread_mention_messages, true);
     assert.equal(list_info.num_possible_topics, 16);
     assert.equal(list_info.more_topics_unread_count_muted, true);
@@ -529,6 +557,34 @@ test("get_list_info unreads", ({override}) => {
             "topic 1",
             "topic 2",
             "topic 3",
+            "topic 6",
+            "topic 11",
+            "topic 12",
+            "topic 13",
+            "topic 14",
+        ],
+    );
+
+    // Unmuting the channel drops topic 5 back down into chronological
+    // order.
+    general.is_muted = false;
+    list_info = get_list_info();
+    assert.equal(list_info.items.length, 10);
+    assert.equal(list_info.more_topics_unreads, 15);
+    // Topic 9's mention still gets counted here (the channel is no longer
+    // muted but the topic is), so that the mention indicator can still be
+    // shown.
+    assert.equal(list_info.more_topics_have_unread_mention_messages, true);
+    assert.equal(list_info.num_possible_topics, 16);
+    assert.equal(list_info.more_topics_unread_count_muted, false);
+    assert.deepEqual(
+        list_info.items.map((li) => li.topic_name),
+        [
+            "topic 0",
+            "topic 1",
+            "topic 2",
+            "topic 3",
+            "topic 5",
             "topic 6",
             "topic 11",
             "topic 12",

--- a/web/tests/topic_list_data.test.cjs
+++ b/web/tests/topic_list_data.test.cjs
@@ -300,7 +300,7 @@ test("get_list_info unreads", ({override}) => {
     let list_info;
 
     let message_id = 0;
-    for (let i = 15; i >= 0; i -= 1) {
+    for (let i = 25; i >= 0; i -= 1) {
         stream_topic_history.add_message({
             stream_id: general.stream_id,
             message_id: (message_id += 1),
@@ -358,7 +358,7 @@ test("get_list_info unreads", ({override}) => {
     assert.equal(list_info.items.length, 8);
     assert.equal(list_info.more_topics_unreads, 0);
     assert.equal(list_info.more_topics_have_unread_mention_messages, false);
-    assert.equal(list_info.num_possible_topics, 16);
+    assert.equal(list_info.num_possible_topics, 26);
 
     assert.deepEqual(
         list_info.items.map((li) => li.topic_name),
@@ -373,7 +373,7 @@ test("get_list_info unreads", ({override}) => {
     assert.equal(list_info.items.length, 10);
     assert.equal(list_info.more_topics_unreads, 2);
     assert.equal(list_info.more_topics_have_unread_mention_messages, true);
-    assert.equal(list_info.num_possible_topics, 16);
+    assert.equal(list_info.num_possible_topics, 26);
 
     assert.deepEqual(
         list_info.items.map((li) => li.topic_name),
@@ -396,10 +396,10 @@ test("get_list_info unreads", ({override}) => {
     override(narrow_state, "stream_id", () => 556);
     override(narrow_state, "topic", () => "topic 15");
     list_info = get_list_info();
-    assert.equal(list_info.items.length, 11);
-    assert.equal(list_info.more_topics_unreads, 2);
+    assert.equal(list_info.items.length, 10);
+    assert.equal(list_info.more_topics_unreads, 3);
     assert.equal(list_info.more_topics_have_unread_mention_messages, true);
-    assert.equal(list_info.num_possible_topics, 16);
+    assert.equal(list_info.num_possible_topics, 26);
 
     assert.deepEqual(
         list_info.items.map((li) => li.topic_name),
@@ -413,7 +413,6 @@ test("get_list_info unreads", ({override}) => {
             "topic 10",
             "topic 11",
             "topic 12",
-            "topic 13",
             "topic 15",
         ],
     );
@@ -436,7 +435,7 @@ test("get_list_info unreads", ({override}) => {
     // unread count, but the unread message in topic 9 is.
     assert.equal(list_info.more_topics_unreads, 3);
     assert.equal(list_info.more_topics_have_unread_mention_messages, true);
-    assert.equal(list_info.num_possible_topics, 16);
+    assert.equal(list_info.num_possible_topics, 26);
 
     assert.deepEqual(
         list_info.items.map((li) => li.topic_name),
@@ -469,7 +468,7 @@ test("get_list_info unreads", ({override}) => {
     // unmuted topics.
     assert.equal(list_info.more_topics_unreads, 3);
     assert.equal(list_info.more_topics_have_unread_mention_messages, true);
-    assert.equal(list_info.num_possible_topics, 16);
+    assert.equal(list_info.num_possible_topics, 26);
     assert.equal(list_info.more_topics_unread_count_muted, false);
 
     assert.deepEqual(
@@ -498,7 +497,7 @@ test("get_list_info unreads", ({override}) => {
     assert.equal(list_info.more_topics_unreads, 4);
     // Topic 14 now makes it above the "show all topics" fold.
     assert.equal(list_info.more_topics_have_unread_mention_messages, false);
-    assert.equal(list_info.num_possible_topics, 16);
+    assert.equal(list_info.num_possible_topics, 26);
     assert.equal(list_info.more_topics_unread_count_muted, true);
     assert.deepEqual(
         list_info.items.map((li) => li.topic_name),
@@ -522,7 +521,7 @@ test("get_list_info unreads", ({override}) => {
     assert.equal(list_info.more_topics_unreads, 5);
     // Topic 9's new mention gets counted here.
     assert.equal(list_info.more_topics_have_unread_mention_messages, true);
-    assert.equal(list_info.num_possible_topics, 16);
+    assert.equal(list_info.num_possible_topics, 26);
     assert.equal(list_info.more_topics_unread_count_muted, true);
     assert.deepEqual(
         list_info.items.map((li) => li.topic_name),
@@ -547,7 +546,7 @@ test("get_list_info unreads", ({override}) => {
     assert.equal(list_info.items.length, 10);
     assert.equal(list_info.more_topics_unreads, 15);
     assert.equal(list_info.more_topics_have_unread_mention_messages, true);
-    assert.equal(list_info.num_possible_topics, 16);
+    assert.equal(list_info.num_possible_topics, 26);
     assert.equal(list_info.more_topics_unread_count_muted, false);
     assert.deepEqual(
         list_info.items.map((li) => li.topic_name),
@@ -575,7 +574,7 @@ test("get_list_info unreads", ({override}) => {
     // muted but the topic is), so that the mention indicator can still be
     // shown.
     assert.equal(list_info.more_topics_have_unread_mention_messages, true);
-    assert.equal(list_info.num_possible_topics, 16);
+    assert.equal(list_info.num_possible_topics, 26);
     assert.equal(list_info.more_topics_unread_count_muted, false);
     assert.deepEqual(
         list_info.items.map((li) => li.topic_name),
@@ -590,6 +589,81 @@ test("get_list_info unreads", ({override}) => {
             "topic 12",
             "topic 13",
             "topic 14",
+        ],
+    );
+
+    // Follow topic 15 and it is now shown. Topics
+    // are still shown in order of recency, e.g.,
+    // topic 15 is still shown last even though it
+    // is followed.
+    override(user_topics, "is_topic_followed", (stream_id, topic_name) => {
+        assert.equal(stream_id, general.stream_id);
+        return topic_name === "topic 15";
+    });
+    list_info = get_list_info();
+    assert.equal(list_info.items.length, 10);
+    assert.equal(list_info.more_topics_unreads, 2);
+    assert.equal(list_info.more_topics_have_unread_mention_messages, true);
+    assert.equal(list_info.num_possible_topics, 26);
+    assert.equal(list_info.more_topics_unread_count_muted, false);
+    assert.deepEqual(
+        list_info.items.map((li) => li.topic_name),
+        [
+            "topic 0",
+            "topic 1",
+            "topic 2",
+            "topic 3",
+            "topic 5",
+            "topic 6",
+            "topic 11",
+            "topic 12",
+            "topic 13",
+            "topic 15",
+        ],
+    );
+
+    // Add unread messages to older topics, which will be
+    // counted in the "all topics" line, and follow topics
+    // that were previously muted, except for topic 9.
+    // Followed topics with unread messages should have
+    // priority over unfollowed topics with unreads, e.g.,
+    // topic 9 is not in the topic list data below.
+    add_unreads_with_mention("topic 25", 1);
+    add_unreads("topic 24", 1);
+    add_unreads("topic 23", 1);
+    add_unreads("topic 22", 1);
+    add_unreads("topic 21", 1);
+    add_unreads("topic 20", 1);
+    add_unreads("topic 19", 1);
+    add_unreads("topic 18", 1);
+    add_unreads("topic 17", 1);
+    add_unreads_with_mention("topic 16", 1);
+    override(user_topics, "is_topic_muted", () => false);
+    override(user_topics, "is_topic_followed", (stream_id, topic_name) => {
+        assert.equal(stream_id, general.stream_id);
+        return ["topic 4", "topic 10", "topic 13", "topic 14", "topic 15", "topic 16"].includes(
+            topic_name,
+        );
+    });
+    list_info = get_list_info();
+    assert.equal(list_info.items.length, 10);
+    assert.equal(list_info.more_topics_unreads, 14);
+    assert.equal(list_info.more_topics_have_unread_mention_messages, true);
+    assert.equal(list_info.num_possible_topics, 26);
+    assert.equal(list_info.more_topics_unread_count_muted, false);
+    assert.deepEqual(
+        list_info.items.map((li) => li.topic_name),
+        [
+            "topic 0",
+            "topic 1",
+            "topic 2",
+            "topic 3",
+            "topic 4",
+            "topic 5",
+            "topic 10",
+            "topic 13",
+            "topic 14",
+            "topic 15",
         ],
     );
 });


### PR DESCRIPTION
Refactors logic of building topic list for the left sidebar based on [#design > left sidebar topic prioritization @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/left.20sidebar.20topic.20prioritization/near/2271022):
- If you've got a lot of unread stuff, followed unread topics are prioritized for not being hidden behind "SHOW ALL TOPICS".

Fixes #36199.

---

**Notes**:
- The #37697 to reduced the max number of topics displayed with and without unread messages.
- The current implementation keeps topics in order of recency.
- Fixes two "bugs" in the current logic of choosing topics for the left sidebar:
  - For showing topics without unread messages, the current logic only checks the first MAX_TOPICS (i.e., 6) topics. If any of those topics are muted, then older topics without unread messages were not shown. If a user had muted the most recent 6 topics in a channel and had no unread messages, this would result in no topics being shown in the left sidebar. In the screenshots below, this is why "red FAILED EXPORT..." is shown in the after screenshots, but not in the before screenshots once all the messages in that topic are read.
  - When showing an older active topic (i.e., the user has navigated to that topic directly) and there are unread messages in many other topics, this would result in showing MAX_TOPICS_WITH_UNREAD + 1 topics in the left sidebar (i.e., 11 topics). With the updated changes, even if the active topic is older, the max topics shown when there are unread messages will be MAX_TOPICS_WITH_UNREAD (i.e., 10 topics).
- Manually testing in a dev environment channel is easier with `./manage.py populate_db --max-topics=25` as that generally creates enough topics to mute and follow a few in a particular channel.
  - Also, having the channel link in the sidebar go to the topic list is helpful for comparing all the topics in the channel to what's displayed in the sidebar.
- Have not made any adjustments to how the `n` key works when going through unread topics in a channel.

---

**Screenshots and screen captures:**

<details>
<summary>List of all topics in channel with all messages unread</summary>

<img width="1330" height="1660" alt="Screenshot From 2026-02-23 15-22-51" src="https://github.com/user-attachments/assets/0df6264f-f3a9-48e1-8256-2eae5362368b" />
</details>

| Description | Before | After |
| --- | --- | --- |
| all topics in channel have unread messages, *no active topic, in channel list view* | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-23-28" src="https://github.com/user-attachments/assets/4d5866b4-ac59-4fe1-a960-f48e7c8193d3" /> | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-23-44" src="https://github.com/user-attachments/assets/5cc172c6-d152-40d2-b625-93f773576d67" /> |
| most recent 6 topics read | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-26-51" src="https://github.com/user-attachments/assets/8fadd6dc-9bd1-49ca-b930-85500d6d4e07" /> | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-27-10" src="https://github.com/user-attachments/assets/889a1525-59fa-4d8d-a034-8e4c0e2f4b23" /> |
| most recent 7 topics read, *"red FAILED EXPORT..." is no longer shown in before logic* | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-28-34" src="https://github.com/user-attachments/assets/3169eec4-09f1-43ea-a478-bc8646840962" /> | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-28-51" src="https://github.com/user-attachments/assets/35c93e3f-74ef-49d0-8284-3b1f9289c361" /> |
| most recent 8 topics read, *"desktop" is no longer shown in both* | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-30-28" src="https://github.com/user-attachments/assets/55478f6c-af4d-4115-8912-3603d8d62cd2" /> | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-30-45" src="https://github.com/user-attachments/assets/d3178e17-a952-4041-a2c1-5ad1a1afb4a3" /> |
| read topics through 2nd followed topic | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-36-05" src="https://github.com/user-attachments/assets/ef809d79-8a6e-440c-898c-833950fa5db4" /> | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-36-51" src="https://github.com/user-attachments/assets/455d54e8-4834-4677-aa1c-ad6702bda93f" /> |
| read topics through 3rd followed topic | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-39-10" src="https://github.com/user-attachments/assets/4e31cade-c4ac-49c6-ae04-3a221de20afc" /> | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-39-23" src="https://github.com/user-attachments/assets/1974bbbe-a95b-4247-90cf-7d2dca59bc7b" /> |
| read topics through 4th followed topic, *all topics read, active topic oldest in channel* | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-40-58" src="https://github.com/user-attachments/assets/ebcd7071-90bc-4567-bdf1-3b0c0b41e863" /> | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-41-05" src="https://github.com/user-attachments/assets/73c6703d-f011-4a1e-b6ac-c1a12a05aed9" /> |

*Second "bug" described above - 11 total topics shown*
| Before | After |
| --- | --- |
| <img width="630" height="980" alt="Screenshot From 2026-02-23 15-54-21" src="https://github.com/user-attachments/assets/f95ec6d6-f584-4f16-a178-18c57c1c4917" /> | <img width="630" height="980" alt="Screenshot From 2026-02-23 15-54-40" src="https://github.com/user-attachments/assets/96a0829a-da89-41c6-a5d2-ce86c7d60d1e" /> |

*First "bug" described above - most recent topics muted*
<details>
<summary>List of all topics in channel with most recent 7 topics muted</summary>

<img width="1334" height="1674" alt="Screenshot From 2026-02-23 15-51-02" src="https://github.com/user-attachments/assets/d23182a6-d27e-4185-a498-f2a6edf0f6aa" />
</details>

| Before | After |
| --- | --- |
| <img width="656" height="924" alt="Screenshot From 2026-02-23 15-50-32" src="https://github.com/user-attachments/assets/c8871191-5609-41bc-a58f-abef4b1f0de5" /> | <img width="656" height="924" alt="Screenshot From 2026-02-23 15-50-47" src="https://github.com/user-attachments/assets/b6daf1d9-b7be-4f99-8162-1f062475f54a" /> |

*Channel is muted - no changes to per topic notifications*
| Description | Before | After |
| --- | --- | --- |
| all topics in channel have unread messages, *no active topic, in channel list view* | <img width="630" height="870" alt="Screenshot From 2026-02-23 16-42-58" src="https://github.com/user-attachments/assets/a1d79c09-8a35-4655-b89d-98883686450c" /> | <img width="630" height="870" alt="Screenshot From 2026-02-23 16-43-07" src="https://github.com/user-attachments/assets/9aff6e7f-2725-4876-bdae-848d7756e550" /> |
| all followed topics have been read | <img width="630" height="870" alt="Screenshot From 2026-02-23 16-46-22" src="https://github.com/user-attachments/assets/27042f77-9fbe-457b-a30a-95c103b72f63" /> | <img width="630" height="870" alt="Screenshot From 2026-02-23 16-46-31" src="https://github.com/user-attachments/assets/2efb1c94-5a42-482f-9079-12467cdf4312" /> |
| all unmuted topics read | <img width="630" height="870" alt="Screenshot From 2026-02-23 16-48-44" src="https://github.com/user-attachments/assets/24ce9573-87e0-45db-8474-0aa9eaf68a6f" /> | <img width="630" height="870" alt="Screenshot From 2026-02-23 16-48-51" src="https://github.com/user-attachments/assets/58685abe-a635-4193-aa44-768194acc4f1" /> |


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
