### PR TITLE
api-docs: Add local_message_id field to message event documentation.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -926,6 +926,21 @@ paths:
                                     [message-flags]: /api/update-message-flags#available-flags
                                   items:
                                     type: string
+                                local_message_id:
+                                  type: string
+                                  description: |
+                                    For clients supporting
+                                    [local echo](https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html#local-echo).
+                                    Only present if [`local_id`](/api/send-message#parameter-local_id) and
+                                    [`queue_id`](/api/send-message#parameter-queue_id) were passed by the
+                                    client when the message was sent to the server.
+
+                                    The same unique string-format identifier chosen by the client to identify
+                                    the locally echoed message (which was the value passed as the `local_id`
+                                    parameter). This lets the client know unambiguously that it should
+                                    replace the locally echoed message, rather than adding this new message
+                                    (which would be correct if the user had sent the new message from another
+                                    device).
                               additionalProperties: false
                               example:
                                 {
@@ -8456,21 +8471,27 @@ paths:
                   description: |
                     For clients supporting
                     [local echo](https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html#local-echo),
-                    the [event queue](/api/register-queue)
-                    ID for the client. If passed, `local_id` is required. If the message is
-                    successfully sent, the server will include `local_id` in the `message` event
-                    that the client with this `queue_id` will receive notifying it of the new message
-                    via [`GET /events`](/api/get-events). This lets the client know unambiguously
-                    that it should replace the locally echoed message, rather than adding this new
-                    message (which would be correct if the user had sent the new message from another
-                    device).
+                    the [event queue](/api/register-queue) ID for the client.
+
+                    If passed, `local_id` is required.
+
+                    If the message is successfully sent, the server will include
+                    `local_message_id` in the [`message` event](/api/get-events#message) that
+                    the client with this `queue_id` will receive.
                   example: "fb67bf8a-c031-47cc-84cf-ed80accacda8"
                 local_id:
                   type: string
                   description: |
-                    For clients supporting local echo, a unique string-format identifier
-                    chosen freely by the client; the server will pass it back to the client without
-                    inspecting it, as described in the `queue_id` description.
+                    For clients supporting
+                    [local echo](https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html#local-echo),
+                    a unique string-format identifier chosen freely by the client.
+
+                    If passed, `queue_id` is required.
+
+                    If the message is successfully sent, the server will pass it back to
+                    the client without inspecting it as `local_message_id` in the
+                    [`message` event](/api/get-events#message) that the client with the
+                    above `queue_id` will receive.
                   example: "100.01"
                 read_by_sender:
                   type: boolean


### PR DESCRIPTION
**Notes**:
- Adds the `local_message_id` field to the `message` event documentation.
- Revises the `local_id` and `queue_id` parameter descriptions in `send-message`.
- Adds links between the events and parameters in the descriptions.
- Does not add it to the example in either the event or endpoint documentation.

Fixes #34164.

---

**Screenshots and screen captures:**

[CURRENT SEND MESSAGE DOC](https://zulip.com/api/send-message#parameter-queue_id)
<img width="1536" height="874" alt="Screenshot From 2026-02-17 17-02-56" src="https://github.com/user-attachments/assets/ea8e5fbc-ed35-40fe-bd47-ed7a194b3ff3" />

[CURRENT MESSAGE EVENT DOC](https://zulip.com/api/get-events#message)
<img width="1536" height="382" alt="Screenshot From 2026-02-17 17-03-16" src="https://github.com/user-attachments/assets/0628539e-5d34-4dc4-b6f2-5e5723f1fd23" />


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
