### PR TITLE
zform: Preserve click handlers when rendering

### DIFF
--- a/web/src/zform.ts
+++ b/web/src/zform.ts
@@ -57,7 +57,7 @@ export function activate(opts: {
 
     function render(): void {
         if (data.type === "choices") {
-            $outer_elem.html(make_choices(data).html());
+            $outer_elem.empty().append(make_choices(data));
         }
     }
 


### PR DESCRIPTION
Fixes: #38081

A regression introduced during the TypeScript conversion of `web/src/zform.ts` where click handlers attached in `make_choices()` were lost.

The refactor changed rendering from passing a jQuery object to `$outer_elem.html()` to passing its `.html()` string, which stripped event bindings. As a result, clicking zform buttons focused the compose box instead of triggering `transmit.reply_message()`.

### Changes:
Restore correct behavior by appending the jQuery object directly: 
`$outer_elem.empty().append(make_choices(data));`

Buttons now correctly auto-send replies.

### How changes were tested:
- Test type: Manual
- Method: By sending a zform message via the API with `widget_content()` containing a choices-type zform.
- Verified: Clicking zform button triggers `transmit.reply_message()` and auto-sends reply, not focuses on the compose box.
- Browser: Chrome/Firefox.

### Screenshots and screen captures:
**Before fix:**
- Clicking the zform button focuses the compose box.
- `transmit.reply_message()` is not triggered.

https://github.com/user-attachments/assets/d397c774-30e8-426f-87d1-f99a8ce29d01




**After fix:**
- Button retains correct UI styling.
- Clicking triggers `transmit.reply_message()`.
- Reply is auto-sent as expected.

https://github.com/user-attachments/assets/d848d82c-70a3-4818-ad43-7826ea5d72c8



<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
