### PR TITLE
auth: Increase login form max character limit to 254.

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -607,6 +607,7 @@ class CreateUserForm(forms.Form):
 
 
 class OurAuthenticationForm(AuthenticationForm):
+    username = forms.CharField(max_length=254)
     logger = logging.getLogger("zulip.auth.OurAuthenticationForm")
 
     @override

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -607,6 +607,7 @@ class CreateUserForm(forms.Form):
 
 
 class OurAuthenticationForm(AuthenticationForm):
+    # Set max_length to 254 to match UserProfile model.
     username = forms.CharField(max_length=254)
     logger = logging.getLogger("zulip.auth.OurAuthenticationForm")
 


### PR DESCRIPTION
In auth, Increased login form max character limit to 254.

This PR increases the max_length of the username field in the login form to 254 characters.

Previously, the OurAuthenticationForm relied on the default Django AuthenticationForm behavior, which typically restricts usernames to 150 characters. This prevented users with valid long email addresses (up to 254 characters, as defined in RFC 5321 and the UserProfile model) from logging in, even though they could successfully register.

This change explicitly defines the username field with max_length=254 to ensure consistency between registration and login validation.

Fixes: #37971

How changes were tested:

Checked zerver/forms.py to ensure OurAuthenticationForm now correctly overrides the default field.

Verified that the max_length matches EMAIL_MAX_LENGTH (254) used elsewhere in the application.

Screenshots and screen captures: N/A - Logic validation change only.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
