### PR TITLE
Enable Markdown image syntax in web app

### DIFF
--- a/web/src/upload_widget.ts
+++ b/web/src/upload_widget.ts
@@ -9,6 +9,7 @@ import render_image_editor_modal from "../templates/image_editor_modal.hbs";
 import * as blueslip from "./blueslip.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import {$t, $t_html} from "./i18n.ts";
+import {SUPPORTED_IMAGE_TYPES, is_supported_image_type} from "./upload.ts";
 import * as util from "./util.ts";
 
 export type UploadWidget = {
@@ -21,27 +22,6 @@ export type UploadFunction = (file: File, night: boolean | null, icon: boolean) 
 const default_max_file_size = 5;
 
 let uppy_widget: Uppy<Meta, Body> | undefined;
-
-// These formats do not need to be universally understood by clients; they are all
-// converted, server-side, currently to PNGs.  This list should be kept in sync with
-// the THUMBNAIL_ACCEPT_IMAGE_TYPES in zerver/lib/thumbnail.py
-const supported_types = [
-    "image/avif",
-    "image/gif",
-    "image/heic",
-    "image/jpeg",
-    "image/png",
-    "image/tiff",
-    "image/webp",
-];
-
-function is_image_format(file: File): boolean {
-    const type = file.type;
-    if (!type) {
-        return false;
-    }
-    return supported_types.includes(type);
-}
 
 export function build_widget(
     // function returns a jQuery file input object
@@ -97,7 +77,7 @@ export function build_widget(
         return false;
     });
 
-    get_file_input().attr("accept", supported_types.toString());
+    get_file_input().attr("accept", [...SUPPORTED_IMAGE_TYPES].toString());
     get_file_input().on("change", (e) => {
         if (e.target.files?.[0] === undefined) {
             $input_error.hide();
@@ -112,7 +92,7 @@ export function build_widget(
                 );
                 $input_error.show();
                 clear();
-            } else if (!is_image_format(file)) {
+            } else if (!is_supported_image_type(file.type)) {
                 $input_error.text($t({defaultMessage: "File type is not supported."}));
                 $input_error.show();
                 clear();
@@ -162,7 +142,7 @@ function ensure_file(resized_img: File | Blob, original_file: File): File {
 function set_up_uppy_widget(property_name: "realm_icon" | "realm_logo" | "user_avatar"): void {
     uppy_widget = new Uppy<Meta, Body>({
         restrictions: {
-            allowedFileTypes: supported_types,
+            allowedFileTypes: [...SUPPORTED_IMAGE_TYPES],
             maxNumberOfFiles: 1,
         },
     }).use(ImageEditor, {
@@ -318,7 +298,7 @@ export function build_direct_upload_widget(
         return false;
     });
 
-    get_file_input().attr("accept", supported_types.toString());
+    get_file_input().attr("accept", [...SUPPORTED_IMAGE_TYPES].toString());
     get_file_input().on("change", (e) => {
         if (e.target.files?.[0] === undefined) {
             $input_error.hide();
@@ -333,7 +313,7 @@ export function build_direct_upload_widget(
                 );
                 $input_error.show();
                 clear();
-            } else if (!is_image_format(file)) {
+            } else if (!is_supported_image_type(file.type)) {
                 $input_error.text($t({defaultMessage: "File type is not supported."}));
                 $input_error.show();
                 clear();

--- a/web/tests/upload.test.cjs
+++ b/web/tests/upload.test.cjs
@@ -458,6 +458,7 @@ test("uppy_events", ({override_rewire, mock_template}) => {
     let state = {};
     const file = {
         name: "copenhagen.png",
+        type: "image/png",
         meta: {
             name: "copenhagen.png",
         },
@@ -485,6 +486,7 @@ test("uppy_events", ({override_rewire, mock_template}) => {
                 return {
                     ...file,
                     name: "modified-name-copenhagen.png",
+                    type: "image/png",
                     meta: {
                         ...file.meta,
                         zulip_url: "/user_uploads/4/cb/rue1c-MlMUjDAUdkRrEM4BTJ/copenhagen.png",
@@ -535,7 +537,7 @@ test("uppy_events", ({override_rewire, mock_template}) => {
         assert.equal(old_syntax, "[translated: Uploading copenhagen.png…]()");
         assert.equal(
             new_syntax,
-            "[modified-name-copenhagen.png](/user_uploads/4/cb/rue1c-MlMUjDAUdkRrEM4BTJ/copenhagen.png)",
+            "![modified-name-copenhagen.png](/user_uploads/4/cb/rue1c-MlMUjDAUdkRrEM4BTJ/copenhagen.png)",
         );
         assert.equal($textarea, $("textarea#compose-textarea"));
     });

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -104,8 +104,8 @@ TRANSCODED_IMAGE_FORMAT = ThumbnailFormat("webp", 4032, 3024, animated=False)
 # this does not provide any *security*, since the content-type is
 # provided by the browser, and may not match the bytes they uploaded.
 #
-# This should be kept synced with the client-side image-picker in
-# web/upload_widget.ts.  Any additions below must be accompanied by
+# This should be kept synced with the client-side list in
+# web/src/upload.ts.  Any additions below must be accompanied by
 # changes to the pyvips block below as well.
 THUMBNAIL_ACCEPT_IMAGE_TYPES = frozenset(
     [


### PR DESCRIPTION
This contains the original final commit from #36226 that enables using the new syntax in the web app for all messages. It was moved to a separate pull request so that we could do chat.zulip.org testing of the end-to-end experience before integrating it fully. 