### PR TITLE
tests: presence.test.cjs: Remove invalid date_joined mocks

### DIFF
--- a/web/tests/presence.test.cjs
+++ b/web/tests/presence.test.cjs
@@ -29,35 +29,33 @@ const me = make_user({
     email: "me@zulip.com",
     user_id: 101,
     full_name: "Me Myself",
-    date_joined: 0,
 });
 
 const alice = make_user({
     email: "alice@zulip.com",
     user_id: 1,
     full_name: "Alice Smith",
-    date_joined: 0,
 });
 
 const fred = make_user({
     email: "fred@zulip.com",
     user_id: 2,
     full_name: "Fred Flintstone",
-    date_joined: 0,
 });
 
 const sally = make_user({
     email: "sally@example.com",
     user_id: 3,
     full_name: "Sally Jones",
-    date_joined: 0,
 });
 
 const zoe = make_user({
     email: "zoe@example.com",
     user_id: 6,
     full_name: "Zoe Yang",
-    date_joined: 0,
+    // User created via the API who never logged in.
+    // In production, such users have no date_joined field.
+    date_joined: undefined,
 });
 
 const bot = make_bot({
@@ -78,7 +76,6 @@ const jane = make_user({
     email: "jane@zulip.com",
     user_id: 9,
     full_name: "Jane Doe",
-    date_joined: 0,
 });
 
 people.add_active_user(me);
@@ -229,6 +226,8 @@ test("set_presence_info", () => {
     });
     assert.equal(presence.get_status(zoe.user_id), "offline");
     assert.equal(presence.last_active_date(zoe.user_id), undefined);
+    assert.strictEqual(zoe.date_joined, undefined);
+    assert.strictEqual(presence.presence_info.get(zoe.user_id).last_active, undefined);
 
     assert.ok(!presence.presence_info.has(bot.user_id));
     assert.equal(presence.get_status(bot.user_id), "offline");


### PR DESCRIPTION
Remove hard-coded `date_joined: 0` values from `presence.test.cjs.`

A few users in this test (`alice`, `sally`, `zoe`, etc.) were being created with
`date_joined: 0`. In production, users who have never been active simply don’t
have a timestamp (undefined), and using `0` creates a state that doesn’t
actually exist.

This caused the presence logic to fall back to the current wall-clock time in some cases,
which can hide bugs and make the test less representative of real data.

The change keeps behavior and coverage the same, but makes the test data more
accurate and easier to reason about.

This is one of the small follow-ups from the Claude refactor work discussed in
[#general > Claude experiment: Refactoring node tests](https://chat.zulip.org/#narrow/channel/2-general/topic/Claude.20experiment.3A.20Refactoring.20node.20tests/with/2383621)
<!-- Describe your pull request here.-->

**Fixes**: <!-- Issue link, or clear description.-->incorrect presence test mock state

**How changes were tested:**

Ran ./tools/test-js-with-node web/tests/presence.test.cjs

Ran ./tools/lint --groups frontend
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
