### PR TITLE
topic_link_util: Fix inaccurate comment on relative vs. absolute URLs.

### DIFF
--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -87,9 +87,9 @@ function _get_topic_link_content(opts: {
     const stream_id = stream.stream_id;
     const escape = html_escape_markdown_syntax_characters;
     if (topic_name !== undefined) {
-        // This url is relative, which is fine since it aims to mimic the behavior of the
-        // #**stream>topic** syntax, which also appears as a relative link in the web app
-        // and is not expected to work outside of the current realm / Zulip.
+        // This URL is relative, unlike the absolute URLs we use in quoting a message.
+        // See discussion:
+        //   https://chat.zulip.org/#narrow/channel/101-design/topic/.E2.9C.94.20.22quote.20message.22.20uses.20absolute.20URL.20instead.20of.20realm-rela.2E.2E.2E/near/2325588
         const stream_topic_url = hash_util.by_stream_topic_url(stream_id, topic_name);
         const topic_display_name = util.get_final_topic_display_name(topic_name);
         if (message_id !== undefined) {


### PR DESCRIPTION
This comment's reasoning wasn't accurate.  The point is that the `#**channel>topic**` syntax itself wouldn't work outside of Zulip nor outside the current realm.  The reference to how the link gets rendered (which moreover is done by the server, not the web app) is irrelevant to our choices here.  After all, the link on a quoted message is equally turned into a relative link when the server renders it -- but that's exactly the case that this contrasts with.

The inaccurate summary was exacerbated by not having a link to the chat thread where this was discussed.  For anyone trying to understand this code in the future, that would leave them in an unenviable situation of archaeology.

Instead, replace the summary with the most essential point: this behavior differs from that of quoted-message links, and that's an intentional choice.  Include the link so a reader can be sure to get the full reasoning behind that choice.

Follow-up from #38067; /cc @kuv2707, @timabbott.