### PR TITLE
portico: Simplify string for alternate Mac processor.

### DIFF
--- a/templates/corporate/apps.html
+++ b/templates/corporate/apps.html
@@ -23,8 +23,8 @@
                         <span id="download-from-microsoft-store" hidden>or <a href="https://apps.microsoft.com/store/detail/XP8HN41S4PLGZ3">download from the Microsoft Store</a></span>
                         <span id="download-android-apk" hidden>or manually download APK for the <a class="android-apk-current" href="">current</a> or <a class="android-apk-legacy" href="">legacy</a> app</span>
                         <div id="download-mac-alt" hidden>
-                            <div id="download-mac-alt-apple-silicon" hidden>or <a href="/apps/download/mac-arm64">download <strong>Apple Silicon</strong> processor build <i>(M1, M2, M3, etc.)</i></a></div>
-                            <div id="download-mac-alt-intel" hidden>or <a href="/apps/download/mac-intel">download <strong>Intel</strong> processor build <i>(some older Macs)</i></a></div>
+                            <div id="download-mac-alt-apple-silicon" hidden>or <a href="/apps/download/mac-arm64">download <strong>Apple Silicon</strong> build <i>(newer Macs)</i></a></div>
+                            <div id="download-mac-alt-intel" hidden>or <a href="/apps/download/mac-intel">download <strong>Intel</strong> build <i>(older Macs)</i></a></div>
                         </div>
                         <p class="download-instructions"></p>
                     </div>


### PR DESCRIPTION
State difference vs. primary CTA, without getting into details many users will find unfamiliar.

Follow-up to #37777.


Not sure how to take the other screenshot, but here's one:

<img width="761" height="422" alt="Screenshot 2026-02-13 at 12 44 01" src="https://github.com/user-attachments/assets/d64aafc3-c762-46de-9b2e-bb4eaa377c24" />
