### PR TITLE
topic: Shake and limit input to 60 characters.

### DIFF
--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -34,6 +34,7 @@ import * as resize from "./resize.ts";
 import {unresolve_name} from "./resolved_topic.ts";
 import * as rows from "./rows.ts";
 import * as scheduled_messages from "./scheduled_messages.ts";
+import {realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_settings_components from "./stream_settings_components.ts";
 import * as sub_store from "./sub_store.ts";
@@ -59,6 +60,7 @@ function setup_compose_actions_hooks(): void {
 }
 
 export function initialize(): void {
+    $("input#stream_message_recipient_topic").removeAttr("maxlength");
     // Register hooks for compose_actions.
     setup_compose_actions_hooks();
 
@@ -682,9 +684,40 @@ export function initialize(): void {
         $compose_recipient.addClass("recently-focused");
     });
 
-    $("input#stream_message_recipient_topic").on("input", () => {
+    $("input#stream_message_recipient_topic").on("input", function (this: HTMLElement) {
+        const $input = $(this);
+        let topic = $input.val()?.toString() ?? "";
+
+        if (topic.length > realm.max_topic_length) {
+            topic = topic.slice(0, realm.max_topic_length);
+            $input.val(topic);
+
+            $input.addClass("shake");
+            setTimeout(() => {
+                $input.removeClass("shake");
+            }, 300);
+        }
+
         compose_recipient.update_placeholder_visibility();
         compose_recipient.update_compose_area_placeholder_text();
+    });
+
+    $("input#stream_message_recipient_topic").on("paste", function (this: HTMLElement) {
+        const $input = $(this);
+
+        setTimeout(() => {
+            let topic = $input.val()?.toString() ?? "";
+
+            if (topic.length > realm.max_topic_length) {
+                topic = topic.slice(0, realm.max_topic_length);
+                $input.val(topic);
+
+                $input.addClass("shake");
+                setTimeout(() => {
+                    $input.removeClass("shake");
+                }, 300);
+            }
+        }, 0);
     });
 
     $("#private_message_recipient").on("focus", () => {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -188,6 +188,10 @@
     }
 }
 
+#stream_message_recipient_topic.shake {
+    animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+}
+
 .message_comp {
     display: none;
     padding: 0 7px 0 0;


### PR DESCRIPTION
 **Problem**

Currently, when users type or paste a topic longer than 60 characters the input silently stops accepting text without any visual feedback. This confuses users who do not know why they can't type more or that their pasted text get cut off.

Fixes: #37926
<hr>

### **Screenshots and screen captures:**


**Writing Text in Topic** 

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/e1150bb8-b171-416e-9c24-accbb7ad6cd0" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/980bd49e-4740-4bf4-af4c-6802bf998fe3" width="400" controls></video> |

**Pasting Text in Topic greater than 60 words**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/143c9c64-a681-46ec-876d-23bb04d4a75e" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/1f4ccd9f-0ee8-4931-ab78-bddb3384452e" width="400" controls></video> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
