### PR TITLE
Compose banner unresponsive

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -249,9 +249,6 @@ export function show_stream_not_subscribed_error(
     sub: StreamSubscription,
     banner_text: string,
 ): void {
-    // Remove any existing banners with this warning.
-    $(`#compose_banners .${CSS.escape(CLASSNAMES.user_not_subscribed)}`).remove();
-
     const new_row_html = render_compose_banner({
         banner_type: ERROR,
         banner_text,

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -208,8 +208,11 @@ export function show_error_message(
 }
 
 export function cannot_send_direct_message_error(error_message: string): void {
-    // Remove any existing banners with this warning.
-    $(`#compose_banners .${CSS.escape(CLASSNAMES.cannot_send_direct_message)}`).remove();
+    // If a banner with this classname already exists, avoid removing
+    // and re-creating it.
+    if ($(`#compose_banners .${CSS.escape(CLASSNAMES.cannot_send_direct_message)}`).length > 0) {
+        return;
+    }
 
     const new_row_html = render_cannot_send_direct_message_error({
         banner_type: ERROR,
@@ -218,8 +221,6 @@ export function cannot_send_direct_message_error(error_message: string): void {
     });
     append_compose_banner_to_banner_list($(new_row_html), $("#compose_banners"));
     hide_compose_spinner();
-
-    $("#private_message_recipient").trigger("focus").trigger("select");
 }
 
 export function topic_missing_error(empty_string_topic_display_name: string): void {

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -223,9 +223,6 @@ export function cannot_send_direct_message_error(error_message: string): void {
 }
 
 export function topic_missing_error(empty_string_topic_display_name: string): void {
-    // Remove any existing banners with this warning.
-    $(`#compose_banners .${CSS.escape(CLASSNAMES.topic_missing)}`).remove();
-
     const new_row_html = render_topics_required_error_banner({
         banner_type: ERROR,
         empty_string_topic_display_name,

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -233,9 +233,6 @@ export function topic_missing_error(empty_string_topic_display_name: string): vo
 }
 
 export function show_stream_does_not_exist_error(stream_name: string): void {
-    // Remove any existing banners with this warning.
-    $(`#compose_banners .${CSS.escape(CLASSNAMES.stream_does_not_exist)}`).remove();
-
     const new_row_html = render_stream_does_not_exist_error({
         banner_type: ERROR,
         channel_name: stream_name,

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -51,6 +51,9 @@ function composing_to_current_topic_narrow(): boolean {
 }
 
 function composing_to_current_private_message_narrow(): boolean {
+    if (compose_state.get_message_type() !== "private") {
+        return false;
+    }
     const compose_state_recipient = new Set(compose_state.private_message_recipient_ids());
     const narrow_state_recipient = narrow_state.pm_ids_set();
     if (narrow_state_recipient.size === 0) {
@@ -83,7 +86,9 @@ export let update_recipient_row_attention_level = (): void => {
     const has_unpilled_input = $("#private_message_recipient").text().length > 0;
     // We also want to watch out for cases where the DM isn't valid,
     // as when trying to message deactivated users.
-    const is_valid_dm = compose_validate.validate_private_message(false);
+    const message_type = compose_state.get_message_type();
+    const is_valid_dm =
+        message_type === "private" && compose_validate.validate_private_message(false);
     // It is possible that focus can remain in the recipient row while
     // narrowing, e.g., with the `Ctrl + .` shortcut. We should account
     // for that in the logic below, so that we don't erroneously add

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -266,6 +266,7 @@ export function update_compose_for_message_type(opts: ComposeTriggeredOptions): 
             `<i class="zulip-icon zulip-icon-users channel-privacy-type-icon"></i>
             <span class="decorated-dm-label">${direct_message_label}</span>`,
         );
+        compose_state.set_private_message_recipient_ids(opts.private_message_recipient_ids);
     }
     compose_banner.clear_errors();
     compose_banner.clear_warnings();

--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -726,6 +726,10 @@ export function initialize(): void {
         // to the recipient row
         compose_recipient.set_high_attention_recipient_row();
         $compose_recipient.addClass("recently-focused");
+        // Validate recipient to show error banners for deactivated
+        // users or insufficient DM permissions, and disable the
+        // compose textarea if the recipient is invalid.
+        compose_validate.validate_private_message(false);
     });
 
     $("input#stream_message_recipient_topic, #private_message_recipient").on("blur", () => {

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -992,6 +992,11 @@ function validate_stream_message(scheduling_message: boolean, show_banner = true
 
 function set_compose_textarea_disabled(disabled: boolean): void {
     $("textarea#compose-textarea").prop("disabled", disabled);
+    // Also toggle keyboard navigation on compose control buttons.
+    $("#compose .disable-on-invalid-recipient .compose_control_button").prop(
+        "tabindex",
+        disabled ? -1 : 0,
+    );
 }
 
 export function validate_private_message(show_banner = true): boolean {

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -990,8 +990,10 @@ function validate_stream_message(scheduling_message: boolean, show_banner = true
     return true;
 }
 
-// The function checks whether the recipients are users of the realm or cross realm users (bots
-// for now)
+function set_compose_textarea_disabled(disabled: boolean): void {
+    $("textarea#compose-textarea").prop("disabled", disabled);
+}
+
 export function validate_private_message(show_banner = true): boolean {
     const user_ids = compose_pm_pill.get_user_ids();
     const user_ids_string = util.sorted_ids(user_ids).join(",");
@@ -1015,6 +1017,7 @@ export function validate_private_message(show_banner = true): boolean {
     const direct_message_error_string = check_dm_permissions_and_get_error_string(user_ids_string);
     if (direct_message_error_string) {
         compose_banner.cannot_send_direct_message_error(direct_message_error_string);
+        set_compose_textarea_disabled(true);
         if (is_validating_compose_box) {
             disabled_send_tooltip_message_html = direct_message_error_string;
         }
@@ -1031,6 +1034,7 @@ export function validate_private_message(show_banner = true): boolean {
             compose_banner.CLASSNAMES.deactivated_user,
             $banner_container,
         );
+        set_compose_textarea_disabled(true);
 
         if (is_validating_compose_box) {
             disabled_send_tooltip_message_html = error_message;
@@ -1038,6 +1042,9 @@ export function validate_private_message(show_banner = true): boolean {
         return false;
     }
 
+    // Re-enable the compose textarea in case it was disabled by a
+    // previous call for an invalid recipient that has since been fixed.
+    set_compose_textarea_disabled(false);
     return true;
 }
 
@@ -1177,6 +1184,9 @@ export let validate = (scheduling_message: boolean, show_banner = true): boolean
     // Clear previous banners from the previous compose state; the
     // validation checks below will re-add any that are still relevant.
     compose_banner.clear_errors();
+    // Reset compose textarea state; validate_private_message may
+    // disable it if the recipient is invalid.
+    set_compose_textarea_disabled(false);
     const message_content = compose_state.message_content();
     // The validation checks in this function are in a specific priority order. Don't
     // change their order unless you want to change which priority they're shown in.

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -1030,7 +1030,6 @@ export function validate_private_message(show_banner = true): boolean {
             error_message,
             compose_banner.CLASSNAMES.deactivated_user,
             $banner_container,
-            $("#private_message_recipient"),
         );
 
         if (is_validating_compose_box) {

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -48,7 +48,6 @@ let message_too_long = false;
 //  we need to track when we are validating compose box.
 let is_validating_compose_box = false;
 let disabled_send_tooltip_message_html = "";
-let posting_policy_error_message = "";
 
 export const NO_PERMISSION_TO_POST_IN_CHANNEL_ERROR_MESSAGE = $t({
     defaultMessage: "You do not have permission to post in this channel.",
@@ -129,17 +128,6 @@ function set_message_too_long_for_edit(status: boolean, $container: JQuery): voi
 
     $container.find(".message_edit_save").prop("disabled", save_is_disabled);
     $message_edit_save_container.toggleClass("disabled-message-edit-save", save_is_disabled);
-}
-
-export function get_posting_policy_error_message(): string {
-    // Contains errors which are shown as compose banner before user
-    // clicks on the send button.
-    // Ensure you are calling `validate` for the current compose state,
-    // before calling this function.
-    // We directly add the error banner instead of setting
-    // `posting_policy_error_message`, when the banner contains special
-    // context for the current compose state.
-    return posting_policy_error_message;
 }
 
 export function get_disabled_send_tooltip_html(): string {
@@ -914,7 +902,6 @@ function validate_permission_to_post_messages_in_stream(sub: StreamSubscription)
 
         if (is_validating_compose_box) {
             disabled_send_tooltip_message_html = NO_PERMISSION_TO_POST_IN_CHANNEL_ERROR_MESSAGE;
-            posting_policy_error_message = NO_PERMISSION_TO_POST_IN_CHANNEL_ERROR_MESSAGE;
         }
         return false;
     }
@@ -1030,7 +1017,6 @@ export function validate_private_message(show_banner = true): boolean {
         compose_banner.cannot_send_direct_message_error(direct_message_error_string);
         if (is_validating_compose_box) {
             disabled_send_tooltip_message_html = direct_message_error_string;
-            posting_policy_error_message = direct_message_error_string;
         }
         return false;
     }
@@ -1131,28 +1117,6 @@ export function check_overflow_text($container: JQuery): number {
     return text.length;
 }
 
-export let update_posting_policy_banner_post_validation = (): void => {
-    const banner_text = get_posting_policy_error_message();
-    if (banner_text === "") {
-        compose_banner.clear_errors();
-        return;
-    }
-
-    let banner_classname = compose_banner.CLASSNAMES.no_post_permissions;
-    if (compose_state.selected_recipient_id === "direct") {
-        banner_classname = compose_banner.CLASSNAMES.cannot_send_direct_message;
-        compose_banner.cannot_send_direct_message_error(banner_text);
-    } else {
-        compose_banner.show_error_message(banner_text, banner_classname, $("#compose_banners"));
-    }
-};
-
-export function rewire_update_posting_policy_banner_post_validation(
-    value: typeof update_posting_policy_banner_post_validation,
-): void {
-    update_posting_policy_banner_post_validation = value;
-}
-
 export let validate_and_update_send_button_status = function (): void {
     const is_valid = validate(false, false);
     const $send_button = $("#compose-send-button");
@@ -1164,7 +1128,6 @@ export let validate_and_update_send_button_status = function (): void {
         send_button_element._tippy.hide();
         send_button_element._tippy.show();
     }
-    update_posting_policy_banner_post_validation();
 };
 
 export function rewire_validate_and_update_send_button_status(
@@ -1211,8 +1174,10 @@ function report_validation_error(
 
 export let validate = (scheduling_message: boolean, show_banner = true): boolean => {
     is_validating_compose_box = true;
-    posting_policy_error_message = "";
     disabled_send_tooltip_message_html = "";
+    // Clear previous banners from the previous compose state; the
+    // validation checks below will re-add any that are still relevant.
+    compose_banner.clear_errors();
     const message_content = compose_state.message_content();
     // The validation checks in this function are in a specific priority order. Don't
     // change their order unless you want to change which priority they're shown in.

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -707,7 +707,10 @@ export function get_person_suggestion_for_topic_typeahead(query: string): UserPi
     if (current_narrow_participant_ids) {
         participants_people = util.try_parse_as_truthy(
             [...current_narrow_participant_ids]
-                .filter((user_id) => user_id !== current_user.user_id)
+                .filter(
+                    (user_id) =>
+                        user_id !== current_user.user_id && people.is_person_active(user_id),
+                )
                 .map((user_id) => people.maybe_get_user_by_id(user_id))
                 .filter(Boolean),
         );
@@ -719,7 +722,11 @@ export function get_person_suggestion_for_topic_typeahead(query: string): UserPi
         dm_people = util.try_parse_as_truthy(
             pm_conversations
                 .get_partners()
-                .filter((user_id) => !current_narrow_participant_ids?.has(user_id))
+                .filter(
+                    (user_id) =>
+                        !current_narrow_participant_ids?.has(user_id) &&
+                        people.is_person_active(user_id),
+                )
                 .map((user_id) => people.maybe_get_user_by_id(user_id))
                 .filter(Boolean),
         );

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -19,6 +19,7 @@ import {$t} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_store from "./message_store.ts";
+import * as message_util from "./message_util.ts";
 import * as muted_users from "./muted_users.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
@@ -705,11 +706,15 @@ export function get_person_suggestion_for_topic_typeahead(query: string): UserPi
     let dm_people;
 
     if (current_narrow_participant_ids) {
+        // Check DM permissions for the user suggestion only, since we
+        // will reset any previously selected DM recipients.
         participants_people = util.try_parse_as_truthy(
             [...current_narrow_participant_ids]
                 .filter(
                     (user_id) =>
-                        user_id !== current_user.user_id && people.is_person_active(user_id),
+                        user_id !== current_user.user_id &&
+                        people.is_person_active(user_id) &&
+                        message_util.user_can_send_direct_message(String(user_id)),
                 )
                 .map((user_id) => people.maybe_get_user_by_id(user_id))
                 .filter(Boolean),
@@ -725,7 +730,8 @@ export function get_person_suggestion_for_topic_typeahead(query: string): UserPi
                 .filter(
                     (user_id) =>
                         !current_narrow_participant_ids?.has(user_id) &&
-                        people.is_person_active(user_id),
+                        people.is_person_active(user_id) &&
+                        message_util.user_can_send_direct_message(String(user_id)),
                 )
                 .map((user_id) => people.maybe_get_user_by_id(user_id))
                 .filter(Boolean),

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -655,47 +655,6 @@ type PersonSuggestionOpts = {
     filter_by_dm_permission?: boolean;
 };
 
-function get_dm_suggestion_candidates(opts: {
-    exclude_non_welcome_bots: boolean;
-    exclude_non_message_people: boolean;
-    active_users_only: boolean;
-    filter_by_dm_permission: boolean;
-}): User[] {
-    if (!opts.filter_by_dm_permission) {
-        return people.get_people_for_dm({
-            exclude_non_welcome_bots: opts.exclude_non_welcome_bots,
-            exclude_non_message_people: opts.exclude_non_message_people,
-            active_users_only: opts.active_users_only,
-        });
-    }
-
-    const recipient_ids = compose_state.private_message_recipient_ids();
-    const check_dm_permission =
-        message_util.make_check_message_permission_for_dm_candidate(recipient_ids);
-
-    if (check_dm_permission === null) {
-        return people.get_people_for_dm({
-            exclude_non_welcome_bots: opts.exclude_non_welcome_bots,
-            exclude_non_message_people: opts.exclude_non_message_people,
-            active_users_only: opts.active_users_only,
-        });
-    }
-
-    // Filter people based on per-user permission checks. We will filter active
-    // user if required in the per-user check itself.
-    const dm_people_candidate = people.get_people_for_dm({
-        exclude_non_welcome_bots: opts.exclude_non_welcome_bots,
-        exclude_non_message_people: opts.exclude_non_message_people,
-        active_users_only: false,
-    });
-    return dm_people_candidate.filter((item) => {
-        if (opts.active_users_only && !people.is_active_user(item.user_id)) {
-            return false;
-        }
-        return check_dm_permission(item.user_id);
-    });
-}
-
 function filter_persons<T>(
     all_persons: User[],
     filter_pills: boolean,
@@ -913,19 +872,33 @@ export function get_person_suggestions(
         );
     };
 
-    const filter_by_dm_permission = opts.filter_by_dm_permission ?? false;
-    const message_persons = get_dm_suggestion_candidates({
+    // The DM-permission check is expensive per candidate, so we apply it after
+    // the query-match filter trims the candidate set — the loop then runs over
+    // the handful of query-matched users rather than the full realm.
+    const check_dm_permission = opts.filter_by_dm_permission
+        ? message_util.make_check_message_permission_for_dm_candidate(
+              compose_state.private_message_recipient_ids(),
+          )
+        : null;
+    const apply_dm_permission_filter = (
+        items: UserOrMentionPillData[],
+    ): UserOrMentionPillData[] => {
+        if (check_dm_permission === null) {
+            return items;
+        }
+        return items.filter(
+            (item) => item.type !== "user" || check_dm_permission(item.user.user_id),
+        );
+    };
+
+    const message_persons = people.get_people_for_dm({
         exclude_non_welcome_bots,
         exclude_non_message_people: true,
         active_users_only: true,
-        filter_by_dm_permission,
     });
 
-    const filtered_message_persons = filter_persons(
-        message_persons,
-        opts.filter_pills,
-        opts.want_broadcast,
-        filterer,
+    const filtered_message_persons = apply_dm_permission_filter(
+        filter_persons(message_persons, opts.filter_pills, opts.want_broadcast, filterer),
     );
 
     let filtered_persons: UserOrMentionPillData[];
@@ -933,17 +906,13 @@ export function get_person_suggestions(
     if (filtered_message_persons.length >= cutoff_length) {
         filtered_persons = filtered_message_persons;
     } else {
-        const realm_people = get_dm_suggestion_candidates({
+        const realm_people = people.get_people_for_dm({
             exclude_non_welcome_bots,
             exclude_non_message_people: false,
             active_users_only: false,
-            filter_by_dm_permission,
         });
-        filtered_persons = filter_persons(
-            realm_people,
-            opts.filter_pills,
-            opts.want_broadcast,
-            filterer,
+        filtered_persons = apply_dm_permission_filter(
+            filter_persons(realm_people, opts.filter_pills, opts.want_broadcast, filterer),
         );
     }
 

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -619,6 +619,7 @@ export function get_pm_people(query: string): (UserGroupPillData | UserPillData)
         stream_id: compose_state.stream_id(),
         topic: compose_state.topic(),
         filter_groups_for_dm: true,
+        filter_by_dm_permission: true,
     };
     const suggestions = get_person_suggestions(query, opts, true);
     const current_user_ids = compose_pm_pill.get_user_ids();
@@ -651,7 +652,49 @@ type PersonSuggestionOpts = {
     filter_groups_for_dm?: boolean;
     filter_groups_for_mention?: boolean;
     allow_custom_profile_field_matching?: boolean;
+    filter_by_dm_permission?: boolean;
 };
+
+function get_dm_suggestion_candidates(opts: {
+    exclude_non_welcome_bots: boolean;
+    exclude_non_message_people: boolean;
+    active_users_only: boolean;
+    filter_by_dm_permission: boolean;
+}): User[] {
+    if (!opts.filter_by_dm_permission) {
+        return people.get_people_for_dm({
+            exclude_non_welcome_bots: opts.exclude_non_welcome_bots,
+            exclude_non_message_people: opts.exclude_non_message_people,
+            active_users_only: opts.active_users_only,
+        });
+    }
+
+    const recipient_ids = compose_state.private_message_recipient_ids();
+    const check_dm_permission =
+        message_util.make_check_message_permission_for_dm_candidate(recipient_ids);
+
+    if (check_dm_permission === null) {
+        return people.get_people_for_dm({
+            exclude_non_welcome_bots: opts.exclude_non_welcome_bots,
+            exclude_non_message_people: opts.exclude_non_message_people,
+            active_users_only: opts.active_users_only,
+        });
+    }
+
+    // Filter people based on per-user permission checks. We will filter active
+    // user if required in the per-user check itself.
+    const dm_people_candidate = people.get_people_for_dm({
+        exclude_non_welcome_bots: opts.exclude_non_welcome_bots,
+        exclude_non_message_people: opts.exclude_non_message_people,
+        active_users_only: false,
+    });
+    return dm_people_candidate.filter((item) => {
+        if (opts.active_users_only && !people.is_active_user(item.user_id)) {
+            return false;
+        }
+        return check_dm_permission(item.user_id);
+    });
+}
 
 function filter_persons<T>(
     all_persons: User[],
@@ -870,11 +913,14 @@ export function get_person_suggestions(
         );
     };
 
-    const message_persons = people.get_people_for_dm({
+    const filter_by_dm_permission = opts.filter_by_dm_permission ?? false;
+    const message_persons = get_dm_suggestion_candidates({
         exclude_non_welcome_bots,
         exclude_non_message_people: true,
         active_users_only: true,
+        filter_by_dm_permission,
     });
+
     const filtered_message_persons = filter_persons(
         message_persons,
         opts.filter_pills,
@@ -887,12 +933,14 @@ export function get_person_suggestions(
     if (filtered_message_persons.length >= cutoff_length) {
         filtered_persons = filtered_message_persons;
     } else {
+        const realm_people = get_dm_suggestion_candidates({
+            exclude_non_welcome_bots,
+            exclude_non_message_people: false,
+            active_users_only: false,
+            filter_by_dm_permission,
+        });
         filtered_persons = filter_persons(
-            people.get_people_for_dm({
-                exclude_non_welcome_bots,
-                exclude_non_message_people: false,
-                active_users_only: false,
-            }),
+            realm_people,
             opts.filter_pills,
             opts.want_broadcast,
             filterer,

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -870,8 +870,13 @@ export function get_person_suggestions(
         );
     };
 
+    const message_persons = people.get_people_for_dm({
+        exclude_non_welcome_bots,
+        exclude_non_message_people: true,
+        active_users_only: true,
+    });
     const filtered_message_persons = filter_persons(
-        people.get_active_message_people(),
+        message_persons,
         opts.filter_pills,
         opts.want_broadcast,
         filterer,
@@ -882,21 +887,16 @@ export function get_person_suggestions(
     if (filtered_message_persons.length >= cutoff_length) {
         filtered_persons = filtered_message_persons;
     } else {
-        if (exclude_non_welcome_bots) {
-            filtered_persons = filter_persons(
-                people.get_realm_users_and_welcome_bot(),
-                opts.filter_pills,
-                opts.want_broadcast,
-                filterer,
-            );
-        } else {
-            filtered_persons = filter_persons(
-                people.get_realm_users_and_system_bots(),
-                opts.filter_pills,
-                opts.want_broadcast,
-                filterer,
-            );
-        }
+        filtered_persons = filter_persons(
+            people.get_people_for_dm({
+                exclude_non_welcome_bots,
+                exclude_non_message_people: false,
+                active_users_only: false,
+            }),
+            opts.filter_pills,
+            opts.want_broadcast,
+            filterer,
+        );
     }
 
     return typeahead_helper.sort_recipients({

--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -178,22 +178,20 @@ export function make_check_message_permission_for_dm_candidate(
             return true;
         }
 
-        // A past conversation exists between the full group {sender, recipient_ids,
-        // candidate} and at least one participant is in the permission group.
-        const conversation_user_ids = [...recipient_ids, candidate_user_id];
-        const conversation_user_ids_string = conversation_user_ids.join(",");
-        const is_known_empty_conversation = get_direct_message_permission_hints(
-            conversation_user_ids_string,
-        ).is_known_empty_conversation;
+        // The remaining path allows the DM only if a past conversation
+        // exists AND at least one participant is in the permission group.
+        // If none of the three permission flags are true, no conversation
+        // history can unlock the DM, so skip the hints lookup.
         if (
-            !is_known_empty_conversation &&
-            (is_current_user_in_permission_group ||
-                recipient_is_in_permission_group ||
-                is_candidate_in_permission_group)
+            !is_current_user_in_permission_group &&
+            !recipient_is_in_permission_group &&
+            !is_candidate_in_permission_group
         ) {
-            return true;
+            return false;
         }
 
-        return false;
+        const conversation_user_ids_string = [...recipient_ids, candidate_user_id].join(",");
+        return !get_direct_message_permission_hints(conversation_user_ids_string)
+            .is_known_empty_conversation;
     };
 }

--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -4,8 +4,10 @@ import type {Message} from "./message_store.ts";
 import * as people from "./people.ts";
 import * as pm_conversations from "./pm_conversations.ts";
 import {recent_view_messages_data} from "./recent_view_messages_data.ts";
+import {realm} from "./state_data.ts";
 import * as unread from "./unread.ts";
 import * as unread_ui from "./unread_ui.ts";
+import * as user_groups from "./user_groups.ts";
 
 type DirectMessagePermissionHints = {
     is_known_empty_conversation: boolean;
@@ -117,4 +119,81 @@ export function user_can_send_direct_message(user_ids_string: string): boolean {
             people.user_can_initiate_direct_message_thread(user_ids_string)) &&
         people.user_can_direct_message(user_ids_string)
     );
+}
+
+// Returns a per user permission check if required for DM message to occur.
+export function make_check_message_permission_for_dm_candidate(
+    recipient_ids: number[],
+): ((candidate_user_id: number) => boolean) | null {
+    const current_user_id = people.my_current_user_id();
+    const is_current_user_in_initiator_group = user_groups.is_user_in_setting_group(
+        realm.realm_direct_message_initiator_group,
+        current_user_id,
+    );
+    const is_current_user_in_permission_group = user_groups.is_user_in_setting_group(
+        realm.realm_direct_message_permission_group,
+        current_user_id,
+    );
+
+    // Current user is in both initiator and permission groups,
+    // so they can message anyone.
+    if (is_current_user_in_initiator_group && is_current_user_in_permission_group) {
+        return null;
+    }
+
+    const recipient_is_in_permission_group = recipient_ids.some(
+        (user_id) =>
+            !people.is_valid_bot_user(user_id) &&
+            user_id !== current_user_id &&
+            user_groups.is_user_in_setting_group(
+                realm.realm_direct_message_permission_group,
+                user_id,
+            ),
+    );
+
+    // Current user is in initiator group and at least one
+    // human recipient is in the permission group.
+    if (is_current_user_in_initiator_group && recipient_is_in_permission_group) {
+        return null;
+    }
+
+    const all_recipients_are_bots = recipient_ids.every(
+        (user_id) => people.is_valid_bot_user(user_id) || user_id === current_user_id,
+    );
+
+    const permission_group_user_ids = user_groups.get_user_ids_in_setting_group(
+        realm.realm_direct_message_permission_group,
+    );
+
+    return (candidate_user_id: number): boolean => {
+        // Include bots when all recipients are bots.
+        if (all_recipients_are_bots && people.is_valid_bot_user(candidate_user_id)) {
+            return true;
+        }
+
+        const is_candidate_in_permission_group = permission_group_user_ids.has(candidate_user_id);
+
+        // Current user can initiate and the candidate is in the permission group.
+        if (is_current_user_in_initiator_group && is_candidate_in_permission_group) {
+            return true;
+        }
+
+        // A past conversation exists between the full group {sender, recipient_ids,
+        // candidate} and at least one participant is in the permission group.
+        const conversation_user_ids = [...recipient_ids, candidate_user_id];
+        const conversation_user_ids_string = conversation_user_ids.join(",");
+        const is_known_empty_conversation = get_direct_message_permission_hints(
+            conversation_user_ids_string,
+        ).is_known_empty_conversation;
+        if (
+            !is_known_empty_conversation &&
+            (is_current_user_in_permission_group ||
+                recipient_is_in_permission_group ||
+                is_candidate_in_permission_group)
+        ) {
+            return true;
+        }
+
+        return false;
+    };
 }

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1154,6 +1154,19 @@ export function get_active_message_people(): User[] {
     return active_message_people;
 }
 
+export function get_people_for_dm(opts: {
+    exclude_non_welcome_bots: boolean;
+    exclude_non_message_people: boolean;
+    active_users_only: boolean;
+}): User[] {
+    if (opts.exclude_non_message_people) {
+        return opts.active_users_only ? get_active_message_people() : get_message_people();
+    } else if (opts.exclude_non_welcome_bots) {
+        return get_realm_users_and_welcome_bot();
+    }
+    return get_realm_users_and_system_bots();
+}
+
 export function get_people_for_search_bar(query: string): User[] {
     const pred = build_person_matcher(query);
 

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -897,6 +897,10 @@ export function is_valid_bulk_user_ids_for_compose(
     });
 }
 
+export function is_active_user(user_id: number): boolean {
+    return active_user_dict.has(user_id);
+}
+
 export function is_active_user_or_system_bot(user_id: number): boolean {
     // For popover menus, we include cross-realm bots as active
     // users.
@@ -1146,9 +1150,7 @@ export function get_message_people(): User[] {
 
 export function get_active_message_people(): User[] {
     const message_people = get_message_people();
-    const active_message_people = message_people.filter((item) =>
-        active_user_dict.has(item.user_id),
-    );
+    const active_message_people = message_people.filter((item) => is_active_user(item.user_id));
     return active_message_people;
 }
 

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -613,6 +613,30 @@ export function is_user_in_setting_group(
     return false;
 }
 
+export function get_user_ids_in_setting_group(setting_value: GroupSettingValue): Set<number> {
+    const user_ids = new Set<number>();
+    const group_ids: number[] =
+        typeof setting_value === "number" ? [setting_value] : [...setting_value.direct_subgroups];
+
+    if (typeof setting_value !== "number") {
+        for (const user_id of setting_value.direct_members) {
+            user_ids.add(user_id);
+        }
+    }
+
+    for (const group_id of group_ids) {
+        const group = user_group_by_id_dict.get(group_id);
+        if (group === undefined) {
+            blueslip.error("Could not find user group", {group_id});
+            continue;
+        }
+        for (const member_id of get_recursive_group_members(group)) {
+            user_ids.add(member_id);
+        }
+    }
+    return user_ids;
+}
+
 export function check_system_user_group_allowed_for_setting(
     group_name: string,
     group_setting_config: GroupPermissionSetting,

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -2120,3 +2120,13 @@ textarea.new_message_textarea {
         overflow: hidden !important;
     }
 }
+
+#compose:has(textarea#compose-textarea:disabled) {
+    .disable-on-invalid-recipient {
+        opacity: 0.3;
+
+        .compose_control_button {
+            pointer-events: none;
+        }
+    }
+}

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -7,47 +7,47 @@
         <a role="button" class="undo_markdown_preview compose_control_button zulip-icon zulip-icon-compose-edit" aria-label="{{t 'Exit preview mode' }}" tabindex=0 style="display:none;"></a>
     </div>
     {{#if file_upload_enabled }}
-    <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tippy-content="{{t 'Upload files' }}">
+    <div class="compose_control_button_container preview_mode_disabled disable-on-invalid-recipient compose_button_tooltip" data-tippy-content="{{t 'Upload files' }}">
         <a role="button" class="compose_control_button compose_upload_file zulip-icon zulip-icon-attachment" aria-label="{{t 'Upload files' }}" tabindex=0></a>
     </div>
     {{/if}}
-    <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tippy-content="{{t 'Add video call' }}">
+    <div class="compose_control_button_container preview_mode_disabled disable-on-invalid-recipient compose_button_tooltip" data-tippy-content="{{t 'Add video call' }}">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-video-call video_link" aria-label="{{t 'Add video call' }}" tabindex=0></a>
     </div>
-    <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tippy-content="{{t 'Add voice call' }}">
+    <div class="compose_control_button_container preview_mode_disabled disable-on-invalid-recipient compose_button_tooltip" data-tippy-content="{{t 'Add voice call' }}">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-voice-call audio_link" aria-label="{{t 'Add voice call' }}" tabindex=0></a>
     </div>
     <div class="divider"></div>
-    <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tippy-content="{{t 'Add emoji' }}">
+    <div class="compose_control_button_container preview_mode_disabled disable-on-invalid-recipient compose_button_tooltip" data-tippy-content="{{t 'Add emoji' }}">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-smile-bigger emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0></a>
     </div>
-    <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tooltip-template-id="add-global-time-tooltip" data-tippy-maxWidth="none">
+    <div class="compose_control_button_container preview_mode_disabled disable-on-invalid-recipient compose_button_tooltip" data-tooltip-template-id="add-global-time-tooltip" data-tippy-maxWidth="none">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-time time_pick" aria-label="{{t 'Add global time' }}" tabindex=0></a>
     </div>
     {{#if (or tenor_enabled giphy_enabled klipy_enabled)}}
         {{!-- In terms of preference, Tenor > KLIPY > GIPHY. --}}
-        <div class="compose_control_button_container  preview_mode_disabled compose_button_tooltip" data-tippy-content="{{t 'Add GIF' }}">
+        <div class="compose_control_button_container  preview_mode_disabled disable-on-invalid-recipient compose_button_tooltip" data-tippy-content="{{t 'Add GIF' }}">
             <a role="button" class="compose_control_button compose-gif-icon zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0></a>
         </div>
     {{/if}}
     {{#unless (eq message_id undefined)}}
-    <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tooltip-template-id="add-saved-snippet-tooltip">
+    <div class="compose_control_button_container preview_mode_disabled disable-on-invalid-recipient compose_button_tooltip" data-tooltip-template-id="add-saved-snippet-tooltip">
         <a role="button" class="saved_snippets_widget saved-snippets-message-edit-widget compose_control_button zulip-icon zulip-icon-message-square-text" aria-label="{{t 'Add saved snippet' }}" data-message-id="{{message_id}}" tabindex=0></a>
     </div>
     {{else}}
-    <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tooltip-template-id="add-saved-snippet-tooltip">
+    <div class="compose_control_button_container preview_mode_disabled disable-on-invalid-recipient compose_button_tooltip" data-tooltip-template-id="add-saved-snippet-tooltip">
         <a role="button" class="saved_snippets_widget saved-snippets-composebox-widget compose_control_button zulip-icon zulip-icon-message-square-text" aria-label="{{t 'Add saved snippet' }}" tabindex=0></a>
     </div>
     {{/unless}}
     <div class="divider"></div>
-    <div class="compose-control-buttons-container preview_mode_disabled">
+    <div class="compose-control-buttons-container preview_mode_disabled disable-on-invalid-recipient">
         <a role="button" data-format-type="link" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-link formatting_button" aria-label="{{t 'Link' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="link-tooltip" data-tippy-maxWidth="none"></a>
         <a role="button" data-format-type="bold" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-bold formatting_button" aria-label="{{t 'Bold' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="bold-tooltip" data-tippy-maxWidth="none"></a>
         <a role="button" data-format-type="italic" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-italic formatting_button" aria-label="{{t 'Italic' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="italic-tooltip" data-tippy-maxWidth="none"></a>
         <a role="button" data-format-type="strikethrough" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-strikethrough formatting_button" aria-label="{{t 'Strikethrough' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Strikethrough' }}"></a>
     </div>
     <div class="divider"></div>
-    <div class="compose-control-buttons-container preview_mode_disabled">
+    <div class="compose-control-buttons-container preview_mode_disabled disable-on-invalid-recipient">
         <a role="button" data-format-type="numbered" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-ordered-list formatting_button" aria-label="{{t 'Numbered list' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Numbered list' }}"></a>
         <a role="button" data-format-type="bulleted" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-unordered-list formatting_button" aria-label="{{t 'Bulleted list' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Bulleted list' }}"></a>
         <div class="divider"></div>
@@ -58,10 +58,10 @@
     </div>
     <div class="divider"></div>
     {{#if (eq message_id undefined)}}
-    <div class="compose_control_button_container preview_mode_disabled needs-empty-compose compose_button_tooltip" data-tooltip-template-id="add-poll-tooltip" data-tippy-maxWidth="none">
+    <div class="compose_control_button_container preview_mode_disabled disable-on-invalid-recipient needs-empty-compose compose_button_tooltip" data-tooltip-template-id="add-poll-tooltip" data-tippy-maxWidth="none">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-poll add-poll" aria-label="{{t 'Add poll' }}" tabindex=0></a>
     </div>
-    <div class="compose_control_button_container preview_mode_disabled needs-empty-compose compose_button_tooltip" data-tooltip-template-id="add-todo-tooltip" data-tippy-maxWidth="none">
+    <div class="compose_control_button_container preview_mode_disabled disable-on-invalid-recipient needs-empty-compose compose_button_tooltip" data-tooltip-template-id="add-todo-tooltip" data-tippy-maxWidth="none">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-todo-list add-todo-list" aria-label="{{t 'Add to-do list' }}" tabindex=0></a>
     </div>
     {{/if}}

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -114,7 +114,6 @@ const people = zrequire("people");
 const compose_state = zrequire("compose_state");
 const compose_actions = zrequire("compose_actions");
 const compose_reply = zrequire("compose_reply");
-const compose_validate = zrequire("compose_validate");
 const message_lists = zrequire("message_lists");
 const stream_data = zrequire("stream_data");
 const compose_recipient = zrequire("compose_recipient");
@@ -188,7 +187,6 @@ test("start", ({override, override_rewire, mock_template}) => {
     $elem.set_find_results(".message-limit-indicator", $indicator);
 
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
-    override_rewire(compose_validate, "update_posting_policy_banner_post_validation", noop);
     override_rewire(compose_recipient, "update_recipient_row_attention_level", noop);
     override_rewire(stream_data, "can_post_messages_in_stream", () => true);
     override_rewire(stream_data, "can_create_new_topics_in_stream", () => true);
@@ -342,7 +340,6 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
     $elem.set_find_results(".message-limit-indicator", $indicator);
 
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
-    override_rewire(compose_validate, "update_posting_policy_banner_post_validation", noop);
     override_rewire(compose_recipient, "update_recipient_row_attention_level", noop);
     override_private_message_recipient_ids({override});
     mock_template("decorated_channel_name.hbs", false, () => "");

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -200,6 +200,8 @@ test_ui("validate", ({mock_template, override}) => {
     $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
     assert.ok(!compose_validate.validate());
     assert.ok(pm_recipient_error_rendered);
+    // Textarea should not be disabled for missing recipient.
+    assert.ok(!$("textarea#compose-textarea").prop("disabled"));
 
     pm_recipient_error_rendered = false;
 
@@ -207,14 +209,17 @@ test_ui("validate", ({mock_template, override}) => {
     compose_state.set_private_message_recipient_ids([bob.user_id]);
     assert.ok(compose_validate.validate());
     assert.ok(!pm_recipient_error_rendered);
+    assert.ok(!$("textarea#compose-textarea").prop("disabled"));
 
     override(realm, "realm_direct_message_initiator_group", admin.id);
     assert.ok(compose_validate.validate());
     assert.ok(!pm_recipient_error_rendered);
+    assert.ok(!$("textarea#compose-textarea").prop("disabled"));
 
     override(realm, "realm_direct_message_permission_group", admin.id);
     assert.ok(compose_validate.validate());
     assert.ok(!pm_recipient_error_rendered);
+    assert.ok(!$("textarea#compose-textarea").prop("disabled"));
 
     override(realm, "realm_direct_message_initiator_group", everyone.id);
     override(realm, "realm_direct_message_permission_group", everyone.id);
@@ -231,6 +236,8 @@ test_ui("validate", ({mock_template, override}) => {
     });
     assert.ok(!compose_validate.validate());
     assert.ok(deactivated_user_error_rendered);
+    // Textarea should be disabled for deactivated user.
+    assert.ok($("textarea#compose-textarea").prop("disabled"));
 
     bob.is_deleted = true;
     let deleted_user_error_rendered = false;
@@ -252,6 +259,7 @@ test_ui("validate", ({mock_template, override}) => {
     compose_state.set_private_message_recipient_ids([welcome_bot.user_id]);
     $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
     assert.ok(compose_validate.validate());
+    assert.ok(!$("textarea#compose-textarea").prop("disabled"));
 
     // For this first block, we should fail due to empty compose.
     initialize_pm_pill(mock_template);
@@ -260,6 +268,7 @@ test_ui("validate", ({mock_template, override}) => {
     assert.ok(!compose_validate.validate());
     assert.ok(!$("#compose-send-button .loader").visible());
     assert.ok($("textarea#compose-textarea").hasClass("invalid"));
+    assert.ok(!$("textarea#compose-textarea").prop("disabled"));
 
     // Now add content to compose.
     add_content_to_compose_box();
@@ -267,6 +276,7 @@ test_ui("validate", ({mock_template, override}) => {
     $("textarea#compose-textarea").addClass("invalid");
     assert.ok(compose_validate.validate());
     assert.ok(!$("textarea#compose-textarea").hasClass("invalid"));
+    assert.ok(!$("textarea#compose-textarea").prop("disabled"));
 
     initialize_pm_pill(mock_template);
     add_content_to_compose_box();
@@ -305,7 +315,31 @@ test_ui("validate", ({mock_template, override}) => {
         missing_topic_error_rendered = false;
         assert.ok(!compose_validate.validate());
         assert.ok(missing_topic_error_rendered);
+        assert.ok(!$("textarea#compose-textarea").prop("disabled"));
     }
+
+    // Test textarea disabled when DMs are disabled in the org.
+    compose_state.set_message_type("private");
+    compose_state.set_private_message_recipient_ids([bob.user_id]);
+    override(realm, "realm_direct_message_permission_group", nobody.id);
+
+    let dm_disabled_error_rendered = false;
+    mock_template("compose_banner/cannot_send_direct_message_error.hbs", false, (data) => {
+        assert.equal(data.classname, compose_banner.CLASSNAMES.cannot_send_direct_message);
+        dm_disabled_error_rendered = true;
+        return "<banner-stub>";
+    });
+    $.reset_selector(`#compose_banners .cannot_send_direct_message`);
+    $.set_results(`#compose_banners .cannot_send_direct_message`, []);
+
+    assert.ok(!compose_validate.validate());
+    assert.ok(dm_disabled_error_rendered);
+    assert.ok($("textarea#compose-textarea").prop("disabled"));
+
+    // Switching to stream message should re-enable textarea.
+    compose_state.set_message_type("stream");
+    assert.ok(!compose_validate.validate());
+    assert.ok(!$("textarea#compose-textarea").prop("disabled"));
 });
 
 test_ui("test_stream_wildcard_mention_allowed", ({override}) => {

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1851,6 +1851,30 @@ test("initialize", ({override, override_rewire, mock_template}) => {
     assert.ok(compose_textarea_typeahead_called);
 });
 
+test("get_person_suggestion_for_topic_typeahead excludes deactivated users", ({override}) => {
+    override(pm_conversations, "get_partners", () => []);
+
+    // Deactivated user from participants should be excluded.
+    message_lists.current = {
+        data: {
+            participants: {
+                visible: () => new Set([deactivated_user.user_id]),
+            },
+        },
+    };
+    assert.deepEqual(ct.get_person_suggestion_for_topic_typeahead("deactivated"), []);
+
+    // Deactivated user from DM partners should be excluded.
+    message_lists.current = undefined;
+    override(pm_conversations, "get_partners", () => [deactivated_user.user_id]);
+    assert.deepEqual(ct.get_person_suggestion_for_topic_typeahead("deactivated"), []);
+
+    // Active user from DM partners should be included.
+    override(pm_conversations, "get_partners", () => [lear.user_id]);
+    const results = ct.get_person_suggestion_for_topic_typeahead("lear");
+    assert.ok(results[0].user.user_id === lear.user_id);
+});
+
 test("begins_typeahead", ({override, override_rewire}) => {
     override(stream_topic_history_util, "get_server_history", noop);
 

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -38,6 +38,16 @@ const compose_validate = mock_esm("../src/compose_validate", {
     initialize: noop,
 });
 const input_pill = mock_esm("../src/input_pill");
+const message_util = mock_esm("../src/message_util", {
+    is_known_empty: () => false,
+    user_can_send_direct_message(user_ids_string) {
+        return (
+            (!message_util.is_known_empty(user_ids_string) ||
+                people.user_can_initiate_direct_message_thread(user_ids_string)) &&
+            people.user_can_direct_message(user_ids_string)
+        );
+    },
+});
 const message_user_ids = mock_esm("../src/message_user_ids", {
     user_ids: () => [],
 });
@@ -569,6 +579,26 @@ const full_members = user_group_item(
     }),
 );
 
+const nobody = user_group_item(
+    make_user_group({
+        name: "role:nobody",
+        id: 8,
+        creator_id: null,
+        date_created: 1596710000,
+        description: "Nobody",
+        members: new Set(),
+        is_system_group: true,
+        direct_subgroup_ids: new Set(),
+        can_add_members_group: 2,
+        can_join_group: 2,
+        can_leave_group: 2,
+        can_manage_group: 2,
+        can_mention_group: 2,
+        can_remove_members_group: 2,
+        deactivated: false,
+    }),
+);
+
 const sweden_stream = stream_item(
     make_stream({
         name: "Sweden",
@@ -681,6 +711,7 @@ function test(label, f) {
             server_supported_permission_settings,
         );
         helpers.override(realm, "realm_can_access_all_users_group", members.id);
+        helpers.override(realm, "realm_direct_message_permission_group", members.id);
 
         people.add_active_user(ali);
         people.add_active_user(alice);
@@ -706,6 +737,7 @@ function test(label, f) {
         user_groups.add(admins);
         user_groups.add(members);
         user_groups.add(full_members);
+        user_groups.add(nobody);
 
         muted_users.set_muted_users([]);
 
@@ -1873,6 +1905,148 @@ test("get_person_suggestion_for_topic_typeahead excludes deactivated users", ({o
     override(pm_conversations, "get_partners", () => [lear.user_id]);
     const results = ct.get_person_suggestion_for_topic_typeahead("lear");
     assert.ok(results[0].user.user_id === lear.user_id);
+});
+
+test("get_person_suggestion_for_topic_typeahead respects DM permissions", ({override}) => {
+    function set_visible_participants(user_ids) {
+        message_lists.current = {
+            data: {
+                participants: {
+                    visible: () => new Set(user_ids),
+                },
+            },
+        };
+    }
+    // Set message history to empty
+    override(pm_conversations, "get_partners", () => []);
+    override(message_util, "is_known_empty", () => true);
+
+    // Bot suggestion doesn't show up if there is no past conversation.
+    override(realm, "realm_direct_message_permission_group", nobody.id);
+    override(realm, "realm_direct_message_initiator_group", nobody.id);
+    let results = ct.get_person_suggestion_for_topic_typeahead("notification");
+    assert.deepEqual(results, []);
+
+    // Don't show suggestion when sender/recipient is in direct_message_permission_group
+    // but the sender isn't in initiator group.
+    override(realm, "realm_direct_message_permission_group", {
+        direct_members: [lear.user_id, hamlet.user_id],
+        direct_subgroups: [],
+    });
+    results = ct.get_person_suggestion_for_topic_typeahead("lear");
+    assert.deepEqual(results, []);
+
+    set_visible_participants([lear.user_id]);
+    results = ct.get_person_suggestion_for_topic_typeahead("lear");
+    assert.deepEqual(results, []);
+
+    // When no conversation history exists between the sender and recipient,
+    // we show the suggestion if the recipient is visible in the current narrow’s
+    // participants and either the sender or recipient is in the
+    // direct_message_permission_group, and the sender is also in the initiator group.
+    override(realm, "realm_direct_message_permission_group", {
+        direct_members: [lear.user_id],
+        direct_subgroups: [],
+    });
+    override(realm, "realm_direct_message_initiator_group", {
+        direct_members: [hamlet.user_id],
+        direct_subgroups: [],
+    });
+    set_visible_participants([]);
+    results = ct.get_person_suggestion_for_topic_typeahead("lear");
+    assert.deepEqual(results, []);
+
+    // Set current narrow participant
+    set_visible_participants([lear.user_id]);
+    results = ct.get_person_suggestion_for_topic_typeahead("lear");
+    assert.equal(results[0].user.user_id, lear.user_id);
+
+    // We don't show suggestion when sender doesn't have initiator
+    // permission when past conversation doesn't exist.
+    override(realm, "realm_direct_message_permission_group", {
+        direct_members: [hamlet.user_id],
+        direct_subgroups: [],
+    });
+    override(realm, "realm_direct_message_initiator_group", nobody.id);
+    results = ct.get_person_suggestion_for_topic_typeahead("lear");
+    assert.deepEqual(results, []);
+
+    // We dont show suggestion if the sender doesn't have initiator permission
+    // even if recipient is in permission group
+    override(realm, "realm_direct_message_permission_group", {
+        direct_members: [lear.user_id],
+        direct_subgroups: [],
+    });
+    results = ct.get_person_suggestion_for_topic_typeahead("lear");
+    assert.deepEqual(results, []);
+
+    // Don't show suggestion if direct message is disabled.
+    override(realm, "realm_direct_message_permission_group", nobody.id);
+    override(realm, "realm_direct_message_initiator_group", {
+        direct_members: [hamlet.user_id, lear.user_id],
+        direct_subgroups: [],
+    });
+    results = ct.get_person_suggestion_for_topic_typeahead("lear");
+    assert.deepEqual(results, []);
+
+    // Set message history
+    override(pm_conversations, "get_partners", () => [notification_bot.user_id, lear.user_id]);
+    override(message_util, "is_known_empty", () => false);
+
+    // Suggestion for bot always show up even if direct message is disabled,
+    // considering past conversation exists.
+    override(realm, "realm_direct_message_permission_group", nobody.id);
+    override(realm, "realm_direct_message_initiator_group", nobody.id);
+    results = ct.get_person_suggestion_for_topic_typeahead("notification");
+    assert.equal(results[0].user.user_id, notification_bot.user_id);
+
+    // Show suggestion when both sender and recipient has permission, and
+    // past conversation exists
+    override(realm, "realm_direct_message_permission_group", {
+        direct_members: [hamlet.user_id, lear.user_id],
+        direct_subgroups: [],
+    });
+    results = ct.get_person_suggestion_for_topic_typeahead("lear");
+    assert.equal(results[0].user.user_id, lear.user_id);
+
+    // Sender in initiator group, recipient in permission group, show suggestion
+    override(realm, "realm_direct_message_permission_group", {
+        direct_members: [lear.user_id],
+        direct_subgroups: [],
+    });
+    override(realm, "realm_direct_message_initiator_group", {
+        direct_members: [hamlet.user_id],
+        direct_subgroups: [],
+    });
+    results = ct.get_person_suggestion_for_topic_typeahead("lear");
+    assert.equal(results[0].user.user_id, lear.user_id);
+
+    // Show suggestion when sender has permission and past conversation exists
+    override(realm, "realm_direct_message_permission_group", {
+        direct_members: [hamlet.user_id],
+        direct_subgroups: [],
+    });
+    override(realm, "realm_direct_message_initiator_group", nobody.id);
+    results = ct.get_person_suggestion_for_topic_typeahead("lear");
+    assert.equal(results[0].user.user_id, lear.user_id);
+
+    // Show suggestion when recipient has permission and past conversation exists
+    override(realm, "realm_direct_message_permission_group", {
+        direct_members: [lear.user_id],
+        direct_subgroups: [],
+    });
+    override(realm, "realm_direct_message_initiator_group", nobody.id);
+    results = ct.get_person_suggestion_for_topic_typeahead("lear");
+    assert.equal(results[0].user.user_id, lear.user_id);
+
+    // No suggestion when direct message is disabled
+    override(realm, "realm_direct_message_permission_group", nobody.id);
+    override(realm, "realm_direct_message_initiator_group", {
+        direct_members: [hamlet.user_id, lear.user_id],
+        direct_subgroups: [],
+    });
+    results = ct.get_person_suggestion_for_topic_typeahead("lear");
+    assert.deepEqual(results, []);
 });
 
 test("begins_typeahead", ({override, override_rewire}) => {

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -39,13 +39,84 @@ const compose_validate = mock_esm("../src/compose_validate", {
 });
 const input_pill = mock_esm("../src/input_pill");
 const message_util = mock_esm("../src/message_util", {
-    is_known_empty: () => false,
+    get_direct_message_permission_hints: () => ({
+        is_known_empty_conversation: false,
+        is_local_echo_safe: true,
+    }),
     user_can_send_direct_message(user_ids_string) {
         return (
-            (!message_util.is_known_empty(user_ids_string) ||
+            (!message_util.get_direct_message_permission_hints(user_ids_string)
+                .is_known_empty_conversation ||
                 people.user_can_initiate_direct_message_thread(user_ids_string)) &&
             people.user_can_direct_message(user_ids_string)
         );
+    },
+    // currently is synced with the actual function.
+    make_check_message_permission_for_dm_candidate(recipient_ids) {
+        const current_user_id = people.my_current_user_id();
+        const is_current_user_in_initiator_group = user_groups.is_user_in_setting_group(
+            realm.realm_direct_message_initiator_group,
+            current_user_id,
+        );
+        const is_current_user_in_permission_group = user_groups.is_user_in_setting_group(
+            realm.realm_direct_message_permission_group,
+            current_user_id,
+        );
+
+        if (is_current_user_in_initiator_group && is_current_user_in_permission_group) {
+            return null;
+        }
+
+        const recipient_is_in_permission_group = recipient_ids.some(
+            (user_id) =>
+                !people.is_valid_bot_user(user_id) &&
+                user_id !== current_user_id &&
+                user_groups.is_user_in_setting_group(
+                    realm.realm_direct_message_permission_group,
+                    user_id,
+                ),
+        );
+
+        if (is_current_user_in_initiator_group && recipient_is_in_permission_group) {
+            return null;
+        }
+
+        const all_recipients_are_bots = recipient_ids.every(
+            (user_id) => people.is_valid_bot_user(user_id) || user_id === current_user_id,
+        );
+
+        const permission_group_user_ids = user_groups.get_user_ids_in_setting_group(
+            realm.realm_direct_message_permission_group,
+        );
+
+        return (candidate_user_id) => {
+            if (all_recipients_are_bots && people.is_valid_bot_user(candidate_user_id)) {
+                return true;
+            }
+
+            const is_candidate_in_permission_group =
+                permission_group_user_ids.has(candidate_user_id);
+
+            if (is_current_user_in_initiator_group && is_candidate_in_permission_group) {
+                return true;
+            }
+
+            const conversation_user_ids = [...recipient_ids, candidate_user_id];
+            const conversation_user_ids_string = conversation_user_ids.join(",");
+            const is_known_empty_conversation = message_util.get_direct_message_permission_hints(
+                conversation_user_ids_string,
+            ).is_known_empty_conversation;
+            if (
+                !is_known_empty_conversation &&
+                (is_current_user_in_permission_group ||
+                    recipient_is_in_permission_group ||
+                    is_candidate_in_permission_group)
+            ) {
+                return true;
+            }
+
+            return false;
+        };
     },
 });
 const message_user_ids = mock_esm("../src/message_user_ids", {
@@ -712,6 +783,7 @@ function test(label, f) {
         );
         helpers.override(realm, "realm_can_access_all_users_group", members.id);
         helpers.override(realm, "realm_direct_message_permission_group", members.id);
+        helpers.override(realm, "realm_direct_message_initiator_group", members.id);
 
         people.add_active_user(ali);
         people.add_active_user(alice);
@@ -1919,7 +1991,10 @@ test("get_person_suggestion_for_topic_typeahead respects DM permissions", ({over
     }
     // Set message history to empty
     override(pm_conversations, "get_partners", () => []);
-    override(message_util, "is_known_empty", () => true);
+    override(message_util, "get_direct_message_permission_hints", () => ({
+        is_known_empty_conversation: true,
+        is_local_echo_safe: true,
+    }));
 
     // Bot suggestion doesn't show up if there is no past conversation.
     override(realm, "realm_direct_message_permission_group", nobody.id);
@@ -1991,7 +2066,10 @@ test("get_person_suggestion_for_topic_typeahead respects DM permissions", ({over
 
     // Set message history
     override(pm_conversations, "get_partners", () => [notification_bot.user_id, lear.user_id]);
-    override(message_util, "is_known_empty", () => false);
+    override(message_util, "get_direct_message_permission_hints", () => ({
+        is_known_empty_conversation: false,
+        is_local_echo_safe: true,
+    }));
 
     // Suggestion for bot always show up even if direct message is disabled,
     // considering past conversation exists.
@@ -2992,4 +3070,126 @@ test("direct message recipients sorted according to stream / topic being viewed"
     // 1st despite having an exact name match with the query.
     results = ct.get_pm_people("ali");
     assert.deepEqual(results, [alice_item, ali_item]);
+});
+
+test("get_pm_people respects DM permissions", ({override}) => {
+    $("#private_message_recipient").set_parent($.create("pm-recipient-container"));
+
+    let pill_items = [];
+
+    override(input_pill, "create", () => ({
+        clear() {
+            pill_items = [];
+        },
+        clear_text() {},
+        items: () => pill_items,
+        onPillCreate() {},
+        onPillRemove() {},
+        appendValidatedData(item) {
+            pill_items.push(item);
+        },
+    }));
+
+    compose_pm_pill.initialize({on_pill_create_or_remove: noop});
+
+    mock_banners();
+    compose_state.set_stream_id("");
+
+    compose_state.set_private_message_recipient_ids([]);
+
+    override(message_util, "get_direct_message_permission_hints", () => ({
+        is_known_empty_conversation: true,
+        is_local_echo_safe: true,
+    }));
+
+    // When DMs are disabled realm-wide, lear should not appear in suggestions.
+    override(realm, "realm_direct_message_permission_group", nobody.id);
+    override(realm, "realm_direct_message_initiator_group", nobody.id);
+    let results = ct.get_pm_people("king lear");
+    assert.deepEqual(results, []);
+
+    // Bot suggestions always appear regardless of DM permissions.
+    results = ct.get_pm_people("welcome");
+    assert.deepEqual(results, [welcome_bot_item]);
+
+    // When DMs are allowed, lear should appear in suggestions.
+    override(realm, "realm_direct_message_permission_group", members.id);
+    override(realm, "realm_direct_message_initiator_group", members.id);
+    results = ct.get_pm_people("king lear");
+    assert.deepEqual(results, [lear_item]);
+
+    // Sender is not in initiator group and no past conversation history;
+    // lear should not appear even though lear is in the permission group.
+    override(realm, "realm_direct_message_permission_group", {
+        direct_members: [lear.user_id],
+        direct_subgroups: [],
+    });
+    override(realm, "realm_direct_message_initiator_group", nobody.id);
+    results = ct.get_pm_people("king lear");
+    assert.deepEqual(results, []);
+
+    // Sender is in initiator group; lear should appear.
+    override(realm, "realm_direct_message_permission_group", {
+        direct_members: [lear.user_id],
+        direct_subgroups: [],
+    });
+    override(realm, "realm_direct_message_initiator_group", {
+        direct_members: [hamlet.user_id],
+        direct_subgroups: [],
+    });
+    results = ct.get_pm_people("king lear");
+    assert.deepEqual(results, [lear_item]);
+
+    // Othello is not in the permission group, so othello should not appear.
+    results = ct.get_pm_people("othello");
+    assert.deepEqual(results, []);
+
+    // With lear already in the recipient box, othello can be added to a group
+    // DM because lear is in the permission group, satisfying the check.
+    compose_state.set_private_message_recipient_ids([lear.user_id]);
+    results = ct.get_pm_people("othello");
+    assert.deepEqual(results, [othello_item]);
+
+    // Sender is not in initiator group but past conversation history exists;
+    // lear should appear because the conversation is not known to be empty.
+    compose_state.set_private_message_recipient_ids([]);
+    override(message_util, "get_direct_message_permission_hints", () => ({
+        is_known_empty_conversation: false,
+        is_local_echo_safe: true,
+    }));
+    override(realm, "realm_direct_message_initiator_group", nobody.id);
+    override(realm, "realm_direct_message_permission_group", {
+        direct_members: [lear.user_id],
+        direct_subgroups: [],
+    });
+    results = ct.get_pm_people("king lear");
+    assert.deepEqual(results, [lear_item]);
+
+    // With a bot already in the recipient box and sender in the initiator
+    // group, another bot should always appear in suggestions.
+    override(message_util, "get_direct_message_permission_hints", () => ({
+        is_known_empty_conversation: true,
+        is_local_echo_safe: true,
+    }));
+    compose_state.set_private_message_recipient_ids([notification_bot.user_id]);
+    override(realm, "realm_direct_message_initiator_group", {
+        direct_members: [hamlet.user_id],
+        direct_subgroups: [],
+    });
+    override(realm, "realm_direct_message_permission_group", {
+        direct_members: [lear.user_id],
+        direct_subgroups: [],
+    });
+    results = ct.get_pm_people("welcome");
+    assert.deepEqual(results, [welcome_bot_item]);
+
+    // With a bot already in the recipient box, a user in the permission
+    // group should appear because the sender can initiate.
+    results = ct.get_pm_people("king lear");
+    assert.deepEqual(results, [lear_item]);
+
+    // With a bot already in the recipient box, a user not in the
+    // permission group should not appear.
+    results = ct.get_pm_people("othello");
+    assert.deepEqual(results, []);
 });

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -101,21 +101,17 @@ const message_util = mock_esm("../src/message_util", {
                 return true;
             }
 
-            const conversation_user_ids = [...recipient_ids, candidate_user_id];
-            const conversation_user_ids_string = conversation_user_ids.join(",");
-            const is_known_empty_conversation = message_util.get_direct_message_permission_hints(
-                conversation_user_ids_string,
-            ).is_known_empty_conversation;
             if (
-                !is_known_empty_conversation &&
-                (is_current_user_in_permission_group ||
-                    recipient_is_in_permission_group ||
-                    is_candidate_in_permission_group)
+                !is_current_user_in_permission_group &&
+                !recipient_is_in_permission_group &&
+                !is_candidate_in_permission_group
             ) {
-                return true;
+                return false;
             }
 
-            return false;
+            const conversation_user_ids_string = [...recipient_ids, candidate_user_id].join(",");
+            return !message_util.get_direct_message_permission_hints(conversation_user_ids_string)
+                .is_known_empty_conversation;
         };
     },
 });
@@ -3167,10 +3163,6 @@ test("get_pm_people respects DM permissions", ({override}) => {
 
     // With a bot already in the recipient box and sender in the initiator
     // group, another bot should always appear in suggestions.
-    override(message_util, "get_direct_message_permission_hints", () => ({
-        is_known_empty_conversation: true,
-        is_local_echo_safe: true,
-    }));
     compose_state.set_private_message_recipient_ids([notification_bot.user_id]);
     override(realm, "realm_direct_message_initiator_group", {
         direct_members: [hamlet.user_id],

--- a/web/tests/upload.test.cjs
+++ b/web/tests/upload.test.cjs
@@ -237,7 +237,6 @@ test("upload_files", async ({mock_template, override, override_rewire}) => {
         return "<banner-stub>";
     });
     override_rewire(compose_validate, "validate", () => false);
-    override_rewire(compose_validate, "update_posting_policy_banner_post_validation", noop);
     await upload.upload_files(uppy, config, files);
     assert.ok($("#compose-send-button").hasClass("disabled-message-send-controls"));
     assert.ok(banner_shown);


### PR DESCRIPTION
Currently, when we try to start a DM when a DM is disabled in org, we get a error banner. Clicking on it seemingly does nothing but actually the blur handler on `private_message_recipient` is replacing the banner and before the click is finished, the banner gets replaced in DOM.

Also the logic tries to keep the focus in private_message_recipient to keep compose recipient on high attention since user needs to fix the recipient(also to prevent from accessing compose textarea). This creates an issue where private_message_recipient never really loses focus and if we try to interact with some other input area with compose open, we end up in a buggy state. Also, user will not be able to backspace remove the user pill since it needs to shift focus to user pill in doing so.

Instead we keep disable the compose textarea if the recipient is invalid and keep recipient in high attention state, and also don't replace banner if it already exists(so that we are able to interact with it).

Fixes: [#issues > DMs disabled in org, but compose box buttons active? @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/DMs.20disabled.20in.20org.2C.20but.20compose.20box.20buttons.20active.3F/near/2381437)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
|After|
|-|
|<video src="https://github.com/user-attachments/assets/0eddb33b-8040-45e3-b4a2-b5cf379272bd">|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
