### PR TITLE
video_calls: Inline server settings check for Constructor Groups.

### DIFF
--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -76,22 +76,16 @@ class UnknownZoomUserError(JsonableError):
 
 class ConstructorGroupsService:
     def __init__(self) -> None:
-        if not self._is_configured():
+        if (
+            (url := settings.CONSTRUCTOR_GROUPS_URL) is None
+            or (access_key := settings.CONSTRUCTOR_GROUPS_ACCESS_KEY) is None
+            or (secret_key := settings.CONSTRUCTOR_GROUPS_SECRET_KEY) is None
+        ):
             raise CreateVideoCallFailedError("Constructor Groups")
 
-        self.access_key = settings.CONSTRUCTOR_GROUPS_ACCESS_KEY
-        self.secret_key = settings.CONSTRUCTOR_GROUPS_SECRET_KEY
-        self.base_url = (
-            settings.CONSTRUCTOR_GROUPS_URL.rstrip("/") if settings.CONSTRUCTOR_GROUPS_URL else ""
-        )
-
-    @staticmethod
-    def _is_configured() -> bool:
-        return (
-            settings.CONSTRUCTOR_GROUPS_URL is not None
-            and settings.CONSTRUCTOR_GROUPS_ACCESS_KEY is not None
-            and settings.CONSTRUCTOR_GROUPS_SECRET_KEY is not None
-        )
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.base_url = url.rstrip("/")
 
     def _make_authenticated_request(
         self, method: str, endpoint: str, data: dict[str, Any] | None = None


### PR DESCRIPTION
And inlined a single-use function.

Follow-up to #35792. The author of that PR is not a GSoC candidate. To not lose track of the feedback, I've opened this PR right away.

See https://github.com/zulip/zulip/pull/35792#discussion_r2796132379 and https://github.com/zulip/zulip/pull/35792#discussion_r2796134879.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
