### PR TITLE
settings: Add disabled styling for text and URL inputs.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -2361,6 +2361,15 @@ label.preferences-radio-choice-label {
     }
 }
 
+/* Use `input.settings_*:disabled` to match the legacy `input[type=...]`
+   specificity and override its background rule in zulip.css. */
+input.settings_url_input:disabled,
+input.settings_text_input:disabled {
+    cursor: not-allowed;
+    background-color: var(--background-color-readonly-modal-input);
+    opacity: var(--opacity-readonly-modal-input);
+}
+
 .empty-required-field {
     border: 1px solid hsl(3deg 57% 33%);
     border-radius: 5px;


### PR DESCRIPTION
This PR adds missing disabled styling for settings text and url inputs.
It affects the Name and Email fields, and custom profile fields that render as text or URL inputs.

Fixes: [#issues > light mode disabled input background appears same](https://chat.zulip.org/#narrow/channel/9-issues/topic/light.20mode.20disabled.20input.20background.20appears.20same/near/2388635)


**Screenshots and screen captures:**

<table>
  <tr>
    <th colspan="2">Text Input</th>
  </tr>
  <tr>
    <td><strong>Before</strong></td>
    <td><strong>After</strong></td>
  </tr>
  <tr>
    <td>
      <img width="354" height="300" alt="Before - Pair 1"
           src="https://github.com/user-attachments/assets/acb27eeb-5cd8-4842-8abf-f9d191aa451d" />
    </td>
    <td>
      <img width="334" height="297" alt="After - Pair 1"
           src="https://github.com/user-attachments/assets/0d6dad78-1c2a-4750-a3e3-afe3c9785875" />
    </td>
  </tr>

  <tr>
    <th colspan="2">URL Input</th>
  </tr>
  <tr>
    <td><strong>Before</strong></td>
    <td><strong>After</strong></td>
  </tr>
  <tr>
    <td>
      <img width="367" height="131" alt="Before - Pair 2"
           src="https://github.com/user-attachments/assets/159464fc-048d-4f2f-a73a-d641e23680ba" />
    </td>
    <td>
      <img width="368" height="129" alt="After - Pair 2"
           src="https://github.com/user-attachments/assets/e1ba4ba6-8a7b-432c-be86-6c7d7d77c933" />
    </td>
  </tr>
</table>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>