### PR TITLE
left_sidebar: Don't zoom out unless already zoomed in for that view.

### DIFF
--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -328,6 +328,9 @@ function zoom_in(): void {
 }
 
 function zoom_out(): void {
+    if (!zoomed) {
+        return;
+    }
     zoomed = false;
     ui_util.enable_left_sidebar_search();
     clear_search();

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -68,12 +68,18 @@ export function clear(): void {
 }
 
 export function close(): void {
-    zoomed = false;
     clear();
-    ui_util.enable_left_sidebar_search();
+    if (zoomed) {
+        zoomed = false;
+        ui_util.enable_left_sidebar_search();
+    }
 }
 
 export function zoom_out(): void {
+    if (!zoomed) {
+        return;
+    }
+
     zoomed = false;
     ui_util.enable_left_sidebar_search();
 


### PR DESCRIPTION
Some of the zoom out logic, like ui_util.enable_left_sidebar_search() breaks if we're currently zoomed in to a different view. For example. when zoomed into direct messages, when topics are cleared, we don't want to run the zoom out code because it could show search when it shouldn't be shown.

Fixes bug that can be reproduced on CZO:

1. Zoom in to DMs
2. Click on a DM conversation
3. Left sidebar search appears at the top when it shouldn't (because DMs are still zoomed)
