### PR TITLE
compose: Correct overlap on vdots outline.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1842,7 +1842,7 @@ textarea.new_message_textarea {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 40px;
+    width: 38px;
     /* Allow to grow but not shrink */
     flex: 1 0 auto;
     height: var(--compose-formatting-buttons-row-height);
@@ -1853,7 +1853,7 @@ textarea.new_message_textarea {
        margin is handled on the vdots icon
        below, so as to make for a maximum
        clickable vdots area. */
-    margin-left: -4px;
+    margin-left: -2px;
     border-radius: 0 4px 4px 0;
     /* Flex items respect z-index values;
        this is needed to keep the vdots
@@ -1887,7 +1887,7 @@ textarea.new_message_textarea {
     }
 
     .zulip-icon {
-        padding: 5px 0 5px 4px;
+        padding: 5px 0 5px 2px;
         /* 17px at 14px/1em */
         font-size: 1.2143em;
         flex-grow: 1;


### PR DESCRIPTION
Fixes: [#issues > keyboard selection box overlaps send button](https://chat.zulip.org/#narrow/channel/9-issues/topic/keyboard.20selection.20box.20overlaps.20send.20button/with/2384407)

**Screenshots and screen captures:**

_No change to the mobile view where the vdots sits above the send button._

| Before | After |
| --- | --- |
| <img width="2060" height="1600" alt="send-vdots-1030-before" src="https://github.com/user-attachments/assets/9ac0401a-1133-47a5-aa72-08ea94ef2096" /> | <img width="2060" height="1600" alt="send-vdots-1030-after" src="https://github.com/user-attachments/assets/7bc819b4-0081-4c31-8ab9-bb77616a7588" /> |
| <img width="1400" height="1600" alt="send-vdots-700-before" src="https://github.com/user-attachments/assets/767ae7cf-4085-4cbd-ace7-d602881991dd" /> | <img width="1400" height="1600" alt="send-vdots-700-after" src="https://github.com/user-attachments/assets/27e201c9-a72f-4648-adc3-3c788e69ee62" /> |
| <img width="800" height="1600" alt="send-vdots-400-before" src="https://github.com/user-attachments/assets/43c46cd8-79d5-4954-a680-58874300188a" /> | <img width="800" height="1600" alt="send-vdots-400-after" src="https://github.com/user-attachments/assets/1d342493-32a5-49a8-bafb-a9207e942f33" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>