### PR TITLE
api-docs: Update feature level 435 for changes to report_type param.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -286,6 +286,12 @@ element to plain escaped text.
 * [`POST /register`](/api/register-queue): Added `server_report_message_types`
   field which contains a list of supported report types for the [message
   report](/help/report-a-message) feature.
+* [`POST /message/{message_id}/report`](/api/report-message): Clients
+  that support the [message report](/help/report-a-message) feature
+  should use the `key` values in the `server_report_message_types` as the
+  valid values for the `report_type` parameter. Prior to this feature
+  level, the valid values for the `report_type` parameter were limited to:
+  `"harassment"`, `"inappropriate"`, `"norms"`, `"other"`, `"spam"`.
 
 **Feature level 434**
 
@@ -774,8 +780,9 @@ No changes; API feature level used for the Zulip 11.0 release.
 
 **Feature level 382**
 
-* `POST /message/{message_id}/report`: Added a new endpoint for submitting
-  a moderation request for a message.
+* [`POST /message/{message_id}/report`](/api/report-message): Added a new
+  endpoint for [submitting a moderation request](/help/report-a-message)
+  for a message.
 
 **Feature level 381**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10275,9 +10275,9 @@ paths:
       summary: Report a message
       tags: ["messages"]
       description: |
-        Sends a notification to the organization's moderation request channel,
-        if it is configured, that reports the targeted message for review and
-        moderation.
+        Sends a notification to the organization's [moderation request
+        channel](/help/enable-moderation-requests), if it is configured, that
+        reports the targeted message for [review and moderation](/help/report-a-message).
 
         Clients should check the `moderation_request_channel` realm setting to
         decide whether to show the option to report messages in the UI.
@@ -10302,13 +10302,14 @@ paths:
                   description: |
                     The reason that best describes why the current user is reporting the
                     target message for moderation.
+
+                    Must be one of the `key` values in the `server_report_message_types`
+                    field in the [`POST /register`](/api/register-queue) response.
+
+                    **Changes**: Prior to Zulip 12.0 (feature level 435), the allowed
+                    values for this parameter were limited to: `"harassment"`,
+                    `"inappropriate"`, `"norms"`, `"other"`, `"spam"`.
                   type: string
-                  enum:
-                    - spam
-                    - harassment
-                    - inappropriate
-                    - norms
-                    - other
                   example: harassment
                 description:
                   description: |


### PR DESCRIPTION
As discussed in [#api design > Adding message report reason types to API. #36489 @ 💬](https://chat.zulip.org/#narrow/channel/378-api-design/topic/Adding.20message.20report.20reason.20types.20to.20API.2E.20.2336489/near/2384719):
- Updates the `report_type` parameter of the `/api/report-message` endpoint doc for the addition of `server_report_message_types` to the `/api/register` response.
- Updates the feature level 435 entry in the API changelog for this as well.
- Adds some links to the help center articles related to the report message feature and configuring the moderation channel, and links to the documentation for the `/api/report-message` endpoint.

---

**Screenshots and screen captures:**

[API CHANGELOG](https://zulip.com/api/changelog)
<img width="1516" height="420" alt="Screenshot From 2026-02-19 16-26-08" src="https://github.com/user-attachments/assets/4845f6ed-6740-4a1c-b919-ecfa9041835a" />

[REPORT_TYPE PARAMETER](https://zulip.com/api/report-message#parameter-report_type)
<img width="1516" height="482" alt="Screenshot From 2026-02-19 16-26-20" src="https://github.com/user-attachments/assets/7d06a816-7853-4c88-b001-1ee5e68f8016" />


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
