### PR TITLE
stream_settings: Clear active channel when hidden by filters.

### DIFF
--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -508,7 +508,8 @@ export function update_settings_for_unsubscribed(slim_sub: StreamSubscription): 
     if (!stream_data.can_toggle_subscription(sub)) {
         stream_ui_updates.update_add_subscriptions_elements(sub);
     }
-    if (current_user.is_guest) {
+
+    if (current_user.is_guest && hash_parser.is_editing_stream(sub.stream_id)) {
         stream_edit.open_edit_panel_empty();
     }
 
@@ -703,6 +704,12 @@ function update_folder_filter_button(left_panel_params: LeftPanelParams): void {
     }
 }
 
+function empty_right_panel_if_active_channel_hidden(): void {
+    if ($(".stream-row.active").hasClass("notdisplayed")) {
+        stream_edit.open_edit_panel_empty();
+    }
+}
+
 // LeftPanelParams { input: String, show_subscribed: Boolean, sort_order: String }
 export function redraw_left_panel(left_panel_params = get_left_panel_params()): number[] {
     // We only get left_panel_params passed in from tests.  Real
@@ -877,6 +884,7 @@ function filter_click_handler(
     const filter_id = $(event.currentTarget).attr("data-unique-id");
     assert(filter_id !== undefined);
     redraw_left_panel();
+    empty_right_panel_if_active_channel_hidden();
     dropdown.hide();
     widget.render();
 }
@@ -1048,10 +1056,13 @@ function setup_page(callback: () => void): void {
 
         stream_ui_updates.set_folder_dropdown_visibility($("#stream-creation"));
 
-        const throttled_redraw_left_panel = _.throttle(redraw_left_panel, 50);
+        const throttled_redraw_left_and_clear_right_panels = _.throttle(() => {
+            redraw_left_panel();
+            empty_right_panel_if_active_channel_hidden();
+        }, 50);
         $("#stream_filter input[type='text']").on("input", () => {
             // Debounce filtering in case a user is typing quickly
-            throttled_redraw_left_panel();
+            throttled_redraw_left_and_clear_right_panels();
         });
 
         settings_banner.set_up_banner(


### PR DESCRIPTION
Fixes #22413

## Summary

Ensure the right panel in Channel Settings is cleared when the active
channel becomes invalid due to filtering.

If filtering in the left panel hides the currently selected channel,
it is deselected and the right panel is cleared.

---

## Videos

### Filter hides active channel

### Before

https://github.com/user-attachments/assets/5e8526c0-b892-4484-ac76-c57348e08ef4



### After

https://github.com/user-attachments/assets/45992e02-7d8e-479b-a2c2-084d10982165

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
