### PR TITLE
Fix: End-to-End Encryption for Group Chat

### DIFF
--- a/docs/production/mobile-push-notifications.md
+++ b/docs/production/mobile-push-notifications.md
@@ -203,6 +203,9 @@ and privacy in mind:
   on the new protocol's better privacy guarantees once [official
   mobile app support][e2ee-flutter-issue] for the new protocol is
   generally available.
+- This E2EE support applies only to mobile push notification payloads.
+  Zulip does not currently support end-to-end encryption for chat
+  message history.
 - A central design goal of the Push Notification Service is to
   avoid any message content being stored or logged by the service,
   even in error cases.

--- a/starlight_help/src/content/docs/mobile-notifications.mdx
+++ b/starlight_help/src/content/docs/mobile-notifications.mdx
@@ -35,6 +35,9 @@ notifications. Support is [coming soon][e2ee-flutter-issue] to the Zulip mobile
 app. Once implemented, all push notifications sent from an up-to-date version of
 the server to an updated version of the app will be end-to-end encrypted.
 
+This E2EE support applies only to mobile push notification payloads. Zulip does
+not currently support end-to-end encryption for chat message history.
+
 [e2ee-flutter-issue]: https://github.com/zulip/zulip-flutter/issues/1764
 
 Organization administrators can require end-to-end encryption for


### PR DESCRIPTION
Draft fix for https://github.com/zulip/zulip/issues/6096

Draft prepared via targeted patch mode.
Validation command not configured in automation.

Changed files:
- `docs/production/mobile-push-notifications.md`
- `starlight_help/src/content/docs/mobile-notifications.mdx`
