### PR TITLE
compose: Preserve indentation when continuing lists.

### DIFF
--- a/web/src/bulleted_numbered_list_util.ts
+++ b/web/src/bulleted_numbered_list_util.ts
@@ -1,15 +1,29 @@
 export const get_last_line = (text: string): string => text.slice(text.lastIndexOf("\n") + 1);
 
-export const is_bulleted = (line: string): boolean =>
-    line.startsWith("- ") || line.startsWith("* ") || line.startsWith("+ ");
-
 // look for all consecutive whitespace characters at the beginning of the line
 export const get_indentation = (line: string): string => /^\s*/.exec(line)?.[0] ?? "";
 
+// look if the line starts with bullet syntaxes ("- ", "* ", "+ "),
+// after trimming the leading whitespace characters (indentation handling)
+export const is_bulleted = (line: string): boolean => {
+    const trimmed_line = line.trimStart();
+    return (
+        trimmed_line.startsWith("- ") ||
+        trimmed_line.startsWith("* ") ||
+        trimmed_line.startsWith("+ ")
+    );
+};
+
 // testing against regex for string with numbered syntax, that is,
 // any string starting with digit/s followed by a period and space
-export const is_numbered = (line: string): boolean => /^\d+\. /.test(line);
+export const is_numbered = (line: string): boolean => /^\s*\d+\. /.test(line);
 
-export const strip_bullet = (line: string): string => line.slice(2);
+export const strip_bullet = (line: string): string => {
+    const trimmed_line = line.trimStart();
+    return trimmed_line.slice(2);
+};
 
-export const strip_numbering = (line: string): string => line.slice(line.indexOf(" ") + 1);
+export const strip_numbering = (line: string): string => {
+    const trimmed_line = line.trimStart();
+    return trimmed_line.slice(trimmed_line.indexOf(" ") + 1);
+};

--- a/web/src/bulleted_numbered_list_util.ts
+++ b/web/src/bulleted_numbered_list_util.ts
@@ -3,6 +3,9 @@ export const get_last_line = (text: string): string => text.slice(text.lastIndex
 export const is_bulleted = (line: string): boolean =>
     line.startsWith("- ") || line.startsWith("* ") || line.startsWith("+ ");
 
+// look for all consecutive whitespace characters at the beginning of the line
+export const get_indentation = (line: string): string => /^\s*/.exec(line)?.[0] ?? "";
+
 // testing against regex for string with numbered syntax, that is,
 // any string starting with digit/s followed by a period and space
 export const is_numbered = (line: string): boolean => /^\d+\. /.test(line);

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -283,9 +283,12 @@ function handle_bulleting_or_numbering(
     if (bulleted_numbered_list_util.is_bulleted(previous_line)) {
         // if previous line had only bullet, remove it and stay on the same line
         if (bulleted_numbered_list_util.strip_bullet(previous_line) === "") {
-            // below we select and replace the last 2 characters in the textarea before
-            // the cursor - the bullet syntax - with an empty string
-            util.the($textarea).setSelectionRange($textarea.caret() - 2, $textarea.caret());
+            // below we select and replace the indentation and last 2 characters
+            // in the textarea before the cursor - the bullet syntax - with an empty string
+            util.the($textarea).setSelectionRange(
+                $textarea.caret() - indentation.length - 2,
+                $textarea.caret(),
+            );
             compose_ui.insert_and_scroll_into_view("", $textarea);
             e.preventDefault();
             return;

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -276,6 +276,8 @@ function handle_bulleting_or_numbering(
     assert(val !== undefined);
     const before_text = split_at_cursor(val, $textarea)[0];
     const previous_line = bulleted_numbered_list_util.get_last_line(before_text);
+    const trimmed_line = previous_line.trim();
+    const indentation = bulleted_numbered_list_util.get_indentation(previous_line);
     let to_append = "";
     // if previous line was bulleted, automatically add a bullet to the new line
     if (bulleted_numbered_list_util.is_bulleted(previous_line)) {
@@ -288,8 +290,8 @@ function handle_bulleting_or_numbering(
             e.preventDefault();
             return;
         }
-        // use same bullet syntax as the previous line
-        to_append = previous_line.slice(0, 2);
+        // use same indentation and bullet syntax as the previous line
+        to_append = indentation + trimmed_line.slice(0, 2);
     } else if (bulleted_numbered_list_util.is_numbered(previous_line)) {
         // if previous line was numbered, continue numbering with the new line
         const previous_number_string = previous_line.slice(0, previous_line.indexOf("."));
@@ -306,7 +308,7 @@ function handle_bulleting_or_numbering(
             return;
         }
         const previous_number = Number.parseInt(previous_number_string, 10);
-        to_append = previous_number + 1 + ". ";
+        to_append = indentation + (previous_number + 1) + ". ";
     }
     // if previous line was neither numbered nor bulleted, only add
     // a new line to emulate default behaviour (to_append is blank)


### PR DESCRIPTION
**Description**
Previously, pressing Shift + Enter on an indented list line would lose the indentation. Also, pressing Shift + Enter on an empty indented list wouldn't remove the list (note that this issue isn't directly mentioned in #37737, but create inconsistent behavior between indented and non-indented list). This updates the list continuation logic to preserve leading whitespace from the previous line and handling indentation for indented list removal.

The change modifies handle_bulleting_or_numbering() to prepend the extracted indentation to new list marker. When removing an empty list item (Shift+Enter on empty list), we now also remove its indentation along with the list marker syntax by calculating the total characters to remove and fixing is_numbered and is_bulleted condition to handle indented list.

Fixes: #37737 

**How changes were tested:**
I manually tested the fix by composing the following messages:
```
- Message 1
  - Message 2
```
Then, when the caret was at the end of the line, I pressed Shift + Enter (on Windows). The same steps were used to test numbered list. Finally, on an empty line, I pressed Shift + Enter once again to test if the list disappeared, which is the behavior for non indented list.

**Screenshots and screen captures:**
> Testing Shift+Enter on indented bullet list, then Shift+Enter on empty bullet indented list
![lIl0dVrkfz](https://github.com/user-attachments/assets/2de44f4b-5bbb-49a0-8b9c-0444e0cfdc3d)

> Testing Shift+Enter on numbered indented list, then Shift+Enter on empty numbered indented list
![QXz8YIGwzt](https://github.com/user-attachments/assets/d1ef7b94-4284-412c-b21e-7ef3ccd4f910)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
