### PR TITLE
swe open source

### DIFF
--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -743,6 +743,55 @@ def send_user_creation_events_on_adding_subscriptions(
                 accessible_user = subscribers_user_id_map[accessible_user_id]
                 notify_created_user(accessible_user, [user.id])
 
+def send_subscription_change_channel_events_notifications(
+    sub_tuples: list[tuple[UserProfile, Stream]],
+    *,
+    acting_user: UserProfile | None,
+    operation: str,
+) -> None:
+    if acting_user is None:
+        return
+
+    assert operation in ["subscribe", "unsubscribe"]
+
+    sender = get_system_bot(settings.NOTIFICATION_BOT, acting_user.realm_id)
+    acting_user_mention = silent_mention_syntax_for_user(acting_user)
+
+    for target_user, stream in sub_tuples:
+        if not stream.invite_only:
+            continue
+
+        with override_language(stream.realm.default_language):
+            if target_user.id == acting_user.id:
+                if operation == "subscribe":
+                    notification_string = _("{user} subscribed to this channel.").format(
+                        user=acting_user_mention
+                    )
+                else:
+                    notification_string = _("{user} unsubscribed from this channel.").format(
+                        user=acting_user_mention
+                    )
+            else:
+                target_user_mention = silent_mention_syntax_for_user(target_user)
+                if operation == "subscribe":
+                    notification_string = _("{user1} subscribed {user2} to this channel.").format(
+                        user1=acting_user_mention,
+                        user2=target_user_mention,
+                    )
+                else:
+                    notification_string = _(
+                        "{user1} unsubscribed {user2} from this channel."
+                    ).format(
+                        user1=acting_user_mention,
+                        user2=target_user_mention,
+                    )
+
+            maybe_send_channel_events_notice(
+                sender,
+                stream,
+                notification_string,
+                archived_channel_notice=stream.deactivated,
+            )
 
 SubT: TypeAlias = tuple[list[SubInfo], list[SubInfo]]
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3398,6 +3398,103 @@ class SubscriptionRestApiTest(ZulipTestCase):
         streams = self.get_streams(user)
         self.assertTrue("my_test_stream_1" not in streams)
 
+    def test_private_channel_subscription_change_notifications(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+
+        stream = self.make_stream("private_notifications", realm=user.realm, invite_only=True)
+
+        request = {
+            "add": orjson.dumps([{"name": stream.name}]).decode(),
+        }
+        result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_success(result)
+
+        msg = self.get_last_message()
+        self.assertEqual(msg.recipient.type, Recipient.STREAM)
+        self.assertEqual(msg.recipient.type_id, stream.id)
+        self.assertEqual(msg.sender_id, self.notification_bot(user.realm).id)
+        self.assertEqual(msg.topic_name(), "channel events")
+        self.assertEqual(msg.content, f"@_**King Hamlet|{user.id}** subscribed to this channel.")
+
+        request = {
+            "delete": orjson.dumps([stream.name]).decode(),
+        }
+        result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_success(result)
+
+        msg = self.get_last_message()
+        self.assertEqual(msg.recipient.type, Recipient.STREAM)
+        self.assertEqual(msg.recipient.type_id, stream.id)
+        self.assertEqual(msg.sender_id, self.notification_bot(user.realm).id)
+        self.assertEqual(msg.topic_name(), "channel events")
+        self.assertEqual(msg.content, f"@_**King Hamlet|{user.id}** unsubscribed from this channel.")
+
+    def test_private_channel_subscription_change_notifications_for_other_user(self) -> None:
+        acting_user = self.example_user("hamlet")
+        target_user = self.example_user("iago")
+        self.login_user(acting_user)
+
+        stream = self.make_stream(
+            "private_notifications_other", realm=acting_user.realm, invite_only=True
+        )
+
+        request = {
+            "add": orjson.dumps([{"name": stream.name}]).decode(),
+            "principals": orjson.dumps([target_user.id]).decode(),
+        }
+        result = self.api_patch(acting_user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_success(result)
+
+        msg = self.get_last_message()
+        self.assertEqual(msg.recipient.type, Recipient.STREAM)
+        self.assertEqual(msg.recipient.type_id, stream.id)
+        self.assertEqual(msg.topic_name(), "channel events")
+        self.assertEqual(
+            msg.content,
+            f"@_**King Hamlet|{acting_user.id}** subscribed @_**Iago|{target_user.id}** to this channel.",
+        )
+
+    def test_private_channel_subscription_notifications_use_general_chat_topic(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+
+        stream = self.make_stream(
+            "private_notifications_general_chat",
+            realm=user.realm,
+            invite_only=True,
+            topics_policy=StreamTopicsPolicyEnum.empty_topic_only.value,
+        )
+
+        request = {
+            "add": orjson.dumps([{"name": stream.name}]).decode(),
+        }
+        result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_success(result)
+
+        msg = self.get_last_message()
+        self.assertEqual(msg.recipient.type_id, stream.id)
+        self.assertEqual(msg.topic_name(), "")
+
+    def test_subscription_change_notifications_respect_channel_events_setting(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+
+        do_set_realm_property(user.realm, "send_channel_events_messages", False, acting_user=None)
+
+        stream = self.make_stream(
+            "private_notifications_disabled", realm=user.realm, invite_only=True
+        )
+
+        previous_last_message = self.get_last_message()
+        request = {
+            "add": orjson.dumps([{"name": stream.name}]).decode(),
+        }
+        result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_success(result)
+
+        self.assertEqual(self.get_last_message().id, previous_last_message.id)
+        
     def test_add_with_color(self) -> None:
         user = self.example_user("hamlet")
         self.login_user(user)


### PR DESCRIPTION
# Add automated private-channel subscribe/unsubscribe notifications to channel events

Fixes: Add join/leave notifications for private channels #2746 

## Problem
Users currently don’t get a clear, channel-local record of subscription changes in private channels.
Public-channel join/leave notices would be noisy, but private channels can benefit from this visibility.

## What this PR changes
Sends automated messages for subscription changes in private channels only.

Uses the existing “Send automated messages for channel events” setting to control whether notices are sent.

Sends notifications to the channel’s channel events topic.

In channels configured for general-chat-only posting, routes messages to general chat (empty topic behavior).