### PR TITLE
channel_email_address: Fix web client missing `sender_id` parameter.

### DIFF
--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -610,6 +610,7 @@ function show_stream_email_address_modal(address: string, sub: StreamSubscriptio
         });
     }
 
+    let sender_dropdown_widget: DropdownWidget;
     function generate_email_modal_post_render(): void {
         function update_option_label(sender: User | CurrentUser | Bot): string {
             if (sender.user_id === people.EMAIL_GATEWAY_BOT.user_id) {
@@ -650,7 +651,7 @@ function show_stream_email_address_modal(address: string, sub: StreamSubscriptio
             event.preventDefault();
         }
 
-        const sender_dropdown_widget = new dropdown_widget.DropdownWidget({
+        sender_dropdown_widget = new dropdown_widget.DropdownWidget({
             widget_name: "sender_channel_email_address",
             get_options,
             item_click_callback,
@@ -667,7 +668,7 @@ function show_stream_email_address_modal(address: string, sub: StreamSubscriptio
         dialog_widget.submit_api_request(
             channel.get,
             "/json/streams/" + sub.stream_id + "/email_address",
-            {},
+            {sender_id: sender_dropdown_widget.value()},
             {
                 success_continuation(response_data) {
                     const email = z.object({email: z.string()}).parse(response_data).email;


### PR DESCRIPTION
Web clients when calling `GET /streams/<int:stream_id>/email_address`, were missing the `sender_id` parameter. It resulted in the sender always being "Email gateway bot", irrespective of what the user selected in the dropdown.

Fixes #37659.

**How changes were tested:**

Manual testing using: `./manage.py send_to_email_mirror`

<img width="889" height="363" alt="Screenshot 2026-02-23 at 1 51 46 PM" src="https://github.com/user-attachments/assets/5edffce0-a936-43bd-b447-a656ccfc4bd2" />


We already have backend tests for it.




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [] Responsiveness and internationalization.
- [] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
