### PR TITLE
channel_settings: Preserve left tab in new channel URL.

### DIFF
--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -367,6 +367,11 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
 
             // e.g. #channels/29/social/subscribers
             const right_side_tab = hash_parser.get_current_nth_hash_section(3);
+            // "new" describes the right panel state, not the left panel section.
+            if (section === "new") {
+                stream_settings_ui.change_state("", undefined, "new");
+                return;
+            }
             stream_settings_ui.change_state(section, undefined, right_side_tab);
             return;
         }
@@ -449,6 +454,15 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
 
         // e.g. #channels/29/social/subscribers
         const right_side_tab = hash_parser.get_current_nth_hash_section(3);
+        // "new" describes the right panel state, not the left panel section.
+        if (section === "new") {
+            if (is_somebody_else_profile_open()) {
+                stream_settings_ui.launch("", "all-streams", "new");
+                return;
+            }
+            stream_settings_ui.launch("", undefined, "new");
+            return;
+        }
 
         if (is_somebody_else_profile_open()) {
             stream_settings_ui.launch(section, "all-streams", right_side_tab);

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -1191,8 +1191,8 @@ export function change_state(
     folder_id?: number,
 ): void {
     assert(toggler !== undefined);
-    // if in #channels/new form.
-    if (section === "new") {
+    // "new" is a right panel state for creating a new channel.
+    if (right_side_tab === "new" || section === "new") {
         do_open_create_stream(folder_id);
         show_right_section();
         return;


### PR DESCRIPTION
Previously, "new" in #channels/new was parsed as a left panel section, causing the left panel state to be incorrectly overridden when the new channel form was opened or the URL was reloaded.
This PR passes "new" as right_side_tab instead so the left panel correctly preserves its state based on the user's subscriptions.
Fixes #27730.

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**


https://github.com/user-attachments/assets/1e6809e8-643d-4b35-bafa-778224b27c8c




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>


