### PR TITLE
hotkey: Fix inbox hotkey not working.

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -1230,7 +1230,11 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
             return true;
         case "open_inbox":
             // Focus search if already in (non-channel) inbox view.
-            if (!inbox_util.is_channel_view() && !inbox_ui.is_search_focused()) {
+            if (
+                inbox_util.is_visible() &&
+                !inbox_util.is_channel_view() &&
+                !inbox_ui.is_search_focused()
+            ) {
                 inbox_ui.focus_inbox_search();
                 return true;
             }


### PR DESCRIPTION
We didn't check if inbox view is visible before processing the hotkey to focus on search.
