### PR TITLE
Fix search box stealing focus.

### DIFF
--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -423,6 +423,7 @@ export function rewire_exit_search(value: typeof exit_search): void {
 
 export let open_search_bar_and_close_narrow_description = (clear = false): void => {
     reset_searchbox(clear);
+    $("#search_query").attr("contenteditable", "true");
     $(".navbar-search").addClass("expanded");
     $("#message_view_header").addClass("hidden");
     popovers.hide_all();
@@ -444,6 +445,7 @@ export function close_search_bar_and_open_narrow_description(): void {
         search_pill_widget.clear(true);
     }
 
+    $("#search_query").attr("contenteditable", "false");
     $(".navbar-search").removeClass("expanded");
     $("#message_view_header").removeClass("hidden");
 

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -28,7 +28,7 @@
                                 <i class="search_icon zulip-icon zulip-icon-search"></i>
                                 <div class="search-input-and-pills">
                                     <div class="search-input input" id="search_query" type="text" data-placeholder-text="{{t 'Search' }}"
-                                      autocomplete="off" contenteditable="true"></div>
+                                      autocomplete="off" contenteditable="false"></div>
                                 </div>
                                 <button class="search_close_button tippy-zulip-delayed-tooltip" type="button" id="search_exit" aria-label="{{t 'Exit search' }}" data-tippy-content="Close"><i class="zulip-icon zulip-icon-close" aria-hidden="true"></i></button>
                             </div>


### PR DESCRIPTION
discussion: [#issues > 🎯 search box stealing focus](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20search.20box.20stealing.20focus/with/2380313)

Don't allow user to type in search box until it is expanded.