### PR TITLE
Onboarding_steps: Replacing dict[str, Any] with APIOnboardingStep

### DIFF
--- a/zerver/actions/onboarding_steps.py
+++ b/zerver/actions/onboarding_steps.py
@@ -1,3 +1,5 @@
+from dataclasses import asdict
+
 from django.db import transaction
 
 from zerver.lib.onboarding_steps import get_next_onboarding_steps
@@ -8,5 +10,8 @@ from zerver.tornado.django_api import send_event_on_commit
 @transaction.atomic(durable=True)
 def do_mark_onboarding_step_as_read(user: UserProfile, onboarding_step: str) -> None:
     OnboardingStep.objects.get_or_create(user=user, onboarding_step=onboarding_step)
-    event = dict(type="onboarding_steps", onboarding_steps=get_next_onboarding_steps(user))
+    event = dict(
+        type="onboarding_steps",
+        onboarding_steps=[asdict(step) for step in get_next_onboarding_steps(user)],
+    )
     send_event_on_commit(user.realm, event, [user.id])

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -297,7 +297,9 @@ def fetch_initial_state_data(
         # account, we'd maybe need to store their state using cookies
         # or local storage, rather than in the database.
         state["onboarding_steps"] = (
-            [] if user_profile is None else get_next_onboarding_steps(user_profile)
+            []
+            if user_profile is None
+            else [asdict(step) for step in get_next_onboarding_steps(user_profile)]
         )
         state["navigation_tour_video_url"] = settings.NAVIGATION_TOUR_VIDEO_URL
 

--- a/zerver/lib/onboarding_steps.py
+++ b/zerver/lib/onboarding_steps.py
@@ -1,7 +1,6 @@
 # See https://zulip.readthedocs.io/en/latest/subsystems/onboarding-steps.html
 # for documentation on this subsystem.
 from dataclasses import dataclass
-from typing import Any
 
 from django.conf import settings
 
@@ -9,25 +8,31 @@ from zerver.models import OnboardingStep, UserProfile
 
 
 @dataclass
+class APIOnboardingStep:
+    type: str
+    name: str
+
+
+@dataclass
 class OneTimeNotice:
     name: str
 
-    def to_dict(self) -> dict[str, str]:
-        return {
-            "type": "one_time_notice",
-            "name": self.name,
-        }
+    def to_dict(self) -> APIOnboardingStep:
+        return APIOnboardingStep(
+            type="one_time_notice",
+            name=self.name,
+        )
 
 
 @dataclass
 class OneTimeAction:
     name: str
 
-    def to_dict(self) -> dict[str, str]:
-        return {
-            "type": "one_time_action",
-            "name": self.name,
-        }
+    def to_dict(self) -> APIOnboardingStep:
+        return APIOnboardingStep(
+            type="one_time_action",
+            name=self.name,
+        )
 
 
 ONE_TIME_NOTICES: list[OneTimeNotice] = [
@@ -68,7 +73,7 @@ ONE_TIME_ACTIONS = [OneTimeAction(name="narrow_to_dm_with_welcome_bot_new_user")
 ALL_ONBOARDING_STEPS: list[OneTimeNotice | OneTimeAction] = ONE_TIME_NOTICES + ONE_TIME_ACTIONS
 
 
-def get_next_onboarding_steps(user: UserProfile) -> list[dict[str, Any]]:
+def get_next_onboarding_steps(user: UserProfile) -> list[APIOnboardingStep]:
     # If a Zulip server has disabled the tutorial, never send any
     # onboarding steps.
     if not settings.TUTORIAL_ENABLED:
@@ -82,7 +87,7 @@ def get_next_onboarding_steps(user: UserProfile) -> list[dict[str, Any]]:
         seen_onboarding_steps.append("navigation_tour_video")
     seen_onboarding_steps_set = frozenset(seen_onboarding_steps)
 
-    onboarding_steps: list[dict[str, Any]] = []
+    onboarding_steps: list[APIOnboardingStep] = []
     for onboarding_step in ALL_ONBOARDING_STEPS:
         if onboarding_step.name in seen_onboarding_steps_set:
             continue

--- a/zerver/tests/test_onboarding_steps.py
+++ b/zerver/tests/test_onboarding_steps.py
@@ -32,15 +32,15 @@ class TestGetNextOnboardingSteps(ZulipTestCase):
         do_mark_onboarding_step_as_read(self.user, "intro_inbox_view_modal")
         onboarding_steps = get_next_onboarding_steps(self.user)
         self.assert_length(onboarding_steps, 9)
-        self.assertEqual(onboarding_steps[0]["name"], "intro_recent_view_modal")
-        self.assertEqual(onboarding_steps[1]["name"], "first_stream_created_banner")
-        self.assertEqual(onboarding_steps[2]["name"], "jump_to_conversation_banner")
-        self.assertEqual(onboarding_steps[3]["name"], "non_interleaved_view_messages_fading")
-        self.assertEqual(onboarding_steps[4]["name"], "interleaved_view_messages_fading")
-        self.assertEqual(onboarding_steps[5]["name"], "intro_resolve_topic")
-        self.assertEqual(onboarding_steps[6]["name"], "navigation_tour_video")
-        self.assertEqual(onboarding_steps[7]["name"], "intro_go_to_conversation_tooltip")
-        self.assertEqual(onboarding_steps[8]["name"], "narrow_to_dm_with_welcome_bot_new_user")
+        self.assertEqual(onboarding_steps[0].name, "intro_recent_view_modal")
+        self.assertEqual(onboarding_steps[1].name, "first_stream_created_banner")
+        self.assertEqual(onboarding_steps[2].name, "jump_to_conversation_banner")
+        self.assertEqual(onboarding_steps[3].name, "non_interleaved_view_messages_fading")
+        self.assertEqual(onboarding_steps[4].name, "interleaved_view_messages_fading")
+        self.assertEqual(onboarding_steps[5].name, "intro_resolve_topic")
+        self.assertEqual(onboarding_steps[6].name, "navigation_tour_video")
+        self.assertEqual(onboarding_steps[7].name, "intro_go_to_conversation_tooltip")
+        self.assertEqual(onboarding_steps[8].name, "narrow_to_dm_with_welcome_bot_new_user")
 
         with self.settings(TUTORIAL_ENABLED=False):
             onboarding_steps = get_next_onboarding_steps(self.user)
@@ -48,7 +48,7 @@ class TestGetNextOnboardingSteps(ZulipTestCase):
 
         with self.settings(NAVIGATION_TOUR_VIDEO_URL=None):
             onboarding_steps = get_next_onboarding_steps(self.user)
-        self.assertNotIn("navigation_tour_video", onboarding_steps)
+        self.assertTrue(all(step.name != "navigation_tour_video" for step in onboarding_steps))
 
     def test_all_onboarding_steps_done(self) -> None:
         self.assertNotEqual(get_next_onboarding_steps(self.user), [])


### PR DESCRIPTION
…class.

<!-- Describe your pull request here.-->
It is based on https://chat.zulip.org/#narrow/channel/3-backend/topic/migrating.20to.20dataclasses Replaces `dict[str, Any]` with an `APIOnboardingStep` dataclass in `onboarding_steps.py`.
Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**
`tools/run-mypy`: passes with no issues
`tools/lint`: passes on all modified files
`tools/test-backend zerver/tests/test_onboarding_steps.py`: all 5 tests pass
`tools/test-backend zerver/tests/test_events.py`:all 149 tests pass

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
