### PR TITLE
left_sidebar: Fix styling for hidden DM section for spectator view.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -2372,7 +2372,8 @@ li.topic-list-item {
     display: none;
 }
 
-#left_sidebar_scroll_container.direct-messages-hidden-by-filters {
+#left_sidebar_scroll_container.direct-messages-hidden-by-filters,
+.spectator-view {
     #direct-messages-section-header {
         display: none;
     }

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -42,7 +42,7 @@
     </a>
     {{~!-- squash whitespace --~}}
     <div id="left_sidebar_scroll_container" class="scrolling_list" data-simplebar data-simplebar-tab-index="-1">
-        <div id="direct-messages-section-header" class="direct-messages-container hidden-for-spectators zoom-out zoom-in-sticky">
+        <div id="direct-messages-section-header" class="direct-messages-container zoom-out zoom-in-sticky">
             <i id="toggle-direct-messages-section-icon" class="zulip-icon zulip-icon-heading-triangle-right sidebar-heading-icon rotate-icon-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
             <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{ LEFT_SIDEBAR_DIRECT_MESSAGES_TITLE }}</span></h4>
             <div class="left-sidebar-controls">


### PR DESCRIPTION
Reported here: [#issues > 🎯 messed up left sidebar in spectator view](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20messed.20up.20left.20sidebar.20in.20spectator.20view/with/2383119)

I removed `hidden-for-spectators` from the header, to have only one source for hiding the DM section for spectators.