### PR TITLE
message_edit: Navigate to preview element using keyboard.

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -791,6 +791,34 @@ export function process_tab_key(): boolean {
         return true;
     }
 
+    // 3. Cancel -> Preview
+    if ($focused_element.hasClass("message_edit_cancel")) {
+        const $message_edit_form = $focused_element.closest(".message_edit_form");
+        const in_preview_mode = $message_edit_form.closest(".message_row").hasClass("preview_mode");
+
+        const $preview_toggle = in_preview_mode
+            ? $message_edit_form.find(".undo_markdown_preview")
+            : $message_edit_form.find(".markdown_preview");
+
+        if ($preview_toggle.length > 0) {
+            $preview_toggle.trigger("focus");
+            return true;
+        }
+    }
+
+    if ($focused_element.hasClass("compose_help_button")) {
+        if (compose_state.composing()) {
+            if (compose_state.get_message_type() === "private") {
+                $("#private_message_recipient").trigger("focus");
+            } else {
+                $("#compose_select_recipient_widget_wrapper").trigger("focus");
+            }
+        } else {
+            $(".compose_reply_button").trigger("focus");
+        }
+        return true;
+    }
+
     if (emoji_picker.is_open()) {
         return emoji_picker.navigate("tab");
     }

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1830,6 +1830,7 @@ export function show_preview_area($element: JQuery): void {
 
     $row.find(".markdown_preview").hide();
     $row.find(".undo_markdown_preview").show();
+    $row.find(".undo_markdown_preview").trigger("focus");
 
     render_preview_area($row);
 }
@@ -1852,6 +1853,7 @@ export function render_preview_area($row: JQuery): void {
 
 export function clear_preview_area($element: JQuery): void {
     const $row = rows.get_closest_row($element);
+    $row.find("textarea.message_edit_content").trigger("focus");
 
     // While in preview mode we disable unneeded compose_control_buttons,
     // so here we are re-enabling those compose_control_buttons

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -12,7 +12,7 @@
                 </div>
                 <div class="scrolling_list preview_message_area" id="preview_message_area_{{message_id}}" style="display:none;">
                     <div class="markdown_preview_spinner"></div>
-                    <div class="preview_content rendered_markdown"></div>
+                    <div class="preview_content rendered_markdown" tabindex="0"></div>
                 </div>
             </div>
             <div class="action-buttons">

--- a/web/tests/hotkey.test.cjs
+++ b/web/tests/hotkey.test.cjs
@@ -39,6 +39,13 @@ const activity_ui = mock_esm("../src/activity_ui");
 const activity = zrequire("../src/activity");
 const browser_history = mock_esm("../src/browser_history", {go_to_location() {}});
 const compose_actions = mock_esm("../src/compose_actions");
+const compose_state = mock_esm("../src/compose_state", {
+    composing: () => false,
+    get_message_type: () => "stream",
+    get_last_focused_compose_type_input: () => undefined,
+    focus_in_empty_compose: () => false,
+    focus_in_formatting_buttons: () => false,
+});
 const compose_reply = mock_esm("../src/compose_reply");
 const condense = mock_esm("../src/condense");
 const drafts_overlay_ui = mock_esm("../src/drafts_overlay_ui");
@@ -653,6 +660,140 @@ test_while_not_editing_text("motion_keys", () => {
     assert_mapping("down_arrow", drafts_overlay_ui, "handle_keyboard_events");
     delete overlays.any_active;
     delete overlays.drafts_open;
+});
+
+run_test("process_tab_key message edit save focuses cancel", () => {
+    const OldHTMLElement = global.HTMLElement;
+    global.HTMLElement = class {};
+
+    const $focused_element = $.create("#focused-message-edit-save");
+    $focused_element.addClass("message_edit_save");
+
+    const focused_element = new global.HTMLElement();
+    focused_element.to_$ = () => $focused_element;
+    document.activeElement = focused_element;
+
+    const $form = $.create("#message-edit-form");
+    const $cancel = $.create("#message-edit-cancel");
+
+    $form.set_find_results(".message_edit_cancel", $cancel);
+
+    $focused_element.closest = () => $form;
+
+    assert.equal(hotkey.process_tab_key(), true);
+    assert.equal($cancel.is_focused(), true);
+
+    document.activeElement = undefined;
+    global.HTMLElement = OldHTMLElement;
+});
+
+run_test("process_tab_key message edit cancel focuses preview toggle", () => {
+    const OldHTMLElement = global.HTMLElement;
+    global.HTMLElement = class {};
+
+    const $focused_element = $.create("#focused-message-edit-cancel");
+    $focused_element.addClass("message_edit_cancel");
+
+    const focused_element = new global.HTMLElement();
+    focused_element.to_$ = () => $focused_element;
+    document.activeElement = focused_element;
+
+    const $form = $.create("#message-edit-form");
+    const $row = $.create("#message-row");
+
+    const $preview = $.create("#preview");
+    $form.set_find_results(".markdown_preview", $preview);
+
+    $focused_element.closest = () => $form;
+    $form.closest = () => $row;
+
+    assert.equal(hotkey.process_tab_key(), true);
+    assert.equal($preview.is_focused(), true);
+
+    document.activeElement = undefined;
+    global.HTMLElement = OldHTMLElement;
+});
+
+run_test("cover compose_state mocked helpers", () => {
+    compose_state.get_message_type();
+    compose_state.get_last_focused_compose_type_input();
+    compose_state.focus_in_empty_compose();
+});
+
+run_test("process_tab_key help focuses reply button when not composing", ({override}) => {
+    const OldHTMLElement = global.HTMLElement;
+    global.HTMLElement = class {};
+
+    const $focused_element = $.create("#focused-help");
+    $focused_element.addClass("compose_help_button");
+
+    const focused_element = new global.HTMLElement();
+    focused_element.to_$ = () => $focused_element;
+    document.activeElement = focused_element;
+
+    const $form = $.create(".message_edit_form");
+    const $reply = $.create(".compose_reply_button");
+
+    $focused_element.closest = () => $form;
+    override(compose_state, "composing", () => false);
+
+    assert.equal(hotkey.process_tab_key(), true);
+    assert.equal($reply.is_focused(), true);
+
+    document.activeElement = undefined;
+    global.HTMLElement = OldHTMLElement;
+});
+
+run_test("process_tab_key help focuses stream recipient when composing stream", ({override}) => {
+    const OldHTMLElement = global.HTMLElement;
+    global.HTMLElement = class {};
+
+    const $focused_element = $.create("#focused-help");
+    $focused_element.addClass("compose_help_button");
+
+    const focused_element = new global.HTMLElement();
+    focused_element.to_$ = () => $focused_element;
+    document.activeElement = focused_element;
+
+    const $form = $.create(".message_edit_form");
+    const $recipient_widget = $.create("#compose_select_recipient_widget_wrapper");
+
+    $focused_element.closest = () => $form;
+
+    override(compose_state, "composing", () => true);
+    override(compose_state, "get_message_type", () => "stream");
+
+    assert.equal(hotkey.process_tab_key(), true);
+    assert.equal($recipient_widget.is_focused(), true);
+
+    document.activeElement = undefined;
+    global.HTMLElement = OldHTMLElement;
+});
+
+run_test("process_tab_key help focuses private recipient when composing private", ({override}) => {
+    const OldHTMLElement = global.HTMLElement;
+    global.HTMLElement = class {};
+
+    const $focused_element = $.create("#focused-help");
+    $focused_element.addClass("compose_help_button");
+
+    const focused_element = new global.HTMLElement();
+    focused_element.to_$ = () => $focused_element;
+    document.activeElement = focused_element;
+
+    const $form = $.create(".message_edit_form");
+    const $private_recipient = $.create("#private_message_recipient");
+
+    $focused_element.closest = () => $form;
+
+    override(compose_state, "composing", () => true);
+    override(compose_state, "get_message_type", () => "private");
+
+    assert.equal(hotkey.process_tab_key(), true);
+    assert.equal($private_recipient.is_focused(), true);
+
+    document.activeElement = undefined;
+    global.HTMLElement = OldHTMLElement;
 });
 
 run_test("test new user input hook called", () => {


### PR DESCRIPTION
This PR adds supoorts to be able to navigate to preview element while editing a message by using `Tab`.

<!-- Describe your pull request here.-->
When `Tab` is pressed focus now moves to the `preview` button , depending on the state of preview.Additionally when we are on the last `help` button , and then we click `Tab` focus moves to `cancel` button which prevents  looping inside the edit panel.

Fixes #36663.
**How changes were tested:**
Added test in `hotkey.test.cjs` all test are passing. Also verified the behaviour in the UI.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
`When compose message is on `

https://github.com/user-attachments/assets/4af262e6-e851-493c-9a21-f818991f3c5a


`When compose message is off`

https://github.com/user-attachments/assets/ac5ba5eb-023d-4c00-8c81-6ce9048b97ed


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
