### PR TITLE
typeahead: Show full members group only if waiting period is set.

### DIFF
--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -165,6 +165,7 @@ export function get_realm_user_groups(include_deactivated = false): UserGroup[] 
 export function get_all_realm_user_groups(
     include_deactivated = false,
     include_internet_group = false,
+    force_include_full_members_group = false,
 ): UserGroup[] {
     const user_groups = [...user_group_by_id_dict.values()];
     user_groups.sort((a, b) => a.id - b.id);
@@ -174,6 +175,19 @@ export function get_all_realm_user_groups(
         }
 
         if (!include_internet_group && group.name === "role:internet") {
+            return false;
+        }
+
+        if (
+            !force_include_full_members_group &&
+            group.name === "role:fullmembers" &&
+            realm.realm_waiting_period_threshold === 0
+        ) {
+            // We hide the full members group in the UI like typeahead menus when there
+            // is no separation between member and full member users due to organization
+            // not having set a waiting period for member users to become full members.
+            // If the caller wants full_members_group in the list even when no waiting
+            // period is set, then force_include_full_members_group can be set to true.
             return false;
         }
 

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -576,6 +576,25 @@ const members = user_group_item(
         deactivated: false,
     }),
 );
+const full_members = user_group_item(
+    make_user_group({
+        name: "role:fullmembers",
+        id: 7,
+        creator_id: null,
+        date_created: 1596710000,
+        description: "Full members",
+        members: new Set([100, 101, 104]),
+        is_system_group: true,
+        direct_subgroup_ids: new Set(),
+        can_add_members_group: 2,
+        can_join_group: 2,
+        can_leave_group: 2,
+        can_manage_group: 2,
+        can_mention_group: 2,
+        can_remove_members_group: 2,
+        deactivated: false,
+    }),
+);
 
 const sweden_stream = stream_item({
     name: "Sweden",
@@ -701,6 +720,7 @@ function test(label, f) {
         user_groups.add(support);
         user_groups.add(admins);
         user_groups.add(members);
+        user_groups.add(full_members);
 
         muted_users.set_muted_users([]);
 
@@ -2702,6 +2722,16 @@ test("message people", ({override, override_rewire}) => {
     override_rewire(ct, "max_group_size_for_dm", 4);
     results = ct.get_person_suggestions("rs", opts);
     assert.deepEqual(results, [hamletcharacters, admins]);
+
+    // Test that full members group is only included if
+    // waiting_period_threshold is not 0.
+    override(realm, "realm_waiting_period_threshold", 10);
+    results = ct.get_person_suggestions("fu", opts);
+    assert.deepEqual(results, [full_members]);
+
+    override(realm, "realm_waiting_period_threshold", 0);
+    results = ct.get_person_suggestions("fu", opts);
+    assert.deepEqual(results, []);
 });
 
 test("person suggestion for unique full name syntax", () => {


### PR DESCRIPTION
This PR updates code to not show "Full members" group in typeaheads when there is
no waiting period configured for the realm.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->https://chat.zulip.org/#narrow/channel/101-design/topic/hide.20.22full.20members.22.20when.20no.20waiting.20period/with/2377846


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

Waiting period set to None

[Screencast from 2026-02-12 17-48-24.webm](https://github.com/user-attachments/assets/d70ee853-4b1f-4ff4-8e63-d56c11e7e86d)

Waiting period set to 3 days

[Screencast from 2026-02-12 17-49-33.webm](https://github.com/user-attachments/assets/4ae3d6e9-ec6d-4dde-ae8b-1f12ff292e7d)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
