### PR TITLE
people: Add non active user ids as valid user ids.

### DIFF
--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1962,6 +1962,7 @@ export function is_displayable_conversation_participant(user_id: number): boolea
 export function populate_valid_user_ids(
     params: StateData["user_groups"],
     cross_realm_bots: StateData["people"]["cross_realm_bots"],
+    realm_non_active_users: StateData["people"]["realm_non_active_users"],
 ): void {
     // Every valid user ID is guaranteed to exist in at least one
     // system group, so we can us that to compute the set of valid
@@ -1974,6 +1975,10 @@ export function populate_valid_user_ids(
 
     for (const bot of cross_realm_bots) {
         valid_user_ids.add(bot.user_id);
+    }
+
+    for (const user of realm_non_active_users) {
+        valid_user_ids.add(user.user_id);
     }
 }
 
@@ -2247,7 +2252,11 @@ export async function initialize(
     user_group_params: StateData["user_groups"],
 ): Promise<void> {
     initialize_current_user(my_user_id);
-    populate_valid_user_ids(user_group_params, people_params.cross_realm_bots);
+    populate_valid_user_ids(
+        user_group_params,
+        people_params.cross_realm_bots,
+        people_params.realm_non_active_users,
+    );
 
     // Compute the set of user IDs that we know are valid in the
     // organization, but do not have a copy of.


### PR DESCRIPTION
These user ids are valid even though they are not part of any system group.

This will avoid bugs where user searching for a deactivated user just gets return `dm:{user_id}` instead of a proper pill with user name.

discussion: [#issues > deactivated bots in searchbar typeahead](https://chat.zulip.org/#narrow/channel/9-issues/topic/deactivated.20bots.20in.20searchbar.20typeahead/with/2371771)

| before | after |
| --- | --- |
| <img width="604" height="287" alt="image" src="https://github.com/user-attachments/assets/53a67085-54b0-452f-bd21-b00f9e17e4c0" /> | <img width="604" height="287" alt="image" src="https://github.com/user-attachments/assets/dc435ee4-f014-4195-88e7-9c1df7b5598b" /> |

