### PR TITLE
left_sidebar: Show parent stream when navigating to a topic

### DIFF
--- a/web/src/scroll_util.ts
+++ b/web/src/scroll_util.ts
@@ -106,3 +106,22 @@ export function scroll_element_into_container(
 export function get_left_sidebar_scroll_container(): JQuery {
     return get_scroll_element($("#left_sidebar_scroll_container"));
 }
+
+export function is_element_fully_visible(
+    $container: JQuery,
+    $element: JQuery,
+    sticky_header_height = 0,
+): boolean {
+    // Check if element's top and bottom are both inside the container's visible viewport
+    const container_offset = $container.offset()?.top ?? 0;
+    const container_scroll_top = $container.scrollTop() ?? 0;
+    const container_height = ($container.height() ?? 0) - sticky_header_height;
+
+    const elem_offset = $element.offset()?.top ?? 0;
+    const elem_height = $element.outerHeight() ?? 0;
+
+    const elem_top = elem_offset - container_offset - sticky_header_height;
+    const elem_bottom = elem_top + elem_height;
+
+    return elem_top >= 0 && elem_bottom <= container_height;
+}

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1539,7 +1539,17 @@ export let scroll_stream_into_view = function ($stream_li?: JQuery): void {
             .closest(".stream-list-section-container")
             .children(".stream-list-subsection-header")
             .outerHeight()! + 2; // + 2px for top border
-    scroll_util.scroll_element_into_container($stream_header, $container, header_height);
+
+    // Check if stream is already visible
+    const stream_visible = scroll_util.is_element_fully_visible(
+        scroll_util.get_scroll_element($container),
+        $stream_header,
+        header_height,
+    );
+
+    if (!stream_visible) {
+        scroll_util.scroll_element_into_container($stream_header, $container, header_height);
+    }
     // Note: If the stream is in a collapsed folder, we don't uncollapse
     // the folder. We do uncollapse when the user clicks on the channel,
     // but that's handled elsewhere.


### PR DESCRIPTION
Fixes #37974

## Summary
When navigating to a topic (for example from Recent conversations), Zulip scrolls the selected topic into view but sometimes the parent stream name remains outside the visible left sidebar viewport. This makes it difficult for users to identify which stream the topic belongs to.

This PR improves the sidebar scrolling behavior so that, whenever possible, both the topic and its parent stream are visible, while keeping the topic as the highest priority.

## Implementation details
The scroll behavior now follows a two-step approach:

1. Ensure the selected topic is visible (existing behavior preserved).
2. If the topic is already visible, minimally adjust the scroll position to reveal the parent stream only if doing so does not hide the topic.

To support this:

- Added a utility to check whether an element is fully visible inside the sidebar viewport.
- Updated topic scrolling logic to conditionally reveal the parent stream.
- Prevented unnecessary scrolling if both elements are already visible.
- Avoided aggressive re-centering and scroll jitter.

## Behavior changes
- Topic visibility always has priority.
- Sidebar scrolls only when required.
- No extra movement if stream and topic are already visible.
- Prevents over-scrolling when switching narrows repeatedly.
- Existing behavior unchanged when topic itself is off-screen.

## How changes were tested
Manual testing covered the following scenarios:

- Navigating to a topic where the stream is already visible
- Navigating to a topic where the stream is above the viewport
- Topic near viewport boundaries
- Repeated narrow switching (no jitter)
- Normal sidebar navigation behavior unchanged

## Screenshots and screen captures
(Add before/after screenshots showing the stream becoming visible while keeping the topic visible)

<details>
<summary>Self-review checklist</summary>

- [ ] Self-reviewed the changes for clarity and maintainability
- [ ] Followed the AI use policy

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans
- [ ] Highlights technical choices and edge cases
- [ ] Calls out remaining concerns
- [ ] Automated tests verify logic where appropriate

Individual commits are ready for review.

- [ ] Each commit is a coherent idea
- [ ] Commit message explains reasoning and motivation

Completed manual review and testing of:

- [ ] Visual appearance
- [ ] Responsiveness and internationalization
- [ ] Strings and tooltips
- [ ] End-to-end functionality
- [ ] Corner cases and error conditions

</details>
