### PR TITLE
[WIP] settings: Add upload and delete info on the bot avatar preview.

### DIFF
--- a/web/src/avatar.ts
+++ b/web/src/avatar.ts
@@ -3,6 +3,7 @@ import $ from "jquery";
 import * as channel from "./channel.ts";
 import * as confirm_dialog from "./confirm_dialog.ts";
 import {$t_html} from "./i18n.ts";
+import * as modals from "./modals.ts";
 import * as settings_data from "./settings_data.ts";
 import {current_user, realm} from "./state_data.ts";
 import * as upload_widget from "./upload_widget.ts";
@@ -33,26 +34,42 @@ export function build_bot_create_widget(): UploadWidget {
     );
 }
 
-export function build_bot_edit_widget($target: JQuery): UploadWidget {
+export function build_bot_edit_widget(upload_function: UploadFunction): void {
     const get_file_input = function (): JQuery<HTMLInputElement> {
-        return $target.find<HTMLInputElement>(".edit_bot_avatar_file_input");
+        return $<HTMLInputElement>("#bot-avatar-upload-widget input.image_file_input").expectOne();
     };
 
-    const $file_name_field = $target.find(".edit_bot_avatar_file");
-    const $input_error = $target.find(".edit_bot_avatar_error");
-    const $clear_button = $target.find(".edit_bot_avatar_clear_button");
-    const $upload_button = $target.find(".edit_bot_avatar_upload_button");
-    const $preview_text = $target.find(".edit_bot_avatar_preview_text");
-    const $preview_image = $target.find(".edit_bot_avatar_preview_image");
+    const $input_error = $(".edit_bot_avatar_error").expectOne();
+    const $upload_button = $("#bot-avatar-upload-widget .image_upload_button").expectOne();
 
-    return upload_widget.build_widget(
+    get_file_input().on("change", (e) => {
+        const file = e.target.files?.[0];
+        if (!file) {
+            return;
+        }
+        // Must be registered before build_direct_upload_widget's handler.
+        e.stopImmediatePropagation();
+        const $file_input = get_file_input();
+        modals.close("user-profile-modal", {
+            on_hidden() {
+                upload_widget.open_uppy_editor(
+                    file,
+                    "bot_avatar",
+                    $file_input,
+                    $upload_button,
+                    upload_function,
+                );
+            },
+        });
+    });
+
+    upload_widget.build_direct_upload_widget(
         get_file_input,
-        $file_name_field,
         $input_error,
-        $clear_button,
         $upload_button,
-        $preview_text,
-        $preview_image,
+        upload_function,
+        realm.max_avatar_file_size_mib,
+        "bot_avatar",
     );
 }
 

--- a/web/src/upload_widget.ts
+++ b/web/src/upload_widget.ts
@@ -139,7 +139,9 @@ function ensure_file(resized_img: File | Blob, original_file: File): File {
     return new File([resized_img], original_file.name, {type: resized_img.type});
 }
 
-function set_up_uppy_widget(property_name: "realm_icon" | "realm_logo" | "user_avatar"): void {
+function set_up_uppy_widget(
+    property_name: "realm_icon" | "realm_logo" | "user_avatar" | "bot_avatar",
+): void {
     uppy_widget = new Uppy<Meta, Body>({
         restrictions: {
             allowedFileTypes: [...SUPPORTED_IMAGE_TYPES],
@@ -174,9 +176,9 @@ function set_up_uppy_widget(property_name: "realm_icon" | "realm_logo" | "user_a
     });
 }
 
-function open_uppy_editor(
+export function open_uppy_editor(
     file: File,
-    property_name: "realm_icon" | "realm_logo" | "user_avatar",
+    property_name: "realm_icon" | "realm_logo" | "user_avatar" | "bot_avatar",
     $file_input: JQuery<HTMLInputElement>,
     $upload_button: JQuery,
     upload_function: UploadFunction,
@@ -255,6 +257,7 @@ function open_uppy_editor(
                 });
             });
         },
+
         on_hidden() {
             assert(uppy_widget !== undefined);
             uppy_widget.destroy();
@@ -272,7 +275,7 @@ export function build_direct_upload_widget(
     $upload_button: JQuery,
     upload_function: UploadFunction,
     max_file_upload_size: number,
-    property_name: "realm_icon" | "realm_logo" | "user_avatar",
+    property_name: "realm_icon" | "realm_logo" | "user_avatar" | "bot_avatar",
 ): void {
     // default value of max uploaded file size
     function accept(): void {

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -58,7 +58,6 @@ import * as timerender from "./timerender.ts";
 import type {HTMLSelectOneElement} from "./types.ts";
 import * as ui_report from "./ui_report.ts";
 import * as ui_util from "./ui_util.ts";
-import type {UploadWidget} from "./upload_widget.ts";
 import * as user_deactivation_ui from "./user_deactivation_ui.ts";
 import * as user_group_edit_members from "./user_group_edit_members.ts";
 import * as user_group_picker_pill from "./user_group_picker_pill.ts";
@@ -876,7 +875,6 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
         realm_bot_domain: realm.realm_bot_domain,
     });
     $container.append($(modal_content_html));
-    let avatar_widget: UploadWidget;
 
     assert(bot.bot_type !== undefined && bot.bot_type !== null);
 
@@ -970,7 +968,6 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
             contentType: false,
             success() {
                 $("#bot-edit-form-error").hide();
-                avatar_widget.clear();
                 hide_button_spinner($submit_button);
                 original_values = get_current_values($("#bot-edit-form"));
                 toggle_submit_button($("#bot-edit-form"));
@@ -1004,6 +1001,48 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
             },
         });
     });
+
+    function upload_bot_avatar(file: File): void {
+        const formData = new FormData();
+
+        assert(csrf_token !== undefined);
+        formData.append("csrfmiddlewaretoken", csrf_token);
+        formData.append("file", file);
+        $("#bot-avatar-upload-widget-error").hide();
+        assert(bot !== undefined);
+        const url = "/json/bots/" + encodeURIComponent(bot.user_id);
+        channel.patch({
+            url,
+            data: formData,
+            processData: false,
+            contentType: false,
+            success() {
+                dialog_widget.close();
+                $("#bot-avatar-upload-widget .image-delete-button").show();
+                $("#bot-avatar-source").hide();
+                ui_report.success(
+                    $t_html({defaultMessage: "Saved"}),
+                    $("#user-profile-modal .save-success"),
+                    1200,
+                );
+            },
+            error(xhr) {
+                const error_message = channel.xhr_error_message(
+                    $t_html({defaultMessage: "Failed"}),
+                    xhr,
+                );
+                banners.open(
+                    {
+                        intent: "danger",
+                        label: error_message,
+                        buttons: [],
+                        close_button: false,
+                    },
+                    $("#bot-edit-form-error"),
+                );
+            },
+        });
+    }
 
     function edit_bot_post_render(): void {
         $("#edit_bot_modal .dialog_submit_button").prop("disabled", true);
@@ -1055,7 +1094,7 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
                 .hide();
         }
 
-        avatar_widget = avatar.build_bot_edit_widget($("#bot-edit-form"));
+        avatar.build_bot_edit_widget(upload_bot_avatar);
 
         if (bot_type === OUTGOING_WEBHOOK_BOT_TYPE) {
             $("#service_data").append(

--- a/web/styles/image_upload_widget.css
+++ b/web/styles/image_upload_widget.css
@@ -186,6 +186,16 @@
     }
 }
 
+/* CSS related to settings page bot avatar upload widget only */
+#bot-avatar-upload-widget {
+    width: fit-content;
+
+    .image-block {
+        width: 200px;
+        height: 200px;
+    }
+}
+
 /* CSS related to settings page realm day/night logo upload widget only */
 #realm-day-logo-upload-widget,
 #realm-night-logo-upload-widget {

--- a/web/templates/settings/edit_bot_form.hbs
+++ b/web/templates/settings/edit_bot_form.hbs
@@ -42,29 +42,17 @@
         <div id="service_data">
         </div>
         <div class="input-group edit-avatar-section">
-            <label class="modal-field-label">{{t "Avatar" }}</label>
-            {{!-- Shows the current avatar --}}
-            <img src="{{bot_avatar_url}}" id="current_bot_avatar_image" />
-            <input type="file" name="bot_avatar_file_input" class="notvisible edit_bot_avatar_file_input" value="{{t 'Upload profile picture' }}" />
             <div class="edit_bot_avatar_file"></div>
-            <div class="edit_bot_avatar_preview_text">
-                <img class="edit_bot_avatar_preview_image" />
-            </div>
-            {{> ../components/action_button
-              label=(t "Change avatar")
-              variant="subtle"
-              intent="neutral"
-              custom_classes="edit_bot_avatar_upload_button"
-              }}
-            {{> ../components/action_button
-              label=(t "Clear profile picture")
-              variant="subtle"
-              intent="danger"
-              custom_classes="edit_bot_avatar_clear_button"
-              hidden=true
-              }}
-            <div><label for="edit_bot_avatar_file" generated="true" class="edit_bot_avatar_error text-error"></label></div>
+            <input type="file" name="bot_avatar_file_input" class="notvisible edit_bot_avatar_file_input" value="{{t 'Upload profile picture' }}" />
+            {{> image_upload_widget
+              widget="bot-avatar"
+              upload_text=(t "Upload bot avatar")
+              delete_text=(t "Delete bot avatar")
+              disabled_text=(t "Avatar changes are disabled in this organization.")
+              is_editable_by_current_user=is_bot_owner_current_user
+              image=bot_avatar_url}}
         </div>
+        <div><label for="edit_bot_avatar_file" generated="true" class="edit_bot_avatar_error text-error"></label></div>
     </form>
     {{#if is_incoming_webhook_bot}}
     <div class="input-group">


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #29766

- [x] The profile image preview acts as an upload button.
- [ ] On-hover text explaining how to upload, and x to delete the image. If the avatar ends up being too small, we can show the upload info in a tooltip instead. - Partially complete.
- [x] The cropping UI implemented in https://github.com/zulip/zulip/pull/36038 is available.
- [x] Changes are saved right away, without needing to click the "Save changes" button.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Before:
<img width="639" height="573" alt="Screenshot 2026-02-17 at 11 23 05 PM" src="https://github.com/user-attachments/assets/0323b42f-b18a-4166-97be-a6724de64d34" />
<img width="638" height="571" alt="Screenshot 2026-02-17 at 11 23 59 PM" src="https://github.com/user-attachments/assets/0b803324-53da-477e-b6bd-55853056a541" />

After:
<img width="601" height="575" alt="Screenshot 2026-02-17 at 11 25 16 PM" src="https://github.com/user-attachments/assets/7a8830d1-0925-47a0-b236-ba29cee086a1" />
<img width="602" height="573" alt="Screenshot 2026-02-17 at 11 25 37 PM" src="https://github.com/user-attachments/assets/7ee5569d-fffd-4284-a014-08872f835920" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
