### PR TITLE
API: Allow bot users to access user group endpoints

### DIFF
--- a/api_docs/unmerged.d/ZF-534222.md
+++ b/api_docs/unmerged.d/ZF-534222.md
@@ -1,0 +1,8 @@
+* [`POST /user_groups/create`](/api/create-user-group),
+  [`PATCH /user_groups/{user_group_id}`](/api/update-user-group),
+  [`POST /user_groups/{user_group_id}/members`](/api/update-user-group-members),
+  [`POST /user_groups/{user_group_id}/subgroups`](/api/update-user-group-subgroups),
+  [`GET /user_groups/{user_group_id}/members/{user_id}`](/api/get-is-user-group-member),
+  [`GET /user_groups/{user_group_id}/members`](/api/get-user-group-members),
+  [`GET /user_groups/{user_group_id}/members`](/api/get-user-group-subgroups),
+  [`GET /user-groups`](/api/get-user-groups): Bots can now access these endpoints.

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -691,7 +691,7 @@ def require_human_non_guest_user(
 def require_user_group_create_permission(
     view_func: Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse],
 ) -> Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]:
-    @require_human_non_guest_user
+    @require_non_guest_user
     @wraps(view_func)
     def _wrapped_view_func(
         request: HttpRequest,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -24570,6 +24570,9 @@ paths:
       tags: ["users"]
       description: |
         Create a new [user group](/help/user-groups).
+
+        **Changes**: Prior to Zulip 12.0 (feature level ZF-534222),
+        bots could not access this endpoint.
       requestBody:
         required: true
         content:
@@ -24768,7 +24771,10 @@ paths:
         Update the members of a [user group](/help/user-groups). The
         user IDs must correspond to non-deactivated users.
 
-        **Changes**: Prior to Zulip 11.0 (feature level 391), members
+        **Changes**: Prior to Zulip 12.0 (feature level ZF-534222),
+        bots could not access this endpoint.
+
+        Prior to Zulip 11.0 (feature level 391), members
         could not be added or removed from a deactivated group.
 
         **Changes**: Prior to Zulip 10.0 (feature level 303), group memberships of
@@ -24839,7 +24845,10 @@ paths:
       description: |
         Get the members of a [user group](/help/user-groups).
 
-        **Changes**: New in Zulip 6.0 (feature level 127).
+        **Changes**: Prior to Zulip 12.0 (feature level ZF-534222),
+        bots could not access this endpoint.
+
+        New in Zulip 6.0 (feature level 127).
       parameters:
         - $ref: "#/components/parameters/UserGroupId"
         - $ref: "#/components/parameters/DirectMemberOnly"
@@ -24881,7 +24890,10 @@ paths:
         membership, the deactivated group itself cannot be mentioned
         or used in the value of any permission without first being reactivated.
 
-        **Changes**: Starting with Zulip 11.0 (feature level 386), this
+        **Changes**: Prior to Zulip 12.0 (feature level ZF-534222),
+        bots could not access this endpoint.
+
+        Starting with Zulip 11.0 (feature level 386), this
         endpoint can be used to reactivate a user group.
 
         Prior to Zulip 10.0 (feature level 340), only the name field
@@ -25089,6 +25101,9 @@ paths:
       tags: ["users"]
       description: |
         Fetches all of the user groups in the organization.
+
+        **Changes**: Prior to Zulip 12.0 (feature level ZF-534222),
+        bots could not access this endpoint.
 
         !!! warn ""
 
@@ -25364,8 +25379,11 @@ paths:
       description: |
         Update the subgroups of a [user group](/help/user-groups).
 
-        **Changes**: Prior to Zulip 11.0 (feature level 391), subgroups
-        could not be added or removed from a deactivated group.
+        **Changes**: Prior to Zulip 12.0 (feature level ZF-534222),
+        bots could not access this endpoint.
+
+        Prior to Zulip 11.0 (feature level 391), subgroups could
+        not be added or removed from a deactivated group.
 
         **Changes**: New in Zulip 6.0 (feature level 127).
       x-curl-examples-parameters:
@@ -25412,7 +25430,10 @@ paths:
       description: |
         Get the subgroups of a [user group](/help/user-groups).
 
-        **Changes**: New in Zulip 6.0 (feature level 127).
+        **Changes**: Prior to Zulip 12.0 (feature level ZF-534222),
+        bots could not access this endpoint.
+
+        New in Zulip 6.0 (feature level 127).
       parameters:
         - $ref: "#/components/parameters/UserGroupId"
         - name: direct_subgroup_only
@@ -25454,7 +25475,10 @@ paths:
       description: |
         Check whether a user is member of user group.
 
-        **Changes**: Prior to Zulip 12.0 (feature level 458), this endpoint
+        **Changes**: Prior to Zulip 12.0 (feature level ZF-534222),
+        bots could not access this endpoint.
+
+        Prior to Zulip 12.0 (feature level 458), this endpoint
         did not support querying group membership of bot users.
 
         Prior to Zulip 10.0 (feature level 303),

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -1123,6 +1123,15 @@ class UserGroupAPITestCase(UserGroupTestCase):
             NamedUserGroup.objects.filter(realm_for_sharding=user_profile.realm).count(),
         )
 
+        # Bot can also get user groups.
+        bot = self.example_user("default_bot")
+        result = self.api_get(bot, "/api/v1/user_groups")
+        response_dict = self.assert_json_success(result)
+        self.assert_length(
+            response_dict["user_groups"],
+            NamedUserGroup.objects.filter(realm_for_sharding=user_profile.realm).count(),
+        )
+
     def test_user_group_update(self) -> None:
         hamlet = self.example_user("hamlet")
         self.login("hamlet")
@@ -1791,14 +1800,24 @@ class UserGroupAPITestCase(UserGroupTestCase):
         support_group.deactivated = False
         support_group.save()
 
+        bot = self.example_user("default_bot")
         setting_group = self.create_or_update_anonymous_group_for_setting(
-            [self.example_user("shiva")], [admins_group]
+            [self.example_user("shiva"), bot], [admins_group]
         )
         do_change_user_group_permission_setting(
             support_group, "can_manage_group", setting_group, acting_user=None
         )
 
         result = self.client_post(f"/json/user_groups/{support_group.id}/deactivate")
+        self.assert_json_success(result)
+        support_group = NamedUserGroup.objects.get(name="support", realm_for_sharding=realm)
+        self.assertTrue(support_group.deactivated)
+
+        support_group.deactivated = False
+        support_group.save()
+
+        # Check that bot can also deactivate a group if it has permission.
+        result = self.api_post(bot, f"/api/v1/user_groups/{support_group.id}/deactivate")
         self.assert_json_success(result)
         support_group = NamedUserGroup.objects.get(name="support", realm_for_sharding=realm)
         self.assertTrue(support_group.deactivated)
@@ -2602,8 +2621,9 @@ class UserGroupAPITestCase(UserGroupTestCase):
 
         # Check if members of an anonymous group are allowed to create user groups.
         cordelia = self.example_user("cordelia")
+        bot = self.example_user("default_bot")
         anonymous_group = self.create_or_update_anonymous_group_for_setting(
-            [cordelia], [admins_group, moderators_group]
+            [cordelia, bot], [admins_group, moderators_group]
         )
         do_change_realm_permission_group_setting(
             realm,
@@ -2617,6 +2637,9 @@ class UserGroupAPITestCase(UserGroupTestCase):
         check_create_user_group("shiva")
         NamedUserGroup.objects.get(name="support", realm_for_sharding=realm).delete()
         check_create_user_group("iago")
+        NamedUserGroup.objects.get(name="support", realm_for_sharding=realm).delete()
+        # Bot can also create a group if it has permission.
+        check_create_user_group("default_bot")
         NamedUserGroup.objects.get(name="support", realm_for_sharding=realm).delete()
 
         # Check only members are allowed to create the user group.
@@ -2853,7 +2876,8 @@ class UserGroupAPITestCase(UserGroupTestCase):
         )
 
         setting_group = self.create_or_update_anonymous_group_for_setting(
-            [self.example_user("cordelia")], [leadership_group, owners_group]
+            [self.example_user("cordelia"), self.example_user("default_bot")],
+            [leadership_group, owners_group],
         )
         do_change_user_group_permission_setting(
             user_group, "can_manage_group", setting_group, acting_user=None
@@ -2866,6 +2890,8 @@ class UserGroupAPITestCase(UserGroupTestCase):
             "cordelia",
         )
         check_update_user_group("help", "Troubleshooting team", "desdemona")
+        # Bot can also update a group if it has permissions.
+        check_update_user_group("support", "Support team", "default_bot")
 
     def test_realm_level_setting_for_updating_members(self) -> None:
         user_group = self.create_user_group_for_test(
@@ -3141,6 +3167,15 @@ class UserGroupAPITestCase(UserGroupTestCase):
         check_adding_members_to_group("othello")
         bulk_remove_members_from_user_groups([user_group], [aaron.id], acting_user=None)
 
+        # Bot can also add members if it has permission.
+        default_bot = self.example_user("default_bot")
+        setting_group = self.create_or_update_anonymous_group_for_setting([default_bot], [])
+        do_change_user_group_permission_setting(
+            user_group, "can_add_members_group", setting_group, acting_user=None
+        )
+        check_adding_members_to_group("default_bot")
+        bulk_remove_members_from_user_groups([user_group], [aaron.id], acting_user=None)
+
     def test_group_level_setting_for_removing_members(self) -> None:
         othello = self.example_user("othello")
         aaron = self.example_user("aaron")
@@ -3245,6 +3280,15 @@ class UserGroupAPITestCase(UserGroupTestCase):
 
         check_removing_members_from_group("hamlet")
 
+        # Bot can also add members if it has permission.
+        default_bot = self.example_user("default_bot")
+        setting_group = self.create_or_update_anonymous_group_for_setting([default_bot], [])
+        do_change_user_group_permission_setting(
+            user_group, "can_remove_members_group", setting_group, acting_user=None
+        )
+        bulk_add_members_to_user_groups([user_group], [aaron.id], acting_user=None)
+        check_removing_members_from_group("default_bot")
+
     def test_adding_yourself_to_group(self) -> None:
         realm = get_realm("zulip")
         othello = self.example_user("othello")
@@ -3324,8 +3368,9 @@ class UserGroupAPITestCase(UserGroupTestCase):
 
         # Test with setting set to an anonymous group.
         shiva = self.example_user("shiva")
+        bot = self.example_user("default_bot")
         setting_group = self.create_or_update_anonymous_group_for_setting(
-            [shiva], [leadership_group]
+            [shiva, bot], [leadership_group]
         )
         do_change_user_group_permission_setting(
             user_group,
@@ -3337,6 +3382,8 @@ class UserGroupAPITestCase(UserGroupTestCase):
         check_adding_yourself_to_group("iago", "Insufficient permission")
         check_adding_yourself_to_group("cordelia")
         check_adding_yourself_to_group("shiva")
+        # Bot can also add themselves if it has permission.
+        check_adding_yourself_to_group("default_bot")
 
         # If user is allowed to add anyone, then they can join themselves
         # even when can_join_group setting does not allow them to do so.
@@ -3465,8 +3512,9 @@ class UserGroupAPITestCase(UserGroupTestCase):
 
         # Test with setting set to an anonymous group.
         shiva = self.example_user("shiva")
+        default_bot = self.example_user("default_bot")
         setting_group = self.create_or_update_anonymous_group_for_setting(
-            [shiva], [leadership_group]
+            [shiva, default_bot], [leadership_group]
         )
         do_change_user_group_permission_setting(
             user_group,
@@ -3478,6 +3526,8 @@ class UserGroupAPITestCase(UserGroupTestCase):
         check_leaving_a_group("iago", "Insufficient permission")
         check_leaving_a_group("cordelia")
         check_leaving_a_group("shiva")
+        # Bot can leave a group if it has permission.
+        check_leaving_a_group("default_bot")
 
         # If user is allowed to remove anyone, then they can leave themselves
         # even when can_leave_group setting does not allow them to do so.
@@ -3795,8 +3845,9 @@ class UserGroupAPITestCase(UserGroupTestCase):
         check_adding_subgroups_to_group("prospero")
 
         # Test case when setting is set to an anonymous group.
+        bot = self.example_user("default_bot")
         setting_group = self.create_or_update_anonymous_group_for_setting(
-            direct_members=[othello],
+            direct_members=[othello, bot],
             direct_subgroups=[owners_group],
         )
         do_change_user_group_permission_setting(
@@ -3809,6 +3860,8 @@ class UserGroupAPITestCase(UserGroupTestCase):
         check_adding_subgroups_to_group("iago", "Insufficient permission")
         check_adding_subgroups_to_group("desdemona")
         check_adding_subgroups_to_group("othello")
+        # Bot can add subgroups to a group if it has permission.
+        check_adding_subgroups_to_group("default_bot")
 
         # Set can_add_members_group setting to nobody, so we can test
         # managing permissions as well.
@@ -3916,8 +3969,9 @@ class UserGroupAPITestCase(UserGroupTestCase):
         check_remove_subgroups_from_group("prospero")
 
         # Test case when setting is set to an anonymous group.
+        bot = self.example_user("default_bot")
         setting_group = self.create_or_update_anonymous_group_for_setting(
-            direct_members=[othello],
+            direct_members=[othello, bot],
             direct_subgroups=[owners_group],
         )
         do_change_user_group_permission_setting(
@@ -3930,6 +3984,8 @@ class UserGroupAPITestCase(UserGroupTestCase):
         check_remove_subgroups_from_group("iago", "Insufficient permission")
         check_remove_subgroups_from_group("desdemona")
         check_remove_subgroups_from_group("othello")
+        # Bot can remove subgroups to a group if it has permission.
+        check_remove_subgroups_from_group("default_bot")
 
         # Set can_manage_group setting to nobody, so we can test
         # can_manage_all_groups behavior.
@@ -4047,6 +4103,13 @@ class UserGroupAPITestCase(UserGroupTestCase):
         result = self.client_get(f"/json/user_groups/{admins_group.id}/members/{iago.id}")
         self.assert_json_error(result, "User is deactivated")
 
+        # Bot can check membership status.
+        bot = self.example_user("default_bot")
+        result_dict = orjson.loads(
+            self.api_get(bot, f"/api/v1/user_groups/{admins_group.id}/members/{othello.id}").content
+        )
+        self.assertFalse(result_dict["is_user_group_member"])
+
     def test_get_user_group_members(self) -> None:
         realm = get_realm("zulip")
         iago = self.example_user("iago")
@@ -4106,6 +4169,17 @@ class UserGroupAPITestCase(UserGroupTestCase):
         )
         self.assertCountEqual(result_dict["members"], [desdemona.id, iago.id])
 
+        # Bot can also get members of a group.
+        bot = self.example_user("default_bot")
+        result_dict = orjson.loads(
+            self.api_get(
+                bot,
+                f"/api/v1/user_groups/{moderators_group.id}/members",
+                info=params,
+            ).content
+        )
+        self.assertCountEqual(result_dict["members"], [desdemona.id, iago.id])
+
     def test_get_subgroups_of_user_group(self) -> None:
         realm = get_realm("zulip")
         owners_group = NamedUserGroup.objects.get(
@@ -4155,6 +4229,15 @@ class UserGroupAPITestCase(UserGroupTestCase):
         result_dict = orjson.loads(
             self.client_get(
                 f"/json/user_groups/{moderators_group.id}/subgroups", info=params
+            ).content
+        )
+        self.assertCountEqual(result_dict["subgroups"], [admins_group.id])
+
+        # Bot can also get subgroups of a group.
+        bot = self.example_user("default_bot")
+        result_dict = orjson.loads(
+            self.api_get(
+                bot, f"/api/v1/user_groups/{moderators_group.id}/subgroups", info=params
             ).content
         )
         self.assertCountEqual(result_dict["subgroups"], [admins_group.id])

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -18,7 +18,7 @@ from zerver.actions.user_groups import (
     do_update_user_group_name,
     remove_subgroups_from_user_group,
 )
-from zerver.decorator import require_human_non_guest_user, require_user_group_create_permission
+from zerver.decorator import require_non_guest_user, require_user_group_create_permission
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.mention import MentionBackend, silent_mention_syntax_for_user
 from zerver.lib.response import json_success
@@ -115,7 +115,7 @@ def add_user_group(
     return json_success(request, data={"group_id": user_group.id})
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 def get_user_groups(
     request: HttpRequest,
@@ -130,7 +130,7 @@ def get_user_groups(
 
 
 @transaction.atomic(durable=True)
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 def edit_user_group(
     request: HttpRequest,
@@ -239,7 +239,7 @@ def deactivate_user_group(
     return json_success(request)
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 @transaction.atomic(durable=True)
 def update_user_group_backend(
@@ -536,7 +536,7 @@ def remove_subgroups_from_group_backend(
     return json_success(request)
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 @transaction.atomic(durable=True)
 def update_subgroups_of_user_group(
@@ -569,7 +569,7 @@ def update_subgroups_of_user_group(
     return json_success(request, data)
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 def get_is_user_group_member(
     request: HttpRequest,
@@ -592,7 +592,7 @@ def get_is_user_group_member(
     )
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 def get_user_group_members(
     request: HttpRequest,
@@ -611,7 +611,7 @@ def get_user_group_members(
     )
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 def get_subgroups_of_user_group(
     request: HttpRequest,


### PR DESCRIPTION
This PR allows bot users to access user group API endpoints by replacing
`@require_human_non_guest_user` with `@require_non_guest_user`
on all user group endpoints (including membership and subgroup updates).

This implements the second step discussed in #37927 and fixes the
unintentional restriction preventing bots from using user groups for ACL logic.

**How changes were tested:**

- Updated and expanded backend tests to verify bot access.
- Confirmed guest users remain restricted.
- Ran `./tools/test-backend` and `./tools/lint`.
- Bumped API feature level and updated OpenAPI documentation.

No UI changes.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>