### PR TITLE
Keep scheduling popover open when choosing custom time.

### DIFF
--- a/web/src/compose_send_menu_popover.ts
+++ b/web/src/compose_send_menu_popover.ts
@@ -54,6 +54,10 @@ export function open_schedule_message_menu(
                 },
             ],
         },
+        onHide() {
+            // onHide returning false prevents Tippy from closing the popover when flatpickr is open.
+            return flatpickr.is_open() ? false : undefined;
+        },
         onShow(instance) {
             // Only show send later options that are possible today.
             const date = new Date();


### PR DESCRIPTION
Previously, clicking inside the flatpickr calendar (e.g., on month or year) would hide the scheduling popover. Now the popover stays open while flatpickr is active.

Fixes: #35464

<!-- Describe your pull request here.-->


**How changes were tested:**
Opened the schedule message popover and clicked "Custom time" , clicked on various flatpickr elements (month dropdown, year, time fields) and verified the schedule popover remains visible


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->
<img width="790" height="463" alt="Screenshot 2026-02-16 at 22 24 37" src="https://github.com/user-attachments/assets/c38c07ea-4106-4b64-b130-6bdb689d4962" />


**Screenshots and screen captures:**

https://github.com/user-attachments/assets/ec7f334a-a35c-434c-ac83-8596708d6502



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
