### PR TITLE
settings: Add copy button to API key modal

### DIFF
--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -1,3 +1,4 @@
+import ClipboardJS from "clipboard";
 import $ from "jquery";
 import assert from "minimalistic-assert";
 import * as z from "zod/mini";
@@ -44,6 +45,36 @@ let password_quality:
     | undefined; // Loaded asynchronously
 let user_avatar_widget_created = false;
 let user_timezone_dropdown_widget: dropdown_widget.DropdownWidget | undefined;
+
+function setup_copy_api_key_button(): void {
+    const clipboard = new ClipboardJS(".copy_api_key_button", {
+        text(): string {
+            return document.querySelector<HTMLElement>("#api_key_value")?.textContent?.trim() ?? "";
+        },
+    });
+
+    clipboard.on("success", (e) => {
+        e.clearSelection();
+
+        const $btn = $(".copy_api_key_button");
+        const $wrapper = $(".copy_api_key_button_wrapper");
+        const $tooltip = $(".copy_api_key_tooltip");
+
+        // Restart animation cleanly if clicked again before reset
+        $btn.removeClass("copied");
+        void $btn[0]!.offsetWidth; // force reflow
+        $btn.addClass("copied");
+
+        $tooltip.text($t({defaultMessage: "Copied!"}));
+        $wrapper.addClass("show-tooltip");
+
+        setTimeout(() => {
+            $btn.removeClass("copied");
+            $tooltip.text($t({defaultMessage: "Copy API key"}));
+            $wrapper.removeClass("show-tooltip");
+        }, 2000);
+    });
+}
 
 export function update_email(new_email: string): void {
     const $email_input = $("#email_field_container");
@@ -462,6 +493,7 @@ export function set_up(): void {
     $("#api_key_button").on("click", (e) => {
         $("body").append($(render_settings_api_key_modal()));
         setup_api_key_modal();
+        setup_copy_api_key_button();
         $("#api_key_status").hide();
         modals.open("api_key_modal", {
             autoremove: true,

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -7,6 +7,147 @@ h4,
 h3,
 /* We need settings-section-title here because some legacy settings
    widgets use a <div> with this class for their heading. */
+/* Wrapper: positions the tooltip */
+.copy_api_key_button_wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+/* The button: no background, no border, ever */
+.copy_api_key_button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    position: relative;
+    appearance: none;
+    flex-shrink: 0;
+}
+
+/* Both SVG icons sit stacked in the same space */
+.copy_api_key_button .copy-icon,
+.copy_api_key_button .check-icon {
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    fill: none;
+    stroke-width: 1.7;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    pointer-events: none;
+}
+
+/* Copy icon: default muted color */
+.copy_api_key_button .copy-icon {
+    stroke: hsl(0deg 0% 50%);
+    opacity: 1;
+    transform: scale(1);
+    transition:
+        stroke 0.15s ease,
+        opacity 0.15s ease,
+        transform 0.15s ease;
+}
+
+/* Hover: only stroke lightens — zero background change */
+.copy_api_key_button:hover .copy-icon {
+    stroke: hsl(0deg 0% 78%);
+}
+
+/* Check icon: hidden by default */
+.copy_api_key_button .check-icon {
+    stroke: hsl(122deg 39% 55%); /* green */
+    opacity: 0;
+    transform: scale(0.5);
+    transition:
+        opacity 0.15s ease,
+        transform 0.15s ease;
+}
+
+/* Stroke draw-on animation for the checkmark */
+.copy_api_key_button .check-icon polyline {
+    stroke-dasharray: 22;
+    stroke-dashoffset: 22;
+}
+
+/* --- .copied state (toggled by JS) --- */
+.copy_api_key_button.copied .copy-icon {
+    opacity: 0;
+    transform: scale(0.5);
+}
+
+.copy_api_key_button.copied .check-icon {
+    opacity: 1;
+    transform: scale(1);
+}
+
+.copy_api_key_button.copied .check-icon polyline {
+    animation: api-key-draw-check 0.22s ease forwards 0.05s;
+}
+
+@keyframes api-key-draw-check {
+    to {
+        stroke-dashoffset: 0;
+    }
+}
+
+/* Black tooltip */
+.copy_api_key_tooltip {
+    position: absolute;
+    left: calc(100% + 8px);
+    top: 50%;
+    transform: translateY(-50%) scale(0.9);
+    background: hsl(0deg 0% 7%);
+    color: hsl(0deg 0% 100%);
+    font-size: 0.75em;
+    font-weight: 500;
+    padding: 4px 8px;
+    border-radius: 4px;
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transition:
+        opacity 0.12s ease,
+        transform 0.12s ease;
+    z-index: 100;
+}
+
+/* Left-pointing arrow */
+.copy_api_key_tooltip::before {
+    content: "";
+    position: absolute;
+    right: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    border: 4px solid transparent;
+    border-right-color: hsl(0deg 0% 7%);
+}
+
+/* Show on hover */
+.copy_api_key_button_wrapper:hover .copy_api_key_tooltip {
+    opacity: 1;
+    transform: translateY(-50%) scale(1);
+}
+
+/* Keep visible after copy (.show-tooltip toggled by JS) */
+.copy_api_key_button_wrapper.show-tooltip .copy_api_key_tooltip {
+    opacity: 1;
+    transform: translateY(-50%) scale(1);
+}
+
+/* Row layout: key value and copy button side by side */
+.api_key_value_row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
 .settings-section-title {
     .fa-info-circle {
         top: 1px;

--- a/web/templates/settings/api_key_modal.hbs
+++ b/web/templates/settings/api_key_modal.hbs
@@ -17,7 +17,7 @@
                         <div class="settings-password-div">
                             <label for="get_api_key_password" class="modal-field-label">{{t "Your password" }}</label>
                             <div class="password-input-row">
-                                <input type="password" autocomplete="off" name="password" id="get_api_key_password" class=" modal_password_input" value="" />
+                                <input type="password" autocomplete="off" name="password" id="get_api_key_password" class="modal_password_input" value="" />
                                 <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button"></i>
                             </div>
                         </div>
@@ -29,7 +29,25 @@
                     </div>
                 </div>
                 <div id="show_api_key">
-                    <p><b class="highlighted-element"><span id="api_key_value"></span></b></p>
+                    <p class="api_key_value_row">
+                        <b class="highlighted-element"><span id="api_key_value"></span></b>
+                        <span class="copy_api_key_button_wrapper">
+                            <button
+                              type="button"
+                              class="copy_api_key_button"
+                              aria-label="{{t 'Copy API key' }}"
+                              >
+                                <svg class="copy-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                                </svg>
+                                <svg class="check-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                                    <polyline points="20 6 9 17 4 12"></polyline>
+                                </svg>
+                            </button>
+                            <span class="copy_api_key_tooltip">{{t "Copy API key" }}</span>
+                        </span>
+                    </p>
                     <div id="user_api_key_error" class="text-error"></div>
                 </div>
             </main>


### PR DESCRIPTION
Previously, users had to manually select and copy their API key from the "Show API key" modal, which was error-prone and inconvenient.

This adds a copy icon (`zulip-icon-copy`) next to the API key value, styled consistently with other copy buttons in Zulip such as the one in the "About Zulip" modal. Clicking it copies the key to the clipboard using ClipboardJS, and briefly shows an inline "Copied!" confirmation with a checkmark that disappears after 2 seconds.

Fixes #38044.

**How changes were tested:**

1. Navigate to **Settings** > **Personal settings** > **API key**.
2. Click "Show/Change your API key" and enter the password.
3. Verified that the copy icon appears immediately to the right of the API key.
4. Clicked the icon and verified that:
   - The API key was successfully copied to the system clipboard.
   - The green "Copied!" text appeared next to the button.
   - The "Copied!" text faded out after 2 seconds.
5. Verified the styling matches the clean, icon-only look of the "About Zulip" modal.

**Screenshots and screen captures:**
<img width="1362" height="674" alt="Screenshot 2026-02-18 150958" src="https://github.com/user-attachments/assets/5345dd3e-a18d-49c4-a8e0-04bb471ac447" />
<img width="1364" height="671" alt="Screenshot 2026-02-18 150948" src="https://github.com/user-attachments/assets/3ebcccd5-47a0-4cd1-bdf1-8c92ad022311" />
<img width="1364" height="673" alt="Screenshot 2026-02-18 151011" src="https://github.com/user-attachments/assets/0534c83e-6413-43ff-b52e-bbb241fe7f5a" />


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>