### PR TITLE
fix(email_mirror): Filter deactivated users from receiving email replies

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -506,7 +506,14 @@ def process_missed_message(to: str, message: EmailMessage) -> None:
         internal_send_private_message(user_profile, recipient_user, body)
     elif recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
         display_recipient = get_display_recipient(recipient)
-        emails = [user_dict["email"] for user_dict in display_recipient]
+        recipient_user_ids = [user_dict["id"] for user_dict in display_recipient]
+
+        emails = list(
+            UserProfile.objects.filter(
+                id__in=recipient_user_ids,
+                is_active=True,
+            ).values_list("email", flat=True)
+        )
         recipient_str = ", ".join(emails)
         internal_send_group_direct_message(user_profile.realm, user_profile, body, emails=emails)
     else:

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -52,7 +52,7 @@ from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import most_recent_message, most_recent_usermessage
 from zerver.models import Attachment, Recipient, Stream, UserProfile
 from zerver.models.groups import NamedUserGroup, SystemGroups
-from zerver.models.messages import Message
+from zerver.models.messages import Message, UserMessage
 from zerver.models.realms import get_realm
 from zerver.models.streams import StreamTopicsPolicyEnum, get_stream
 from zerver.models.users import get_system_bot
@@ -1368,11 +1368,11 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         self.assertEqual(message.sender, self.example_user("cordelia"))
         self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
-    def test_recieve_missed_group_direct_message_with_deactivated_user_email_messages(self) -> None:
-        # Build dummy messages for message notification email reply.
-        # Hamlet send Othello and Cordelia a group direct message.
-        # Cordelia will reply via email Hamlet will receive
-        # the message and Othello should not.
+    def test_receive_missed_group_dm_collapses_to_personal_when_only_two_remain(self) -> None:
+        # When a group DM has a deactivated user and only one active user remains
+        # (plus the sender), the group DM should collapse to a personal message.
+        # This tests the case: Group DM (Hamlet, Othello) -> Deactivate Othello
+        # -> Cordelia replies -> Should collapse to personal DM
         self.login("hamlet")
         othello = self.example_user("othello")
         cordelia = self.example_user("cordelia")
@@ -1386,29 +1386,100 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
             },
         )
         self.assert_json_success(result)
-        message = most_recent_message(cordelia)
+        initial_message = self.get_last_message()
 
-        mm_address = create_missed_message_address(cordelia, message)
+        # Verify initial message is a group DM
+        self.assertEqual(initial_message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
+        mm_address = create_missed_message_address(cordelia, initial_message)
+
+        # Deactivate one of the group members
         do_deactivate_user(othello, acting_user=None)
 
         incoming_valid_message = EmailMessage()
-        incoming_valid_message.set_content("TestMissedMessageEmailMessages body")
+        incoming_valid_message.set_content("Reply to group DM")
 
-        incoming_valid_message["Subject"] = "TestMissedMessageEmailMessages subject"
+        incoming_valid_message["Subject"] = "Reply subject"
         incoming_valid_message["From"] = cordelia.delivery_email
         incoming_valid_message["To"] = mm_address
         incoming_valid_message["Reply-to"] = cordelia.delivery_email
 
-        initial_last_message = self.get_last_message()
         process_message(incoming_valid_message)
 
-        # Cordelia's reply should still be posted, even though Othello (a recipient) is deactivated.
-        # The message should be delivered to the remaining active members.
-        self.assertNotEqual(initial_last_message, self.get_last_message())
+        new_message = self.get_last_message()
+        self.assertEqual(new_message.content, "Reply to group DM")
+        self.assertEqual(new_message.sender, cordelia)
 
-        new_last_message = self.get_last_message()
-        self.assertEqual(new_last_message.content, "TestMissedMessageEmailMessages body")
+        # After deactivation, with only Hamlet and Cordelia remaining,
+        # the group DM should collapse to a personal message
+        self.assertEqual(new_message.recipient.type, Recipient.PERSONAL)
+
+    def test_receive_missed_group_dm_remains_group_with_multiple_active_users(self) -> None:
+        # When a group DM has 3+ members and one is deactivated, the remaining
+        # active members should still receive a group DM (not collapsed to personal).
+        # This tests the case: Group DM (Hamlet, Othello, Cordelia) -> Deactivate Othello
+        # -> Replica from Cordelia -> Should remain DIRECT_MESSAGE_GROUP
+        self.login("hamlet")
+        othello = self.example_user("othello")
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
+
+        result = self.client_post(
+            "/json/messages",
+            {
+                "type": "private",
+                "content": "Initial group DM with 3 people",
+                "to": orjson.dumps([othello.id, cordelia.id, iago.id]).decode(),
+            },
+        )
+        self.assert_json_success(result)
+        initial_message = self.get_last_message()
+
+        # Verify initial message is a group DM
+        self.assertEqual(initial_message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+
+        mm_address = create_missed_message_address(cordelia, initial_message)
+
+        # Deactivate one of the group members
+        do_deactivate_user(othello, acting_user=None)
+
+        incoming_valid_message = EmailMessage()
+        incoming_valid_message.set_content("Reply to group DM with multiple members")
+
+        incoming_valid_message["Subject"] = "Reply subject"
+        incoming_valid_message["From"] = cordelia.delivery_email
+        incoming_valid_message["To"] = mm_address
+        incoming_valid_message["Reply-to"] = cordelia.delivery_email
+
+        process_message(incoming_valid_message)
+        new_message = self.get_last_message()
+
+        # Message properties
+        self.assertEqual(new_message.content, "Reply to group DM with multiple members")
+        self.assertEqual(new_message.sender, cordelia)
+        self.assertEqual(new_message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+
+        # Delivery verification
+        self.assertTrue(
+            UserMessage.objects.filter(
+                user_profile=self.example_user("hamlet"),
+                message=new_message,
+            ).exists()
+        )
+
+        self.assertTrue(
+            UserMessage.objects.filter(
+                user_profile=iago,
+                message=new_message,
+            ).exists()
+        )
+
+        self.assertFalse(
+            UserMessage.objects.filter(
+                user_profile=othello,
+                message=new_message,
+            ).exists()
+        )
 
     def test_receive_missed_stream_message_email_messages(self) -> None:
         # build dummy messages for message notification email reply

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1349,7 +1349,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         incoming_valid_message["To"] = mm_address
         incoming_valid_message["Reply-to"] = self.example_email("cordelia")
 
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(23):
             process_message(incoming_valid_message)
 
         # Confirm Iago received the message.
@@ -1367,6 +1367,48 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         self.assertEqual(message.content, "TestMissedGroupDirectMessageEmailMessages body")
         self.assertEqual(message.sender, self.example_user("cordelia"))
         self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+
+    def test_recieve_missed_group_direct_message_with_deactivated_user_email_messages(self) -> None:
+        # Build dummy messages for message notification email reply.
+        # Hamlet send Othello and Cordelia a group direct message.
+        # Cordelia will reply via email Hamlet will receive
+        # the message and Othello should not.
+        self.login("hamlet")
+        othello = self.example_user("othello")
+        cordelia = self.example_user("cordelia")
+
+        result = self.client_post(
+            "/json/messages",
+            {
+                "type": "private",
+                "content": "Initial group DM",
+                "to": orjson.dumps([othello.id, cordelia.id]).decode(),
+            },
+        )
+        self.assert_json_success(result)
+        message = most_recent_message(cordelia)
+
+        mm_address = create_missed_message_address(cordelia, message)
+
+        do_deactivate_user(othello, acting_user=None)
+
+        incoming_valid_message = EmailMessage()
+        incoming_valid_message.set_content("TestMissedMessageEmailMessages body")
+
+        incoming_valid_message["Subject"] = "TestMissedMessageEmailMessages subject"
+        incoming_valid_message["From"] = cordelia.delivery_email
+        incoming_valid_message["To"] = mm_address
+        incoming_valid_message["Reply-to"] = cordelia.delivery_email
+
+        initial_last_message = self.get_last_message()
+        process_message(incoming_valid_message)
+
+        # Cordelia's reply should still be posted, even though Othello (a recipient) is deactivated.
+        # The message should be delivered to the remaining active members.
+        self.assertNotEqual(initial_last_message, self.get_last_message())
+
+        new_last_message = self.get_last_message()
+        self.assertEqual(new_last_message.content, "TestMissedMessageEmailMessages body")
 
     def test_receive_missed_stream_message_email_messages(self) -> None:
         # build dummy messages for message notification email reply


### PR DESCRIPTION
Fixes Issue #35273 
email_mirror.py has a check to see if user is not deactivated before sending messages in group dm

**Original Issue**: When replying via email to a group DM that includes deactivated users, the email-mirror worker currently raises a ValidationError, causing the entire message to be dropped. 
The solution up until date was to surround it with a try-except block, so as to fix the error from popping up but still silently fail to send the message to the remaining active members

This change filters out deactivated users from the recipient list in `process_missed_message` before calling `internal_send_group_direct_message.` This ensures that the message is delivered to active participants while ignoring deactivated users, aligning the email-reply behavior with expected handling of deactivated users.

**How changes were tested:**
Added a new test for this scenario with 3 users, one sender and one of the two receivers being deactivated, `test_receive_missed_group_direct_message_with_deactivated_user_email_messages` 
This test verifies:
* Message delivers when a recipient is deactivated. 
* Deactivated users do not receive the message.

Ran the full backend test suite 
```bash
./tools/test-backend
```
with all test passed [ OK ]

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
