### PR TITLE
email_notifications: Refactor build_message_list payload to use dataclasses

### DIFF
--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -50,6 +50,25 @@ from zerver.models.messages import get_context_for_message
 from zerver.models.scheduled_jobs import NotificationTriggers
 from zerver.models.users import get_user_profile_by_id
 
+
+@dataclass
+class FormattedText:
+    plain: str
+    html: Markup
+
+
+@dataclass
+class SenderPayload:
+    sender: str
+    content: list[FormattedText]
+
+
+@dataclass
+class MessageListPayload:
+    senders: list[SenderPayload]
+    header: FormattedText | None = None
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -235,7 +254,7 @@ def build_message_list(
     user: UserProfile,
     messages: list[Message],
     stream_id_map: dict[int, Stream] | None = None,  # only needs id, name
-) -> dict[str, Any]:
+) -> MessageListPayload:
     """
     Builds the message list object for the message notification email and
     digest email template. All `messages` share the same recipient (and topic).
@@ -273,9 +292,7 @@ def build_message_list(
             message_soup.insert(0, sender_name_soup)
         return message_plain, Markup(BeautifulSoup.decode(message_soup))
 
-    def build_message_payload(
-        message: Message, sender: str | None = None
-    ) -> dict[str, str | Markup]:
+    def build_message_payload(message: Message, sender: str | None = None) -> FormattedText:
         plain = message.content
         plain = fix_plaintext_image_urls(plain)
         # There's a small chance of colliding with non-Zulip URLs containing
@@ -298,13 +315,13 @@ def build_message_list(
         html = Markup(lxml.html.tostring(fragment, encoding="unicode"))
         if sender:
             plain, html = prepend_sender_to_message(plain, html, sender)
-        return {"plain": plain, "html": html}
+        return FormattedText(plain=plain, html=html)
 
-    def build_sender_payload(message: Message) -> dict[str, Any]:
+    def build_sender_payload(message: Message) -> SenderPayload:
         sender = sender_string(message)
-        return {"sender": sender, "content": [build_message_payload(message, sender)]}
+        return SenderPayload(sender=sender, content=[build_message_payload(message, sender)])
 
-    def digest_block_header(message: Message) -> dict[str, Any]:
+    def digest_block_header(message: Message) -> FormattedText:
         assert message.recipient.type == Recipient.STREAM
         stream_id = message.recipient.type_id
         assert stream_id_map is not None
@@ -334,24 +351,7 @@ def build_message_list(
             narrow_link=narrow_link,
             topic_html=topic_html,
         )
-        return {
-            "plain": header,
-            "html": header_html,
-        }
-
-    # Collapse message list to:
-    # {
-    #     "header": {"plain": "header", "html": "htmlheader"},
-    #     "senders": [
-    #         {
-    #             "sender": "sender_name",
-    #             "content": [
-    #                 {"plain": "content", "html": "htmlcontent"},
-    #                 {"plain": "content", "html": "htmlcontent"},
-    #             ],
-    #         }
-    #     ],
-    # }
+        return FormattedText(plain=header, html=header_html)
 
     assert len(messages) > 0
     recipients = {(message.recipient_id, message.topic_name().lower()) for message in messages}
@@ -359,17 +359,17 @@ def build_message_list(
     messages.sort(key=lambda message: message.date_sent)
 
     sender_block = [build_sender_payload(messages[0])]
-    messages_to_render: dict[str, Any] = {"senders": sender_block}
+    messages_to_render = MessageListPayload(senders=sender_block)
+
     if stream_id_map:
         # Needed only for digest emails
-        header = digest_block_header(messages[0])
-        messages_to_render["header"] = header
+        messages_to_render.header = digest_block_header(messages[0])
 
     for message in messages[1:]:
         sender = sender_string(message)
-        # Same message sender, collapse again
-        if sender_block[-1]["sender"] == sender:
-            sender_block[-1]["content"].append(build_message_payload(message))
+        # Same message sender, collapse again using object attributes
+        if sender_block[-1].sender == sender:
+            sender_block[-1].content.append(build_message_payload(message))
         else:
             # Start a new sender block
             sender_block.append(build_sender_payload(message))

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -77,9 +77,9 @@ class TestDigestEmailMessages(ZulipTestCase):
 
         self.assertEqual(set(hot_convo["participants"]), expected_participants)
         self.assertEqual(hot_convo["count"], 5 - 2)  # 5 messages, but 2 shown
-        teaser_messages = hot_convo["first_few_messages"]["senders"]
-        self.assertIn("some content", teaser_messages[0]["content"][0]["plain"])
-        self.assertIn(teaser_messages[0]["sender"], expected_participants)
+        teaser_messages = hot_convo["first_few_messages"].senders
+        self.assertIn("some content", teaser_messages[0].content[0].plain)
+        self.assertIn(teaser_messages[0].sender, expected_participants)
 
         # If we run another batch, we reuse the topic queries; there
         # are 3 reused streams and one new one, for a net of two fewer
@@ -278,9 +278,9 @@ class TestDigestEmailMessages(ZulipTestCase):
 
             self.assertEqual(set(hot_convo["participants"]), expected_participants)
             self.assertEqual(hot_convo["count"], 5 - 2)  # 5 messages, but 2 shown
-            teaser_messages = hot_convo["first_few_messages"]["senders"]
-            self.assertIn("some content", teaser_messages[0]["content"][0]["plain"])
-            self.assertIn(teaser_messages[0]["sender"], expected_participants)
+            teaser_messages = hot_convo["first_few_messages"].senders
+            self.assertIn("some content", teaser_messages[0].content[0].plain)
+            self.assertIn(teaser_messages[0].sender, expected_participants)
 
         last_message_id = get_last_message_id()
         for digest_user in digest_users:
@@ -711,11 +711,11 @@ class TestDigestEmailMessages(ZulipTestCase):
 
         hot_convo = kwargs["context"]["hot_conversations"][0]
         # Verify the header HTML contains the general chat
-        header_html = hot_convo["first_few_messages"]["header"]["html"]
+        header_html = hot_convo["first_few_messages"].header.html
         self.assertIn("<span class='empty-topic-display'>general chat</span>", header_html)
 
         # Verify the Plain header contains the general chat
-        header_plain = hot_convo["first_few_messages"]["header"]["plain"]
+        header_plain = hot_convo["first_few_messages"].header.plain
         self.assertIn("general chat", header_plain)
 
 


### PR DESCRIPTION
### Motivation
This PR is part of the GSoC 2026 initiative: **"Replace hundreds of `dict[str, Any]` types with modern dataclasses."** This specific refactor targets the complex nested structures in `build_message_list` to improve type safety, following the patterns from #37907 and #38087 and I've initiated a discussion in the **#backend** stream with @Tim Abbott and @Anders Kaseorg.

---

**What this PR does / why we need it:**
This PR refactors the payload generated by `build_message_list` to use strictly-typed dataclasses (`MessageListPayload`, `SenderPayload`, and `MessagePayload`) instead of a complex, heavily-nested dictionary.

Previously, the shape of the return data required a 13-line block comment just to explain the dictionary structure to future developers. By converting this to dataclasses, we gain:
* Static type safety and better autocomplete.
* Self-documenting code (allowing us to remove the giant explanatory comment).
* Cleaner assembly logic at the end of the function (using object attributes instead of dictionary keys).

**Compatibility Note:**
Because Jinja2/Django templates treat object attribute access (`.`) and dictionary key access (`[]`) interchangeably, this backend refactor is fully compatible with the existing HTML email templates without requiring a single change to the frontend templates. 