### PR TITLE
compose_reply: Avoid scrolling selected msg on click when compose open.

### DIFF
--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -140,6 +140,10 @@ export let respond_to_message = (opts: {
         private_message_recipient_ids = people.pm_with_user_ids(message);
     }
 
+    // On message click, if compose box is already open,
+    // never scroll the selected message.
+    const skip_scrolling_selected_message =
+        opts.trigger === "message click" && compose_state.composing();
     compose_actions.start({
         message_type: msg_type,
         stream_id,
@@ -148,6 +152,7 @@ export let respond_to_message = (opts: {
         ...(opts.trigger !== undefined && {trigger: opts.trigger}),
         is_reply: true,
         keep_composebox_empty: opts.keep_composebox_empty,
+        skip_scrolling_selected_message,
     });
 };
 


### PR DESCRIPTION
We don't scroll the selected message if user clicks on the message which compose box is open since the experience is less than ideal.

discussion: [#issues > 🎯 Clicking messages moving scroll position](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Clicking.20messages.20moving.20scroll.20position/with/2319180)