### PR TITLE
message_edit: Use server-relative time for message edit eligibility

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -51,6 +51,7 @@ import * as resize from "./resize.ts";
 import * as resolved_topic from "./resolved_topic.ts";
 import * as rows from "./rows.ts";
 import * as saved_snippets_ui from "./saved_snippets_ui.ts";
+import * as server_time from "./server_time.ts";
 import {current_user, realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_topic_history from "./stream_topic_history.ts";
@@ -137,7 +138,7 @@ export function is_topic_editable(message: Message, edit_limit_seconds_buffer = 
     return (
         realm.realm_move_messages_within_stream_limit_seconds +
             edit_limit_seconds_buffer +
-            (message.timestamp - Date.now() / 1000) >
+            (message.timestamp - server_time.now()) >
         0
     );
 }
@@ -216,7 +217,7 @@ export function is_content_editable(message: Message, edit_limit_seconds_buffer 
     if (
         realm.realm_message_content_edit_limit_seconds +
             edit_limit_seconds_buffer +
-            (message.timestamp - Date.now() / 1000) >
+            (message.timestamp - server_time.now()) >
         0
     ) {
         return true;
@@ -229,7 +230,7 @@ export function remaining_content_edit_time(message: Message): number {
         return 0;
     }
     const limit_seconds = realm.realm_message_content_edit_limit_seconds ?? Infinity;
-    return limit_seconds + (message.timestamp - Date.now() / 1000);
+    return limit_seconds + (message.timestamp - server_time.now());
 }
 
 export function is_stream_editable(message: Message, edit_limit_seconds_buffer = 0): boolean {
@@ -266,7 +267,7 @@ export function is_stream_editable(message: Message, edit_limit_seconds_buffer =
     return (
         realm.realm_move_messages_between_streams_limit_seconds +
             edit_limit_seconds_buffer +
-            (message.timestamp - Date.now() / 1000) >
+            (message.timestamp - server_time.now()) >
         0
     );
 }
@@ -281,7 +282,7 @@ export function remaining_message_move_time(message: Message): number {
     }
 
     const limit_seconds = realm.realm_move_messages_within_stream_limit_seconds ?? Infinity;
-    return limit_seconds + (message.timestamp - Date.now() / 1000);
+    return limit_seconds + (message.timestamp - server_time.now());
 }
 
 export function stream_and_topic_exist_in_edit_history(
@@ -723,7 +724,7 @@ function edit_message($row: JQuery, raw_content: string): void {
         // zerver.actions.message_edit.check_update_message
         const min_seconds_to_edit = 10;
         let seconds_left =
-            realm_message_content_edit_limit_seconds + (message.timestamp - Date.now() / 1000);
+            realm_message_content_edit_limit_seconds + (message.timestamp - server_time.now());
         seconds_left = Math.floor(Math.max(seconds_left, min_seconds_to_edit));
 
         // I believe this needs to be defined outside the countdown_timer, since

--- a/web/src/presence.ts
+++ b/web/src/presence.ts
@@ -4,6 +4,7 @@ import * as z from "zod/mini";
 
 import * as people from "./people.ts";
 import type {User} from "./people.ts";
+import * as server_time from "./server_time.ts";
 import type {StateData, presence_schema} from "./state_data.ts";
 import {realm} from "./state_data.ts";
 import {user_settings} from "./user_settings.ts";
@@ -224,6 +225,7 @@ export function set_info(
         }
     */
 
+    server_time.update_server_offset(server_timestamp);
     presence_last_update_id = last_update_id;
     const all_active_or_idle_user_ids = new Set(get_active_or_idle_user_ids());
 

--- a/web/src/server_time.ts
+++ b/web/src/server_time.ts
@@ -1,0 +1,26 @@
+// Track the difference between the server's clock and the client's
+// clock, so that time-limit checks (message editing, topic moving,
+// etc.) use the server's idea of "now" instead of the local clock.
+// Without this, a client whose clock is ahead will hide the edit
+// option even when the server would still accept the edit.
+
+let clock_offset_seconds = 0;
+
+export function now(): number {
+    return Date.now() / 1000 + clock_offset_seconds;
+}
+
+// Called with a server-supplied timestamp (presence responses,
+// page load) to update our offset estimate.
+export function update_server_offset(server_timestamp: number): void {
+    clock_offset_seconds = server_timestamp - Date.now() / 1000;
+}
+
+// Test helpers.
+export function get_clock_offset_seconds(): number {
+    return clock_offset_seconds;
+}
+
+export function set_clock_offset_seconds(offset: number): void {
+    clock_offset_seconds = offset;
+}

--- a/web/tests/message_edit.test.cjs
+++ b/web/tests/message_edit.test.cjs
@@ -3,9 +3,10 @@
 const assert = require("node:assert/strict");
 
 const {make_realm} = require("./lib/example_realm.cjs");
-const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {clock, mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 
+const server_time = zrequire("server_time");
 const message_edit = zrequire("message_edit");
 const {set_current_user, set_realm} = zrequire("state_data");
 
@@ -186,6 +187,92 @@ run_test("is_stream_editable", ({override}) => {
 
     override(current_user, "is_moderator", true);
     assert.equal(message_edit.is_stream_editable(message), true);
+});
+
+run_test("is_content_editable with client clock ahead of server", ({override}) => {
+    // Client clock 1 hour ahead of server.
+    const server_now = 1000000000;
+    const client_now = server_now + 3600;
+    clock.setSystemTime(client_now * 1000);
+    server_time.set_clock_offset_seconds(-3600);
+
+    override(realm, "realm_allow_message_editing", true);
+    override(realm, "realm_message_content_edit_limit_seconds", 300);
+
+    const message = {
+        sent_by_me: true,
+        submessages: [],
+        timestamp: server_now - 30,
+    };
+
+    // 30s old, 300s limit — still editable.
+    assert.equal(message_edit.is_content_editable(message), true);
+
+    // 400s old, 300s limit — expired.
+    message.timestamp = server_now - 400;
+    assert.equal(message_edit.is_content_editable(message), false);
+
+    clock.setSystemTime(0);
+    server_time.set_clock_offset_seconds(0);
+});
+
+run_test("is_topic_editable with client clock ahead of server", ({override}) => {
+    const server_now = 1000000000;
+    const client_now = server_now + 3600;
+    clock.setSystemTime(client_now * 1000);
+    server_time.set_clock_offset_seconds(-3600);
+
+    override(realm, "realm_allow_message_editing", true);
+    override(realm, "realm_move_messages_within_stream_limit_seconds", 300);
+    override(stream_data, "is_stream_archived_by_id", () => false);
+    override(stream_data, "user_can_move_messages_within_channel", () => true);
+    override(stream_data, "get_sub_by_id", () => ({}));
+    override(stream_data, "is_empty_topic_only_channel", () => false);
+    override(current_user, "is_moderator", false);
+
+    const message = {
+        sent_by_me: true,
+        type: "stream",
+        submessages: [],
+        timestamp: server_now - 30,
+    };
+
+    assert.equal(message_edit.is_topic_editable(message), true);
+
+    message.timestamp = server_now - 400;
+    assert.equal(message_edit.is_topic_editable(message), false);
+
+    clock.setSystemTime(0);
+    server_time.set_clock_offset_seconds(0);
+});
+
+run_test("is_stream_editable with client clock ahead of server", ({override}) => {
+    const server_now = 1000000000;
+    const client_now = server_now + 3600;
+    clock.setSystemTime(client_now * 1000);
+    server_time.set_clock_offset_seconds(-3600);
+
+    override(realm, "realm_allow_message_editing", true);
+    override(realm, "realm_move_messages_between_streams_limit_seconds", 300);
+    override(stream_data, "user_can_move_messages_out_of_channel", () => true);
+    override(stream_data, "get_sub_by_id", () => ({}));
+    override(current_user, "is_moderator", false);
+    override(stream_data, "is_stream_archived_by_id", () => false);
+
+    const message = {
+        sent_by_me: true,
+        type: "stream",
+        submessages: [],
+        timestamp: server_now - 30,
+    };
+
+    assert.equal(message_edit.is_stream_editable(message), true);
+
+    message.timestamp = server_now - 400;
+    assert.equal(message_edit.is_stream_editable(message), false);
+
+    clock.setSystemTime(0);
+    server_time.set_clock_offset_seconds(0);
 });
 
 run_test("stream_and_topic_exist_in_edit_history", () => {

--- a/web/tests/server_time.test.cjs
+++ b/web/tests/server_time.test.cjs
@@ -1,0 +1,56 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {clock, zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const server_time = zrequire("server_time");
+
+run_test("now returns client time when offset is zero", () => {
+    server_time.set_clock_offset_seconds(0);
+    const client_now = Date.now() / 1000;
+    const result = server_time.now();
+    assert.ok(Math.abs(result - client_now) < 1);
+});
+
+run_test("now adjusts for positive clock offset", () => {
+    // Server 1 hour ahead of client.
+    clock.setSystemTime(1000000000 * 1000);
+    server_time.set_clock_offset_seconds(3600);
+    const result = server_time.now();
+    assert.ok(Math.abs(result - (1000000000 + 3600)) < 1);
+    clock.setSystemTime(0);
+    server_time.set_clock_offset_seconds(0);
+});
+
+run_test("now adjusts for negative clock offset", () => {
+    // Client 1 hour ahead of server.
+    clock.setSystemTime(1000000000 * 1000);
+    server_time.set_clock_offset_seconds(-3600);
+    const result = server_time.now();
+    assert.ok(Math.abs(result - (1000000000 - 3600)) < 1);
+    clock.setSystemTime(0);
+    server_time.set_clock_offset_seconds(0);
+});
+
+run_test("update_server_offset computes correct offset", () => {
+    // Client at 1000000000, server at 1000003600.
+    clock.setSystemTime(1000000000 * 1000);
+    server_time.update_server_offset(1000003600);
+    assert.ok(Math.abs(server_time.get_clock_offset_seconds() - 3600) < 1);
+    clock.setSystemTime(0);
+});
+
+run_test("update_server_offset with client ahead of server", () => {
+    // Client at 1000003600, server at 1000000000.
+    clock.setSystemTime(1000003600 * 1000);
+    server_time.update_server_offset(1000000000);
+    assert.ok(Math.abs(server_time.get_clock_offset_seconds() - -3600) < 1);
+
+    // now() returns server-relative time.
+    const result = server_time.now();
+    assert.ok(Math.abs(result - 1000000000) < 1);
+    clock.setSystemTime(0);
+    server_time.set_clock_offset_seconds(0);
+});


### PR DESCRIPTION
Fixes #21717.

The web client determines whether a message can be edited by comparing the message timestamp with the client’s local clock (`Date.now()`). Since message timestamps originate from the server but the “current time” used in these checks comes from the client machine, any clock skew between the two can lead to incorrect results. If the client clock is ahead of the server clock, the client may conclude that the edit window has already expired and hide the Edit message option immediately after sending a message, even though the server would still accept the edit.

Previously, edit eligibility checks in `message_edit.ts` relied directly on expressions such as `message.timestamp - Date.now() / 1000`. When the client clock was ahead, this made the message appear older than it actually was, causing the client to prematurely disable editing. The same logic is also used for other time-limited actions such as topic edits and moving messages between streams, so those operations were affected by the same issue.

This change introduces a small client-side estimate of the server’s current time. A new `server_time` module tracks the offset between the server clock and the client clock using server timestamps received through presence responses. Using this offset, the client derives a server-relative “now” value (`Date.now() + offset`). The edit-window calculations in `message_edit.ts` now use `server_time.now()` instead of `Date.now()`, ensuring that edit, topic change, and stream move eligibility checks are evaluated relative to the server’s notion of time rather than the local machine clock.

This keeps the client UI consistent with what the server will allow and prevents valid edits from being hidden when the client clock is skewed.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
