### PR TITLE
Add S3_SIGNATURE_VERSION setting

### DIFF
--- a/docs/production/upload-backends.md
+++ b/docs/production/upload-backends.md
@@ -47,7 +47,9 @@ backend. To enable this backend, you need to do the following:
 
 1. If you are using a non-AWS block storage provider,
    you need to set the `S3_ENDPOINT_URL` setting to your
-   endpoint url (e.g., `"https://s3.eu-central-1.amazonaws.com"`).
+   endpoint url (e.g., `"https://s3.eu-central-1.amazonaws.com"`). You may also
+   need to set the `S3_SIGNATURE_VERSION` to one of the values recognized by
+   the `boto` library (e.g., `"s3v4"`).
 
    For certain AWS regions, you may need to set the `S3_REGION`
    setting to your default AWS region's code (e.g., `"eu-central-1"`).

--- a/zerver/lib/upload/s3.py
+++ b/zerver/lib/upload/s3.py
@@ -65,7 +65,7 @@ def get_bucket(bucket_name: str, authed: bool = True) -> "Bucket":
         region_name=settings.S3_REGION,
         endpoint_url=settings.S3_ENDPOINT_URL,
         config=Config(
-            signature_version=None if authed else botocore.UNSIGNED,
+            signature_version=settings.S3_SIGNATURE_VERSION if authed else botocore.UNSIGNED,
             s3={"addressing_style": settings.S3_ADDRESSING_STYLE},
             request_checksum_calculation=checksum,
         ),

--- a/zerver/migrations/0509_fix_emoji_metadata.py
+++ b/zerver/migrations/0509_fix_emoji_metadata.py
@@ -21,7 +21,7 @@ def fix_emoji_metadata(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor)
         region_name=settings.S3_REGION,
         endpoint_url=settings.S3_ENDPOINT_URL,
         config=Config(
-            signature_version=None,
+            signature_version=settings.S3_SIGNATURE_VERSION,
             s3={"addressing_style": settings.S3_ADDRESSING_STYLE},
         ),
     ).Bucket(settings.S3_AVATAR_BUCKET)

--- a/zerver/migrations/0544_copy_avatar_images.py
+++ b/zerver/migrations/0544_copy_avatar_images.py
@@ -93,7 +93,7 @@ def thumbnail_s3_avatars(users: QuerySet[Any], apps: StateApps) -> None:
         region_name=settings.S3_REGION,
         endpoint_url=settings.S3_ENDPOINT_URL,
         config=Config(
-            signature_version=None,
+            signature_version=settings.S3_SIGNATURE_VERSION,
             s3={"addressing_style": settings.S3_ADDRESSING_STYLE},
         ),
     ).Bucket(settings.S3_AVATAR_BUCKET)

--- a/zerver/migrations/0553_copy_emoji_images.py
+++ b/zerver/migrations/0553_copy_emoji_images.py
@@ -235,7 +235,7 @@ def thumbnail_s3(apps: StateApps) -> None:
         region_name=settings.S3_REGION,
         endpoint_url=settings.S3_ENDPOINT_URL,
         config=Config(
-            signature_version=None,
+            signature_version=settings.S3_SIGNATURE_VERSION,
             s3={"addressing_style": settings.S3_ADDRESSING_STYLE},
         ),
     ).Bucket(settings.S3_AVATAR_BUCKET)

--- a/zerver/migrations/0576_backfill_imageattachment.py
+++ b/zerver/migrations/0576_backfill_imageattachment.py
@@ -28,7 +28,7 @@ def backfill_imageattachment(apps: StateApps, schema_editor: BaseDatabaseSchemaE
             region_name=settings.S3_REGION,
             endpoint_url=settings.S3_ENDPOINT_URL,
             config=Config(
-                signature_version=None,
+                signature_version=settings.S3_SIGNATURE_VERSION,
                 s3={"addressing_style": settings.S3_ADDRESSING_STYLE},
             ),
         ).Bucket(settings.S3_AUTH_UPLOADS_BUCKET)

--- a/zerver/migrations/0622_backfill_imageattachment_again.py
+++ b/zerver/migrations/0622_backfill_imageattachment_again.py
@@ -32,7 +32,7 @@ def backfill_imageattachment(apps: StateApps, schema_editor: BaseDatabaseSchemaE
             region_name=settings.S3_REGION,
             endpoint_url=settings.S3_ENDPOINT_URL,
             config=Config(
-                signature_version=None,
+                signature_version=settings.S3_SIGNATURE_VERSION,
                 s3={"addressing_style": settings.S3_ADDRESSING_STYLE},
             ),
         ).Bucket(settings.S3_AUTH_UPLOADS_BUCKET)

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -170,6 +170,7 @@ S3_UPLOADS_STORAGE_CLASS: Literal[
 ] = "STANDARD"
 S3_AVATAR_PUBLIC_URL_PREFIX: str | None = None
 S3_SKIP_CHECKSUM: bool = False
+S3_SIGNATURE_VERSION: Literal["s3v4", "s3"] | None = None
 LOCAL_UPLOADS_DIR: str | None = None
 LOCAL_AVATARS_DIR: str | None = None
 LOCAL_FILES_DIR: str | None = None

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -839,6 +839,7 @@ LOCAL_UPLOADS_DIR = "/home/zulip/uploads"
 # S3_SKIP_PROXY = True
 # S3_UPLOADS_STORAGE_CLASS = "STANDARD"
 # S3_SKIP_CHECKSUM = False
+# S3_SIGNATURE_VERSION = None
 
 ## Maximum allowed size of uploaded files, in megabytes. Set
 ## MAX_FILE_UPLOAD_SIZE to 0 to disable file uploads completely


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes compatibility with private Backblaze B2 buckets emitting `UnauthorizedAccess` errors for user uploads.

Adds a setting `S3_SIGNATURE_VERSION` defaulting to existing `None` value used everywhere previously hardcoded as `None` and adds documentation where relevant concerning usage of this new setting.

Considering `boto3` expects either `"s3v4"` or `"s3"` for `signature_version`, the existing `None` may not be correct as a default, and may need to be changed to `"s3v4"` to match upstream `boto3` default value.

No tests have been adjusted as the default value is preserved everywhere it is altered.

Additional context/motivation:
[#production help > unset local uploads dir with docker-compose deployment](https://chat.zulip.org/#narrow/channel/31-production-help/topic/unset.20local.20uploads.20dir.20with.20docker-compose.20deployment/with/2379872)

**How changes were tested:**

* Tested by patching `signature_version=None` to `signature_version="s3v4"` in-situ
* Built docker container using these changes and used image in deployment

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
