### PR TITLE
topics: Zoom in `show all topics` whenever possible.

### DIFF
--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -480,7 +480,15 @@ export function left_sidebar_scroll_zoomed_in_topic_into_view(): void {
             .find(".stream-list-subsection-header")
             .outerHeight(true) ?? 0;
     sticky_header_height += channel_folder_header_height;
-    scroll_util.scroll_element_into_container($selected_topic, $container, sticky_header_height);
+    const $topic_list = $selected_topic.closest(".topic-list");
+    const topic_list_height = $topic_list.outerHeight(true) ?? 0;
+    const available_topic_height = ($container.height() ?? 0) - sticky_header_height;
+
+    let $scroll_target = $selected_topic;
+    if (topic_list_height <= available_topic_height) {
+        $scroll_target = $topic_list;
+    }
+    scroll_util.scroll_element_into_container($scroll_target, $container, sticky_header_height);
 }
 
 // For zooming, we only do topic-list stuff here...let stream_list


### PR DESCRIPTION
Earlier, we only used to scroll until the topic if the topic was not in view. If there is space available, it will be better for the user to see all topics in the channel and the show all topics button instead of just the topic in question.

Fixes https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20left.20sidebar.20not.20showing.20channel.20when.20navigating.20to.20topic/with/2386282

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**
manually

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
![big screen scroll](https://github.com/user-attachments/assets/d3a6b797-8247-412e-9a63-e571ecb49f13)
![small screen scroll](https://github.com/user-attachments/assets/466838e8-9375-405f-b8d7-2573d5afae3e)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
