### PR TITLE
api docs: Document POST /users/me/api_key/regenerate.

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -116,6 +116,7 @@
 * [Get all alert words](/api/get-alert-words)
 * [Add alert words](/api/add-alert-words)
 * [Remove alert words](/api/remove-alert-words)
+* [Regenerate your API key](/api/regenerate-api-key)
 * [Get a bot's API key](/api/get-bot-api-key)
 
 #### Invitations

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -429,3 +429,21 @@ def get_temporary_url_for_uploaded_file() -> dict[str, object]:
         realm_id = upload_path_parts[1]
         filename = upload_path_parts[2]
     return {"realm_id_str": realm_id, "filename": filename}
+
+
+@openapi_param_value_generator(["/users/me/api_key/regenerate:post"])
+def regenerate_api_key_test_user() -> dict[str, object]:
+    test_user_email = "regenerate-api-key-test@zulip.com"
+    test_user = do_create_user(
+        test_user_email,
+        "secret",
+        get_realm("zulip"),
+        "Mr. Regenerate",
+        role=200,
+        acting_user=None,
+    )
+    realm = get_realm("zulip")
+    test_user_api_key = get_user(test_user_email, realm).api_key
+    # Change authentication line to allow test_client to regenerate its own key.
+    AUTHENTICATION_LINE[0] = f"{test_user.email}:{test_user_api_key}"
+    return {}

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -783,6 +783,22 @@ def deactivate_own_user(client: Client, owner_client: Client) -> None:
     owner_client.reactivate_user_by_id(user_id)
 
 
+@openapi_test_function("/users/me/api_key/regenerate:post")
+def regenerate_api_key(client: Client) -> None:
+    # {code_example|start}
+    # Generate a new API key for the current user/bot.
+    result = client.call_endpoint(
+        url="/users/me/api_key/regenerate",
+        method="POST",
+    )
+    # {code_example|end}
+    assert_success_response(result)
+    validate_against_openapi_schema(result, "/users/me/api_key/regenerate", "post", "200")
+
+    # Update the client with the new API key so subsequent tests don't fail.
+    client.api_key = result["api_key"]
+
+
 @openapi_test_function("/get_stream_id:get")
 def get_stream_id(client: Client) -> int:
     name = "python-test"
@@ -2150,6 +2166,7 @@ def test_the_api(client: Client, nonadmin_client: Client, owner_client: Client) 
     test_errors(client)
     test_invitations(client)
     test_welcome_bot_custom_message(client)
+    regenerate_api_key(client)
 
     sys.stdout.flush()
     if REGISTERED_TEST_FUNCTIONS != CALLED_TEST_FUNCTIONS:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11325,6 +11325,47 @@ paths:
 
                       An example JSON error response when the current user is the only
                       organization owner in the organization:
+  /users/me/api_key/regenerate:
+    post:
+      operationId: regenerate-api-key
+      summary: Regenerate your API key
+      tags: ["users"]
+      description: |
+        !!! warn ""
+
+             **Note**: Users should treat their Zulip API key as
+             [carefully as they would their password](/help/protect-your-account).
+
+        Generate a new API key for the user making the request.
+
+        Changing a user's API key will immediately log them out of Zulip
+        on devices registered for [mobile push notifications][mobile-push].
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      api_key:
+                        type: string
+                        description: The new API key for the user.
+                    required:
+                      - api_key
+                    example:
+                      {
+                        "result": "success",
+                        "msg": "",
+                        "api_key": "a1b2c3d4e5f6g7h8i9j0",
+                      }
   /users/me/alert_words:
     get:
       operationId: get-alert-words

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -228,7 +228,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/dev_list_users",
         #### These personal settings endpoints have modest value to document:
         "/users/me/avatar",
-        "/users/me/api_key/regenerate",
         # Much more valuable would be an org admin bulk-upload feature.
         "/users/me/profile_data",
         #### Should be documented as part of interactive bots documentation


### PR DESCRIPTION
This PR adds the missing documentation for the `POST /users/me/api_key/regenerate` endpoint and removes it from the pending endpoints list.

**Changes included:**
* **OpenAPI Schema:** Added the endpoint definition to `zerver/openapi/zulip.yaml`. I declared `msg` and `result` in the properties block to make it play nicely with the `additionalProperties: false` check alongside `JsonSuccessBase`.
* **Python Code Example:** Added the test example using `@openapi_test_function`. Since regenerating an API key breaks auth for the test user, I passed the `nonadmin_client` instead and put it at the bottom of `python_examples.py` so it doesn't mess up the rest of the test suite.
* **cURL Test Exclusion:** For similar reasons, I added `regenerate_api_key` to `UNTESTED_GENERATED_CURL_EXAMPLES` in `test_curl_examples.py` so the automated cURL runner doesn't regenerate the key and lock itself out during testing.
* **Docs & Changelog:** Added the endpoint to `rest-endpoints.md` for the sidebar and created the unmerged changelog entry.

Fixes: Part of the pending documentation for personal settings endpoints in `zerver/tests/test_openapi.py`.

**How changes were tested:**
* Ran `tools/check-openapi.ts` (Passed)
* Ran `tools/test-backend zerver/tests/test_openapi.py` (Passed)
* Ran the full `tools/test-api` suite (Passed)
* Manually verified the UI rendering locally at `http://localhost:9991/api/regenerate_api_key`

---

**Screenshots and screen captures:**

Sidebar showing the new "Regenerate your API key" link:
<img width="289" height="192" alt="image" src="https://github.com/user-attachments/assets/1b0b01b6-cb2e-45b7-bef8-1de492242011" />

Rendered documentation page:
<img width="1386" height="2136" alt="Screenshot From 2026-02-26 17-20-27" src="https://github.com/user-attachments/assets/ad2c9f59-b747-453c-be47-cf3b57e0f395" />

---

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>