### PR TITLE
message_store: Conditionally update message's raw_content.

### DIFF
--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -16,6 +16,7 @@ import * as inbox_ui from "./inbox_ui.ts";
 import * as inbox_util from "./inbox_util.ts";
 import * as message_lists from "./message_lists.ts";
 import {type Message, single_message_content_schema} from "./message_store.ts";
+import * as message_store from "./message_store.ts";
 import * as narrow_state from "./narrow_state.ts";
 import * as people from "./people.ts";
 import * as recent_view_ui from "./recent_view_ui.ts";
@@ -328,7 +329,7 @@ export function quote_message(opts: {
         success(raw_data) {
             const data = single_message_content_schema.parse(raw_data);
             assert(data.message.content_type === "text/x-markdown");
-            message.raw_content = data.message.content;
+            message_store.maybe_update_raw_content(message, data.message.content);
             replace_content(message, data.message.content);
         },
         // We set a timeout here to trigger usage of the fallback markdown via the

--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -394,7 +394,7 @@ export function edit_locally(message: Message, request: LocalEditRequest): Messa
     }
 
     if (message_content_edited) {
-        message.raw_content = raw_content;
+        message_store.maybe_update_raw_content(message, raw_content);
         if (request.content !== undefined) {
             // This happens in the code path where message editing
             // failed and we're trying to undo the local echo.  We use
@@ -410,7 +410,7 @@ export function edit_locally(message: Message, request: LocalEditRequest): Messa
             // all flags, so we need to restore those flags that are
             // properties of how the user has interacted with the
             // message, and not its rendering.
-            const {content, flags, is_me_message} = markdown.render(message.raw_content);
+            const {content, flags, is_me_message} = markdown.render(raw_content);
             message_store.update_message_content(message, content);
             message.flags = flags;
             message.is_me_message = is_me_message;

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -824,8 +824,8 @@ export function start($row: JQuery, edit_box_open_callback?: () => void): void {
 
             const message_markdown_content = data.message.content;
             if (message_lists.current === msg_list) {
-                message.raw_content = message_markdown_content;
-                start_edit_with_content($row, message.raw_content, edit_box_open_callback);
+                message_store.maybe_update_raw_content(message, message_markdown_content);
+                start_edit_with_content($row, message_markdown_content, edit_box_open_callback);
             }
         },
     });

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -505,7 +505,7 @@ export function update_messages(events: UpdateMessageEvent[]): void {
                 any_message_content_edited = true;
 
                 // Update raw_content, so that editing a few times in a row is fast.
-                anchor_message.raw_content = event.content;
+                message_store.maybe_update_raw_content(anchor_message, event.content);
 
                 // Editing a message may change the titles for linked
                 // media, so we must invalidate the asset map.

--- a/web/tests/message_events.test.cjs
+++ b/web/tests/message_events.test.cjs
@@ -45,7 +45,7 @@ const alice = {
 people.add_active_user(alice);
 
 const denmark = {
-    subscribed: false,
+    subscribed: true,
     name: "Denmark",
     stream_id: 101,
 };


### PR DESCRIPTION
This prevents the edge case where we might cache
stale versions of raw_content, when we fetch
it to quote/edit a message.

I enforce using maybe_update_raw_content at places where we are sure that the cached raw_content will be updated, like in message_events.ts for the
sake of consistency. It is not expensive and should appear as the default pattern for updating raw_content to future readers.

Fixes: #37908

```
git --no-pager grep "raw_content = "
web/src/echo.ts:    const raw_content = message_request.content;
web/src/echo.ts:    const raw_content = request.raw_content;
web/src/message_store.ts:        message.raw_content = undefined;
web/src/message_store.ts:    message.raw_content = raw_content;
```
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
