### PR TITLE
[ai] openapi: Enable OpenAPI error response validation.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -28329,6 +28329,8 @@ components:
       allOf:
         - $ref: "#/components/schemas/CodedErrorBase"
         - additionalProperties: false
+          required:
+            - stream
           properties:
             result: {}
             msg: {}
@@ -28348,6 +28350,8 @@ components:
       allOf:
         - $ref: "#/components/schemas/CodedErrorBase"
         - additionalProperties: false
+          required:
+            - stream_id
           properties:
             result: {}
             msg: {}
@@ -28380,6 +28384,11 @@ components:
       allOf:
         - $ref: "#/components/schemas/CodedErrorBase"
         - additionalProperties: false
+          required:
+            - errors
+            - sent_invitations
+            - daily_limit_reached
+            - license_limit_reached
           properties:
             result: {}
             msg: {}
@@ -28415,6 +28424,8 @@ components:
       allOf:
         - $ref: "#/components/schemas/CodedErrorBase"
         - additionalProperties: false
+          required:
+            - var_name
           description: |
             ### Missing request parameter
 
@@ -28441,6 +28452,8 @@ components:
       allOf:
         - $ref: "#/components/schemas/CodedErrorBase"
         - additionalProperties: false
+          required:
+            - parameters
           description: |
             ### Incompatible request parameters
 
@@ -28464,6 +28477,148 @@ components:
               "msg": "Unsupported parameter combination: object_id, object_name",
               "result": "error",
               "parameters": "object_id, object_name",
+            }
+    MoveMessagesTimeLimitExceededError:
+      allOf:
+        - $ref: "#/components/schemas/CodedErrorBase"
+        - additionalProperties: false
+          required:
+            - first_message_id_allowed_to_move
+            - total_messages_in_topic
+            - total_messages_allowed_to_move
+          properties:
+            result: {}
+            msg: {}
+            code: {}
+            first_message_id_allowed_to_move:
+              type: integer
+              nullable: true
+              description: |
+                The oldest message ID in this topic that the user has
+                permission to move. `null` if the user does not have
+                permission to move any messages.
+            total_messages_in_topic:
+              type: integer
+              description: |
+                Total number of messages in the topic.
+            total_messages_allowed_to_move:
+              type: integer
+              description: |
+                Total number of messages the user has permission to move
+                (the most recent ones in the topic).
+          example:
+            {
+              "code": "MOVE_MESSAGES_TIME_LIMIT_EXCEEDED",
+              "first_message_id_allowed_to_move": 123,
+              "msg": "You only have permission to move the 2/5 most recent messages in this topic.",
+              "result": "error",
+              "total_messages_allowed_to_move": 2,
+              "total_messages_in_topic": 5,
+            }
+    ChannelAlreadyExistsError:
+      allOf:
+        - $ref: "#/components/schemas/CodedErrorBase"
+        - additionalProperties: false
+          required:
+            - channel_name
+          properties:
+            result: {}
+            msg: {}
+            code: {}
+            channel_name:
+              type: string
+              description: |
+                The name of the channel that already exists.
+          example:
+            {
+              "code": "CHANNEL_ALREADY_EXISTS",
+              "msg": "Channel 'discussions' already exists",
+              "channel_name": "discussions",
+              "result": "error",
+            }
+    TopicConfigurationError:
+      allOf:
+        - $ref: "#/components/schemas/CodedErrorBase"
+        - additionalProperties: false
+          required:
+            - empty_topic_display_name
+          properties:
+            result: {}
+            msg: {}
+            code: {}
+            empty_topic_display_name:
+              type: string
+              description: |
+                The display name of the empty/general chat topic.
+          example:
+            {
+              "code": "BAD_REQUEST",
+              "msg": "To enable this configuration, all messages in this channel must be in the general chat topic. Consider renaming or deleting other topics.",
+              "empty_topic_display_name": "general chat",
+              "result": "error",
+            }
+    CannotDeactivateGroupInUseError:
+      allOf:
+        - $ref: "#/components/schemas/CodedErrorBase"
+        - additionalProperties: false
+          required:
+            - objections
+          properties:
+            result: {}
+            msg: {}
+            code: {}
+            objections:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: |
+                      The type of object using the group. One of `"realm"`,
+                      `"channel"`, `"user_group"`, or `"subgroup"`.
+                  settings:
+                    type: array
+                    items:
+                      type: string
+                    description: |
+                      The setting names that reference the group. Present for
+                      `"realm"`, `"channel"`, and `"user_group"` types.
+                  channel_id:
+                    type: integer
+                    description: |
+                      The ID of the channel using the group. Present when
+                      `type` is `"channel"`.
+                  group_id:
+                    type: integer
+                    description: |
+                      The ID of the user group using the group. Present when
+                      `type` is `"user_group"`.
+                  supergroup_ids:
+                    type: array
+                    items:
+                      type: integer
+                    description: |
+                      The IDs of groups that include this group as a subgroup.
+                      Present when `type` is `"subgroup"`.
+                required:
+                  - type
+                additionalProperties: false
+              description: |
+                An array of objects describing why the group cannot be
+                deactivated.
+          example:
+            {
+              "code": "CANNOT_DEACTIVATE_GROUP_IN_USE",
+              "msg": "Cannot deactivate user group in use.",
+              "objections":
+                [
+                  {
+                    "type": "realm",
+                    "settings": ["can_create_public_channel_group"],
+                  },
+                ],
+              "result": "error",
             }
     UserNotAuthorizedError:
       allOf:
@@ -28519,7 +28674,7 @@ components:
             msg: {}
             code: {}
             retry-after:
-              type: integer
+              type: number
               description: |
                 How many seconds the client must wait before making
                 additional requests.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6582,17 +6582,17 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Invalid attachment",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          A typical failed JSON response for when the `attachment_id` is invalid
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                invalid_attachment:
+                  description: |
+                    A typical failed JSON response for when the `attachment_id` is invalid
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Invalid attachment",
+                      "code": "BAD_REQUEST",
+                    }
         "401":
           description: Error.
           content:
@@ -7585,22 +7585,30 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/NonExistingChannelIdError"
-                      - description: |
-                          A typical failed JSON response for when a channel message is scheduled
-                          to be sent to a channel that does not exist:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "Invalid user ID 10",
-                            "result": "error",
-                          }
-                        description: |
-                          A typical failed JSON response for when a direct message is scheduled
-                          to be sent to a user that does not exist:
+                  - $ref: "#/components/schemas/NonExistingChannelIdError"
+                  - $ref: "#/components/schemas/CodedError"
+              examples:
+                nonexisting_channel:
+                  description: |
+                    A typical failed JSON response for when a channel message is scheduled
+                    to be sent to a channel that does not exist:
+                  value:
+                    {
+                      "code": "STREAM_DOES_NOT_EXIST",
+                      "msg": "Channel with ID '9' does not exist",
+                      "result": "error",
+                      "stream_id": 9,
+                    }
+                invalid_user:
+                  description: |
+                    A typical failed JSON response for when a direct message is scheduled
+                    to be sent to a user that does not exist:
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "Invalid user ID 10",
+                      "result": "error",
+                    }
   /scheduled_messages/{scheduled_message_id}:
     patch:
       operationId: update-scheduled-message
@@ -7740,22 +7748,30 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/NonExistingChannelIdError"
-                      - description: |
-                          A typical failed JSON response for when a channel message is scheduled
-                          to be sent to a channel that does not exist:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "Invalid user ID 10",
-                            "result": "error",
-                          }
-                        description: |
-                          A typical failed JSON response for when a direct message is scheduled
-                          to be sent to a user that does not exist:
+                  - $ref: "#/components/schemas/NonExistingChannelIdError"
+                  - $ref: "#/components/schemas/CodedError"
+              examples:
+                nonexisting_channel:
+                  description: |
+                    A typical failed JSON response for when a channel message is scheduled
+                    to be sent to a channel that does not exist:
+                  value:
+                    {
+                      "code": "STREAM_DOES_NOT_EXIST",
+                      "msg": "Channel with ID '9' does not exist",
+                      "result": "error",
+                      "stream_id": 9,
+                    }
+                invalid_user:
+                  description: |
+                    A typical failed JSON response for when a direct message is scheduled
+                    to be sent to a user that does not exist:
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "Invalid user ID 10",
+                      "result": "error",
+                    }
         "404":
           description: Not Found.
           content:
@@ -7848,22 +7864,27 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/InvalidChannelError"
-                      - description: |
-                          A typical failed JSON response for when an invalid channel ID is passed:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "Private channels cannot be made default.",
-                            "result": "error",
-                          }
-                        description: |
-                          A typical failed JSON response for when a user tries to add a private channel
-                          to the default channels set:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                invalid_channel:
+                  description: |
+                    A typical failed JSON response for when an invalid channel ID is passed:
+                  value:
+                    {
+                      "msg": "Invalid channel ID",
+                      "code": "BAD_REQUEST",
+                      "result": "error",
+                    }
+                private_channel:
+                  description: |
+                    A typical failed JSON response for when a user tries to add a private channel
+                    to the default channels set:
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "Private channels cannot be made default.",
+                      "result": "error",
+                    }
     delete:
       operationId: remove-default-stream
       summary: Remove a default channel
@@ -8519,56 +8540,64 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/NonExistingChannelNameError"
-                      - description: |
-                          A typical failed JSON response for when a channel message is sent to a channel
-                          that does not exist:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "Invalid email 'eeshan@zulip.com'",
-                            "result": "error",
-                          }
-                        description: |
-                          A typical failed JSON response for when a direct message is sent to a user
-                          that does not exist:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "You do not have permission to use channel wildcard mentions in this channel.",
-                            "code": "STREAM_WILDCARD_MENTION_NOT_ALLOWED",
-                          }
-                        description: |
-                          An example JSON error response for when the message was rejected because
-                          the message contains a stream wildcard mention, but the user doesn't have
-                          permission to use such a mention in this channel as the user is not present
-                          in `can_mention_many_users_group` and the channel contains a large number
-                          of subscribers.
+                  - $ref: "#/components/schemas/NonExistingChannelNameError"
+                  - $ref: "#/components/schemas/NonExistingChannelIdError"
+                  - $ref: "#/components/schemas/TopicConfigurationError"
+                  - $ref: "#/components/schemas/CodedError"
+              examples:
+                nonexisting_channel:
+                  description: |
+                    A typical failed JSON response for when a channel message is sent to a channel
+                    that does not exist:
+                  value:
+                    {
+                      "code": "STREAM_DOES_NOT_EXIST",
+                      "msg": "Channel 'nonexistent' does not exist",
+                      "result": "error",
+                      "stream": "nonexistent",
+                    }
+                invalid_email:
+                  description: |
+                    A typical failed JSON response for when a direct message is sent to a user
+                    that does not exist:
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "Invalid email 'eeshan@zulip.com'",
+                      "result": "error",
+                    }
+                stream_wildcard_mention_not_allowed:
+                  description: |
+                    An example JSON error response for when the message was rejected because
+                    the message contains a stream wildcard mention, but the user doesn't have
+                    permission to use such a mention in this channel as the user is not present
+                    in `can_mention_many_users_group` and the channel contains a large number
+                    of subscribers.
 
-                          **Changes**: New in Zulip 8.0 (feature level 229). Previously, this
-                          error returned the `"BAD_REQUEST"` code.
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "You do not have permission to use topic wildcard mentions in this topic.",
-                            "code": "TOPIC_WILDCARD_MENTION_NOT_ALLOWED",
-                          }
-                        description: |
-                          An example JSON error response for when the message was rejected because
-                          the message contains a topic wildcard mention, but the user doesn't have
-                          permission to use such a mention in this topic as the user is not present
-                          in `can_mention_many_users_group` and the topic contains a large number
-                          of participants.
+                    **Changes**: New in Zulip 8.0 (feature level 229). Previously, this
+                    error returned the `"BAD_REQUEST"` code.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "You do not have permission to use channel wildcard mentions in this channel.",
+                      "code": "STREAM_WILDCARD_MENTION_NOT_ALLOWED",
+                    }
+                topic_wildcard_mention_not_allowed:
+                  description: |
+                    An example JSON error response for when the message was rejected because
+                    the message contains a topic wildcard mention, but the user doesn't have
+                    permission to use such a mention in this topic as the user is not present
+                    in `can_mention_many_users_group` and the topic contains a large number
+                    of participants.
 
-                          **Changes**: New in Zulip 8.0 (feature level 229). Previously,
-                          `wildcard_mention_policy` was not enforced for topic mentions.
+                    **Changes**: New in Zulip 8.0 (feature level 229). Previously,
+                    `wildcard_mention_policy` was not enforced for topic mentions.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "You do not have permission to use topic wildcard mentions in this topic.",
+                      "code": "TOPIC_WILDCARD_MENTION_NOT_ALLOWED",
+                    }
   /messages/{message_id}/history:
     get:
       operationId: get-message-history
@@ -9244,30 +9273,29 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Invalid emoji code",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response for when the emoji code is invalid:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Reaction already exists.",
-                            "code": "REACTION_ALREADY_EXISTS",
-                          }
-                        description: |
-                          An example JSON error response for when the reaction already exists.
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                invalid_emoji_code:
+                  description: |
+                    An example JSON error response for when the emoji code is invalid:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Invalid emoji code",
+                      "code": "BAD_REQUEST",
+                    }
+                reaction_already_exists:
+                  description: |
+                    An example JSON error response for when the reaction already exists.
 
-                          **Changes**: New in Zulip 8.0 (feature level 193). Previously, this
-                          error returned the `"BAD_REQUEST"` code.
+                    **Changes**: New in Zulip 8.0 (feature level 193). Previously, this
+                    error returned the `"BAD_REQUEST"` code.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Reaction already exists.",
+                      "code": "REACTION_ALREADY_EXISTS",
+                    }
     delete:
       operationId: remove-reaction
       summary: Remove an emoji reaction
@@ -9312,30 +9340,29 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Invalid emoji code",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response for when the emoji code is invalid:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Reaction doesn't exist.",
-                            "code": "REACTION_DOES_NOT_EXIST",
-                          }
-                        description: |
-                          An example JSON error response for when the reaction does not exist.
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                invalid_emoji_code:
+                  description: |
+                    An example JSON error response for when the emoji code is invalid:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Invalid emoji code",
+                      "code": "BAD_REQUEST",
+                    }
+                reaction_does_not_exist:
+                  description: |
+                    An example JSON error response for when the reaction does not exist.
 
-                          **Changes**: New in Zulip 8.0 (feature level 193). Previously, this
-                          error returned the `"BAD_REQUEST"` code.
+                    **Changes**: New in Zulip 8.0 (feature level 193). Previously, this
+                    error returned the `"BAD_REQUEST"` code.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Reaction doesn't exist.",
+                      "code": "REACTION_DOES_NOT_EXIST",
+                    }
 
   /messages/{message_id}/read_receipts:
     get:
@@ -9955,120 +9982,112 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - properties:
-                          msg:
-                            enum:
-                              - Your organization has turned off message editing
-                              - You don't have permission to edit this message
-                              - The time limit for editing this message has past
-                              - Nothing to change
-                              - Topic can't be empty
-                        example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "You don't have permission to edit this message",
-                            "result": "error",
-                          }
-                        description: |
-                          A typical JSON response for when one doesn't have the permission to
-                          edit a particular message:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "MOVE_MESSAGES_TIME_LIMIT_EXCEEDED",
-                            "first_message_id_allowed_to_move": 123,
-                            "msg": "You only have permission to move the 2/5 most recent messages in this topic.",
-                            "result": "error",
-                            "total_messages_allowed_to_move": 2,
-                            "total_messages_in_topic": 5,
-                          }
-                        description: |
-                          A special failed JSON response (`"code": "MOVE_MESSAGES_TIME_LIMIT_EXCEEDED"`)
-                          for when the user has permission to move
-                          the target message, but asked to move all messages in a topic
-                          (`"propagate_mode": "change_all"`) and the user does not have permission
-                          to move the entire topic.
+                  - $ref: "#/components/schemas/MoveMessagesTimeLimitExceededError"
+                  - $ref: "#/components/schemas/TopicConfigurationError"
+                  - $ref: "#/components/schemas/CodedError"
+              examples:
+                no_permission:
+                  description: |
+                    A typical JSON response for when one doesn't have the permission to
+                    edit a particular message:
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "You don't have permission to edit this message",
+                      "result": "error",
+                    }
+                move_messages_time_limit_exceeded:
+                  description: |
+                    A special failed JSON response (`"code": "MOVE_MESSAGES_TIME_LIMIT_EXCEEDED"`)
+                    for when the user has permission to move
+                    the target message, but asked to move all messages in a topic
+                    (`"propagate_mode": "change_all"`) and the user does not have permission
+                    to move the entire topic.
 
-                          This happens when the topic contains some messages that are older than an
-                          applicable time limit for the requested topic move (see
-                          `move_messages_within_stream_limit_seconds` and/or
-                          `move_messages_between_streams_limit_seconds` in the
-                          [`POST /register`](/api/register-queue) response).
+                    This happens when the topic contains some messages that are older than an
+                    applicable time limit for the requested topic move (see
+                    `move_messages_within_stream_limit_seconds` and/or
+                    `move_messages_between_streams_limit_seconds` in the
+                    [`POST /register`](/api/register-queue) response).
 
-                          The error response contains data on which portion of this topic the user has
-                          permission to move. `first_message_id_allowed_to_move` is the oldest message
-                          ID in this topic that the user has permission to move.
-                          There are `total_messages_in_topic` in the topic, but the user only has
-                          permission to move the (most recent) `total_messages_allowed_to_move`
-                          messages.
+                    The error response contains data on which portion of this topic the user has
+                    permission to move. `first_message_id_allowed_to_move` is the oldest message
+                    ID in this topic that the user has permission to move.
+                    There are `total_messages_in_topic` in the topic, but the user only has
+                    permission to move the (most recent) `total_messages_allowed_to_move`
+                    messages.
 
-                          Clients should support this error code with
-                          `"first_message_id_allowed_to_move": null` for forward compatibility
-                          with future server versions that may use this error code with other
-                          propagation modes where the user does not have permission to move any
-                          messages, or where the server did not calculate the total message counts
-                          noted above.
+                    Clients should support this error code with
+                    `"first_message_id_allowed_to_move": null` for forward compatibility
+                    with future server versions that may use this error code with other
+                    propagation modes where the user does not have permission to move any
+                    messages, or where the server did not calculate the total message counts
+                    noted above.
 
-                          Clients can either only present the error to the user or, if
-                          `first_message_id_allowed_to_move` is not `null`, prompt the user to adjust
-                          their query with the above information.
+                    Clients can either only present the error to the user or, if
+                    `first_message_id_allowed_to_move` is not `null`, prompt the user to adjust
+                    their query with the above information.
 
-                          If clients choose to present a prompt for this error code, they should
-                          recommend the option of cancelling and (manually) asking a moderator to
-                          move the entire topic, since that's often a better experience than
-                          partially moving a topic. This API supports a client that wishes to allow
-                          the user to repeat the request with a `change_later` propagation mode and
-                          a target message ID of `first_message_id_allowed_to_move`, if the user
-                          desires to move only the portion of the topic that they can.
+                    If clients choose to present a prompt for this error code, they should
+                    recommend the option of cancelling and (manually) asking a moderator to
+                    move the entire topic, since that's often a better experience than
+                    partially moving a topic. This API supports a client that wishes to allow
+                    the user to repeat the request with a `change_later` propagation mode and
+                    a target message ID of `first_message_id_allowed_to_move`, if the user
+                    desires to move only the portion of the topic that they can.
 
-                          Note that in a [private channel with protected history][private-channels],
-                          the Zulip security model requires that the above calculations only include
-                          messages the acting user has access to. So in the rare case of a user
-                          attempting to move a topic that started before the user joined a private
-                          channel with protected history, this API endpoint might move only the portion
-                          of a topic that they have access to, without this error or any confirmation
-                          dialog.
+                    Note that in a [private channel with protected history][private-channels],
+                    the Zulip security model requires that the above calculations only include
+                    messages the acting user has access to. So in the rare case of a user
+                    attempting to move a topic that started before the user joined a private
+                    channel with protected history, this API endpoint might move only the portion
+                    of a topic that they have access to, without this error or any confirmation
+                    dialog.
 
-                          **Changes**: New in Zulip 7.0 (feature level 172).
+                    **Changes**: New in Zulip 7.0 (feature level 172).
 
-                          [private-channels]: /help/channel-permissions#private-channels
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "You do not have permission to use channel wildcard mentions in this channel.",
-                            "code": "STREAM_WILDCARD_MENTION_NOT_ALLOWED",
-                          }
-                        description: |
-                          An example JSON error response for when the message was rejected because
-                          the message contains a stream wildcard mention, but the user doesn't have
-                          permission to use such a mention in this channel as the user is not present
-                          in `can_mention_many_users_group` and the channel contains a large number
-                          of subscribers.
+                    [private-channels]: /help/channel-permissions#private-channels
+                  value:
+                    {
+                      "code": "MOVE_MESSAGES_TIME_LIMIT_EXCEEDED",
+                      "first_message_id_allowed_to_move": 123,
+                      "msg": "You only have permission to move the 2/5 most recent messages in this topic.",
+                      "result": "error",
+                      "total_messages_allowed_to_move": 2,
+                      "total_messages_in_topic": 5,
+                    }
+                stream_wildcard_mention_not_allowed:
+                  description: |
+                    An example JSON error response for when the message was rejected because
+                    the message contains a stream wildcard mention, but the user doesn't have
+                    permission to use such a mention in this channel as the user is not present
+                    in `can_mention_many_users_group` and the channel contains a large number
+                    of subscribers.
 
-                          **Changes**: New in Zulip 8.0 (feature level 229). Previously, this
-                          error returned the `"BAD_REQUEST"` code.
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "You do not have permission to use topic wildcard mentions in this topic.",
-                            "code": "TOPIC_WILDCARD_MENTION_NOT_ALLOWED",
-                          }
-                        description: |
-                          An example JSON error response for when the message was rejected because
-                          the message contains a topic wildcard mention, but the user doesn't have
-                          permission to use such a mention in this topic as the user is not present
-                          in `can_mention_many_users_group` and the topic contains a large number
-                          of participants.
+                    **Changes**: New in Zulip 8.0 (feature level 229). Previously, this
+                    error returned the `"BAD_REQUEST"` code.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "You do not have permission to use channel wildcard mentions in this channel.",
+                      "code": "STREAM_WILDCARD_MENTION_NOT_ALLOWED",
+                    }
+                topic_wildcard_mention_not_allowed:
+                  description: |
+                    An example JSON error response for when the message was rejected because
+                    the message contains a topic wildcard mention, but the user doesn't have
+                    permission to use such a mention in this topic as the user is not present
+                    in `can_mention_many_users_group` and the topic contains a large number
+                    of participants.
 
-                          **Changes**: New in Zulip 8.0 (feature level 229). Previously,
-                          `wildcard_mention_policy` was not enforced for topic mentions.
+                    **Changes**: New in Zulip 8.0 (feature level 229). Previously,
+                    `wildcard_mention_policy` was not enforced for topic mentions.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "You do not have permission to use topic wildcard mentions in this topic.",
+                      "code": "TOPIC_WILDCARD_MENTION_NOT_ALLOWED",
+                    }
     delete:
       operationId: delete-message
       summary: Delete a message
@@ -10119,22 +10138,27 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/InvalidMessageError"
-                      - description: |
-                          An example JSON response for when the specified message does not exist:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - description: |
-                          An example JSON response for when the user making the query does not
-                          have permission to delete the message:
-                        example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "You don't have permission to delete this message",
-                            "result": "error",
-                          }
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                invalid_message:
+                  description: |
+                    An example JSON response for when the specified message does not exist:
+                  value:
+                    {
+                      "msg": "Invalid message(s)",
+                      "code": "BAD_REQUEST",
+                      "result": "error",
+                    }
+                no_permission:
+                  description: |
+                    An example JSON response for when the user making the query does not
+                    have permission to delete the message:
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "You don't have permission to delete this message",
+                      "result": "error",
+                    }
   /messages/{message_id}/report:
     post:
       operationId: report-message
@@ -10703,80 +10727,81 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Insufficient permission",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response user making request does not have permission to update other user's status.:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Client did not pass any new values.",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response when no changes were requested:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "status_text is too long (limit: 60 characters)",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response when the
-                          `status_text` message exceeds the limit of
-                          60 characters:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Client must pass emoji_name if they pass either emoji_code or reaction_type.",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response when `emoji_name` is not specified
-                          but `emoji_code` or `reaction_type` is specified:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Emoji 'invalid' does not exist",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response when the emoji name does not exist:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Invalid emoji name.",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response when the emoji name is invalid:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Invalid custom emoji.",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response when the custom emoji is invalid:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                insufficient_permission:
+                  description: |
+                    An example JSON error response when the user making
+                    the request does not have permission to update another
+                    user's status.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Insufficient permission",
+                      "code": "BAD_REQUEST",
+                    }
+                no_new_values:
+                  description: |
+                    An example JSON error response when no changes were
+                    requested.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Client did not pass any new values.",
+                      "code": "BAD_REQUEST",
+                    }
+                status_text_too_long:
+                  description: |
+                    An example JSON error response when the
+                    `status_text` message exceeds the limit of
+                    60 characters.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "status_text is too long (limit: 60 characters)",
+                      "code": "BAD_REQUEST",
+                    }
+                missing_emoji_name:
+                  description: |
+                    An example JSON error response when `emoji_name` is
+                    not specified but `emoji_code` or `reaction_type` is
+                    specified.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Client must pass emoji_name if they pass either emoji_code or reaction_type.",
+                      "code": "BAD_REQUEST",
+                    }
+                emoji_does_not_exist:
+                  description: |
+                    An example JSON error response when the emoji name
+                    does not exist.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Emoji 'invalid' does not exist",
+                      "code": "BAD_REQUEST",
+                    }
+                invalid_emoji_name:
+                  description: |
+                    An example JSON error response when the emoji name
+                    is invalid.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Invalid emoji name.",
+                      "code": "BAD_REQUEST",
+                    }
+                invalid_custom_emoji:
+                  description: |
+                    An example JSON error response when the custom emoji
+                    is invalid.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Invalid custom emoji.",
+                      "code": "BAD_REQUEST",
+                    }
     get:
       operationId: get-user-status
       summary: Get a user's status
@@ -11720,70 +11745,65 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Client did not pass any new values.",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response when no changes were requested:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "status_text is too long (limit: 60 characters)",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response when the
-                          `status_text` message exceeds the limit of
-                          60 characters:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Client must pass emoji_name if they pass either emoji_code or reaction_type.",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response when `emoji_name` is not specified
-                          but `emoji_code` or `reaction_type` is specified:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Emoji 'invalid' does not exist",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response when the emoji name does not exist:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Invalid emoji name.",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response when the emoji name is invalid:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Invalid custom emoji.",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          An example JSON error response when the custom emoji is invalid:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                no_new_values:
+                  description: |
+                    An example JSON error response when no changes were requested:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Client did not pass any new values.",
+                      "code": "BAD_REQUEST",
+                    }
+                status_text_too_long:
+                  description: |
+                    An example JSON error response when the
+                    `status_text` message exceeds the limit of
+                    60 characters:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "status_text is too long (limit: 60 characters)",
+                      "code": "BAD_REQUEST",
+                    }
+                missing_emoji_name:
+                  description: |
+                    An example JSON error response when `emoji_name` is not specified
+                    but `emoji_code` or `reaction_type` is specified:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Client must pass emoji_name if they pass either emoji_code or reaction_type.",
+                      "code": "BAD_REQUEST",
+                    }
+                emoji_does_not_exist:
+                  description: |
+                    An example JSON error response when the emoji name does not exist:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Emoji 'invalid' does not exist",
+                      "code": "BAD_REQUEST",
+                    }
+                invalid_emoji_name:
+                  description: |
+                    An example JSON error response when the emoji name is invalid:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Invalid emoji name.",
+                      "code": "BAD_REQUEST",
+                    }
+                invalid_custom_emoji:
+                  description: |
+                    An example JSON error response when the custom emoji is invalid:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Invalid custom emoji.",
+                      "code": "BAD_REQUEST",
+                    }
   /users/me/{stream_id}/topics:
     get:
       operationId: get-stream-topics
@@ -12284,17 +12304,21 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
+                oneOf:
+                  - $ref: "#/components/schemas/IncompatibleParametersError"
                   - $ref: "#/components/schemas/CodedError"
-                  - example:
-                      {
-                        "msg": "Unable to access channel (private).",
-                        "result": "error",
-                        "code": "BAD_REQUEST",
-                      }
-                    description: |
-                      An example JSON response for when the requesting user does not have
-                      access to a private channel and `"authorization_errors_fatal": true`:
+              examples:
+                unauthorized_channel:
+                  description: |
+                    An example JSON response for when the requesting
+                    user does not have access to a private channel and
+                    `"authorization_errors_fatal": true`.
+                  value:
+                    {
+                      "msg": "Unable to access channel (private).",
+                      "result": "error",
+                      "code": "BAD_REQUEST",
+                    }
     patch:
       operationId: update-subscriptions
       summary: Update subscriptions
@@ -12552,10 +12576,31 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
+                oneOf:
                   - $ref: "#/components/schemas/NonExistingChannelNameError"
-                  - description: |
-                      A typical failed JSON response for when the target channel does not exist:
+                  - $ref: "#/components/schemas/CodedError"
+              examples:
+                nonexisting_channel:
+                  description: |
+                    A typical failed JSON response for when the target
+                    channel does not exist.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Channel 'nonexistent' does not exist",
+                      "code": "STREAM_DOES_NOT_EXIST",
+                      "stream": "nonexistent",
+                    }
+                insufficient_permission:
+                  description: |
+                    An example JSON error response for when the user does
+                    not have permission to unsubscribe another user.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Insufficient permission",
+                      "code": "BAD_REQUEST",
+                    }
   /users/me/subscriptions/muted_topics:
     patch:
       deprecated: true
@@ -12686,9 +12731,32 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/InvalidPushDeviceTokenError"
-                  - $ref: "#/components/schemas/InvalidRemotePushDeviceTokenError"
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                invalid_push_device_token:
+                  description: |
+                    ## Invalid push device token
+
+                    A typical failed JSON response for when the push device token is not
+                    recognized by the Zulip server:
+                  value:
+                    {
+                      "code": "INVALID_PUSH_DEVICE_TOKEN",
+                      "msg": "Device not recognized",
+                      "result": "error",
+                    }
+                invalid_remote_push_device_token:
+                  description: |
+                    ## Invalid push device token
+
+                    A typical failed JSON response for when the push device token is not recognized
+                    by the push notification bouncer:
+                  value:
+                    {
+                      "code": "INVALID_REMOTE_PUSH_DEVICE_TOKEN",
+                      "msg": "Device not recognized by the push bouncer",
+                      "result": "error",
+                    }
   /mobile_push/e2ee/test_notification:
     post:
       operationId: e2ee-test-notify
@@ -12733,25 +12801,45 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/NoActivePushDeviceError"
+                $ref: "#/components/schemas/NoActivePushDeviceError"
         "403":
           description: |
             Forbidden.
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/PushNotificationAdminActionRequiredError"
+                $ref: "#/components/schemas/PushNotificationAdminActionRequiredError"
         "502":
           description: |
             Bad gateway.
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/FailedToConnectBouncerError"
-                  - $ref: "#/components/schemas/InternalBouncerServerError"
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                failed_to_connect_bouncer:
+                  description: |
+                    ## Failed to connect bouncer
+
+                    A typical failed JSON response for when a network error occurs
+                    while the server attempts to connect to the bouncer server.
+                  value:
+                    {
+                      "code": "FAILED_TO_CONNECT_BOUNCER",
+                      "msg": "Network error while connecting to Zulip push notification service.",
+                      "result": "error",
+                    }
+                internal_bouncer_server_error:
+                  description: |
+                    ## Internal bouncer server error
+
+                    A typical failed JSON response for when a 5xx error occurs on the bouncer server.
+                  value:
+                    {
+                      "code": "INTERNAL_SERVER_ERROR_ON_BOUNCER",
+                      "msg": "Internal server error on Zulip push notification service, retry later.",
+                      "result": "error",
+                    }
   /mobile_push/register:
     post:
       operationId: register-push-device
@@ -12937,38 +13025,36 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "INVALID_BOUNCER_PUBLIC_KEY",
-                            "msg": "Invalid bouncer_public_key",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON response for when the given `bouncer_public_key` is invalid:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "REQUEST_EXPIRED",
-                            "msg": "Request expired",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON response for when the given `encrypted_push_registration` is stale:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "Invalid encrypted_push_registration",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON response for when either the bouncer fails to decrypt
-                          the given `encrypted_push_registration` or the decrypted data is invalid:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                invalid_bouncer_public_key:
+                  description: |
+                    An example JSON response for when the given `bouncer_public_key` is invalid:
+                  value:
+                    {
+                      "code": "INVALID_BOUNCER_PUBLIC_KEY",
+                      "msg": "Invalid bouncer_public_key",
+                      "result": "error",
+                    }
+                request_expired:
+                  description: |
+                    An example JSON response for when the given `encrypted_push_registration` is stale:
+                  value:
+                    {
+                      "code": "REQUEST_EXPIRED",
+                      "msg": "Request expired",
+                      "result": "error",
+                    }
+                invalid_encrypted_push_registration:
+                  description: |
+                    An example JSON response for when either the bouncer fails to decrypt
+                    the given `encrypted_push_registration` or the decrypted data is invalid:
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "Invalid encrypted_push_registration",
+                      "result": "error",
+                    }
         "403":
           description: |
             Forbidden.
@@ -13111,38 +13197,36 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "Cannot mute self",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON response for when the user ID is the current
-                          user's ID:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "No such user",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON response for when the user is nonexistent or inaccessible:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "User already muted",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON response for when the user is already muted:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                cannot_mute_self:
+                  description: |
+                    An example JSON response for when the user ID is the current
+                    user's ID:
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "Cannot mute self",
+                      "result": "error",
+                    }
+                no_such_user:
+                  description: |
+                    An example JSON response for when the user is nonexistent or inaccessible:
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "No such user",
+                      "result": "error",
+                    }
+                user_already_muted:
+                  description: |
+                    An example JSON response for when the user is already muted:
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "User already muted",
+                      "result": "error",
+                    }
     delete:
       operationId: unmute-user
       summary: Unmute a user
@@ -13162,27 +13246,26 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "No such user",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON response for when the user is nonexistent or inaccessible:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "User is not muted",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON response for when the user is not previously muted:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                no_such_user:
+                  description: |
+                    An example JSON response for when the user is nonexistent or inaccessible:
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "No such user",
+                      "result": "error",
+                    }
+                user_not_muted:
+                  description: |
+                    An example JSON response for when the user is not previously muted:
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "User is not muted",
+                      "result": "error",
+                    }
   /users/me/apns_device_token:
     post:
       deprecated: true
@@ -13229,28 +13312,27 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - description: |
-                          A typical failed JSON response for when the token's length is invalid
-                          or it is empty:
-                        example:
-                          {
-                            "result": "error",
-                            "msg": "Empty or invalid length token",
-                            "code": "BAD_REQUEST",
-                          }
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Invalid APNS token",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          A typical failed JSON response for when the APNs token is invalid:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                invalid_length_token:
+                  description: |
+                    A typical failed JSON response for when the token's length is invalid
+                    or it is empty:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Empty or invalid length token",
+                      "code": "BAD_REQUEST",
+                    }
+                invalid_apns_token:
+                  description: |
+                    A typical failed JSON response for when the APNs token is invalid:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Invalid APNS token",
+                      "code": "BAD_REQUEST",
+                    }
     delete:
       deprecated: true
       operationId: remove-apns-token
@@ -13287,28 +13369,27 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - description: |
-                          A typical failed JSON response for when the token's length is invalid
-                          or it is empty:
-                        example:
-                          {
-                            "result": "error",
-                            "msg": "Empty or invalid length token",
-                            "code": "BAD_REQUEST",
-                          }
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Token does not exist",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          A typical failed JSON response for when the token does not exist:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                invalid_length_token:
+                  description: |
+                    A typical failed JSON response for when the token's length is invalid
+                    or it is empty:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Empty or invalid length token",
+                      "code": "BAD_REQUEST",
+                    }
+                token_does_not_exist:
+                  description: |
+                    A typical failed JSON response for when the token does not exist:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Token does not exist",
+                      "code": "BAD_REQUEST",
+                    }
   /users/me/android_gcm_reg_id:
     post:
       deprecated: true
@@ -13391,28 +13472,27 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - description: |
-                          A typical failed JSON response for when the token's length is invalid
-                          or is empty:
-                        example:
-                          {
-                            "result": "error",
-                            "msg": "Empty or invalid length token",
-                            "code": "BAD_REQUEST",
-                          }
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Token does not exist",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          A typical failed JSON response for when the token does not exist:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                invalid_length_token:
+                  description: |
+                    A typical failed JSON response for when the token's length is invalid
+                    or is empty:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Empty or invalid length token",
+                      "code": "BAD_REQUEST",
+                    }
+                token_does_not_exist:
+                  description: |
+                    A typical failed JSON response for when the token does not exist:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Token does not exist",
+                      "code": "BAD_REQUEST",
+                    }
   /users/{user_id}/subscriptions/{stream_id}:
     get:
       operationId: get-subscription-status
@@ -15967,72 +16047,70 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/InvitationFailedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Some of those addresses are already using Zulip, so we didn't send them an invitation. We did send invitations to everyone else!",
-                            "errors":
-                              [
-                                [
-                                  "hamlet@zulip.com",
-                                  "Already has an account.",
-                                  false,
-                                ],
-                              ],
-                            "sent_invitations": true,
-                            "license_limit_reached": false,
-                            "daily_limit_reached": false,
-                            "code": "INVITATION_FAILED",
-                          }
-                        description: |
-                          An example JSON error response for when some of the specified email addresses
-                          have existing Zulip accounts.
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "Insufficient permission",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON error response for when the user doesn't have permission
-                          to send invitations.
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "You must specify at least one email address.",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON error response for when no email address is specified.
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "Invalid channel ID 11. No invites were sent.",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON error response for when any of the specified channels
-                          does not exist or the user does not have permission to access one of
-                          the targeted channels.
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "You do not have permission to subscribe other users to channels.",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON error response for when the user doesn't have permission
-                          to subscribe other users to channels and `stream_ids` is not empty.
+                  - $ref: "#/components/schemas/InvitationFailedError"
+                  - $ref: "#/components/schemas/CodedError"
+              examples:
+                invitation_failed:
+                  description: |
+                    An example JSON error response for when some of the specified email addresses
+                    have existing Zulip accounts.
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Some of those addresses are already using Zulip, so we didn't send them an invitation. We did send invitations to everyone else!",
+                      "errors":
+                        [
+                          [
+                            "hamlet@zulip.com",
+                            "Already has an account.",
+                            false,
+                          ],
+                        ],
+                      "sent_invitations": true,
+                      "license_limit_reached": false,
+                      "daily_limit_reached": false,
+                      "code": "INVITATION_FAILED",
+                    }
+                insufficient_permission:
+                  description: |
+                    An example JSON error response for when the user doesn't have permission
+                    to send invitations.
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "Insufficient permission",
+                      "result": "error",
+                    }
+                no_email_specified:
+                  description: |
+                    An example JSON error response for when no email address is specified.
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "You must specify at least one email address.",
+                      "result": "error",
+                    }
+                invalid_channel:
+                  description: |
+                    An example JSON error response for when any of the specified channels
+                    does not exist or the user does not have permission to access one of
+                    the targeted channels.
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "Invalid channel ID 11. No invites were sent.",
+                      "result": "error",
+                    }
+                no_permission_to_subscribe:
+                  description: |
+                    An example JSON error response for when the user doesn't have permission
+                    to subscribe other users to channels and `stream_ids` is not empty.
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "You do not have permission to subscribe other users to channels.",
+                      "result": "error",
+                    }
   /invites/multiuse:
     post:
       operationId: create-invite-link
@@ -16182,41 +16260,39 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "Insufficient permission",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON error response for when the user doesn't have permission
-                          to send invitations.
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "Invalid channel ID 11. No invites were sent.",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON error response for when any of the specified channels
-                          does not exist or the user does not have permission to access one of
-                          the targeted channels.
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "You do not have permission to subscribe other users to channels.",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON error response for when the user doesn't have permission
-                          to subscribe other users to channels and `stream_ids` is not empty.
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                insufficient_permission:
+                  description: |
+                    An example JSON error response for when the user doesn't have permission
+                    to send invitations.
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "Insufficient permission",
+                      "result": "error",
+                    }
+                invalid_channel:
+                  description: |
+                    An example JSON error response for when any of the specified channels
+                    does not exist or the user does not have permission to access one of
+                    the targeted channels.
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "Invalid channel ID 11. No invites were sent.",
+                      "result": "error",
+                    }
+                no_permission_to_subscribe:
+                  description: |
+                    An example JSON error response for when the user doesn't have permission
+                    to subscribe other users to channels and `stream_ids` is not empty.
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "You do not have permission to subscribe other users to channels.",
+                      "result": "error",
+                    }
   /invites/{invite_id}:
     delete:
       operationId: revoke-email-invite
@@ -16244,17 +16320,17 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "No such invitation",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          A typical failed JSON response for an invalid email invitation ID:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                no_such_invitation:
+                  description: |
+                    A typical failed JSON response for an invalid email invitation ID:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "No such invitation",
+                      "code": "BAD_REQUEST",
+                    }
   /invites/multiuse/{invite_id}:
     delete:
       operationId: revoke-invite-link
@@ -16285,28 +16361,27 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "No such invitation",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          A typical failed JSON response for an invalid invitation link ID:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "Invitation has already been revoked",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          A typical failed JSON response for when the invitation link has already
-                          been revoked:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                no_such_invitation:
+                  description: |
+                    A typical failed JSON response for an invalid invitation link ID:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "No such invitation",
+                      "code": "BAD_REQUEST",
+                    }
+                already_revoked:
+                  description: |
+                    A typical failed JSON response for when the invitation link has already
+                    been revoked:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "Invitation has already been revoked",
+                      "code": "BAD_REQUEST",
+                    }
   /invites/{invite_id}/resend:
     post:
       operationId: resend-email-invite
@@ -16334,17 +16409,17 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "result": "error",
-                            "msg": "No such invitation",
-                            "code": "BAD_REQUEST",
-                          }
-                        description: |
-                          A typical failed JSON response for an invalid email invitation ID:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                no_such_invitation:
+                  description: |
+                    A typical failed JSON response for an invalid email invitation ID:
+                  value:
+                    {
+                      "result": "error",
+                      "msg": "No such invitation",
+                      "code": "BAD_REQUEST",
+                    }
   /realm/test_welcome_bot_custom_message:
     post:
       operationId: test-welcome-bot-custom-message
@@ -23140,32 +23215,54 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/InvalidChannelError"
-                      - description: |
-                          An example JSON response for when the supplied channel does not exist:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "Invalid parameters",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON response for when invalid combination of channel permission
-                          parameters are passed:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "A moderation request channel cannot be public.",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON response for when trying to set moderation request channel to
-                          be public:
+                  - $ref: "#/components/schemas/IncompatibleParametersError"
+                  - $ref: "#/components/schemas/TopicConfigurationError"
+                  - $ref: "#/components/schemas/CodedError"
+              examples:
+                invalid_channel:
+                  description: |
+                    An example JSON response for when the supplied
+                    channel does not exist.
+                  value:
+                    {
+                      "msg": "Invalid channel ID",
+                      "code": "BAD_REQUEST",
+                      "result": "error",
+                    }
+                invalid_parameters:
+                  description: |
+                    An example JSON response for when an invalid
+                    combination of channel permission parameters are
+                    passed.
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "Unsupported parameter combination: history_public_to_subscribers, can_create_topic_group",
+                      "result": "error",
+                      "parameters": "history_public_to_subscribers, can_create_topic_group",
+                    }
+                topic_configuration:
+                  description: |
+                    An example JSON response for when the topics policy
+                    change requires all messages to be in the general
+                    chat topic.
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "To enable this configuration, all messages in this channel must be in the general chat topic. Consider renaming or deleting other topics.",
+                      "empty_topic_display_name": "general chat",
+                      "result": "error",
+                    }
+                moderation_request_channel_public:
+                  description: |
+                    An example JSON response for when trying to set a
+                    moderation request channel to be public.
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "A moderation request channel cannot be public.",
+                      "result": "error",
+                    }
   /streams/{stream_id}/email_address:
     get:
       operationId: get-stream-email-address
@@ -23770,17 +23867,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: "#/components/schemas/CodedError"
-                  - example:
-                      {
-                        result: "error",
-                        msg: "Channel 'discussions' already exists",
-                        code: "CHANNEL_ALREADY_EXISTS",
-                      }
-                    description: |
-                      An example JSON error response for when a channel with the submitted
-                      name already exists.
+                $ref: "#/components/schemas/ChannelAlreadyExistsError"
   /user_groups/create:
     post:
       operationId: create-user-group
@@ -24734,38 +24821,38 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "Invalid user group",
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON response when the user group ID is invalid.
-                  - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "CANNOT_DEACTIVATE_GROUP_IN_USE",
-                            "msg": "Cannot deactivate user group in use.",
-                            "objections":
-                              [
-                                {
-                                  "type": "realm",
-                                  "settings":
-                                    ["can_create_public_channel_group"],
-                                },
-                              ],
-                            "result": "error",
-                          }
-                        description: |
-                          An example JSON response when the user group being deactivated
-                          is used for a setting or as a subgroup.
+                  - $ref: "#/components/schemas/CannotDeactivateGroupInUseError"
+                  - $ref: "#/components/schemas/CodedError"
+              examples:
+                invalid_user_group:
+                  description: |
+                    An example JSON response when the user group ID is invalid.
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "Invalid user group",
+                      "result": "error",
+                    }
+                cannot_deactivate_group_in_use:
+                  description: |
+                    An example JSON response when the user group being deactivated
+                    is used for a setting or as a subgroup.
 
-                          **Changes**: New in Zulip 10.0 (feature level 298). Previously,
-                          this error returned the `"BAD_REQUEST"` code.
+                    **Changes**: New in Zulip 10.0 (feature level 298). Previously,
+                    this error returned the `"BAD_REQUEST"` code.
+                  value:
+                    {
+                      "code": "CANNOT_DEACTIVATE_GROUP_IN_USE",
+                      "msg": "Cannot deactivate user group in use.",
+                      "objections":
+                        [
+                          {
+                            "type": "realm",
+                            "settings": ["can_create_public_channel_group"],
+                          },
+                        ],
+                      "result": "error",
+                    }
   /channel_folders/create:
     post:
       operationId: create-channel-folder
@@ -25096,27 +25183,78 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/InvalidApiKeyError"
                   - $ref: "#/components/schemas/MissingArgumentError"
                   - $ref: "#/components/schemas/IncompatibleParametersError"
-                  - $ref: "#/components/schemas/UserNotAuthorizedError"
+                  - $ref: "#/components/schemas/CodedError"
+              examples:
+                invalid_api_key:
+                  description: |
+                    ### Invalid API key
+
+                    A typical failed JSON response for when the API key is invalid.
+                  value:
+                    {
+                      "code": "INVALID_API_KEY",
+                      "msg": "Invalid API key",
+                      "result": "error",
+                    }
+                user_not_authorized:
+                  description: |
+                    ### User not authorized for query
+
+                    A typical failed JSON response for when the user is not authorized for
+                    a query.
+                  value:
+                    {
+                      "code": "BAD_REQUEST",
+                      "msg": "User not authorized for this query",
+                      "result": "error",
+                    }
         "401":
           description: |
             Unauthorized.
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/UserDeactivatedError"
-                  - $ref: "#/components/schemas/RealmDeactivatedError"
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                user_deactivated:
+                  description: |
+                    ### User account deactivated
+
+                    A typical failed json response for when user's account is deactivated.
+
+                    **Changes**: As of Zulip 5.0 (feature level 76), these errors use the
+                    HTTP 401 status code. Before this feature level, they used the HTTP 403
+                    status code.
+                  value:
+                    {
+                      "code": "USER_DEACTIVATED",
+                      "msg": "Account is deactivated",
+                      "result": "error",
+                    }
+                realm_deactivated:
+                  description: |
+                    ### Realm deactivated
+
+                    A typical failed json response for when user's organization is deactivated.
+
+                    **Changes**: As of Zulip 5.0 (feature level 76), these errors use the
+                    HTTP 401 status code. Before this feature level, they used the HTTP 403
+                    status code.
+                  value:
+                    {
+                      "code": "REALM_DEACTIVATED",
+                      "msg": "This organization is deactivated",
+                      "result": "error",
+                    }
         "429":
           description: |
             Rate limit exceeded.
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/RateLimitedError"
+                $ref: "#/components/schemas/RateLimitedError"
   /zulip-outgoing-webhook:
     post:
       operationId: zulip-outgoing-webhooks


### PR DESCRIPTION
Claude's description:

  Previously, validate_test_response() had a blanket skip for all 4xx/502 responses        
  (https://github.com/zulip/zulip/pull/37719#discussion_r2796250995), meaning error
  response schemas in zulip.yaml were never validated against actual server responses
  during tests. This allowed several categories of problems to go undetected:

  - oneOf unions where every subschema was structurally identical (e.g., multiple
  CodedError entries differing only in example/description), violating oneOf semantics
  since a response matches all branches
  - Error responses with extra fields not declared in any schema
  - retry-after in RateLimitedError typed as integer when the server returns a float

  This PR fixes all broken error response schemas in zulip.yaml and then enables validation
   for documented error responses in the test suite, so these kinds of issues are caught
  going forward.

  The series of commits:

  1. Prepare Python tooling for media-type-level examples: Update get_schema(),
  get_openapi_fixture(), generate_openapi_fixture(), and test_attributes to support the
  media-type-level examples pattern (examples at the response content level rather than
  embedded in each oneOf subschema). This is backward-compatible with the existing
  per-subschema pattern.
  2. Add component schemas for error response validation: Add required fields to 5 existing
   error schemas so they're structurally distinguishable from CodedError in oneOf unions.
  Create 4 new error schemas for responses with extra fields
  (MoveMessagesTimeLimitExceededError, ChannelAlreadyExistsError, TopicConfigurationError,
  CannotDeactivateGroupInUseError). Fix RateLimitedError's retry-after type.
  3. Fix broken oneOf error response schemas: Convert ~30 endpoints to use correct OpenAPI
  3.0 patterns — collapsing all-identical oneOf entries into a single schema with
  media-type-level examples, unwrapping single-entry oneOf, and ensuring mixed-schema oneOf
   unions have structurally distinguishable schemas.
  4. Enable error response validation: Replace the blanket 4xx/502 skip with targeted logic
   that validates documented error responses while skipping undocumented ones and framework
   error codes (REQUEST_VARIABLE_MISSING, etc.) that are documented centrally at
  /rest-error-handling.

  Test plan

  - ./tools/test-backend zerver.tests.test_openapi — all 21 tests pass with each commit
  - ./tools/test-backend across 11 modules (746 tests) that exercise error responses — all
  pass with validation enabled
  - ./tools/lint zerver/openapi/openapi.py zerver/openapi/zulip.yaml

  Fixes part of #37719.

-----------------

Generated with Claude Code with significant prompting on strategy and commit structure. I'm not sure it's perfect but Claude did write a helper tool to do before/after diff of the generated HTML and used it. 