### PR TITLE
upload: Coerce EmailMessage content-type header to str.

### DIFF
--- a/zerver/lib/upload/__init__.py
+++ b/zerver/lib/upload/__init__.py
@@ -98,7 +98,7 @@ def maybe_add_charset(content_type: str, file_data: bytes | StreamingSourceWithS
         # so we set a much lower threshold if that's the best guess.
         # https://en.wikipedia.org/wiki/Popularity_of_text_encodings
         fake_msg.set_param("charset", detected["encoding"], replace=True)
-    return fake_msg["content-type"]
+    return str(fake_msg["content-type"])
 
 
 def create_attachment(
@@ -154,7 +154,7 @@ def get_file_info(user_file: UploadedFile) -> tuple[str, str]:
     if user_file.content_type_extra:
         extras = {k: v.decode() if v else None for k, v in user_file.content_type_extra.items()}
     fake_msg.add_header("content-type", content_type, **extras)
-    content_type = fake_msg["content-type"]
+    content_type = str(fake_msg["content-type"])
 
     uploaded_file_name = unquote(uploaded_file_name)
 


### PR DESCRIPTION
`fake_msg["content-type"]` returns a
`email.headerregistry._ContentTypeHeader` object, which stringifies to the expected thing.  However, this is not enough for Django's `FileResponse`, which requires that it actually be a `str`.  This caused failures when attempting to download files with guessed charsets in development.

Coerce the object into being a string, so our return types are not lies.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
