### PR TITLE
settings: Improve organization wide logo scaling and documentation.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1179,11 +1179,12 @@ nav {
 
         .nav-logo {
             display: inline-block;
-            height: 1.25em; /* 20px at 16px em */
+            height: auto;
+            max-height: 1.5625em; /* 25px at 16px/1em */
             max-width: var(--realm-logo-max-width);
 
             @media (height < $short_navbar_cutoff_height) {
-                height: 0.9375em; /* 15px at 16px em */
+                max-height: 1.1719em; /* 18.75px at 16px/1em */
             }
         }
 

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -60,7 +60,7 @@
         </div>
         {{> upgrade_tip_widget . }}
 
-        <p>{{t "A wide image (200×25 pixels) for the upper left corner of the app." }}</p>
+        <p>{{t "A wide logo for the upper left corner of the app (at least 200×25 pixels recommended)." }}</p>
         <div class="realm-logo-group">
             <div class="realm-logo-block realm-logo-section">
                 <h5 class="realm-logo-title">{{t "Light theme logo" }}</h5>


### PR DESCRIPTION
Fixes #22121.

At present, Zulip doesn't provide clear guidance on the size of organization-wide logos, and the app distorts logos with an aspect ratio wider than 8:1. 

This PR resolves these display and documentation issues by:

1. **CSS updates (`web/styles/zulip.css`)**: Updating `.nav-logo` to use `height: auto` and `max-height: 1.5625em` (25px). This ensures wide logos scale proportionally to fit inside the 200x25px bounding box without vertical distortion, and narrower logos remain left-aligned without stretching horizontally.
2. **UI Text (`web/templates/settings/organization_profile_admin.hbs`)**: Updating the settings description to explicitly state: "A wide logo for the upper left corner of the app (at least 200×25 pixels recommended)."
3. **Documentation (`starlight_help/...`)**: Clarifying the expected dimensions for both the square profile picture (100x100px) and the wide logo (200x25px) in the help center, including instructions for high-DPI displays.

*(Note: The `aspectRatio` constraints for the cropper widget mentioned in the original issue were resolved and merged via #38140, so I have dropped those changes from this branch to avoid conflicts.)*

**How changes were tested:**

1. Navigated to Organization settings > Organization profile.
2. Uploaded an extremely wide test logo (> 8:1 ratio) and verified it scales down proportionally to fit the 25x200px container without vertically squishing or distorting.
3. Uploaded a narrow/square logo and verified it scales down to 25px tall, does not stretch horizontally, and correctly aligns to the left side of the container in the app header.

**Screenshots and screen captures:**

| Before (Bug: Severe Vertical Distortion) | After (Fix: Scaled Proportionally) |
| --- | --- |
| <img width="1918" alt="image" src="https://github.com/user-attachments/assets/9ab12b75-5c90-4250-adc3-079dc9885342" /> | <img width="1918" alt="image" src="https://github.com/user-attachments/assets/1b32011c-00eb-49d7-ae60-4d8196588286" /> |

| After (Square Logo Fix: Left-aligned, No Stretch) |
| --- |
| <img width="1918" alt="image" src="https://github.com/user-attachments/assets/4764a48f-70a5-4c32-99a1-33607052e4ac" /> |
<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
- [x] Explains differences from previous plans (e.g., dropped cropper changes due to #38140).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>