### PR TITLE
zform: Preserve click handlers when rendering

### DIFF
--- a/web/src/zform.ts
+++ b/web/src/zform.ts
@@ -64,7 +64,6 @@ export function render(opts: {$elem: JQuery; message: Message; widget_data: Widg
         const html = render_widgets_zform_choices(data);
         const $elem = $(html);
 
-
         $elem.find("button").on("click", (e) => {
             e.stopPropagation();
 
@@ -81,9 +80,6 @@ export function render(opts: {$elem: JQuery; message: Message; widget_data: Widg
         return $elem;
     }
 
-    if (data_with_choices_with_idx.type === "choices") {
-        const $choices = make_choices(data_with_choices_with_idx);
-        $outer_elem.empty().append($choices);
-    }
-    return;
+    const $choices = make_choices(data);
+    $outer_elem.empty().append($choices);
 }

--- a/web/src/zform.ts
+++ b/web/src/zform.ts
@@ -62,7 +62,9 @@ export function render(opts: {$elem: JQuery; message: Message; widget_data: Widg
 
     function make_choices(data: ZFormExtraData): JQuery {
         const html = render_widgets_zform_choices(data_with_choices_with_idx);
-        const $elem = $(html);
+        const $elem = $("<div>");
+        $elem.html(html);
+
 
         $elem.find("button").on("click", (e) => {
             e.stopPropagation();

--- a/web/src/zform.ts
+++ b/web/src/zform.ts
@@ -55,15 +55,14 @@ export function activate(opts: {any_data: AnyWidgetData; message: Message}): {
 export function render(opts: {$elem: JQuery; message: Message; widget_data: WidgetData}): void {
     assert(opts.widget_data.widget_type === "zform");
     const $outer_elem = opts.$elem;
-    const data_with_choices_with_idx = opts.widget_data.data;
-    if (!data_with_choices_with_idx) {
+    const data = opts.widget_data.data;
+    if (!data || data.type !== "choices") {
         return;
     }
 
     function make_choices(data: ZFormExtraData): JQuery {
-        const html = render_widgets_zform_choices(data_with_choices_with_idx);
-        const $elem = $("<div>");
-        $elem.html(html);
+        const html = render_widgets_zform_choices(data);
+        const $elem = $(html);
 
 
         $elem.find("button").on("click", (e) => {

--- a/web/src/zform.ts
+++ b/web/src/zform.ts
@@ -17,7 +17,7 @@ export function activate(opts: {any_data: AnyWidgetData; message: Message}): {
     widget_data: WidgetData;
 } {
     assert(opts.any_data.widget_type === "zform");
-    if (opts.any_data.extra_data === null) {
+    if (!opts.any_data.extra_data) {
         blueslip.error("invalid zform extra data");
         const widget_data = {
             widget_type: opts.any_data.widget_type,
@@ -56,7 +56,7 @@ export function render(opts: {$elem: JQuery; message: Message; widget_data: Widg
     assert(opts.widget_data.widget_type === "zform");
     const $outer_elem = opts.$elem;
     const data = opts.widget_data.data;
-    if (!data || data.type !== "choices") {
+    if (data?.type !== "choices") {
         return;
     }
 


### PR DESCRIPTION
Fixes: #38081

A regression introduced during the TypeScript conversion of `web/src/zform.ts` where click handlers attached in `make_choices()` were lost.

The refactor changed rendering from passing a jQuery object to `$outer_elem.html()` to passing its `.html()` string, which stripped event bindings. As a result, clicking zform buttons focused the compose box instead of triggering `transmit.reply_message()`.

### Changes:
Restore correct behavior by appending the jQuery object directly: 
```
$outer_elem.empty();
const $choices = make_choices(data);
$outer_elem.append($choices);
```

Buttons now correctly auto-send replies.

### How changes were tested:
- Test type: Manual
- Method: By sending a zform message via the API with `widget_content()` containing a choices-type zform.
- Verified: Clicking zform button triggers `transmit.reply_message()` and auto-sends reply, not focuses on the compose box.
- Browser: Chrome/Firefox.

### Screenshots and screen captures:
**Before fix:**
- Clicking the zform button focuses the compose box.
- `transmit.reply_message()` is not triggered.

https://github.com/user-attachments/assets/d0fd6a7f-b62b-481a-b842-57b21a811f26





**After fix:**
- Button retains correct UI styling.
- Clicking triggers `transmit.reply_message()`.
- Reply is auto-sent as expected.

https://github.com/user-attachments/assets/8ce6faf9-f3c2-428c-b357-a60c14062430




<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
