### PR TITLE
message_edit: Improve how message move/edit history is displayed.

### DIFF
--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -216,6 +216,9 @@ IGNORED_PHRASES = [
     r"strikethrough",
     r"support team",
     r"topic name",
+    # Used in message edit history overlay.
+    r"<z-link></z-link> was marked as resolved",
+    r"<z-link></z-link> was marked as unresolved",
 ]
 
 # Sort regexes in descending order of their lengths. As a result, the

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -279,46 +279,46 @@ export function fetch_and_render_message_history(message: Message): void {
 
             const content_edit_history: EditHistoryEntry[] = [];
             let prev_stream_item: EditHistoryEntry | null = null;
-            for (const [index, msg] of data.message_history.entries()) {
+            for (const [index, server_entry] of data.message_history.entries()) {
                 // Format times and dates nicely for display
-                const time = new Date(msg.timestamp * 1000);
+                const time = new Date(server_entry.timestamp * 1000);
                 const edited_at_time = timerender.get_full_datetime(time, "time");
 
-                if (!msg.user_id) {
+                if (!server_entry.user_id) {
                     continue;
                 }
 
-                const person = people.get_user_by_id_assert_valid(msg.user_id);
+                const person = people.get_user_by_id_assert_valid(server_entry.user_id);
                 const full_name = person.full_name;
 
                 let entry_data: Partial<EditHistoryEntry>;
                 if (index === 0) {
-                    entry_data = build_initial_entry(msg, full_name, move_history_only);
-                } else if (msg.prev_topic !== undefined && msg.prev_content) {
-                    entry_data = build_topic_and_content_edit_entry(msg, full_name);
-                } else if (msg.prev_topic !== undefined && msg.prev_stream) {
-                    entry_data = build_topic_and_stream_move_entry(msg, full_name);
+                    entry_data = build_initial_entry(server_entry, full_name, move_history_only);
+                } else if (server_entry.prev_topic !== undefined && server_entry.prev_content) {
+                    entry_data = build_topic_and_content_edit_entry(server_entry, full_name);
+                } else if (server_entry.prev_topic !== undefined && server_entry.prev_stream) {
+                    entry_data = build_topic_and_stream_move_entry(server_entry, full_name);
                     if (prev_stream_item !== null) {
-                        prev_stream_item.new_stream = get_display_stream_name(msg.prev_stream);
+                        prev_stream_item.new_stream = get_display_stream_name(server_entry.prev_stream);
                     }
-                } else if (msg.prev_topic !== undefined) {
-                    entry_data = build_topic_move_entry(msg, full_name);
-                } else if (msg.prev_stream) {
-                    entry_data = build_stream_move_entry(msg, full_name);
+                } else if (server_entry.prev_topic !== undefined) {
+                    entry_data = build_topic_move_entry(server_entry, full_name);
+                } else if (server_entry.prev_stream) {
+                    entry_data = build_stream_move_entry(server_entry, full_name);
                     if (prev_stream_item !== null) {
-                        prev_stream_item.new_stream = get_display_stream_name(msg.prev_stream);
+                        prev_stream_item.new_stream = get_display_stream_name(server_entry.prev_stream);
                     }
                 } else {
-                    entry_data = build_content_edit_entry(msg, full_name);
+                    entry_data = build_content_edit_entry(server_entry, full_name);
                 }
                 const item = make_edit_history_entry(
-                    msg,
+                    server_entry,
                     edited_at_time,
                     message.is_stream,
                     entry_data,
                 );
 
-                if (msg.prev_stream) {
+                if (server_entry.prev_stream) {
                     prev_stream_item = item;
                 }
 

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -7,6 +7,7 @@ import render_message_history_overlay from "../templates/message_history_overlay
 
 import {exit_overlay} from "./browser_history.ts";
 import * as channel from "./channel.ts";
+import {by_stream_topic_url} from "./hash_util.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as loading from "./loading.ts";
 import * as message_lists from "./message_lists.ts";
@@ -16,6 +17,7 @@ import * as overlays from "./overlays.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as rendered_markdown from "./rendered_markdown.ts";
+import {is_resolved, unresolve_name} from "./resolved_topic.ts";
 import * as rows from "./rows.ts";
 import {message_edit_history_visibility_policy_values} from "./settings_config.ts";
 import * as spectators from "./spectators.ts";
@@ -28,6 +30,14 @@ import * as timerender from "./timerender.ts";
 import * as ui_report from "./ui_report.ts";
 import * as util from "./util.ts";
 
+type ChannelTopicLink = {
+    stream_name: string;
+    stream_sub: sub_store.StreamSubscription | undefined;
+    topic_display_name: string;
+    is_empty_string_topic: boolean;
+    url: string;
+};
+
 type EditHistoryEntry = {
     initial_entry_for_move_history: boolean;
     edited_at_time: string;
@@ -36,15 +46,9 @@ type EditHistoryEntry = {
     is_stream: boolean;
     recipient_bar_color: string | undefined;
     body_to_render: string | undefined;
-    topic_edited: boolean | undefined;
-    prev_topic_display_name: string | undefined;
-    new_topic_display_name: string | undefined;
-    is_empty_string_prev_topic: boolean | undefined;
-    is_empty_string_new_topic: boolean | undefined;
-    stream_changed: boolean | undefined;
-    prev_stream: string | undefined;
-    prev_stream_id: number | undefined;
-    new_stream: string | undefined;
+    prev_location: ChannelTopicLink | undefined;
+    new_location: ChannelTopicLink | undefined;
+    topic_resolved_or_unresolved: "resolved" | "unresolved" | "none";
 };
 
 const server_message_history_schema = z.object({
@@ -103,6 +107,16 @@ function get_display_stream_name(stream_id: number): string {
     return stream_name;
 }
 
+function make_channel_topic_link(stream_id: number, topic: string): ChannelTopicLink {
+    return {
+        stream_name: get_display_stream_name(stream_id),
+        stream_sub: sub_store.get(stream_id),
+        topic_display_name: util.get_final_topic_display_name(topic),
+        is_empty_string_topic: topic === "",
+        url: by_stream_topic_url(stream_id, topic),
+    };
+}
+
 function show_loading_indicator(): void {
     loading.make_indicator($(".message-edit-history-container .loading_indicator"));
     $(".message-edit-history-container .loading_indicator").addClass(
@@ -117,27 +131,6 @@ function hide_loading_indicator(): void {
     );
 }
 
-function get_topic_change_fields(
-    server_entry: ServerMessageHistoryEntry,
-): Pick<
-    EditHistoryEntry,
-    | "topic_edited"
-    | "prev_topic_display_name"
-    | "new_topic_display_name"
-    | "is_empty_string_prev_topic"
-    | "is_empty_string_new_topic"
-> {
-    assert(server_entry.prev_topic !== undefined);
-
-    return {
-        topic_edited: true,
-        prev_topic_display_name: util.get_final_topic_display_name(server_entry.prev_topic),
-        new_topic_display_name: util.get_final_topic_display_name(server_entry.topic),
-        is_empty_string_prev_topic: server_entry.prev_topic === "",
-        is_empty_string_new_topic: server_entry.topic === "",
-    };
-}
-
 function build_initial_entry(
     server_entry: ServerMessageHistoryEntry,
     full_name: string,
@@ -147,7 +140,6 @@ function build_initial_entry(
         return {
             edited_by_notice: $t({defaultMessage: "Posted by {full_name}"}, {full_name}),
             initial_entry_for_move_history: true,
-            new_topic_display_name: util.get_final_topic_display_name(server_entry.topic),
         };
     }
 
@@ -164,7 +156,6 @@ function build_topic_and_content_edit_entry(
     return {
         edited_by_notice: $t({defaultMessage: "Edited by {full_name}"}, {full_name}),
         body_to_render: server_entry.content_html_diff,
-        ...get_topic_change_fields(server_entry),
     };
 }
 
@@ -176,10 +167,6 @@ function build_topic_and_stream_move_entry(
 
     return {
         edited_by_notice: $t({defaultMessage: "Moved by {full_name}"}, {full_name}),
-        ...get_topic_change_fields(server_entry),
-        stream_changed: true,
-        prev_stream_id: server_entry.prev_stream,
-        prev_stream: get_display_stream_name(server_entry.prev_stream),
     };
 }
 
@@ -187,9 +174,29 @@ function build_topic_move_entry(
     server_entry: ServerMessageHistoryEntry,
     full_name: string,
 ): Partial<EditHistoryEntry> {
+    let edited_by_notice = $t({defaultMessage: "Moved by {full_name}"}, {full_name});
+    assert(server_entry.prev_topic !== undefined);
+    let topic_resolved_or_unresolved: "resolved" | "unresolved" | "none" = "none";
+    const prev_topic_resolved = is_resolved(server_entry.prev_topic);
+    const current_topic_resolved = is_resolved(server_entry.topic);
+    // Only treat this as a resolve/unresolve toggle when the base topic name
+    // (stripped of the resolved prefix) is unchanged; otherwise it's a rename
+    // that also happened to add/remove the prefix.
+    if (
+        prev_topic_resolved !== current_topic_resolved &&
+        unresolve_name(server_entry.prev_topic) === unresolve_name(server_entry.topic)
+    ) {
+        if (current_topic_resolved) {
+            topic_resolved_or_unresolved = "resolved";
+            edited_by_notice = $t({defaultMessage: "Topic resolved by {full_name}"}, {full_name});
+        } else {
+            topic_resolved_or_unresolved = "unresolved";
+            edited_by_notice = $t({defaultMessage: "Topic unresolved by {full_name}"}, {full_name});
+        }
+    }
     return {
-        edited_by_notice: $t({defaultMessage: "Moved by {full_name}"}, {full_name}),
-        ...get_topic_change_fields(server_entry),
+        edited_by_notice,
+        topic_resolved_or_unresolved,
     };
 }
 
@@ -198,12 +205,10 @@ function build_stream_move_entry(
     full_name: string,
 ): Partial<EditHistoryEntry> {
     assert(server_entry.prev_stream !== undefined);
+    assert(server_entry.stream !== undefined);
 
     return {
         edited_by_notice: $t({defaultMessage: "Moved by {full_name}"}, {full_name}),
-        stream_changed: true,
-        prev_stream_id: server_entry.prev_stream,
-        prev_stream: get_display_stream_name(server_entry.prev_stream),
     };
 }
 
@@ -231,15 +236,9 @@ function make_edit_history_entry(
         is_stream,
         recipient_bar_color: undefined,
         body_to_render: undefined,
-        topic_edited: undefined,
-        prev_topic_display_name: undefined,
-        new_topic_display_name: undefined,
-        is_empty_string_prev_topic: undefined,
-        is_empty_string_new_topic: undefined,
-        stream_changed: undefined,
-        prev_stream: undefined,
-        prev_stream_id: undefined,
-        new_stream: undefined,
+        prev_location: undefined,
+        new_location: undefined,
+        topic_resolved_or_unresolved: "none",
         ...entry_data,
     };
 }
@@ -278,7 +277,8 @@ export function fetch_and_render_message_history(message: Message): void {
             const data = server_message_history_schema.parse(raw_data);
 
             const content_edit_history: EditHistoryEntry[] = [];
-            let prev_stream_item: EditHistoryEntry | null = null;
+            const server_entries: ServerMessageHistoryEntry[] = [];
+
             for (const [index, server_entry] of data.message_history.entries()) {
                 // Format times and dates nicely for display
                 const time = new Date(server_entry.timestamp * 1000);
@@ -298,16 +298,10 @@ export function fetch_and_render_message_history(message: Message): void {
                     entry_data = build_topic_and_content_edit_entry(server_entry, full_name);
                 } else if (server_entry.prev_topic !== undefined && server_entry.prev_stream) {
                     entry_data = build_topic_and_stream_move_entry(server_entry, full_name);
-                    if (prev_stream_item !== null) {
-                        prev_stream_item.new_stream = get_display_stream_name(server_entry.prev_stream);
-                    }
                 } else if (server_entry.prev_topic !== undefined) {
                     entry_data = build_topic_move_entry(server_entry, full_name);
                 } else if (server_entry.prev_stream) {
                     entry_data = build_stream_move_entry(server_entry, full_name);
-                    if (prev_stream_item !== null) {
-                        prev_stream_item.new_stream = get_display_stream_name(server_entry.prev_stream);
-                    }
                 } else {
                     entry_data = build_content_edit_entry(server_entry, full_name);
                 }
@@ -318,44 +312,53 @@ export function fetch_and_render_message_history(message: Message): void {
                     entry_data,
                 );
 
-                if (server_entry.prev_stream) {
-                    prev_stream_item = item;
-                }
-
                 content_edit_history.push(item);
-            }
-            if (prev_stream_item !== null) {
-                assert(message.type === "stream");
-                prev_stream_item.new_stream = get_display_stream_name(message.stream_id);
+                server_entries.push(server_entry);
             }
 
-            // In order to correctly compute the recipient_bar_color
-            // values, it is convenient to iterate through the array of edit history
-            // entries in reverse chronological order.
+            // The server only reports what each event changed, so we reconstruct
+            // the message's full location at each event by walking backwards from
+            // its current location, undoing one event's changes at each step.
             if (message.is_stream) {
-                // Start with the message's current location.
-                let stream_display_name: string = get_display_stream_name(message.stream_id);
-                let stream_color: string = get_color(message.stream_id);
-                let recipient_bar_color: string = get_recipient_bar_color(stream_color);
-                for (const edit_history_entry of content_edit_history.toReversed()) {
-                    // The stream following this move is the one whose color we already have.
-                    edit_history_entry.recipient_bar_color = recipient_bar_color;
-                    if (edit_history_entry.stream_changed) {
-                        // If this event moved the message, then immediately
-                        // prior to this event, the message must have been in
-                        // edit_history_event.prev_stream_id; fetch its color.
-                        assert(edit_history_entry.prev_stream_id !== undefined);
-                        stream_display_name = get_display_stream_name(
-                            edit_history_entry.prev_stream_id,
+                let location_after = {stream_id: message.stream_id, topic: message.topic};
+
+                for (let i = content_edit_history.length - 1; i >= 0; i -= 1) {
+                    const edit_history_entry = content_edit_history[i]!;
+                    const server_entry = server_entries[i]!;
+
+                    edit_history_entry.recipient_bar_color = get_recipient_bar_color(
+                        get_color(location_after.stream_id),
+                    );
+
+                    const location_before = {
+                        stream_id: server_entry.prev_stream ?? location_after.stream_id,
+                        topic: server_entry.prev_topic ?? location_after.topic,
+                    };
+
+                    if (
+                        server_entry.prev_stream !== undefined ||
+                        server_entry.prev_topic !== undefined
+                    ) {
+                        edit_history_entry.prev_location = make_channel_topic_link(
+                            location_before.stream_id,
+                            location_before.topic,
                         );
-                        stream_color = get_color(edit_history_entry.prev_stream_id);
-                        recipient_bar_color = get_recipient_bar_color(stream_color);
+                        edit_history_entry.new_location = make_channel_topic_link(
+                            location_after.stream_id,
+                            location_after.topic,
+                        );
                     }
+
+                    location_after = location_before;
                 }
+
                 if (move_history_only) {
-                    // If message history is limited to moves only, then we
-                    // display the original topic and channel for the message.
-                    content_edit_history[0]!.new_stream = stream_display_name;
+                    // The initial entry shows where the message was originally
+                    // posted, i.e. the location we walked back to.
+                    content_edit_history[0]!.new_location = make_channel_topic_link(
+                        location_after.stream_id,
+                        location_after.topic,
+                    );
                 }
             }
             const rendered_list_html = render_message_edit_history({

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -65,6 +65,9 @@ const server_message_history_schema = z.object({
     ),
 });
 
+type ServerMessageHistoryData = z.infer<typeof server_message_history_schema>;
+type ServerMessageHistoryEntry = ServerMessageHistoryData["message_history"][number];
+
 // This will be used to handle up and down keyws
 const keyboard_handling_context: messages_overlay_ui.Context = {
     items_container_selector: "message-edit-history-container",
@@ -114,6 +117,133 @@ function hide_loading_indicator(): void {
     );
 }
 
+function get_topic_change_fields(
+    server_entry: ServerMessageHistoryEntry,
+): Pick<
+    EditHistoryEntry,
+    | "topic_edited"
+    | "prev_topic_display_name"
+    | "new_topic_display_name"
+    | "is_empty_string_prev_topic"
+    | "is_empty_string_new_topic"
+> {
+    assert(server_entry.prev_topic !== undefined);
+
+    return {
+        topic_edited: true,
+        prev_topic_display_name: util.get_final_topic_display_name(server_entry.prev_topic),
+        new_topic_display_name: util.get_final_topic_display_name(server_entry.topic),
+        is_empty_string_prev_topic: server_entry.prev_topic === "",
+        is_empty_string_new_topic: server_entry.topic === "",
+    };
+}
+
+function build_initial_entry(
+    server_entry: ServerMessageHistoryEntry,
+    full_name: string,
+    move_history_only: boolean,
+): Partial<EditHistoryEntry> {
+    if (move_history_only) {
+        return {
+            edited_by_notice: $t({defaultMessage: "Posted by {full_name}"}, {full_name}),
+            initial_entry_for_move_history: true,
+            new_topic_display_name: util.get_final_topic_display_name(server_entry.topic),
+        };
+    }
+
+    return {
+        edited_by_notice: $t({defaultMessage: "Posted by {full_name}"}, {full_name}),
+        body_to_render: server_entry.rendered_content,
+    };
+}
+
+function build_topic_and_content_edit_entry(
+    server_entry: ServerMessageHistoryEntry,
+    full_name: string,
+): Partial<EditHistoryEntry> {
+    return {
+        edited_by_notice: $t({defaultMessage: "Edited by {full_name}"}, {full_name}),
+        body_to_render: server_entry.content_html_diff,
+        ...get_topic_change_fields(server_entry),
+    };
+}
+
+function build_topic_and_stream_move_entry(
+    server_entry: ServerMessageHistoryEntry,
+    full_name: string,
+): Partial<EditHistoryEntry> {
+    assert(server_entry.prev_stream !== undefined);
+
+    return {
+        edited_by_notice: $t({defaultMessage: "Moved by {full_name}"}, {full_name}),
+        ...get_topic_change_fields(server_entry),
+        stream_changed: true,
+        prev_stream_id: server_entry.prev_stream,
+        prev_stream: get_display_stream_name(server_entry.prev_stream),
+    };
+}
+
+function build_topic_move_entry(
+    server_entry: ServerMessageHistoryEntry,
+    full_name: string,
+): Partial<EditHistoryEntry> {
+    return {
+        edited_by_notice: $t({defaultMessage: "Moved by {full_name}"}, {full_name}),
+        ...get_topic_change_fields(server_entry),
+    };
+}
+
+function build_stream_move_entry(
+    server_entry: ServerMessageHistoryEntry,
+    full_name: string,
+): Partial<EditHistoryEntry> {
+    assert(server_entry.prev_stream !== undefined);
+
+    return {
+        edited_by_notice: $t({defaultMessage: "Moved by {full_name}"}, {full_name}),
+        stream_changed: true,
+        prev_stream_id: server_entry.prev_stream,
+        prev_stream: get_display_stream_name(server_entry.prev_stream),
+    };
+}
+
+function build_content_edit_entry(
+    server_entry: ServerMessageHistoryEntry,
+    full_name: string,
+): Partial<EditHistoryEntry> {
+    return {
+        edited_by_notice: $t({defaultMessage: "Edited by {full_name}"}, {full_name}),
+        body_to_render: server_entry.content_html_diff,
+    };
+}
+
+function make_edit_history_entry(
+    server_entry: ServerMessageHistoryEntry,
+    edited_at_time: string,
+    is_stream: boolean,
+    entry_data: Partial<EditHistoryEntry>,
+): EditHistoryEntry {
+    return {
+        initial_entry_for_move_history: false,
+        edited_at_time,
+        edited_by_notice: "",
+        timestamp: server_entry.timestamp,
+        is_stream,
+        recipient_bar_color: undefined,
+        body_to_render: undefined,
+        topic_edited: undefined,
+        prev_topic_display_name: undefined,
+        new_topic_display_name: undefined,
+        is_empty_string_prev_topic: undefined,
+        is_empty_string_new_topic: undefined,
+        stream_changed: undefined,
+        prev_stream: undefined,
+        prev_stream_id: undefined,
+        new_stream: undefined,
+        ...entry_data,
+    };
+}
+
 export function fetch_and_render_message_history(message: Message): void {
     assert(message_lists.current !== undefined);
     const message_container = message_lists.current.view.message_containers.get(message.id);
@@ -161,88 +291,32 @@ export function fetch_and_render_message_history(message: Message): void {
                 const person = people.get_user_by_id_assert_valid(msg.user_id);
                 const full_name = person.full_name;
 
-                let edited_by_notice;
-                let body_to_render;
-                let topic_edited;
-                let prev_topic_display_name;
-                let new_topic_display_name;
-                let is_empty_string_prev_topic;
-                let is_empty_string_new_topic;
-                let stream_changed;
-                let prev_stream;
-                let prev_stream_id;
-                let initial_entry_for_move_history = false;
-
+                let entry_data: Partial<EditHistoryEntry>;
                 if (index === 0) {
-                    edited_by_notice = $t({defaultMessage: "Posted by {full_name}"}, {full_name});
-                    if (move_history_only) {
-                        // If message history is limited to moves only, then we
-                        // display the original topic and channel for the message.
-                        initial_entry_for_move_history = true;
-                        new_topic_display_name = util.get_final_topic_display_name(msg.topic);
-                    } else {
-                        // Otherwise, we display the original message content.
-                        body_to_render = msg.rendered_content;
-                    }
+                    entry_data = build_initial_entry(msg, full_name, move_history_only);
                 } else if (msg.prev_topic !== undefined && msg.prev_content) {
-                    edited_by_notice = $t({defaultMessage: "Edited by {full_name}"}, {full_name});
-                    body_to_render = msg.content_html_diff;
-                    topic_edited = true;
-                    prev_topic_display_name = util.get_final_topic_display_name(msg.prev_topic);
-                    new_topic_display_name = util.get_final_topic_display_name(msg.topic);
-                    is_empty_string_prev_topic = msg.prev_topic === "";
-                    is_empty_string_new_topic = msg.topic === "";
+                    entry_data = build_topic_and_content_edit_entry(msg, full_name);
                 } else if (msg.prev_topic !== undefined && msg.prev_stream) {
-                    edited_by_notice = $t({defaultMessage: "Moved by {full_name}"}, {full_name});
-                    topic_edited = true;
-                    prev_topic_display_name = util.get_final_topic_display_name(msg.prev_topic);
-                    new_topic_display_name = util.get_final_topic_display_name(msg.topic);
-                    is_empty_string_prev_topic = msg.prev_topic === "";
-                    is_empty_string_new_topic = msg.topic === "";
-                    stream_changed = true;
-                    prev_stream_id = msg.prev_stream;
-                    prev_stream = get_display_stream_name(msg.prev_stream);
+                    entry_data = build_topic_and_stream_move_entry(msg, full_name);
                     if (prev_stream_item !== null) {
                         prev_stream_item.new_stream = get_display_stream_name(msg.prev_stream);
                     }
                 } else if (msg.prev_topic !== undefined) {
-                    edited_by_notice = $t({defaultMessage: "Moved by {full_name}"}, {full_name});
-                    topic_edited = true;
-                    prev_topic_display_name = util.get_final_topic_display_name(msg.prev_topic);
-                    new_topic_display_name = util.get_final_topic_display_name(msg.topic);
-                    is_empty_string_prev_topic = msg.prev_topic === "";
-                    is_empty_string_new_topic = msg.topic === "";
+                    entry_data = build_topic_move_entry(msg, full_name);
                 } else if (msg.prev_stream) {
-                    edited_by_notice = $t({defaultMessage: "Moved by {full_name}"}, {full_name});
-                    stream_changed = true;
-                    prev_stream_id = msg.prev_stream;
-                    prev_stream = get_display_stream_name(msg.prev_stream);
+                    entry_data = build_stream_move_entry(msg, full_name);
                     if (prev_stream_item !== null) {
                         prev_stream_item.new_stream = get_display_stream_name(msg.prev_stream);
                     }
                 } else {
-                    // just a content edit
-                    edited_by_notice = $t({defaultMessage: "Edited by {full_name}"}, {full_name});
-                    body_to_render = msg.content_html_diff;
+                    entry_data = build_content_edit_entry(msg, full_name);
                 }
-                const item: EditHistoryEntry = {
-                    initial_entry_for_move_history,
+                const item = make_edit_history_entry(
+                    msg,
                     edited_at_time,
-                    edited_by_notice,
-                    timestamp: msg.timestamp,
-                    is_stream: message.is_stream,
-                    recipient_bar_color: undefined,
-                    body_to_render,
-                    topic_edited,
-                    prev_topic_display_name,
-                    new_topic_display_name,
-                    is_empty_string_prev_topic,
-                    is_empty_string_new_topic,
-                    stream_changed,
-                    prev_stream,
-                    prev_stream_id,
-                    new_stream: undefined,
-                };
+                    message.is_stream,
+                    entry_data,
+                );
 
                 if (msg.prev_stream) {
                     prev_stream_item = item;

--- a/web/templates/message_edit_history.hbs
+++ b/web/templates/message_edit_history.hbs
@@ -27,27 +27,47 @@
             <div class="message_row{{#unless is_stream}} private-message{{/unless}}" role="listitem">
                 <div class="messagebox">
                     <div class="messagebox-content">
+                        {{! Renders a "#channel > topic" link for a ChannelTopicLink; used for both sides of a move. }}
+                        {{#*inline "channel-topic-link"~}}
+                            <a class="white-space-preserve-wrap" href="{{url}}">
+                                {{~!-- squash whitespace --~}}
+                                {{#if stream_sub~}}
+                                {{~> decorated_channel_name stream=stream_sub inline_with_text=true show_colored_icon=false~}}
+                                {{~else~}}
+                                #{{stream_name}}
+                                {{~/if}} &gt; <span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{topic_display_name}}</span>
+                                {{~!-- squash whitespace --~}}
+                            </a>
+                        {{~/inline}}
                         {{#if initial_entry_for_move_history}}
                         <div class="message_content message_edit_history_content">
-                            <p>{{t "Channel" }}: <span class="highlight_text_inserted">{{ new_stream }}</span></p>
-                            <p>{{t "Topic" }}:
-                                <span class="highlight_text_inserted {{#if is_empty_string_new_topic}}empty-topic-display{{/if}}">{{ new_topic_display_name }}</span>
-                            </p>
+                            {{#tr}}
+                                Posted to <z-link></z-link>.
+                                {{#*inline "z-link"~}}{{~> channel-topic-link new_location~}}{{~/inline}}
+                            {{/tr}}
                         </div>
                         {{else}}
-                        {{#if stream_changed}}
+                        {{#if (eq topic_resolved_or_unresolved "resolved")}}
                         <div class="message_content message_edit_history_content">
-                            <p>{{t "Channel" }}: <span class="highlight_text_inserted">{{ new_stream }}</span>
-                                <span class="highlight_text_deleted">{{ prev_stream }}</span>
-                            </p>
+                            {{#tr}}
+                                <z-link></z-link> was marked as resolved.
+                                {{#*inline "z-link"~}}{{~> channel-topic-link new_location~}}{{~/inline}}
+                            {{/tr}}
                         </div>
-                        {{/if}}
-                        {{#if topic_edited}}
+                        {{else if (eq topic_resolved_or_unresolved "unresolved")}}
                         <div class="message_content message_edit_history_content">
-                            <p>{{t "Topic" }}:
-                                <span class="highlight_text_inserted {{#if is_empty_string_new_topic}}empty-topic-display{{/if}}">{{ new_topic_display_name }}</span>
-                                <span class="highlight_text_deleted {{#if is_empty_string_prev_topic}}empty-topic-display{{/if}}">{{ prev_topic_display_name }}</span>
-                            </p>
+                            {{#tr}}
+                                <z-link></z-link> was marked as unresolved.
+                                {{#*inline "z-link"~}}{{~> channel-topic-link new_location~}}{{~/inline}}
+                            {{/tr}}
+                        </div>
+                        {{else if new_location}}
+                        <div class="message_content message_edit_history_content">
+                            {{#tr}}
+                                Moved from <prev-link></prev-link> to <new-link></new-link>.
+                                {{#*inline "prev-link"~}}{{~> channel-topic-link prev_location~}}{{~/inline}}
+                                {{#*inline "new-link"~}}{{~> channel-topic-link new_location~}}{{~/inline}}
+                            {{/tr}}
                         </div>
                         {{/if}}
                         {{#if body_to_render}}
@@ -62,4 +82,3 @@
         </div>
     </div>
 {{/each}}
-


### PR DESCRIPTION
This PR changes the wordings we use for `edit/move` actions in `edit/move` history.

For message moves, the old content has been updated as: 
"Moved from #channel > topic" to "#channel > topic". 
This is regardless of whether the channel, topic, or both are changed.

For moves that are just resolving/unreslolving a topic, the new texts are:
Header: "Topic {resolved/unresolved} by {user}"
Content:"#channel > topic was marked as {resolved/unsresolved}."

<details>
<summary>Screenshots</summary>

Before

<img width="1114" height="525" alt="image" src="https://github.com/user-attachments/assets/2b4e60b5-65e5-44d6-bc84-bf74739b3f0e" />

After

<img width="1114" height="525" alt="image" src="https://github.com/user-attachments/assets/423eef8f-8ec3-4b82-96bd-0f1e0b010716" />


</details>

Fixes: #34006 

Continues the work done in PR #35439 by @saubhagya-patel.

**Discussion**
Design: [#design > Changes in message history overlay format #34006](https://chat.zulip.org/#narrow/channel/101-design/topic/Changes.20in.20message.20history.20overlay.20format.20.2334006/with/2162411)
Frontend: [#frontend > message move history display](https://chat.zulip.org/#narrow/channel/6-frontend/topic/message.20move.20history.20display/with/2391721)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
