### PR TITLE
settings: Improve icon alignment in channel info title.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -536,6 +536,16 @@ h4.user_group_setting_subsection_title {
             .large-icon {
                 display: inline-block;
                 margin-left: 5px;
+                /* Square off the icon box for better alignment
+                   with adjacent text. */
+                line-height: 1;
+                /* Middle alignment looks good for all but the lock icon. */
+                vertical-align: middle;
+
+                &:has(.zulip-icon-lock) {
+                    /* Keep the default baseline alignment for the lock icon. */
+                    vertical-align: baseline;
+                }
 
                 .zulip-icon {
                     font-size: 0.75em; /* 18px at 24px/em */


### PR DESCRIPTION
This PR improves the vertical alignment of icons in the channel settings pane; it leaves the baseline alignment in place for the private channel lock icon, which looks better as-is.

A further improvement here would be to bring a flexbox setting to the area, but that would probably be better done in the context of reworking the alignment of the entire row (there are some brittle things here that would otherwise cause the channel-title area to fall out of alignment with the controls in the lefthand pane).

[#issues > archived channel icon too high](https://chat.zulip.org/#narrow/channel/9-issues/topic/archived.20channel.20icon.20too.20high/with/2379371)

**Screenshots and screen captures:**

| Before | After (no change on lock icon) |
| --- | --- |
| <img width="1840" height="1600" alt="settings-private-icon-before" src="https://github.com/user-attachments/assets/d4e1fed1-9dd2-436b-897c-b3ffc2d3254a" /> | <img width="1840" height="1600" alt="settings-private-icon-after" src="https://github.com/user-attachments/assets/77e6a72f-ccd5-47e9-aa9f-33e449df6e62" /> |
| <img width="1840" height="1600" alt="settings-archived-icon-before" src="https://github.com/user-attachments/assets/56bee029-c265-45fc-ae16-c9c2dbae7d03" /> | <img width="1840" height="1600" alt="settings-archived-icon-after" src="https://github.com/user-attachments/assets/7b54ab8b-82cd-4d3f-9263-8f0e7a996543" /> |
| <img width="1840" height="1600" alt="settings-channel-icon-before" src="https://github.com/user-attachments/assets/a72b2907-fed3-42c2-a5f9-f0dcfb26fff5" /> | <img width="1840" height="1600" alt="settings-channel-icon-after" src="https://github.com/user-attachments/assets/52a3492e-4488-4bf5-9e38-fc5f467f502d" /> |
| <img width="1840" height="1600" alt="settings-public-icon-before" src="https://github.com/user-attachments/assets/628e7697-dcac-4323-9c56-3bffb56481b5" /> | <img width="1840" height="1600" alt="settings-public-icon-after" src="https://github.com/user-attachments/assets/aab2748e-d643-4fb0-a7d4-243ac1348049" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
