### PR TITLE
api-docs: Update placeholder for curl user credentials for authentication.

### DIFF
--- a/api_docs/create-scheduled-message.md
+++ b/api_docs/create-scheduled-message.md
@@ -10,10 +10,12 @@
 
 {tab|curl}
 
+{!curl-auth-credentials.md!}
+
 ``` curl
 # Create a scheduled channel message
 curl -X POST {{ api_url }}/v1/scheduled_messages \
-    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
+    -u EMAIL_ADDRESS:API_KEY \
     --data-urlencode type=stream \
     --data-urlencode to=9 \
     --data-urlencode topic=Hello \
@@ -22,7 +24,7 @@ curl -X POST {{ api_url }}/v1/scheduled_messages \
 
 # Create a scheduled direct message
 curl -X POST {{ api_url }}/v1/messages \
-    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
+    -u EMAIL_ADDRESS:API_KEY \
     --data-urlencode type=direct \
     --data-urlencode 'to=[9, 10]' \
     --data-urlencode 'content=Can we meet on Monday?' \

--- a/api_docs/http-headers.md
+++ b/api_docs/http-headers.md
@@ -24,7 +24,7 @@ Otherwise, to authenticate an API request:
 - For `Basic` authentication credentials in the Zulip API, a "username"
   takes the form of an email address, and a "password" takes the form of
   an API key. In the `curl` example for each endpoint, this is shown as:
-  `-u BOT_EMAIL_ADDRESS:BOT_API_KEY`.
+  `-u EMAIL_ADDRESS:API_KEY`.
 
 - A bot's credentials can be obtained through the web and desktop apps'
   [bot management UI](/help/manage-a-bot) or by [downloading the bot's

--- a/api_docs/include/curl-auth-credentials.md
+++ b/api_docs/include/curl-auth-credentials.md
@@ -1,0 +1,6 @@
+The [`-u` line][curl-man-user] implements HTTP `Basic` authentication.
+See the [`Authorization` header][auth-header] documentation for how
+to get those credentials for Zulip users and bots.
+
+[curl-man-user]: https://curl.se/docs/manpage.html#--user
+[auth-header]: /api/http-headers#the-authorization-header

--- a/api_docs/send-message.md
+++ b/api_docs/send-message.md
@@ -10,10 +10,12 @@
 
 {tab|curl}
 
+{!curl-auth-credentials.md!}
+
 ``` curl
 # For channel messages
 curl -X POST {{ api_url }}/v1/messages \
-    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
+    -u EMAIL_ADDRESS:API_KEY \
     --data-urlencode type=stream \
     --data-urlencode 'to="Denmark"' \
     --data-urlencode topic=Castle \
@@ -21,7 +23,7 @@ curl -X POST {{ api_url }}/v1/messages \
 
 # For direct messages
 curl -X POST {{ api_url }}/v1/messages \
-    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
+    -u EMAIL_ADDRESS:API_KEY \
     --data-urlencode type=direct \
     --data-urlencode 'to=[9]' \
     --data-urlencode 'content=With mirth and laughter let old wrinkles come.'

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -99,8 +99,8 @@ const config = { zuliprc: "zuliprc-admin" };
 
 """
 
-DEFAULT_AUTH_EMAIL = "BOT_EMAIL_ADDRESS"
-DEFAULT_AUTH_API_KEY = "BOT_API_KEY"
+DEFAULT_AUTH_EMAIL = "EMAIL_ADDRESS"
+DEFAULT_AUTH_API_KEY = "API_KEY"
 DEFAULT_EXAMPLE = {
     "integer": 1,
     "string": "demo",
@@ -271,10 +271,16 @@ def generate_curl_example(
     exclude: list[str] | None = None,
     include: list[str] | None = None,
 ) -> list[str]:
-    lines = ["```curl"]
     operation = endpoint + ":" + method.lower()
     operation_entry = openapi_spec.openapi()["paths"][endpoint][method.lower()]
     global_security = openapi_spec.openapi()["security"]
+
+    insecure_operations = ["/dev_fetch_api_key:post", "/fetch_api_key:post"]
+    lines = []
+    if operation in insecure_operations:
+        lines.append("```curl")
+    else:
+        lines.append("{!curl-auth-credentials.md!}\n\n```curl")
 
     parameters = get_openapi_parameters(endpoint, method)
     operation_request_body = operation_entry.get("requestBody", None)
@@ -298,7 +304,6 @@ def generate_curl_example(
     curl_first_line_parts = ["curl", *curl_method_arguments(example_endpoint, method, api_url)]
     lines.append(shlex.join(curl_first_line_parts))
 
-    insecure_operations = ["/dev_fetch_api_key:post", "/fetch_api_key:post"]
     if operation_security is None:
         if global_security == [{"basicAuth": []}]:
             authentication_required = True

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -98,7 +98,7 @@ def test_generated_curl_examples_for_success(client: Client) -> None:
 
             for curl_command_text in commands:
                 curl_command_text = curl_command_text.replace(
-                    "BOT_EMAIL_ADDRESS:BOT_API_KEY", AUTHENTICATION_LINE[0]
+                    "EMAIL_ADDRESS:API_KEY", AUTHENTICATION_LINE[0]
                 )
 
                 print("Testing {} ...".format(curl_command_text.split("\n")[0]))

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -3735,7 +3735,7 @@ class MarkdownErrorTests(ZulipTestCase):
         markdown_input = [
             "``` curl",
             "curl {{ api_url }}/v1/register",
-            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY",
+            "    -u EMAIL_ADDRESS:API_KEY",
             '    -d "queue_id=fb67bf8a-c031-47cc-84cf-ed80accacda8"',
             "```",
         ]
@@ -3749,14 +3749,14 @@ class MarkdownErrorTests(ZulipTestCase):
         markdown_input = [
             "``` curl",
             "curl {{ api_url }}/v1/register",
-            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY",
+            "    -u EMAIL_ADDRESS:API_KEY",
             '    -d "queue_id=fb67bf8a-c031-47cc-84cf-ed80accacda8"',
             "```",
         ]
         expected = [
             "",
             "**curl:curl {{ api_url }}/v1/register",
-            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY",
+            "    -u EMAIL_ADDRESS:API_KEY",
             '    -d "queue_id=fb67bf8a-c031-47cc-84cf-ed80accacda8"**',
             "",
             "",

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -760,9 +760,9 @@ class TestCurlExampleGeneration(ZulipTestCase):
     def test_generate_and_render_curl_example(self) -> None:
         generated_curl_example = self.curl_example("/get_stream_id", "GET")
         expected_curl_example = [
-            "```curl",
+            "{!curl-auth-credentials.md!}\n\n```curl",
             "curl -sSX GET -G http://localhost:9991/api/v1/get_stream_id \\",
-            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
             "    --data-urlencode stream=Denmark",
             "```",
         ]
@@ -789,9 +789,9 @@ class TestCurlExampleGeneration(ZulipTestCase):
         spec_mock.return_value = self.spec_mock_without_examples
         generated_curl_example = self.curl_example("/mark_stream_as_read", "POST")
         expected_curl_example = [
-            "```curl",
+            "{!curl-auth-credentials.md!}\n\n```curl",
             "curl -sSX POST http://localhost:9991/api/v1/mark_stream_as_read \\",
-            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
             "    --data-urlencode stream_id=1 \\",
             "    --data-urlencode bool_param=false",
             "```",
@@ -816,9 +816,9 @@ class TestCurlExampleGeneration(ZulipTestCase):
             ],
         )
         expected_curl_example = [
-            "```curl",
+            "{!curl-auth-credentials.md!}\n\n```curl",
             "curl -sSX GET -G http://localhost:9991/api/v1/messages \\",
-            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
             "    --data-urlencode anchor=43 \\",
             "    --data-urlencode include_anchor=false \\",
             "    --data-urlencode num_before=4 \\",
@@ -835,9 +835,9 @@ class TestCurlExampleGeneration(ZulipTestCase):
         spec_mock.return_value = self.spec_mock_using_object
         generated_curl_example = self.curl_example("/endpoint", "GET")
         expected_curl_example = [
-            "```curl",
+            "{!curl-auth-credentials.md!}\n\n```curl",
             "curl -sSX GET -G http://localhost:9991/api/v1/endpoint \\",
-            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
             '    --data-urlencode \'param1={"key": "value"}\'',
             "```",
         ]
@@ -864,9 +864,9 @@ class TestCurlExampleGeneration(ZulipTestCase):
         spec_mock.return_value = self.spec_mock_using_param_in_path
         generated_curl_example = self.curl_example("/endpoint/{param1}", "GET")
         expected_curl_example = [
-            "```curl",
+            "{!curl-auth-credentials.md!}\n\n```curl",
             "curl -sSX GET -G http://localhost:9991/api/v1/endpoint/35 \\",
-            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
             '    --data-urlencode \'param2={"key": "value"}\'',
             "```",
         ]
@@ -877,9 +877,9 @@ class TestCurlExampleGeneration(ZulipTestCase):
             "/get_stream_id:GET", api_url="https://zulip.example.com/api"
         )
         expected_curl_example = [
-            "```curl",
+            "{!curl-auth-credentials.md!}\n\n```curl",
             "curl -sSX GET -G https://zulip.example.com/api/v1/get_stream_id \\",
-            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
             "    --data-urlencode stream=Denmark",
             "```",
         ]
@@ -899,9 +899,9 @@ class TestCurlExampleGeneration(ZulipTestCase):
             ],
         )
         expected_curl_example = [
-            "```curl",
+            "{!curl-auth-credentials.md!}\n\n```curl",
             "curl -sSX GET -G http://localhost:9991/api/v1/messages \\",
-            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
             "    --data-urlencode anchor=43 \\",
             "    --data-urlencode include_anchor=false \\",
             "    --data-urlencode num_before=4 \\",


### PR DESCRIPTION
Updates the placeholder in the curl examples of the API docs for the user authentication line (-u) to be `EMAIL_ADDRESS:API_KEY`.

Relevant CZO discussion: [#api documentation > API docs shouldn't refer to "BOT_EMAIL_ADDRESS" #479](https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/API.20docs.20shouldn't.20refer.20to.20.22BOT_EMAIL_ADDRESS.22.20.23479/with/2390575)

**Notes**:
- Adds text to the top of the curl tab about the user authentication line with links to the curl man doc and the authorization header section of the HTTP headers article.
  - Uses a shared include markdown file (`api_docs/include/curl-auth-credentials.md`) for this text so that it's consistent across generated examples and hardcoded examples (e.g., `send-message.md`).
- If the endpoint does not have the user auth line (e.g., fetching an API key in dev and production), then the text is not added to the curl tab.
- `git grep 'BOT_EMAIL_ADDRESS'` after these changes returns no results. See below for results before changes.

Fixes #479.

<details>
<summary>git grep 'BOT_EMAIL_ADDRESS' - before changes</summary>

```console
$ git grep 'BOT_EMAIL_ADDRESS'
api_docs/create-scheduled-message.md:    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
api_docs/create-scheduled-message.md:    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
api_docs/http-headers.md:  `-u BOT_EMAIL_ADDRESS:BOT_API_KEY`.
api_docs/send-message.md:    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
api_docs/send-message.md:    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
zerver/openapi/markdown_extension.py:DEFAULT_AUTH_EMAIL = "BOT_EMAIL_ADDRESS"
zerver/openapi/test_curl_examples.py:                    "BOT_EMAIL_ADDRESS:BOT_API_KEY", AUTHENTICATION_LINE[0]
zerver/tests/test_markdown.py:            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY",
zerver/tests/test_markdown.py:            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY",
zerver/tests/test_markdown.py:            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY",
zerver/tests/test_openapi.py:            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
zerver/tests/test_openapi.py:            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
zerver/tests/test_openapi.py:            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
zerver/tests/test_openapi.py:            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
zerver/tests/test_openapi.py:            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
zerver/tests/test_openapi.py:            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
zerver/tests/test_openapi.py:            "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
```
</details>

---

**Screenshots and screen captures:**

[HTTP HEADERS - CURRENT DOC](https://zulip.com/api/http-headers)
<img width="1536" height="1174" alt="Screenshot From 2026-02-24 13-58-01" src="https://github.com/user-attachments/assets/2bd59a3e-d802-49f9-976e-c5508eccb587" />

[SEND MESSAGE - CURRENT DOC](https://zulip.com/api/send-message)
<img width="1508" height="1284" alt="Screenshot From 2026-02-25 16-00-41" src="https://github.com/user-attachments/assets/e584e424-63bd-49cd-890c-b8adf3ba5e89" />

[CREATE MESSAGE REMINDER - CURRENT DOC](https://zulip.com/api/create-message-reminder)
<img width="1508" height="1028" alt="Screenshot From 2026-02-25 16-01-01" src="https://github.com/user-attachments/assets/e908f31b-b233-4948-b14c-00d40bff9fa5" />

[FETCH API KEY DEV - CURRENT DOC](https://zulip.com/api/dev-fetch-api-key)
*NO USER AUTHENTICATION LINE*
<img width="1536" height="918" alt="Screenshot From 2026-02-24 13-58-34" src="https://github.com/user-attachments/assets/c2a8b3f1-2c90-42b2-9539-905b00e200fb" />


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
