### PR TITLE
corporate: Make dry run the default for initialize_fixed_price_plan.

### DIFF
--- a/corporate/management/commands/initialize_fixed_price_plan.py
+++ b/corporate/management/commands/initialize_fixed_price_plan.py
@@ -22,7 +22,10 @@ if settings.BILLING_ENABLED:
 
 
 class Command(ZulipBaseCommand):
-    help = """Initialize a paid fixed-price plan for a billing customer (Realm, RemoteRealm or RemoteZulipServer)."""
+    help = """
+    Initialize a paid fixed-price plan for a billing customer (Realm, RemoteRealm or RemoteZulipServer).
+    Defaults to `--dry-run=True` so that the billing changes are run in preview mode first.
+    """
 
     @override
     def add_arguments(self, parser: CommandParser) -> None:
@@ -57,8 +60,9 @@ class Command(ZulipBaseCommand):
             "--dry-run",
             dest="dry_run",
             action="store_true",
+            default=True,
             required=False,
-            help="Check for errors before initializing paid fixed-price plan.",
+            help="Check for errors before initializing paid fixed-price plan. Default value is True.",
         )
 
     @override


### PR DESCRIPTION
Follow up from https://github.com/zulip/zulip/pull/37725#discussion_r2808268215:
> A possible refinement would be to make the default for `--dry-run` true or not present, so it's most natural to run in preview mode first. Not exactly important.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
