### PR TITLE
Avoid double local_id tracking in transmit.reply_message

### DIFF
--- a/web/src/transmit.ts
+++ b/web/src/transmit.ts
@@ -121,16 +121,10 @@ export function reply_message(message: Message, content: string): void {
         //       For now do nothing.
     }
 
-    const locally_echoed = false;
     const local_id = sent_messages.get_new_local_id();
 
     const sender_id = current_user.user_id;
     const queue_id = server_events_state.queue_id;
-
-    sent_messages.start_tracking_message({
-        local_id,
-        locally_echoed,
-    });
 
     if (message.type === "stream") {
         const stream_name = stream_data.get_stream_name_from_id(message.stream_id);

--- a/web/tests/transmit.test.cjs
+++ b/web/tests/transmit.test.cjs
@@ -150,9 +150,13 @@ run_test("reply_message_stream", ({override}) => {
     const content = "hello";
 
     let send_message_args;
+    const tracked_local_ids = [];
 
     override(channel, "post", ({data}) => {
         send_message_args = data;
+    });
+    override(sent_messages, "start_tracking_message", ({local_id}) => {
+        tracked_local_ids.push(local_id);
     });
 
     override(current_user, "user_id", 44);
@@ -161,6 +165,7 @@ run_test("reply_message_stream", ({override}) => {
 
     transmit.reply_message(stream_message, content);
 
+    assert.deepEqual(tracked_local_ids, ["99"]);
     assert.deepEqual(send_message_args, {
         sender_id: 44,
         queue_id: 66,


### PR DESCRIPTION
## Summary
- Fix a client-side BlueslipError where `transmit.reply_message()` registers the same `local_id` twice (once directly and once via `send_message()`), triggering `We are reusing a local_id`.

## Details
`send_message()` already calls `sent_messages.start_tracking_message()` when `!request.resend`. `reply_message()` should not pre-register the same `local_id`.

## Test plan
- In a dev realm with a zform/choices widget (or any code path that calls `transmit.reply_message()`), click a choice.
- Verify the reply is sent and no `We are reusing a local_id` error appears in the console.

👾 Generated with [Letta Code](https://letta.com)