### PR TITLE
auth: Allow login with long email addresses (up to 254 chars)

### DIFF
--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -91,7 +91,7 @@ page can be easily identified in it's respective JavaScript file. -->
                                 <input id="id_username" type="{% if not require_email_format_usernames %}text{% else %}email{% endif %}"
                                   name="username" class="{% if require_email_format_usernames %}email {% endif %}required"
                                   {% if email %} value="{{ email }}" {% else %} value="" autofocus {% endif %}
-                                  maxlength="72" required />
+                                  maxlength="{{ form.username.field.max_length }}" required />
                                 <label for="id_username">
                                     {% if not require_email_format_usernames and email_auth_enabled %}
                                     {{ _('Email or username') }}


### PR DESCRIPTION
This PR fixes an issue where users with long email addresses (longer than the previously hardcoded limit of 72 characters or the default Django user limit of 150) were unable to log in via the web interface, despite being able to log in via mobile.

The UserProfile model supports emails up to 254 characters (EMAIL_MAX_LENGTH), but the frontend login form restricted input length.

Fixes: [#37971 ](https://github.com/zulip/zulip/issues/37971)

Changes:

- Backend (zerver/forms.py): Updated OurAuthenticationForm to explicitly set the username field's max_length to 254 in the __init__ method. This approach was chosen over class-level redefinition to preserve the parent AuthenticationForm's widget attributes (specifically autofocus).
- Frontend (zerver/templates/zerver/login.html): Removed the hardcoded maxlength="72" attribute from the username input field and replaced it with {{ form.username.field.max_length }}. This ensures the frontend input limit is dynamically synced with the backend form definition.

**Screenshots and screen captures:**
<img width="1804" height="1014" alt="image" src="https://github.com/user-attachments/assets/3afc10a4-4060-4b93-b7f6-3d80cc5edda5" />

1. Shows the updated `max_length`.

https://github.com/user-attachments/assets/f415f318-c69d-4046-a92b-34c477d7fbe6

2. Shows successfull login of a user of length > 200.

Testing:

- Manual Verification:
  - Inspected the Login page HTML source and verified that the username input field now has maxlength="254".
  - Successfully typed an email address longer than 72 characters into the login field.
  - Verified successful login with a 200-character email address.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
