### PR TITLE
message_header: Hide icons on mobile widths.

### DIFF
--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -341,3 +341,27 @@
         display: none;
     }
 }
+
+@container message-lists (width <  $cq_ml_min) {
+    .recipient-bar-control {
+        display: none;
+
+        /* Always show the vdots */
+        &.recipient-row-topic-menu {
+            display: block;
+        }
+    }
+}
+
+@media (width < $ml_min) {
+    .without-container-query-support {
+        .recipient-bar-control {
+            display: none;
+
+            /* Always show the vdots */
+            &.recipient-row-topic-menu {
+                display: block;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is another attempt at redoing
fb40a7fc61f3dea72e2e5646a37b2948273997a2 with a very conservative breakpoint that would only hide icons on mobile widths. It should be a net improvement
though it doesn't factor the content length
to decide whether to hide the message header icons.

This is a partial fix for the closed #34338.

The ideal fix for this is documented in #37491.

<details>
  <summary> demo</summary>
  <br>

  <img src="https://github.com/user-attachments/assets/3ebbe951-b376-4fe0-8233-638ec1f8110a" alt="demo gif" />

</details>