### PR TITLE
api-docs: Expand the section on the HTTP Basic auth header.

### DIFF
--- a/api_docs/http-headers.md
+++ b/api_docs/http-headers.md
@@ -4,8 +4,9 @@ This page documents the HTTP headers used by the Zulip API.
 
 !!! tip ""
 
-    The `curl` example on each endpoint's documentation page, details
-    the request format. You can access curl's documentation at `man curl`.
+    Full details of the HTTP requests are given in the `curl` example
+    on each endpoint's documentation page. You can access curl's
+    documentation at [`man curl`](https://curl.se/docs/manpage.html).
 
 ## The `Authorization` header
 
@@ -16,15 +17,21 @@ care of when you configure said bindings.
 
 Otherwise, to authenticate an API request:
 
-- Use HTTP Basic authentication, which is described [here][mdn-auth-headers].
-  This means sending an HTTP header named Authorization, with your
+- Use HTTP `Basic` authentication, which is described [here][mdn-auth-headers].
+  This means sending an HTTP header named `Authorization`, with your
   credentials [in a certain format][mdn-basic-auth].
 
-- For your credentials in HTTP Basic authentication, use a bot's email
-  as the "username" and its [API key](/api/api-keys) as the "password".
-  In the `curl` example for each endpoint, this is shown as:
+- For `Basic` authentication credentials in the Zulip API, a "username"
+  takes the form of an email address, and a "password" takes the form of
+  an API key. In the `curl` example for each endpoint, this is shown as:
+  `-u BOT_EMAIL_ADDRESS:BOT_API_KEY`.
 
-    `-u BOT_EMAIL_ADDRESS:BOT_API_KEY`.
+- A bot's credentials can be obtained through the web and desktop apps'
+  [bot management UI](/help/manage-a-bot) or by [downloading the bot's
+  zuliprc file](/api/configuring-python-bindings#download-a-zuliprc-file).
+
+- See [fetch an API key (production)](/api/fetch-api-key) for the
+  password-based authentication flow for getting a user's credentials.
 
 ## The `User-Agent` header
 


### PR DESCRIPTION
Based on @gnprice's review feedback on #38024 and discussion in [#api documentation > API docs shouldn't refer to "BOT_EMAIL_ADDRESS" #479](https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/API.20docs.20shouldn't.20refer.20to.20.22BOT_EMAIL_ADDRESS.22.20.23479/with/2385670):
- Expands the section on the `Authorization` header to include the basic structure of the `Basic` auth credentials in the Zulip API and information for how to get those credentials for bots and users.
- Cleans up some formatting, revises the tip at the top of the page and adds a link to the `man curl` doc online.
- Potential follow-up is updating the `-u BOT_EMAIL_ADDRESS:BOT_API_KEY` line shown in the curl examples of the API docs.

**Screenshots and screen captures:**

[CURRENT DOC ON CZO](https://chat.zulip.org/api/http-headers)
<img width="1496" height="1178" alt="Screenshot From 2026-02-20 12-03-57" src="https://github.com/user-attachments/assets/fa749051-e863-48ea-99b2-ebaed4e75f75" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
