### PR TITLE
docs: Improve wording of development community chat invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ world, with 99+ people who have each contributed 100+ commits. With
 over 1,500 contributors merging over 500 commits a month, Zulip is the
 largest and fastest growing open source team chat project.
 
-Come find us on the [development community chat](https://zulip.com/development-community/)!
+Join our [development community chat](https://zulip.com/development-community/) to get help and contribute.
 
 [![GitHub Actions build status](https://github.com/zulip/zulip/actions/workflows/zulip-ci.yml/badge.svg)](https://github.com/zulip/zulip/actions/workflows/zulip-ci.yml?query=branch%3Amain)
 [![coverage status](https://img.shields.io/codecov/c/github/zulip/zulip/main.svg)](https://codecov.io/gh/zulip/zulip)


### PR DESCRIPTION
Improved clarity and tone of the sentence inviting users to join the development community chat.  Reworded for a more direct and professional call to action while keeping the original meaning.

