### PR TITLE
stream list: Preserve expanded topic-list state in sidebar.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1505,6 +1505,15 @@ export function set_event_handlers({
 }: {
     show_channel_feed: (stream_id: number, trigger: string) => void;
 }): void {
+    $("#stream_filters").on("mousedown", "li .subscription_block", (e) => {
+        // Prevent default behavior of text selection upon multiple clicks
+        // to allow toggling in #topics narrows.
+        // https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
+        if (e.detail > 1) {
+            e.preventDefault();
+        }
+    });
+
     $("#stream_filters").on("click", "li .subscription_block", (e) => {
         // Left sidebar channel links have an `href` so that the
         // browser will preview the URL and you can middle-click it.

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -74,6 +74,10 @@ const collapsed_sections_ls_key = "left_sidebar_collapsed_stream_sections";
 const collapsed_sections_ls_schema = z._default(z.array(z.string()), []);
 const ls = localstorage();
 
+let expanded_topic_list_channels = new Set<number>();
+const expanded_channels_ls_key = "left_sidebar_expanded_topic_list_channels";
+const expanded_channels_ls_schema = z._default(z.array(z.number()), []);
+
 export function is_zoomed_in(): boolean {
     return zoomed_in;
 }
@@ -320,6 +324,10 @@ export function add_sidebar_row(sub: StreamSubscription): void {
 
 export function remove_sidebar_row(stream_id: number): void {
     stream_sidebar.remove_row(stream_id);
+    if (expanded_topic_list_channels.has(stream_id)) {
+        expanded_topic_list_channels.delete(stream_id);
+        save_expanded_topic_list_channels();
+    }
     const force_rerender = stream_id === topic_list.active_stream_id();
     update_streams_sidebar(force_rerender);
 }
@@ -663,6 +671,29 @@ function restore_collapsed_sections_state(): void {
     for (const section_id of collapsed_array) {
         collapsed_sections.add(section_id);
     }
+}
+
+function save_expanded_topic_list_channels(): void {
+    ls.set(expanded_channels_ls_key, [...expanded_topic_list_channels]);
+}
+
+function restore_expanded_topic_list_channels(): void {
+    expanded_topic_list_channels = new Set(
+        expanded_channels_ls_schema.parse(ls.get(expanded_channels_ls_key)),
+    );
+}
+
+function is_topic_list_expanded(stream_id: number): boolean {
+    return expanded_topic_list_channels.has(stream_id);
+}
+
+function set_topic_list_expanded(stream_id: number, expanded: boolean): void {
+    if (expanded) {
+        expanded_topic_list_channels.add(stream_id);
+    } else {
+        expanded_topic_list_channels.delete(stream_id);
+    }
+    save_expanded_topic_list_channels();
 }
 
 export let set_sections_states = function (): void {
@@ -1244,6 +1275,20 @@ export function update_stream_sidebar_for_narrow(filter: Filter): JQuery | undef
     // We want to update channel view for inbox for the same reasons
     // we want to the topics list here.
     update_inbox_channel_view_callback(stream_id);
+
+    if (
+        user_settings.web_channel_default_view ===
+            web_channel_default_view_values.list_of_topics.code &&
+        !info.topic_selected &&
+        !is_topic_list_expanded(stream_id)
+    ) {
+        // With the `list_of_topics` setting, the topic list is already
+        // visible in the main content area, so keep the sidebar topic
+        // list collapsed.
+        maybe_hide_topic_bracket(get_section_id_for_stream_li($stream_li));
+        return $stream_li;
+    }
+
     topic_list.rebuild_left_sidebar($stream_li, stream_id);
     topic_list.topic_state_typeahead?.lookup(true);
 
@@ -1304,6 +1349,7 @@ export function initialize({
 }): void {
     update_inbox_channel_view_callback = update_inbox_channel_view;
     restore_collapsed_sections_state();
+    restore_expanded_topic_list_channels();
     create_initial_sidebar_rows();
 
     // We build the stream_list now.  It may get re-built again very shortly
@@ -1432,6 +1478,40 @@ export function on_sidebar_channel_click(
         user_settings.web_channel_default_view ===
         web_channel_default_view_values.list_of_topics.code
     ) {
+        const is_same_channel = current_narrow_stream_id === stream_id;
+
+        if (is_same_channel && current_topic === undefined) {
+            // Already viewing this channel's topic list in the middle pane.
+            if (zoomed_in) {
+                return;
+            }
+            // Toggle the topic list in the sidebar.
+            const currently_expanded = is_topic_list_expanded(stream_id);
+            set_topic_list_expanded(stream_id, !currently_expanded);
+
+            const $stream_li = get_stream_li(stream_id);
+            if (!$stream_li) {
+                blueslip.error("No stream_li for subscribed stream", {stream_id});
+                return;
+            }
+
+            if (currently_expanded) {
+                clear_topics();
+            } else {
+                topic_list.rebuild_left_sidebar($stream_li, stream_id);
+            }
+            return;
+        }
+
+        if (is_same_channel && current_topic !== undefined) {
+            // Viewing a topic in this channel. Navigate to topic list,
+            // keep sidebar expanded so user can see topic list.
+            set_topic_list_expanded(stream_id, true);
+        } else {
+            // Navigating to a different channel. Start collapsed.
+            set_topic_list_expanded(stream_id, false);
+        }
+
         browser_history.go_to_location(hash_util.by_channel_topic_list_url(stream_id));
         return;
     }


### PR DESCRIPTION
For users with the "List of topics" setting for Channel links in the left sidebar, the topic list in the left sidebar no longer expands immediately when navigating to a channel. Instead, clicking the channel name toggles the topic list.

Fixes: #35197

**How changes were tested:**
Manual testing of the following scenarios:
- Clicking a channel not currently being viewed : topics collapsed in sidebar
- Clicking the same channel again :  topics expand
- Clicking again : topics collapse
- From a topic view, clicking its channel : navigates to topic list, topics stay expanded

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/09b9c06f-adce-48b3-8878-cce149a40b9a

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>