### PR TITLE
web: ignore invalid widget submessage payloads

### DIFF
--- a/web/src/submessage.ts
+++ b/web/src/submessage.ts
@@ -41,12 +41,25 @@ export function get_message_events(message: Message): SubmessageEvents | undefin
 
     message.submessages.sort((m1, m2) => m1.id - m2.id);
 
-    const events = message.submessages.map((obj): {sender_id: number; data: unknown} => ({
-        sender_id: obj.sender_id,
-        data: JSON.parse(obj.content),
-    }));
-    const clean_events = submessages_event_schema.parse(events);
-    return clean_events;
+    const events: {sender_id: number; data: unknown}[] = [];
+
+    for (const obj of message.submessages) {
+        let data: unknown;
+        try {
+            data = JSON.parse(obj.content);
+        } catch {
+            return undefined;
+        }
+
+        events.push({sender_id: obj.sender_id, data});
+    }
+
+    const parsed = submessages_event_schema.safeParse(events);
+    if (!parsed.success) {
+        return undefined;
+    }
+
+    return parsed.data;
 }
 
 export function process_widget_rows_in_list(list: MessageList | undefined): void {


### PR DESCRIPTION
Hi Zulip folks — I'm Paul (new user of Zulip, happy to be here and hopefully contribute).

## What
This changes widget submessage decoding to use `safeParse` and gracefully ignore invalid payloads.

## Why
In development (and potentially during mixed-version rollouts), malformed/unknown widget submessage payloads can throw during message rendering and break the message feed.

This keeps the UI resilient: if a widget payload can't be decoded, we simply skip widget activation for that message.

## Testing
- Verified locally by reproducing a `ZodError: No matching discriminator` crash in the message list and confirming this patch prevents the failure.