### PR TITLE
left_sidebar: Fix bug where viewing all DMs didn't highlight header.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -289,7 +289,11 @@
     position: sticky;
     top: 0;
     z-index: 3;
-    background-color: var(--color-background);
+
+    /* The active direct messages section has a different background color */
+    &:not(.active-direct-messages-section) {
+        background-color: var(--color-background);
+    }
 
     /* Prevent hover styles set on other rows when zoomed in. */
     &:not(.zoom-in):hover {


### PR DESCRIPTION
Fixes bug introduced in #37902

Before:

<img width="317" height="432" alt="image" src="https://github.com/user-attachments/assets/921606a0-4d82-4f0c-87f3-49781853942a" />


After:

<img width="327" height="445" alt="image" src="https://github.com/user-attachments/assets/be590c74-a949-42bc-b0f7-134689296225" />
