### PR TITLE
tooltips: Add Tippy tooltips for emoji with enlarged preview

### DIFF
--- a/web/src/emoji_tooltip.ts
+++ b/web/src/emoji_tooltip.ts
@@ -1,0 +1,54 @@
+import assert from "minimalistic-assert";
+import type * as tippy from "tippy.js";
+
+import render_emoji_tooltip from "../templates/emoji_tooltip.hbs";
+
+import {parse_html} from "./ui_util.ts";
+
+// Reads the canonical `:name:` an emoji carries in the DOM, so we
+// never rebuild it from the human-friendly `title` (which has spaces,
+// not underscores): custom emoji (<img>) use `alt` and Unicode emoji
+// (<span>) use their text content.
+export function get_canonical_emoji_name(emoji_element: Element): string | undefined {
+    const raw = emoji_element.getAttribute("alt") ?? emoji_element.textContent ?? "";
+    if (raw.startsWith(":") && raw.endsWith(":") && raw.length > 2) {
+        return raw.slice(1, -1);
+    }
+    // Our caller needs to handle this possibility.
+    return undefined;
+}
+
+// Builds the tooltip body: an enlarged copy of the emoji above its `:name:`.
+export function build_emoji_tooltip_content(
+    emoji_element: Element,
+    emoji_name: string,
+): DocumentFragment {
+    const enlarged_emoji = emoji_element.cloneNode(true);
+    assert(enlarged_emoji instanceof HTMLElement);
+    // The clone is decorative (the `:name:` line carries the name), and
+    // Unicode emoji have role="img", so hide it from assistive tech to
+    // avoid announcing an unnamed image.
+    enlarged_emoji.setAttribute("aria-hidden", "true");
+    // Drop the native title and the name it duplicates, so the copy
+    // can't show a tooltip of its own inside this one.
+    enlarged_emoji.removeAttribute("title");
+    enlarged_emoji.removeAttribute("aria-label");
+    enlarged_emoji.classList.add("emoji-tooltip-enlarged");
+
+    const fragment = parse_html(render_emoji_tooltip({emoji_name}));
+    const emoji_container = fragment.querySelector(".emoji-tooltip-emoji");
+    assert(emoji_container !== null);
+    emoji_container.append(enlarged_emoji);
+    return fragment;
+}
+
+// Shared `onShow` for the emoji tooltip delegates: render the enlarged
+// preview, or decline to show when the element carries no emoji name.
+export function show_emoji_tooltip(instance: tippy.Instance): false | undefined {
+    const emoji_name = get_canonical_emoji_name(instance.reference);
+    if (emoji_name === undefined) {
+        return false;
+    }
+    instance.setContent(build_emoji_tooltip_content(instance.reference, emoji_name));
+    return undefined;
+}

--- a/web/src/emoji_tooltip.ts
+++ b/web/src/emoji_tooltip.ts
@@ -7,10 +7,14 @@ import {parse_html} from "./ui_util.ts";
 
 // Reads the canonical `:name:` an emoji carries in the DOM, so we
 // never rebuild it from the human-friendly `title` (which has spaces,
-// not underscores): custom emoji (<img>) use `alt` and Unicode emoji
-// (<span>) use their text content.
+// not underscores): custom emoji (<img>) use `alt`, Unicode emoji
+// (<span>) use their text content, status emoji use `data-tippy-content`.
 export function get_canonical_emoji_name(emoji_element: Element): string | undefined {
-    const raw = emoji_element.getAttribute("alt") ?? emoji_element.textContent ?? "";
+    const raw =
+        emoji_element.getAttribute("alt") ??
+        emoji_element.getAttribute("data-tippy-content") ??
+        emoji_element.textContent ??
+        "";
     if (raw.startsWith(":") && raw.endsWith(":") && raw.length > 2) {
         return raw.slice(1, -1);
     }
@@ -33,6 +37,10 @@ export function build_emoji_tooltip_content(
     // can't show a tooltip of its own inside this one.
     enlarged_emoji.removeAttribute("title");
     enlarged_emoji.removeAttribute("aria-label");
+    // Status emoji keep their tooltip in data-tippy-content, and layout
+    // classes for sitting beside a name; neither suits the copy.
+    enlarged_emoji.removeAttribute("data-tippy-content");
+    enlarged_emoji.classList.remove("status-emoji", "status-emoji-name");
     enlarged_emoji.classList.add("emoji-tooltip-enlarged");
 
     const fragment = parse_html(render_emoji_tooltip({emoji_name}));

--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -9,6 +9,7 @@ import render_narrow_tooltip from "../templates/narrow_tooltip.hbs";
 import render_narrow_tooltip_list_of_topics from "../templates/narrow_tooltip_list_of_topics.hbs";
 
 import * as compose_validate from "./compose_validate.ts";
+import {show_emoji_tooltip} from "./emoji_tooltip.ts";
 import * as flatpickr from "./flatpickr.ts";
 import {$t} from "./i18n.ts";
 import * as message_lists from "./message_lists.ts";
@@ -186,6 +187,27 @@ export function initialize(): void {
             instance.setContent(
                 parse_html(render_narrow_tooltip({content: instance.props.content})),
             );
+        },
+    });
+
+    // Enlarged emoji preview in message content. Reactions are excluded
+    // (they live in `.message_reaction`, not `.message_content`) since
+    // their tooltip shows who reacted.
+    message_list_tooltip(".message_content .emoji", {
+        delay: LONG_HOVER_DELAY,
+        onTrigger(instance) {
+            // Remove the native `title` on hover-start so it can't flash
+            // alongside Tippy, but only when the tooltip will actually show:
+            // message_list_tooltip skips showing with no current message list
+            // (e.g. an overlay opened from Inbox), where stripping the title
+            // would leave the emoji with no tooltip at all.
+            if (message_lists.current !== undefined) {
+                instance.reference.removeAttribute("title");
+            }
+        },
+        onShow: show_emoji_tooltip,
+        onHidden(instance) {
+            instance.destroy();
         },
     });
 

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -642,7 +642,7 @@ export function initialize(): void {
     tippy.delegate("body", {
         target: ".status-emoji-name:not(.typeahead-item .status-emoji-name)",
         placement: "top",
-        delay: INSTANT_HOVER_DELAY,
+        delay: LONG_HOVER_DELAY,
         appendTo: () => document.body,
 
         /*
@@ -653,6 +653,7 @@ export function initialize(): void {
             those regions.
         */
 
+        onShow: show_emoji_tooltip,
         onHidden(instance) {
             instance.destroy();
         },

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -11,6 +11,7 @@ import render_topics_not_allowed_error from "../templates/topics_not_allowed_err
 
 import * as compose_state from "./compose_state.ts";
 import * as compose_validate from "./compose_validate.ts";
+import {show_emoji_tooltip} from "./emoji_tooltip.ts";
 import {$t} from "./i18n.ts";
 import * as information_density from "./information_density.ts";
 import * as people from "./people.ts";
@@ -674,6 +675,23 @@ export function initialize(): void {
         onHidden(instance) {
             instance.destroy();
             typeahead_status_emoji_tooltip = undefined;
+        },
+    });
+
+    // Enlarged emoji preview in the compose and edit previews,
+    // mirroring the message-content tooltip in message_list_tooltips.ts.
+    tippy.delegate("body", {
+        target: ".preview_content .emoji",
+        delay: LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        onTrigger(instance) {
+            // Drop the native `title` at hover-start (not in `onShow`, which
+            // waits for the delay) so no native tooltip flashes alongside Tippy.
+            instance.reference.removeAttribute("title");
+        },
+        onShow: show_emoji_tooltip,
+        onHidden(instance) {
+            instance.destroy();
         },
     });
 

--- a/web/styles/tooltips.css
+++ b/web/styles/tooltips.css
@@ -46,6 +46,22 @@
             line-height: 1.2143em;
         }
 
+        .emoji-tooltip-content {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            /* 4px at 16px/1em */
+            gap: 0.25em;
+            text-align: center;
+        }
+
+        .emoji-tooltip-enlarged {
+            /* 32px at the 16px default, matching the emoji picker preview;
+               em so it scales with the user's font size. */
+            width: 2em;
+            height: 2em;
+        }
+
         &[data-placement^="top"] > .tippy-arrow::before {
             border-top-color: var(--color-background-tippy-box);
         }

--- a/web/templates/emoji_tooltip.hbs
+++ b/web/templates/emoji_tooltip.hbs
@@ -1,0 +1,4 @@
+<div class="emoji-tooltip-content">
+    <div class="emoji-tooltip-emoji"></div>
+    <div class="emoji-tooltip-name">:{{emoji_name}}:</div>
+</div>

--- a/web/tests/emoji_tooltip.test.cjs
+++ b/web/tests/emoji_tooltip.test.cjs
@@ -4,6 +4,8 @@ const assert = require("node:assert/strict");
 
 const {JSDOM} = require("jsdom");
 
+const render_status_emoji = require("../templates/status_emoji.hbs");
+
 const {set_global, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 
@@ -45,6 +47,14 @@ function render_message_emoji(raw_content) {
     return emoji_element;
 }
 
+function render_status_emoji_element(status_emoji_info) {
+    const container = document.createElement("div");
+    container.innerHTML = render_status_emoji(status_emoji_info);
+    const emoji_element = container.querySelector(".status-emoji-name");
+    assert.ok(emoji_element !== null);
+    return emoji_element;
+}
+
 run_test("get_canonical_emoji_name reads the name from the DOM", () => {
     assert.equal(
         emoji_tooltip.get_canonical_emoji_name(render_message_emoji(":heart_eyes:")),
@@ -55,6 +65,19 @@ run_test("get_canonical_emoji_name reads the name from the DOM", () => {
     const custom_emoji = render_message_emoji(":green_tick:");
     assert.equal(custom_emoji.getAttribute("title"), "green tick");
     assert.equal(emoji_tooltip.get_canonical_emoji_name(custom_emoji), "green_tick");
+
+    // Status emoji carry the name only in `data-tippy-content`.
+    const unicode_status_emoji = render_status_emoji_element(
+        emoji.get_emoji_details_by_name("working_on_it"),
+    );
+    assert.equal(emoji_tooltip.get_canonical_emoji_name(unicode_status_emoji), "working_on_it");
+
+    const custom_status_emoji = render_status_emoji_element(
+        emoji.get_emoji_details_by_name("green_tick"),
+    );
+    assert.equal(custom_status_emoji.nodeName, "IMG");
+    assert.equal(custom_status_emoji.getAttribute("alt"), null);
+    assert.equal(emoji_tooltip.get_canonical_emoji_name(custom_status_emoji), "green_tick");
 
     // Nothing we render omits the `:name:`, so build that case by hand.
     const unnamed_emoji = document.createElement("span");
@@ -81,6 +104,19 @@ run_test("build_emoji_tooltip_content renders an enlarged copy and :name:", () =
     assert.equal(enlarged_emoji.getAttribute("aria-hidden"), "true");
     assert.equal(enlarged_emoji.getAttribute("title"), null);
     assert.equal(enlarged_emoji.getAttribute("aria-label"), null);
+});
+
+run_test("build_emoji_tooltip_content strips status-emoji layout from the copy", () => {
+    const fragment = emoji_tooltip.build_emoji_tooltip_content(
+        render_status_emoji_element(emoji.get_emoji_details_by_name("working_on_it")),
+        "working_on_it",
+    );
+
+    const enlarged_emoji = fragment.querySelector(".emoji-tooltip-emoji span");
+    assert.ok(enlarged_emoji !== null);
+    assert.ok(!enlarged_emoji.classList.contains("status-emoji"));
+    assert.ok(!enlarged_emoji.classList.contains("status-emoji-name"));
+    assert.equal(enlarged_emoji.getAttribute("data-tippy-content"), null);
 });
 
 run_test("build_emoji_tooltip_content does not mutate the original element", () => {

--- a/web/tests/emoji_tooltip.test.cjs
+++ b/web/tests/emoji_tooltip.test.cjs
@@ -1,0 +1,114 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {JSDOM} = require("jsdom");
+
+const {set_global, zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+// One JSDOM window, so nodes we build and nodes `parse_html` produces
+// share the `HTMLElement` the module's `instanceof` check needs.
+const {window} = new JSDOM("");
+set_global("document", window.document);
+set_global("HTMLElement", window.HTMLElement);
+set_global("DocumentFragment", window.DocumentFragment);
+
+const emoji = zrequire("emoji");
+const emoji_codes = zrequire("../../static/generated/emoji/emoji_codes.json");
+const linkifiers = zrequire("linkifiers");
+const markdown = zrequire("markdown");
+const markdown_config = zrequire("markdown_config");
+const {initialize_user_settings} = zrequire("user_settings");
+const emoji_tooltip = zrequire("emoji_tooltip");
+
+initialize_user_settings({user_settings: {translate_emoticons: false}});
+emoji.initialize({
+    realm_emoji: {
+        1: {
+            id: 1,
+            name: "green_tick",
+            source_url: "/static/generated/emoji/images/emoji/green_tick.png",
+            deactivated: false,
+        },
+    },
+    emoji_codes,
+});
+linkifiers.initialize([]);
+markdown.initialize(markdown_config.get_helpers());
+
+function render_message_emoji(raw_content) {
+    const message_content = document.createElement("div");
+    message_content.innerHTML = markdown.render(raw_content).content;
+    const emoji_element = message_content.querySelector(".emoji");
+    assert.ok(emoji_element !== null);
+    return emoji_element;
+}
+
+run_test("get_canonical_emoji_name reads the name from the DOM", () => {
+    assert.equal(
+        emoji_tooltip.get_canonical_emoji_name(render_message_emoji(":heart_eyes:")),
+        "heart_eyes",
+    );
+
+    // Reading `title` instead of `alt` here would yield `:green tick:`.
+    const custom_emoji = render_message_emoji(":green_tick:");
+    assert.equal(custom_emoji.getAttribute("title"), "green tick");
+    assert.equal(emoji_tooltip.get_canonical_emoji_name(custom_emoji), "green_tick");
+
+    // Nothing we render omits the `:name:`, so build that case by hand.
+    const unnamed_emoji = document.createElement("span");
+    unnamed_emoji.classList.add("emoji");
+    assert.equal(emoji_tooltip.get_canonical_emoji_name(unnamed_emoji), undefined);
+});
+
+run_test("build_emoji_tooltip_content renders an enlarged copy and :name:", () => {
+    const fragment = emoji_tooltip.build_emoji_tooltip_content(
+        render_message_emoji(":heart_eyes:"),
+        "heart_eyes",
+    );
+
+    assert.equal(fragment.querySelector(".emoji-tooltip-name").textContent, ":heart_eyes:");
+
+    const enlarged_emoji = fragment.querySelector(".emoji-tooltip-emoji span");
+    assert.ok(enlarged_emoji !== null);
+    assert.ok(enlarged_emoji.classList.contains("emoji-tooltip-enlarged"));
+    // The sprite class is what actually draws the emoji.
+    assert.ok(enlarged_emoji.classList.contains("emoji-1f60d"));
+    // The copy keeps markdown's role="img", so it needs hiding from screen
+    // readers to avoid announcing an unnamed image.
+    assert.equal(enlarged_emoji.getAttribute("role"), "img");
+    assert.equal(enlarged_emoji.getAttribute("aria-hidden"), "true");
+    assert.equal(enlarged_emoji.getAttribute("title"), null);
+    assert.equal(enlarged_emoji.getAttribute("aria-label"), null);
+});
+
+run_test("build_emoji_tooltip_content does not mutate the original element", () => {
+    const emoji_element = render_message_emoji(":green_tick:");
+
+    emoji_tooltip.build_emoji_tooltip_content(emoji_element, "green_tick");
+
+    assert.equal(emoji_element.getAttribute("title"), "green tick");
+    assert.equal(emoji_element.getAttribute("alt"), ":green_tick:");
+    assert.ok(!emoji_element.classList.contains("emoji-tooltip-enlarged"));
+});
+
+run_test("show_emoji_tooltip renders content, or declines when unnamed", () => {
+    let content = null;
+    const instance = {
+        reference: render_message_emoji(":green_tick:"),
+        setContent(fragment) {
+            content = fragment;
+        },
+    };
+    assert.equal(emoji_tooltip.show_emoji_tooltip(instance), undefined);
+    assert.equal(content.querySelector(".emoji-tooltip-name").textContent, ":green_tick:");
+
+    // Returning false keeps the delegate from showing an empty tooltip.
+    const unnamed_emoji = document.createElement("span");
+    unnamed_emoji.classList.add("emoji");
+    assert.equal(
+        emoji_tooltip.show_emoji_tooltip({reference: unnamed_emoji, setContent() {}}),
+        false,
+    );
+});


### PR DESCRIPTION
Fixes #35170.

Emoji tooltips currently rely on the browser’s native title attribute, which only shows plain text and makes fine details hard to see.

This change replaces native tooltips with Tippy tooltips that display an enlarged emoji along with its :name:. The tooltip scales with the user’s font size and removes the native `title` attribute to avoid double tooltips.
Reactions are intentionally unchanged.

---

## Screenshots

### Standard emoji - minimum font size
<img width="1278" height="796" alt="image" src="https://github.com/user-attachments/assets/2a1c8544-8816-4527-8fb4-7c4e09afebae" />



---

### Standard emoji - default font size
<img width="1278" height="795" alt="Screenshot 2026-07-11 170628" src="https://github.com/user-attachments/assets/66500ed0-33f2-4dfc-bb0b-a1508f7ef09a" />


---

### Standard emoji - maximum font size
<img width="1277" height="796" alt="image" src="https://github.com/user-attachments/assets/ebcf9d8b-4215-4db2-8758-61bc521de1e5" />


---

### Custom emoji - default font size
<img width="1278" height="800" alt="image" src="https://github.com/user-attachments/assets/62684e0f-0588-406b-bbfe-869feba3f380" />


---

### Status emoji - default font size
<img width="1276" height="797" alt="Screenshot 2026-07-11 171330" src="https://github.com/user-attachments/assets/dde8594e-f7e8-435d-953a-ae15fa6c7ca5" />


---

### Compose preview - default font size
<img width="1278" height="798" alt="Screenshot 2026-07-11 171156" src="https://github.com/user-attachments/assets/5cef69e0-d4a8-4955-9e4c-376bc1eeb497" />


---

### Reactions (unchanged)
<img width="1275" height="795" alt="image" src="https://github.com/user-attachments/assets/e9417d65-1d4a-42ca-a2c5-3f01e003389a" />


---

### Relationship to previous PRs

This addresses the same feature request as #36771, but is an independent implementation.

I reviewed the feedback on that PR and ensured this version addresses the open concerns, particularly font scaling and visual consistency.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
