### PR TITLE
attachments: Replace `messages` field with `message_ids` in Attachment objects.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 472**
+
+* [`GET /attachments`](/api/get-attachments), [`GET /events`](/api/get-events):
+  Previously, the `messages` field in `Attachment` was array of
+  objects containing `id` and `date_sent` properties. That has been replaced
+  by a `message_ids` field, which is a flat array of message IDs.
+
 **Feature level 471**
 
 * [`GET /events`](/api/get-events), [`GET /realm/linkifiers`](/api/get-linkifiers),

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 471
+API_FEATURE_LEVEL = 472
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/attachments.ts
+++ b/web/src/attachments.ts
@@ -6,12 +6,7 @@ export const attachment_schema = z.object({
     path_id: z.string(),
     size: z.number(),
     create_time: z.number(),
-    messages: z.array(
-        z.object({
-            id: z.number(),
-            date_sent: z.number(),
-        }),
-    ),
+    message_ids: z.array(z.number()),
 });
 
 const attachments_schema = z.array(attachment_schema);

--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -131,19 +131,19 @@ function delete_attachments(attachment: string, file_name: string): void {
 }
 
 function sort_mentioned_in(a: Attachment, b: Attachment): number {
-    const a_m = a.messages[0];
-    const b_m = b.messages[0];
+    const a_id = a.message_ids[0];
+    const b_id = b.message_ids[0];
 
-    if (!a_m) {
+    if (a_id === undefined) {
         return 1;
     }
-    if (!b_m) {
+    if (b_id === undefined) {
         return -1;
     }
 
-    if (a_m.id > b_m.id) {
+    if (a_id > b_id) {
         return 1;
-    } else if (a_m.id === b_m.id) {
+    } else if (a_id === b_id) {
         return 0;
     }
 

--- a/web/templates/settings/uploaded_files_list.hbs
+++ b/web/templates/settings/uploaded_files_list.hbs
@@ -1,23 +1,24 @@
 {{#with attachment}}
 <tr class="uploaded_file_row" data-attachment-name="{{name}}" data-attachment-id="{{id}}">
     <td>
-        <a type="submit" class="tippy-zulip-delayed-tooltip" href="/user_uploads/{{path_id}}" target="_blank" rel="noopener noreferrer" data-tippy-content="{{t 'View file' }}">
+        <a type="submit" class="tippy-zulip-delayed-tooltip" href="/user_uploads/{{path_id}}" target="_blank"
+          rel="noopener noreferrer" data-tippy-content="{{t 'View file' }}">
             {{ name }}
         </a>
     </td>
     <td>{{ create_time_str }}</td>
     <td>
-        {{#unless (eq messages.length 0)}}
+        {{#unless (eq message_ids.length 0)}}
         <div class="attachment-messages">
-            {{#each messages}}
-                <a class="ind-message" href="/#narrow/id/{{ this.id }}">
-                    #{{ this.id }}
+            {{#each message_ids}}
+                <a class="ind-message" href="/#narrow/id/{{ this }}">
+                    #{{ this }}
                 </a>
             {{/each}}
         </div>
         {{/unless}}
     </td>
-    <td class="upload-size" >{{ size_str }}</td>
+    <td class="upload-size">{{ size_str }}</td>
     <td class="actions">
         <span class="edit-attachment-buttons">
             <a type="submit" href="/user_uploads/{{path_id}}" class="hidden-attachment-download" download></a>

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -143,12 +143,7 @@ exports.fixtures = {
             size: 4096,
             path_id: "path_id",
             create_time: fake_now,
-            messages: [
-                {
-                    id: 1000,
-                    date_sent: fake_now,
-                },
-            ],
+            message_ids: [1000],
         },
         upload_space_used: 90000,
     },

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -28,18 +28,13 @@ class EventAlertWords(BaseEvent):
     alert_words: list[str]
 
 
-class AttachmentMessage(BaseModel):
-    id: int
-    date_sent: int
-
-
 class Attachment(BaseModel):
     id: int
     name: str
     size: int
     path_id: str
     create_time: int
-    messages: list[AttachmentMessage]
+    message_ids: list[int]
 
 
 class EventAttachmentAdd(BaseEvent):

--- a/zerver/models/messages.py
+++ b/zerver/models/messages.py
@@ -818,13 +818,7 @@ class Attachment(AbstractAttachment):
             "path_id": self.path_id,
             "size": self.size,
             "create_time": int(time.mktime(self.create_time.timetuple())),
-            "messages": [
-                {
-                    "id": m.id,
-                    "date_sent": int(time.mktime(m.date_sent.timetuple())),
-                }
-                for m in self.messages.all()
-            ],
+            "message_ids": [m.id for m in self.messages.all()],
         }
 
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1704,7 +1704,7 @@ paths:
                                       "path_id": "2/ce/2Xpnnwgh8JWKxBXtTfD6BHKV/zulip.txt",
                                       "size": 6,
                                       "create_time": 1594825414,
-                                      "messages": [],
+                                      "message_ids": [],
                                     },
                                   "upload_space_used": 6,
                                   "id": 0,
@@ -1745,7 +1745,7 @@ paths:
                                       "path_id": "2/ce/2Xpnnwgh8JWKxBXtTfD6BHKV/zulip.txt",
                                       "size": 6,
                                       "create_time": 1594825414,
-                                      "messages": [],
+                                      "message_ids": [],
                                     },
                                   "upload_space_used": 6,
                                   "id": 0,
@@ -6704,11 +6704,7 @@ paths:
                               "path_id": "2/ce/DfOkzwdg_IwlrN3myw3KGtiJ/166050.jpg",
                               "size": 571946,
                               "create_time": 1588145417,
-                              "messages":
-                                [
-                                  {"id": 102, "date_sent": 1588145424},
-                                  {"id": 103, "date_sent": 1588145448},
-                                ],
+                              "message_ids": [102, 103],
                             },
                           ],
                         "upload_space_used": 571946,
@@ -10116,7 +10112,7 @@ paths:
                               "path_id": "2/5d/BD5NRptFxPDKY3RUKwhhup8r/1253601-1.jpg",
                               "size": 1339060,
                               "create_time": 1687984706,
-                              "messages": [],
+                              "message_ids": [],
                             },
                           ],
                       }
@@ -25924,34 +25920,19 @@ components:
 
             Changed in Zulip 3.0 (feature level 22). This field was
             previously a floating point number.
-        messages:
+        message_ids:
           type: array
           description: |
-            Contains basic details on any Zulip messages that have been
-            sent referencing this [uploaded file](/api/upload-file).
-            This includes messages sent by any user in the Zulip
-            organization who sent a message containing a link to the
-            uploaded file.
+            Array containing the IDs of messages that reference this
+            [uploaded file](/api/upload-file). This includes messages
+            sent by any user in the Zulip organization who sent a
+            message containing a link to the uploaded file.
+
+            **Changes**: In Zulip 12.0 (feature level 472), this
+            replaced the previous `messages` field, which was an array
+            of objects containing both `id` and `date_sent` properties.
           items:
-            type: object
-            additionalProperties: false
-            properties:
-              date_sent:
-                type: integer
-                description: |
-                  Time when the message was sent as a UNIX timestamp.
-
-                  **Changes**: Before Zulip 12.0 (feature level 443), this value
-                  was milliseconds since the epoch, not seconds.
-
-                  Changed in Zulip 3.0 (feature level 22). This
-                  field was previously strangely called `name` and was a floating
-                  point number.
-              id:
-                type: integer
-                description: |
-                  The unique message ID. Messages should always be
-                  displayed sorted by ID.
+            type: integer
     BasicChannel:
       allOf:
         - $ref: "#/components/schemas/BasicChannelBase"


### PR DESCRIPTION
Previously, Attachment objects in events and the `GET /attachments` API
response contained a `messages` field with an array of objects having
[id](cci:1://file:///home/nkh/gsoc/zulip/zulip/zerver/models/messages.py:688:0-692:19) and `date_sent` properties. The `date_sent` field was unused by
any client.

This replaces `messages` with a flat `message_ids` array of integers,
making the `add`/[update](cci:1://file:///home/nkh/gsoc/zulip/zulip/web/src/attachments_ui.ts:169:12-173:13) attachment events consistent with the `remove`
event, which already used `message_ids`.
ALL decision were taken based on CZO Disscusion: https://chat.zulip.org/#narrow/channel/378-api-design/topic/attachment.20events.20for.20deletion.20notifications/with/2384208

Fixes: Preparatory commit for #37425.

**How changes were tested:**

- All backend tests pass (`test_attachments` — 9/9, `test_events` — 148/148)
- All frontend tests pass (`dispatch.test.cjs`)
- Manually verified `GET /attachments` and `attachment/update` events return `message_ids`
- Manually verified uploaded files UI renders correctly

**Screenshots and screen captures:**

N/A — no visual changes.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>