### PR TITLE
search: Allow closed searchbox to have keyboard focus to open.

### DIFF
--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -163,6 +163,24 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
         $("#searchbox-input-container").toggleClass("focused", false);
     });
 
+    $("#searchbox-input-container").on("keydown", (e) => {
+        if (e.key === "Enter" && $("#searchbox .navbar-search.expanded").length === 0) {
+            // Prevent propagation, and wait for the keyup to open search, because
+            // we also need to prevent propagation there to not have the event caught
+            // by the typeahead event handlers.
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    });
+
+    $("#searchbox-input-container").on("keyup", (e) => {
+        if (e.key === "Enter" && $("#searchbox .navbar-search.expanded").length === 0) {
+            initiate_search();
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    });
+
     search_pill_widget = search_pill.create_pills($pill_container);
     search_pill_widget.onPillRemove(() => {
         search_input_has_changed = true;

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -13,6 +13,10 @@
         z-index: 1;
     }
 
+    .navbar-search:has(#searchbox-input-container:focus-visible) {
+        outline: 2px solid var(--color-outline-focus);
+    }
+
     .search_icon {
         grid-area: search-icon;
         align-self: center;

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -24,7 +24,7 @@
                     </div>
                     <div id="searchbox">
                         <form id="searchbox_form" class="navbar-search">
-                            <div id="searchbox-input-container" class="input-append pill-container">
+                            <div id="searchbox-input-container" class="input-append pill-container" tabindex="0">
                                 <i class="search_icon zulip-icon zulip-icon-search"></i>
                                 <div class="search-input-and-pills">
                                     <div class="search-input input" id="search_query" type="text" data-placeholder-text="{{t 'Search' }}"


### PR DESCRIPTION
As discussed here:
https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20search.20box.20stealing.20focus/near/2381758

![Kapture 2026-02-18 at 15 40 16](https://github.com/user-attachments/assets/3921f7c9-32ec-4249-aafe-211a456d4bd4)
