### PR TITLE
modals: Fix spacing issue in generate integration url modal.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -1099,6 +1099,12 @@
             }
         }
     }
+
+    #integration-url-config-options-container {
+        /* Same bottom margin as that of input-group,
+           to maintain consistent gap between fields. */
+        margin-bottom: 1.25em; /* 20px at 16px/em */
+    }
 }
 
 .slack-topics-dropdown-dropdown-list-container {


### PR DESCRIPTION
As part of the modal redesign, a CSS logic was written in commit c6168e3382eb5358370b2f2f13225e91a00e6728 to remove the bottom margin from the last `input-group` element to remove any excess margin at the bottom of the modals.

The CSS selector `.input-group:last-of-type` however, also removes the bottom margin when an input group is wrapped inside a parent div.

This PR fixes the above mentioned issue present in the integration-url-config-options-container div in the generate integration url modal.

<!-- Describe your pull request here.-->

Fixes: [#issues > generate integration URL modal - spacing off](https://chat.zulip.org/#narrow/channel/9-issues/topic/generate.20integration.20URL.20modal.20-.20spacing.20off/with/2370813)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| <img width="641" height="651" alt="Screenshot 2026-02-18 at 9 04 22 PM" src="https://github.com/user-attachments/assets/0280db77-f8c1-408e-8d29-a4d202faf54e" /> | <img width="641" height="651" alt="Screenshot 2026-02-18 at 8 59 36 PM" src="https://github.com/user-attachments/assets/c38af2b0-ea6f-4850-a2a4-40c5ed64b432" /> |
| <img width="641" height="651" alt="Screenshot 2026-02-18 at 9 03 41 PM" src="https://github.com/user-attachments/assets/99f8f1ed-7975-4d76-8bc6-4770e9b2c1af" /> | <img width="641" height="651" alt="Screenshot 2026-02-18 at 9 02 12 PM" src="https://github.com/user-attachments/assets/d66ff175-794e-4194-88ec-a4665d1877f7" /> | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
