### PR TITLE
Fix documentation to use local_message_id for message events

### DIFF
--- a/docs/subsystems/sending-messages.md
+++ b/docs/subsystems/sending-messages.md
@@ -144,17 +144,17 @@ messages.
   visually).
 - The `POST /messages` API request to the server to send the message
   is passed two special parameters that clients not implementing local
-  echo don't use: `queue_id` and `local_id`. The `queue_id` is the ID
+  echo don't use: `queue_id` and `local_message_id`. The `queue_id` is the ID
   of the client's event queue; here, it is used just as a unique
   identifier for the specific client (e.g., a browser tab) that sent
-  the message. And the `local_id` is, by the construction above, a
+  the message. And the `local_message_id` is, by the construction above, a
   unique value within that namespace identifying the message.
 - The `do_send_messages` backend code path includes the `queue_id` and
-  `local_id` in the data it passes to the
+  `local_message_id` in the data it passes to the
   [events system](events-system.md). The events
   system will extend the `message` event dictionary it delivers to
   the client containing the `queue_id` with `local_message_id` field,
-  containing the `local_id` that the relevant client used when sending
+  containing the `local_message_id` that the relevant client used when sending
   the message. This allows the client to know that the `message`
   event it is receiving is the same message it itself had sent.
 - Using that information, rather than adding the "new message" to the
@@ -169,7 +169,7 @@ messages.
 Zulip also supports local echo in the message editing code path for
 edits to just the content of a message. The approach is analogous
 (using `markdown.contains_backend_only_syntax`, etc.), except we
-don't need any of the `local_id` tracking logic, because the message
+don't need any of the `local_message_id` tracking logic, because the message
 already has a permanent message id; as a result, the whole
 implementation was under 150 lines of code.
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
The PR corrects incorrect documentation in docs/subsystems/sending-messages.md regarding local echo.

The documentation had referred to the message event field as local_id, but the actual field that is sent in message events is local_message_id. This PR corrects the documentation to refer to the correct field name and its usage in local echo.

Nothing in the code functionality is changed; this is a documentation fix to make the documentation consistent with the current functionality of the server and client.

Fixes: #34164 

**How changes were tested:**

 Verified that `local_message_id` matches the actual field
 used in message events.
Searched the repository to ensure no incorrect references
  to `local_id` remain in API documentation.
Confirmed documentation renders correctly.
CI validates documentation build and lint checks.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/9152b23a-9f5d-45a7-b40c-305a1f3c19df" width="600"> | <img src="https://github.com/user-attachments/assets/49f1c930-7294-4c6e-8b2b-63be93f5b274" width="650"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
