### PR TITLE
compose: Add intro tooltip for go to conversation button.

### DIFF
--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -724,6 +724,10 @@ export function initialize(): void {
             $compose_recipient.removeClass("recently-focused");
         }, 500);
         compose_recipient.update_recipient_row_attention_level();
+        // Show one-time tooltip when user confirms topic change
+        setTimeout(() => {
+            compose_recipient.show_go_to_conversation_button_intro_tooltip();
+        }, 0);
     });
 
     $(window).on("blur", () => {

--- a/web/src/onboarding_steps.ts
+++ b/web/src/onboarding_steps.ts
@@ -5,6 +5,7 @@ import type * as z from "zod/mini";
 import render_navigation_tour_video_modal from "../templates/navigation_tour_video_modal.hbs";
 
 import * as channel from "./channel.ts";
+// eslint-disable-next-line import/no-cycle
 import * as compose_recipient from "./compose_recipient.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import {$t, $t_html} from "./i18n.ts";

--- a/web/templates/onboarding_compose_go_to_conversation_button_tooltip_template.hbs
+++ b/web/templates/onboarding_compose_go_to_conversation_button_tooltip_template.hbs
@@ -1,0 +1,3 @@
+<div class="onboarding-compose-tooltip">
+    <p>Go to conversation</p>
+</div>

--- a/zerver/lib/onboarding_steps.py
+++ b/zerver/lib/onboarding_steps.py
@@ -58,6 +58,9 @@ ONE_TIME_NOTICES: list[OneTimeNotice] = [
     OneTimeNotice(
         name="navigation_tour_video",
     ),
+    OneTimeNotice(
+        name="intro_go_to_conversation_button_tooltip",
+    ),
 ]
 
 ONE_TIME_ACTIONS = [OneTimeAction(name="narrow_to_dm_with_welcome_bot_new_user")]

--- a/zerver/tests/test_onboarding_steps.py
+++ b/zerver/tests/test_onboarding_steps.py
@@ -31,7 +31,7 @@ class TestGetNextOnboardingSteps(ZulipTestCase):
 
         do_mark_onboarding_step_as_read(self.user, "intro_inbox_view_modal")
         onboarding_steps = get_next_onboarding_steps(self.user)
-        self.assert_length(onboarding_steps, 8)
+        self.assert_length(onboarding_steps, 9)
         self.assertEqual(onboarding_steps[0]["name"], "intro_recent_view_modal")
         self.assertEqual(onboarding_steps[1]["name"], "first_stream_created_banner")
         self.assertEqual(onboarding_steps[2]["name"], "jump_to_conversation_banner")
@@ -39,7 +39,8 @@ class TestGetNextOnboardingSteps(ZulipTestCase):
         self.assertEqual(onboarding_steps[4]["name"], "interleaved_view_messages_fading")
         self.assertEqual(onboarding_steps[5]["name"], "intro_resolve_topic")
         self.assertEqual(onboarding_steps[6]["name"], "navigation_tour_video")
-        self.assertEqual(onboarding_steps[7]["name"], "narrow_to_dm_with_welcome_bot_new_user")
+        self.assertEqual(onboarding_steps[7]["name"], "intro_go_to_conversation_button_tooltip")
+        self.assertEqual(onboarding_steps[8]["name"], "narrow_to_dm_with_welcome_bot_new_user")
 
         with self.settings(TUTORIAL_ENABLED=False):
             onboarding_steps = get_next_onboarding_steps(self.user)


### PR DESCRIPTION
Adds a one-time onboarding tooltip that guides users to the "go to conversation" button when they change topics while composing.
fixes #32166

### Changes

- Added `show_go_to_conversation_button_intro_tooltip()` and `hide_go_to_conversation_button_intro_tooltip()` functions in `compose_recipient.ts`
- Registered `intro_go_to_conversation_button_tooltip` as a new one-time notice in `zerver/lib/onboarding_steps.py`
- Created tooltip template in `web/templates/onboarding_compose_go_to_conversation_button_tooltip_template.hbs`
- Tooltip appears when user changes the topic in the compose recipient selector

### Behavior

The tooltip:
- Shows when the user confirms a topic change in the compose box
- Only displays if the conversation arrow button is active (has `narrow_to_compose_recipients` class)
- Does not show if compose banners are visible
- Automatically dismisses when clicked and marks the onboarding step as complete
- Only shows once per user (one-time notice)

### Screenshot

<img width="2069" height="1131" alt="Screenshot 2026-02-11 121713" src="https://github.com/user-attachments/assets/d042b404-f4f7-4bd1-8eba-77faa2e7b3ab" />

### Testing

Manually tested:
- Tooltip appears on topic change ✓
- Tooltip dismisses on click ✓
- Tooltip doesn't reappear after being dismissed ✓
- Tooltip respects preconditions (button active, no banners) ✓
```