### PR TITLE
Document avatar URL endpoints and filename convention.

### DIFF
--- a/zerver/lib/storage.py
+++ b/zerver/lib/storage.py
@@ -32,23 +32,21 @@ class IgnoreBundlesManifestStaticFilesStorage(ManifestStaticFilesStorage):
         filename: str | None = None,
     ) -> str:
         """
-        Because the protocol for getting medium-size avatar URLs
-        was never fully documented, the mobile apps use a
-        substitution of the form s/.png/-medium.png/ to get the
-        medium-size avatar URLs.
+        Generate hashed filenames for system bot avatars that follow the
+        same "-medium" suffix convention used for user-uploaded avatars.
 
-        This function hashes system bots' avatar files in a way
-        that follows the pattern used for user-uploaded avatars.
+        Clients obtain medium-size avatar URLs by adding the "-medium"
+        suffix before the file extension:
 
-        It ensures the following:
+            avatar.png → avatar-medium.png
 
-            * Hashed filenames for system bot avatars follow this
-            naming convention:
-            - avatar.png -> avatar-medium.png
+        This function ensures that:
 
-            * The system bots' default avatar file and its medium
-            version share the same hash:
-            - bot.36f721bad3d0.png -> bot.36f721bad3d0-medium.png
+        * System bot avatars follow the same naming convention as
+        user-uploaded avatars.
+        * The default and medium versions share the same hash:
+
+            bot.36f721bad3d0.png → bot.36f721bad3d0-medium.png
         """
 
         def reformat_medium_filename(hashed_name: str) -> str:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10499,6 +10499,73 @@ paths:
                         "url": "/user_uploads/temporary/322F32632F39765378464E4C63306D3961396F4970705A4D74424565432F7A756C69702E7478743A316A5053616A3A3938625F44393446466D37357254315F4F414C425A4553464F6A55",
                       }
 
+  /avatar/{email_or_id}:
+    get:
+      operationId: get-avatar
+      summary: Get a user's avatar
+      tags: ["users"]
+      description: |
+        Fetches the avatar for a user, by redirecting (HTTP 302) to
+        the URL of the avatar image.
+
+        The redirect target depends on the user's avatar source:
+
+        - User-uploaded avatars: `/user_avatars/{realm_id}/{hash}.png`
+        - Gravatar users: `https://secure.gravatar.com/avatar/{hash}?d=identicon`
+        - System bots: `/static/images/static_avatars/{name}.png`
+
+        The default avatar is at most 100x100 pixels. Non-Gravatar
+        avatars are always served as PNG files. Gravatar avatars may
+        be in other formats depending on the user's Gravatar settings.
+
+        Clients can construct custom-sized Gravatar URLs as described
+        in the [Gravatar documentation](https://docs.gravatar.com/api/avatars/images/).
+
+        This endpoint does not require authentication.
+      parameters:
+        - name: email_or_id
+          in: path
+          description: |
+            The user ID or email of the target user.
+          schema:
+            oneOf:
+              - type: integer
+              - type: string
+          example: 12
+          required: true
+      responses:
+        "302":
+          description: |
+            Redirects to the avatar image URL.
+  /avatar/{email_or_id}/medium:
+    get:
+      operationId: get-avatar-medium
+      summary: Get a user's medium-size avatar
+      tags: ["users"]
+      description: |
+        Like [`GET /avatar/{email_or_id}`](/api/get-avatar), but
+        returns the 500x500 pixel version of the avatar.
+
+        Clients can also obtain the medium-size avatar by appending
+        `-medium` before the file extension in the default avatar
+        URL (e.g., `avatar.png` becomes `avatar-medium.png`). This
+        works for user-uploaded avatars and system bot avatars.
+      parameters:
+        - name: email_or_id
+          in: path
+          description: |
+            The user ID or email of the target user.
+          schema:
+            oneOf:
+              - type: integer
+              - type: string
+          example: 12
+          required: true
+      responses:
+        "302":
+          description: |
+            Redirects to the medium-size avatar image URL.
+
   /users:
     get:
       operationId: get-users

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -210,6 +210,7 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         # and thus may be complicated to document with our current tooling.
         # (No /api/v1/ or /json prefix).
         "/avatar/{email_or_id}",
+        "/avatar/{email_or_id}/medium",
         ## This one isn't really representable
         # "/user_uploads/{realm_id_str}/{filename}",
         #### These realm administration settings are valuable to document:
@@ -921,7 +922,7 @@ class OpenAPIAttributesTest(ZulipTestCase):
         * All example events in `/get-events` match an event schema.
         * That no opaque object exists.
         """
-        EXCLUDE = ["/real-time"]
+        EXCLUDE = ["/real-time", "/avatar/{email_or_id}", "/avatar/{email_or_id}/medium"]
         VALID_TAGS = [
             "users",
             "server_and_organizations",
@@ -1043,6 +1044,9 @@ class APIDocsSidebarTest(ZulipTestCase):
         exempted_docs = {
             # (No /api/v1/ or /json prefix).
             "get-file-temporary-url",
+            # (No /api/v1/ or /json prefix).
+            "get-avatar",
+            "get-avatar-medium",
             # This one is not used by any clients and is likely to get
             # deprecated.
             "update-subscriptions",


### PR DESCRIPTION
**Api Docs: Document avatar URL endpoints and filename convention.**

<!-- Describe your pull request here.-->

Currently the avatar URLs via /avatar/{email|user_id}/ and
/avatar/{email|user_id}/medium endpoints, which primarily redirect
to user-uploaded avatars, Gravatar URLs, or static bot avatars.
These endpoints and their behavior were previously undocumented.

Redirect behavior and avatar sources (uploaded, Gravatar, system bots)
Default and medium avatar sizes
The "-medium" filename convention for medium avatars
File formats served by the server



Fixes: <!-- Issue link, or clear description.-->(#32103 )


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<div style="display: flex; justify-content: center; gap: 10px;">
  <img src="https://github.com/user-attachments/assets/4c486535-ab7f-4ed7-b0e0-c758dfafe2a6"
       width="350"
       height="600"
       style="object-fit: cover;" />

  <img src="https://github.com/user-attachments/assets/3b94ed63-6fd8-4558-8642-5c94fd21037c"
       width="350"
       height="600"
       style="object-fit: cover;" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>