### PR TITLE
json: Ensure JSON endpoints always return valid JSON on server errors.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -6,6 +6,48 @@ include /etc/nginx/zulip-include/headers;
 # Serve a custom error page when the app is down
 error_page 502 503 504 /static/webpack-bundles/5xx.html;
 
+location @api_error_500 {
+    include /etc/nginx/zulip-include/api_headers;
+    default_type application/json;
+    return 500 '{"result":"error","msg":"Internal server error"}';
+}
+location @api_error_502 {
+    include /etc/nginx/zulip-include/api_headers;
+    default_type application/json;
+    return 502 '{"result":"error","msg":"Bad gateway"}';
+}
+location @api_error_503 {
+    include /etc/nginx/zulip-include/api_headers;
+    default_type application/json;
+    return 503 '{"result":"error","msg":"Service unavailable"}';
+}
+location @api_error_504 {
+    include /etc/nginx/zulip-include/api_headers;
+    default_type application/json;
+    return 504 '{"result":"error","msg":"Gateway timeout"}';
+}
+
+location @json_error_500 {
+    include /etc/nginx/zulip-include/headers;
+    default_type application/json;
+    return 500 '{"result":"error","msg":"Internal server error"}';
+}
+location @json_error_502 {
+    include /etc/nginx/zulip-include/headers;
+    default_type application/json;
+    return 502 '{"result":"error","msg":"Bad gateway"}';
+}
+location @json_error_503 {
+    include /etc/nginx/zulip-include/headers;
+    default_type application/json;
+    return 503 '{"result":"error","msg":"Service unavailable"}';
+}
+location @json_error_504 {
+    include /etc/nginx/zulip-include/headers;
+    default_type application/json;
+    return 504 '{"result":"error","msg":"Gateway timeout"}';
+}
+
 # Serve static files directly
 location /local-static {
     alias /home/zulip/local-static;
@@ -77,6 +119,11 @@ location /json/events {
     }
 
     proxy_pass $tornado_server;
+    proxy_intercept_errors on;
+    error_page 500 = @json_error_500;
+    error_page 502 = @json_error_502;
+    error_page 503 = @json_error_503;
+    error_page 504 = @json_error_504;
     include /etc/nginx/zulip-include/proxy_longpolling;
 }
 
@@ -97,6 +144,11 @@ location /api/v1/events {
 
     include /etc/nginx/zulip-include/tornado_cors_headers;
     proxy_pass $tornado_server;
+    proxy_intercept_errors on;
+    error_page 500 = @api_error_500;
+    error_page 502 = @api_error_502;
+    error_page 503 = @api_error_503;
+    error_page 504 = @api_error_504;
     include /etc/nginx/zulip-include/proxy_longpolling;
 }
 
@@ -155,9 +207,26 @@ location /api/internal/ {
     include uwsgi_params;
 }
 
+location /json/ {
+    include /etc/nginx/zulip-include/headers;
+
+    uwsgi_intercept_errors on;
+    error_page 500 = @json_error_500;
+    error_page 502 = @json_error_502;
+    error_page 503 = @json_error_503;
+    error_page 504 = @json_error_504;
+
+    include uwsgi_params;
+}
+
 # Send all API routes not covered above to Django via uWSGI
 location /api/ {
     include /etc/nginx/zulip-include/api_headers;
+    uwsgi_intercept_errors on;
+    error_page 500 = @api_error_500;
+    error_page 502 = @api_error_502;
+    error_page 503 = @api_error_503;
+    error_page 504 = @api_error_504;
 
     include uwsgi_params;
 }

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -377,7 +377,14 @@ class LogRequests(MiddlewareMixin):
 
 
 class JsonErrorHandler(MiddlewareMixin):
+    def request_expects_json(self, request: HttpRequest) -> bool:
+        error_format = RequestNotes.get_notes(request).error_format
+        if error_format == "JSON":
+            return True
+        return request.path.startswith("/api") or request.path.startswith("/json")
+
     def process_exception(self, request: HttpRequest, exception: Exception) -> HttpResponse | None:
+        expect_json = self.request_expects_json(request)
         if isinstance(exception, MissingAuthenticationError):
             if request.get_preferred_type(["application/json", "text/html"]) == "text/html":
                 # If this looks like a request from a top-level page in a
@@ -410,7 +417,7 @@ class JsonErrorHandler(MiddlewareMixin):
                 # `InternalBouncerServerError` raised (status code 502) as
                 # it helps the client to show the user a more accurate error message.
                 return response
-        elif RequestNotes.get_notes(request).error_format == "JSON" and not settings.TEST_SUITE:
+        elif expect_json and not settings.TEST_SUITE:
             response = json_response(
                 res_type="error", msg=_("Internal server error"), status=500, exception=exception
             )

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -1,8 +1,10 @@
 import time
-from unittest.mock import patch
+from typing import cast
+from unittest.mock import Mock, patch
 
 from bs4 import BeautifulSoup
 from django.http import HttpResponse
+from django.test import override_settings
 
 from zerver.actions.realm_settings import do_set_realm_property
 from zerver.lib.realm_icon import get_realm_icon_url
@@ -10,7 +12,7 @@ from zerver.lib.request import RequestNotes
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import HostRequestMock
 from zerver.lib.utils import assert_is_not_none
-from zerver.middleware import LogRequests, is_slow_query, write_log_line
+from zerver.middleware import JsonErrorHandler, LogRequests, is_slow_query, write_log_line
 from zerver.models.realms import get_realm
 from zilencer.models import RemoteZulipServer
 
@@ -214,3 +216,22 @@ class LogRequestsTest(ZulipTestCase):
         with self.assertLogs("zulip.requests", level="INFO") as m:
             LogRequests(lambda _: HttpResponse())(request)
             self.assertIn(expected_requester, m.output[0])
+
+
+class JsonErrorHandlerTest(ZulipTestCase):
+    @override_settings(TEST_SUITE=False)
+    @patch("zerver.middleware.signals.got_request_exception.send")
+    @patch("zerver.middleware.log_response")
+    def test_json_endpoint_exception_returns_json_error(
+        self,
+        mock_log_response: Mock,
+        mock_send: Mock,
+    ) -> None:
+        request = HostRequestMock(path="/json/messages")
+        handler = JsonErrorHandler(lambda _: HttpResponse())
+
+        response = handler.process_exception(request, Exception("Server error"))
+
+        self.assertIsNotNone(response)
+        response = cast(HttpResponse, response)
+        self.assert_json_error(response, "Internal server error", status_code=500)


### PR DESCRIPTION
## Problem

JSON endpoints could return HTML on server errors,causing the client to crash with:

`Unexpected token < in JSON at position 0`

## Solution

- **Django Middleware**: `JsonErrorHandler` now ensures API and `/json` routes always return JSON for unexpected exceptions.  
- **Nginx**: API and `/json` locations return JSON for 500/502/503/504 errors using dedicated error locations.  
- **Tests**: Backend test added to verify JSON error responses.

## Related Issue

Fixes #6296

<details>
<summary>Self-review checklist</summary>
- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code)
 the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
- [x] Communicate decisions, questions, and potential concerns.


Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
