### PR TITLE
unread: mark messages read in /near/ views after scrolling past oldest unread Fixes #37342

### DIFF
--- a/web/src/message_list.ts
+++ b/web/src/message_list.ts
@@ -312,7 +312,7 @@ export class MessageList {
 
         const viewport_info = message_viewport.message_viewport_info();
         const message_top = $first_unread_row.get_offset_to_window().top;
-        
+
         // Return true if the top of the message is above the visible viewport
         return message_top < viewport_info.visible_top;
     }
@@ -328,13 +328,13 @@ export class MessageList {
              turned on in their user settings.
         */
         const filter = this.data.filter;
-        const is_conversation_view = filter === undefined ? false : filter.is_conversation_view();
-        
+        const is_conversation_view = filter?.is_conversation_view() ?? false;
+
         // Special handling for /near/ views: Allow marking as read if the oldest
         // unread message is above the viewport (user has scrolled past it)
-        const is_near_view = filter !== undefined && filter.has_operator("near");
+        const is_near_view = filter?.has_operator("near") ?? false;
         const can_mark_in_near_view = is_near_view && this.oldest_unread_above_viewport();
-        
+
         return (
             (this.data.can_mark_messages_read() || can_mark_in_near_view) &&
             !this.reading_prevented &&
@@ -357,12 +357,12 @@ export class MessageList {
             the "Automatically mark messages as read" setting.
         */
         const filter = this.data.filter;
-        
+
         // Special handling for /near/ views: Allow marking as read if the oldest
         // unread message is above the viewport (user has scrolled past it)
-        const is_near_view = filter !== undefined && filter.has_operator("near");
+        const is_near_view = filter?.has_operator("near") ?? false;
         const can_mark_in_near_view = is_near_view && this.oldest_unread_above_viewport();
-        
+
         return (
             (this.data.can_mark_messages_read() || can_mark_in_near_view) &&
             !this.reading_prevented


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #37342

## Summary

Improve read-marking behavior in `/near/` views by allowing messages to be marked as read once the user scrolls past the oldest unread message.
This makes `/near/` narrows behave consistently with normal conversation views after the user has clearly seen the content.

---

## Problem

Currently `/near/` views completely block automatic read-marking to prevent accidentally marking unseen messages as read.
However, even after scrolling beyond the target message and viewing newer messages, they remain unread, forcing users to manually clear them.

---

## Solution

Enable standard read-marking behavior in `/near/` views **only after the oldest unread message moves above the viewport**.

This preserves safety while restoring expected UX.

---

## Implementation details

* Detect `/near/` narrows using `filter.has_operator("near")`
* Add helper logic to check if the oldest unread message is above the viewport
* Allow marking messages as read when the condition is satisfied
* Preserve existing behavior for all other narrows

---

**How changes were tested:**

* Before scrolling in `/near/` view → messages remain unread
* After scrolling past oldest unread → messages marked read
* Normal conversation narrows → unchanged
* Search and other narrows → unchanged

---

<details>
<summary>Self-review checklist</summary>

* [x] Self-reviewed the changes for clarity and
