### PR TITLE
Add channels:all filter.

### DIFF
--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -58,6 +58,9 @@ as an empty string.
 
 ## Changes
 
+* In Zulip 13.0 (feature level ZF-cf1fc8), support was added for a new
+  `channels:all` filter, matching messages in all the accessible channels.
+
 * In Zulip 12.0 (feature level 489), support was added for a new
   filter, `channels:archived`, which returns messages the current user
   received in channels that have been [archived](/help/archive-a-channel).

--- a/api_docs/unmerged.d/ZF-cf1fc8.md
+++ b/api_docs/unmerged.d/ZF-cf1fc8.md
@@ -1,0 +1,7 @@
+* [`GET /messages`](/api/get-messages),
+  [`GET /messages/matches_narrow`](/api/check-messages-match-narrow),
+  [`POST /messages/flags/narrow`](/api/update-message-flags-for-narrow),
+  [`POST /register`](/api/register-queue):
+  Added a new [search/narrow filter](/api/construct-narrow),
+  `channels:all`, which allows users to search messages
+  across all accessible channels.

--- a/starlight_help/src/content/docs/search-for-messages.mdx
+++ b/starlight_help/src/content/docs/search-for-messages.mdx
@@ -106,6 +106,8 @@ To avoid cluttering your search results, by default, Zulip searches just the
 messages you received. You can use the `channel:` filter, and some `channels:`
 filters, to search additional messages.
 
+* `channels:all`: Search messages across all channels you are allowed to access,
+  including channels you aren't subscribed to.
 * `channels:public`: Search messages in all
   [public](/help/channel-permissions#public-channels) and
   [web-public](/help/channel-permissions#web-public-channels) channels.

--- a/starlight_help/src/content/docs/search-for-messages.mdx
+++ b/starlight_help/src/content/docs/search-for-messages.mdx
@@ -106,6 +106,11 @@ To avoid cluttering your search results, by default, Zulip searches just the
 messages you received. You can use the `channel:` filter, and some `channels:`
 filters, to search additional messages.
 
+* `channels:all`: Search messages across all channels you are allowed to access,
+  including channels you aren't subscribed to. In [private channels with
+  protected history](/help/channel-permissions#private-channels), only the
+  messages you received are searched. [Guests](/help/guest-users) can search
+  only the messages they received in channels they are subscribed to.
 * `channels:public`: Search messages in all
   [public](/help/channel-permissions#public-channels) and
   [web-public](/help/channel-permissions#web-public-channels) channels.

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -67,7 +67,7 @@ type Part =
           is_empty_string_topic?: boolean;
       };
 
-const channels_operands = new Set(["archived", "public", "web-public"]);
+const channels_operands = new Set(["archived", "public", "web-public", "all"]);
 
 function message_in_home(message: Message): boolean {
     // The home view contains messages not sent to muted channels,
@@ -180,6 +180,8 @@ function build_term_predicate(term: NarrowCanonicalTerm): ((message: Message) =>
                     return (message) =>
                         message.type === "stream" &&
                         stream_data.is_stream_archived_by_id(message.stream_id);
+                case "all":
+                    return (message) => message.type === "stream";
                 default:
                     return () => false;
             }
@@ -740,6 +742,7 @@ export class Filter {
     static sorted_term_types(term_types: string[]): string[] {
         const levels = [
             "in",
+            "channels-all",
             "channels-public",
             "channels-archived",
             "not-channels-archived",
@@ -972,6 +975,8 @@ export class Filter {
                 return possible_prefix + "all web-public channels";
             case "archived":
                 return possible_prefix + "archived channels";
+            case "all":
+                return possible_prefix + "all channels that you can view";
             default:
                 return possible_prefix + "all public channels";
         }
@@ -1239,6 +1244,8 @@ export class Filter {
             "not-is-muted",
             "in-home",
             "in-all",
+            "channels-all",
+            "not-channels-all",
             "channels-public",
             "not-channels-public",
             "channels-archived",
@@ -1361,6 +1368,9 @@ export class Filter {
         if (_.isEqual(term_types, ["is-starred"])) {
             return true;
         }
+        if (_.isEqual(term_types, ["channels-all"])) {
+            return true;
+        }
         if (_.isEqual(term_types, ["channels-public"])) {
             return true;
         }
@@ -1446,6 +1456,8 @@ export class Filter {
                     return "/#narrow/is/starred";
                 case "is-mentioned":
                     return "/#narrow/is/mentioned";
+                case "channels-all":
+                    return "/#narrow/channels/all";
                 case "channels-public":
                     return "/#narrow/channels/public";
                 case "channels-archived":
@@ -1635,6 +1647,8 @@ export class Filter {
                     return $t({defaultMessage: "Combined feed"});
                 case "in-all":
                     return $t({defaultMessage: "All messages including muted channels"});
+                case "channels-all":
+                    return $t({defaultMessage: "Messages in all channels you can view"});
                 case "channels-public":
                     if (page_params.is_spectator || current_user.is_guest) {
                         return $t({
@@ -1743,7 +1757,9 @@ export class Filter {
         return (
             (this.has_operator("is") && this.terms_with_operator("is")[0]!.operand === "dm") ||
             this.has_operator("dm") ||
-            this.has_operator("dm-including")
+            this.has_operator("dm-including") ||
+            // Negating "all channels" leaves only direct messages.
+            this.has_negated_operand("channels", "all")
         );
     }
 
@@ -2072,6 +2088,7 @@ export class Filter {
             "not-is-followed",
             "is-resolved",
             "not-is-resolved",
+            "channels-all",
             "channels-public",
             "not-channels-public",
             "channels-archived",

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -68,7 +68,7 @@ type Part =
           is_empty_string_topic?: boolean;
       };
 
-const channels_operands = new Set(["archived", "public", "web-public"]);
+const channels_operands = new Set(["archived", "public", "web-public", "all"]);
 
 function message_in_home(message: Message): boolean {
     // The home view contains messages not sent to muted channels,
@@ -181,6 +181,8 @@ function build_term_predicate(term: NarrowCanonicalTerm): ((message: Message) =>
                     return (message) =>
                         message.type === "stream" &&
                         stream_data.is_stream_archived_by_id(message.stream_id);
+                case "all":
+                    return (message) => message.type === "stream";
                 default:
                     return () => false;
             }
@@ -676,6 +678,11 @@ export class Filter {
             case "channel":
                 return stream_data.get_sub_by_id_string(term.operand) !== undefined;
             case "channels":
+                if (term.negated && term.operand === "all") {
+                    // The server rejects -channels:all as an unsupported
+                    // narrow; is:dm is the way to narrow to direct messages.
+                    return false;
+                }
                 return channels_operands.has(term.operand);
             case "topic":
                 return true;
@@ -756,6 +763,7 @@ export class Filter {
     static sorted_term_types(term_types: string[]): string[] {
         const levels = [
             "in",
+            "channels-all",
             "channels-public",
             "channels-archived",
             "not-channels-archived",
@@ -997,7 +1005,8 @@ export class Filter {
     static describe_channels_operator(negated: boolean, operand: string): string {
         const possible_prefix = negated ? "exclude " : "";
         assert(channels_operands.has(operand));
-        if ((page_params.is_spectator || current_user.is_guest) && operand === "public") {
+        const has_limited_channel_access = page_params.is_spectator || current_user.is_guest;
+        if (has_limited_channel_access && operand === "public") {
             return possible_prefix + "all public channels that you can view";
         }
         switch (operand) {
@@ -1005,6 +1014,13 @@ export class Filter {
                 return possible_prefix + "all web-public channels";
             case "archived":
                 return possible_prefix + "archived channels";
+            case "all":
+                // Spectators and guests can only reach a subset of the
+                // organization's channels, so we avoid implying otherwise.
+                if (has_limited_channel_access) {
+                    return possible_prefix + "all channels that you can view";
+                }
+                return possible_prefix + "all channels (including unsubscribed)";
             default:
                 return possible_prefix + "all public channels";
         }
@@ -1284,6 +1300,7 @@ export class Filter {
             "not-is-muted",
             "in-home",
             "in-all",
+            "channels-all",
             "channels-public",
             "not-channels-public",
             "channels-archived",
@@ -1407,6 +1424,9 @@ export class Filter {
         if (_.isEqual(term_types, ["is-starred"])) {
             return true;
         }
+        if (_.isEqual(term_types, ["channels-all"])) {
+            return true;
+        }
         if (_.isEqual(term_types, ["channels-public"])) {
             return true;
         }
@@ -1492,6 +1512,8 @@ export class Filter {
                     return "/#narrow/is/starred";
                 case "is-mentioned":
                     return "/#narrow/is/mentioned";
+                case "channels-all":
+                    return "/#narrow/channels/all";
                 case "channels-public":
                     return "/#narrow/channels/public";
                 case "channels-archived":
@@ -1681,6 +1703,15 @@ export class Filter {
                     return $t({defaultMessage: "Combined feed"});
                 case "in-all":
                     return $t({defaultMessage: "All messages including muted channels"});
+                case "channels-all":
+                    if (page_params.is_spectator || current_user.is_guest) {
+                        return $t({
+                            defaultMessage: "Messages in all channels that you can view",
+                        });
+                    }
+                    return $t({
+                        defaultMessage: "Messages in all channels (including unsubscribed)",
+                    });
                 case "channels-public":
                     if (page_params.is_spectator || current_user.is_guest) {
                         return $t({
@@ -1828,6 +1859,12 @@ export class Filter {
         }
 
         if (this.has_operator("mentions")) {
+            return false;
+        }
+
+        if (this.has_negated_operand("channels", "all")) {
+            // The server rejects -channels:all as an unsupported narrow, so
+            // we must not filter messages locally as if it were valid.
             return false;
         }
 
@@ -2118,6 +2155,7 @@ export class Filter {
             "not-is-followed",
             "is-resolved",
             "not-is-resolved",
+            "channels-all",
             "channels-public",
             "not-channels-public",
             "channels-archived",

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -191,9 +191,9 @@ export function group_edit_url(group: UserGroup, right_side_tab: string): string
     return hash;
 }
 
-export function search_public_streams_notice_url(terms: NarrowCanonicalTerm[]): string {
-    const public_operator: NarrowCanonicalTerm = {operator: "channels", operand: "public"};
-    return search_terms_to_hash([public_operator, ...terms]);
+export function search_all_channels_notice_url(terms: NarrowCanonicalTerm[]): string {
+    const all_channels_operator: NarrowCanonicalTerm = {operator: "channels", operand: "all"};
+    return search_terms_to_hash([all_channels_operator, ...terms]);
 }
 
 export function parse_narrow(hash: string[]): NarrowCanonicalTerm[] | undefined {

--- a/web/src/message_feed_top_notices.ts
+++ b/web/src/message_feed_top_notices.ts
@@ -39,9 +39,9 @@ function show_end_of_results_notice(): void {
         return;
     }
     const terms = narrow_filter.terms();
-    // Set the link to point to this search with streams:public added.
+    // Set the link to point to this search with channels:all added.
     // Note that element we adjust is not visible to spectators.
-    const update_hash = hash_util.search_public_streams_notice_url(terms);
+    const update_hash = hash_util.search_all_channels_notice_url(terms);
     $(".all-messages-search-caution").show();
     $(".all-messages-search-caution .search-shared-history").attr("data-url", update_hash);
 }

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -655,7 +655,7 @@ export function show_empty_narrow_message(current_filter: Filter, invalid_narrow
         $(".empty_feed_notice .empty-feed-notice-action").show();
 
         const terms = current_filter.terms();
-        const update_hash = hash_util.search_public_streams_notice_url(terms);
+        const update_hash = hash_util.search_all_channels_notice_url(terms);
 
         $(".empty_feed_notice .search-shared-history").attr("data-url", update_hash);
     }

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -48,6 +48,7 @@ const channels_public_incompatible_patterns: TermPattern[] = [
     ...common_incompatible_patterns,
     {operator: "channels", operand: "public"},
     {operator: "channels", operand: "web-public"},
+    {operator: "channels", operand: "all"},
 ];
 
 // TODO: Expand this to support all available filters and its description.
@@ -76,6 +77,7 @@ type SearchFilter =
     | "channels:public"
     | "channels:web-public"
     | "channels:archived"
+    | "channels:all"
     | "is:resolved"
     | "-is:resolved"
     | "is:dm"
@@ -98,7 +100,9 @@ const incompatible_patterns: Record<SearchFilter, TermPattern[]> = {
     "channels:archived": [
         ...common_incompatible_patterns,
         {operator: "channels", operand: "archived"},
+        {operator: "channels", operand: "all"},
     ],
+    "channels:all": channel_incompatible_patterns,
     topic: [
         {operator: "dm"},
         {operator: "is", operand: "dm"},
@@ -745,10 +749,14 @@ function get_channels_filter_suggestions(
     const public_channels_search_string = "channels:public";
     const web_public_channels_search_string = "channels:web-public";
     const archived_channels_search_string = "channels:archived";
+    const all_accessible_channels_search_string = "channels:all";
     const suggestions: Suggestion[] = [];
 
     if (!page_params.is_spectator) {
-        suggestions.push(...filter_suggestions_by_criteria(terms, [public_channels_search_string]));
+        suggestions.push(
+            ...filter_suggestions_by_criteria(terms, [all_accessible_channels_search_string]),
+            ...filter_suggestions_by_criteria(terms, [public_channels_search_string]),
+        );
     }
 
     if (stream_data.realm_has_web_public_streams()) {

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -49,6 +49,7 @@ const channels_public_incompatible_patterns: TermPattern[] = [
     ...common_incompatible_patterns,
     {operator: "channels", operand: "public"},
     {operator: "channels", operand: "web-public"},
+    {operator: "channels", operand: "all"},
 ];
 
 // TODO: Expand this to support all available filters and its description.
@@ -77,6 +78,7 @@ type SearchFilter =
     | "channels:public"
     | "channels:web-public"
     | "channels:archived"
+    | "channels:all"
     | "is:resolved"
     | "-is:resolved"
     | "is:dm"
@@ -100,6 +102,7 @@ const incompatible_patterns: Record<SearchFilter, TermPattern[]> = {
         ...common_incompatible_patterns,
         {operator: "channels", operand: "archived"},
     ],
+    "channels:all": channels_public_incompatible_patterns,
     topic: [
         {operator: "dm"},
         {operator: "is", operand: "dm"},
@@ -735,6 +738,9 @@ function get_special_filter_suggestions(
     if (last.negated === true || is_search_operand_negated) {
         suggestions = suggestions
             .filter((suggestion) => suggestion !== "-is:resolved")
+            // channels:all does not support negation, so never suggest
+            // -channels:all; is:dm is the way to narrow to direct messages.
+            .filter((suggestion) => suggestion !== "channels:all")
             .map((suggestion) => "-" + suggestion);
     }
 
@@ -769,10 +775,14 @@ function get_channels_filter_suggestions(
     const public_channels_search_string = "channels:public";
     const web_public_channels_search_string = "channels:web-public";
     const archived_channels_search_string = "channels:archived";
+    const all_accessible_channels_search_string = "channels:all";
     const suggestions: Suggestion[] = [];
 
     if (!page_params.is_spectator) {
-        suggestions.push(...filter_suggestions_by_criteria(terms, [public_channels_search_string]));
+        suggestions.push(
+            ...filter_suggestions_by_criteria(terms, [all_accessible_channels_search_string]),
+            ...filter_suggestions_by_criteria(terms, [public_channels_search_string]),
+        );
     }
 
     if (stream_data.realm_has_web_public_streams()) {

--- a/web/templates/empty_feed_notice.hbs
+++ b/web/templates/empty_feed_notice.hbs
@@ -23,7 +23,7 @@
         <button
           class="search-shared-history hidden-for-spectators action-button action-button-subtle-neutral"
           type="button">
-            {{t 'Search all public channels'}}
+            {{t 'Search all channels'}}
         </button>
     </div>
     {{/if}}

--- a/web/templates/message_feed_errors.hbs
+++ b/web/templates/message_feed_errors.hbs
@@ -15,7 +15,7 @@
             {{#if is_guest}}
                 {{#tr}}
                     End of results from
-                    <z-link>your message history</z-link>. Include messages in your public channels
+                    <z-link>your message history</z-link>. Include messages in your channels
                     sent when you weren't subscribed?
                     {{#*inline "z-link"}}<a href="/help/search-for-messages#search-shared-history"
                     target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
@@ -23,7 +23,7 @@
             {{else}}
                 {{#tr}}
                     End of results from
-                    <z-link>your message history</z-link>. Include messages in public channels
+                    <z-link>your message history</z-link>. Include messages in all channels
                     sent when you weren't subscribed?
                     {{#*inline "z-link"}}<a href="/help/search-for-messages#search-shared-history"
                     target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -61,6 +61,12 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">channels:all</td>
+                        <td class="definition">
+                            {{t 'Search all channels that you can view.'}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">channels:public</td>
                         <td class="definition">
                             {{#if can_access_all_public_channels }}

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -70,6 +70,16 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">channels:all</td>
+                        <td class="definition">
+                            {{#if can_access_all_public_channels }}
+                            {{t 'Search all channels, including unsubscribed.'}}
+                            {{else}}
+                            {{t 'Search all channels that you can view.'}}
+                            {{/if}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">channels:public</td>
                         <td class="definition">
                             {{#if can_access_all_public_channels }}

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -348,6 +348,37 @@ test("basics", () => {
     assert.ok(filter.may_contain_multiple_conversations());
     assert.ok(!filter.has_exactly_channel_topic_operators());
 
+    terms = [{operator: "channels", operand: "all", negated: true}];
+    filter = new Filter(terms);
+    assert.ok(filter.contains_only_private_messages());
+    assert.ok(!filter.may_have_incomplete_message_history());
+    assert.ok(!filter.has_operator("channels"));
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.contains_no_partial_conversations());
+    assert.ok(filter.has_negated_operand("channels", "all"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.is_channel_view());
+    assert.ok(filter.may_contain_multiple_conversations());
+    assert.ok(!filter.has_exactly_channel_topic_operators());
+
+    terms = [{operator: "channels", operand: "all"}];
+    filter = new Filter(terms);
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.may_have_incomplete_message_history());
+    assert.ok(filter.has_operator("channels"));
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.contains_no_partial_conversations());
+    assert.ok(!filter.has_negated_operand("channels", "all"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(filter.includes_full_stream_history());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.is_channel_view());
+    assert.ok(filter.may_contain_multiple_conversations());
+    assert.ok(!filter.has_exactly_channel_topic_operators());
+
     terms = [{operator: "channels", operand: "public", negated: true}];
     filter = new Filter(terms);
     assert.ok(filter.may_have_incomplete_message_history());
@@ -694,6 +725,7 @@ test("basics", () => {
 
     terms = [
         {operator: "channel", operand: "channel_name"},
+        {operator: "channels", operand: "all"},
         {operator: "channels", operand: "public"},
         {operator: "topic", operand: "patience"},
     ];
@@ -1300,6 +1332,11 @@ test("predicate_basics", ({override}) => {
     assert.ok(predicate({type: direct_message}));
     assert.ok(!predicate({type: stream_message}));
 
+    predicate = get_predicate([["channels", "all"]]);
+    assert.ok(predicate({type: stream_message, stream_id: old_sub_id}));
+    assert.ok(predicate({type: stream_message, stream_id: private_sub_id}));
+    assert.ok(predicate({type: stream_message, stream_id: web_public_sub_id}));
+
     predicate = get_predicate([["channels", "public"]]);
     assert.ok(predicate({type: stream_message, stream_id: old_sub_id}));
     assert.ok(!predicate({type: stream_message, stream_id: private_sub_id}));
@@ -1637,6 +1674,10 @@ test("negated_predicates", () => {
     assert.ok(predicate({type: stream_message, stream_id: 999999}));
     assert.ok(!predicate({type: stream_message, stream_id: social_stream_id}));
 
+    narrow = [{operator: "channels", operand: "all", negated: true}];
+    predicate = new Filter(narrow).predicate();
+    assert.ok(predicate({}));
+
     narrow = [{operator: "channels", operand: "public", negated: true}];
     predicate = new Filter(narrow).predicate();
     assert.ok(predicate({}));
@@ -1762,12 +1803,28 @@ test("parse", () => {
     ];
     _test();
 
+    string = "text channels:all more text";
+    terms = [
+        {operator: "search", operand: "text"},
+        {operator: "channels", operand: "all"},
+        {operator: "search", operand: "more text"},
+    ];
+    _test();
+
     string = "text channels:public more text";
     terms = [
         {operator: "search", operand: "text"},
         {operator: "channels", operand: "public"},
         {operator: "search", operand: "more text"},
     ];
+    _test();
+
+    string = "channels:all";
+    terms = [{operator: "channels", operand: "all"}];
+    _test();
+
+    string = "-channels:all";
+    terms = [{operator: "channels", operand: "all", negated: true}];
     _test();
 
     string = "channels:public";
@@ -1779,6 +1836,10 @@ test("parse", () => {
     _test();
 
     // "streams" was renamed to "channels"
+    string = "streams:all";
+    terms = [{operator: "channels", operand: "all"}];
+    _test();
+
     string = "streams:public";
     terms = [{operator: "channels", operand: "public"}];
     _test();
@@ -1844,6 +1905,22 @@ test("unparse", () => {
     assert.deepEqual(Filter.unparse(terms), string);
 
     terms = [
+        {operator: "channels", operand: "all"},
+        {operator: "search", operand: "text"},
+    ];
+
+    string = "channels:all text";
+    assert.deepEqual(Filter.unparse(terms), string);
+
+    terms = [{operator: "channels", operand: "all"}];
+    string = "channels:all";
+    assert.deepEqual(Filter.unparse(terms), string);
+
+    terms = [{operator: "channels", operand: "all", negated: true}];
+    string = "-channels:all";
+    assert.deepEqual(Filter.unparse(terms), string);
+
+    terms = [
         {operator: "channels", operand: "public"},
         {operator: "search", operand: "text"},
     ];
@@ -1892,6 +1969,14 @@ test("describe", ({mock_template, override}) => {
     let terms;
     mock_template("search_description.hbs", true, (_data, html) => html);
 
+    narrow = [{operator: "channels", operand: "all"}];
+    string = "all channels that you can view";
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
+
+    narrow = [{operator: "channels", operand: "all", negated: true}];
+    string = "exclude all channels that you can view";
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
+
     narrow = [{operator: "channels", operand: "public"}];
     string = "all public channels";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
@@ -1927,6 +2012,10 @@ test("describe", ({mock_template, override}) => {
 
     narrow = [{operator: "channels", operand: "web-public", negated: true}];
     string = "exclude all web-public channels";
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
+
+    narrow = [{operator: "channels", operand: "all"}];
+    string = "all channels that you can view";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
     page_params.is_spectator = false;
 
@@ -2215,6 +2304,7 @@ test("term_type", () => {
         };
     }
 
+    assert_term_type(term("channels", "all"), "channels-all");
     assert_term_type(term("channels", "public"), "channels-public");
     assert_term_type(term("channel", "whatever"), "channel");
     assert_term_type(term("dm", "whomever"), "dm");
@@ -2241,6 +2331,7 @@ test("term_type", () => {
     assert_term_sort(["bogus", "channel", "topic"], ["channel", "topic", "bogus"]);
     assert_term_sort(["channel", "topic", "channel"], ["channel", "channel", "topic"]);
 
+    assert_term_sort(["search", "channels-all"], ["channels-all", "search"]);
     assert_term_sort(["search", "channels-public"], ["channels-public", "search"]);
 
     const terms = [
@@ -2329,6 +2420,7 @@ test("convert_suggestion_to_term", () => {
         ["near:home", false],
         ["channel:" + denmark.stream_id, true],
         [`channel:${invalid_sub_id}`, false],
+        ["channels:all", true],
         ["channels:public", true],
         ["channels:private", false],
         ["topic:GhostTown", true],
@@ -2652,6 +2744,7 @@ test("navbar_helpers", ({override}) => {
     const is_mentioned = [{operator: "is", operand: "mentioned"}];
     const is_resolved = [{operator: "is", operand: "resolved"}];
     const is_followed = [{operator: "is", operand: "followed"}];
+    const channels_all = [{operator: "channels", operand: "all"}];
     const channels_public = [{operator: "channels", operand: "public"}];
     const channels_archived = [{operator: "channels", operand: "archived"}];
     const not_channels_archived = [{operator: "channels", operand: "archived", negated: true}];
@@ -2834,6 +2927,13 @@ test("navbar_helpers", ({override}) => {
             icon: "question-circle-o",
             title: "translated: Unknown channel",
             redirect_url_with_search: "#",
+        },
+        {
+            terms: channels_all,
+            is_common_narrow: true,
+            icon: undefined,
+            title: "translated: Messages in all channels you can view",
+            redirect_url_with_search: "/#narrow/channels/all",
         },
         {
             terms: channels_public,
@@ -3172,6 +3272,7 @@ run_test("is_spectator_compatible", () => {
     );
     assert.ok(!Filter.is_spectator_compatible([{operator: "is", operand: "starred"}]));
     assert.ok(!Filter.is_spectator_compatible([{operator: "is", operand: "dm"}]));
+    assert.ok(Filter.is_spectator_compatible([{operator: "channels", operand: "all"}]));
     assert.ok(Filter.is_spectator_compatible([{operator: "channels", operand: "public"}]));
     assert.ok(Filter.is_spectator_compatible([{operator: "channels", operand: "archived"}]));
 
@@ -3187,6 +3288,7 @@ run_test("is_spectator_compatible", () => {
     // "stream" was renamted to "channel"
     assert.ok(Filter.is_spectator_compatible([{operator: "stream", operand: "Denmark"}]));
     // "streams" was renamed to "channels"
+    assert.ok(Filter.is_spectator_compatible([{operator: "streams", operand: "all"}]));
     assert.ok(Filter.is_spectator_compatible([{operator: "streams", operand: "public"}]));
     // "group-pm-with:" was replaced with "dm-including:"
     assert.ok(

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -348,6 +348,29 @@ test("basics", () => {
     assert.ok(filter.may_contain_multiple_conversations());
     assert.ok(!filter.has_exactly_channel_topic_operators());
 
+    terms = [{operator: "channels", operand: "all"}];
+    filter = new Filter(terms);
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.may_have_incomplete_message_history());
+    assert.ok(filter.has_operator("channels"));
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.contains_no_partial_conversations());
+    assert.ok(!filter.has_negated_operand("channels", "all"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(filter.includes_full_stream_history());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.is_channel_view());
+    assert.ok(filter.may_contain_multiple_conversations());
+    assert.ok(!filter.has_exactly_channel_topic_operators());
+
+    // The server rejects -channels:all as unsupported, so it must not be
+    // applied locally.
+    terms = [{operator: "channels", operand: "all", negated: true}];
+    filter = new Filter(terms);
+    assert.ok(filter.has_negated_operand("channels", "all"));
+    assert.ok(!filter.can_apply_locally());
+
     terms = [{operator: "channels", operand: "public", negated: true}];
     filter = new Filter(terms);
     assert.ok(filter.may_have_incomplete_message_history());
@@ -694,6 +717,7 @@ test("basics", () => {
 
     terms = [
         {operator: "channel", operand: "channel_name"},
+        {operator: "channels", operand: "all"},
         {operator: "channels", operand: "public"},
         {operator: "topic", operand: "patience"},
     ];
@@ -1305,6 +1329,12 @@ test("predicate_basics", ({override}) => {
     assert.ok(predicate({type: direct_message}));
     assert.ok(!predicate({type: stream_message}));
 
+    predicate = get_predicate([["channels", "all"]]);
+    assert.ok(predicate({type: stream_message, stream_id: old_sub_id}));
+    assert.ok(predicate({type: stream_message, stream_id: private_sub_id}));
+    assert.ok(predicate({type: stream_message, stream_id: web_public_sub_id}));
+    assert.ok(!predicate({type: direct_message}));
+
     predicate = get_predicate([["channels", "public"]]);
     assert.ok(predicate({type: stream_message, stream_id: old_sub_id}));
     assert.ok(!predicate({type: stream_message, stream_id: private_sub_id}));
@@ -1767,12 +1797,24 @@ test("parse", () => {
     ];
     _test();
 
+    string = "text channels:all more text";
+    terms = [
+        {operator: "search", operand: "text"},
+        {operator: "channels", operand: "all"},
+        {operator: "search", operand: "more text"},
+    ];
+    _test();
+
     string = "text channels:public more text";
     terms = [
         {operator: "search", operand: "text"},
         {operator: "channels", operand: "public"},
         {operator: "search", operand: "more text"},
     ];
+    _test();
+
+    string = "channels:all";
+    terms = [{operator: "channels", operand: "all"}];
     _test();
 
     string = "channels:public";
@@ -1784,6 +1826,10 @@ test("parse", () => {
     _test();
 
     // "streams" was renamed to "channels"
+    string = "streams:all";
+    terms = [{operator: "channels", operand: "all"}];
+    _test();
+
     string = "streams:public";
     terms = [{operator: "channels", operand: "public"}];
     _test();
@@ -1863,6 +1909,18 @@ test("unparse", () => {
     assert.deepEqual(Filter.unparse(terms), string);
 
     terms = [
+        {operator: "channels", operand: "all"},
+        {operator: "search", operand: "text"},
+    ];
+
+    string = "channels:all text";
+    assert.deepEqual(Filter.unparse(terms), string);
+
+    terms = [{operator: "channels", operand: "all"}];
+    string = "channels:all";
+    assert.deepEqual(Filter.unparse(terms), string);
+
+    terms = [
         {operator: "channels", operand: "public"},
         {operator: "search", operand: "text"},
     ];
@@ -1911,6 +1969,10 @@ test("describe", ({mock_template, override}) => {
     let terms;
     mock_template("search_description.hbs", true, (_data, html) => html);
 
+    narrow = [{operator: "channels", operand: "all"}];
+    string = "all channels (including unsubscribed)";
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
+
     narrow = [{operator: "channels", operand: "public"}];
     string = "all public channels";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
@@ -1947,7 +2009,20 @@ test("describe", ({mock_template, override}) => {
     narrow = [{operator: "channels", operand: "web-public", negated: true}];
     string = "exclude all web-public channels";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
+
+    narrow = [{operator: "channels", operand: "all"}];
+    string = "all channels that you can view";
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
     page_params.is_spectator = false;
+
+    // Guests, like spectators, cannot access every channel in the
+    // organization, so they get the same description.
+    with_overrides(({override}) => {
+        override(me, "is_guest", true);
+        narrow = [{operator: "channels", operand: "all"}];
+        string = "all channels that you can view";
+        assert.equal(Filter.search_description_as_html(narrow, false), string);
+    });
 
     narrow = [{operator: "date", operand: ""}];
     string = "messages sent around a specific date";
@@ -2243,6 +2318,7 @@ test("term_type", () => {
         };
     }
 
+    assert_term_type(term("channels", "all"), "channels-all");
     assert_term_type(term("channels", "public"), "channels-public");
     assert_term_type(term("channel", "whatever"), "channel");
     assert_term_type(term("dm", "whomever"), "dm");
@@ -2269,6 +2345,7 @@ test("term_type", () => {
     assert_term_sort(["bogus", "channel", "topic"], ["channel", "topic", "bogus"]);
     assert_term_sort(["channel", "topic", "channel"], ["channel", "channel", "topic"]);
 
+    assert_term_sort(["search", "channels-all"], ["channels-all", "search"]);
     assert_term_sort(["search", "channels-public"], ["channels-public", "search"]);
 
     const terms = [
@@ -2362,7 +2439,12 @@ test("convert_suggestion_to_term", () => {
         ["near:home", false],
         ["channel:" + denmark.stream_id, true],
         [`channel:${invalid_sub_id}`, false],
+        ["channels:all", true],
+        // The server rejects -channels:all, so it must not become a search
+        // pill; the other channels: operands can still be negated.
+        ["-channels:all", false],
         ["channels:public", true],
+        ["-channels:public", true],
         ["channels:private", false],
         ["topic:GhostTown", true],
         [`dm-including:${alice.user_id}`, true],
@@ -2696,6 +2778,7 @@ test("navbar_helpers", ({override}) => {
     const is_mentioned = [{operator: "is", operand: "mentioned"}];
     const is_resolved = [{operator: "is", operand: "resolved"}];
     const is_followed = [{operator: "is", operand: "followed"}];
+    const channels_all = [{operator: "channels", operand: "all"}];
     const channels_public = [{operator: "channels", operand: "public"}];
     const channels_archived = [{operator: "channels", operand: "archived"}];
     const not_channels_archived = [{operator: "channels", operand: "archived", negated: true}];
@@ -2878,6 +2961,13 @@ test("navbar_helpers", ({override}) => {
             icon: "question-circle-o",
             title: "translated: Unknown channel",
             redirect_url_with_search: "#",
+        },
+        {
+            terms: channels_all,
+            is_common_narrow: true,
+            icon: undefined,
+            title: "translated: Messages in all channels (including unsubscribed)",
+            redirect_url_with_search: "/#narrow/channels/all",
         },
         {
             terms: channels_public,
@@ -3128,6 +3218,11 @@ test("navbar_helpers", ({override}) => {
         title: "translated: Messages in all public channels that you can view",
     };
     test_get_title(channels_public_search_test_case_for_spectator);
+    const channels_all_search_test_case_for_spectator = {
+        terms: channels_all,
+        title: "translated: Messages in all channels that you can view",
+    };
+    test_get_title(channels_all_search_test_case_for_spectator);
     page_params.is_spectator = false;
 
     override(realm, "realm_enable_guest_user_indicator", false);
@@ -3216,6 +3311,7 @@ run_test("is_spectator_compatible", () => {
     );
     assert.ok(!Filter.is_spectator_compatible([{operator: "is", operand: "starred"}]));
     assert.ok(!Filter.is_spectator_compatible([{operator: "is", operand: "dm"}]));
+    assert.ok(Filter.is_spectator_compatible([{operator: "channels", operand: "all"}]));
     assert.ok(Filter.is_spectator_compatible([{operator: "channels", operand: "public"}]));
     assert.ok(Filter.is_spectator_compatible([{operator: "channels", operand: "archived"}]));
 
@@ -3231,6 +3327,7 @@ run_test("is_spectator_compatible", () => {
     // "stream" was renamted to "channel"
     assert.ok(Filter.is_spectator_compatible([{operator: "stream", operand: "Denmark"}]));
     // "streams" was renamed to "channels"
+    assert.ok(Filter.is_spectator_compatible([{operator: "streams", operand: "all"}]));
     assert.ok(Filter.is_spectator_compatible([{operator: "streams", operand: "public"}]));
     // "group-pm-with:" was replaced with "dm-including:"
     assert.ok(

--- a/web/tests/hash_util.test.cjs
+++ b/web/tests/hash_util.test.cjs
@@ -254,26 +254,26 @@ run_test("test_by_conversation_and_time_url", () => {
     );
 });
 
-run_test("test_search_public_streams_notice_url", () => {
+run_test("test_search_all_channels_notice_url", () => {
     function get_terms(url) {
         return hash_util.parse_narrow(url.split("/"));
     }
 
     assert.equal(
-        hash_util.search_public_streams_notice_url(get_terms("#narrow/search/abc")),
-        "#narrow/channels/public/search/abc",
+        hash_util.search_all_channels_notice_url(get_terms("#narrow/search/abc")),
+        "#narrow/channels/all/search/abc",
     );
 
     assert.equal(
-        hash_util.search_public_streams_notice_url(
+        hash_util.search_all_channels_notice_url(
             get_terms("#narrow/has/link/has/image/has/attachment"),
         ),
-        "#narrow/channels/public/has/link/has/image/has/attachment",
+        "#narrow/channels/all/has/link/has/image/has/attachment",
     );
 
     assert.equal(
-        hash_util.search_public_streams_notice_url(get_terms("#narrow/sender/15")),
-        "#narrow/channels/public/sender/15-Hamlet",
+        hash_util.search_all_channels_notice_url(get_terms("#narrow/sender/15")),
+        "#narrow/channels/all/sender/15-Hamlet",
     );
 });
 

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -171,7 +171,7 @@ run_test("empty_narrow_html", ({mock_template}) => {
         <button
           class="search-shared-history hidden-for-spectators action-button action-button-subtle-neutral"
           type="button">
-            translated: Search all public channels
+            translated: Search all channels
         </button>
     </div>
 </div>
@@ -765,6 +765,12 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
             undefined,
             true,
         ),
+    );
+    // The action widens the search to every channel the user can access,
+    // not just the public ones.
+    assert.equal(
+        $(".empty_feed_notice .search-shared-history").attr("data-url"),
+        "#narrow/channels/all/has/image",
     );
     current_filter = set_filter([
         ["has", "reaction"],

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -798,7 +798,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
             "translated: You are not allowed to view messages in this private channel.",
         ),
     );
-    const channels_operands = ["archived", "public", "web-public"];
+    const channels_operands = ["all", "archived", "public", "web-public"];
     for (const operand of channels_operands) {
         current_filter = set_filter([["channels", operand]]);
         narrow_banner.show_empty_narrow_message(current_filter);

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -1160,6 +1160,30 @@ test("operator_suggestions", ({override}) => {
     expected = ["-s", "-sender:", "-channels:", "-channel:", `-sender:${me.user_id}`];
     assert.deepEqual(suggestions, expected);
 
+    query = "channels:";
+    suggestions = get_suggestions(query);
+    expected = ["channels:all", "channels:public", "channels:archived"];
+    assert.deepEqual(suggestions, expected);
+
+    // channels:all does not support negation, so -channels:all is never
+    // suggested even though the other negated channels operands are.
+    query = "-channels:";
+    suggestions = get_suggestions(query);
+    expected = ["-channels:public", "-channels:archived"];
+    assert.deepEqual(suggestions, expected);
+
+    // channels:archived selects channels along a separate axis, so it and
+    // channels:all are each still worth suggesting alongside the other.
+    query = "channels:";
+    suggestions = get_suggestions(query, "channels:archived");
+    expected = ["channels:archived channels:all", "channels:archived channels:public"];
+    assert.deepEqual(suggestions, expected);
+
+    query = "channels:";
+    suggestions = get_suggestions(query, "channels:all");
+    expected = ["channels:all channels:archived"];
+    assert.deepEqual(suggestions, expected);
+
     stream_data.add_sub_for_tests(
         make_stream({
             stream_id: 66,

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -24,11 +24,16 @@ from zerver.lib.message import (
 )
 from zerver.lib.narrow_predicate import channel_operators, channels_operators
 from zerver.lib.recipient_users import recipient_for_user_profiles
+from zerver.lib.stream_subscription import (
+    get_subscribed_stream_ids_for_user,
+    get_user_subscribed_streams,
+)
 from zerver.lib.streams import (
     access_stream_common,
     can_access_stream_history_by_id,
     can_access_stream_history_by_name,
     get_archived_streams_queryset,
+    get_content_accessible_streams_queryset,
     get_public_streams_queryset,
     get_stream_by_narrow_operand_access_unchecked,
     get_web_public_streams_queryset,
@@ -320,6 +325,19 @@ class NarrowBuilder:
         recipient_ids = queryset.values_list("recipient_id", flat=True).order_by("id")
         return Q(recipient_id__in=list(recipient_ids))
 
+    def get_protected_history_condition(
+        self, streams_with_protected_history: QuerySet[Stream]
+    ) -> Q:
+        assert self.user_profile is not None
+
+        recipient_cond = self.get_recipient_condition(streams_with_protected_history)
+        has_usermessage = Exists(
+            UserMessage.objects.filter(
+                user_profile_id=self.user_profile.id, message_id=OuterRef("id")
+            )
+        )
+        return recipient_cond & Q(has_usermessage)
+
     def add_term(self, query: QuerySet[Message], term: NarrowParameter) -> QuerySet[Message]:
         """
         Extend the given query to one narrowed by the given term, and return the result.
@@ -459,7 +477,14 @@ class NarrowBuilder:
     def by_channels(
         self, query: QuerySet[Message], operand: str, maybe_negate: ConditionTransform
     ) -> QuerySet[Message]:
-        self.check_not_both_channel_and_dm_narrow(maybe_negate, is_channel_narrow=True)
+        if maybe_negate is not_ and operand == "all":
+            # Negating all channels leaves only DMs, so treat -channels:all as a
+            # DM narrow.
+            self.check_not_both_channel_and_dm_narrow(
+                maybe_negate=lambda cond: cond, is_dm_narrow=True
+            )
+        else:
+            self.check_not_both_channel_and_dm_narrow(maybe_negate, is_channel_narrow=True)
 
         if operand == "public":
             # Get all both subscribed and non-subscribed public channels
@@ -472,6 +497,42 @@ class NarrowBuilder:
         elif operand == "archived":
             recipient_queryset = get_archived_streams_queryset(self.realm)
             cond = self.get_recipient_condition(recipient_queryset)
+        elif operand == "all":
+            if self.user_profile is None:
+                recipient_queryset = get_web_public_streams_queryset(self.realm)
+                cond = self.get_recipient_condition(recipient_queryset)
+            elif self.user_profile.is_guest:
+                subscribed_streams = get_user_subscribed_streams(self.user_profile)
+                cond = self.get_recipient_condition(subscribed_streams)
+            else:
+                subscribed_stream_ids = get_subscribed_stream_ids_for_user(self.user_profile)
+                user_recursive_group_ids = set(
+                    get_recursive_membership_groups(self.user_profile).values_list("id", flat=True)
+                )
+
+                content_accessible_streams = get_content_accessible_streams_queryset(
+                    self.user_profile,
+                    subscribed_stream_ids,
+                    user_recursive_group_ids,
+                )
+
+                # Streams whose history is public to subscribers: every
+                # accessible message is fair game.
+                full_history_recipient_cond = self.get_recipient_condition(
+                    content_accessible_streams.filter(history_public_to_subscribers=True)
+                )
+
+                # For channels with protected history, this only includes channels the
+                # user can currently access. Combined with the UserMessage check in
+                # get_protected_history_condition, messages from protected-history
+                # channels the user has left are excluded, even though UserMessage rows
+                # still exist. This is intentional, since leaving such a channel
+                # revokes access to its history.
+                protected_history_recipient_cond = self.get_protected_history_condition(
+                    content_accessible_streams.filter(history_public_to_subscribers=False)
+                )
+
+                cond = full_history_recipient_cond | protected_history_recipient_cond
         else:
             raise BadNarrowOperatorError("unknown channels operand " + operand)
 
@@ -796,7 +857,7 @@ def ok_to_include_history(
                     include_history = can_access_stream_history_by_id(user_profile, operand)
             elif (
                 term.operator in channels_operators
-                and term.operand in ["public", "web-public"]
+                and term.operand in ["public", "web-public", "all"]
                 and not term.negated
                 and user_profile.can_access_public_streams()
             ):

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -316,6 +316,10 @@ class NarrowBuilder:
                 "No message can be both a channel message and direct message"
             )
 
+    def get_recipient_condition(self, queryset: QuerySet[Stream]) -> Q:
+        recipient_ids = queryset.values_list("recipient_id", flat=True).order_by("id")
+        return Q(recipient_id__in=list(recipient_ids))
+
     def add_term(self, query: QuerySet[Message], term: NarrowParameter) -> QuerySet[Message]:
         """
         Extend the given query to one narrowed by the given term, and return the result.
@@ -461,15 +465,16 @@ class NarrowBuilder:
             # Get all both subscribed and non-subscribed public channels
             # but exclude any private subscribed channels.
             recipient_queryset = get_public_streams_queryset(self.realm)
+            cond = self.get_recipient_condition(recipient_queryset)
         elif operand == "web-public":
             recipient_queryset = get_web_public_streams_queryset(self.realm)
+            cond = self.get_recipient_condition(recipient_queryset)
         elif operand == "archived":
             recipient_queryset = get_archived_streams_queryset(self.realm)
+            cond = self.get_recipient_condition(recipient_queryset)
         else:
             raise BadNarrowOperatorError("unknown channels operand " + operand)
 
-        recipient_ids = recipient_queryset.values_list("recipient_id", flat=True).order_by("id")
-        cond = Q(recipient_id__in=list(recipient_ids))
         return query.filter(maybe_negate(cond))
 
     def by_topic(

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -24,11 +24,16 @@ from zerver.lib.message import (
 )
 from zerver.lib.narrow_predicate import channel_operators, channels_operators
 from zerver.lib.recipient_users import recipient_for_user_profiles
+from zerver.lib.stream_subscription import (
+    get_subscribed_stream_ids_for_user,
+    get_user_subscribed_streams,
+)
 from zerver.lib.streams import (
     access_stream_common,
     can_access_stream_history_by_id,
     can_access_stream_history_by_name,
     get_archived_streams_queryset,
+    get_content_accessible_streams_queryset,
     get_public_streams_queryset,
     get_stream_by_narrow_operand_access_unchecked,
     get_web_public_streams_queryset,
@@ -320,6 +325,19 @@ class NarrowBuilder:
         recipient_ids = queryset.values_list("recipient_id", flat=True).order_by("id")
         return Q(recipient_id__in=list(recipient_ids))
 
+    def get_protected_history_condition(
+        self, streams_with_protected_history: QuerySet[Stream]
+    ) -> Q:
+        assert self.user_profile is not None
+
+        recipient_cond = self.get_recipient_condition(streams_with_protected_history)
+        has_usermessage = Exists(
+            UserMessage.objects.filter(
+                user_profile_id=self.user_profile.id, message_id=OuterRef("id")
+            )
+        )
+        return recipient_cond & Q(has_usermessage)
+
     def add_term(self, query: QuerySet[Message], term: NarrowParameter) -> QuerySet[Message]:
         """
         Extend the given query to one narrowed by the given term, and return the result.
@@ -459,6 +477,12 @@ class NarrowBuilder:
     def by_channels(
         self, query: QuerySet[Message], operand: str, maybe_negate: ConditionTransform
     ) -> QuerySet[Message]:
+        if operand == "all" and maybe_negate is not_:
+            # The negated form is synonymous with is:dm, which is the canonical
+            # way to express a direct message narrow, so we reject it rather
+            # than maintain a second spelling with its own DM-narrow checks.
+            raise BadNarrowOperatorError("channels:all does not support negation")
+
         self.check_not_both_channel_and_dm_narrow(maybe_negate, is_channel_narrow=True)
 
         if operand == "public":
@@ -472,6 +496,44 @@ class NarrowBuilder:
         elif operand == "archived":
             recipient_queryset = get_archived_streams_queryset(self.realm)
             cond = self.get_recipient_condition(recipient_queryset)
+        elif operand == "all":
+            if self.user_profile is None:
+                assert self.is_web_public_query
+                recipient_queryset = get_web_public_streams_queryset(self.realm)
+                cond = self.get_recipient_condition(recipient_queryset)
+            elif self.user_profile.is_guest:
+                subscribed_streams = get_user_subscribed_streams(self.user_profile)
+                cond = self.get_recipient_condition(subscribed_streams)
+            else:
+                subscribed_stream_ids = get_subscribed_stream_ids_for_user(self.user_profile)
+                user_recursive_group_ids = set(
+                    get_recursive_membership_groups(self.user_profile).values_list("id", flat=True)
+                )
+
+                content_accessible_streams = get_content_accessible_streams_queryset(
+                    self.user_profile,
+                    subscribed_stream_ids,
+                    user_recursive_group_ids,
+                )
+
+                # Streams whose history is public to subscribers: every
+                # accessible message is fair game.
+                full_history_recipient_cond = self.get_recipient_condition(
+                    content_accessible_streams.filter(history_public_to_subscribers=True)
+                )
+
+                # For channels with protected history, a message is included only
+                # if the user has content access to the channel now and received
+                # the message when it was sent. Content access can come from a
+                # subscription or from a group permission, so unsubscribing hides
+                # such a channel's history only for a user whose subscription was
+                # their sole route to it; surviving UserMessage rows are not
+                # enough on their own.
+                protected_history_recipient_cond = self.get_protected_history_condition(
+                    content_accessible_streams.filter(history_public_to_subscribers=False)
+                )
+
+                cond = full_history_recipient_cond | protected_history_recipient_cond
         else:
             raise BadNarrowOperatorError("unknown channels operand " + operand)
 
@@ -796,7 +858,7 @@ def ok_to_include_history(
                     include_history = can_access_stream_history_by_id(user_profile, operand)
             elif (
                 term.operator in channels_operators
-                and term.operand in ["public", "web-public"]
+                and term.operand in ["public", "web-public", "all"]
                 and not term.negated
                 and user_profile.can_access_public_streams()
             ):
@@ -1000,6 +1062,11 @@ def get_base_query_for_search(
     # Mirror the restrictions in bulk_access_stream_messages_query, in order
     # to prevent leftover UserMessage rows from granting access to messages
     # the user was previously allowed to access but no longer is.
+
+    # These filters are the message-queryset form of our content-access
+    # rules; user_has_content_access applies them to a single channel and
+    # get_content_accessible_streams_queryset to a channel queryset.
+    # Keep all three in sync when changing content-access rules.
     stream_access_filters = Q(pk__in=[])  # Always false.
     if user_profile.can_access_public_streams():
         stream_access_filters |= Q(invite_only=False)

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -813,6 +813,9 @@ def user_has_content_access(
     *,
     is_subscribed: bool,
 ) -> bool:
+    # This is the per-stream form of our content-access rules.
+    # get_content_accessible_streams_queryset implements the same rules as a
+    # bulk queryset; keep the two in sync when changing content-access rules.
     if stream.is_web_public:
         return True
 
@@ -1022,6 +1025,40 @@ def access_stream_by_id(
         require_content_access=require_content_access,
     )
     return (stream, sub)
+
+
+def get_content_accessible_streams_queryset(
+    user_profile: UserProfile,
+    subscribed_stream_ids: QuerySet[Subscription, int],
+    user_recursive_group_ids: set[int],
+) -> QuerySet[Stream]:
+    # This is the bulk queryset form of our content-access rules.
+    # user_has_content_access implements the same rules for a single stream;
+    # keep the two in sync when changing content-access rules.
+    realm = user_profile.realm
+
+    if user_profile.is_guest:
+        return Stream.objects.filter(
+            Q(realm=realm)
+            & (Q(id__in=subscribed_stream_ids) | Q(is_web_public=True, invite_only=False))
+        )
+
+    return Stream.objects.filter(
+        Q(realm=realm)
+        & (
+            # Public streams, plus the user's own subscriptions.
+            Q(invite_only=False)
+            | Q(id__in=subscribed_stream_ids)
+            # Private streams the user can subscribe to via group permissions.
+            | (
+                Q(invite_only=True)
+                & (
+                    Q(can_add_subscribers_group_id__in=user_recursive_group_ids)
+                    | Q(can_subscribe_group_id__in=user_recursive_group_ids)
+                )
+            )
+        )
+    )
 
 
 def get_public_streams_queryset(realm: Realm) -> QuerySet[Stream]:

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -836,6 +836,11 @@ def user_has_content_access(
     *,
     is_subscribed: bool,
 ) -> bool:
+    # This is the per-stream form of our content-access rules.
+    # get_content_accessible_streams_queryset implements the same rules as a
+    # channel queryset, and the stream_access_filters in
+    # get_base_query_for_search apply them to a message queryset; keep all
+    # three in sync when changing content-access rules.
     if stream.is_web_public:
         return True
 
@@ -1045,6 +1050,42 @@ def access_stream_by_id(
         require_content_access=require_content_access,
     )
     return (stream, sub)
+
+
+def get_content_accessible_streams_queryset(
+    user_profile: UserProfile,
+    subscribed_stream_ids: QuerySet[Subscription, int],
+    user_recursive_group_ids: set[int],
+) -> QuerySet[Stream]:
+    # This is the bulk queryset form of our content-access rules.
+    # user_has_content_access implements the same rules for a single stream,
+    # and the stream_access_filters in get_base_query_for_search apply them to
+    # a message queryset rather than a stream one; keep all three in sync when
+    # changing content-access rules.
+    realm = user_profile.realm
+
+    if user_profile.is_guest:
+        return Stream.objects.filter(
+            Q(realm=realm)
+            & (Q(id__in=subscribed_stream_ids) | Q(is_web_public=True, invite_only=False))
+        )
+
+    return Stream.objects.filter(
+        Q(realm=realm)
+        & (
+            # Public streams, plus the user's own subscriptions.
+            Q(invite_only=False)
+            | Q(id__in=subscribed_stream_ids)
+            # Private streams the user can subscribe to via group permissions.
+            | (
+                Q(invite_only=True)
+                & (
+                    Q(can_add_subscribers_group_id__in=user_recursive_group_ids)
+                    | Q(can_subscribe_group_id__in=user_recursive_group_ids)
+                )
+            )
+        )
+    )
 
 
 def get_public_streams_queryset(realm: Realm) -> QuerySet[Stream]:

--- a/zerver/tests/test_channel_access.py
+++ b/zerver/tests/test_channel_access.py
@@ -2,18 +2,22 @@ from zerver.actions.streams import do_change_stream_group_based_setting, do_deac
 from zerver.actions.user_groups import check_add_user_group
 from zerver.actions.users import do_change_user_role
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.stream_subscription import get_subscribed_stream_ids_for_user
 from zerver.lib.streams import (
+    StreamDict,
     access_stream_by_id,
     access_stream_by_name,
     bulk_can_access_stream_metadata_user_ids,
     can_access_stream_history,
     can_access_stream_metadata_user_ids,
+    create_streams_if_needed,
     ensure_stream,
+    get_content_accessible_streams_queryset,
     user_has_content_access,
 )
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.types import UserGroupMembersData
-from zerver.lib.user_groups import UserGroupMembershipDetails
+from zerver.lib.user_groups import UserGroupMembershipDetails, get_recursive_membership_groups
 from zerver.models import NamedUserGroup, Stream, UserProfile
 from zerver.models.realms import get_realm
 from zerver.models.streams import get_stream
@@ -435,6 +439,76 @@ class AccessStreamTest(ZulipTestCase):
                 is_subscribed=True,
             ),
             True,
+        )
+
+    def test_get_content_accessible_streams_queryset_for_guest(self) -> None:
+        realm = get_realm("zulip")
+        guest = self.example_user("polonius")
+        self.assertTrue(guest.is_guest)
+        hamlet = self.example_user("hamlet")
+
+        channel_dicts: list[StreamDict] = [
+            {"name": "web-public", "is_web_public": True},
+            {"name": "public", "is_web_public": False},
+            {
+                "name": "private-history-public",
+                "invite_only": True,
+                "history_public_to_subscribers": True,
+            },
+            {
+                "name": "subscribed-history-public",
+                "invite_only": True,
+                "history_public_to_subscribers": True,
+            },
+            {"name": "private-protected", "invite_only": True},
+            {"name": "subscribed-protected", "invite_only": True},
+        ]
+        create_streams_if_needed(realm, channel_dicts)
+
+        self.subscribe(guest, "subscribed-history-public")
+        self.subscribe(guest, "subscribed-protected")
+
+        # Grant both the guest and a non-guest group-based access to the
+        # private channels they are not subscribed to. The guest should
+        # not gain access from this, but the non-guest should — which also
+        # confirms the channels are set up such that group access works.
+        access_group = check_add_user_group(
+            realm, "channel_access_group", [guest, hamlet], acting_user=guest
+        )
+        for channel_name in ["private-history-public", "private-protected"]:
+            do_change_stream_group_based_setting(
+                get_stream(channel_name, realm),
+                "can_add_subscribers_group",
+                access_group,
+                acting_user=self.example_user("iago"),
+            )
+
+        channel_names = {channel_dict["name"] for channel_dict in channel_dicts}
+
+        def accessible_channel_names(user_profile: UserProfile) -> set[str]:
+            queryset = get_content_accessible_streams_queryset(
+                user_profile,
+                get_subscribed_stream_ids_for_user(user_profile),
+                set(get_recursive_membership_groups(user_profile).values_list("id", flat=True)),
+            )
+            # Restrict to the channels created here, ignoring the realm's
+            # pre-existing streams and default subscriptions.
+            return set(queryset.values_list("name", flat=True)) & channel_names
+
+        # Web-public and subscribed channels are accessible to the guest; the
+        # non-subscribed public and private channels are not, and group
+        # permissions don't grant a guest access.
+        self.assertEqual(
+            accessible_channel_names(guest),
+            {"web-public", "subscribed-history-public", "subscribed-protected"},
+        )
+
+        # A non-guest with the same group membership does gain access to the
+        # group-permission private channels, confirming the guest exclusions
+        # above are specific to the guest short-circuit.
+        self.assertEqual(
+            accessible_channel_names(hamlet),
+            {"web-public", "public", "private-history-public", "private-protected"},
         )
 
     def test_can_access_stream_metadata_user_ids(self) -> None:

--- a/zerver/tests/test_channel_access.py
+++ b/zerver/tests/test_channel_access.py
@@ -2,6 +2,7 @@ from zerver.actions.streams import do_change_stream_group_based_setting, do_deac
 from zerver.actions.user_groups import check_add_user_group
 from zerver.actions.users import do_change_user_role
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.stream_subscription import get_subscribed_stream_ids_for_user
 from zerver.lib.streams import (
     access_stream_by_id,
     access_stream_by_name,
@@ -9,11 +10,12 @@ from zerver.lib.streams import (
     can_access_stream_history,
     can_access_stream_metadata_user_ids,
     ensure_stream,
+    get_content_accessible_streams_queryset,
     user_has_content_access,
 )
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.types import UserGroupMembersData
-from zerver.lib.user_groups import UserGroupMembershipDetails
+from zerver.lib.user_groups import UserGroupMembershipDetails, get_recursive_membership_groups
 from zerver.models import NamedUserGroup, Stream, UserProfile
 from zerver.models.realms import get_realm
 from zerver.models.streams import get_stream
@@ -435,6 +437,87 @@ class AccessStreamTest(ZulipTestCase):
                 is_subscribed=True,
             ),
             True,
+        )
+
+    def test_get_content_accessible_streams_queryset_for_guest(self) -> None:
+        realm = get_realm("zulip")
+        guest = self.example_user("polonius")
+        self.assertTrue(guest.is_guest)
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+
+        channels = [
+            self.make_stream("web-public", realm, is_web_public=True),
+            self.make_stream("public", realm),
+            self.make_stream(
+                "private-history-public",
+                realm,
+                invite_only=True,
+                history_public_to_subscribers=True,
+            ),
+            self.make_stream(
+                "subscribed-history-public",
+                realm,
+                invite_only=True,
+                history_public_to_subscribers=True,
+            ),
+            self.make_stream("private-protected", realm, invite_only=True),
+            self.make_stream("subscribed-protected", realm, invite_only=True),
+        ]
+
+        self.subscribe(guest, "subscribed-history-public")
+        self.subscribe(guest, "subscribed-protected")
+
+        # Grant both the guest and a non-guest group-based access to the
+        # private channels they are not subscribed to. The guest should
+        # not gain access from this, but the non-guest should — which also
+        # confirms the channels are set up such that group access works.
+        access_group = check_add_user_group(
+            realm, "channel_access_group", [guest, hamlet], acting_user=guest
+        )
+        for channel_name in ["private-history-public", "private-protected"]:
+            do_change_stream_group_based_setting(
+                get_stream(channel_name, realm),
+                "can_add_subscribers_group",
+                access_group,
+                acting_user=iago,
+            )
+
+        channel_names = {channel.name for channel in channels}
+
+        def accessible_channel_names(user_profile: UserProfile) -> set[str]:
+            queryset = get_content_accessible_streams_queryset(
+                user_profile,
+                get_subscribed_stream_ids_for_user(user_profile),
+                set(get_recursive_membership_groups(user_profile).values_list("id", flat=True)),
+            )
+            # Restrict to the channels created here, ignoring the realm's
+            # pre-existing streams and default subscriptions.
+            return set(queryset.values_list("name", flat=True)) & channel_names
+
+        # Web-public and subscribed channels are accessible to the guest; the
+        # non-subscribed public and private channels are not, and group
+        # permissions don't grant a guest access.
+        self.assertEqual(
+            accessible_channel_names(guest),
+            {"web-public", "subscribed-history-public", "subscribed-protected"},
+        )
+
+        # A non-guest with the same group membership does gain access to the
+        # group-permission private channels, confirming the guest exclusions
+        # above are specific to the guest short-circuit.
+        self.assertEqual(
+            accessible_channel_names(hamlet),
+            {"web-public", "public", "private-history-public", "private-protected"},
+        )
+
+        # Realm administrators have only metadata access to private channels
+        # they are not subscribed to, so they get no content access beyond
+        # what any other non-guest would.
+        self.assertTrue(iago.is_realm_admin)
+        self.assertEqual(
+            accessible_channel_names(iago),
+            {"web-public", "public"},
         )
 
     def test_can_access_stream_metadata_user_ids(self) -> None:

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -17,8 +17,9 @@ from analytics.models import RealmCount
 from zerver.actions.message_edit import build_message_edit_request, do_update_message
 from zerver.actions.reactions import check_add_reaction
 from zerver.actions.realm_settings import do_set_realm_property
-from zerver.actions.streams import do_deactivate_stream
+from zerver.actions.streams import do_change_stream_group_based_setting, do_deactivate_stream
 from zerver.actions.uploads import do_claim_attachments
+from zerver.actions.user_groups import check_add_user_group
 from zerver.actions.user_settings import do_change_avatar_fields, do_change_user_setting
 from zerver.actions.users import do_deactivate_user
 from zerver.lib.avatar import avatar_url
@@ -239,6 +240,119 @@ class NarrowBuilderTest(ZulipTestCase):
             (stream.recipient_id,),
         )
 
+    def test_add_term_using_channels_operator_and_all_operand(self) -> None:
+        hamlet = self.user_profile
+        term = NarrowParameter(operator="channels", operand="all")
+        self._do_add_term_test(
+            term,
+            'WHERE "zerver_message"."recipient_id" IN (%s, %s, %s, %s, %s, %s, %s, %s)',
+        )
+        realm = get_realm("zulip")
+        hamlet_group = check_add_user_group(
+            realm,
+            "hamlet_group",
+            [hamlet],
+            acting_user=hamlet,
+        )
+        # Add new channels
+        channel_dicts: list[StreamDict] = [
+            {
+                "name": "private-channel",
+                "description": "Private channel with non-public history",
+                "invite_only": True,
+            },
+            {
+                "name": "private-channel-with-history",
+                "description": "Private channel with public history",
+                "invite_only": True,
+                "history_public_to_subscribers": True,
+                "can_add_subscribers_group": hamlet_group,
+            },
+            {
+                "name": "protected-group-access",
+                "description": "Protected-history channel hamlet can access via group",
+                "invite_only": True,
+                "history_public_to_subscribers": False,
+                "can_add_subscribers_group": hamlet_group,
+            },
+        ]
+        created, existing = create_streams_if_needed(realm, channel_dicts)
+
+        self.assert_length(created, 3)
+        self.assert_length(existing, 0)
+
+        # "private-channel-with-history" has public history and group-based
+        # content access, so it joins the plain recipient_id IN (...) arm.
+        # "protected-group-access" has protected history but the same group
+        # access, so — even without a subscription — it appears in the
+        # "recipient_id IN (...) AND EXISTS(usermessage)" arm, which restricts
+        # results to messages the user actually received. "private-channel"
+        # has neither public history nor group access, so it is excluded.
+        self._do_add_term_test(
+            term,
+            'WHERE ("zerver_message"."recipient_id" IN (%s, %s, %s, %s, %s, %s, %s, %s, %s) '
+            'OR ("zerver_message"."recipient_id" IN (%s) AND EXISTS('
+            'SELECT %s AS "a" FROM "zerver_usermessage" U0 WHERE '
+            '(U0."message_id" = ("zerver_message"."id") AND U0."user_profile_id" = %s) LIMIT 1)))',
+        )
+
+        # A user without group access still reaches the protected-history
+        # EXISTS(usermessage) arm by subscribing. cordelia is not in
+        # hamlet_group, so her only route to "private-channel" (protected
+        # history) is the subscription, which is why it is the sole channel in
+        # her EXISTS arm.
+        cordelia = self.example_user("cordelia")
+        self.subscribe(cordelia, "private-channel")
+        cordelia_query = NarrowBuilder(cordelia, self.realm).add_term(self.raw_query, term)
+        cordelia_sql, _params = cordelia_query.query.sql_with_params()
+        self.assertEqual(
+            cordelia_sql[cordelia_sql.index("WHERE ") :],
+            'WHERE ("zerver_message"."recipient_id" IN (%s, %s, %s, %s, %s, %s, %s) '
+            'OR ("zerver_message"."recipient_id" IN (%s) AND EXISTS('
+            'SELECT %s AS "a" FROM "zerver_usermessage" U0 WHERE '
+            '(U0."message_id" = ("zerver_message"."id") AND U0."user_profile_id" = %s) LIMIT 1)))',
+        )
+
+    def test_add_term_using_channels_operator_and_all_operand_negated(self) -> None:
+        hamlet = self.user_profile
+        term = NarrowParameter(operator="channels", operand="all", negated=True)
+        self._do_add_term_test(
+            term,
+            'WHERE NOT ("zerver_message"."recipient_id" IN (%s, %s, %s, %s, %s, %s, %s, %s))',
+        )
+        realm = get_realm("zulip")
+        hamlet_group = check_add_user_group(
+            realm,
+            "hamlet_group",
+            [hamlet],
+            acting_user=hamlet,
+        )
+        # Add new channels
+        channel_dicts: list[StreamDict] = [
+            {
+                "name": "private-channel",
+                "description": "Private channel with non-public history",
+                "invite_only": True,
+            },
+            {
+                "name": "private-channel-with-history",
+                "description": "Private channel with public history",
+                "invite_only": True,
+                "history_public_to_subscribers": True,
+                "can_add_subscribers_group": hamlet_group,
+            },
+        ]
+        created, existing = create_streams_if_needed(realm, channel_dicts)
+
+        self.assert_length(created, 2)
+        self.assert_length(existing, 0)
+
+        # Number of recipient ids will increase by 1 and not 2
+        self._do_add_term_test(
+            term,
+            'WHERE NOT ("zerver_message"."recipient_id" IN (%s, %s, %s, %s, %s, %s, %s, %s, %s))',
+        )
+
     def test_add_term_using_is_operator_and_dm_operand(self) -> None:
         term = NarrowParameter(operator="is", operand="dm")
         self._do_add_term_test(term, 'WHERE "zerver_usermessage"."flags" & %s != 0')
@@ -418,12 +532,35 @@ class NarrowBuilderTest(ZulipTestCase):
             self._build_query(channels_term)
         self.assertEqual(expected_error_message, str(error.exception))
 
+        channels_term = NarrowParameter(operator="channels", operand="all")
+        with self.assertRaises(BadNarrowOperatorError) as error:
+            self._build_query(channels_term)
+        self.assertEqual(expected_error_message, str(error.exception))
+
     def test_combined_channel_with_negated_is_dm(self) -> None:
         dm_term = NarrowParameter(operator="is", operand="dm", negated=True)
         self._build_query(dm_term)
 
         channel_term = NarrowParameter(operator="channels", operand="public")
         self._build_query(channel_term)
+
+        channel_term = NarrowParameter(operator="channels", operand="all")
+        self._build_query(channel_term)
+
+    def test_negated_channels_all_conflicts_with_channel_narrow(self) -> None:
+        # -channels:all matches only direct messages, so combining it with a
+        # channel narrow can never match a message and is rejected. -is:dm is
+        # itself a channel narrow ("not a direct message"), so it conflicts too.
+        expected_error_message = (
+            "Invalid narrow operator: No message can be both a channel message and direct message"
+        )
+        term = NarrowParameter(operator="channels", operand="all", negated=True)
+        self._build_query(term)
+
+        negated_is_dm = NarrowParameter(operator="is", operand="dm", negated=True)
+        with self.assertRaises(BadNarrowOperatorError) as error:
+            self._build_query(negated_is_dm)
+        self.assertEqual(expected_error_message, str(error.exception))
 
     def test_combined_negated_channel_with_is_dm(self) -> None:
         dm_term = NarrowParameter(operator="is", operand="dm")
@@ -902,6 +1039,20 @@ class NarrowBuilderTest(ZulipTestCase):
             'WHERE NOT ("zerver_message"."recipient_id" IN (%s, %s, %s, %s, %s, %s, %s))',
         )
 
+    def test_add_term_using_streams_operator_and_all_operand(self) -> None:
+        term = NarrowParameter(operator="streams", operand="all")
+        self._do_add_term_test(
+            term,
+            'WHERE "zerver_message"."recipient_id" IN (%s, %s, %s, %s, %s, %s, %s, %s)',
+        )
+
+    def test_add_term_using_streams_operator_and_all_operand_negated(self) -> None:
+        term = NarrowParameter(operator="streams", operand="all", negated=True)
+        self._do_add_term_test(
+            term,
+            'WHERE NOT ("zerver_message"."recipient_id" IN (%s, %s, %s, %s, %s, %s, %s, %s))',
+        )
+
     def _do_add_term_test(
         self, term: NarrowParameter, where_clause: str, params: tuple[object, ...] | None = None
     ) -> None:
@@ -1285,6 +1436,9 @@ class NarrowLibraryTest(ZulipTestCase):
         self.assertTrue(
             is_spectator_compatible([NarrowParameter(operator="channels", operand="archived")])
         )
+        self.assertTrue(
+            is_spectator_compatible([NarrowParameter(operator="channels", operand="all")])
+        )
 
         # "is:private" is a legacy alias for "is:dm".
         self.assertFalse(
@@ -1317,6 +1471,9 @@ class NarrowLibraryTest(ZulipTestCase):
         # "streams" is a legacy alias for "channels" operator
         self.assertTrue(
             is_spectator_compatible([NarrowParameter(operator="streams", operand="public")])
+        )
+        self.assertTrue(
+            is_spectator_compatible([NarrowParameter(operator="streams", operand="all")])
         )
 
 
@@ -1363,6 +1520,18 @@ class IncludeHistoryTest(ZulipTestCase):
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
         narrow = [
             NarrowParameter(operator="channels", operand="archived", negated=True),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+
+        # channels:all searches should include history for non-guest members.
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+        ]
+        self.assertTrue(ok_to_include_history(narrow, user_profile, False))
+
+        # Negated -channels:all searches should not include history.
+        narrow = [
+            NarrowParameter(operator="channels", operand="all", negated=True),
         ]
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
 
@@ -1446,6 +1615,36 @@ class IncludeHistoryTest(ZulipTestCase):
         ]
         self.assertTrue(ok_to_include_history(narrow, user_profile, False))
 
+        # No point in searching history for is operator even if included with
+        # channels:all
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+            NarrowParameter(operator="is", operand="mentioned"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+            NarrowParameter(operator="is", operand="unread"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+            NarrowParameter(operator="is", operand="alerted"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+            NarrowParameter(operator="is", operand="resolved"),
+        ]
+        self.assertTrue(ok_to_include_history(narrow, user_profile, False))
+
+        # Search history for archived channel searches combined with channels:all.
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+            NarrowParameter(operator="channels", operand="archived"),
+        ]
+        self.assertTrue(ok_to_include_history(narrow, user_profile, False))
+
         # simple True case
         narrow = [
             NarrowParameter(operator="channel", operand="public_channel"),
@@ -1475,6 +1674,12 @@ class IncludeHistoryTest(ZulipTestCase):
         narrow = [
             NarrowParameter(operator="channels", operand="public"),
             NarrowParameter(operator="channels", operand="archived"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
+
+        # channels:all searches should not include history for guest members.
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
         ]
         self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
 
@@ -3855,6 +4060,205 @@ class GetOldMessagesTest(ZulipTestCase):
         )
         self.assert_length(result["messages"], 1)
         self.assertEqual(result["messages"][0]["id"], anchor)
+
+    def test_get_messages_using_narrow_channels_all(self) -> None:
+        realm = get_realm("zulip")
+
+        iago = self.example_user("iago")
+        self.login("iago")
+
+        self.subscribe(iago, "public-channel")
+        self.subscribe(iago, "private-channel", invite_only=True)
+        self.make_stream(
+            "private-channel-with-history", invite_only=True, history_public_to_subscribers=True
+        )
+        self.subscribe(iago, "private-channel-with-history")
+        self.subscribe(iago, "protected-no-group-access", invite_only=True)
+
+        # Send one message to each channel before hamlet has any access, so we
+        # can verify how pre-subscription history is treated per channel type.
+        message_id = {
+            stream_name: self.send_stream_message(iago, stream_name)
+            for stream_name in [
+                "public-channel",
+                "private-channel",
+                "private-channel-with-history",
+                "protected-no-group-access",
+            ]
+        }
+        self.logout()
+
+        hamlet = self.example_user("hamlet")
+        self.login("hamlet")
+
+        hamlet_group = check_add_user_group(
+            realm,
+            "hamlet_group",
+            [hamlet],
+            acting_user=hamlet,
+        )
+        # Grant hamlet permission-based access to the two private channels, but
+        # deliberately not to "protected-no-group-access".
+        for stream_name in ["private-channel", "private-channel-with-history"]:
+            do_change_stream_group_based_setting(
+                get_stream(stream_name, realm),
+                "can_add_subscribers_group",
+                hamlet_group,
+                acting_user=iago,
+            )
+
+        narrow = [dict(operator="channels", operand="all")]
+
+        def channels_all_message_ids() -> set[int]:
+            result = self.get_and_check_messages(
+                dict(
+                    narrow=orjson.dumps(narrow).decode(),
+                    anchor=message_id["public-channel"],
+                    num_before=0,
+                    num_after=10,
+                )
+            )
+            return {message["id"] for message in result["messages"]}
+
+        # Messages from public channels and from private channels whose history
+        # is public to subscribers are included, even without a subscription.
+        # The pre-subscription message in the protected-history "private-channel"
+        # is excluded, as is the message in "protected-no-group-access", which
+        # hamlet cannot access at all.
+        self.assertEqual(
+            channels_all_message_ids(),
+            {message_id["public-channel"], message_id["private-channel-with-history"]},
+        )
+
+        self.subscribe(hamlet, "private-channel")
+        # In a protected-history channel, the user only sees messages sent while
+        # subscribed: hamlet's new message appears, but iago's earlier message,
+        # sent before hamlet subscribed, remains hidden.
+        hamlet_private_message_id = self.send_stream_message(hamlet, "private-channel")
+        self.assertEqual(
+            channels_all_message_ids(),
+            {
+                message_id["public-channel"],
+                message_id["private-channel-with-history"],
+                hamlet_private_message_id,
+            },
+        )
+
+        # After unsubscribing, hamlet retains permission-based access to
+        # "private-channel" and still has a UserMessage row for the message he
+        # sent, so that message stays visible; the pre-subscription message
+        # remains excluded.
+        self.unsubscribe(hamlet, "private-channel")
+        self.assertEqual(
+            channels_all_message_ids(),
+            {
+                message_id["public-channel"],
+                message_id["private-channel-with-history"],
+                hamlet_private_message_id,
+            },
+        )
+
+        # "protected-no-group-access" has protected history and no group access,
+        # so hamlet's access depends solely on his subscription. While
+        # subscribed, his own message is visible.
+        self.subscribe(hamlet, "protected-no-group-access")
+        hamlet_no_access_message_id = self.send_stream_message(hamlet, "protected-no-group-access")
+        self.assertEqual(
+            channels_all_message_ids(),
+            {
+                message_id["public-channel"],
+                message_id["private-channel-with-history"],
+                hamlet_private_message_id,
+                hamlet_no_access_message_id,
+            },
+        )
+
+        # After unsubscribing he has no content access to the protected-history
+        # channel at all, so the message is excluded even though his UserMessage
+        # row for it still exists.
+        self.unsubscribe(hamlet, "protected-no-group-access")
+        self.assertEqual(
+            channels_all_message_ids(),
+            {
+                message_id["public-channel"],
+                message_id["private-channel-with-history"],
+                hamlet_private_message_id,
+            },
+        )
+
+    def test_get_messages_using_narrow_channels_all_for_guest(self) -> None:
+        iago = self.example_user("iago")
+        guest = self.example_user("polonius")
+        self.assertTrue(guest.is_guest)
+
+        # Start from a clean slate so the assertions below cover exactly the
+        # messages sent in this test.
+        Message.objects.all().delete()
+
+        self.login("iago")
+        self.subscribe(iago, "web-public-subscribed", is_web_public=True)
+        self.subscribe(iago, "web-public-unsubscribed", is_web_public=True)
+        self.subscribe(iago, "public-subscribed")
+        self.subscribe(iago, "private-subscribed", invite_only=True)
+
+        # Messages sent before the guest subscribes. Even for the web-public
+        # channel, the guest has no UserMessage row for these, so they are not
+        # surfaced by channels:all.
+        presubscription_web_public_id = self.send_stream_message(iago, "web-public-subscribed")
+        self.send_stream_message(iago, "public-subscribed")
+        self.send_stream_message(iago, "private-subscribed")
+
+        # Subscribe the guest before the remaining messages, so they have
+        # UserMessage rows for the messages in their subscribed channels.
+        self.subscribe(guest, "web-public-subscribed")
+        self.subscribe(guest, "public-subscribed")
+        self.subscribe(guest, "private-subscribed")
+
+        subscribed_web_public_id = self.send_stream_message(iago, "web-public-subscribed")
+        subscribed_public_id = self.send_stream_message(iago, "public-subscribed")
+        subscribed_private_id = self.send_stream_message(iago, "private-subscribed")
+        # A message in a web-public channel the guest is not subscribed to.
+        self.send_stream_message(iago, "web-public-unsubscribed")
+        self.logout()
+
+        self.login("polonius")
+        narrow = [dict(operator="channels", operand="all")]
+        result = self.get_and_check_messages(
+            dict(
+                narrow=orjson.dumps(narrow).decode(),
+                anchor=presubscription_web_public_id,
+                num_before=0,
+                num_after=10,
+            )
+        )
+
+        # The guest sees messages only from their subscribed channels — web-public,
+        # public, and private alike — and only those sent while subscribed: the
+        # unsubscribed web-public channel's message and the pre-subscription
+        # messages are all excluded.
+        message_ids = {message["id"] for message in result["messages"]}
+        self.assertEqual(
+            message_ids,
+            {subscribed_web_public_id, subscribed_public_id, subscribed_private_id},
+        )
+
+    def test_get_messages_using_narrow_channels_all_for_spectator(self) -> None:
+        # An unauthenticated spectator must include channels:web-public for the
+        # request to be accepted as a web-public query (otherwise it is
+        # rejected by is_web_public_narrow). channels:all then resolves to the
+        # web-public channels, exercising the spectator branch of by_channels.
+        result = self.get_and_check_messages(
+            dict(
+                narrow=orjson.dumps(
+                    [
+                        dict(operator="channels", operand="web-public"),
+                        dict(operator="channels", operand="all"),
+                    ]
+                ).decode()
+            )
+        )
+        self.assert_length(result["messages"], 1)
+        self.assertEqual(result["messages"][0]["display_recipient"], "Rome")
 
     def test_get_visible_messages_with_anchor(self) -> None:
         def messages_matches_ids(messages: list[dict[str, Any]], message_ids: list[int]) -> None:

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -17,8 +17,9 @@ from analytics.models import RealmCount
 from zerver.actions.message_edit import build_message_edit_request, do_update_message
 from zerver.actions.reactions import check_add_reaction
 from zerver.actions.realm_settings import do_set_realm_property
-from zerver.actions.streams import do_deactivate_stream
+from zerver.actions.streams import do_change_stream_group_based_setting, do_deactivate_stream
 from zerver.actions.uploads import do_claim_attachments
+from zerver.actions.user_groups import check_add_user_group
 from zerver.actions.user_settings import do_change_avatar_fields, do_change_user_setting
 from zerver.actions.users import do_deactivate_user
 from zerver.lib.avatar import avatar_url
@@ -239,6 +240,82 @@ class NarrowBuilderTest(ZulipTestCase):
             (stream.recipient_id,),
         )
 
+    def test_add_term_using_channels_operator_and_all_operand(self) -> None:
+        hamlet = self.user_profile
+        term = NarrowParameter(operator="channels", operand="all")
+        self._do_add_term_test(
+            term,
+            'WHERE "zerver_message"."recipient_id" IN (%s, %s, %s, %s, %s, %s, %s, %s)',
+        )
+        realm = get_realm("zulip")
+        hamlet_group = check_add_user_group(
+            realm,
+            "hamlet_group",
+            [hamlet],
+            acting_user=hamlet,
+        )
+        # Add new channels. hamlet has no subscription to any of them; his
+        # only route to the last two is hamlet_group.
+        self.make_stream("private-channel", realm, invite_only=True)
+        group_access_channels = [
+            self.make_stream(
+                "private-channel-with-history",
+                realm,
+                invite_only=True,
+                history_public_to_subscribers=True,
+            ),
+            self.make_stream(
+                "protected-group-access",
+                realm,
+                invite_only=True,
+                history_public_to_subscribers=False,
+            ),
+        ]
+        for channel in group_access_channels:
+            do_change_stream_group_based_setting(
+                channel,
+                "can_add_subscribers_group",
+                hamlet_group,
+                acting_user=hamlet,
+            )
+
+        # "private-channel-with-history" has public history and group-based
+        # content access, so it joins the plain recipient_id IN (...) arm.
+        # "protected-group-access" has protected history but the same group
+        # access, so — even without a subscription — it appears in the
+        # "recipient_id IN (...) AND EXISTS(usermessage)" arm, which restricts
+        # results to messages the user actually received. "private-channel"
+        # has neither public history nor group access, so it is excluded.
+        self._do_add_term_test(
+            term,
+            'WHERE ("zerver_message"."recipient_id" IN (%s, %s, %s, %s, %s, %s, %s, %s, %s) '
+            'OR ("zerver_message"."recipient_id" IN (%s) AND EXISTS('
+            'SELECT %s AS "a" FROM "zerver_usermessage" U0 WHERE '
+            '(U0."message_id" = ("zerver_message"."id") AND U0."user_profile_id" = %s) LIMIT 1)))',
+        )
+
+        # cordelia is not in hamlet_group and is not subscribed to any of the
+        # new private channels, so none of them are content-accessible to her.
+        # With no protected-history channels left to check, the
+        # EXISTS(usermessage) arm drops out entirely.
+        self.user_profile = self.example_user("cordelia")
+        self.builder = NarrowBuilder(self.user_profile, self.realm)
+        self._do_add_term_test(
+            term,
+            'WHERE "zerver_message"."recipient_id" IN (%s, %s, %s, %s, %s, %s, %s)',
+        )
+
+    def test_add_term_using_channels_operator_and_all_operand_negated(self) -> None:
+        # The negated form would be synonymous with is:dm, so we reject it
+        # rather than maintain a second spelling of the direct message narrow.
+        term = NarrowParameter(operator="channels", operand="all", negated=True)
+        with self.assertRaises(BadNarrowOperatorError) as error:
+            self._build_query(term)
+        self.assertEqual(
+            "Invalid narrow operator: channels:all does not support negation",
+            str(error.exception),
+        )
+
     def test_add_term_using_is_operator_and_dm_operand(self) -> None:
         term = NarrowParameter(operator="is", operand="dm")
         self._do_add_term_test(term, 'WHERE "zerver_usermessage"."flags" & %s != 0')
@@ -418,11 +495,19 @@ class NarrowBuilderTest(ZulipTestCase):
             self._build_query(channels_term)
         self.assertEqual(expected_error_message, str(error.exception))
 
+        channels_term = NarrowParameter(operator="channels", operand="all")
+        with self.assertRaises(BadNarrowOperatorError) as error:
+            self._build_query(channels_term)
+        self.assertEqual(expected_error_message, str(error.exception))
+
     def test_combined_channel_with_negated_is_dm(self) -> None:
         dm_term = NarrowParameter(operator="is", operand="dm", negated=True)
         self._build_query(dm_term)
 
         channel_term = NarrowParameter(operator="channels", operand="public")
+        self._build_query(channel_term)
+
+        channel_term = NarrowParameter(operator="channels", operand="all")
         self._build_query(channel_term)
 
     def test_combined_negated_channel_with_is_dm(self) -> None:
@@ -902,6 +987,24 @@ class NarrowBuilderTest(ZulipTestCase):
             'WHERE NOT ("zerver_message"."recipient_id" IN (%s, %s, %s, %s, %s, %s, %s))',
         )
 
+    def test_add_term_using_streams_operator_and_all_operand(self) -> None:
+        term = NarrowParameter(operator="streams", operand="all")
+        self._do_add_term_test(
+            term,
+            'WHERE "zerver_message"."recipient_id" IN (%s, %s, %s, %s, %s, %s, %s, %s)',
+        )
+
+    def test_add_term_using_streams_operator_and_all_operand_negated(self) -> None:
+        # streams:all is an alias for channels:all, whose negated form is
+        # rejected as unsupported.
+        term = NarrowParameter(operator="streams", operand="all", negated=True)
+        with self.assertRaises(BadNarrowOperatorError) as error:
+            self._build_query(term)
+        self.assertEqual(
+            "Invalid narrow operator: channels:all does not support negation",
+            str(error.exception),
+        )
+
     def _do_add_term_test(
         self, term: NarrowParameter, where_clause: str, params: tuple[object, ...] | None = None
     ) -> None:
@@ -1285,6 +1388,9 @@ class NarrowLibraryTest(ZulipTestCase):
         self.assertTrue(
             is_spectator_compatible([NarrowParameter(operator="channels", operand="archived")])
         )
+        self.assertTrue(
+            is_spectator_compatible([NarrowParameter(operator="channels", operand="all")])
+        )
 
         # "is:private" is a legacy alias for "is:dm".
         self.assertFalse(
@@ -1317,6 +1423,9 @@ class NarrowLibraryTest(ZulipTestCase):
         # "streams" is a legacy alias for "channels" operator
         self.assertTrue(
             is_spectator_compatible([NarrowParameter(operator="streams", operand="public")])
+        )
+        self.assertTrue(
+            is_spectator_compatible([NarrowParameter(operator="streams", operand="all")])
         )
 
 
@@ -1365,6 +1474,12 @@ class IncludeHistoryTest(ZulipTestCase):
             NarrowParameter(operator="channels", operand="archived", negated=True),
         ]
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+
+        # channels:all searches should include history for non-guest members.
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+        ]
+        self.assertTrue(ok_to_include_history(narrow, user_profile, False))
 
         # Definitely forbid seeing history on private channels.
         self.make_stream("private_channel", realm=user_profile.realm, invite_only=True)
@@ -1446,6 +1561,36 @@ class IncludeHistoryTest(ZulipTestCase):
         ]
         self.assertTrue(ok_to_include_history(narrow, user_profile, False))
 
+        # No point in searching history for is operator even if included with
+        # channels:all
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+            NarrowParameter(operator="is", operand="mentioned"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+            NarrowParameter(operator="is", operand="unread"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+            NarrowParameter(operator="is", operand="alerted"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+            NarrowParameter(operator="is", operand="resolved"),
+        ]
+        self.assertTrue(ok_to_include_history(narrow, user_profile, False))
+
+        # Search history for archived channel searches combined with channels:all.
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
+            NarrowParameter(operator="channels", operand="archived"),
+        ]
+        self.assertTrue(ok_to_include_history(narrow, user_profile, False))
+
         # simple True case
         narrow = [
             NarrowParameter(operator="channel", operand="public_channel"),
@@ -1475,6 +1620,12 @@ class IncludeHistoryTest(ZulipTestCase):
         narrow = [
             NarrowParameter(operator="channels", operand="public"),
             NarrowParameter(operator="channels", operand="archived"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
+
+        # channels:all searches should not include history for guest members.
+        narrow = [
+            NarrowParameter(operator="channels", operand="all"),
         ]
         self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
 
@@ -3855,6 +4006,203 @@ class GetOldMessagesTest(ZulipTestCase):
         )
         self.assert_length(result["messages"], 1)
         self.assertEqual(result["messages"][0]["id"], anchor)
+
+    def test_get_messages_using_narrow_channels_all(self) -> None:
+        realm = get_realm("zulip")
+
+        iago = self.example_user("iago")
+
+        self.subscribe(iago, "public-channel")
+        self.subscribe(iago, "private-channel", invite_only=True)
+        self.make_stream(
+            "private-channel-with-history", invite_only=True, history_public_to_subscribers=True
+        )
+        self.subscribe(iago, "private-channel-with-history")
+        self.subscribe(iago, "protected-no-group-access", invite_only=True)
+
+        # Send one message to each channel before hamlet has any access, so we
+        # can verify how pre-subscription history is treated per channel type.
+        message_id = {
+            stream_name: self.send_stream_message(iago, stream_name)
+            for stream_name in [
+                "public-channel",
+                "private-channel",
+                "private-channel-with-history",
+                "protected-no-group-access",
+            ]
+        }
+
+        hamlet = self.example_user("hamlet")
+        self.login("hamlet")
+
+        hamlet_group = check_add_user_group(
+            realm,
+            "hamlet_group",
+            [hamlet],
+            acting_user=hamlet,
+        )
+        # Grant hamlet permission-based access to the two private channels, but
+        # deliberately not to "protected-no-group-access".
+        for stream_name in ["private-channel", "private-channel-with-history"]:
+            do_change_stream_group_based_setting(
+                get_stream(stream_name, realm),
+                "can_add_subscribers_group",
+                hamlet_group,
+                acting_user=iago,
+            )
+
+        narrow = [dict(operator="channels", operand="all")]
+
+        def channels_all_message_ids() -> set[int]:
+            result = self.get_and_check_messages(
+                dict(
+                    narrow=orjson.dumps(narrow).decode(),
+                    anchor=message_id["public-channel"],
+                    num_before=0,
+                    num_after=10,
+                )
+            )
+            return {message["id"] for message in result["messages"]}
+
+        # Messages from public channels and from private channels whose history
+        # is public to subscribers are included, even without a subscription.
+        # The pre-subscription message in the protected-history "private-channel"
+        # is excluded, as is the message in "protected-no-group-access", which
+        # hamlet cannot access at all.
+        self.assertEqual(
+            channels_all_message_ids(),
+            {message_id["public-channel"], message_id["private-channel-with-history"]},
+        )
+
+        self.subscribe(hamlet, "private-channel")
+        # In a protected-history channel, the user only sees messages sent while
+        # subscribed: iago's new message appears, but the one he sent before
+        # hamlet subscribed remains hidden.
+        subscribed_private_message_id = self.send_stream_message(iago, "private-channel")
+        self.assertEqual(
+            channels_all_message_ids(),
+            {
+                message_id["public-channel"],
+                message_id["private-channel-with-history"],
+                subscribed_private_message_id,
+            },
+        )
+
+        # After unsubscribing, hamlet retains permission-based access to
+        # "private-channel" and still has a UserMessage row for the message he
+        # received while subscribed, so that message stays visible; the
+        # pre-subscription message remains excluded.
+        self.unsubscribe(hamlet, "private-channel")
+        self.assertEqual(
+            channels_all_message_ids(),
+            {
+                message_id["public-channel"],
+                message_id["private-channel-with-history"],
+                subscribed_private_message_id,
+            },
+        )
+
+        # "protected-no-group-access" has protected history and no group access,
+        # so hamlet's access depends solely on his subscription. While
+        # subscribed, messages he receives there are visible.
+        self.subscribe(hamlet, "protected-no-group-access")
+        subscribed_no_group_access_message_id = self.send_stream_message(
+            iago, "protected-no-group-access"
+        )
+        self.assertEqual(
+            channels_all_message_ids(),
+            {
+                message_id["public-channel"],
+                message_id["private-channel-with-history"],
+                subscribed_private_message_id,
+                subscribed_no_group_access_message_id,
+            },
+        )
+
+        # After unsubscribing he has no content access to the protected-history
+        # channel at all, so the message is excluded even though his UserMessage
+        # row for it still exists.
+        self.unsubscribe(hamlet, "protected-no-group-access")
+        self.assertEqual(
+            channels_all_message_ids(),
+            {
+                message_id["public-channel"],
+                message_id["private-channel-with-history"],
+                subscribed_private_message_id,
+            },
+        )
+
+    def test_get_messages_using_narrow_channels_all_for_guest(self) -> None:
+        iago = self.example_user("iago")
+        guest = self.example_user("polonius")
+        self.assertTrue(guest.is_guest)
+
+        # Start from a clean slate so the assertions below cover exactly the
+        # messages sent in this test.
+        Message.objects.all().delete()
+
+        self.subscribe(iago, "web-public-subscribed", is_web_public=True)
+        self.subscribe(iago, "web-public-unsubscribed", is_web_public=True)
+        self.subscribe(iago, "public-subscribed")
+        self.subscribe(iago, "private-subscribed", invite_only=True)
+
+        # Messages sent before the guest subscribes. Even for the web-public
+        # channel, the guest has no UserMessage row for these, so they are not
+        # surfaced by channels:all.
+        presubscription_web_public_id = self.send_stream_message(iago, "web-public-subscribed")
+        self.send_stream_message(iago, "public-subscribed")
+        self.send_stream_message(iago, "private-subscribed")
+
+        # Subscribe the guest before the remaining messages, so they have
+        # UserMessage rows for the messages in their subscribed channels.
+        self.subscribe(guest, "web-public-subscribed")
+        self.subscribe(guest, "public-subscribed")
+        self.subscribe(guest, "private-subscribed")
+
+        subscribed_web_public_id = self.send_stream_message(iago, "web-public-subscribed")
+        subscribed_public_id = self.send_stream_message(iago, "public-subscribed")
+        subscribed_private_id = self.send_stream_message(iago, "private-subscribed")
+        # A message in a web-public channel the guest is not subscribed to.
+        self.send_stream_message(iago, "web-public-unsubscribed")
+
+        self.login("polonius")
+        narrow = [dict(operator="channels", operand="all")]
+        result = self.get_and_check_messages(
+            dict(
+                narrow=orjson.dumps(narrow).decode(),
+                anchor=presubscription_web_public_id,
+                num_before=0,
+                num_after=10,
+            )
+        )
+
+        # The guest sees messages only from their subscribed channels — web-public,
+        # public, and private alike — and only those sent while subscribed: the
+        # unsubscribed web-public channel's message and the pre-subscription
+        # messages are all excluded.
+        message_ids = {message["id"] for message in result["messages"]}
+        self.assertEqual(
+            message_ids,
+            {subscribed_web_public_id, subscribed_public_id, subscribed_private_id},
+        )
+
+    def test_get_messages_using_narrow_channels_all_for_spectator(self) -> None:
+        # An unauthenticated spectator must include channels:web-public for the
+        # request to be accepted as a web-public query (otherwise it is
+        # rejected by is_web_public_narrow). channels:all then resolves to the
+        # web-public channels, exercising the spectator branch of by_channels.
+        result = self.get_and_check_messages(
+            dict(
+                narrow=orjson.dumps(
+                    [
+                        dict(operator="channels", operand="web-public"),
+                        dict(operator="channels", operand="all"),
+                    ]
+                ).decode()
+            )
+        )
+        self.assert_length(result["messages"], 1)
+        self.assertEqual(result["messages"][0]["display_recipient"], "Rome")
 
     def test_get_visible_messages_with_anchor(self) -> None:
         def messages_matches_ids(messages: list[dict[str, Any]], message_ids: list[int]) -> None:


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This is a replacement PR for #34927
1st commit adds channels:all filter.

Fixes: https://github.com/zulip/zulip/issues/33534

**How changes were tested:**
Ran all test and checked if tests are passing also verified manually.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/81f93b29-7860-482f-969f-f6f842c0fd25

`Private stream messages the user has unsuscribed from but has message access`

https://github.com/user-attachments/assets/acc6fe5b-0e1f-46c9-b286-dafa7d12d2a0








<img width="888" height="657" alt="image" src="https://github.com/user-attachments/assets/5a6128db-e17c-4b44-97c8-9650460bd0fb" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
