### PR TITLE
topic_list: Hide resolved filters when no resolved topics are available.

### DIFF
--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -596,7 +596,19 @@ export function setup_topic_search_typeahead(): void {
             const pills = topic_filter_pill_widget!.items();
             const current_syntaxes = new Set(pills.map((pill) => pill.syntax));
             const query = $("#topic_filter_query").text().trim();
+            const has_locally_available_resolved_topics =
+                stream_topic_history.stream_has_locally_available_resolved_topics(stream_id);
             return topic_filter_pill.filter_options.filter((option) => {
+                if (!has_locally_available_resolved_topics && option.syntax.endsWith("resolved")) {
+                    // Technically, it could still be useful to show
+                    // the is:resolved option, as local data is not
+                    // complete. But because zooming the topic list
+                    // does the topic history fetch, it's reasonable to
+                    // ignore that possibility and just only show the
+                    // resolved topic options if we can confirm
+                    // they're relevant.
+                    return false;
+                }
                 if (current_syntaxes.has(option.syntax)) {
                     return false;
                 }


### PR DESCRIPTION
This PR restores the conditional behavior for is:resolved and -is:resolved in the topic-filter typeahead that was removed in #36937.

These filters are now skipped when the active stream has no locally available resolved topics.

Fixes: Discussed in [#design > conditional visibility of filters ](https://chat.zulip.org/#narrow/channel/101-design/topic/conditional.20visibility.20of.20filters/with/2380153)

**Screenshots and screen captures:**
Before:

https://github.com/user-attachments/assets/e7208802-d5dd-4ddf-b2a2-461c13b0e2e2

After:

https://github.com/user-attachments/assets/4ffc1ba7-b042-4dbb-80be-0eacf7ea8b8d


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
