### PR TITLE
Implement enhanced emoji tooltips with larger previews

### DIFF
--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -1,4 +1,4 @@
-import {getUnixTime, isValid} from "date-fns";
+import { getUnixTime, isValid } from "date-fns";
 import katex from "katex";
 import _ from "lodash";
 import assert from "minimalistic-assert";
@@ -7,7 +7,7 @@ import type Template from "uri-template-lite";
 import render_channel_message_link from "../templates/channel_message_link.hbs";
 import render_topic_link from "../templates/topic_link.hbs";
 import marked from "../third/marked/lib/marked.cjs";
-import type {LinkifierMatch, ParseOptions, RegExpOrStub} from "../third/marked/lib/marked.cjs";
+import type { LinkifierMatch, ParseOptions, RegExpOrStub } from "../third/marked/lib/marked.cjs";
 
 import * as fenced_code from "./fenced_code.ts";
 import * as util from "./util.ts";
@@ -47,7 +47,7 @@ export type AbstractMap<K, V> = {
 
 export type AbstractLinkifierMap = AbstractMap<
     RegExp,
-    {url_template: Template; group_number_to_name: Record<number, string>}
+    { url_template: Template; group_number_to_name: Record<number, string> }
 >;
 
 type GetLinkifierMap = () => AbstractLinkifierMap;
@@ -61,11 +61,11 @@ export type MarkdownHelpers = {
     is_valid_user_id: (user_id: number) => boolean;
 
     // user groups
-    get_user_group_from_name: (name: string) => {id: number; name: string} | undefined;
+    get_user_group_from_name: (name: string) => { id: number; name: string } | undefined;
     is_member_of_user_group: (user_group_id: number, user_id: number) => boolean;
 
     // stream hashes
-    get_stream_by_name: (stream_name: string) => {stream_id: number; name: string} | undefined;
+    get_stream_by_name: (stream_name: string) => { stream_id: number; name: string } | undefined;
     stream_hash: (stream_id: number) => string;
     stream_topic_hash: (stream_id: number, topic: string) => string;
 
@@ -75,7 +75,7 @@ export type MarkdownHelpers = {
     // emojis
     get_emoji_name: (codepoint: string) => string | undefined;
     get_emoji_codepoint: (emoji_name: string) => string | undefined;
-    get_emoticon_translations: () => {regex: RegExp; replacement_text: string}[];
+    get_emoticon_translations: () => { regex: RegExp; replacement_text: string }[];
     get_realm_emoji_url: (emoji_name: string) => string | undefined;
 
     // linkifiers
@@ -87,7 +87,7 @@ export function translate_emoticons_to_names({
     get_emoticon_translations,
 }: {
     src: string;
-    get_emoticon_translations: () => {regex: RegExp; replacement_text: string}[];
+    get_emoticon_translations: () => { regex: RegExp; replacement_text: string }[];
 }): string {
     // Translates emoticons in a string to their colon syntax.
     let translated = src;
@@ -385,7 +385,7 @@ function parse_with_options(
         flags.push("topic_wildcard_mentioned");
     }
 
-    return {content, flags};
+    return { content, flags };
 }
 
 function is_x_between(x: number, start: number, length: number): boolean {
@@ -406,7 +406,7 @@ type Link = {
     precedence: number | null;
 };
 
-type TopicLink = {url: string; text: string};
+type TopicLink = { url: string; text: string };
 
 export function get_topic_links(topic: string): TopicLink[] {
     // We export this for testing purposes, and mobile may want to
@@ -418,7 +418,7 @@ export function get_topic_links(topic: string): TopicLink[] {
     assert(web_app_helpers !== undefined);
     const get_linkifier_map = web_app_helpers.get_linkifier_map;
 
-    for (const [pattern, {url_template, group_number_to_name}] of get_linkifier_map().entries()) {
+    for (const [pattern, { url_template, group_number_to_name }] of get_linkifier_map().entries()) {
         let match;
         while ((match = pattern.exec(topic)) !== null) {
             const template_context = Object.fromEntries(
@@ -429,7 +429,7 @@ export function get_topic_links(topic: string): TopicLink[] {
             const link_url = url_template.expand(template_context);
             // We store the starting index as well, to sort the order of occurrence of the links
             // in the topic, similar to the logic implemented in zerver/lib/markdown/__init__.py
-            links.push({url: link_url, text: match[0], index: match.index, precedence});
+            links.push({ url: link_url, text: match[0], index: match.index, precedence });
         }
         precedence += 1;
     }
@@ -452,7 +452,7 @@ export function get_topic_links(topic: string): TopicLink[] {
     const url_re = /\b(https?:\/\/[^\s<]+[^\s"'),.:;<\]])/g; // Slightly modified from third/marked.js
     let match;
     while ((match = url_re.exec(topic)) !== null) {
-        links.push({url: match[0], text: match[0], index: match.index, precedence: null});
+        links.push({ url: match[0], text: match[0], index: match.index, precedence: null });
     }
     // The following removes overlapping intervals depending on the precedence of linkifier patterns.
     // This uses the same algorithm implemented in zerver/lib/markdown/__init__.py.
@@ -475,7 +475,7 @@ export function get_topic_links(topic: string): TopicLink[] {
     // We need to sort applied_matches again because the links were previously ordered by precedence,
     // so that the links are displayed in the order their patterns are matched.
     applied_matches.sort((a, b) => a.index - b.index);
-    return applied_matches.map((match) => ({url: match.url, text: match.text}));
+    return applied_matches.map((match) => ({ url: match.url, text: match.text }));
 }
 
 export function is_status_message(raw_content: string): boolean {
@@ -485,7 +485,9 @@ export function is_status_message(raw_content: string): boolean {
 function make_emoji_span(codepoint: string, title: string, alt_text: string): string {
     return `<span aria-label="${_.escape(title)}" class="emoji emoji-${_.escape(
         codepoint,
-    )}" role="img" title="${_.escape(title)}">${_.escape(alt_text)}</span>`;
+    )}" data-tippy-content="${_.escape(alt_text)}" role="img" title="${_.escape(title)}">${_.escape(
+        alt_text,
+    )}</span>`;
 }
 
 function handleUnicodeEmoji(
@@ -540,9 +542,9 @@ function handleEmoji({
     const emoji_url = get_realm_emoji_url(emoji_name);
 
     if (emoji_url) {
-        return `<img alt="${_.escape(alt_text)}" class="emoji" src="${_.escape(
-            emoji_url,
-        )}" title="${_.escape(title)}">`;
+        return `<img alt="${_.escape(alt_text)}" class="emoji" data-tippy-content="${_.escape(
+            alt_text,
+        )}" src="${_.escape(emoji_url)}" title="${_.escape(title)}">`;
     }
 
     const codepoint = get_emoji_codepoint(emoji_name);
@@ -564,7 +566,7 @@ function handleLinkifier({
 }): string {
     const item = get_linkifier_map().get(pattern);
     assert(item !== undefined);
-    const {url_template, group_number_to_name} = item;
+    const { url_template, group_number_to_name } = item;
     const template_context = Object.fromEntries(
         matches.map((match, i) => [group_number_to_name[i + 1]!, match]),
     );
@@ -607,9 +609,9 @@ function handleStream({
     stream_name: string;
     get_stream_by_name: (stream_name: string) =>
         | {
-              stream_id: number;
-              name: string;
-          }
+            stream_id: number;
+            name: string;
+        }
         | undefined;
     stream_hash: (stream_id: number) => string;
 }): string | undefined {
@@ -633,9 +635,9 @@ function handleStreamTopic({
     topic: string;
     get_stream_by_name: (stream_name: string) =>
         | {
-              stream_id: number;
-              name: string;
-          }
+            stream_id: number;
+            name: string;
+        }
         | undefined;
     stream_topic_hash: (stream_id: number, topic: string) => string;
 }): string | undefined {
@@ -665,9 +667,9 @@ function handleStreamTopicMessage({
     message_id: number;
     get_stream_by_name: (stream_name: string) =>
         | {
-              stream_id: number;
-              name: string;
-          }
+            stream_id: number;
+            name: string;
+        }
         | undefined;
     stream_topic_hash: (stream_id: number, topic: string) => string;
 }): string | undefined {
@@ -872,7 +874,7 @@ export function render(
     // This is generally only intended to be called by the web app. Most
     // other platforms should call parse().
     assert(web_app_helpers !== undefined);
-    const {content, flags} = parse({raw_content, helper_config: helper_config ?? web_app_helpers});
+    const { content, flags } = parse({ raw_content, helper_config: helper_config ?? web_app_helpers });
     return {
         content,
         flags,
@@ -891,5 +893,5 @@ export function parse_non_message(raw_content: string): string {
     // a message, but we want to convert it to HTML. Note that we parse
     // raw_content exactly as if it were a Zulip message, so we will
     // handle things like mentions, stream links, and linkifiers.
-    return parse({raw_content, helper_config: web_app_helpers}).content;
+    return parse({ raw_content, helper_config: web_app_helpers }).content;
 }

--- a/web/styles/tooltips.css
+++ b/web/styles/tooltips.css
@@ -46,19 +46,19 @@
             line-height: 1.2143em;
         }
 
-        &[data-placement^="top"] > .tippy-arrow::before {
+        &[data-placement^="top"]>.tippy-arrow::before {
             border-top-color: var(--color-background-tippy-box);
         }
 
-        &[data-placement^="bottom"] > .tippy-arrow::before {
+        &[data-placement^="bottom"]>.tippy-arrow::before {
             border-bottom-color: var(--color-background-tippy-box);
         }
 
-        &[data-placement^="left"] > .tippy-arrow::before {
+        &[data-placement^="left"]>.tippy-arrow::before {
             border-left-color: var(--color-background-tippy-box);
         }
 
-        &[data-placement^="right"] > .tippy-arrow::before {
+        &[data-placement^="right"]>.tippy-arrow::before {
             border-right-color: var(--color-background-tippy-box);
         }
     }
@@ -72,6 +72,7 @@
          */
         height: 0 !important;
     }
+
     /* If the text in the tooltips stretches to multiple lines,
      * we want the lines to be left-indented and not right-indented
      * by default.
@@ -116,4 +117,26 @@
     [data-reference-hidden]:not(.show-when-reference-hidden) {
         display: none;
     }
+}
+
+.emoji-tooltip-container {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.emoji-tooltip-container .emoji,
+.emoji-tooltip-container .emoji-image {
+    height: 3.5em;
+    width: 3.5em;
+    object-fit: contain;
+}
+
+.emoji-tooltip-container .emoji-native {
+    font-size: 3.5em;
+    line-height: 1;
+}
+
+.emoji-tooltip-container .emoji-name {
+    font-weight: 600;
 }

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -311,3 +311,10 @@
         </div>
     </div>
 </template>
+<template id="emoji-tooltip-template">
+    <div class="emoji-tooltip-container">
+        <div class="emoji-native"></div>
+        <img class="emoji-image" src="" />
+        <span class="emoji-name"></span>
+    </div>
+</template>

--- a/web/tests/markdown.test.cjs
+++ b/web/tests/markdown.test.cjs
@@ -6,11 +6,11 @@ const katex = require("katex");
 
 const markdown_test_cases = require("../../zerver/tests/fixtures/markdown_test_cases.json");
 
-const {make_realm} = require("./lib/example_realm.cjs");
+const { make_realm } = require("./lib/example_realm.cjs");
 const markdown_assert = require("./lib/markdown_assert.cjs");
-const {mock_esm, set_global, zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
-const {page_params} = require("./lib/zpage_params.cjs");
+const { mock_esm, set_global, zrequire } = require("./lib/namespace.cjs");
+const { run_test } = require("./lib/test.cjs");
+const { page_params } = require("./lib/zpage_params.cjs");
 
 const example_realm_linkifiers = [
     {
@@ -42,7 +42,7 @@ const example_realm_linkifiers = [
     },
 ];
 
-set_global("document", {compatMode: "CSS1Compat"});
+set_global("document", { compatMode: "CSS1Compat" });
 
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => false,
@@ -56,18 +56,18 @@ const markdown_config = zrequire("markdown_config");
 const markdown = zrequire("markdown");
 const people = zrequire("people");
 const pygments_data = zrequire("pygments_data");
-const {set_realm} = zrequire("state_data");
+const { set_realm } = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 const user_groups = zrequire("user_groups");
 const settings_config = zrequire("settings_config");
-const {initialize_user_settings} = zrequire("user_settings");
+const { initialize_user_settings } = zrequire("user_settings");
 
 const REALM_EMPTY_TOPIC_DISPLAY_NAME = "general chat";
-set_realm(make_realm({realm_empty_topic_display_name: REALM_EMPTY_TOPIC_DISPLAY_NAME}));
+set_realm(make_realm({ realm_empty_topic_display_name: REALM_EMPTY_TOPIC_DISPLAY_NAME }));
 const user_settings = {
     web_channel_default_view: settings_config.web_channel_default_view_values.channel_feed.code,
 };
-initialize_user_settings({user_settings});
+initialize_user_settings({ user_settings });
 
 const emoji_params = {
     realm_emoji: {
@@ -271,7 +271,7 @@ test("markdown_detection", () => {
     }
 });
 
-test("marked_shared", ({override}) => {
+test("marked_shared", ({ override }) => {
     const tests = markdown_test_cases.regular_tests;
 
     for (const test of tests) {
@@ -281,7 +281,7 @@ test("marked_shared", ({override}) => {
             continue;
         }
 
-        let message = {raw_content: test.input};
+        let message = { raw_content: test.input };
         override(user_settings, "translate_emoticons", test.translate_emoticons || false);
         message = {
             ...message,
@@ -301,21 +301,21 @@ test("marked_shared", ({override}) => {
 });
 
 test("message_flags", () => {
-    let message = {raw_content: "@**Leo**"};
+    let message = { raw_content: "@**Leo**" };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
     };
     assert.ok(!message.flags.includes("mentioned"));
 
-    message = {raw_content: "@**Cordelia, Lear's daughter**"};
+    message = { raw_content: "@**Cordelia, Lear's daughter**" };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
     };
     assert.ok(message.flags.includes("mentioned"));
 
-    message = {raw_content: "@**all**"};
+    message = { raw_content: "@**all**" };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -323,7 +323,7 @@ test("message_flags", () => {
     assert.ok(message.flags.includes("stream_wildcard_mentioned"));
     assert.ok(!message.flags.includes("topic_wildcard_mentioned"));
 
-    message = {raw_content: "@**topic**"};
+    message = { raw_content: "@**topic**" };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -332,16 +332,16 @@ test("message_flags", () => {
     assert.ok(message.flags.includes("topic_wildcard_mentioned"));
 });
 
-test("marked", ({override}) => {
+test("marked", ({ override }) => {
     const test_cases = [
-        {input: "hello", expected: "<p>hello</p>"},
-        {input: "hello there", expected: "<p>hello there</p>"},
-        {input: "hello **bold** for you", expected: "<p>hello <strong>bold</strong> for you</p>"},
+        { input: "hello", expected: "<p>hello</p>" },
+        { input: "hello there", expected: "<p>hello there</p>" },
+        { input: "hello **bold** for you", expected: "<p>hello <strong>bold</strong> for you</p>" },
         {
             input: "hello ***foo*** for you",
             expected: "<p>hello <strong><em>foo</em></strong> for you</p>",
         },
-        {input: "__hello__", expected: "<p>__hello__</p>"},
+        { input: "__hello__", expected: "<p>__hello__</p>" },
         {
             input: "\n```\nfenced code\n```\n\nand then after\n",
             expected:
@@ -392,7 +392,7 @@ test("marked", ({override}) => {
             input: "These # #**** are not mentions",
             expected: "<p>These # #<em>**</em> are not mentions</p>",
         },
-        {input: "These @* are not mentions", expected: "<p>These @* are not mentions</p>"},
+        { input: "These @* are not mentions", expected: "<p>These @* are not mentions</p>" },
         {
             input: "These #* #*** are also not mentions",
             expected: "<p>These #* #*** are also not mentions</p>",
@@ -441,17 +441,17 @@ test("marked", ({override}) => {
         {
             input: "mmm...:burrito:s",
             expected:
-                '<p>mmm...<img alt=":burrito:" class="emoji" src="/static/generated/emoji/images/emoji/burrito.png" title="burrito">s</p>',
+                '<p>mmm...<img alt=":burrito:" class="emoji" data-tippy-content=":burrito:" src="/static/generated/emoji/images/emoji/burrito.png" title="burrito">s</p>',
         },
         {
             input: "This is an :poop: message",
             expected:
-                '<p>This is an <span aria-label="poop" class="emoji emoji-1f4a9" role="img" title="poop">:poop:</span> message</p>',
+                '<p>This is an <span aria-label="poop" class="emoji emoji-1f4a9" data-tippy-content=":poop:" role="img" title="poop">:poop:</span> message</p>',
         },
         {
             input: "\uD83D\uDCA9",
             expected:
-                '<p><span aria-label="poop" class="emoji emoji-1f4a9" role="img" title="poop">:poop:</span></p>',
+                '<p><span aria-label="poop" class="emoji emoji-1f4a9" data-tippy-content=":poop:" role="img" title="poop">:poop:</span></p>',
         },
         {
             input: "Silent mention: @_**Cordelia, Lear's daughter**",
@@ -521,7 +521,7 @@ test("marked", ({override}) => {
             expected:
                 '<p>This is a complicated linkifier <a href="https://zone_e.zulip.net/ticket/luxembourg/abcde?name=foo&amp;chapter=23#testi" title="https://zone_e.zulip.net/ticket/luxembourg/abcde?name=foo&amp;chapter=23#testi">FOO_abcde;e;zulip;luxembourg;foo;23;testing</a> with text after it</p>',
         },
-        {input: "#1234is not a linkifier.", expected: "<p>#1234is not a linkifier.</p>"},
+        { input: "#1234is not a linkifier.", expected: "<p>#1234is not a linkifier.</p>" },
         {
             input: "A pattern written as #1234is not a linkifier.",
             expected: "<p>A pattern written as #1234is not a linkifier.</p>",
@@ -531,7 +531,7 @@ test("marked", ({override}) => {
             expected:
                 '<p>This is a linkifier with <a href="https://zone_45.zulip.net/ticket/123" title="https://zone_45.zulip.net/ticket/123">ZGROUP_123:45</a> groups</p>',
         },
-        {input: "Test *italic*", expected: "<p>Test <em>italic</em></p>"},
+        { input: "Test *italic*", expected: "<p>Test <em>italic</em></p>" },
         {
             input: "T\n#**Denmark**",
             expected:
@@ -547,7 +547,7 @@ test("marked", ({override}) => {
             expected:
                 '<p><span class="user-mention" data-user-id="104">@Mark Twin</span> and <span class="user-mention" data-user-id="105">@Mark Twin</span> are out to confuse you.</p>',
         },
-        {input: "@**Invalid User|1234**", expected: "<p>@**Invalid User|1234**</p>"},
+        { input: "@**Invalid User|1234**", expected: "<p>@**Invalid User|1234**</p>" },
         {
             input: "@**Cordelia, Lear's daughter|103** has a wrong user_id.",
             expected: "<p>@**Cordelia, Lear&#39;s daughter|103** has a wrong user_id.</p>",
@@ -579,30 +579,30 @@ test("marked", ({override}) => {
             input: "@**Unknown user|108** mention inaccessible user using name and ID.",
             expected: "<p>@**Unknown user|108** mention inaccessible user using name and ID.</p>",
         },
-        {input: "@**|1234** invalid id.", expected: "<p>@**|1234** invalid id.</p>"},
-        {input: "T\n@hamletcharacters", expected: "<p>T<br>\n@hamletcharacters</p>"},
+        { input: "@**|1234** invalid id.", expected: "<p>@**|1234** invalid id.</p>" },
+        { input: "T\n@hamletcharacters", expected: "<p>T<br>\n@hamletcharacters</p>" },
         {
             input: "T\n@*hamletcharacters*",
             expected:
                 '<p>T<br>\n<span class="user-group-mention" data-user-group-id="1">@hamletcharacters</span></p>',
         },
-        {input: "T\n@*notagroup*", expected: "<p>T<br>\n@*notagroup*</p>"},
+        { input: "T\n@*notagroup*", expected: "<p>T<br>\n@*notagroup*</p>" },
         {
             input: "T\n@*backend*",
             expected:
                 '<p>T<br>\n<span class="user-group-mention" data-user-group-id="2">@Backend</span></p>',
         },
-        {input: "@*notagroup*", expected: "<p>@*notagroup*</p>"},
+        { input: "@*notagroup*", expected: "<p>@*notagroup*</p>" },
         {
             input: "This is a linkifier `hello` with text after it",
             expected: "<p>This is a linkifier <code>hello</code> with text after it</p>",
         },
         // Test the emoticon conversion
-        {input: ":)", expected: "<p>:)</p>"},
+        { input: ":)", expected: "<p>:)</p>" },
         {
             input: ":)",
             expected:
-                '<p><span aria-label="slight smile" class="emoji emoji-1f642" role="img" title="slight smile">:slight_smile:</span></p>',
+                '<p><span aria-label="slight smile" class="emoji emoji-1f642" data-tippy-content=":slight_smile:" role="img" title="slight smile">:slight_smile:</span></p>',
             translate_emoticons: true,
         },
         // Test HTML escaping in custom Zulip rules
@@ -618,7 +618,7 @@ test("marked", ({override}) => {
             input: ":<h1>The Rogue One</h1>:",
             expected: "<p>:&lt;h1&gt;The Rogue One&lt;/h1&gt;:</p>",
         },
-        {input: "@**O'Connell**", expected: "<p>@**O&#39;Connell**</p>"},
+        { input: "@**O'Connell**", expected: "<p>@**O&#39;Connell**</p>" },
         {
             input: "@*Bobby <h1>Tables</h1>*",
             expected:
@@ -670,11 +670,11 @@ test("marked", ({override}) => {
 });
 
 test("topic_links", () => {
-    let message = {type: "stream", topic: "No links here"};
+    let message = { type: "stream", topic: "No links here" };
     message.topic_links = markdown.get_topic_links(message.topic);
     assert.equal(message.topic_links.length, 0);
 
-    message = {type: "stream", topic: "One #123 link here"};
+    message = { type: "stream", topic: "One #123 link here" };
     message.topic_links = markdown.get_topic_links(message.topic);
     assert.equal(message.topic_links.length, 1);
     assert.deepEqual(message.topic_links[0], {
@@ -682,7 +682,7 @@ test("topic_links", () => {
         text: "#123",
     });
 
-    message = {type: "stream", topic: "Two #123 #456 link here"};
+    message = { type: "stream", topic: "Two #123 #456 link here" };
     message.topic_links = markdown.get_topic_links(message.topic);
     assert.equal(message.topic_links.length, 2);
     assert.deepEqual(message.topic_links[0], {
@@ -694,7 +694,7 @@ test("topic_links", () => {
         text: "#456",
     });
 
-    message = {type: "stream", topic: "New ZBUG_123 link here"};
+    message = { type: "stream", topic: "New ZBUG_123 link here" };
     message.topic_links = markdown.get_topic_links(message.topic);
     assert.equal(message.topic_links.length, 1);
     assert.deepEqual(message.topic_links[0], {
@@ -702,7 +702,7 @@ test("topic_links", () => {
         text: "ZBUG_123",
     });
 
-    message = {type: "stream", topic: "New ZBUG_123 with #456 link here"};
+    message = { type: "stream", topic: "New ZBUG_123 with #456 link here" };
     message.topic_links = markdown.get_topic_links(message.topic);
     assert.equal(message.topic_links.length, 2);
     assert.deepEqual(message.topic_links[0], {
@@ -714,7 +714,7 @@ test("topic_links", () => {
         text: "#456",
     });
 
-    message = {type: "stream", topic: "One ZGROUP_123:45 link here"};
+    message = { type: "stream", topic: "One ZGROUP_123:45 link here" };
     message.topic_links = markdown.get_topic_links(message.topic);
     assert.equal(message.topic_links.length, 1);
     assert.deepEqual(message.topic_links[0], {
@@ -722,7 +722,7 @@ test("topic_links", () => {
         text: "ZGROUP_123:45",
     });
 
-    message = {type: "stream", topic: "Hello https://google.com"};
+    message = { type: "stream", topic: "Hello https://google.com" };
     message.topic_links = markdown.get_topic_links(message.topic);
     assert.equal(message.topic_links.length, 1);
     assert.deepEqual(message.topic_links[0], {
@@ -730,7 +730,7 @@ test("topic_links", () => {
         text: "https://google.com",
     });
 
-    message = {type: "stream", topic: "#456 https://google.com https://github.com"};
+    message = { type: "stream", topic: "#456 https://google.com https://github.com" };
     message.topic_links = markdown.get_topic_links(message.topic);
     assert.equal(message.topic_links.length, 3);
     assert.deepEqual(message.topic_links[0], {
@@ -746,11 +746,11 @@ test("topic_links", () => {
         text: "https://github.com",
     });
 
-    message = {type: "not-stream"};
+    message = { type: "not-stream" };
     message.topic_links = markdown.get_topic_links(message.topic);
     assert.equal(message.topic_links.length, 0);
 
-    message = {type: "stream", topic: "FOO_abcde;e;zulip;luxembourg;foo;23;testing"};
+    message = { type: "stream", topic: "FOO_abcde;e;zulip;luxembourg;foo;23;testing" };
     message.topic_links = markdown.get_topic_links(message.topic);
     assert.equal(message.topic_links.length, 1);
     assert.deepEqual(message.topic_links[0], {
@@ -761,7 +761,7 @@ test("topic_links", () => {
 
 test("message_flags", () => {
     let input = "/me is testing this";
-    let message = {topic: "No links here", raw_content: input};
+    let message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -771,7 +771,7 @@ test("message_flags", () => {
     assert.ok(!message.unread);
 
     input = "/me is testing\nthis";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -780,7 +780,7 @@ test("message_flags", () => {
     assert.equal(message.is_me_message, true);
 
     input = "testing this @**all** @**Cordelia, Lear's daughter**";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -791,7 +791,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
 
     input = "test @**everyone**";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -802,7 +802,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @**stream**";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -813,7 +813,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @**channel**";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -824,7 +824,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @**topic**";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -835,7 +835,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @all";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -845,7 +845,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @everyone";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -855,7 +855,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @topic";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -865,7 +865,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @any";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -875,7 +875,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @alleycat.com";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -885,7 +885,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @*hamletcharacters*";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -895,7 +895,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), true);
 
     input = "test @*backend*";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -905,7 +905,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @**invalid_user**";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -915,7 +915,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @_**all**";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -925,7 +925,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "> test @**all**";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -935,7 +935,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @_**topic**";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -945,7 +945,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "> test @**topic**";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -955,7 +955,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @_*hamletcharacters*";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -965,7 +965,7 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "> test @*hamletcharacters*";
-    message = {topic: "No links here", raw_content: input};
+    message = { topic: "No links here", raw_content: input };
     message = {
         ...message,
         ...markdown.render(message.raw_content),
@@ -989,7 +989,7 @@ test("translate_emoticons_to_names", () => {
     const get_emoticon_translations = emoji.get_emoticon_translations;
 
     function translate_emoticons_to_names(src) {
-        return markdown.translate_emoticons_to_names({src, get_emoticon_translations});
+        return markdown.translate_emoticons_to_names({ src, get_emoticon_translations });
     }
 
     // Simple test
@@ -1002,17 +1002,17 @@ test("translate_emoticons_to_names", () => {
     // The following code loops over the test cases and each emoticon conversion
     // to generate multiple test cases.
     for (const [shortcut, full_name] of Object.entries(emoji_codes.emoticon_conversions)) {
-        for (const {original, expected} of [
-            {name: `only emoticon`, original: shortcut, expected: full_name},
-            {name: `space at start`, original: ` ${shortcut}`, expected: ` ${full_name}`},
-            {name: `space at end`, original: `${shortcut} `, expected: `${full_name} `},
-            {name: `symbol at end`, original: `${shortcut}!`, expected: `${full_name}!`},
+        for (const { original, expected } of [
+            { name: `only emoticon`, original: shortcut, expected: full_name },
+            { name: `space at start`, original: ` ${shortcut}`, expected: ` ${full_name}` },
+            { name: `space at end`, original: `${shortcut} `, expected: `${full_name} ` },
+            { name: `symbol at end`, original: `${shortcut}!`, expected: `${full_name}!` },
             {
                 name: `symbol at start`,
                 original: `Hello,${shortcut}`,
                 expected: `Hello,${full_name}`,
             },
-            {name: `after a word`, original: `Hello${shortcut}`, expected: `Hello${shortcut}`},
+            { name: `after a word`, original: `Hello${shortcut}`, expected: `Hello${shortcut}` },
             {
                 name: `between words`,
                 original: `Hello${shortcut}World`,
@@ -1044,8 +1044,8 @@ test("parse_non_message", () => {
     assert.equal(markdown.parse_non_message("type `/day`"), "<p>type <code>/day</code></p>");
 });
 
-test("missing unicode emojis", ({override}) => {
-    let message = {raw_content: "\u{1F6B2}"};
+test("missing unicode emojis", ({ override }) => {
+    let message = { raw_content: "\u{1F6B2}" };
 
     message = {
         ...message,
@@ -1053,7 +1053,7 @@ test("missing unicode emojis", ({override}) => {
     };
     assert.equal(
         message.content,
-        '<p><span aria-label="bike" class="emoji emoji-1f6b2" role="img" title="bike">:bike:</span></p>',
+        '<p><span aria-label="bike" class="emoji emoji-1f6b2" data-tippy-content=":bike:" role="img" title="bike">:bike:</span></p>',
     );
 
     // Now simulate that we don't know this emoji name.
@@ -1067,8 +1067,8 @@ test("missing unicode emojis", ({override}) => {
     assert.equal(message.content, "<p>\u{1F6B2}</p>");
 });
 
-test("katex_throws_unexpected_exceptions", ({override}) => {
-    const message = {raw_content: "$$a$$"};
+test("katex_throws_unexpected_exceptions", ({ override }) => {
+    const message = { raw_content: "$$a$$" };
     override(katex, "renderToString", () => {
         throw new Error("some-exception");
     });

--- a/web/tests/markdown_parse.test.cjs
+++ b/web/tests/markdown_parse.test.cjs
@@ -4,8 +4,8 @@ const assert = require("node:assert/strict");
 
 const Template = require("uri-template-lite");
 
-const {zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
+const { zrequire } = require("./lib/namespace.cjs");
+const { run_test } = require("./lib/test.cjs");
 
 const markdown = zrequire("markdown");
 const linkifiers = zrequire("linkifiers");
@@ -82,8 +82,8 @@ function stream_topic_hash(stream_id, topic) {
 
 function get_emoticon_translations() {
     return [
-        {regex: /(:\))/g, replacement_text: ":smile:"},
-        {regex: /(<3)/g, replacement_text: ":heart:"},
+        { regex: /(:\))/g, replacement_text: ":smile:" },
+        { regex: /(<3)/g, replacement_text: ":heart:" },
     ];
 }
 
@@ -119,7 +119,7 @@ const linkifier_map = new Map([
         regex,
         {
             url_template: new Template("http://foo.com/{id}"),
-            group_number_to_name: {1: "id"},
+            group_number_to_name: { 1: "id" },
         },
     ],
 ]);
@@ -159,7 +159,7 @@ const helper_config = {
 };
 
 function assert_parse(raw_content, expected_content) {
-    const {content} = markdown.parse({raw_content, helper_config});
+    const { content } = markdown.parse({ raw_content, helper_config });
     assert.equal(content, expected_content);
 }
 
@@ -206,15 +206,15 @@ run_test("stream links", () => {
 run_test("emojis", () => {
     assert_parse(
         "yup :)",
-        '<p>yup <span aria-label="smile" class="emoji emoji-1f604" role="img" title="smile">:smile:</span></p>',
+        '<p>yup <span aria-label="smile" class="emoji emoji-1f604" data-tippy-content=":smile:" role="img" title="smile">:smile:</span></p>',
     );
     assert_parse(
         "I <3 JavaScript",
-        '<p>I <img alt=":heart:" class="emoji" src="/images/emoji/heart.bmp" title="heart"> JavaScript</p>',
+        '<p>I <img alt=":heart:" class="emoji" data-tippy-content=":heart:" src="/images/emoji/heart.bmp" title="heart"> JavaScript</p>',
     );
     assert_parse(
         "Mars Attacks! \uD83D\uDC7D",
-        '<p>Mars Attacks! <span aria-label="alien" class="emoji emoji-1f47d" role="img" title="alien">:alien:</span></p>',
+        '<p>Mars Attacks! <span aria-label="alien" class="emoji emoji-1f47d" data-tippy-content=":alien:" role="img" title="alien">:alien:</span></p>',
     );
 });
 
@@ -231,7 +231,7 @@ function assert_topic_links(topic, expected_links) {
 }
 
 run_test("topic links", () => {
-    linkifiers.initialize([{pattern: "#foo(?P<id>\\d+)", url_template: "http://foo.com/{id}"}]);
+    linkifiers.initialize([{ pattern: "#foo(?P<id>\\d+)", url_template: "http://foo.com/{id}" }]);
     markdown.initialize({
         get_linkifier_map: linkifiers.get_linkifier_map,
     });
@@ -251,7 +251,7 @@ run_test("topic links repeated", () => {
     // Links generated from repeated patterns should preserve the order.
     const topic =
         "#foo101 https://google.com #foo102 #foo103 https://google.com #foo101 #foo102 #foo103";
-    linkifiers.initialize([{pattern: "#foo(?P<id>\\d+)", url_template: "http://foo.com/{id}"}]);
+    linkifiers.initialize([{ pattern: "#foo(?P<id>\\d+)", url_template: "http://foo.com/{id}" }]);
     assert_topic_links(topic, [
         {
             text: "#foo101",
@@ -290,10 +290,10 @@ run_test("topic links repeated", () => {
 
 run_test("topic links overlapping", () => {
     linkifiers.initialize([
-        {pattern: "[a-z]+(?P<id>1\\d+) #[a-z]+", url_template: "http://a.com/{id}"},
-        {pattern: "[a-z]+(?P<id>1\\d+)", url_template: "http://b.com/{id}"},
-        {pattern: ".+#(?P<id>[a-z]+)", url_template: "http://wildcard.com/{id}"},
-        {pattern: "#(?P<id>[a-z]+)", url_template: "http://c.com/{id}"},
+        { pattern: "[a-z]+(?P<id>1\\d+) #[a-z]+", url_template: "http://a.com/{id}" },
+        { pattern: "[a-z]+(?P<id>1\\d+)", url_template: "http://b.com/{id}" },
+        { pattern: ".+#(?P<id>[a-z]+)", url_template: "http://wildcard.com/{id}" },
+        { pattern: "#(?P<id>[a-z]+)", url_template: "http://c.com/{id}" },
     ]);
     // b.com's pattern should be matched while it overlaps with c.com's.
     assert_topic_links("#foo100", [
@@ -350,13 +350,13 @@ run_test("topic links overlapping", () => {
 run_test("topic links ordering by priority", () => {
     // The same test case is also implemented in zerver/tests/test_markdown.py
     linkifiers.initialize([
-        {pattern: "http", url_template: "http://example.com/"},
-        {pattern: "b#(?P<id>[a-z]+)", url_template: "http://example.com/b/{id}"},
+        { pattern: "http", url_template: "http://example.com/" },
+        { pattern: "b#(?P<id>[a-z]+)", url_template: "http://example.com/b/{id}" },
         {
             pattern: "a#(?P<aid>[a-z]+) b#(?P<bid>[a-z]+)",
             url_template: "http://example.com/a/{aid}/b/%(bid)",
         },
-        {pattern: "a#(?P<id>[a-z]+)", url_template: "http://example.com/a/{id}"},
+        { pattern: "a#(?P<id>[a-z]+)", url_template: "http://example.com/a/{id}" },
     ]);
 
     // There should be 5 link matches in the topic, if ordered from the most prioritized to the least:

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1286,6 +1286,7 @@ def make_emoji(codepoint: str, display_string: str) -> Element:
     span.set("title", title)
     span.set("role", "img")
     span.set("aria-label", title)
+    span.set("data-tippy-content", display_string)
     span.text = markdown.util.AtomicString(display_string)
     return span
 
@@ -1296,6 +1297,7 @@ def make_realm_emoji(src: str, display_string: str) -> Element:
     elt.set("class", "emoji")
     elt.set("alt", display_string)
     elt.set("title", display_string[1:-1].replace("_", " "))
+    elt.set("data-tippy-content", display_string)
     return elt
 
 

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -249,7 +249,7 @@
       "name": "ulist_codeblock_interference",
       "input": "* One \n  * Two\n\n    Two continued\n    This shouldn't be a code block\n",
       "expected_output": "<ul>\n<li>One <ul>\n<li>\n<p>Two</p>\n<p>Two continued<br>\nThis shouldn't be a code block</p>\n</li>\n</ul>\n</li>\n</ul>",
-      "marked_expected_output":"<ul>\n<li><p>One </p>\n<ul>\n<li><p>Two</p>\n<p>Two continued<br>\nThis shouldn't be a code block</p>\n</li>\n</ul>\n</li>\n</ul>",
+      "marked_expected_output": "<ul>\n<li><p>One </p>\n<ul>\n<li><p>Two</p>\n<p>Two continued<br>\nThis shouldn't be a code block</p>\n</li>\n</ul>\n</li>\n</ul>",
       "text_content": "\nOne \n\nTwo\nTwo continued\nThis shouldn't be a code block\n\n\n\n"
     },
     {
@@ -361,7 +361,7 @@
     {
       "name": "star_emoji",
       "input": "**:smile:**",
-      "expected_output": "<p><strong><span aria-label=\"smile\" class=\"emoji emoji-1f604\" role=\"img\" title=\"smile\">:smile:</span></strong></p>",
+      "expected_output": "<p><strong><span aria-label=\"smile\" class=\"emoji emoji-1f604\" data-tippy-content=\":smile:\" role=\"img\" title=\"smile\">:smile:</span></strong></p>",
       "text_content": "\ud83d\ude04"
     },
     {
@@ -449,7 +449,7 @@
     {
       "name": "only_named_inline_image",
       "input": "[Google link](https://www.google.com/images/srpr/logo4w.png)",
-        "expected_output": "<p><a href=\"https://www.google.com/images/srpr/logo4w.png\">Google link</a></p>\n<div class=\"message_inline_image\"><a href=\"https://www.google.com/images/srpr/logo4w.png\" title=\"Google link\"><img src=\"https://external-content.zulipcdn.net/external_content/56c362a24201593891955ff526b3b412c0f9fcd2/68747470733a2f2f7777772e676f6f676c652e636f6d2f696d616765732f737270722f6c6f676f34772e706e67\"></a></div>",
+      "expected_output": "<p><a href=\"https://www.google.com/images/srpr/logo4w.png\">Google link</a></p>\n<div class=\"message_inline_image\"><a href=\"https://www.google.com/images/srpr/logo4w.png\" title=\"Google link\"><img src=\"https://external-content.zulipcdn.net/external_content/56c362a24201593891955ff526b3b412c0f9fcd2/68747470733a2f2f7777772e676f6f676c652e636f6d2f696d616765732f737270722f6c6f676f34772e706e67\"></a></div>",
       "backend_only_rendering": true,
       "text_content": "Google link\n"
     },
@@ -530,8 +530,8 @@
     },
     {
       "name": "many_emoji",
-      "input":  "test :smile: again :poop:\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:",
-      "expected_output": "<p>test <span aria-label=\"smile\" class=\"emoji emoji-1f604\" role=\"img\" title=\"smile\">:smile:</span> again <span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span><br>\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:</p>",
+      "input": "test :smile: again :poop:\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:",
+      "expected_output": "<p>test <span aria-label=\"smile\" class=\"emoji emoji-1f604\" data-tippy-content=\":smile:\" role=\"img\" title=\"smile\">:smile:</span> again <span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" data-tippy-content=\":poop:\" role=\"img\" title=\"poop\">:poop:</span><br>\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:</p>",
       "text_content": "test \ud83d\ude04 again \ud83d\udca9\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:"
     },
     {
@@ -544,34 +544,34 @@
     {
       "name": "translate_emoticons_enabled",
       "input": ":)",
-      "expected_output": "<p><span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"slight smile\">:slight_smile:</span></p>",
+      "expected_output": "<p><span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" data-tippy-content=\":slight_smile:\" role=\"img\" title=\"slight smile\">:slight_smile:</span></p>",
       "text_content": "\ud83d\ude42",
       "translate_emoticons": true
     },
     {
       "name": "translate_emoticons",
-      "input":  ":) foo :( bar <3 with space : ) real emoji :smile:",
-      "expected_output": "<p><span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"slight smile\">:slight_smile:</span> foo <span aria-label=\"frown\" class=\"emoji emoji-1f641\" role=\"img\" title=\"frown\">:frown:</span> bar <span aria-label=\"heart\" class=\"emoji emoji-2764\" role=\"img\" title=\"heart\">:heart:</span> with space : ) real emoji <span aria-label=\"smile\" class=\"emoji emoji-1f604\" role=\"img\" title=\"smile\">:smile:</span></p>",
+      "input": ":) foo :( bar <3 with space : ) real emoji :smile:",
+      "expected_output": "<p><span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" data-tippy-content=\":slight_smile:\" role=\"img\" title=\"slight smile\">:slight_smile:</span> foo <span aria-label=\"frown\" class=\"emoji emoji-1f641\" data-tippy-content=\":frown:\" role=\"img\" title=\"frown\">:frown:</span> bar <span aria-label=\"heart\" class=\"emoji emoji-2764\" data-tippy-content=\":heart:\" role=\"img\" title=\"heart\">:heart:</span> with space : ) real emoji <span aria-label=\"smile\" class=\"emoji emoji-1f604\" data-tippy-content=\":smile:\" role=\"img\" title=\"smile\">:smile:</span></p>",
       "text_content": "\ud83d\ude42 foo \ud83d\ude41 bar \u2764 with space : ) real emoji \ud83d\ude04",
       "translate_emoticons": true
     },
     {
       "name": "translate_emoticons_whitespace",
-      "input":  "a:) ;)b",
+      "input": "a:) ;)b",
       "expected_output": "<p>a:) ;)b</p>",
       "text_content": "a:) ;)b",
       "translate_emoticons": true
     },
     {
       "name": "translate_emoticons_newline",
-      "input":  ":) test\n:) test",
-      "expected_output": "<p><span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"slight smile\">:slight_smile:</span> test<br>\n<span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"slight smile\">:slight_smile:</span> test</p>",
+      "input": ":) test\n:) test",
+      "expected_output": "<p><span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" data-tippy-content=\":slight_smile:\" role=\"img\" title=\"slight smile\">:slight_smile:</span> test<br>\n<span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" data-tippy-content=\":slight_smile:\" role=\"img\" title=\"slight smile\">:slight_smile:</span> test</p>",
       "text_content": "\ud83d\ude42 test\n\ud83d\ude42 test",
       "translate_emoticons": true
     },
     {
       "name": "translate_emoticons_in_code",
-      "input":  "`:)`",
+      "input": "`:)`",
       "expected_output": "<p><code>:)</code></p>",
       "text_content": ":)",
       "translate_emoticons": true
@@ -579,14 +579,14 @@
     {
       "name": "translate_emoticons_at_sentence_end",
       "input": "Translate this :).",
-      "expected_output": "<p>Translate this <span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"slight smile\">:slight_smile:</span>.</p>",
+      "expected_output": "<p>Translate this <span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" data-tippy-content=\":slight_smile:\" role=\"img\" title=\"slight smile\">:slight_smile:</span>.</p>",
       "text_content": "Translate this \ud83d\ude42.",
       "translate_emoticons": true
     },
     {
       "name": "translate_emoticons_between_symbols",
       "input": "Translate this !:)?",
-      "expected_output": "<p>Translate this !<span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"slight smile\">:slight_smile:</span>?</p>",
+      "expected_output": "<p>Translate this !<span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" data-tippy-content=\":slight_smile:\" role=\"img\" title=\"slight smile\">:slight_smile:</span>?</p>",
       "marked_expected_output": "<p>Translate this !:)?</p>",
       "text_content": "Translate this !\ud83d\ude42?",
       "translate_emoticons": true
@@ -594,43 +594,43 @@
     {
       "name": "random_emoji_1",
       "input": ":airplane:",
-      "expected_output": "<p><span aria-label=\"airplane\" class=\"emoji emoji-2708\" role=\"img\" title=\"airplane\">:airplane:</span></p>"
+      "expected_output": "<p><span aria-label=\"airplane\" class=\"emoji emoji-2708\" data-tippy-content=\":airplane:\" role=\"img\" title=\"airplane\">:airplane:</span></p>"
     },
     {
       "name": "zulip_emoji",
       "input": ":zulip:",
-      "expected_output": "<p><img alt=\":zulip:\" class=\"emoji\" src=\"/static/generated/emoji/images/emoji/unicode/zulip.png\" title=\"zulip\"></p>",
+      "expected_output": "<p><img alt=\":zulip:\" class=\"emoji\" data-tippy-content=\":zulip:\" src=\"/static/generated/emoji/images/emoji/unicode/zulip.png\" title=\"zulip\"></p>",
       "text_content": ":zulip:"
     },
     {
       "name": "random_emoji_2",
       "input": ":poop:",
-      "expected_output": "<p><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span></p>"
+      "expected_output": "<p><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" data-tippy-content=\":poop:\" role=\"img\" title=\"poop\">:poop:</span></p>"
     },
     {
       "name": "emoji_sequence_one",
       "input": "🤷‍♀️",
-      "expected_output": "<p><span aria-label=\"woman shrugging\" class=\"emoji emoji-1f937-200d-2640\" role=\"img\" title=\"woman shrugging\">:woman_shrugging:</span></p>"
+      "expected_output": "<p><span aria-label=\"woman shrugging\" class=\"emoji emoji-1f937-200d-2640\" data-tippy-content=\":woman_shrugging:\" role=\"img\" title=\"woman shrugging\">:woman_shrugging:</span></p>"
     },
     {
       "name": "emoji_sequence_two",
       "input": "👁‍🗨 #️⃣",
-      "expected_output": "<p><span aria-label=\"eye in speech bubble\" class=\"emoji emoji-1f441-200d-1f5e8\" role=\"img\" title=\"eye in speech bubble\">:eye_in_speech_bubble:</span> <span aria-label=\"hash\" class=\"emoji emoji-0023-20e3\" role=\"img\" title=\"hash\">:hash:</span></p>"
+      "expected_output": "<p><span aria-label=\"eye in speech bubble\" class=\"emoji emoji-1f441-200d-1f5e8\" data-tippy-content=\":eye_in_speech_bubble:\" role=\"img\" title=\"eye in speech bubble\">:eye_in_speech_bubble:</span> <span aria-label=\"hash\" class=\"emoji emoji-0023-20e3\" data-tippy-content=\":hash:\" role=\"img\" title=\"hash\">:hash:</span></p>"
     },
     {
       "name": "emoji_sequence_three",
       "input": "phoenix bird from 15.1: 🐦‍🔥",
-      "expected_output": "<p>phoenix bird from 15.1: <span aria-label=\"phoenix\" class=\"emoji emoji-1f426-200d-1f525\" role=\"img\" title=\"phoenix\">:phoenix:</span></p>"
+      "expected_output": "<p>phoenix bird from 15.1: <span aria-label=\"phoenix\" class=\"emoji emoji-1f426-200d-1f525\" data-tippy-content=\":phoenix:\" role=\"img\" title=\"phoenix\">:phoenix:</span></p>"
     },
     {
       "name": "emoji_sequence_four",
       "input": "lime from 15.1: 🍋‍🟩",
-      "expected_output": "<p>lime from 15.1: <span aria-label=\"lime\" class=\"emoji emoji-1f34b-200d-1f7e9\" role=\"img\" title=\"lime\">:lime:</span></p>"
+      "expected_output": "<p>lime from 15.1: <span aria-label=\"lime\" class=\"emoji emoji-1f34b-200d-1f7e9\" data-tippy-content=\":lime:\" role=\"img\" title=\"lime\">:lime:</span></p>"
     },
     {
       "name": "unrecognized_emoji_sequence_three",
       "input": "normal lemon 🍋, purple lemon? 🍋‍🟪",
-      "expected_output": "<p>normal lemon <span aria-label=\"lemon\" class=\"emoji emoji-1f34b\" role=\"img\" title=\"lemon\">:lemon:</span>, purple lemon? 🍋‍🟪</p>"
+      "expected_output": "<p>normal lemon <span aria-label=\"lemon\" class=\"emoji emoji-1f34b\" data-tippy-content=\":lemon:\" role=\"img\" title=\"lemon\">:lemon:</span>, purple lemon? 🍋‍🟪</p>"
     },
     {
       "name": "unrecognized_emoji_sequence_four",
@@ -645,13 +645,13 @@
     {
       "name": "emojis_without_space",
       "input": ":cat:hello:dog::rabbit:",
-      "expected_output": "<p><span aria-label=\"cat\" class=\"emoji emoji-1f408\" role=\"img\" title=\"cat\">:cat:</span>hello<span aria-label=\"dog\" class=\"emoji emoji-1f415\" role=\"img\" title=\"dog\">:dog:</span><span aria-label=\"rabbit\" class=\"emoji emoji-1f407\" role=\"img\" title=\"rabbit\">:rabbit:</span></p>",
+      "expected_output": "<p><span aria-label=\"cat\" class=\"emoji emoji-1f408\" data-tippy-content=\":cat:\" role=\"img\" title=\"cat\">:cat:</span>hello<span aria-label=\"dog\" class=\"emoji emoji-1f415\" data-tippy-content=\":dog:\" role=\"img\" title=\"dog\">:dog:</span><span aria-label=\"rabbit\" class=\"emoji emoji-1f407\" data-tippy-content=\":rabbit:\" role=\"img\" title=\"rabbit\">:rabbit:</span></p>",
       "text_content": "\ud83d\udc08hello\ud83d\udc15\ud83d\udc07"
     },
     {
       "name": "emojis_newline",
       "input": ":cat:\n:dog:",
-      "expected_output": "<p><span aria-label=\"cat\" class=\"emoji emoji-1f408\" role=\"img\" title=\"cat\">:cat:</span><br>\n<span aria-label=\"dog\" class=\"emoji emoji-1f415\" role=\"img\" title=\"dog\">:dog:</span></p>",
+      "expected_output": "<p><span aria-label=\"cat\" class=\"emoji emoji-1f408\" data-tippy-content=\":cat:\" role=\"img\" title=\"cat\">:cat:</span><br>\n<span aria-label=\"dog\" class=\"emoji emoji-1f415\" data-tippy-content=\":dog:\" role=\"img\" title=\"dog\">:dog:</span></p>",
       "text_content": "\ud83d\udc08\n\ud83d\udc15"
     },
     {
@@ -663,67 +663,67 @@
     {
       "name": "unicode_emoji",
       "input": "\ud83d\udca9",
-      "expected_output":"<p><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span></p>",
+      "expected_output": "<p><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" data-tippy-content=\":poop:\" role=\"img\" title=\"poop\">:poop:</span></p>",
       "text_content": "\ud83d\udca9"
     },
     {
       "name": "two_unicode_emoji",
       "input": "\ud83d\udca9\ud83d\udca9",
-      "expected_output":"<p><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span><\/p>",
+      "expected_output": "<p><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" data-tippy-content=\":poop:\" role=\"img\" title=\"poop\">:poop:</span><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" data-tippy-content=\":poop:\" role=\"img\" title=\"poop\">:poop:</span><\/p>",
       "text_content": "\ud83d\udca9\ud83d\udca9"
     },
     {
       "name": "two_unicode_emoji_separated_by_text",
       "input": "\ud83d\udca9 word \ud83d\udca9",
-      "expected_output":"<p><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span> word <span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span><\/p>",
+      "expected_output": "<p><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" data-tippy-content=\":poop:\" role=\"img\" title=\"poop\">:poop:</span> word <span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" data-tippy-content=\":poop:\" role=\"img\" title=\"poop\">:poop:</span><\/p>",
       "text_content": "\ud83d\udca9 word \ud83d\udca9"
     },
     {
       "name": "miscellaneous_symbols_and_pictographs",
       "input": "Merry Christmas!!\ud83c\udf84",
-      "expected_output":"<p>Merry Christmas!!<span aria-label=\"holiday tree\" class=\"emoji emoji-1f384\" role=\"img\" title=\"holiday tree\">:holiday_tree:</span><\/p>",
+      "expected_output": "<p>Merry Christmas!!<span aria-label=\"holiday tree\" class=\"emoji emoji-1f384\" data-tippy-content=\":holiday_tree:\" role=\"img\" title=\"holiday tree\">:holiday_tree:</span><\/p>",
       "text_content": "Merry Christmas!!\ud83c\udf84"
     },
     {
       "name": "miscellaneous_and_dingbats_emoji",
       "input": "\u2693\u2797",
-      "expected_output":"<p><span aria-label=\"anchor\" class=\"emoji emoji-2693\" role=\"img\" title=\"anchor\">:anchor:</span><span aria-label=\"division\" class=\"emoji emoji-2797\" role=\"img\" title=\"division\">:division:</span><\/p>"
+      "expected_output": "<p><span aria-label=\"anchor\" class=\"emoji emoji-2693\" data-tippy-content=\":anchor:\" role=\"img\" title=\"anchor\">:anchor:</span><span aria-label=\"division\" class=\"emoji emoji-2797\" data-tippy-content=\":division:\" role=\"img\" title=\"division\">:division:</span><\/p>"
     },
     {
       "name": "supplemental_symbols_and_pictographs",
       "input": "I am a robot \ud83e\udd16.",
-      "expected_output":"<p>I am a robot <span aria-label=\"robot\" class=\"emoji emoji-1f916\" role=\"img\" title=\"robot\">:robot:</span>.<\/p>"
+      "expected_output": "<p>I am a robot <span aria-label=\"robot\" class=\"emoji emoji-1f916\" data-tippy-content=\":robot:\" role=\"img\" title=\"robot\">:robot:</span>.<\/p>"
     },
     {
       "name": "miscellaneous_symbols_and_arrows",
       "input": "Black upward arrow \u2b06\ufe0f",
-      "expected_output":"<p>Black upward arrow <span aria-label=\"up\" class=\"emoji emoji-2b06\" role=\"img\" title=\"up\">:up:</span><\/p>"
+      "expected_output": "<p>Black upward arrow <span aria-label=\"up\" class=\"emoji emoji-2b06\" data-tippy-content=\":up:\" role=\"img\" title=\"up\">:up:</span><\/p>"
     },
     {
       "name": "unicode_emoji_without_space",
       "input": "Extra\ud83d\udc7dTerrestrial",
-      "expected_output":"<p>Extra<span aria-label=\"alien\" class=\"emoji emoji-1f47d\" role=\"img\" title=\"alien\">:alien:</span>Terrestrial<\/p>"
+      "expected_output": "<p>Extra<span aria-label=\"alien\" class=\"emoji emoji-1f47d\" data-tippy-content=\":alien:\" role=\"img\" title=\"alien\">:alien:</span>Terrestrial<\/p>"
     },
     {
       "name": "unicode_emojis_new_line",
       "input": "\ud83d\udc7d\n\ud83d\udc7d",
-      "expected_output":"<p><span aria-label=\"alien\" class=\"emoji emoji-1f47d\" role=\"img\" title=\"alien\">:alien:</span><br>\n<span aria-label=\"alien\" class=\"emoji emoji-1f47d\" role=\"img\" title=\"alien\">:alien:</span></p>",
+      "expected_output": "<p><span aria-label=\"alien\" class=\"emoji emoji-1f47d\" data-tippy-content=\":alien:\" role=\"img\" title=\"alien\">:alien:</span><br>\n<span aria-label=\"alien\" class=\"emoji emoji-1f47d\" data-tippy-content=\":alien:\" role=\"img\" title=\"alien\">:alien:</span></p>",
       "text_content": "\ud83d\udc7d\n\ud83d\udc7d"
     },
     {
       "name": "emoji_alongside_punctuation",
       "input": ":smile:, :smile:; :smile:",
-      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji emoji-1f604\" role=\"img\" title=\"smile\">:smile:</span>, <span aria-label=\"smile\" class=\"emoji emoji-1f604\" role=\"img\" title=\"smile\">:smile:</span>; <span aria-label=\"smile\" class=\"emoji emoji-1f604\" role=\"img\" title=\"smile\">:smile:</span></p>"
+      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji emoji-1f604\" data-tippy-content=\":smile:\" role=\"img\" title=\"smile\">:smile:</span>, <span aria-label=\"smile\" class=\"emoji emoji-1f604\" data-tippy-content=\":smile:\" role=\"img\" title=\"smile\">:smile:</span>; <span aria-label=\"smile\" class=\"emoji emoji-1f604\" data-tippy-content=\":smile:\" role=\"img\" title=\"smile\">:smile:</span></p>"
     },
     {
       "name": "new_emoji_test",
       "input": ":avocado:, :kiwi:, :selfie:, :gear:, :comet:, :gold:",
-      "expected_output": "<p><span aria-label=\"avocado\" class=\"emoji emoji-1f951\" role=\"img\" title=\"avocado\">:avocado:</span>, <span aria-label=\"kiwi\" class=\"emoji emoji-1f95d\" role=\"img\" title=\"kiwi\">:kiwi:</span>, <span aria-label=\"selfie\" class=\"emoji emoji-1f933\" role=\"img\" title=\"selfie\">:selfie:</span>, <span aria-label=\"gear\" class=\"emoji emoji-2699\" role=\"img\" title=\"gear\">:gear:</span>, <span aria-label=\"comet\" class=\"emoji emoji-2604\" role=\"img\" title=\"comet\">:comet:</span>, <span aria-label=\"gold\" class=\"emoji emoji-1f947\" role=\"img\" title=\"gold\">:gold:</span></p>"
+      "expected_output": "<p><span aria-label=\"avocado\" class=\"emoji emoji-1f951\" data-tippy-content=\":avocado:\" role=\"img\" title=\"avocado\">:avocado:</span>, <span aria-label=\"kiwi\" class=\"emoji emoji-1f95d\" data-tippy-content=\":kiwi:\" role=\"img\" title=\"kiwi\">:kiwi:</span>, <span aria-label=\"selfie\" class=\"emoji emoji-1f933\" data-tippy-content=\":selfie:\" role=\"img\" title=\"selfie\">:selfie:</span>, <span aria-label=\"gear\" class=\"emoji emoji-2699\" data-tippy-content=\":gear:\" role=\"img\" title=\"gear\">:gear:</span>, <span aria-label=\"comet\" class=\"emoji emoji-2604\" data-tippy-content=\":comet:\" role=\"img\" title=\"comet\">:comet:</span>, <span aria-label=\"gold\" class=\"emoji emoji-1f947\" data-tippy-content=\":gold:\" role=\"img\" title=\"gold\">:gold:</span></p>"
     },
     {
       "name": "emoji_pipeline_newline",
       "input": "The winner is:\nsmiley:smiley:",
-      "expected_output": "<p>The winner is:<br>\nsmiley<span aria-label=\"smiley\" class=\"emoji emoji-1f603\" role=\"img\" title=\"smiley\">:smiley:</span></p>"
+      "expected_output": "<p>The winner is:<br>\nsmiley<span aria-label=\"smiley\" class=\"emoji emoji-1f603\" data-tippy-content=\":smiley:\" role=\"img\" title=\"smiley\">:smiley:</span></p>"
     },
     {
       "name": "emoji_pipeline_emphasis",
@@ -733,7 +733,7 @@
     {
       "name": "emoji_pipeline_link",
       "input": "Visit https:smiley://google.com.",
-      "expected_output": "<p>Visit https<span aria-label=\"smiley\" class=\"emoji emoji-1f603\" role=\"img\" title=\"smiley\">:smiley:</span>//google.com.</p>"
+      "expected_output": "<p>Visit https<span aria-label=\"smiley\" class=\"emoji emoji-1f603\" data-tippy-content=\":smiley:\" role=\"img\" title=\"smiley\">:smiley:</span>//google.com.</p>"
     },
     {
       "name": "skin_tones_are_banned",
@@ -754,7 +754,7 @@
     {
       "name": "valid_emoji_preceded_by_invalid_emoji",
       "input": "This is :invalidemoji: which should not prevent rendering :smile:",
-      "expected_output": "<p>This is :invalidemoji: which should not prevent rendering <span aria-label=\"smile\" class=\"emoji emoji-1f604\" role=\"img\" title=\"smile\">:smile:</span></p>"
+      "expected_output": "<p>This is :invalidemoji: which should not prevent rendering <span aria-label=\"smile\" class=\"emoji emoji-1f604\" data-tippy-content=\":smile:\" role=\"img\" title=\"smile\">:smile:</span></p>"
     },
     {
       "name": "safe_html",
@@ -1000,15 +1000,15 @@
     {
       "name": "spoilers_with_header_markdown",
       "input": "```spoiler [Header](https://example.com) :slight_smile:\ncontent\n```",
-      "expected_output": "<div class=\"spoiler-block\"><div class=\"spoiler-header\">\n<p><a href=\"https://example.com\">Header</a> <span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"slight smile\">:slight_smile:</span></p>\n</div><div class=\"spoiler-content\" aria-hidden=\"true\">\n<p>content</p>\n</div></div>",
+      "expected_output": "<div class=\"spoiler-block\"><div class=\"spoiler-header\">\n<p><a href=\"https://example.com\">Header</a> <span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" data-tippy-content=\":slight_smile:\" role=\"img\" title=\"slight smile\">:slight_smile:</span></p>\n</div><div class=\"spoiler-content\" aria-hidden=\"true\">\n<p>content</p>\n</div></div>",
       "text_content": "Header 🙂 (…)\n"
     },
     {
       "name": "spoiler_with_inline_image",
       "input": "```spoiler header\nContent http://example.com/image.png\n```",
-        "expected_output": "<div class=\"spoiler-block\"><div class=\"spoiler-header\">\n<p>header</p>\n</div><div class=\"spoiler-content\" aria-hidden=\"true\">\n<p>Content <a href=\"http://example.com/image.png\">http://example.com/image.png</a></p>\n<div class=\"message_inline_image\"><a href=\"http://example.com/image.png\"><img src=\"https://external-content.zulipcdn.net/external_content/25fef3bfd3a93e0266153205ea66a83c53d310b4/687474703a2f2f6578616d706c652e636f6d2f696d6167652e706e67\"></a></div></div></div>",
-        "marked_expected_output": "<div class=\"spoiler-block\"><div class=\"spoiler-header\">\n<p>header</p>\n</div><div class=\"spoiler-content\" aria-hidden=\"true\">\n<p>Content <a href=\"http://example.com/image.png\">http://example.com/image.png</a></p>\n</div></div>",
-        "text_content": "header (…)\n"
+      "expected_output": "<div class=\"spoiler-block\"><div class=\"spoiler-header\">\n<p>header</p>\n</div><div class=\"spoiler-content\" aria-hidden=\"true\">\n<p>Content <a href=\"http://example.com/image.png\">http://example.com/image.png</a></p>\n<div class=\"message_inline_image\"><a href=\"http://example.com/image.png\"><img src=\"https://external-content.zulipcdn.net/external_content/25fef3bfd3a93e0266153205ea66a83c53d310b4/687474703a2f2f6578616d706c652e636f6d2f696d6167652e706e67\"></a></div></div></div>",
+      "marked_expected_output": "<div class=\"spoiler-block\"><div class=\"spoiler-header\">\n<p>header</p>\n</div><div class=\"spoiler-content\" aria-hidden=\"true\">\n<p>Content <a href=\"http://example.com/image.png\">http://example.com/image.png</a></p>\n</div></div>",
+      "text_content": "header (…)\n"
     },
     {
       "name": "embedded_link_inside_Bold",
@@ -1033,9 +1033,9 @@
       "marked_expected_output": "<p>&lt;h1&gt;<em>&lt;h1&gt;<a href=\"https://blog.zulip.com/2016/10/13/static-types-in-python-oh-mypy\">&lt;h2&gt;Static types in Python&lt;/h2&gt;</a>&lt;/h1&gt;</em>&lt;/h1&gt;\n\n</p>"
     },
     {
-        "name": "telephone_sms_link",
-        "input": "[call me](tel:+14155551234) [or maybe not](sms:+14155551234)",
-        "expected_output": "<p><a href=\"tel:+14155551234\">call me</a> <a href=\"sms:+14155551234\">or maybe not</a></p>"
+      "name": "telephone_sms_link",
+      "input": "[call me](tel:+14155551234) [or maybe not](sms:+14155551234)",
+      "expected_output": "<p><a href=\"tel:+14155551234\">call me</a> <a href=\"sms:+14155551234\">or maybe not</a></p>"
     },
     {
       "name": "codeblock_hilite_shebang_feature_no_path_1",

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1301,8 +1301,10 @@ class MarkdownEmojiTest(ZulipTestCase):
 
     def test_realm_emoji(self) -> None:
         def emoji_img(name: str, file_name: str, realm_id: int) -> str:
-            return '<img alt="{}" class="emoji" src="{}" title="{}">'.format(
-                name, get_emoji_url(file_name, realm_id), name[1:-1].replace("_", " ")
+            return (
+                '<img alt="{}" class="emoji" data-tippy-content="{}" src="{}" title="{}">'.format(
+                    name, name, get_emoji_url(file_name, realm_id), name[1:-1].replace("_", " ")
+                )
             )
 
         realm = get_realm("zulip")
@@ -1338,14 +1340,14 @@ class MarkdownEmojiTest(ZulipTestCase):
         converted = markdown_convert_wrapper(msg)
         self.assertEqual(
             converted,
-            '<p><span aria-label="coffee" class="emoji emoji-2615" role="img" title="coffee">:coffee:</span></p>',
+            '<p><span aria-label="coffee" class="emoji emoji-2615" data-tippy-content=":coffee:" role="img" title="coffee">:coffee:</span></p>',
         )
 
         msg = "\u2615\u2615"  # ☕☕
         converted = markdown_convert_wrapper(msg)
         self.assertEqual(
             converted,
-            '<p><span aria-label="coffee" class="emoji emoji-2615" role="img" title="coffee">:coffee:</span><span aria-label="coffee" class="emoji emoji-2615" role="img" title="coffee">:coffee:</span></p>',
+            '<p><span aria-label="coffee" class="emoji emoji-2615" data-tippy-content=":coffee:" role="img" title="coffee">:coffee:</span><span aria-label="coffee" class="emoji emoji-2615" data-tippy-content=":coffee:" role="img" title="coffee">:coffee:</span></p>',
         )
 
     def test_no_translate_emoticons_if_off(self) -> None:


### PR DESCRIPTION
### Changes
This PR implements enhanced emoji tooltips as requested in #35170.

- Replaced basic `title` tooltips with enhanced Tippy.js tooltips for emojis.
- Show a larger preview of the emoji image (or native unicode character) followed by the emoji shortname.
- Implemented support for the 'Plain text' (Native) emojiset, correctly extracting and displaying the unicode character in the tooltip.
- Used `INSTANT_HOVER_DELAY` [100, 20] for a natural yet snappy feel.
- Enabled enhanced tooltips in the message feed, compose box preview, and user status emojis.
- Added necessary CSS and templates for the new tooltip layout.

Fixes: #35170

**How changes were tested:**
Verified the implementation in the development environment (`localhost:9991` via Vagrant):
1. Hovered over standard emojis in the message feed with the default 'Google' emojiset.
2. Verified that increasing the font size in Zulip settings correctly scales the tooltip and the preview emoji.
3. Switched to 'Plain text' (Native) emojiset and verified that the tooltip correctly displays the unicode character preview.
4. Verified that tooltips on user status emojis and compose box previews also use the new enhanced format.
5. Ran frontend tests: `node web/tests/markdown.test.cjs`.
6. Ran backend tests: `./tools/test-backend zerver/tests/test_markdown.py`.

**Screenshots and screen captures:**
<details>
<summary>View Screenshots</summary>

1. **Default Enhanced Tooltip**: 
<img width="1494" height="748" alt="Default Enhanced Tooltip" src="https://github.com/user-attachments/assets/af398ede-4adb-4a91-ae44-67275d9a47ca" />


2. **Scaled Tooltip (Large Font)**: 
<img width="1480" height="692" alt="Scaled Tooltip" src="https://github.com/user-attachments/assets/79a7698d-337e-4d8d-8939-891b78c72471" />


4. **Native Unicode Tooltip**: 
<img width="1499" height="747" alt="Native Unicode Support" src="https://github.com/user-attachments/assets/98824417-4d6b-4baf-99ed-02a045345265" />



Note for reviewer: The following absolute paths on the local system contain the verification images:
- /Users/sahityasingh/.gemini/antigravity/brain/cc582b5c-f1fa-4749-90a2-f718ea7e6843/enhanced_tooltip_hover_check_1770894937384.png
- /Users/sahityasingh/.gemini/antigravity/brain/cc582b5c-f1fa-4749-90a2-f718ea7e6843/screenshot_2_scaled_tooltip_final_1770898074249.png
- /Users/sahityasingh/.gemini/antigravity/brain/cc582b5c-f1fa-4749-90a2-f718ea7e6843/screenshot_3_native_emoji_tooltip_1770896393430.png
</details>

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
- [x] Explains differences from previous plans.
- [x] Highlights technical choices and bugs encountered.
- [x] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>