### PR TITLE
lightbox: Disallow flex-item behavior on img.

### DIFF
--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -20,6 +20,10 @@
 
         & img {
             cursor: move;
+            /* Disallow flex behavior; we want to center this, but
+               not have the image container grow beyond the bounds
+               of the replaced media (the actual image.) */
+            flex: 0 0 0;
             max-height: 100%;
             max-width: 100%;
             object-fit: contain;


### PR DESCRIPTION
This fixes a tricky little annoying bug that would cause the `<img>` tag's area in the lightbox to extend beyond the boundaries of the replaced media (the actual image file). This was owing to default flexbox behavior to grow to fit the available width, especially in cases of images that were substantially larger than the viewport.

In addition to having more precise image dimensions here, this restores the lightbox's intended close behavior, where clicking anywhere outside the image should close the lightbox.

[#feedback > easily dismissing the image preview on desktop @ 💬](https://chat.zulip.org/#narrow/channel/137-feedback/topic/easily.20dismissing.20the.20image.20preview.20on.20desktop/near/2381632)

**Screenshots and screen captures:**

_Showing the flex area (purple lines) and `<img>` container (blue highlight):_

| Before | After |
| --- | --- |
| <img width="2942" height="2490" alt="lightbox-img-element-before" src="https://github.com/user-attachments/assets/656619e6-aaf9-4e8e-89dc-1277ebd31b9c" /> | <img width="2942" height="2490" alt="lightbox-img-element-after" src="https://github.com/user-attachments/assets/8f15e34c-da02-46e4-87b6-0ce3af9a630b" /> |

_Double-click zoom behavior (slight jog is owing to imprecise double-click location; the zoom behavior is what matters here):_

| Before | After |
| --- | --- |
| <img width="2942" height="2490" alt="lightbox-double-click-zoom-before" src="https://github.com/user-attachments/assets/e9fe2656-3f57-4f91-8d1d-4d8bfa858f65" /> | <img width="2942" height="2490" alt="lightbox-double-click-zoom-after" src="https://github.com/user-attachments/assets/8b8940eb-839d-45f1-8aca-668326761a43" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>