### PR TITLE
settings: Improve Code Playground language typeahead alias matching

### DIFF
--- a/web/src/realm_playground.ts
+++ b/web/src/realm_playground.ts
@@ -33,6 +33,10 @@ export function get_playground_info_for_languages(lang: string): RealmPlayground
     return map_language_to_playground_info.get(lang);
 }
 
+export function get_aliases_for_pretty_name(pretty_name: string): string[] {
+    return map_pygments_pretty_name_to_aliases.get(pretty_name) ?? [];
+}
+
 function sort_pygments_pretty_names_by_priority(
     comparator_func: (a: string, b: string) => number,
 ): void {

--- a/web/src/settings_playgrounds.ts
+++ b/web/src/settings_playgrounds.ts
@@ -3,7 +3,6 @@ import $ from "jquery";
 import render_admin_playground_list from "../templates/settings/admin_playground_list.hbs";
 
 import {Typeahead} from "./bootstrap_typeahead.ts";
-import * as bootstrap_typeahead from "./bootstrap_typeahead.ts";
 import type {TypeaheadInputElement} from "./bootstrap_typeahead.ts";
 import * as channel from "./channel.ts";
 import * as confirm_dialog from "./confirm_dialog.ts";
@@ -14,6 +13,7 @@ import * as realm_playground from "./realm_playground.ts";
 import type {RealmPlayground} from "./realm_playground.ts";
 import * as scroll_util from "./scroll_util.ts";
 import {current_user, realm} from "./state_data.ts";
+import * as typeahead from "./typeahead.ts";
 import {render_typeahead_item} from "./typeahead_helper.ts";
 import * as ui_report from "./ui_report.ts";
 
@@ -170,10 +170,48 @@ function build_page(): void {
         },
         matcher(query: string): (item: string) => boolean {
             const q = query.trim().toLowerCase();
-            return (item: string) => item.toLowerCase().startsWith(q);
+
+            if (q === "") {
+                return () => true;
+            }
+
+            return (item: string) =>
+                item.toLowerCase().startsWith(q) ||
+                realm_playground
+                    .get_aliases_for_pretty_name(item)
+                    .some((alias) => alias.toLowerCase().startsWith(q));
         },
         sorter(items: string[], query: string): string[] {
-            return bootstrap_typeahead.defaultSorter(items, query);
+            const q = query.trim().toLowerCase();
+
+            if (q === "") {
+                return items;
+            }
+
+            const {
+                exact_matches,
+                begins_with_case_sensitive_matches,
+                begins_with_case_insensitive_matches,
+            } = typeahead.triage_raw_with_multiple_items(q, items, (item) => [
+                item,
+                ...realm_playground.get_aliases_for_pretty_name(item),
+            ]);
+
+            const begins_with = [
+                ...exact_matches,
+                ...begins_with_case_sensitive_matches,
+                ...begins_with_case_insensitive_matches,
+            ];
+
+            // Move the "Custom language" option to the end so that
+            // canonical language names matched via aliases appear above it in the typeahead.
+            const exact_match_index = begins_with.indexOf(q);
+            if (exact_match_index !== -1 && begins_with.length > 1) {
+                begins_with.splice(exact_match_index, 1);
+                begins_with.push(q);
+            }
+
+            return begins_with;
         },
     });
 


### PR DESCRIPTION
Improve Code Playground language typeahead alias matching

Fixes: #24045

The language field in Code Playground settings only matched the canonical language name.
Aliases such as py, py3, python3 did not surface the canonical option.
The dropdown suggested creating a custom language, which could lead to misconfigured playgrounds.

This change makes the typeahead aware of Pygments aliases so the canonical language appears when an alias prefix is typed.

**Changes**

- Expose an alias lookup helper from realm_playground.ts
- Extend the typeahead matcher to match canonical names through aliases
- Replace the default sorter with an alias aware sorter
- Ensure canonical languages appear above the Custom language entry when matched through an alias
- Frontend only change. No backend or API impact

**Design decisions**

The issue was updated to clarify the expected behavior. Typing the start of any alias should match the canonical option instead of suggesting a custom language.
This change implements the behavior directly in the existing typeahead matcher and sorter to keep the scope small and focused.

**How changes were tested**

Manual testing in the development environment.

Scenarios tested

- Typing py shows Python as the first result
- Typing py3 shows Python as the first result
- Typing python3 shows Python as the first result
- Typing rs shows Rust as the first result
- Typing rust keeps Rust as the first result
- Typing a custom language keeps the existing behavior unchanged
- Creating and deleting playgrounds still works as before

Automated checks

- tools/test-js-with-node web/tests/realm_playground.test.cjs
- npx eslint web/src/settings_playgrounds.ts web/src/realm_playground.ts

Automated test note

No new unit tests were added because this change updates UI typeahead behavior. Existing JS tests pass and manual UI verification covers the change.

**Screenshots and screen captures:**

Before
Alias input suggested Custom language first.

<img width="979" height="365" alt="Screenshot 2026-02-20 005503" src="https://github.com/user-attachments/assets/ed624bf3-5d72-4cfc-bfab-d6f4eec242f0" />

After
Alias input suggests the canonical language first.

<img width="995" height="309" alt="Screenshot 2026-02-20 215620" src="https://github.com/user-attachments/assets/1efc8d43-1c3a-4dff-9da1-b6e7a7f4f6a1" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
