### PR TITLE
bitbucket: Match users by UUID for silent mentions.

### DIFF
--- a/zerver/lib/external_accounts.py
+++ b/zerver/lib/external_accounts.py
@@ -45,6 +45,12 @@ DEFAULT_EXTERNAL_ACCOUNTS = {
         name=gettext_lazy("Bitbucket username"),
         hint="",
     ),
+    "bitbucket_uuid": ExternalAccount(
+        text="Bitbucket UUID",
+        url_pattern="",
+        name=gettext_lazy("Bitbucket UUID"),
+        hint="Find it at bitbucket.org/!api/2.0/user while logged in",
+    ),
     "bluesky": ExternalAccount(
         text="Bluesky",
         url_pattern="https://bsky.app/profile/%(username)s",

--- a/zerver/webhooks/bitbucket/doc.md
+++ b/zerver/webhooks/bitbucket/doc.md
@@ -2,6 +2,15 @@
 
 Zulip supports both Git and Mercurial notifications from Bitbucket.
 
+!!! tip ""
+
+    If you also configure a [custom profile
+    field](/help/custom-profile-fields) for Bitbucket UUIDs, this
+    integration will refer to Bitbucket users using [Zulip silent
+    mentions](/help/mention-a-user-or-group#silently-mention-a-user),
+    rather than their Bitbucket display name. Users can find their UUID
+    by visiting `bitbucket.org/!api/2.0/user` while logged in.
+
 {start_tabs}
 
 1. {!create-an-incoming-webhook.md!}


### PR DESCRIPTION
Since Bitbucket Cloud's 2019 GDPR changes, the username field is no longer available in API responses or webhook payloads. Now account_id or uuid should be used to identify an account instead (see Bitbucket API changes for GDPR (https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/)).

This PR adds support for matching Bitbucket users to Zulip users via their UUID, enabling silent mentions in webhook messages (similar to how the GitHub integration works).

[#integrations > git webhook: optionally use zulip formatting for usernames](https://chat.zulip.org/#narrow/channel/127-integrations/topic/git.20webhook.3A.20optionally.20use.20zulip.20formatting.20for.20usernames/with/2378067)

Fixes part of #34079

**How changes were tested:**
The changes are manually tested using vagrant development environment (/devtools?integrations).

**Screenshots and screen captures:**

**New external account field:**
<img width="617" height="552" alt="image" src="https://github.com/user-attachments/assets/311ac215-cc99-423d-88e6-0f5d6eae8c7a" />

<img width="408" height="124" alt="image" src="https://github.com/user-attachments/assets/16500b12-fde0-4d95-aff0-b967c2babdaf" />


**Zulip mentions:**
<img width="1171" height="521" alt="image" src="https://github.com/user-attachments/assets/f71994ad-6bb6-4922-94e4-f6ddc1800a35" />


**Documentation updated:**
<img width="1171" height="521" alt="image" src="https://github.com/user-attachments/assets/4efd77b6-ad39-4c1b-8b12-ab748ef71cd5" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
