### PR TITLE
Prevent scroll-to-bottom button from auto-hiding when user is not at bottom

### DIFF
--- a/web/src/message_scroll.ts
+++ b/web/src/message_scroll.ts
@@ -37,7 +37,7 @@ export function hide_scroll_to_bottom(): void {
     hide_scroll_to_bottom_timer = setTimeout(() => {
         // Don't hide if user is hovered on it.
         if (
-            !narrow_state.narrowed_by_topic_reply() &&
+            message_viewport.bottom_rendered_message_visible() &&
             !the($show_scroll_to_bottom_button).matches(":hover")
         ) {
             $show_scroll_to_bottom_button.removeClass("show");


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR fixes an issue where the scroll-to-bottom button auto-hides after 3 seconds even when the user is not at the bottom of the message list.

The issue was caused by `hide_scroll_to_bottom()` starting a timer that removed the button without re-checking whether the bottom message was visible when the timer executed.

This patch updates the timer callback to hide the button only if `bottom_rendered_message_visible()` returns true at execution time. As a result, the button now remains visible while the user is away from the bottom and hides correctly once the bottom is reached.

Discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/scroll-to-bottom.20button.20hangs.20around.20in.20topic.20views

---

**How changes were tested:**

- Reproduced the issue locally in Combined Feed.
- Scrolled to the middle of the message list and confirmed the button no longer auto-hides after 3 seconds.
- Verified that the button hides correctly once the bottom message becomes visible.
- Tested in:
  - Combined Feed
  - Stream view
  - Topic view
- Verified hover behavior still prevents auto-hide.
- Confirmed no regressions in keyboard-triggered scrolling.

---

**Screenshots and screen captures:**

[Screen Recording 2026-02-14 233306.zip](https://github.com/user-attachments/files/25317799/Screen.Recording.2026-02-14.233306.zip)

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Followed the AI use policy.

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans.
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review.

- [x] Each commit is a coherent idea.
- [x] Commit message explains reasoning and motivation.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
