### PR TITLE
views_util: Fix keyboard navigation not working when compose is open.

### DIFF
--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -154,6 +154,16 @@ export function hide(opts: {$view: JQuery; set_visible: (value: boolean) => void
 export function is_in_focus(): boolean {
     let can_current_view_steal_focus = true;
     const focused_element = document.activeElement;
+
+    // If current view has focus we don't need to check anything else.
+    if (
+        focused_element instanceof HTMLElement &&
+        (focused_element.closest("#recent_view") !== null ||
+            focused_element.closest("#inbox-view") !== null)
+    ) {
+        return true;
+    }
+
     if (
         focused_element instanceof HTMLElement &&
         // Pill input elements.


### PR DESCRIPTION
Even if the view has focus, keyboard navigation doesn't work if the compose box is open.

discussion: [#issues > keyboard navigation in inbox/recent](https://chat.zulip.org/#narrow/channel/9-issues/topic/keyboard.20navigation.20in.20inbox.2Frecent/with/2372341)