### PR TITLE
compose_banner: Fix duplicating banners due to incorrect CSS selector.

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -305,7 +305,6 @@ export function show_convert_pasted_text_to_file_banner({
     $textarea: JQuery<HTMLTextAreaElement>;
 }): JQuery {
     const $banner_container = get_compose_banner_container($textarea);
-    $banner_container.find(CSS.escape(CLASSNAMES.convert_pasted_text_to_file)).remove();
     const $new_row = $(
         render_long_paste_options({
             banner_type: INFO,
@@ -315,6 +314,6 @@ export function show_convert_pasted_text_to_file_banner({
     );
     $new_row.on("click", ".main-view-banner-action-button.convert-to-file", convert_to_file_cb);
     $new_row.on("click", ".main-view-banner-action-button.paste-to-compose", paste_to_compose_cb);
-    append_compose_banner_to_banner_list($new_row, $banner_container);
+    update_or_append_banner($new_row, CLASSNAMES.convert_pasted_text_to_file, $banner_container);
     return $new_row;
 }


### PR DESCRIPTION
The commit a9be18e03fb1599ae98c58db0364277e2fd55383, used an incorrect CSS selector (missing the `.` before the class name) leading to duplicating convert pasted text to file_banners.

This commit fixes this bug, by using the predefined function for this use case — `update_or_append_banner` stripping away the incorrect CSS selector.


Fixes: [#issues > 🎯 pasted text banner doesn't disappear on editing message](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20pasted.20text.20banner.20doesn't.20disappear.20on.20editing.20message/with/2381357)

**How changes were tested:**
- Fix long message multiple times.
- Check whether any duplication issues occur.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| <img width="970" height="686" alt="Screenshot 2026-02-16 at 5 46 34 PM" src="https://github.com/user-attachments/assets/92c395ea-a956-4b87-901c-7e48ca535102" /> | <img width="970" height="686" alt="Screenshot 2026-02-16 at 5 45 55 PM" src="https://github.com/user-attachments/assets/559eb804-d0e8-474f-9f45-fac98cd64da3" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
