### PR TITLE
channel_folders: Refactor to use dataclasses

### DIFF
--- a/zerver/actions/channel_folders.py
+++ b/zerver/actions/channel_folders.py
@@ -1,8 +1,10 @@
+from dataclasses import asdict
+
 from django.db import transaction
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
-from zerver.lib.channel_folders import get_channel_folder_dict, render_channel_folder_description
+from zerver.lib.channel_folders import get_channel_folder_data, render_channel_folder_description
 from zerver.lib.exceptions import JsonableError
 from zerver.models import ChannelFolder, Realm, RealmAuditLog, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
@@ -39,7 +41,7 @@ def check_add_channel_folder(
     event = dict(
         type="channel_folder",
         op="add",
-        channel_folder=get_channel_folder_dict(channel_folder),
+        channel_folder=asdict(get_channel_folder_data(channel_folder)),
     )
     send_event_on_commit(realm, event, active_user_ids(realm.id))
 

--- a/zerver/lib/channel_folders.py
+++ b/zerver/lib/channel_folders.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from dataclasses import dataclass
 
 from django.utils.translation import gettext as _
 
@@ -10,7 +10,8 @@ from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.models import ChannelFolder, Realm, Stream, UserProfile
 
 
-class ChannelFolderDict(TypedDict):
+@dataclass
+class ChannelFolderData:
     id: int
     name: str
     description: str
@@ -43,9 +44,9 @@ def render_channel_folder_description(text: str, realm: Realm, *, acting_user: U
     ).rendered_content
 
 
-def get_channel_folder_dict(channel_folder: ChannelFolder) -> ChannelFolderDict:
+def get_channel_folder_data(channel_folder: ChannelFolder) -> ChannelFolderData:
     date_created = datetime_to_timestamp(channel_folder.date_created)
-    return ChannelFolderDict(
+    return ChannelFolderData(
         id=channel_folder.id,
         name=channel_folder.name,
         description=channel_folder.description,
@@ -59,13 +60,13 @@ def get_channel_folder_dict(channel_folder: ChannelFolder) -> ChannelFolderDict:
 
 def get_channel_folders_in_realm(
     realm: Realm, include_archived: bool = False
-) -> list[ChannelFolderDict]:
+) -> list[ChannelFolderData]:
     folders = ChannelFolder.objects.filter(realm=realm)
     if not include_archived:
         folders = folders.exclude(is_archived=True)
 
-    channel_folders = [get_channel_folder_dict(channel_folder) for channel_folder in folders]
-    return sorted(channel_folders, key=lambda folder: folder["order"])
+    channel_folders = [get_channel_folder_data(channel_folder) for channel_folder in folders]
+    return sorted(channel_folders, key=lambda folder: folder.order)
 
 
 def get_channel_folder_by_id(channel_folder_id: int, realm: Realm) -> ChannelFolder:
@@ -76,13 +77,13 @@ def get_channel_folder_by_id(channel_folder_id: int, realm: Realm) -> ChannelFol
         raise JsonableError(_("Invalid channel folder ID"))
 
 
-def get_channel_folders_for_spectators(realm: Realm) -> list[ChannelFolderDict]:
+def get_channel_folders_for_spectators(realm: Realm) -> list[ChannelFolderData]:
     folder_ids_for_web_public_streams = set(
         get_web_public_streams_queryset(realm).values_list("folder_id", flat=True)
     )
     folders = ChannelFolder.objects.filter(id__in=folder_ids_for_web_public_streams)
-    channel_folders = [get_channel_folder_dict(channel_folder) for channel_folder in folders]
-    return sorted(channel_folders, key=lambda folder: folder["id"])
+    channel_folders = [get_channel_folder_data(channel_folder) for channel_folder in folders]
+    return sorted(channel_folders, key=lambda folder: folder.id)
 
 
 def check_channel_folder_in_use(channel_folder: ChannelFolder) -> bool:

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -4,6 +4,7 @@ import copy
 import logging
 import time
 from collections.abc import Callable, Collection, Iterable, Sequence
+from dataclasses import asdict
 from typing import Any, Literal
 
 from django.conf import settings
@@ -838,9 +839,13 @@ def fetch_initial_state_data(
 
     if want("channel_folders"):
         if user_profile is None:
-            state["channel_folders"] = get_channel_folders_for_spectators(realm)
+            state["channel_folders"] = [
+                asdict(folder) for folder in get_channel_folders_for_spectators(realm)
+            ]
         else:
-            state["channel_folders"] = get_channel_folders_in_realm(user_profile.realm, True)
+            state["channel_folders"] = [
+                asdict(folder) for folder in get_channel_folders_in_realm(user_profile.realm, True)
+            ]
 
     if want("update_message_flags") and want("message"):
         # Keeping unread_msgs updated requires both message flag updates and

--- a/zerver/views/channel_folders.py
+++ b/zerver/views/channel_folders.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from typing import Annotated
 
 from django.http import HttpRequest, HttpResponse
@@ -50,7 +51,10 @@ def get_channel_folders(
     include_archived: Json[bool] = False,
 ) -> HttpResponse:
     channel_folders = get_channel_folders_in_realm(user_profile.realm, include_archived)
-    return json_success(request, data={"channel_folders": channel_folders})
+    return json_success(
+        request,
+        data={"channel_folders": [asdict(folder) for folder in channel_folders]},
+    )
 
 
 @require_realm_admin


### PR DESCRIPTION
### Motivation
This PR is part of the GSoC 2026 initiative: **"Replace hundreds of `dict[str, Any]` types with modern dataclasses."** The goal is to improve type safety and internal object handling across the Zulip backend. This follows the established refactoring pattern from my previously merged PRs (#37907 and #38087) and I've initiated a discussion in the **#backend** stream with @Tim Abbott and @Anders Kaseorg.

---

This PR refactors the `channel_folders` backend logic to use Python `dataclasses` instead of `TypedDict`, improving type safety and internal object handling.

**Changes included:**
* **`zerver/lib/channel_folders.py`**: Replaced the `ChannelFolderDict` TypedDict with a `ChannelFolderData` dataclass. Updated the getter functions to return dataclasses and updated the sorting keys to use dot notation (`folder.id` / `folder.order`).
* **`zerver/actions/channel_folders.py`**: Wrapped the outgoing `channel_folder` event payload in `asdict()` to ensure the frontend receives the exact same JSON dictionary as before.
* **`zerver/lib/events.py`**: Updated `fetch_initial_state_data` to serialize the `channel_folders` lists using `asdict()` list comprehensions.

**Testing:**
Because the dataclasses are converted back to standard dictionaries before being sent via the API or event queues, no frontend or test data changes are required. The JSON payloads remain identical.