### PR TITLE
Use more modern instruction for singning of zulip deb repository

### DIFF
--- a/starlight_help/src/content/docs/desktop-app-install-guide.mdx
+++ b/starlight_help/src/content/docs/desktop-app-install-guide.mdx
@@ -73,6 +73,25 @@ releases](#install-a-beta-release).
       `sudo apt update && sudo apt upgrade`.
     </ZulipTip>
 
+    Ubuntu 22.04 and Debian 11 and above
+    <Steps>
+      1. Enter the following commands into a terminal:
+         ```bash
+         sudo apt install curl
+         curl -fsSL https://download.zulip.com/desktop/apt/zulip-desktop.asc | \
+         sudo gpg --dearmor -o /usr/share/keyrings/zulip-archive-keyring.gpg
+         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/zulip-archive-keyring.gpg] https://download.zulip.com/desktop/apt stable main" | \
+         sudo tee /etc/apt/sources.list.d/zulip-desktop.list
+         sudo apt update
+         sudo apt install zulip
+         ```
+         These commands set up the Zulip Desktop APT repository and its signing
+         key, and then install the Zulip client.
+      1. Run Zulip from your app launcher, or with `zulip` from a terminal.
+    </Steps>
+
+    Older ubuntu and Debian:
+
     <Steps>
       1. Enter the following commands into a terminal:
          ```bash


### PR DESCRIPTION
The current instructions use /etc/apt/trusted.gpg.d/, which is now considered deprecated in modern Debian-based distributions (starting from Ubuntu 22.04 LTS and Debian 11).

Using the old method causes apt to display security warnings (Key is stored in legacy trusted.gpg keyring) and, more importantly, grants the Zulip key trust over all other configured repositories on the user's system.

This PR updates the instructions to use the recommended "signed-by" approach:

1. Stores the GPG key in /usr/share/keyrings/ (not globally trusted).
2. Explicitly links the key to the Zulip repository in the .list file.

Reference: [Debian Wiki - UseThirdParty](https://wiki.debian.org/DebianRepository/UseThirdParty)


**How changes were tested:**

Added repository on my machine and successfully install zulip


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
