### PR TITLE
topic_link_util: Add comment clarifying intent.

### DIFF
--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -64,6 +64,9 @@ export function get_topic_link_content(
     assert(stream_id !== undefined);
     const escape = html_escape_markdown_syntax_characters;
     if (topic_name !== undefined) {
+        // This url is relative, which is fine since it aims to mimic the behavior of the
+        // #**stream>topic** syntax, which also appears as a relative link in the web app
+        // and is not expected to work outside of the current realm / Zulip.
         const stream_topic_url = hash_util.by_stream_topic_url(stream_id, topic_name);
         const topic_display_name = util.get_final_topic_display_name(topic_name);
         if (message_id !== undefined) {


### PR DESCRIPTION
Quoting a message generates markdown with a message link that uses an absolute URL instead of a relative one, while the fallback stream-topic urls are relative.

This is because quotes are expected to work outside Zulip while stream-topic links are not. This commit adds a comment expressing this intent.

CZO: [#design > "quote message" uses absolute URL instead of realm-relative @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/.22quote.20message.22.20uses.20absolute.20URL.20instead.20of.20realm-relative/near/2325588)


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
