### PR TITLE
tests: Use example_user factories in people.test.cjs.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -323,7 +323,6 @@ EXEMPT_FILES = make_set(
         "web/src/zform.ts",
         "web/src/zulip_test.ts",
         # Test library code isn't always fully used.
-        "web/tests/lib/example_user.cjs",
         "web/tests/lib/mdiff.cjs",
         "web/tests/lib/real_jquery.cjs",
         "web/tests/lib/zjquery_element.cjs",

--- a/web/tests/lib/example_user.cjs
+++ b/web/tests/lib/example_user.cjs
@@ -35,6 +35,7 @@ const bot_or_user_props = (opts = {}) => {
         is_owner: false,
         is_admin: false,
         is_guest: false,
+        is_moderator: false,
         timezone: "UTC",
         avatar_version: 0,
         // By default a member.

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -8,6 +8,7 @@ const MockDate = require("mockdate");
 
 const {make_user_group} = require("./lib/example_group.cjs");
 const {make_realm} = require("./lib/example_realm.cjs");
+const example_user = require("./lib/example_user.cjs");
 const {$t} = require("./lib/i18n.cjs");
 const {mock_esm, zrequire, set_global} = require("./lib/namespace.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
@@ -42,41 +43,34 @@ set_realm(realm);
 const user_settings = {};
 initialize_user_settings({user_settings});
 
-const welcome_bot = {
+const welcome_bot = example_user.make_cross_realm_bot({
     email: "welcome-bot@example.com",
     user_id: 4,
     full_name: "Welcome Bot",
-    is_bot: true,
     // cross realm bots have no owner
-};
+});
 
-const email_gateway_bot = {
+const email_gateway_bot = example_user.make_cross_realm_bot({
     email: "emailgateway@example.com",
     user_id: 5,
     full_name: "Email Gateway",
-    is_bot: true,
     // cross realm bots have no owner
-};
+});
 
-const me = {
+const me = example_user.make_user({
     email: "me@example.com",
     user_id: 30,
     full_name: "Me Myself",
     timezone: "America/Los_Angeles",
-    is_admin: false,
-    is_guest: false,
-    is_moderator: false,
-    is_bot: false,
-    role: 400,
     // no avatar, so client should construct a /avatar/{user_id} URL.
-};
+});
 
-const isaac = {
+const isaac = example_user.make_user({
     email: "isaac@example.com",
     delivery_email: "isaac-delivery@example.com",
     user_id: 32,
     full_name: "Isaac Newton",
-};
+});
 
 const unknown_user = people.make_user(1500, "unknown@example.com", "Unknown user");
 
@@ -121,192 +115,176 @@ user_groups.initialize({realm_user_groups: [nobody, everyone]});
     to be rigorous about sort order.
 */
 
-const realm_admin = {
+const realm_admin = example_user.make_user({
     email: "realm_admin@example.com",
     full_name: "Realm Admin",
     user_id: 32,
-    is_owner: false,
     is_admin: true,
-    is_guest: false,
     is_moderator: true,
-    is_bot: false,
     role: 200,
-};
+});
 
-const guest = {
+const guest = example_user.make_user({
     email: "guest@example.com",
     full_name: "Guest User",
     user_id: 33,
-    is_owner: false,
-    is_admin: false,
     is_guest: true,
-    is_moderator: false,
-    is_bot: false,
     role: 600,
-};
+});
 
-const realm_owner = {
+const realm_owner = example_user.make_user({
     email: "realm_owner@example.com",
     full_name: "Realm Owner",
     user_id: 34,
     is_owner: true,
     is_admin: true,
-    is_guest: false,
     is_moderator: true,
-    is_bot: false,
     role: 100,
-};
+});
 
-const bot_botson = {
+const bot_botson = example_user.make_bot({
     email: "botson-bot@example.com",
     user_id: 35,
     full_name: "Bot Botson",
-    is_bot: true,
     bot_owner_id: isaac.user_id,
     role: 300,
-};
+});
 
-const moderator = {
+const moderator = example_user.make_user({
     email: "moderator@example.com",
     full_name: "Moderator",
     user_id: 36,
-    is_owner: false,
-    is_admin: false,
-    is_guest: false,
     is_moderator: true,
-    is_bot: false,
     role: 300,
-};
+});
 
-const bot_with_inaccessible_owner = {
+const bot_with_inaccessible_owner = example_user.make_bot({
     email: "inaccessible-owner-bot@example.com",
     user_id: 37,
     full_name: "Inaccessible owner bot",
-    is_bot: true,
     bot_owner_id: 38,
     role: 300,
-};
+});
 
-const steven = {
+const steven = example_user.make_user({
     email: "steven@example.com",
     delivery_email: "steven-delivery@example.com",
     user_id: 77,
     full_name: "Steven",
-};
+});
 
-const alice1 = {
+const alice1 = example_user.make_user({
     email: "alice1@example.com",
     delivery_email: "alice1-delivery@example.com",
     user_id: 202,
     full_name: "Alice",
-};
+});
 
-const bob = {
+const bob = example_user.make_user({
     email: "bob@example.com",
     delivery_email: "bob-delivery@example.com",
     user_id: 203,
     full_name: "Bob van Roberts",
-};
+});
 
-const charles = {
+const charles = example_user.make_user({
     email: "charles@example.com",
     user_id: 301,
     full_name: "Charles Dickens",
     avatar_url: "http://charles.com/foo.png",
-    is_guest: false,
-};
+});
 
-const maria = {
+const maria = example_user.make_user({
     email: "Athens@example.com",
     user_id: 302,
     full_name: "Maria Athens",
     // With client_gravatar enabled, requests that client compute gravatar
     avatar_url: null,
-};
+});
 
-const cedar = {
+const cedar = example_user.make_user({
     email: "Cedar@example.com",
     user_id: 305,
     full_name: "Cedar Athens",
     // With client_gravatar enabled, requests that client compute gravatar
     avatar_url: null,
-};
+});
 
-const leo = {
+const leo = example_user.make_user({
     email: "Leo@example.com",
     user_id: 306,
     full_name: "Leo Athens",
     // With client_gravatar enabled, requests that client compute gravatar
     avatar_url: null,
-};
+});
 
-const ashton = {
+const ashton = example_user.make_user({
     email: "ashton@example.com",
     user_id: 303,
     full_name: "Ashton Smith",
-};
+});
 
-const linus = {
+const linus = example_user.make_user({
     email: "ltorvalds@example.com",
     user_id: 304,
     full_name: "Linus Torvalds",
-};
+});
 
-const emp401 = {
+const emp401 = example_user.make_user({
     email: "emp401@example.com",
     user_id: 401,
     full_name: "whatever 401",
-};
+});
 
-const emp402 = {
+const emp402 = example_user.make_user({
     email: "EMP402@example.com",
     user_id: 402,
     full_name: "whatever 402",
-};
+});
 
-const debbie = {
+const debbie = example_user.make_user({
     email: "deBBie71@example.com",
     user_id: 501,
     full_name: "Debra Henton",
-};
+});
 
-const stephen1 = {
+const stephen1 = example_user.make_user({
     email: "stephen-the-author@example.com",
     user_id: 601,
     full_name: "Stephen King",
-};
+});
 
-const stephen2 = {
+const stephen2 = example_user.make_user({
     email: "stephen-the-explorer@example.com",
     user_id: 602,
     full_name: "Stephen King",
-};
+});
 
-const noah = {
+const noah = example_user.make_user({
     email: "emnoa@example.com",
     user_id: 1200,
     full_name: "Nöôáàh Ëmerson",
-};
+});
 
-const plain_noah = {
+const plain_noah = example_user.make_user({
     email: "otheremnoa@example.com",
     user_id: 1201,
     full_name: "Nooaah Emerson",
-};
+});
 
-const all1 = {
+const all1 = example_user.make_user({
     email: "all1@example.com",
     user_id: 1202,
     full_name: "all",
-};
+});
 
-const all2 = {
+const all2 = example_user.make_user({
     email: "all2@example.com",
     user_id: 1203,
     full_name: "all",
-};
+});
 
-const stewie = {
+const stewie = example_user.make_user({
     email: "stewie@example.com",
     user_id: 1204,
     full_name: "Stewart Gilligan",
@@ -315,7 +293,7 @@ const stewie = {
         2: "(555) 555-5555",
         3: "he/him",
     },
-};
+});
 
 function get_all_persons() {
     return people.filter_all_persons(() => true);
@@ -788,13 +766,13 @@ run_test("is_current_user_only_owner", ({override}) => {
 
 run_test("user_can_change_their_own_role", ({override}) => {
     initialize();
-    const bob = {
+    const bob = example_user.make_user({
         email: "bob@example.com",
         user_id: 1,
         full_name: "Bob",
         is_owner: false,
         is_admin: false,
-    };
+    });
     people.add_active_user(bob);
 
     const person = people.get_by_email(bob.email);
@@ -1040,9 +1018,7 @@ run_test("message_methods", () => {
     people.add_active_user(ashton);
 
     assert.equal(people.get_muted_user_avatar_url(), "/static/images/muted-user/muted-sender.png");
-    // We don't rely on Maria to have all flags set explicitly--
-    // undefined values are just treated as falsy.
-    assert.equal(maria.is_guest, undefined);
+    assert.equal(maria.is_guest, false);
 
     assert.equal(
         people.small_avatar_url_for_person(maria),
@@ -1072,17 +1048,9 @@ run_test("message_methods", () => {
     muted_users.add_muted_user(30);
     assert.deepEqual(people.sender_info_for_recent_view_row([30]), [
         {
+            ...me,
             avatar_url_small: "/avatar/30",
             is_muted: true,
-            email: "me@example.com",
-            full_name: me.full_name,
-            is_admin: false,
-            is_bot: false,
-            is_guest: false,
-            is_moderator: false,
-            role: 400,
-            timezone: "America/Los_Angeles",
-            user_id: 30,
         },
     ]);
 
@@ -1165,7 +1133,7 @@ run_test("message_methods", () => {
     assert.equal(people.sender_is_bot(message), true);
 
     message = {sender_id: maria.user_id};
-    assert.equal(people.sender_is_bot(message), undefined);
+    assert.equal(people.sender_is_bot(message), false);
 
     message = {sender_id: undefined};
     assert.equal(people.sender_is_bot(message), false);
@@ -1177,7 +1145,7 @@ run_test("message_methods", () => {
     assert.equal(people.sender_is_guest(message), true);
 
     message = {sender_id: maria.user_id};
-    assert.equal(people.sender_is_guest(message), undefined);
+    assert.equal(people.sender_is_guest(message), false);
 
     message = {sender_id: charles.user_id};
     assert.equal(people.sender_is_guest(message), false);
@@ -1254,11 +1222,11 @@ run_test("get_people_for_search_bar", ({override}) => {
     override(message_user_ids, "user_ids", () => user_ids);
 
     for (const i of _.range(20)) {
-        const person = {
+        const person = example_user.make_user({
             email: "whatever@email.com",
             full_name: "James Jones",
             user_id: 1000 + i,
-        };
+        });
         people.add_active_user(person);
     }
 
@@ -1282,11 +1250,11 @@ run_test("updates", () => {
     const new_email = "bar@example.com";
     const user_id = 502;
 
-    let person = {
+    let person = example_user.make_user({
         email: old_email,
         user_id,
         full_name: "Foo Barson",
-    };
+    });
     people.add_active_user(person);
 
     // Do sanity checks on our data.
@@ -1403,29 +1371,29 @@ run_test("initialize", () => {
 
     const params = {};
 
-    const retiree = {
+    const retiree = example_user.make_user({
         email: "retiree@example.com",
         user_id: 15,
         full_name: "Retiree",
-    };
+    });
     params.realm_non_active_users = [retiree];
 
-    const current_user = {
+    const current_user = example_user.make_user({
         email: "my_email@example.com",
         user_id: 42,
         full_name: "Me Myself",
-    };
-    const alice = {
+    });
+    const alice = example_user.make_user({
         email: "alice@example.com",
         user_id: 16,
         full_name: "Alice",
-    };
+    });
     params.realm_users = [alice, current_user];
-    const test_bot = {
+    const test_bot = example_user.make_user({
         email: "bot@example.com",
         user_id: 17,
         full_name: "Test Bot",
-    };
+    });
     params.cross_realm_bots = [test_bot];
     const user_group_params = {
         realm_user_groups: [


### PR DESCRIPTION
This refactor replaces manual user/bot objects with standardized factories to ensure type coherence with production data.

Updated `web/tests/lib/example_user.cjs` to include `is_moderator` as a default property, as verified via production JS console.

<!-- Describe your pull request here.-->
**Changes:**
- Added `is_moderator: false` to `common_props` in `web/tests/lib/example_user.cjs`.

- Converted all manual human and bot objects in `people.test.cjs` to use `make_user`, `make_bot`, and `make_cross_realm_bot`.

- Ensured cross-realm bots (Welcome Bot, Email Gateway) use the correct factory helper to include the `is_system_bot: true` flag.

- Updated tests to expect `false` instead of `undefined` for booleans like `is_guest`, ensuring strict equality with factory-generated data.

- Used the spread operator (...me) in `deepEqual` assertions to make tests more resilient to future schema changes.

Fixes: <!-- Issue link, or clear description.-->
This is part of the GSoC 2026 goal to improve node test type safety. Using factory functions ensures that our test data structures stay in sync with the actual application schema and provides a cleaner path for future TypeScript migrations of legacy tests.

**How changes were tested:**
- Verified the actual `people` object for both human and system bot objects using `zulip_test.get_person_by_user_id(id)` in the browser console on a live dev server.

- Confirmed that all tests in `web/tests/people.test.cjs` pass successfully.

- Verified via `grep` that adding `is_moderator` to the global factory did not negatively impact other test files.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<!-- **Screenshots and screen captures:** -->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
