### PR TITLE
settings: Add copy button to API key modal.

### DIFF
--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -1,3 +1,4 @@
+import ClipboardJS from "clipboard";
 import $ from "jquery";
 import assert from "minimalistic-assert";
 import * as z from "zod/mini";
@@ -13,6 +14,7 @@ import * as avatar from "./avatar.ts";
 import * as bot_helper from "./bot_helper.ts";
 import * as channel from "./channel.ts";
 import * as common from "./common.ts";
+import {show_copied_confirmation} from "./copied_tooltip.ts";
 import {csrf_token} from "./csrf.ts";
 import * as custom_profile_fields_ui from "./custom_profile_fields_ui.ts";
 import type {CustomProfileFieldData, PillUpdateField} from "./custom_profile_fields_ui.ts";
@@ -456,6 +458,16 @@ export function set_up(): void {
                 "#get_api_key_password",
                 "#get_api_key_password + .password_visibility_toggle",
             );
+        });
+        new ClipboardJS("#show_api_key .copy-button", {
+            text() {
+                return $("#api_key_value").text();
+            },
+        }).on("success", (e) => {
+            assert(e.trigger instanceof HTMLElement);
+            show_copied_confirmation(e.trigger, {
+                show_check_icon: true,
+            });
         });
     };
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1374,6 +1374,22 @@ label.preferences-radio-choice-label {
     min-width: initial !important;
 }
 
+#show_api_key {
+    .api-key-container {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+
+        .copy-button {
+            padding: 0;
+
+            &:focus {
+                outline: none;
+            }
+        }
+    }
+}
+
 #api_key_buttons {
     display: inline-flex;
 

--- a/web/templates/settings/api_key_modal.hbs
+++ b/web/templates/settings/api_key_modal.hbs
@@ -29,7 +29,12 @@
                     </div>
                 </div>
                 <div id="show_api_key">
-                    <p><b class="highlighted-element"><span id="api_key_value"></span></b></p>
+                    <div class="api-key-container">
+                        <b class="highlighted-element api-key-value-box"><span id="api_key_value"></span></b>
+                        <span role="button" tabindex="0" class="copy-button tippy-zulip-tooltip" data-tippy-content="{{t 'Copy API key' }}" data-tippy-placement="right" aria-label="{{t 'Copy API key' }}">
+                            <i class="zulip-icon zulip-icon-copy" aria-hidden="true"></i>
+                        </span>
+                    </div>
                     <div id="user_api_key_error" class="text-error"></div>
                 </div>
             </main>


### PR DESCRIPTION
Previously, in the "Your API key" modal, users had to manually highlight and copy their API key. This resulted in a slower user experience compared to other areas of the application.

This PR adds a dedicated copy button next to the API key, matching the styling and behaviour of the existing copy button in the "About Zulip" modal.

<!-- Describe your pull request here.-->

- Utilizes `ClipboardJS` for the copy action and the shared `show_copied_confirmation` helper for immediate, localized visual feedback ("Copied!") upon success, which also ensures proper functionality on touch devices.
- Upgraded the copy element from a non-interactive <span> to <button type="button"> to ensure full accessibility and keyboard navigation support, while stripping default browser styles to maintain the UI design.

Fixes #38044.

**How changes were tested:**

- Manually tested clicking the copy button to ensure it writes to the clipboard. Tested pasting it and it works.
- Manually test the "Generate new API key" edge case to ensure the icon and tooltip instantly reset.
- Passed all the local linters and TypeScript checks (`./tools/lint`)

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="2139" height="1181" alt="image" src="https://github.com/user-attachments/assets/cbb8190f-418c-417b-a905-acfedaaaf6f4" />

"Copy API key" shown beside the API Key with the copy logo.

<img width="2208" height="1185" alt="image" src="https://github.com/user-attachments/assets/d0ec676e-5e85-40dd-a5da-da22a145909b" />

showing "Copied" with the green tick mark.


https://github.com/user-attachments/assets/1ed6f601-fc6b-4b9f-be50-ef9877da2af6



A screen capture, showing the same changes with the clipboard showing the Resetting the copy button logic.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
