### PR TITLE
refactoring typeahead css to use gridded rows

### DIFF
--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -199,7 +199,7 @@
 .typeahead-image {
     display: grid;
     position: relative;
-    grid-template-rows: 1fr 1fr;   /* reserve space for status */
+    grid-template-rows: 1fr 1fr; /* reserve space for status */
     grid-template-columns: 1fr;
     height: 1.3125em; /* 21px at 16px/1em */
     width: 1.3125em; /* 21px at 16px/1em */
@@ -210,7 +210,7 @@
     }
 
     .user-circle {
-        grid-row: 3 / 2;
+        grid-row: 2 / 3;
         justify-self: last baseline;
         font-size: 0.4375em; /* 7px at 16px/1em */
         line-height: 1;

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -197,28 +197,28 @@
 
 /* For FontAwesome icons and zulip icons used in place of images for some users. */
 .typeahead-image {
-    flex: 0 0 auto;
+    display: grid;
     position: relative;
+    grid-template-rows: 1fr 1fr;   /* reserve space for status */
+    grid-template-columns: 1fr;
     height: 1.3125em; /* 21px at 16px/1em */
     width: 1.3125em; /* 21px at 16px/1em */
     border-radius: 4px;
 
     .typeahead-image-avatar {
         border-radius: 4px;
-        /* Override bootstrap img */
-        vertical-align: baseline;
     }
 
     .user-circle {
-        position: absolute;
-        /* This is smaller than the sidebar because avatars here are smaller */
+        grid-row: 3 / 2;
+        justify-self: last baseline;
         font-size: 0.4375em; /* 7px at 16px/1em */
         line-height: 1;
-        bottom: -0.5px;
-        right: -0.5px;
         background-color: var(--color-background-dropdown-widget);
         padding: 1px;
         border-radius: 50%;
+
+        transform: translate(0.5px, -8.5px);
 
         &.user-circle-offline {
             display: none;


### PR DESCRIPTION
This PR refactors the .typeahead-image and .user-circle classes to use modern CSS Grid layout.

The vertical-align: baseline caused minor inconsistencies in alignment between the status indicator and the user avatar, Switching to CSS Grid will allow us to remedy that behaviour.

**Screenshots (There is no visual change)**

before:
<img width="1757" height="1057" alt="Screenshot From 2026-02-11 11-31-13" src="https://github.com/user-attachments/assets/2e63e09b-4615-4101-b5cc-b6394530e78c" />
after:
<img width="1757" height="1057" alt="Screenshot From 2026-02-11 11-32-34" src="https://github.com/user-attachments/assets/1bde1057-7d56-42d0-ba68-7cfa7de134c5" />

**Testing**

- Manual Testing via visual looks and variable screen zoom settings.

**Fixes**
Fixes https://github.com/zulip/zulip/issues/37030