### PR TITLE
Introduce ImmutableMessage class.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -171,6 +171,7 @@ EXEMPT_FILES = make_set(
         "web/src/message_report.ts",
         "web/src/message_scroll.ts",
         "web/src/message_scroll_state.ts",
+        "web/src/message_store.ts",
         "web/src/message_summary.ts",
         "web/src/message_util.ts",
         "web/src/message_view.ts",

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -252,9 +252,7 @@ export function initialize(): void {
         }
 
         const message_id = rows.id($(this).closest(".message_row"));
-        const message = message_store.get(message_id);
-        assert(message !== undefined);
-        starred_messages_ui.toggle_starred_and_update_server(message);
+        starred_messages_ui.toggle_starred_and_update_server(message_id);
     });
 
     $("#main_div").on("click", ".message_reaction", function (this: HTMLElement, e) {

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -259,15 +259,15 @@ export function update_recipient_text_for_reply_button(
 }
 
 function can_user_reply_to_message(message_id: number): boolean {
-    const selected_message = message_store.get(message_id);
+    const selected_message = message_store.maybe_get_immutable_message(message_id);
     if (selected_message === undefined) {
         return false;
     }
-    if (selected_message.is_stream) {
+    if (selected_message.is_stream()) {
         return !should_disable_compose_reply_button_for_stream();
     }
-    assert(selected_message.is_private);
-    return message_util.user_can_send_direct_message(selected_message.to_user_ids);
+    assert(selected_message.is_private());
+    return message_util.user_can_send_direct_message(selected_message.to_user_ids());
 }
 
 export function initialize(): void {

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -905,11 +905,11 @@ function get_stream_topic_data(input_element: TypeaheadInputElement): {
     const $message_row = input_element.$element.closest(".message_row");
     if ($message_row.length === 1) {
         // we are editing a message so we try to use its keys.
-        const msg = message_store.get(rows.id($message_row));
+        const msg = message_store.maybe_get_immutable_message(rows.id($message_row));
         assert(msg !== undefined);
-        if (msg.type === "stream") {
-            stream_id = msg.stream_id;
-            topic = msg.topic;
+        if (msg.get_type() === "stream") {
+            stream_id = msg.get_stream_id();
+            topic = msg.get_topic_name();
         }
     } else {
         stream_id = compose_state.stream_id();

--- a/web/src/desktop_integration.ts
+++ b/web/src/desktop_integration.ts
@@ -34,23 +34,23 @@ export function initialize(): void {
     // to narrow to the message being sent.
     electron_bridge.set_send_notification_reply_message_supported?.(true);
     electron_bridge.on_event("send_notification_reply_message", (message_id, reply) => {
-        const message = message_store.get(message_id);
+        const message = message_store.maybe_get_immutable_message(message_id);
         assert(message !== undefined);
         const data = {
-            type: message.type,
+            type: message.get_type(),
             content: reply,
-            ...(message.type === "private"
+            ...(message.get_type() === "private"
                 ? {
-                      to: message.reply_to,
+                      to: message.get_reply_to(),
                   }
                 : {
-                      to: stream_data.get_stream_name_from_id(message.stream_id),
-                      topic: message.topic,
+                      to: stream_data.get_stream_name_from_id(message.get_stream_id()),
+                      topic: message.get_topic_name(),
                   }),
         };
 
         const success = (): void => {
-            if (message.type === "stream") {
+            if (message.get_type() === "stream") {
                 message_view.narrow_by_topic(message_id, {trigger: "desktop_notification_reply"});
             } else {
                 message_view.narrow_by_recipient(message_id, {

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1735,17 +1735,9 @@ export class Filter {
 
     first_valid_id_from(msg_ids: number[]): number | undefined {
         const predicate = this.predicate();
-
-        const first_id = msg_ids.find((msg_id) => {
-            const message = message_store.get(msg_id);
-
-            if (message === undefined) {
-                return false;
-            }
-
-            return predicate(message);
-        });
-
+        const first_id = msg_ids.find((msg_id) =>
+            message_store.does_message_pass_predicate(msg_id, predicate),
+        );
         return first_id;
     }
 
@@ -1888,7 +1880,7 @@ export class Filter {
 
         if (!message) {
             const message_id = Number.parseInt(this.terms_with_operator("with")[0]!.operand, 10);
-            message = message_store.get(message_id);
+            message = message_store.get_message_for_performant_code(message_id);
         }
 
         if (!message) {

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -1412,7 +1412,7 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
         case "message_actions":
             return message_actions_popover.toggle_message_actions_menu(msg);
         case "star_message":
-            starred_messages_ui.toggle_starred_and_update_server(msg);
+            starred_messages_ui.toggle_starred_and_update_server(msg.id);
             return true;
         case "toggle_conversation_view":
             if (narrow_state.narrowed_by_topic_reply()) {

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -510,11 +510,11 @@ export function parse_media_data(media: HTMLMediaElement | HTMLImageElement): Me
             return payload;
         }
 
-        const message = message_store.get(message_id);
+        const message = message_store.maybe_get_immutable_message(message_id);
         if (message === undefined) {
             blueslip.error("Lightbox for unknown message", {message_id});
         } else {
-            sender_full_name = message.sender_full_name;
+            sender_full_name = message.get_sender_full_name();
         }
     }
 

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1535,10 +1535,12 @@ export function edit_last_sent_message(): void {
         return;
     }
 
-    const current_selected_msg = message_store.get(message_lists.current.selected_id());
+    const current_selected_msg = message_store.maybe_get_immutable_message(
+        message_lists.current.selected_id(),
+    );
     if (
         current_selected_msg &&
-        current_selected_msg.id < last_sent_msg.id &&
+        current_selected_msg.get_id() < last_sent_msg.id &&
         message_lists.current.can_mark_messages_read()
     ) {
         // If there are any unread messages between the selected message and the
@@ -1546,7 +1548,7 @@ export function edit_last_sent_message(): void {
         // marking messages as read unintentionally.
         let num_unread = 0;
         for (const msg of message_lists.current.all_messages()) {
-            if (current_selected_msg.id < msg.id && msg.id < last_sent_msg.id && msg.unread) {
+            if (current_selected_msg.get_id() < msg.id && msg.id < last_sent_msg.id && msg.unread) {
                 num_unread += 1;
             }
         }

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -276,6 +276,10 @@ export class ImmutableMessage {
     is_private(): boolean {
         return this.message.is_private;
     }
+
+    get_sender_email(): string {
+        return this.message.sender_email;
+    }
 }
 
 export function maybe_get_immutable_message(message_id: number): ImmutableMessage | undefined {

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -253,6 +253,11 @@ class ImmutableMessage {
     get_reply_to(): string {
         return this.message.reply_to;
     }
+
+    to_user_ids(): string {
+        assert(this.message.type === "private");
+        return this.message.to_user_ids;
+    }
 }
 
 export function maybe_get_immutable_message(message_id: number): ImmutableMessage | undefined {

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
 import * as blueslip from "./blueslip.ts";
@@ -228,6 +229,35 @@ export type Message = (
               display_reply_to: undefined;
           }
     );
+
+class ImmutableMessage {
+    private message: Message;
+    constructor(message: Message) {
+        this.message = message;
+    }
+
+    get_type(): string {
+        return this.message.type;
+    }
+
+    get_stream_id(): number {
+        assert(this.message.type === "stream");
+        return this.message.stream_id;
+    }
+
+    get_topic_name(): string {
+        assert(this.message.type === "stream");
+        return this.message.topic;
+    }
+}
+
+export function maybe_get_immutable_message(message_id: number): ImmutableMessage | undefined {
+    const message = stored_messages.get(message_id)?.message;
+    if (message) {
+        return new ImmutableMessage(message);
+    }
+    return undefined;
+}
 
 export function update_message_cache(message_data: ProcessedMessage): void {
     // You should only call this from message_helper (or in tests).

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -258,6 +258,14 @@ class ImmutableMessage {
         assert(this.message.type === "private");
         return this.message.to_user_ids;
     }
+
+    is_stream(): boolean {
+        return this.message.is_stream;
+    }
+
+    is_private(): boolean {
+        return this.message.is_private;
+    }
 }
 
 export function maybe_get_immutable_message(message_id: number): ImmutableMessage | undefined {

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -292,6 +292,18 @@ export class ImmutableMessage {
     get_id(): number {
         return this.message.id;
     }
+
+    is_stream_wildcard_mentioned(): boolean {
+        return this.message.stream_wildcard_mentioned;
+    }
+
+    did_mention_me_directly(): boolean {
+        return this.message.mentioned_me_directly;
+    }
+
+    is_topic_wildcard_mentioned(): boolean {
+        return this.message.topic_wildcard_mentioned;
+    }
 }
 
 export function maybe_get_immutable_message(message_id: number): ImmutableMessage | undefined {

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -249,6 +249,10 @@ class ImmutableMessage {
         assert(this.message.type === "stream");
         return this.message.topic;
     }
+
+    get_reply_to(): string {
+        return this.message.reply_to;
+    }
 }
 
 export function maybe_get_immutable_message(message_id: number): ImmutableMessage | undefined {

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -284,6 +284,10 @@ export class ImmutableMessage {
     get_sender_id(): number {
         return this.message.sender_id;
     }
+
+    get_sender_full_name(): string {
+        return this.message.sender_full_name;
+    }
 }
 
 export function maybe_get_immutable_message(message_id: number): ImmutableMessage | undefined {

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -304,6 +304,15 @@ export class ImmutableMessage {
     is_topic_wildcard_mentioned(): boolean {
         return this.message.topic_wildcard_mentioned;
     }
+
+    get_timestamp(): number {
+        return this.message.timestamp;
+    }
+
+    get_display_reply_to(): string {
+        assert(this.message.type === "private");
+        return this.message.display_reply_to;
+    }
 }
 
 export function maybe_get_immutable_message(message_id: number): ImmutableMessage | undefined {

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -230,7 +230,17 @@ export type Message = (
           }
     );
 
-class ImmutableMessage {
+export function maybe_get_clean_reactions(
+    message_id: number,
+): Map<string, MessageCleanReaction> | undefined {
+    const message = get(message_id);
+    if (!message) {
+        return undefined;
+    }
+    return message.clean_reactions;
+}
+
+export class ImmutableMessage {
     private message: Message;
     constructor(message: Message) {
         this.message = message;

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -253,6 +253,25 @@ export function get(message_id: number): Message | undefined {
     return stored_messages.get(message_id)?.message;
 }
 
+export function does_message_pass_predicate(
+    msg_id: number,
+    predicate: (message: Message) => boolean,
+): boolean {
+    const message = get(msg_id);
+
+    if (message === undefined) {
+        return false;
+    }
+
+    return predicate(message);
+}
+
+// Required by callers like the ones in filter.ts that we are sure won't be
+// mutating the message struct.
+export function get_message_for_performant_code(message_id: number): Message | undefined {
+    return stored_messages.get(message_id)?.message;
+}
+
 export function set_messages_for_tests(messages: ProcessedMessage[]): void {
     stored_messages.clear();
     for (const message of messages) {

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -288,6 +288,10 @@ export class ImmutableMessage {
     get_sender_full_name(): string {
         return this.message.sender_full_name;
     }
+
+    get_id(): number {
+        return this.message.id;
+    }
 }
 
 export function maybe_get_immutable_message(message_id: number): ImmutableMessage | undefined {

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -253,6 +253,13 @@ export function get(message_id: number): Message | undefined {
     return stored_messages.get(message_id)?.message;
 }
 
+export function set_messages_for_tests(messages: ProcessedMessage[]): void {
+    stored_messages.clear();
+    for (const message of messages) {
+        stored_messages.set(message.message.id, message);
+    }
+}
+
 export function get_pm_emails(
     message: Message | MessageWithBooleans | LocalMessageWithBooleans,
 ): string {

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -280,6 +280,10 @@ export class ImmutableMessage {
     get_sender_email(): string {
         return this.message.sender_email;
     }
+
+    get_sender_id(): number {
+        return this.message.sender_id;
+    }
 }
 
 export function maybe_get_immutable_message(message_id: number): ImmutableMessage | undefined {

--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -62,16 +62,16 @@ export function get_topics_for_message_ids(message_ids: number[]): Map<string, [
     const topics = new Map<string, [number, string]>(); // key = stream_id:topic
     for (const msg_id of message_ids) {
         // message_store still has data on deleted messages when this runs.
-        const message = message_store.get(msg_id);
+        const message = message_store.maybe_get_immutable_message(msg_id);
         if (message === undefined) {
             // We may not have the deleted message cached locally in
             // message_store; if so, we can just skip processing it.
             continue;
         }
-        if (message.type === "stream") {
+        if (message.get_type() === "stream") {
             // Create unique keys for stream_id and topic.
-            const topic_key = message.stream_id + ":" + message.topic;
-            topics.set(topic_key, [message.stream_id, message.topic]);
+            const topic_key = message.get_stream_id() + ":" + message.get_topic_name();
+            topics.set(topic_key, [message.get_stream_id(), message.get_topic_name()]);
         }
     }
     return topics;

--- a/web/src/read_receipts.ts
+++ b/web/src/read_receipts.ts
@@ -25,10 +25,10 @@ let interval_id: number | null = null;
 let has_initial_data = false;
 
 export function fetch_read_receipts(message_id: number): void {
-    const message = message_store.get(message_id);
+    const message = message_store.maybe_get_immutable_message(message_id);
     assert(message !== undefined, "message is undefined");
 
-    if (message.sender_email === "notification-bot@zulip.com") {
+    if (message.get_sender_email() === "notification-bot@zulip.com") {
         $("#read_receipts_modal .read_receipts_info").text(
             $t({
                 defaultMessage: "Read receipts are not available for Notification Bot messages.",

--- a/web/src/recent_senders.ts
+++ b/web/src/recent_senders.ts
@@ -174,11 +174,11 @@ export function process_topic_edit(opts: {
     // the messages were moved to another stream or deleted.
 
     for (const message_id of message_ids) {
-        const message = message_store.get(message_id);
+        const message = message_store.maybe_get_immutable_message(message_id);
         if (!message) {
             continue;
         }
-        const sender_id = message.sender_id;
+        const sender_id = message.get_sender_id();
 
         remove_topic_message({stream_id: old_stream_id, topic: old_topic, sender_id, message_id});
         add_topic_message({stream_id: new_stream_id, topic: new_topic, sender_id, message_id});
@@ -189,14 +189,14 @@ export function process_topic_edit(opts: {
 
 export function update_topics_of_deleted_message_ids(message_ids: number[]): void {
     for (const message_id of message_ids) {
-        const message = message_store.get(message_id);
-        if (!message || message.type !== "stream") {
+        const message = message_store.maybe_get_immutable_message(message_id);
+        if (message?.get_type() !== "stream") {
             continue;
         }
 
-        const stream_id = message.stream_id;
-        const topic = message.topic;
-        const sender_id = message.sender_id;
+        const stream_id = message.get_stream_id();
+        const topic = message.get_topic_name();
+        const sender_id = message.get_sender_id();
 
         remove_topic_message({stream_id, topic, sender_id, message_id});
     }

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1312,24 +1312,24 @@ function channel_sort(a: Row, b: Row): number {
 
 function conversation_sort(a: Row, b: Row): number {
     if (a.type === b.type) {
-        const a_msg = message_store.get(a.last_msg_id);
+        const a_msg = message_store.maybe_get_immutable_message(a.last_msg_id);
         assert(a_msg !== undefined);
-        const b_msg = message_store.get(b.last_msg_id);
+        const b_msg = message_store.maybe_get_immutable_message(b.last_msg_id);
         assert(b_msg !== undefined);
 
-        if (a_msg.type === "stream") {
-            assert(b_msg.type === "stream");
-            const a_stream_name = stream_data.get_stream_name_from_id(a_msg.stream_id);
-            const b_stream_name = stream_data.get_stream_name_from_id(b_msg.stream_id);
+        if (a_msg.get_type() === "stream") {
+            assert(b_msg.get_type() === "stream");
+            const a_stream_name = stream_data.get_stream_name_from_id(a_msg.get_stream_id());
+            const b_stream_name = stream_data.get_stream_name_from_id(b_msg.get_stream_id());
 
             if (a_stream_name === b_stream_name) {
-                return sort_comparator(a_msg.topic, b_msg.topic);
+                return sort_comparator(a_msg.get_topic_name(), b_msg.get_topic_name());
             }
             return sort_comparator(a_stream_name, b_stream_name);
         }
-        assert(a_msg.type === "private");
-        assert(b_msg.type === "private");
-        return sort_comparator(a_msg.display_reply_to, b_msg.display_reply_to);
+        assert(a_msg.get_type() === "private");
+        assert(b_msg.get_type() === "private");
+        return sort_comparator(a_msg.get_display_reply_to(), b_msg.get_display_reply_to());
     }
     // if type is not same sort between "private" and "stream"
     return sort_comparator(a.type, b.type);
@@ -1562,9 +1562,9 @@ export function update_recent_view_rendered_time(): void {
     // only update it when the user comes back from idle which has
     // maximum chance of user seeing incorrect rendered time.
     for (const conversation_data of topics_widget.get_rendered_list()) {
-        const last_msg = message_store.get(conversation_data.last_msg_id);
+        const last_msg = message_store.maybe_get_immutable_message(conversation_data.last_msg_id);
         assert(last_msg !== undefined);
-        const time = new Date(last_msg.timestamp * 1000);
+        const time = new Date(last_msg.get_timestamp() * 1000);
         const updated_time = timerender.relative_time_string_from_date(time, true);
         const $row = get_topic_row(conversation_data);
         const rendered_time = $row.find(".recent_topic_timestamp").text().trim();
@@ -1659,12 +1659,12 @@ function has_unread(row: number): boolean {
     const current_row = topics_widget.get_current_list()[row];
     assert(current_row !== undefined);
     const last_msg_id = current_row.last_msg_id;
-    const last_msg = message_store.get(last_msg_id);
+    const last_msg = message_store.maybe_get_immutable_message(last_msg_id);
     assert(last_msg !== undefined);
-    if (last_msg.type === "stream") {
-        return unread.num_unread_for_topic(last_msg.stream_id, last_msg.topic) > 0;
+    if (last_msg.get_type() === "stream") {
+        return unread.num_unread_for_topic(last_msg.get_stream_id(), last_msg.get_topic_name()) > 0;
     }
-    return unread.num_unread_for_user_ids_string(last_msg.to_user_ids) > 0;
+    return unread.num_unread_for_user_ids_string(last_msg.to_user_ids()) > 0;
 }
 
 export function focus_clicked_element(

--- a/web/src/starred_messages.ts
+++ b/web/src/starred_messages.ts
@@ -37,7 +37,7 @@ export function get_count_in_topic(stream_id?: number, topic?: string): number {
     }
 
     const messages = [...starred_ids].filter((id) => {
-        const message = message_store.get(id);
+        const message = message_store.maybe_get_immutable_message(id);
 
         if (message === undefined) {
             // We know the `id` from the initial data fetch from page_params,
@@ -54,9 +54,9 @@ export function get_count_in_topic(stream_id?: number, topic?: string): number {
         }
 
         return (
-            message.type === "stream" &&
-            message.stream_id === stream_id &&
-            message.topic.toLowerCase() === topic.toLowerCase()
+            message.get_type() === "stream" &&
+            message.get_stream_id() === stream_id &&
+            message.get_topic_name().toLowerCase() === topic.toLowerCase()
         );
     });
 

--- a/web/src/starred_messages_ui.ts
+++ b/web/src/starred_messages_ui.ts
@@ -7,7 +7,6 @@ import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area.ts
 import * as message_flags from "./message_flags.ts";
 import * as message_live_update from "./message_live_update.ts";
 import * as message_store from "./message_store.ts";
-import type {Message} from "./message_store.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as starred_messages from "./starred_messages.ts";
 import * as sub_store from "./sub_store.ts";
@@ -15,7 +14,11 @@ import * as unread_ops from "./unread_ops.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
 
-export function toggle_starred_and_update_server(message: Message): void {
+export function toggle_starred_and_update_server(message_id: number): void {
+    const message = message_store.get(message_id);
+    if (message === undefined) {
+        return;
+    }
     if (message.locally_echoed) {
         // This is defensive code for when you hit the "*" key
         // before we get a server ack.  It's rare that somebody

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -632,17 +632,20 @@ class UnreadTopicCounter {
 const unread_topic_counter = new UnreadTopicCounter();
 
 function add_message_to_unread_mentions(message_id: number): void {
-    const message = message_store.get(message_id);
-    if (message?.type === "stream") {
-        const topic_key = recent_view_util.get_topic_key(message.stream_id, message.topic);
+    const message = message_store.maybe_get_immutable_message(message_id);
+    if (message?.get_type() === "stream") {
+        const topic_key = recent_view_util.get_topic_key(
+            message.get_stream_id(),
+            message.get_topic_name(),
+        );
         const topic_message_ids = unread_mention_topics.get(topic_key);
         if (topic_message_ids !== undefined) {
             topic_message_ids.add(message_id);
         } else {
             unread_mention_topics.set(topic_key, new Set([message_id]));
         }
-    } else if (message?.type === "private") {
-        const user_ids_string = message.to_user_ids;
+    } else if (message?.get_type() === "private") {
+        const user_ids_string = message.to_user_ids();
         const dm_message_ids = unread_mention_dms.get(user_ids_string);
         if (dm_message_ids !== undefined) {
             dm_message_ids.add(message_id);

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -13,7 +13,7 @@ const blueslip = require("./lib/zblueslip.cjs");
 const $ = require("./lib/zjquery.cjs");
 const {page_params} = require("./lib/zpage_params.cjs");
 
-const message_store = mock_esm("../src/message_store");
+const message_store = zrequire("message_store");
 const user_topics = mock_esm("../src/user_topics");
 
 const resolved_topic = zrequire("resolved_topic");
@@ -2095,22 +2095,36 @@ test("term_type", () => {
     assert.ok(!filter._build_sorted_term_types_called);
 });
 
-test("first_valid_id_from", ({override}) => {
+test("first_valid_id_from", () => {
     const terms = [{operator: "is", operand: "alerted"}];
 
     const filter = new Filter(terms);
 
-    const messages = {
-        5: {id: 5, alerted: true},
-        10: {id: 10},
-        20: {id: 20, alerted: true},
-        30: {id: 30, type: stream_message},
-        40: {id: 40, alerted: false},
-    };
+    const messages = [
+        {
+            message: {
+                id: 5,
+                alerted: true,
+            },
+        },
+        {
+            message: {
+                id: 12,
+            },
+        },
+        {
+            message: {id: 20, alerted: true},
+        },
+        {
+            message: {id: 30, type: stream_message},
+        },
+        {
+            message: {id: 40, alerted: false},
+        },
+    ];
 
+    message_store.set_messages_for_tests(messages);
     const msg_ids = [10, 20, 30, 40];
-
-    override(message_store, "get", (msg_id) => messages[msg_id]);
 
     assert.equal(filter.first_valid_id_from([999]), undefined);
 
@@ -2161,30 +2175,39 @@ test("convert_suggestion_to_term", () => {
     );
 });
 
-test("try_adjusting_for_moved_with_target", ({override}) => {
+test("try_adjusting_for_moved_with_target", () => {
     const scotland_id = new_stream_id();
     make_sub("Scotland", scotland_id);
     const verona_id = new_stream_id();
     make_sub("Verona", verona_id);
-    const messages = {
-        12: {
-            type: "stream",
-            stream_id: scotland_id,
-            display_recipient: "Scotland",
-            topic: "Test 1",
-            id: 12,
+    const messages = [
+        {
+            message: {
+                type: "stream",
+                stream_id: scotland_id,
+                display_recipient: "Scotland",
+                topic: "Test 1",
+                id: 12,
+            },
         },
-        17: {
-            type: "stream",
-            stream_id: verona_id,
-            display_recipient: "Verona",
-            topic: "Test 2",
-            id: 17,
+        {
+            message: {
+                type: "stream",
+                stream_id: verona_id,
+                display_recipient: "Verona",
+                topic: "Test 2",
+                id: 17,
+            },
         },
-        2: {type: "direct", id: 2, display_recipient: [{id: 3, email: "user3@zulip.com"}]},
-    };
-
-    override(message_store, "get", (msg_id) => messages[msg_id]);
+        {
+            message: {
+                type: "direct",
+                id: 2,
+                display_recipient: [{id: 3, email: "user3@zulip.com"}],
+            },
+        },
+    ];
+    message_store.set_messages_for_tests(messages);
 
     // When the narrow terms are correct, it returns the same terms
     let terms = [
@@ -2308,7 +2331,7 @@ test("try_adjusting_for_moved_with_target", ({override}) => {
     filter.try_adjusting_for_moved_with_target();
     // now messages are fetched from server, and a single
     // fetched message is used to adjust narrow terms.
-    filter.try_adjusting_for_moved_with_target(messages["12"]);
+    filter.try_adjusting_for_moved_with_target(message_store.get(12));
     assert.deepEqual(filter.narrow_requires_hash_change, true);
 });
 

--- a/web/tests/message_flags.test.cjs
+++ b/web/tests/message_flags.test.cjs
@@ -7,6 +7,7 @@ const {run_test} = require("./lib/test.cjs");
 
 const channel = mock_esm("../src/channel");
 const message_live_update = mock_esm("../src/message_live_update");
+const message_store = zrequire("message_store");
 
 set_global("document", {hasFocus: () => true});
 
@@ -30,6 +31,7 @@ run_test("starred", ({override}) => {
     const message = {
         id: 50,
     };
+    message_store.set_messages_for_tests([{type: "server_message", message}]);
     let ui_updated;
 
     override(message_live_update, "update_starred_view", () => {
@@ -43,7 +45,7 @@ run_test("starred", ({override}) => {
         posted_data = opts.data;
     });
 
-    starred_messages_ui.toggle_starred_and_update_server(message);
+    starred_messages_ui.toggle_starred_and_update_server(message.id);
 
     assert.ok(ui_updated);
 
@@ -60,7 +62,7 @@ run_test("starred", ({override}) => {
 
     ui_updated = false;
 
-    starred_messages_ui.toggle_starred_and_update_server(message);
+    starred_messages_ui.toggle_starred_and_update_server(message.id);
 
     assert.ok(ui_updated);
 

--- a/web/tests/recent_senders.test.cjs
+++ b/web/tests/recent_senders.test.cjs
@@ -2,11 +2,11 @@
 
 const assert = require("node:assert/strict");
 
-const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 
 let next_id = 0;
-const messages = new Map();
+const message_store = zrequire("message_store");
 
 function make_stream_message({stream_id, topic, sender_id}) {
     next_id += 1;
@@ -18,14 +18,11 @@ function make_stream_message({stream_id, topic, sender_id}) {
         topic,
         sender_id,
     };
-    messages.set(message.id, message);
+    message_store.update_message_cache({message});
 
     return message;
 }
 
-mock_esm("../src/message_store", {
-    get: (message_id) => messages.get(message_id),
-});
 const people = zrequire("people");
 people.initialize_current_user(1);
 const rs = zrequire("recent_senders");
@@ -33,7 +30,7 @@ zrequire("message_util.ts");
 
 function test(label, f) {
     run_test(label, ({override}) => {
-        messages.clear();
+        message_store.clear_for_testing();
         next_id = 0;
         rs.clear_for_testing();
         f({override});

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -109,14 +109,7 @@ mock_esm("../src/stream_topic_history", {
 mock_esm("../src/message_list_data", {
     MessageListData: class {},
 });
-mock_esm("../src/message_store", {
-    get(msg_id) {
-        if (msg_id < 15) {
-            return messages[msg_id - 1];
-        }
-        return private_messages[msg_id - 15];
-    },
-});
+const message_store = zrequire("message_store");
 mock_esm("../src/message_view_header", {
     render_title_area: noop,
 });
@@ -489,6 +482,9 @@ function test(label, f) {
         page_params.development_environment = true;
         page_params.is_node_test = true;
         messages = sample_messages.map((message) => ({...message}));
+        message_store.set_messages_for_tests(
+            [...messages, ...private_messages].map((message) => ({message})),
+        );
         f(helpers);
     });
 }

--- a/web/tests/rendered_markdown.test.cjs
+++ b/web/tests/rendered_markdown.test.cjs
@@ -12,6 +12,8 @@ const {run_test, noop} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
 const $ = require("./lib/zjquery.cjs");
 
+const message_store = zrequire("message_store");
+
 let clipboard_args;
 class Clipboard {
     constructor(...args) {
@@ -32,7 +34,6 @@ const people = zrequire("people");
 const user_groups = zrequire("user_groups");
 const stream_data = zrequire("stream_data");
 const rows = mock_esm("../src/rows");
-const message_store = mock_esm("../src/message_store");
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => false,
 });
@@ -116,10 +117,12 @@ function set_message_for_message_content($content, value) {
         assert.equal($message_row_[0], $message_row[0]);
         return message_id;
     };
-    message_store.get = (message_id_opt) => {
-        assert.equal(message_id_opt, message_id);
-        return value;
-    };
+    message_store.update_message_cache({
+        message: {
+            id: message_id,
+            ...value,
+        },
+    });
 }
 
 const get_content_element = () => {

--- a/web/tests/topic_list_data.test.cjs
+++ b/web/tests/topic_list_data.test.cjs
@@ -8,14 +8,16 @@ const {make_realm} = require("./lib/example_realm.cjs");
 const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 
-mock_esm("../src/message_store", {
-    get() {
-        return {
+const message_store = zrequire("message_store");
+message_store.set_messages_for_tests([
+    {
+        message: {
             stream_id: 556,
             topic: "general",
-        };
+        },
     },
-});
+]);
+
 const user_topics = mock_esm("../src/user_topics", {
     is_topic_muted() {
         return false;


### PR DESCRIPTION
Ongoing frontend discussion: [#frontend > Replacing message_store.get](https://chat.zulip.org/#narrow/channel/6-frontend/topic/Replacing.20message_store.2Eget/with/2380774)

The goal here is to eventually prevent `message_store.ts` from handing out mutable `Message` objects with its `get` API and to enforce callers to use the exposed `update_foo` methods instead of doing direct mutations on the `Message` object.

This PR fixes some tests to use the actual `message_store` instead of trying to use mocks by creating Maps/objects. It then introduces an `ImmutableMessage` class that wraps a `Message` and exposes only readonly operations.

The problem first became apparent while working on https://github.com/zulip/zulip/commit/be5c6f10918df52787ed842b7b97f257e644fbb8, where I *hope* the caller uses the prescribed method to perform mutations on the raw_content, instead of enforcing it in some way.

Most of the commits here were discussed with @showell

We are yet to introduce the `MutableMessage` class or use `ImmutableMessage` at every place that doesn't perform updates on the message object, but ways to do so could use some discussion.

For example:
A function like `recent_view_util.get_key_from_message` might have some callers that could pass in an `ImmutableMessage` while others may not because they actually mutate `Message`(hopefully `MutableMessage` in the future). A way to tackle this sort of migration, could be just passing in the message_id to `get_key_from_message` and using `message_store` to get the ImmutableMessage object there. This helps us to avoid having to do a one-shot migration where we change the parameter of `get_key_from_message` to an `ImmutableMessage` and update the callers accordingly(possibly in ugly ways) or having an `ImmutableMessage | Message` as the expected paramter type and then adjusting `get_key_from_message` to work with both of these types.