### PR TITLE
scripts: Replace parse_os_release with platform.freedesktop_os_release

### DIFF
--- a/scripts/lib/create-production-venv
+++ b/scripts/lib/create-production-venv
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import os
+import platform
 import sys
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -8,14 +9,14 @@ if ZULIP_PATH not in sys.path:
     sys.path.append(ZULIP_PATH)
 
 from scripts.lib.setup_venv import get_venv_dependencies
-from scripts.lib.zulip_tools import os_families, parse_os_release, run
+from scripts.lib.zulip_tools import os_families, run
 
 parser = argparse.ArgumentParser(description="Create a production virtualenv with caching")
 parser.add_argument("deploy_path")
 args = parser.parse_args()
 
 # install dependencies for setting up the virtualenv
-distro_info = parse_os_release()
+distro_info = platform.freedesktop_os_release()
 vendor = distro_info["ID"]
 os_version = distro_info["VERSION_ID"]
 VENV_DEPENDENCIES = get_venv_dependencies(vendor, os_version)

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import os
+import platform
 import pwd
 import random
 import shlex
@@ -432,35 +433,6 @@ def maybe_perform_purging(
 
 
 @functools.lru_cache(None)
-def parse_os_release() -> dict[str, str]:
-    """
-    Example of the useful subset of the data:
-    {
-     'ID': 'ubuntu',
-     'VERSION_ID': '18.04',
-     'NAME': 'Ubuntu',
-     'VERSION': '18.04.3 LTS (Bionic Beaver)',
-     'PRETTY_NAME': 'Ubuntu 18.04.3 LTS',
-    }
-
-    VERSION_CODENAME (e.g. 'bionic') is nice and readable to Ubuntu
-    developers, but we avoid using it, as it is not available on
-    RHEL-based platforms.
-    """
-    distro_info: dict[str, str] = {}
-    with open("/etc/os-release") as fp:
-        for line in fp:
-            line = line.strip()
-            if not line or line.startswith("#"):
-                # The line may be blank or a comment, see:
-                # https://www.freedesktop.org/software/systemd/man/os-release.html
-                continue
-            k, v = line.split("=", 1)
-            [distro_info[k]] = shlex.split(v)
-    return distro_info
-
-
-@functools.lru_cache(None)
 def os_families() -> set[str]:
     """
     Known families:
@@ -470,7 +442,7 @@ def os_families() -> set[str]:
     rhel (includes: rhel, centos)
     centos (includes: centos)
     """
-    distro_info = parse_os_release()
+    distro_info = platform.freedesktop_os_release()
     return {distro_info["ID"], *distro_info.get("ID_LIKE", "").split()}
 
 

--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -2,6 +2,7 @@
 import argparse
 import configparser
 import os
+import platform
 import re
 import subprocess
 import sys
@@ -13,7 +14,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, BASE_DIR)
 
 from scripts.lib.puppet_cache import setup_puppet_modules
-from scripts.lib.zulip_tools import assert_running_as_root, parse_os_release
+from scripts.lib.zulip_tools import assert_running_as_root
 
 assert_running_as_root()
 
@@ -30,7 +31,7 @@ config.read(args.config)
 
 setup_puppet_modules()
 
-distro_info = parse_os_release()
+distro_info = platform.freedesktop_os_release()
 puppet_config = """
 Exec { path => "/usr/sbin:/usr/bin:/sbin:/bin" }
 """

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -23,7 +23,6 @@ from scripts.lib.zulip_tools import (
     WARNING,
     get_dev_uuid_var_path,
     os_families,
-    parse_os_release,
     run,
     run_as_root,
 )
@@ -72,7 +71,7 @@ except OSError:
     )
     sys.exit(1)
 
-distro_info = parse_os_release()
+distro_info = platform.freedesktop_os_release()
 vendor = distro_info["ID"]
 os_version = distro_info["VERSION_ID"]
 if vendor == "debian" and os_version == "12":  # bookworm

--- a/zerver/management/commands/backup.py
+++ b/zerver/management/commands/backup.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import re
 import tempfile
 from argparse import ArgumentParser, RawTextHelpFormatter
@@ -11,7 +12,7 @@ from django.db import connection
 from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
-from scripts.lib.zulip_tools import TIMESTAMP_FORMAT, parse_os_release, run
+from scripts.lib.zulip_tools import TIMESTAMP_FORMAT, run
 from version import ZULIP_VERSION
 from zerver.lib.management import ZulipBaseCommand
 from zerver.logging_handlers import try_git_describe
@@ -51,7 +52,7 @@ class Command(ZulipBaseCommand):
 
             with open(os.path.join(tmp, "zulip-backup", "os-version"), "w") as f:
                 print(
-                    "{ID} {VERSION_ID}".format(**parse_os_release()),
+                    "{ID} {VERSION_ID}".format(**platform.freedesktop_os_release()),
                     file=f,
                 )
             members.append("zulip-backup/os-version")


### PR DESCRIPTION
This is available in Python ≥ 3.10.

https://docs.python.org/3/library/platform.html#platform.freedesktop_os_release