### PR TITLE
message_scroll: Fix scroll-to-bottom hiding behavior.

### DIFF
--- a/web/src/message_scroll.ts
+++ b/web/src/message_scroll.ts
@@ -14,7 +14,7 @@ import * as unread_ops from "./unread_ops.ts";
 import * as unread_ui from "./unread_ui.ts";
 import {the} from "./util.ts";
 
-let hide_scroll_to_bottom_timer: ReturnType<typeof setTimeout> | undefined;
+let hide_scroll_to_bottom_timer: ReturnType<typeof setInterval> | undefined;
 export function hide_scroll_to_bottom(): void {
     const $show_scroll_to_bottom_button = $("#scroll-to-bottom-button-container");
     if (message_lists.current === undefined) {
@@ -33,11 +33,15 @@ export function hide_scroll_to_bottom(): void {
         return;
     }
 
-    // Wait before hiding to allow user time to click on the button.
-    hide_scroll_to_bottom_timer = setTimeout(() => {
-        // Don't hide if user is hovered on it.
+    hide_scroll_to_bottom_timer = setInterval(() => {
+        // Check if the user is hovered over the scroll-to-bottom
+        // button every 3 seconds to allow time for interaction.
+        // If the user is not hovered on the button, hide the button
+        // and clear the timer until the next scroll event triggers
+        // showing the button again.
         if (!the($show_scroll_to_bottom_button).matches(":hover")) {
             $show_scroll_to_bottom_button.removeClass("show");
+            clearInterval(hide_scroll_to_bottom_timer);
         }
     }, 3000);
 }
@@ -50,7 +54,7 @@ export function show_scroll_to_bottom_button(): void {
         return;
     }
 
-    clearTimeout(hide_scroll_to_bottom_timer);
+    clearInterval(hide_scroll_to_bottom_timer);
     $("#scroll-to-bottom-button-container").addClass("show");
 }
 


### PR DESCRIPTION
This PR fixes the following issues:
- Scroll-to-bottom button not hiding in topic views.
- Scroll-to-bottom button not hiding in non-message views.
- Scroll-to-bottom button not hiding after hovering on it for longer than 3 seconds.

Fixes: [#issues > 🎯 scroll-to-bottom in recent conversations](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20scroll-to-bottom.20in.20recent.20conversations/with/2385528) & [#issues > 🎯 scroll-to-bottom button hangs around in topic views](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20scroll-to-bottom.20button.20hangs.20around.20in.20topic.20views/with/2385512)

**How changes were tested:** Checking the actual behavior against the expected behavior.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
| Desc | Before | After |
|--------|--------|--------|
| Topic View | ![stb-hover-topic-before](https://github.com/user-attachments/assets/920a7145-faca-4a9e-9f4e-06026dd9490a) | ![stb-hover-topic-after](https://github.com/user-attachments/assets/ca485dc3-710e-40eb-8164-acfb979db228) |
| Non-message View | ![stb-hiding-recent-conv-before](https://github.com/user-attachments/assets/e9c341ee-10e7-4a7b-8a6c-2a3efedfdcd2) | ![stb-hiding-recent-conv-after](https://github.com/user-attachments/assets/d734d412-463a-4189-b71c-24ae1ddaa748) |
| Hovering longer than 3 seconds | ![stb-hover-hiding-before](https://github.com/user-attachments/assets/d3606f07-998f-4739-95ec-be0816973267) | ![stb-hover-hiding-after](https://github.com/user-attachments/assets/7cc87b8e-7e90-44b8-9a89-307f361dabb1) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
