### PR TITLE
checks: Name the required settings better when running in Docker.

### DIFF
--- a/zerver/checks.py
+++ b/zerver/checks.py
@@ -34,9 +34,15 @@ def check_required_settings(
         ):
             continue
 
+        if settings.RUNNING_IN_DOCKER:
+            settings_location = "your Docker environment configuration"
+            setting_display_name = "SETTING_" + setting_name
+        else:
+            settings_location = "/etc/zulip/settings.py"
+            setting_display_name = setting_name
         errors.append(
             checks.Error(
-                f"You must set {setting_name} in /etc/zulip/settings.py",
+                f"You must set {setting_display_name} in {settings_location}",
                 obj=f"settings.{setting_name}",
                 id="zulip.E001",
             )

--- a/zerver/tests/test_checks.py
+++ b/zerver/tests/test_checks.py
@@ -19,6 +19,7 @@ class TestChecks(ZulipTestCase):
                 stack.enter_context(self.assertRaisesRegex(SystemCheckError, test))
             call_command("check", stdout=DEVNULL)
 
+    @override_settings(RUNNING_IN_DOCKER=False)
     def test_checks_required_setting(self) -> None:
         self.assert_check_with_error(
             "(zulip.E001) You must set ZULIP_ADMINISTRATOR in /etc/zulip/settings.py",
@@ -32,6 +33,23 @@ class TestChecks(ZulipTestCase):
 
         self.assert_check_with_error(
             "(zulip.E001) You must set ZULIP_ADMINISTRATOR in /etc/zulip/settings.py",
+            ZULIP_ADMINISTRATOR=None,
+        )
+
+    @override_settings(RUNNING_IN_DOCKER=True)
+    def test_checks_required_setting_docker(self) -> None:
+        self.assert_check_with_error(
+            "(zulip.E001) You must set SETTING_ZULIP_ADMINISTRATOR in your Docker environment configuration",
+            ZULIP_ADMINISTRATOR="zulip-admin@example.com",
+        )
+
+        self.assert_check_with_error(
+            "(zulip.E001) You must set SETTING_ZULIP_ADMINISTRATOR in your Docker environment configuration",
+            ZULIP_ADMINISTRATOR="",
+        )
+
+        self.assert_check_with_error(
+            "(zulip.E001) You must set SETTING_ZULIP_ADMINISTRATOR in your Docker environment configuration",
             ZULIP_ADMINISTRATOR=None,
         )
 


### PR DESCRIPTION
Fixes: zulip/docker-zulip#594.

**How changes were tested:**

```
$ docker compose up
[+] up 1/1
 ✔ Container docker-zulip-zulip-1 Recreated                                                                     0.1s
Attaching to zulip-1
zulip-1  | === Begin Initial Configuration Phase ===
zulip-1  | Preparing and linking the uploads folder ...
zulip-1  | Prepared and linked the uploads directory.
zulip-1  | Executing puppet configuration ...
zulip-1  | Disabling https in nginx.
zulip-1  | Setting zulip.conf application_server.nginx_worker_processes = 2
zulip-1  | /usr/lib/x86_64-linux-gnu/rubygems-integration/3.2.0/gems/ruby-augeas-0.5.0/lib/augeas.rb:48: warning: undefining the allocator of T_DATA class Augeas
zulip-1  | Notice: Compiled catalog for f2c93c975c0c in environment production in 4.29 seconds
zulip-1  | Notice: /Stage[main]/Zulip::Profile::Base/File[/etc/zulip/settings.py]/ensure: created
zulip-1  | Notice: /Stage[main]/Zulip::Profile::Base/File[/etc/zulip/zulip-secrets.conf]/ensure: created
zulip-1  | Notice: /Stage[main]/Zulip::Nginx/File[/etc/nginx/nginx.conf]/content: content changed '{sha256}c785e6310bf18c3e3859307189976416960a1abe3e7b3c68111b8949451c4d4f' to '{sha256}879a1680c9f1aafbbbe563712ec525ed4c04921462b553792104a448fafc18fb'
zulip-1  | Notice: /Stage[main]/Zulip::App_frontend_base/File[/etc/nginx/zulip-include/s3-cache]/content: content changed '{sha256}b6e1edeedc1b977d32b121d217d54e59912b27835bea6d391525cd56bf0ba904' to '{sha256}fec0e50ba5dd5a26c82ae00e29ba72583e5630a57ee55fa5646b07788e0ed25f'
zulip-1  | Notice: /Stage[main]/Zulip::Profile::App_frontend/File[/etc/nginx/sites-available/zulip-enterprise]/content: content changed '{sha256}04531d4096daa142c1b4f9e8f65c9ffa30ae4508c1dd9f5a496402d579fdeebd' to '{sha256}9513f78b70d895c17e4921359deb73b8f370e250565176953d7229f53f1d31f6'
zulip-1  | Notice: /Stage[main]/Zulip::Nginx/Service[nginx]: Triggered 'refresh' from 3 events
zulip-1  | Notice: /Stage[main]/Zulip::Camo/File[/etc/supervisor/conf.d/zulip/go-camo.conf]/content: content changed '{sha256}6e7d5576955b178ca736af8654d301c250e1e03f5d34394765bdbde7d4298976' to '{sha256}7d7e246b503f580ee4b7a2c63eb2046f2ac68663aacf81fd822444fdd4fd4e40'
zulip-1  | Notice: /Stage[main]/Zulip::Supervisor/Service[supervisor]: Triggered 'refresh' from 1 event
zulip-1  | Notice: Applied catalog in 0.61 seconds
zulip-1  | No certificates will be installed; HTTP-only serving configured.
zulip-1  | Setting Zulip secrets ...
zulip-1  | generate_secrets: No new secrets to generate.
zulip-1  | Setting email_password from secret in /run/secrets/zulip__email_password
zulip-1  | Setting memcached_password from secret in /run/secrets/zulip__memcached_password
zulip-1  | Setting postgres_password from secret in /run/secrets/zulip__postgres_password
zulip-1  | Setting rabbitmq_password from secret in /run/secrets/zulip__rabbitmq_password
zulip-1  | Setting redis_password from secret in /run/secrets/zulip__redis_password
zulip-1  | Setting secret_key from secret in /run/secrets/zulip__secret_key
zulip-1  | Zulip secrets configuration succeeded.
zulip-1  | Activating authentication backends ...
zulip-1  | Setting key "AUTHENTICATION_BACKENDS", type "array".
zulip-1  | Adding authentication backend "EmailAuthBackend".
zulip-1  | Authentication backend activation succeeded.
zulip-1  | Executing Zulip configuration ...
zulip-1  | Setting key "EXTERNAL_HOST", type "string".
zulip-1  | Setting key "MEMCACHED_LOCATION", type "string".
zulip-1  | Setting key "RABBITMQ_HOST", type "string".
zulip-1  | Setting key "REDIS_HOST", type "string".
zulip-1  | Setting key "REMOTE_POSTGRES_HOST", type "string".
zulip-1  | Setting key "REMOTE_POSTGRES_SSLMODE", type "string".
zulip-1  | Setting key "ZULIP_ADMINISTRATOR", type "string".
zulip-1  | Zulip configuration succeeded.
zulip-1  | SystemCheckError: System check identified some issues:
zulip-1  |
zulip-1  | ERRORS:
zulip-1  | settings.EXTERNAL_HOST: (zulip.E001) You must set SETTING_EXTERNAL_HOST in your Docker environment configuration
zulip-1  | settings.ZULIP_ADMINISTRATOR: (zulip.E001) You must set SETTING_ZULIP_ADMINISTRATOR in your Docker environment configuration
zulip-1  |
zulip-1  | System check identified 2 issues (35 silenced).
zulip-1  | Error in the Zulip configuration. Exiting.
zulip-1 exited with code 1 (restarting)
```
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
