### PR TITLE
compose: Add autosave for drafts while typing.

### DIFF
--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -62,20 +62,25 @@ function setup_compose_actions_hooks(): void {
     });
 }
 
-// This throttled callback does not track the compose_draft_id that was
-// active when scheduled; it simply calls update_draft() on whatever
-// compose state is current when it fires.
-//
+// This throttled callback does not track the compose_draft_id that
+// was active when scheduled; it simply calls update_draft() if we are
+// still composing, and updates whichever draft is currently active.
+
 // This is safe because compose context transitions (send, close,
-// switching/restoring drafts) already perform explicit draft saves, and
-// compose_draft_id is only changed through those controlled flows.
-//
-// At worst, a delayed call results in an extra save of the current draft,
-// which is harmless. Adding draft_id tracking here would introduce
-// significant complexity without meaningful benefit.
+// switching/restoring drafts) already perform explicit draft saves,
+// and compose_draft_id is only changed through those
+// controlled flows.
+
+// At worst, a delayed call results in an extra save of the
+// current draft if compose is still open.
 const throttled_update_draft = _.throttle(
     () => {
-        drafts.update_draft({no_notify: true});
+        if (compose_state.composing()) {
+            // Drafts count is not incremented as you are drafting, despite of the
+            // autosave happening for that draft, but is only incremented if you
+            // either close the compose box or open the drafts modal.
+            drafts.update_draft({no_notify: true, update_count: false});
+        }
     },
     60000,
     {leading: false, trailing: true},

--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -62,6 +62,25 @@ function setup_compose_actions_hooks(): void {
     });
 }
 
+// This throttled callback does not track the compose_draft_id that was
+// active when scheduled; it simply calls update_draft() on whatever
+// compose state is current when it fires.
+//
+// This is safe because compose context transitions (send, close,
+// switching/restoring drafts) already perform explicit draft saves, and
+// compose_draft_id is only changed through those controlled flows.
+//
+// At worst, a delayed call results in an extra save of the current draft,
+// which is harmless. Adding draft_id tracking here would introduce
+// significant complexity without meaningful benefit.
+const throttled_update_draft = _.throttle(
+    () => {
+        drafts.update_draft({no_notify: true});
+    },
+    60000,
+    {leading: false, trailing: true},
+);
+
 export function initialize(): void {
     // Register hooks for compose_actions.
     setup_compose_actions_hooks();
@@ -124,6 +143,9 @@ export function initialize(): void {
             if (compose_state.get_is_content_unedited_restored_draft()) {
                 compose_state.set_is_content_unedited_restored_draft(false);
             }
+
+            // We occasionally update the saved draft while the user is typing to minimize data loss risk.
+            throttled_update_draft();
         }, 25),
     );
 

--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -198,7 +198,7 @@ export const draft_model = (function () {
         return id;
     }
 
-    function editDraft(id: string, draft: LocalStorageDraft): boolean {
+    function editDraft(id: string, draft: LocalStorageDraft, update_count = true): boolean {
         const drafts = get();
         let changed = false;
 
@@ -210,7 +210,7 @@ export const draft_model = (function () {
         if (old_draft !== undefined) {
             changed = !check_if_equal(old_draft, draft);
             drafts[id] = draft;
-            save(drafts);
+            save(drafts, update_count);
         }
         return changed;
     }
@@ -453,11 +453,12 @@ export let update_draft = (opts: UpdateDraftOptions = {}): string | undefined =>
 
     // Now that it's been updated, we consider it to be the most recent version.
     draft.drafts_version = CURRENT_DRAFT_VERSION;
+    const update_count = opts.update_count ?? true;
 
     if (draft_id !== undefined) {
         // We don't save multiple drafts of the same message;
         // just update the existing draft.
-        const changed = draft_model.editDraft(draft_id, draft);
+        const changed = draft_model.editDraft(draft_id, draft, update_count);
         if (changed) {
             maybe_notify(no_notify);
         }
@@ -465,7 +466,6 @@ export let update_draft = (opts: UpdateDraftOptions = {}): string | undefined =>
     }
 
     // We have never saved a draft for this message, so add one.
-    const update_count = opts.update_count ?? true;
     const new_draft_id = draft_model.addDraft(draft, update_count);
     compose_draft_id = new_draft_id;
     maybe_notify(no_notify);


### PR DESCRIPTION
This PR adds autosave feature for drafts while typing. It builds on the groundwork done in #36222 by @nirvedh-harpal while addressing remaining reviewer feedback and resolving merge conflicts.

Fixes: #36102

Addresses : https://github.com/zulip/zulip/pull/36222#issuecomment-3572322205 by @timabbott 

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/5dc76d19-ac1f-4df8-8878-d21c03f9c6da

Console logs were added to indicate that autosave was working correctly and the times was reduced to 5s for the sake of the screen capture.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
