### PR TITLE
navbar: Show banner when API rate limit is exceeded

### DIFF
--- a/web/src/channel.ts
+++ b/web/src/channel.ts
@@ -36,6 +36,12 @@ export function set_password_change_in_progress(value: boolean): void {
     }
 }
 
+let rate_limit_handler: ((retrySeconds: number) => void) | undefined;
+
+export function set_rate_limit_handler(handler: (retrySeconds: number) => void): void {
+    rate_limit_handler = handler;
+}
+
 function call(args: AjaxRequestHandlerOptions): JQuery.jqXHR<unknown> | undefined {
     if (reload_state.is_in_progress() && !args.ignore_reload) {
         // If we're in the process of reloading, most HTTP requests
@@ -98,47 +104,64 @@ function call_in_span(
             return;
         }
 
-        if (xhr.status === 401) {
-            if (password_change_in_progress || orig_password_changes !== password_changes) {
-                // The backend for handling password change API requests
-                // will replace the user's session; this results in a
-                // brief race where any API request will fail with a 401
-                // error after the old session is deactivated but before
-                // the new one has been propagated to the browser.  So we
-                // skip our normal HTTP 401 error handling if we're in the
-                // process of executing a password change.
-                return;
-            }
+        switch (xhr.status) {
+            case 401: {
+                if (password_change_in_progress || orig_password_changes !== password_changes) {
+                    // The backend for handling password change API requests
+                    // will replace the user's session; this results in a
+                    // brief race where any API request will fail with a 401
+                    // error after the old session is deactivated but before
+                    // the new one has been propagated to the browser.  So we
+                    // skip our normal HTTP 401 error handling if we're in the
+                    // process of executing a password change.
+                    return;
+                }
 
-            if (page_params.page_type === "home" && page_params.is_spectator) {
-                // In theory, the spectator implementation should be
-                // designed to prevent accessing widgets that would
-                // make network requests not available to spectators.
-                //
-                // In the case that we have a bug in that logic, we
-                // prefer the user experience of offering the
-                // login_to_access widget over reloading the page.
-                spectators.login_to_access();
-            } else if (page_params.page_type === "home") {
-                // We got logged out somehow, perhaps from another window
-                // changing the user's password, or a session timeout.  We
-                // could display an error message, but jumping right to
-                // the login page conveys the same information with a
-                // smoother relogin experience.
-                window.location.replace(page_params.login_page);
-                return;
+                if (page_params.page_type === "home" && page_params.is_spectator) {
+                    // In theory, the spectator implementation should be
+                    // designed to prevent accessing widgets that would
+                    // make network requests not available to spectators.
+                    //
+                    // In the case that we have a bug in that logic, we
+                    // prefer the user experience of offering the
+                    // login_to_access widget over reloading the page.
+                    spectators.login_to_access();
+                } else if (page_params.page_type === "home") {
+                    // We got logged out somehow, perhaps from another window
+                    // changing the user's password, or a session timeout.  We
+                    // could display an error message, but jumping right to
+                    // the login page conveys the same information with a
+                    // smoother relogin experience.
+                    window.location.replace(page_params.login_page);
+                    return;
+                }
+                break;
             }
-        } else if (xhr.status === 403) {
-            if (xhr.responseJSON === undefined) {
-                blueslip.error("Unexpected 403 response from server", {
-                    xhr: xhr.responseText,
-                    args,
-                });
-            } else if (
-                z.object({code: z.literal("CSRF_FAILED")}).safeParse(xhr.responseJSON).success &&
-                reload_state.csrf_failed_handler !== undefined
-            ) {
-                reload_state.csrf_failed_handler();
+            case 403: {
+                if (xhr.responseJSON === undefined) {
+                    blueslip.error("Unexpected 403 response from server", {
+                        xhr: xhr.responseText,
+                        args,
+                    });
+                } else if (
+                    z.object({code: z.literal("CSRF_FAILED")}).safeParse(xhr.responseJSON)
+                        .success &&
+                    reload_state.csrf_failed_handler !== undefined
+                ) {
+                    reload_state.csrf_failed_handler();
+                }
+                break;
+            }
+            case 429: {
+                const response_json = z
+                    .object({"retry-after": z.number()})
+                    .safeParse(xhr.responseJSON);
+                const retry_after = Number(
+                    xhr.getResponseHeader("Retry-After") ??
+                        (response_json.success ? response_json.data["retry-after"] : 0),
+                );
+                rate_limit_handler?.(retry_after);
+                break;
             }
         }
         orig_error(xhr, error_type, xhn);

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -181,6 +181,14 @@ export function should_offer_to_update_timezone(): boolean {
     );
 }
 
+export function show_rate_limit_banner(retry_seconds: number): void {
+    const $existing = $("#navbar_alerts_wrapper").find("[data-process='rate-limit']");
+    if ($existing.length > 0) {
+        return;
+    }
+    open_navbar_banner_and_resize(rate_limit_banner(retry_seconds));
+}
+
 const DESKTOP_NOTIFICATIONS_BANNER: AlertBanner = {
     process: "desktop-notifications",
     intent: "brand",
@@ -460,6 +468,26 @@ const majority_messages_muted_banner = (percent_muted_messages: number): AlertBa
                 custom_classes: "dismiss-majority-messages-muted-banner",
             },
         ],
+        close_button: true,
+        custom_classes: "navbar-alert-banner",
+    };
+};
+
+const rate_limit_banner = (retry_seconds: number): AlertBanner => {
+    const minutes = Math.floor(retry_seconds / 60);
+    const seconds = retry_seconds % 60;
+    const time_str = minutes > 0 ? `${minutes} minutes ${seconds} seconds` : `${seconds} seconds`;
+    return {
+        process: "rate-limit",
+        intent: "danger",
+        label: $t(
+            {
+                defaultMessage:
+                    "You've exceeded Zulip's usage limits. Please close any extra Zulip tabs, and try again after {time}.",
+            },
+            {time: time_str},
+        ),
+        buttons: [],
         close_button: true,
         custom_classes: "navbar-alert-banner",
     };
@@ -813,10 +841,18 @@ export function initialize(): void {
                     open_navbar_banner_and_resize(time_zone_update_offer_banner());
                     popover_menus.hide_current_popover_if_visible(instance);
                 });
+                $popper.on("click", ".rate-limit", () => {
+                    show_rate_limit_banner(125);
+                    popover_menus.hide_current_popover_if_visible(instance);
+                });
             },
             onHidden(instance) {
                 instance.destroy();
             },
         });
+    });
+
+    channel.set_rate_limit_handler((retry_seconds) => {
+        show_rate_limit_banner(retry_seconds);
     });
 }

--- a/web/templates/popovers/navbar_banners_testing_popover.hbs
+++ b/web/templates/popovers/navbar_banners_testing_popover.hbs
@@ -60,5 +60,11 @@
                 <span class="popover-menu-label">{{t "Time zone update offer"}}</span>
             </a>
         </li>
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="rate-limit popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-edit" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Rate limit exceeded"}}</span>
+            </a>
+        </li>
     </ul>
 </div>

--- a/web/tests/channel.test.cjs
+++ b/web/tests/channel.test.cjs
@@ -302,6 +302,30 @@ test("unexpected_403_response", () => {
     });
 });
 
+test("rate_limit_429", () => {
+    let rate_limit_seconds;
+    channel.set_rate_limit_handler((seconds) => {
+        rate_limit_seconds = seconds;
+    });
+
+    test_with_mock_ajax({
+        xhr: {
+            status: 429,
+            getResponseHeader: (header) => (header === "Retry-After" ? "120" : null),
+            responseJSON: undefined,
+        },
+
+        run_code() {
+            channel.post({url: "/json/endpoint"});
+        },
+
+        check_ajax_options(options) {
+            options.simulate_error();
+            assert.equal(rate_limit_seconds, 120);
+        },
+    });
+});
+
 test("xhr_error_message", () => {
     let xhr = {
         status: "200",


### PR DESCRIPTION
When a user exceeds the API rate limit and receives a 429 response, we now show a dedicated red banner in the navbar with the message and retry time parsed from the Retry-After header.

Changes:
- channel.ts: Added a set_rate_limit_handler callback and 429 handling in wrapped_error using a switch statement (refactored from if/else if). The retry time is safely parsed from the response using zod.
- navbar_alerts.ts: Added rate_limit_banner and show_rate_limit_banner with a duplicate guard. Registered the handler in initialize(). Added entry to the dev testing popover.
- navbar_banners_testing_popover.hbs: Added "Rate limit exceeded" entry to the testing popover.

Fixes: #37618

**How changes were tested:**
Triggered manually via the navbar banners testing popover in the dev environment.

**Screenshots and screen captures:**
<img width="1439" height="562" alt="Screenshot 2026-02-19 171152" src="https://github.com/user-attachments/assets/bca22872-48cc-4d45-899e-94e11b93865c" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
