### PR TITLE
checks: Add basic checks for https:// EXTERNAL_URI_SCHEME values.

### DIFF
--- a/zerver/checks.py
+++ b/zerver/checks.py
@@ -59,6 +59,17 @@ def check_external_host_setting(
         return []
 
     errors = []
+    scheme = settings.EXTERNAL_URI_SCHEME
+    if scheme != "https://" and not settings.DEVELOPMENT:
+        errors.append(
+            checks.Error(
+                "Zulip does not support a non-HTTPS external scheme in production",
+                obj="settings.EXTERNAL_URI_SCHEME",
+                hint="Do not override EXTERNAL_URI_SCHEME in production",
+                id="zulip.E004",
+            )
+        )
+
     hostname = settings.EXTERNAL_HOST
     if "." not in hostname and os.environ.get("ZULIP_TEST_SUITE") != "true" and settings.PRODUCTION:
         suggest = ".localdomain" if hostname == "localhost" else ".local"

--- a/zerver/tests/test_checks.py
+++ b/zerver/tests/test_checks.py
@@ -53,7 +53,7 @@ class TestChecks(ZulipTestCase):
             ZULIP_ADMINISTRATOR=None,
         )
 
-    @override_settings(DEVELOPMENT=False, PRODUCTION=True)
+    @override_settings(DEVELOPMENT=False, PRODUCTION=True, EXTERNAL_URI_SCHEME="https://")
     def test_checks_external_host_domain(self) -> None:
         message_re = r"\(zulip\.E002\) EXTERNAL_HOST \(\S+\) does not contain a domain part"
         try:
@@ -97,6 +97,27 @@ class TestChecks(ZulipTestCase):
         self.assert_check_with_error(
             "EXTERNAL_HOST (-bogus-.example.com) does not validate as a hostname",
             EXTERNAL_HOST="-bogus-.example.com:443",
+        )
+
+    def test_checks_external_scheme(self) -> None:
+        self.assert_check_with_error(
+            None, EXTERNAL_URI_SCHEME="https://", DEVELOPMENT=False, PRODUCTION=True
+        )
+        self.assert_check_with_error(
+            None, EXTERNAL_URI_SCHEME="http://", DEVELOPMENT=True, PRODUCTION=False
+        )
+
+        self.assert_check_with_error(
+            "Zulip does not support a non-HTTPS external scheme in production",
+            EXTERNAL_URI_SCHEME="http://",
+            DEVELOPMENT=False,
+            PRODUCTION=True,
+        )
+        self.assert_check_with_error(
+            "Zulip does not support a non-HTTPS external scheme in production",
+            EXTERNAL_URI_SCHEME="https",
+            DEVELOPMENT=False,
+            PRODUCTION=True,
         )
 
     def test_checks_auth(self) -> None:


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
