### PR TITLE
sidebar_ui: Fix error on searching when DM header is hidden.

### DIFF
--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -475,7 +475,7 @@ function get_header_rows_selectors(): string {
         // Views header.
         "#left-sidebar-navigation-area:not(.hidden-by-filters) #views-label-container, " +
         // DM Headers
-        "#direct-messages-section-header, " +
+        "#left_sidebar_scroll_container:not(.direct-messages-hidden-by-filters) #direct-messages-section-header, " +
         // All channel headers.
         ".stream-list-section-container:not(.no-display) .stream-list-subsection-header"
     );


### PR DESCRIPTION
discussion: [#issues > 🎯 exception with &#96;is:&#96; in left sidebar filter](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20exception.20with.20.60is.3A.60.20in.20left.20sidebar.20filter/with/2382536)


Introduced in a432c3bd44e3bd0cc54c783512dae0ee0007a79d.

When searching in left sidebar, when DM header is hidden and you type anything in search box, we throw an error since DM header element was returned even if it hidden.
Fixed by using the correct selector for DM header when it is visible.
