### PR TITLE
search: Center search icon for closed search on narrow screens.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -84,6 +84,8 @@
             width: var(--search-box-width);
 
             @media (width < $md_min) {
+                /* Square off the icon-only presentation. */
+                width: var(--search-box-height);
                 grid-template:
                     "search-icon search-pills" var(--search-box-height)
                     / var(--search-box-height) 0;


### PR DESCRIPTION
Fixes bug discussed here: [#issues > center search icon at mobile widths @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/center.20search.20icon.20at.20mobile.20widths/near/2375865)

<img width="501" height="491" alt="image" src="https://github.com/user-attachments/assets/8c15ec59-5d21-4d54-874f-a9a2dedb23eb" />
