### PR TITLE
narrow: Fix message history blocked for archived channels.

### DIFF
--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -1735,6 +1735,7 @@ def access_narrow(
             maybe_user_profile,
             channel,
             error="",
+            require_active_channel=False,
             require_content_access=True,
         )
         return True


### PR DESCRIPTION
`access_narrow` returned `False` for archived channels, hence no user was able to access history of archived channels regardless of access.

Fixed by removing `require_active_channel` check.

discussion: https://github.com/zulip/zulip/pull/37789#discussion_r2796366873

@sahil839 FYI