### PR TITLE
help: Update instruction for disabling DMs in organization.

### DIFF
--- a/starlight_help/src/content/docs/restrict-direct-messages.mdx
+++ b/starlight_help/src/content/docs/restrict-direct-messages.mdx
@@ -65,8 +65,8 @@ to bots and to themselves.
 <FlattenedSteps>
   <NavigationSteps target="settings/organization-permissions" />
 
-  1. Under **Direct message permissions**, set **Who can authorize a direct
-     message conversation** to **Direct messages disabled**.
+  1. Under **Direct message permissions**, remove any configured roles, groups
+     and individual users from **Who can authorize a direct message conversation**.
 
   <SaveChanges />
 </FlattenedSteps>


### PR DESCRIPTION
There is no "Direct messages disabled" option now that this is controlled via the user-groups system. To disable sending DMs in an organization, then an admin needs to remove any configured roles, groups or users from this field.

See [#documentation > DM permissions: doc references nonexistent option](https://chat.zulip.org/#narrow/channel/19-documentation/topic/DM.20permissions.3A.20doc.20references.20nonexistent.20option/with/2381237).

**Notes**:
- Checked for other places in the help center that might have this issue with `git grep Disable starlight_help/`. All other places with settings like this are a checkbox toggle vs a user-group system setting.

---

**Screenshots and screen captures:**

[CURRENT DOC](https://zulip.com/help/restrict-direct-messages#disable-direct-messages)
<img width="1386" height="342" alt="Screenshot From 2026-02-16 14-09-23" src="https://github.com/user-attachments/assets/f706a5a2-40e9-409b-adab-1f82dc5b3134" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
