### PR TITLE
[ai] recipient_row: Convert .message-header-contents to CSS grid.

### DIFF
--- a/web/styles/color_picker.css
+++ b/web/styles/color_picker.css
@@ -45,11 +45,13 @@
     background: var(--gradient-custom-swatch);
 }
 
-.color-picker-popover .message-header-contents {
+.color-picker-popover .message_header .message-header-contents {
+    grid-template-columns: minmax(0, 1fr) 0 0 auto 0 0;
     border: none;
 }
 
 .color_picker_confirm_button {
+    grid-area: controls;
     height: 100%;
 
     &:focus-visible {

--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -13,9 +13,10 @@
     .message-header-contents {
         font-size: 1.0714em; /* 15px at 14px em */
         line-height: 1.2;
-        display: flex;
+        display: grid;
+        grid-template-areas: "stream-label separator topic controls error date";
+        grid-template-columns: minmax(0, 1fr) 0 0 0 auto auto;
         align-items: center;
-        justify-content: space-between;
         height: 1.8666em; /* 28px at 15px em */
         border: 1px solid var(--color-message-header-contents-border);
         border-bottom-color: var(--color-message-header-contents-border-bottom);
@@ -29,6 +30,14 @@
         box-shadow:
             -1px -5px 0 5px var(--color-background),
             1px -5px 0 0 var(--color-background);
+
+        .message-header-contents {
+            /* The separator column holds only the fixed-size chevron
+               icon, so it gets an explicit width; the other columns
+               hold variable-width content and stay auto/1fr. */
+            grid-template-columns: auto 1em auto 1fr auto auto;
+            align-items: stretch;
+        }
 
         & .message_label_clickable {
             user-select: text;
@@ -46,23 +55,26 @@
         }
 
         .stream_topic_separator {
+            grid-area: separator;
             line-height: 0;
+            display: flex;
+            align-items: center;
             color: var(--color-message-header-icon-non-interactive);
             position: relative;
             top: 0.5px;
         }
 
         .stream_topic {
-            display: inline-block;
+            grid-area: topic;
+            display: flex;
+            align-items: center;
             padding: 5px 6px 5px 2px;
-            height: 1.2142em; /* 17px at 14px em */
-            line-height: 1.2142em; /* 17px at 14px em */
             overflow: hidden;
             text-overflow: ellipsis;
+            position: relative;
+            top: 0.5px;
 
             .message_label_clickable.narrows_by_topic {
-                position: relative;
-                top: 0.5px;
                 overflow: hidden;
                 text-overflow: ellipsis;
 
@@ -222,19 +234,18 @@
                 var(--color-background);
 
             .recipient_row_date {
-                display: block;
+                display: flex;
             }
         }
     }
 }
 
 .stream_label {
+    grid-area: stream-label;
     display: flex;
     align-items: center;
     gap: 5px;
     padding: 5px 2px 5px 10px;
-    height: 1.2142em; /* 17px at 14px em */
-    line-height: 1.2142em; /* 17px at 14px em */
     position: relative;
     top: 0.5px;
     text-decoration: none;
@@ -278,8 +289,8 @@
 }
 
 .recipient_bar_controls {
+    grid-area: controls;
     display: flex;
-    flex-grow: 1;
     align-items: center;
 
     &.topic-edit-mode .recipient-bar-control {
@@ -296,7 +307,12 @@
     }
 }
 
+.error-icon-message-recipient {
+    grid-area: error;
+}
+
 .recipient_row_date {
+    grid-area: date;
     color: var(--color-date);
     font-size: calc(12em / 14);
     padding: 0 10px;
@@ -315,7 +331,7 @@
         display: none;
 
         .sticky_header & {
-            display: block;
+            display: flex;
         }
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2415,7 +2415,6 @@ body:not(.spectator-view) {
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    flex-grow: 1;
     color: var(--color-failed-message-send-icon);
 
     .zulip-icon {


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip/issues/37491.

The base `.message-header-contents` grid uses `align-items: center` for DM and other simpler headers. Stream headers override to `align-items: stretch` so that all children fill the row height uniformly; `.stream_label`, `.stream_topic`, and `.stream_topic_separator` then use flexbox internally for content centering, replacing the hardcoded em heights and line-heights they previously needed.

Named grid areas are used on all children so that each element is placed by name rather than source order. This makes the layout robust when a child is absent: empty area columns collapse to zero, eliminating the need for grid-template overrides in contexts like edit history where only a subset of children is present.

The `position: relative; top: 0.5px` on `.stream_topic` is moved from the inner `.narrows_by_topic` to the outer `.stream_topic` container, matching how `.stream_label` and `.stream_topic_separator` apply the same shift. 
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**
Manually

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

Same height children:
<img width="637" height="109" alt="Screenshot 2026-06-03 at 3 07 49 PM" src="https://github.com/user-attachments/assets/9d822742-31c7-4eae-884d-93d97d6f2fa0" />

please note that there is some layout shift in a few of these screenshots, e.g. https://www.diffchecker.com/image-compare/eubn6zId/. That set of screenshots was taken using node screenshot in chrome. When I took the screenshots using the manual screenshot tool in mac, this was the result: https://www.diffchecker.com/image-compare/XX4jkzDx/. All the screenshots below are taken with node-screenshot.

I think the diff is because of how node screenshot takes screenshot, but if we think it's not, then I can take manual screenshots all over again. All these screenshots take a ton of time, so I think it's better to wait for a second opinion before putting the effort to take the screenshots all over again.

| Name        | Before | After |
|---------------------------------|---|---|
| [Message Edit Row](https://www.diffchecker.com/image-compare/zjMCOFKJ/)         | <img width="1404" height="294" alt="edit_history_message_row_before" src="https://github.com/user-attachments/assets/a25b06a8-116b-41cb-9b16-a0b1781442fc" /> | <img width="1404" height="294" alt="edit_history_message_row_after" src="https://github.com/user-attachments/assets/2c6c7037-9b01-4513-8228-78fd3d34b873" /> |
| [Message Header (14px)](https://www.diffchecker.com/image-compare/6RgkgF9c/)   | <img width="1480" height="80" alt="message_header_before_14px" src="https://github.com/user-attachments/assets/a880854b-e7a5-404b-898e-85ecb2e2aefe" /> | <img width="1480" height="80" alt="message_header_after_14px" src="https://github.com/user-attachments/assets/bd006641-d084-439b-9d1c-6e92761168eb" /> |
| [Message Header (16px)]( https://www.diffchecker.com/image-compare/UaaYZ7QY/)       | <img width="1398" height="68" alt="message_header_before_16px" src="https://github.com/user-attachments/assets/f41ee56e-6ae9-49b2-82dc-d1e5dfe0e7ea" /> | <img width="1398" height="68" alt="message_header_after_16px" src="https://github.com/user-attachments/assets/fb71cb56-e5e4-4d80-957a-a2b7d7de8b2c" /> |
| [Message Header (18px)]( https://www.diffchecker.com/image-compare/PPrvhDWM/)    | <img width="1812" height="96" alt="message_header_before_18px" src="https://github.com/user-attachments/assets/78839ea2-28de-4ce9-a33b-f3ad5b1332c9" /> | <img width="1812" height="96" alt="message_header_after_18px" src="https://github.com/user-attachments/assets/760183a2-1739-4722-ae1e-beecb1979df3" /> |
| [Scheduled Messages Row ](https://www.diffchecker.com/image-compare/A7WpVEMT/)        | <img width="1404" height="352" alt="reminder_row_before" src="https://github.com/user-attachments/assets/ac54b4c3-42c5-4a98-818a-bd6e6a714115" /> | <img width="1404" height="352" alt="remind_row_after" src="https://github.com/user-attachments/assets/459dcefe-fcd9-45b3-bf07-762df8c31387" /> |
| [Error scheduled messages](https://www.diffchecker.com/image-compare/p3D60cs8/)  | <img width="1404" height="352" alt="reminder_row_error_before" src="https://github.com/user-attachments/assets/128f7f13-0a9a-4abc-9cc8-20a70c7755d0" /> | <img width="1404" height="352" alt="reminder_row_error_after" src="https://github.com/user-attachments/assets/c5698f22-665d-4c57-8962-ad78d3f50743" /> |
| [Draft Message Row ](https://www.diffchecker.com/image-compare/oKqhvCka/)            | <img width="1404" height="222" alt="draft_message_row_before" src="https://github.com/user-attachments/assets/28126a90-d97c-429c-b619-ff79810db58d" /> | <img width="1404" height="222" alt="draft_message_row_after" src="https://github.com/user-attachments/assets/ee864561-47ca-4a23-903d-eaab6f95dac8" /> |
| [Color picker]( https://www.diffchecker.com/image-compare/O3OU4vUh/) |  <img width="211" height="224" alt="color_before" src="https://github.com/user-attachments/assets/2ee155bd-6626-41ee-b35f-0f39a6e2f6b3" /> |  <img width="211" height="224" alt="color_after" src="https://github.com/user-attachments/assets/3ba452b6-c68f-4a6c-ac0a-2b14f1823fe3" /> |
| [DM row](https://www.diffchecker.com/image-compare/eubn6zId/) | <img width="1398" height="68" alt="dm_message_header_row_16px_before" src="https://github.com/user-attachments/assets/d37cadfa-23e8-49d8-8be2-de4be5568aea" /> | <img width="1398" height="68" alt="message_header_row_after_16px" src="https://github.com/user-attachments/assets/74b095c6-73ac-40e2-9848-fa5234450fb8" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
