### PR TITLE
slack_converter: Support converting `rich_text` blocks.

### DIFF
--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -55,6 +55,7 @@ from zerver.data_import.sequencer import NEXT_ID
 from zerver.data_import.slack_message_conversion import (
     convert_to_zulip_markdown,
     get_user_full_name,
+    get_zulip_mention_for_slack_user,
     process_slack_block_and_attachment,
 )
 from zerver.lib.emoji import codepoint_to_name
@@ -1173,6 +1174,24 @@ def create_topic_name_for_message(
         return f"{thread_ts_str} No channel message"
 
 
+def channel_mention_processor(
+    slack_channel_id_to_name: dict[str, str], slack_channel_id: str
+) -> str | None:
+    if slack_channel_id in slack_channel_id_to_name:
+        return f"#**{slack_channel_id_to_name[slack_channel_id]}**"
+    return None
+
+
+def user_mention_processor(
+    users: list[ZerverFieldsT],
+    slack_user_id_to_zulip_user_id: SlackToZulipUserIDT,
+    slack_user_id: str,
+) -> tuple[str, int] | None:
+    if mention := get_zulip_mention_for_slack_user(slack_user_id, None, users):
+        return (mention, slack_user_id_to_zulip_user_id[slack_user_id])
+    return None
+
+
 def channel_message_to_zerver_message(
     realm_id: int,
     users: list[ZerverFieldsT],
@@ -1198,6 +1217,10 @@ def channel_message_to_zerver_message(
 
     total_user_messages = 0
     total_skipped_user_messages = 0
+    slack_channel_id_to_name = {v[0]: k for k, v in added_channels.items()}
+    channel_processor = partial(channel_mention_processor, slack_channel_id_to_name)
+    user_processor = partial(user_mention_processor, users, slack_user_id_to_zulip_user_id)
+
     for message in all_messages:
         if is_message_skipped_during_conversion(message):
             continue
@@ -1206,18 +1229,28 @@ def channel_message_to_zerver_message(
         assert slack_user_id
         subtype = message.get("subtype", False)
 
-        raw_content = process_slack_block_and_attachment(
-            (to_wild_value("message", json.dumps(message))),
-        )
-
         try:
-            content, mentioned_user_ids, has_link = convert_to_zulip_markdown(
-                raw_content, users, added_channels, slack_user_id_to_zulip_user_id
-            )
-        except Exception:
-            print("Slack message unexpectedly missing text representation:")
+            if message["text"] and not message.get("blocks"):
+                # TODO: Don't support converting using convert_to_zulip_markdown, some
+                # tests with false fixture still use this code path.
+
+                content, mentioned_user_ids, has_link = convert_to_zulip_markdown(
+                    message["text"], users, added_channels, slack_user_id_to_zulip_user_id
+                )
+            else:
+                result = process_slack_block_and_attachment(
+                    to_wild_value("message", json.dumps(message)),
+                    channel_processor,
+                    user_processor,
+                )
+                content = result.content
+                mentioned_user_ids = result.mentioned_user_ids
+                has_link = result.has_link
+        except Exception as e:
+            print(f"Failed to process message: {e}")
             print(orjson.dumps(message, option=orjson.OPT_INDENT_2).decode())
             continue
+
         rendered_content = None
 
         channel_name: str | None = None

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -53,7 +53,6 @@ from zerver.data_import.import_util import (
 )
 from zerver.data_import.sequencer import NEXT_ID
 from zerver.data_import.slack_message_conversion import (
-    convert_to_zulip_markdown,
     get_user_full_name,
     get_zulip_mention_for_slack_user,
     process_slack_block_and_attachment,
@@ -1230,22 +1229,14 @@ def channel_message_to_zerver_message(
         subtype = message.get("subtype", False)
 
         try:
-            if message["text"] and not message.get("blocks"):
-                # TODO: Don't support converting using convert_to_zulip_markdown, some
-                # tests with false fixture still use this code path.
-
-                content, mentioned_user_ids, has_link = convert_to_zulip_markdown(
-                    message["text"], users, added_channels, slack_user_id_to_zulip_user_id
-                )
-            else:
-                result = process_slack_block_and_attachment(
-                    to_wild_value("message", json.dumps(message)),
-                    channel_processor,
-                    user_processor,
-                )
-                content = result.content
-                mentioned_user_ids = result.mentioned_user_ids
-                has_link = result.has_link
+            result = process_slack_block_and_attachment(
+                to_wild_value("message", json.dumps(message)),
+                channel_processor,
+                user_processor,
+            )
+            content = result.content
+            mentioned_user_ids = result.mentioned_user_ids
+            has_link = result.has_link
         except Exception as e:
             print(f"Failed to process message: {e}")
             print(orjson.dumps(message, option=orjson.OPT_INDENT_2).decode())

--- a/zerver/data_import/slack_message_conversion.py
+++ b/zerver/data_import/slack_message_conversion.py
@@ -208,11 +208,15 @@ def convert_slack_workspace_mentions(text: str) -> str:
     return text
 
 
-def convert_slack_formatting(text: str) -> str:
+def convert_slack_formatting(text: str) -> tuple[str, bool]:
     text = convert_markdown_syntax(text, SLACK_BOLD_REGEX, "**")
     text = convert_markdown_syntax(text, SLACK_STRIKETHROUGH_REGEX, "~~")
     text = convert_markdown_syntax(text, SLACK_ITALIC_REGEX, "*")
-    return text
+    # Check and convert link format
+    text, has_link = convert_link_format(text)
+    # convert `<mailto:foo@foo.com>` to `mailto:foo@foo.com`
+    text, has_mailto_link = convert_mailto_format(text)
+    return text, has_link or has_mailto_link
 
 
 # Markdown mapping
@@ -223,7 +227,7 @@ def convert_to_zulip_markdown(
     slack_user_id_to_zulip_user_id: SlackToZulipUserIDT,
 ) -> tuple[str, list[int], bool]:
     mentioned_users_id = []
-    text = convert_slack_formatting(text)
+    text, message_has_link = convert_slack_formatting(text)
     text = convert_slack_workspace_mentions(text)
 
     # Map Slack channel mention: '<#C5Z73A7RA|general>' to '#**general**'
@@ -243,13 +247,6 @@ def convert_to_zulip_markdown(
                 mentioned_users_id.append(user_id)
 
     text = " ".join(tokens)
-
-    # Check and convert link format
-    text, has_link = convert_link_format(text)
-    # convert `<mailto:foo@foo.com>` to `mailto:foo@foo.com`
-    text, has_mailto_link = convert_mailto_format(text)
-
-    message_has_link = has_link or has_mailto_link
 
     return text, mentioned_users_id, message_has_link
 

--- a/zerver/data_import/slack_message_conversion.py
+++ b/zerver/data_import/slack_message_conversion.py
@@ -1,17 +1,22 @@
-import contextlib
 import re
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from itertools import zip_longest
 from typing import Any, Literal, TypeAlias, TypedDict, cast
+from xmlrpc.client import boolean
 
 import regex
 from django.core.exceptions import ValidationError
 from requests.utils import requote_uri
 
+from zerver.lib.markdown import get_markdown_link_for_url
+from zerver.lib.markdown.fenced_code import get_unused_fence
 from zerver.lib.timestamp import datetime_to_global_time
 from zerver.lib.types import Validator
 from zerver.lib.validator import (
     WildValue,
+    check_anything,
     check_dict,
     check_int,
     check_list,
@@ -25,6 +30,16 @@ ZerverFieldsT: TypeAlias = dict[str, Any]
 SlackToZulipUserIDT: TypeAlias = dict[str, int]
 AddedChannelsT: TypeAlias = dict[str, tuple[str, int]]
 SlackFieldsT: TypeAlias = dict[str, Any]
+ChannelMentionProcessorT: TypeAlias = Callable[[str], str | None]
+UserMentionProcessorT: TypeAlias = Callable[[str], tuple[str, int] | None]
+
+
+@dataclass
+class RenderResult:
+    content: str
+    mentioned_user_ids: list[int]
+    has_link: boolean
+
 
 # Slack link can be in the format <http://www.foo.com|www.foo.com> and <http://foo.com/>
 LINK_REGEX = r"""
@@ -255,7 +270,152 @@ class LossyConversionError(Exception):
     pass
 
 
-def render_block(block: WildValue) -> str:
+def render_rich_text_inline_style(element: WildValue, text: str) -> str:
+    if "style" not in element:
+        return text
+
+    # Whitespace between words is included as part of the rich_text block of
+    # the text to its right. Pull out trailing whitespace from each rich_text
+    # block so that we only format the text. This helps our Markdown engine
+    # parse each formatted text correctly.
+    stripped = text.rstrip()
+    trailing_whitespace = text[len(stripped) :]
+    text = stripped
+
+    element_style = element["style"]
+    if text.strip() != "":
+        # The order is important. Other formatting syntaxes cannot be inside an
+        # inline code block (backticks).
+        if "code" in element_style:
+            text = f"`{text}`"
+        if "bold" in element_style:
+            text = f"**{text}**"
+        if "italic" in element_style:
+            text = f"*{text}*"
+        if "strike" in element_style:
+            text = f"~~{text}~~"
+    text += trailing_whitespace
+    return text
+
+
+def render_rich_text_element(
+    element: WildValue,
+    channel_mention_processor: ChannelMentionProcessorT,
+    user_mention_processor: UserMentionProcessorT,
+) -> RenderResult:
+    element_type = element["type"].tame(check_string)
+    has_link = False
+    mentioned_user_ids = []
+    match element_type:
+        case "rich_text_section":
+            # This element is composed of "text", "link", or "emoji" elements.
+            # A "rich_text_section" as a sentence looks something like this
+            # (each [{text}] is a rich text element):
+            #
+            # "[bold text here ][followed by some basic texts, ][some italic text, ]
+            # [an inline code][ , etc.\n]"
+            pieces = []
+            for sub_element in element["elements"]:
+                result = render_rich_text_element(
+                    sub_element, channel_mention_processor, user_mention_processor
+                )
+                pieces.append(result.content)
+                if result.has_link:
+                    has_link = True
+                mentioned_user_ids += result.mentioned_user_ids
+            text = "".join(piece for piece in pieces)
+        case "rich_text_list":
+            # This element is a list.
+            pieces = []
+            for sub_element in element["elements"]:
+                result = render_rich_text_element(
+                    sub_element, channel_mention_processor, user_mention_processor
+                )
+                pieces.append(result.content)
+                if result.has_link:
+                    has_link = True
+                mentioned_user_ids += result.mentioned_user_ids
+            list_style = element["style"].tame(check_string_in(["ordered", "bullet"]))
+            list_syntax = "1." if list_style == "ordered" else "-"
+            indent_depth = element["indent"].tame(check_int)
+            # We start to reliably render a list item as a sub list item at 3 or
+            # more indents/white spaces.
+            indents = " " * 3 * indent_depth if indent_depth > 0 else ""
+            text = "".join(f"{indents}{list_syntax} {piece}\n" for piece in pieces).rstrip()
+        case "rich_text_quote":
+            # This element is a quote block.
+            pieces = []
+            for sub_element in element["elements"]:
+                result = render_rich_text_element(
+                    sub_element, channel_mention_processor, user_mention_processor
+                )
+                pieces.append(result.content)
+            quote_content = "".join(piece for piece in pieces)
+            fence = get_unused_fence(quote_content)
+            text = f"{fence}quote\n{quote_content}\n{fence}"
+        case "rich_text_preformatted":
+            # This is a code block, it should contain exactly one "text" element.
+            assert len(element["elements"]) == 1
+            code_block_content = element["elements"][0]["text"].tame(check_string)
+            fence = get_unused_fence(code_block_content)
+            # Slack code block is programming language agnostic.
+            text = f"{fence}text\n{code_block_content}\n{fence}"
+        case "text":
+            text = element["text"].tame(check_string)
+            text = render_rich_text_inline_style(element, text)
+        case "link":
+            url = element["url"].tame(check_string)
+            if "text" in element:
+                # The text field here may contain trailing whitespace that might mess up
+                # Markdown rendering if included inside any formatting syntax.
+                linked_text = element["text"].tame(check_string)
+                stripped = linked_text.rstrip()
+                trailing_whitespace = linked_text[len(stripped) :]
+                linked_text = stripped
+                text = get_markdown_link_for_url(linked_text, url) + trailing_whitespace
+            else:
+                text = url
+            has_link = True
+            text = render_rich_text_inline_style(element, text)
+        case "emoji":
+            emoji_name = element["name"].tame(check_string)
+            text = f":{emoji_name}:"
+        case "user":
+            slack_user_id = element["user_id"].tame(check_string)
+            if mention_result := user_mention_processor(slack_user_id):
+                user_mention, zulip_user_id = mention_result
+                text = user_mention
+                mentioned_user_ids.append(zulip_user_id)
+            else:
+                text = f"**#Unknown Slack user {slack_user_id}**"
+        case "channel":
+            slack_channel_id = element["channel_id"].tame(check_string)
+            channel_mention = channel_mention_processor(slack_channel_id)
+            text = channel_mention or f"**#Unknown Slack channel {slack_channel_id}**"
+        case "broadcast":
+            if element["range"].tame(check_string) in ["here", "everyone", "channel"]:
+                text = "@**all**"
+        case "canvas":
+            # This is attached files, both the Slack importer and webhook integration
+            # have a different way of handling files, so we don't need to do anything
+            # special here.
+            text = ""
+        case _:
+            raise LossyConversionError(
+                f"Unknown rich_text block: {element_type}.\n{element.tame(check_anything)}"
+            )
+    return RenderResult(
+        content=text,
+        mentioned_user_ids=mentioned_user_ids,
+        has_link=has_link,
+    )
+
+
+def render_block(
+    block: WildValue,
+    channel_mention_processor: ChannelMentionProcessorT,
+    user_mention_processor: UserMentionProcessorT,
+) -> RenderResult:
     """
     Raises `LossyConversionError` if it's a rich_text block type.
     """
@@ -266,6 +426,7 @@ def render_block(block: WildValue) -> str:
         "header",
         "image",
         "section",
+        "rich_text",
     }
     unhandled_types = {
         # `call` is a block type we've observed in the wild in a Slack export,
@@ -289,18 +450,25 @@ def render_block(block: WildValue) -> str:
     known_types = {
         *supported_types,
         *unhandled_types,
-        # rich_text is a special case. It probably composes the bulk of a message
-        # body since it's responsible for very basic text formatting--such as
-        # plain text, bold, italic, etc. Our current Slack text conversion module
-        # can't process this block since this is not formatted in Markdown.
-        "rich_text",
     }
     block_type = block["type"].tame(check_string_in(known_types))
 
+    content: str = ""
+    has_link = False
+    mentioned_user_ids = []
     if block_type in unhandled_types:
-        return ""
+        content = ""
     elif block_type == "rich_text":
-        raise LossyConversionError
+        pieces = []
+        for sub_element in block["elements"]:
+            result = render_rich_text_element(
+                sub_element, channel_mention_processor, user_mention_processor
+            )
+            pieces.append(result.content)
+            if result.has_link:
+                has_link = True
+            mentioned_user_ids += result.mentioned_user_ids
+        content = "\n".join(piece for piece in pieces if piece.strip() != "")
     elif block_type == "context" and block.get("elements"):
         pieces = []
         # Slack renders these pieces left-to-right, packed in as
@@ -311,23 +479,29 @@ def render_block(block: WildValue) -> str:
             if element_type == "image":
                 pieces.append(render_block_element(element))
             else:
-                pieces.append(element.tame(check_text_block())["text"])
-        return "\n\n".join(piece.strip() for piece in pieces if piece.strip() != "")
+                text_field = element.tame(check_text_block())
+                text, block_has_link = convert_slack_formatting(text_field["text"])
+                has_link = has_link or block_has_link
+                pieces.append(text)
+        content = "\n\n".join(piece.strip() for piece in pieces if piece.strip() != "")
     elif block_type == "divider":
-        return "----"
+        content = "----"
     elif block_type == "header":
-        return "## " + block["text"].tame(check_text_block(plain_text_only=True))["text"]
+        content = "## " + block["text"].tame(check_text_block(plain_text_only=True))["text"]
     elif block_type == "image":
         image_url = block["image_url"].tame(check_url)
         alt_text = block["alt_text"].tame(check_string)
         if "title" in block:
             alt_text = block["title"].tame(check_text_block(plain_text_only=True))["text"]
-        return f"[{alt_text}]({image_url})"
+        content = f"[{alt_text}]({image_url})"
+        has_link = True
     elif block_type == "section":
         pieces = []
         if "text" in block:
-            pieces.append(block["text"].tame(check_text_block())["text"])
-
+            text_field = block["text"].tame(check_text_block())
+            text, block_has_link = convert_slack_formatting(text_field["text"])
+            has_link = has_link or block_has_link
+            pieces.append(text)
         if "accessory" in block:
             pieces.append(render_block_element(block["accessory"]))
 
@@ -337,7 +511,9 @@ def render_block(block: WildValue) -> str:
                 # Special-case a single field to display a bit more
                 # nicely, without extraneous borders and limitations
                 # on its contents.
-                pieces.append(fields[0]["text"])
+                text, block_has_link = convert_slack_formatting(fields[0]["text"])
+                has_link = has_link or block_has_link
+                pieces.append(text)
             else:
                 # It is not possible to have newlines in a table, nor
                 # escape the pipes that make it up; replace them with
@@ -353,9 +529,9 @@ def render_block(block: WildValue) -> str:
                     table += f"| {left} | {right} |\n"
                 pieces.append(table)
 
-        return "\n\n".join(piece.strip() for piece in pieces if piece.strip() != "")
+        content = "\n\n".join(piece.strip() for piece in pieces if piece.strip() != "")
 
-    return ""  # nocoverage
+    return RenderResult(content=content, mentioned_user_ids=mentioned_user_ids, has_link=has_link)
 
 
 class TextField(TypedDict):
@@ -399,12 +575,18 @@ def render_block_element(element: WildValue) -> str:
         return ""
 
 
-def render_attachment(attachment: WildValue) -> str:
+def render_attachment(
+    attachment: WildValue,
+    channel_mention_processor: ChannelMentionProcessorT,
+    user_mention_processor: UserMentionProcessorT,
+) -> RenderResult:
     # https://api.slack.com/reference/messaging/attachments
     # Slack recommends the usage of "blocks" even within attachments; the
     # rest of the fields we handle here are legacy fields. These fields are
     # optional and may contain null values.
     pieces = []
+    has_link = False
+    mentioned_user_ids = []
     if attachment.get("title"):
         title = attachment["title"].tame(check_string)
         if attachment.get("title_link"):
@@ -415,30 +597,29 @@ def render_attachment(attachment: WildValue) -> str:
     if attachment.get("pretext"):
         pieces.append(attachment["pretext"].tame(check_string))
     if attachment.get("text"):
-        pieces.append(attachment["text"].tame(check_string))
+        text, has_link = convert_slack_formatting(attachment["text"].tame(check_string))
+        pieces.append(text)
     if "fields" in attachment:
         fields = []
         for field in attachment["fields"]:
             if "title" in field and "value" in field and field["title"] and field["value"]:
                 title = field["title"].tame(check_string)
                 value = field["value"].tame(check_string)
-                fields.append(f"*{title}*: {value}")
+                fields.append(f"**{title}**: {value}")
             elif field.get("title"):
                 title = field["title"].tame(check_string)
-                fields.append(f"*{title}*")
+                fields.append(f"**{title}**")
             elif field.get("value"):
                 value = field["value"].tame(check_string)
                 fields.append(f"{value}")
         pieces.append("\n".join(fields))
     if attachment.get("blocks"):
         for block in attachment["blocks"]:
-            # rich_text blocks in "attachments" elements don't have a
-            # corresponding raw value in the "text" field, so we can't
-            # fallback to the "text" field in this case like we can do
-            # with rich_text in message "blocks".
-            # TODO: We should use the raw rich_text strings instead.
-            with contextlib.suppress(LossyConversionError):  # nocoverage
-                pieces.append(render_block(block))
+            result = render_block(block, channel_mention_processor, user_mention_processor)
+            pieces.append(result.content)
+            if result.has_link:
+                has_link = True
+            mentioned_user_ids += result.mentioned_user_ids
     if image_url_wv := attachment.get("image_url"):
         try:
             image_url = image_url_wv.tame(check_url)
@@ -446,6 +627,7 @@ def render_attachment(attachment: WildValue) -> str:
             image_url = image_url_wv.tame(check_string)
             image_url = requote_uri(image_url)
         pieces.append(f"[]({image_url})")
+        has_link = True
     if attachment.get("footer"):
         pieces.append(attachment["footer"].tame(check_string))
     if attachment.get("ts"):
@@ -464,7 +646,11 @@ def render_attachment(attachment: WildValue) -> str:
             time = int(ts_float)
         pieces.append(datetime_to_global_time(datetime.fromtimestamp(time, timezone.utc)))
 
-    return "\n\n".join(piece.strip() for piece in pieces if piece.strip() != "")
+    return RenderResult(
+        content="\n\n".join(piece.strip() for piece in pieces if piece.strip() != ""),
+        mentioned_user_ids=mentioned_user_ids,
+        has_link=has_link,
+    )
 
 
 def replace_links(text: str) -> str:
@@ -473,24 +659,46 @@ def replace_links(text: str) -> str:
     return text
 
 
-def process_slack_block_and_attachment(message: WildValue) -> str:
+def process_slack_block_and_attachment(
+    message: WildValue,
+    channel_mention_processor: ChannelMentionProcessorT,
+    user_mention_processor: UserMentionProcessorT,
+) -> RenderResult:
     pieces: list[str] = []
+    has_link = False
+    mentioned_user_ids = []
     raw_text = message["text"].tame(check_string)
 
     if message.get("blocks"):
-        try:
-            pieces += map(render_block, message["blocks"])
-        except LossyConversionError:
-            # render_block doesn't yet handle the "rich_text" block, which is used
-            # for very basic text formatting. To avoid message content loss, process
-            # the message["text"] field instead if rich_text is used.
-            pieces.append(raw_text)
+        for block in message["blocks"]:
+            result = render_block(block, channel_mention_processor, user_mention_processor)
+            pieces.append(result.content)
+            if result.has_link:
+                has_link = True
+            mentioned_user_ids += result.mentioned_user_ids
 
-    if set(pieces) in ({""}, set()):
-        pieces.append(raw_text)
+    # This is primarily for payloads like zerver/webhooks/slack/fixtures/message_with_variety_files.json
+    # where the message contains the "text" field but no "blocks" field.
+    # Although, upon trying to recreate the message data again, it seems
+    # to have generated proper "blocks" for any text the message might
+    # have, so for the most part this is just an extra safe guard.
+    # See test_variety_files_and_rich_text in test_slack_message_conversion.py.
+    if set(pieces) in ({""}, set()) and raw_text:
+        text, text_has_link = convert_slack_formatting(raw_text)
+        has_link = has_link or text_has_link
+        pieces.append(text)
 
-    # The attachments typically don't have a corresponding raw value in
-    # message["text"] and only add to it, so the output is appended unconditionally.
     if message.get("attachments"):
-        pieces += map(render_attachment, message["attachments"])
-    return "\n".join(piece.strip() for piece in pieces if piece.strip() != "")
+        for attachment in message["attachments"]:
+            result = render_attachment(
+                attachment, channel_mention_processor, user_mention_processor
+            )
+            pieces.append(result.content)
+            if result.has_link:
+                has_link = True
+            mentioned_user_ids += result.mentioned_user_ids
+    return RenderResult(
+        content="\n".join(piece.strip() for piece in pieces if piece.strip() != ""),
+        mentioned_user_ids=mentioned_user_ids,
+        has_link=has_link,
+    )

--- a/zerver/data_import/slack_message_conversion.py
+++ b/zerver/data_import/slack_message_conversion.py
@@ -59,13 +59,6 @@ SLACK_MAILTO_REGEX = r"""
                       ([\w\.-]+@[\w\.-]+(\.[\w]+)+)?>  # match email
                       """
 
-SLACK_USERMENTION_REGEX = r"""
-                           (<@)                  # Start with '<@'
-                               ([a-zA-Z0-9]+)    # Here we have the Slack id
-                           (\|)?                 # We not always have a vertical line in mention
-                               ([a-zA-Z0-9]+)?   # If vertical line is present, this is short name
-                           (>)                   # ends with '>'
-                           """
 # Slack doesn't have mid-word message-formatting like Zulip.
 # Hence, ~stri~ke doesn't format the word in Slack, but ~~stri~~ke
 # formats the word in Zulip
@@ -148,23 +141,6 @@ def get_zulip_mention_for_slack_user(
     return None
 
 
-def get_user_mentions(
-    token: str,
-    users: list[ZerverFieldsT],
-    slack_user_id_to_zulip_user_id: SlackToZulipUserIDT,
-) -> tuple[str, int | None]:
-    slack_usermention_match = re.search(SLACK_USERMENTION_REGEX, token, re.VERBOSE)
-    assert slack_usermention_match is not None
-    short_name = slack_usermention_match.group(4)
-    slack_id = slack_usermention_match.group(2)
-    zulip_mention = get_zulip_mention_for_slack_user(slack_id, short_name, users)
-    if zulip_mention is not None:
-        token = re.sub(SLACK_USERMENTION_REGEX, zulip_mention, token, flags=re.VERBOSE)
-        user_id = slack_user_id_to_zulip_user_id[slack_id]
-        return token, user_id
-    return token, None
-
-
 def convert_link_format(text: str) -> tuple[str, bool]:
     """
     1. Converts '<https://foo.com>' to 'https://foo.com'
@@ -212,17 +188,6 @@ def convert_markdown_syntax(text: str, pattern: str, zulip_keyword: str) -> str:
     return regex.sub(pattern, replace_slack_format, text, flags=re.VERBOSE | re.MULTILINE)
 
 
-def convert_slack_workspace_mentions(text: str) -> str:
-    # Map Slack's '<!everyone>', '<!channel>' and '<!here>'
-    # mentions to Zulip's '@**all**' wildcard mention.
-    # No regex for these as they can be present anywhere
-    # in the sentence.
-    text = text.replace("<!everyone>", "@**all**")
-    text = text.replace("<!channel>", "@**all**")
-    text = text.replace("<!here>", "@**all**")
-    return text
-
-
 def convert_slack_formatting(text: str) -> tuple[str, bool]:
     text = convert_markdown_syntax(text, SLACK_BOLD_REGEX, "**")
     text = convert_markdown_syntax(text, SLACK_STRIKETHROUGH_REGEX, "~~")
@@ -232,38 +197,6 @@ def convert_slack_formatting(text: str) -> tuple[str, bool]:
     # convert `<mailto:foo@foo.com>` to `mailto:foo@foo.com`
     text, has_mailto_link = convert_mailto_format(text)
     return text, has_link or has_mailto_link
-
-
-# Markdown mapping
-def convert_to_zulip_markdown(
-    text: str,
-    users: list[ZerverFieldsT],
-    added_channels: AddedChannelsT,
-    slack_user_id_to_zulip_user_id: SlackToZulipUserIDT,
-) -> tuple[str, list[int], bool]:
-    mentioned_users_id = []
-    text, message_has_link = convert_slack_formatting(text)
-    text = convert_slack_workspace_mentions(text)
-
-    # Map Slack channel mention: '<#C5Z73A7RA|general>' to '#**general**'
-    for cname, ids in added_channels.items():
-        cid = ids[0]
-        text = text.replace(f"<#{cid}|{cname}>", "#**" + cname + "**")
-
-    tokens = text.split(" ")
-    for iterator in range(len(tokens)):
-        # Check user mentions and change mention format from
-        # '<@slack_id|short_name>' to '@**full_name**'
-        if re.findall(SLACK_USERMENTION_REGEX, tokens[iterator], re.VERBOSE):
-            tokens[iterator], user_id = get_user_mentions(
-                tokens[iterator], users, slack_user_id_to_zulip_user_id
-            )
-            if user_id is not None:
-                mentioned_users_id.append(user_id)
-
-    text = " ".join(tokens)
-
-    return text, mentioned_users_id, message_has_link
 
 
 class LossyConversionError(Exception):

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_basic_formatting.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_basic_formatting.json
@@ -1,0 +1,103 @@
+{
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1772029070.889249",
+    "text": "Hello there, I am a basic rich text block! Hello there, *I am a bold rich text block!* Hello there, _I am an italic rich text block!_ Hello there, ~I am a strikethrough rich text block!~",
+    "team": "T06NRA6HM3P",
+    "user_team": "T06NRA6HM3P",
+    "source_team": "T06NRA6HM3P",
+    "user_profile": {
+        "avatar_hash": "112be04f818e",
+        "image_72": "https://avatars.slack-edge.com/2024-03-10/6773346635957_112be04f818e7bd093d5_72.png",
+        "first_name": "Peter",
+        "real_name": "Peter",
+        "display_name": "",
+        "team": "T06NRA6HM3P",
+        "name": "pieterceka123",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+    },
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "K9Baq",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "Hello there, I am a basic rich text block!"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "rich_text",
+            "block_id": "wjKKV",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "Hello there, "
+                        },
+                        {
+                            "type": "text",
+                            "text": "I am a bold rich text block!",
+                            "style": {
+                                "bold": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "rich_text",
+            "block_id": "2PcsX",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "Hello there, "
+                        },
+                        {
+                            "type": "text",
+                            "text": "I am an italic rich text block!",
+                            "style": {
+                                "italic": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "rich_text",
+            "block_id": "LjYw+",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "Hello there, "
+                        },
+                        {
+                            "type": "text",
+                            "text": "I am a strikethrough rich text block!",
+                            "style": {
+                                "strike": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_bullet_list.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_bullet_list.json
@@ -1,0 +1,150 @@
+{
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1772029239.785859",
+    "text": "Basic bullet list with rich elements\n• item 1: :basketball:\n• item 2: *this* is _a list_ item\n• item 3: *<https://example.com/|with a link>*\n• item 4: we are near ~the end~\n• item 5: ~_*<https://chat.zulip.org/|this is the end>*_~",
+    "team": "T06NRA6HM3P",
+    "user_team": "T06NRA6HM3P",
+    "source_team": "T06NRA6HM3P",
+    "user_profile": {
+        "avatar_hash": "112be04f818e",
+        "image_72": "https://avatars.slack-edge.com/2024-03-10/6773346635957_112be04f818e7bd093d5_72.png",
+        "first_name": "Peter",
+        "real_name": "Peter",
+        "display_name": "",
+        "team": "T06NRA6HM3P",
+        "name": "pieterceka123",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+    },
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "t/I1F",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "Basic bullet list with rich elements\n"
+                        }
+                    ]
+                },
+                {
+                    "type": "rich_text_list",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "item 1: "
+                                },
+                                {
+                                    "type": "emoji",
+                                    "name": "basketball",
+                                    "unicode": "1f3c0"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "item 2: "
+                                },
+                                {
+                                    "type": "text",
+                                    "text": "this ",
+                                    "style": {
+                                        "bold": true
+                                    }
+                                },
+                                {
+                                    "type": "text",
+                                    "text": "is "
+                                },
+                                {
+                                    "type": "text",
+                                    "text": "a list",
+                                    "style": {
+                                        "italic": true
+                                    }
+                                },
+                                {
+                                    "type": "text",
+                                    "text": " "
+                                },
+                                {
+                                    "type": "text",
+                                    "text": "item",
+                                    "style": {
+                                        "underline": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "item 3: "
+                                },
+                                {
+                                    "type": "link",
+                                    "url": "https://example.com/",
+                                    "text": "with a link",
+                                    "style": {
+                                        "bold": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "item 4: we are near "
+                                },
+                                {
+                                    "type": "text",
+                                    "text": "the end",
+                                    "style": {
+                                        "strike": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "item 5: "
+                                },
+                                {
+                                    "type": "link",
+                                    "url": "https://chat.zulip.org/",
+                                    "text": "this is the end",
+                                    "style": {
+                                        "bold": true,
+                                        "italic": true,
+                                        "strike": true,
+                                        "underline": true
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "style": "bullet",
+                    "indent": 0,
+                    "border": 0
+                }
+            ]
+        }
+    ]
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_channel_mentions.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_channel_mentions.json
@@ -1,0 +1,54 @@
+{
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1772112421.729059",
+    "client_msg_id": "56907df1-f96c-4f40-824e-346e6aed7a14",
+    "text": "<#C079A3FA12P> <#C0AHX20ADQQ|rich-text-blocks> <#C06P6T3QGD7|general>",
+    "team": "T06NRA6HM3P",
+    "user_team": "T06NRA6HM3P",
+    "source_team": "T06NRA6HM3P",
+    "user_profile": {
+        "avatar_hash": "112be04f818e",
+        "image_72": "https://avatars.slack-edge.com/2024-03-10/6773346635957_112be04f818e7bd093d5_72.png",
+        "first_name": "Peter",
+        "real_name": "Peter",
+        "display_name": "",
+        "team": "T06NRA6HM3P",
+        "name": "pieterceka123",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+    },
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "tnZ0A",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "channel",
+                            "channel_id": "C079A3FA12P"
+                        },
+                        {
+                            "type": "text",
+                            "text": " "
+                        },
+                        {
+                            "type": "channel",
+                            "channel_id": "C0AHX20ADQQ"
+                        },
+                        {
+                            "type": "text",
+                            "text": " "
+                        },
+                        {
+                            "type": "channel",
+                            "channel_id": "C06P6T3QGD7"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_code_block.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_code_block.json
@@ -1,0 +1,38 @@
+{
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1772029642.852459",
+    "text": "```# I'm a code block!\n\ndef convert_slack_formatting(text: str) -&gt; str:\n    return text```",
+    "team": "T06NRA6HM3P",
+    "user_team": "T06NRA6HM3P",
+    "source_team": "T06NRA6HM3P",
+    "user_profile": {
+        "avatar_hash": "112be04f818e",
+        "image_72": "https://avatars.slack-edge.com/2024-03-10/6773346635957_112be04f818e7bd093d5_72.png",
+        "first_name": "Peter",
+        "real_name": "Peter",
+        "display_name": "",
+        "team": "T06NRA6HM3P",
+        "name": "pieterceka123",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+    },
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "Nath4",
+            "elements": [
+                {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "# I'm a code block!\n\ndef convert_slack_formatting(text: str) -> str:\n    return text"
+                        }
+                    ],
+                    "border": 0
+                }
+            ]
+        }
+    ]
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_emojis.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_emojis.json
@@ -1,0 +1,60 @@
+{
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1772029104.463999",
+    "text": "Hello there! Here are some emojis :basketball: :snowboarder: :checkered_flag:",
+    "team": "T06NRA6HM3P",
+    "user_team": "T06NRA6HM3P",
+    "source_team": "T06NRA6HM3P",
+    "user_profile": {
+        "avatar_hash": "112be04f818e",
+        "image_72": "https://avatars.slack-edge.com/2024-03-10/6773346635957_112be04f818e7bd093d5_72.png",
+        "first_name": "Peter",
+        "real_name": "Peter",
+        "display_name": "",
+        "team": "T06NRA6HM3P",
+        "name": "pieterceka123",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+    },
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "YAela",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "Hello there! Here are some emojis "
+                        },
+                        {
+                            "type": "emoji",
+                            "name": "basketball",
+                            "unicode": "1f3c0"
+                        },
+                        {
+                            "type": "text",
+                            "text": " "
+                        },
+                        {
+                            "type": "emoji",
+                            "name": "snowboarder",
+                            "unicode": "1f3c2"
+                        },
+                        {
+                            "type": "text",
+                            "text": " "
+                        },
+                        {
+                            "type": "emoji",
+                            "name": "checkered_flag",
+                            "unicode": "1f3c1"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_inline_code.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_inline_code.json
@@ -1,0 +1,114 @@
+{
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1772029539.293359",
+    "text": "Hello there, I am an `inline code`\n*Hello there, I am an `inline code`*\n ~_*<https://chat.zulip.org|Hello there, I am an >`inline code`*_~",
+    "team": "T06NRA6HM3P",
+    "user_team": "T06NRA6HM3P",
+    "source_team": "T06NRA6HM3P",
+    "user_profile": {
+        "avatar_hash": "112be04f818e",
+        "image_72": "https://avatars.slack-edge.com/2024-03-10/6773346635957_112be04f818e7bd093d5_72.png",
+        "first_name": "Peter",
+        "real_name": "Peter",
+        "display_name": "",
+        "team": "T06NRA6HM3P",
+        "name": "pieterceka123",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+    },
+    "attachments": [
+        {
+            "from_url": "https://chat.zulip.org/",
+            "thumb_url": "https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3",
+            "thumb_width": 100,
+            "thumb_height": 100,
+            "id": 1,
+            "original_url": "https://chat.zulip.org",
+            "fallback": "Zulip: Public view of Zulip Community | Zulip team chat",
+            "text": "Browse the publicly accessible channels in Zulip Community without logging in.",
+            "title": "Public view of Zulip Community | Zulip team chat",
+            "title_link": "https://chat.zulip.org/",
+            "service_name": "Zulip"
+        }
+    ],
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "6rWGR",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "Hello there, I am an "
+                        },
+                        {
+                            "type": "text",
+                            "text": "inline code",
+                            "style": {
+                                "code": true
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "text": "\n"
+                        },
+                        {
+                            "type": "text",
+                            "text": "Hello there, I am an ",
+                            "style": {
+                                "bold": true
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "text": "inline code",
+                            "style": {
+                                "bold": true,
+                                "code": true
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "text": "\n"
+                        },
+                        {
+                            "type": "text",
+                            "text": " ",
+                            "style": {
+                                "bold": true,
+                                "italic": true,
+                                "strike": true,
+                                "underline": true
+                            }
+                        },
+                        {
+                            "type": "link",
+                            "url": "https://chat.zulip.org",
+                            "text": "Hello there, I am an ",
+                            "style": {
+                                "bold": true,
+                                "italic": true,
+                                "strike": true,
+                                "underline": true
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "text": "inline code",
+                            "style": {
+                                "bold": true,
+                                "italic": true,
+                                "strike": true,
+                                "code": true,
+                                "underline": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_links.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_links.json
@@ -1,0 +1,109 @@
+{
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1772029188.953659",
+    "text": "<https://chat.zulip.org/|Text with a link>\n*<https://chat.zulip.org/|Text with a link>*\n_<https://chat.zulip.org/|Text with a link>_\n<https://chat.zulip.org/|Text with a link>\n~<https://chat.zulip.org/|Text with a link>~\nhttps://chat.zulip.org",
+    "team": "T06NRA6HM3P",
+    "user_team": "T06NRA6HM3P",
+    "source_team": "T06NRA6HM3P",
+    "user_profile": {
+        "avatar_hash": "112be04f818e",
+        "image_72": "https://avatars.slack-edge.com/2024-03-10/6773346635957_112be04f818e7bd093d5_72.png",
+        "first_name": "Peter",
+        "real_name": "Peter",
+        "display_name": "",
+        "team": "T06NRA6HM3P",
+        "name": "pieterceka123",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+    },
+    "attachments": [
+        {
+            "from_url": "https://chat.zulip.org/",
+            "thumb_url": "https://chat.zulip.org/user_avatars/2/realm/icon.png?version=3",
+            "thumb_width": 100,
+            "thumb_height": 100,
+            "id": 1,
+            "original_url": "https://chat.zulip.org/",
+            "fallback": "Zulip: Public view of Zulip Community | Zulip team chat",
+            "text": "Browse the publicly accessible channels in Zulip Community without logging in.",
+            "title": "Public view of Zulip Community | Zulip team chat",
+            "title_link": "https://chat.zulip.org/",
+            "service_name": "Zulip"
+        }
+    ],
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "djG5e",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "link",
+                            "url": "https://chat.zulip.org/",
+                            "text": "Text with a link"
+                        },
+                        {
+                            "type": "text",
+                            "text": "\n"
+                        },
+                        {
+                            "type": "link",
+                            "url": "https://chat.zulip.org/",
+                            "text": "Text with a link",
+                            "style": {
+                                "bold": true
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "text": "\n"
+                        },
+                        {
+                            "type": "link",
+                            "url": "https://chat.zulip.org/",
+                            "text": "Text with a link",
+                            "style": {
+                                "italic": true
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "text": "\n"
+                        },
+                        {
+                            "type": "link",
+                            "url": "https://chat.zulip.org/",
+                            "text": "Text with a link",
+                            "style": {
+                                "underline": true
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "text": "\n"
+                        },
+                        {
+                            "type": "link",
+                            "url": "https://chat.zulip.org/",
+                            "text": "Text with a link",
+                            "style": {
+                                "strike": true
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "text": "\n"
+                        },
+                        {
+                            "type": "link",
+                            "url": "https://chat.zulip.org"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_nested_ordered_list.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_nested_ordered_list.json
@@ -1,0 +1,124 @@
+{
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1772029460.121289",
+    "text": "ordered list with subitems:\n1. main item 1\n    ◦ nested item 1\n    ◦ nested item 2\n    ◦ nested item 3\n2. main item 2\n    a. nested item 1",
+    "team": "T06NRA6HM3P",
+    "user_team": "T06NRA6HM3P",
+    "source_team": "T06NRA6HM3P",
+    "user_profile": {
+        "avatar_hash": "112be04f818e",
+        "image_72": "https://avatars.slack-edge.com/2024-03-10/6773346635957_112be04f818e7bd093d5_72.png",
+        "first_name": "Peter",
+        "real_name": "Peter",
+        "display_name": "",
+        "team": "T06NRA6HM3P",
+        "name": "pieterceka123",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+    },
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "UopR3",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "ordered list with subitems:\n"
+                        }
+                    ]
+                },
+                {
+                    "type": "rich_text_list",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "main item 1"
+                                }
+                            ]
+                        }
+                    ],
+                    "style": "ordered",
+                    "indent": 0,
+                    "border": 0
+                },
+                {
+                    "type": "rich_text_list",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "nested item 1"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "nested item 2"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "nested item 3"
+                                }
+                            ]
+                        }
+                    ],
+                    "style": "bullet",
+                    "indent": 1,
+                    "border": 0
+                },
+                {
+                    "type": "rich_text_list",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "main item 2"
+                                }
+                            ]
+                        }
+                    ],
+                    "style": "ordered",
+                    "indent": 0,
+                    "offset": 1,
+                    "border": 0
+                },
+                {
+                    "type": "rich_text_list",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "nested item 1"
+                                }
+                            ]
+                        }
+                    ],
+                    "style": "ordered",
+                    "indent": 1,
+                    "border": 0
+                }
+            ]
+        }
+    ]
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_nested_unordered_list.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_nested_unordered_list.json
@@ -1,0 +1,127 @@
+{
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1772029387.573109",
+    "text": "unordered list with subitems:\n• main item 1\n    a. nested item 1\n    b. nested item 2\n    c. nested item 3\n• main item 2\n    a. nested item 1\n",
+    "team": "T06NRA6HM3P",
+    "user_team": "T06NRA6HM3P",
+    "source_team": "T06NRA6HM3P",
+    "user_profile": {
+        "avatar_hash": "112be04f818e",
+        "image_72": "https://avatars.slack-edge.com/2024-03-10/6773346635957_112be04f818e7bd093d5_72.png",
+        "first_name": "Peter",
+        "real_name": "Peter",
+        "display_name": "",
+        "team": "T06NRA6HM3P",
+        "name": "pieterceka123",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+    },
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "kKyAj",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "unordered list with subitems:\n"
+                        }
+                    ]
+                },
+                {
+                    "type": "rich_text_list",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "main item 1"
+                                }
+                            ]
+                        }
+                    ],
+                    "style": "bullet",
+                    "indent": 0,
+                    "border": 0
+                },
+                {
+                    "type": "rich_text_list",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "nested item 1"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "nested item 2"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "nested item 3"
+                                }
+                            ]
+                        }
+                    ],
+                    "style": "ordered",
+                    "indent": 1,
+                    "border": 0
+                },
+                {
+                    "type": "rich_text_list",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "main item 2"
+                                }
+                            ]
+                        }
+                    ],
+                    "style": "bullet",
+                    "indent": 0,
+                    "border": 0
+                },
+                {
+                    "type": "rich_text_list",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "nested item 1"
+                                }
+                            ]
+                        }
+                    ],
+                    "style": "ordered",
+                    "indent": 1,
+                    "border": 0
+                },
+                {
+                    "type": "rich_text_section",
+                    "elements": []
+                }
+            ]
+        }
+    ]
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_quote_block.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_quote_block.json
@@ -1,0 +1,59 @@
+{
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1772029790.709499",
+    "text": "&gt; Hello there, I am a rich text section block!\n&gt; *Hello there, I am a rich text section block!*\n&gt; ~_*`Hello there, I am a rich text section block!`*_~",
+    "team": "T06NRA6HM3P",
+    "user_team": "T06NRA6HM3P",
+    "source_team": "T06NRA6HM3P",
+    "user_profile": {
+        "avatar_hash": "112be04f818e",
+        "image_72": "https://avatars.slack-edge.com/2024-03-10/6773346635957_112be04f818e7bd093d5_72.png",
+        "first_name": "Peter",
+        "real_name": "Peter",
+        "display_name": "",
+        "team": "T06NRA6HM3P",
+        "name": "pieterceka123",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+    },
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "Ko0Dj",
+            "elements": [
+                {
+                    "type": "rich_text_quote",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "Hello there, I am a rich text section block!\n"
+                        },
+                        {
+                            "type": "text",
+                            "text": "Hello there, I am a rich text section block!",
+                            "style": {
+                                "bold": true
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "text": "\n"
+                        },
+                        {
+                            "type": "text",
+                            "text": "Hello there, I am a rich text section block!",
+                            "style": {
+                                "bold": true,
+                                "italic": true,
+                                "strike": true,
+                                "code": true,
+                                "underline": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_unknown_rich_text_block.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_unknown_rich_text_block.json
@@ -1,0 +1,46 @@
+{
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1772029070.889249",
+    "text": "Hello there, I am a basic rich text block! unknown block",
+    "team": "T06NRA6HM3P",
+    "user_team": "T06NRA6HM3P",
+    "source_team": "T06NRA6HM3P",
+    "user_profile": {
+        "avatar_hash": "112be04f818e",
+        "image_72": "https://avatars.slack-edge.com/2024-03-10/6773346635957_112be04f818e7bd093d5_72.png",
+        "first_name": "Peter",
+        "real_name": "Peter",
+        "display_name": "",
+        "team": "T06NRA6HM3P",
+        "name": "pieterceka123",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+    },
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "K9Baq",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "Hello there, I am a basic rich text block!"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "rich_text",
+            "block_id": "LjYw+",
+            "elements": [
+                {
+                    "type": "unknown_block"
+                }
+            ]
+        }
+    ]
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_user_mentions.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_user_mentions.json
@@ -1,0 +1,46 @@
+{
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1772112471.400529",
+    "client_msg_id": "d9639f19-8840-4758-8d8b-0116ecaf41a4",
+    "text": "<@U06NU4E26M9> test user mention <@U074VRHQ11T>",
+    "team": "T06NRA6HM3P",
+    "user_team": "T06NRA6HM3P",
+    "source_team": "T06NRA6HM3P",
+    "user_profile": {
+        "avatar_hash": "112be04f818e",
+        "image_72": "https://avatars.slack-edge.com/2024-03-10/6773346635957_112be04f818e7bd093d5_72.png",
+        "first_name": "Peter",
+        "real_name": "Peter",
+        "display_name": "",
+        "team": "T06NRA6HM3P",
+        "name": "pieterceka123",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+    },
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "pYfWB",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "user",
+                            "user_id": "U06NU4E26M9"
+                        },
+                        {
+                            "type": "text",
+                            "text": " test user mention "
+                        },
+                        {
+                            "type": "user",
+                            "user_id": "U074VRHQ11T"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_variety_files_and_rich_text.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_variety_files_and_rich_text.json
@@ -1,0 +1,147 @@
+{
+    "text": "message with *files  <@U074VRHQ11T>* \nF07A32DC2GG",
+    "files": [
+        {
+            "id": "F07A32DC2GG",
+            "created": 1719212228,
+            "timestamp": 1719212228,
+            "name": "Untitled",
+            "title": "Weekly Sync",
+            "mimetype": "application/vnd.slack-docs",
+            "filetype": "quip",
+            "pretty_type": "Canvas",
+            "user": "U06NU4E26M9",
+            "user_team": "T06NRA6HM3P",
+            "editable": true,
+            "size": 602,
+            "mode": "quip",
+            "is_external": false,
+            "external_type": "",
+            "is_public": true,
+            "public_url_shared": false,
+            "display_as_bot": false,
+            "username": "",
+            "url_private": "https://files.slack.com/files-pri/T06NRA6HM3P-F07A32DC2GG/canvas?token=xoxe-6773346599125-10627512423494-10622973772373-3297a1441684b168ed941456c939c391",
+            "url_private_download": "https://files.slack.com/files-pri/T06NRA6HM3P-F07A32DC2GG/download/canvas?token=xoxe-6773346599125-10627512423494-10622973772373-3297a1441684b168ed941456c939c391",
+            "permalink": "https://ds-py62195.slack.com/docs/T06NRA6HM3P/F07A32DC2GG",
+            "permalink_public": "https://slack-files.com/T06NRA6HM3P-F07A32DC2GG-0acf0ea037",
+            "url_static_preview": "https://ds-py62195.slack.com/docs/T06NRA6HM3P/F07A32DC2GG/mobile",
+            "quip_thread_id": "RaO9AA21YEm",
+            "updated": 1724304153,
+            "update_notification": 0,
+            "canvas_readtime": 0.30991569650743,
+            "is_starred": false,
+            "skipped_shares": true,
+            "teams_shared_with": [],
+            "is_restricted_sharing_enabled": true,
+            "has_rich_preview": false,
+            "file_access": "visible",
+            "access": "owner",
+            "org_or_workspace_access": "none",
+            "title_blocks": [
+                {
+                    "type": "rich_text",
+                    "block_id": "DOYmi",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": "Untitled"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "canvas_creator_id": "U06NU4E26M9",
+            "team_pref_version_history_enabled": true,
+            "canvas_printing_enabled": true,
+            "source_canvas_id": "F06NWMACFE0",
+            "is_ai_suggested": false
+        },
+        {
+            "id": "F07A2TVQ7C0",
+            "created": 1719210132,
+            "timestamp": 1719210132,
+            "name": "channels.json",
+            "title": "channels.json",
+            "mimetype": "text/plain",
+            "filetype": "json",
+            "pretty_type": "JSON",
+            "user": "U06NU4E26M9",
+            "user_team": "T06NRA6HM3P",
+            "editable": true,
+            "size": 1563,
+            "mode": "snippet",
+            "is_external": false,
+            "external_type": "",
+            "is_public": true,
+            "public_url_shared": false,
+            "display_as_bot": false,
+            "username": "",
+            "url_private": "https://files.slack.com/files-pri/T06NRA6HM3P-F07A2TVQ7C0/channels.json?token=xoxe-6773346599125-10627512423494-10622973772373-3297a1441684b168ed941456c939c391",
+            "url_private_download": "https://files.slack.com/files-pri/T06NRA6HM3P-F07A2TVQ7C0/download/channels.json?token=xoxe-6773346599125-10627512423494-10622973772373-3297a1441684b168ed941456c939c391",
+            "permalink": "https://ds-py62195.slack.com/files/U06NU4E26M9/F07A2TVQ7C0/channels.json",
+            "permalink_public": "https://slack-files.com/T06NRA6HM3P-F07A2TVQ7C0-5b1d277896",
+            "edit_link": "https://ds-py62195.slack.com/files/U06NU4E26M9/F07A2TVQ7C0/channels.json/edit",
+            "is_starred": false,
+            "skipped_shares": true,
+            "has_rich_preview": false,
+            "file_access": "visible"
+        }
+    ],
+    "upload": false,
+    "user": "U06NU4E26M9",
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "euFEj",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "message with "
+                        },
+                        {
+                            "type": "text",
+                            "text": "files  ",
+                            "style": {
+                                "bold": true
+                            }
+                        },
+                        {
+                            "type": "user",
+                            "user_id": "U074VRHQ11T",
+                            "style": {
+                                "bold": true
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "text": " ",
+                            "style": {
+                                "bold": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "canvas",
+                            "file_id": "F07A32DC2GG"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "type": "message",
+    "ts": "1772636065.551219",
+    "client_msg_id": "54bea93c-8a96-4f6b-9b52-f64af8b8e6a9"
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_varying_block_types.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_varying_block_types.json
@@ -1,0 +1,157 @@
+{
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1776874317.427959",
+    "text": "Hello there, I am a basic rich text block! Hello there, *I am a bold rich text block!* This is a mrkdwn section block :ghost: *this is bold*, and ~this is crossed out~, and <https:\/\/google.com|this is a link> This is a header block, with interactive elements",
+    "team": "T06NRA6HM3P",
+    "user_team": "T06NRA6HM3P",
+    "source_team": "T06NRA6HM3P",
+    "user_profile": {
+        "avatar_hash": "112be04f818e",
+        "image_72": "https:\/\/avatars.slack-edge.com\/2024-03-10\/6773346635957_112be04f818e7bd093d5_72.png",
+        "first_name": "Peter",
+        "real_name": "Peter",
+        "display_name": "",
+        "team": "T06NRA6HM3P",
+        "name": "pieterceka123",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+    },
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "vlcln",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "Hello there, I am a basic rich text block!"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "rich_text",
+            "block_id": "3bUuq",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "Hello there, "
+                        },
+                        {
+                            "type": "text",
+                            "text": "I am a bold rich text block!",
+                            "style": {
+                                "bold": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "divider",
+            "block_id": "6CDU1"
+        },
+        {
+            "type": "section",
+            "block_id": "9SUkm",
+            "text": {
+                "type": "mrkdwn",
+                "text": "This is a mrkdwn section block :ghost: *this is bold*, and ~this is crossed out~, and <https:\/\/google.com|this is a link>",
+                "verbatim": false
+            }
+        },
+        {
+            "type": "header",
+            "block_id": "IXIr+",
+            "text": {
+                "type": "plain_text",
+                "text": "This is a header block",
+                "emoji": true
+            }
+        },
+        {
+            "type": "table",
+            "block_id": "nsnOP",
+            "rows": [
+                [
+                    {
+                        "type": "rich_text",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [
+                                    {
+                                        "type": "text",
+                                        "text": "Header 1",
+                                        "style": {
+                                            "bold": true
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        "block_id": "kEn4y"
+                    },
+                    {
+                        "type": "rich_text",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [
+                                    {
+                                        "type": "text",
+                                        "text": "Header 2",
+                                        "style": {
+                                            "bold": true
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        "block_id": "xMooE"
+                    }
+                ],
+                [
+                    {
+                        "type": "rich_text",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [
+                                    {
+                                        "type": "text",
+                                        "text": "Datum 1"
+                                    }
+                                ]
+                            }
+                        ],
+                        "block_id": "F\/cwk"
+                    },
+                    {
+                        "type": "rich_text",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [
+                                    {
+                                        "type": "text",
+                                        "text": "Datum 2"
+                                    }
+                                ]
+                            }
+                        ],
+                        "block_id": "Zlx8J"
+                    }
+                ]
+            ]
+        }
+    ]
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_workspace_mentions.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/message_with_workspace_mentions.json
@@ -1,0 +1,55 @@
+{
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1772112449.216879",
+    "client_msg_id": "51805843-3b6c-4da6-ab25-234da192e0ea",
+    "text": "<!channel> _*<!here>*_ test mention",
+    "team": "T06NRA6HM3P",
+    "user_team": "T06NRA6HM3P",
+    "source_team": "T06NRA6HM3P",
+    "user_profile": {
+        "avatar_hash": "112be04f818e",
+        "image_72": "https://avatars.slack-edge.com/2024-03-10/6773346635957_112be04f818e7bd093d5_72.png",
+        "first_name": "Peter",
+        "real_name": "Peter",
+        "display_name": "",
+        "team": "T06NRA6HM3P",
+        "name": "pieterceka123",
+        "is_restricted": false,
+        "is_ultra_restricted": false
+    },
+    "blocks": [
+        {
+            "type": "rich_text",
+            "block_id": "7Kcpi",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {
+                            "type": "broadcast",
+                            "range": "channel"
+                        },
+                        {
+                            "type": "text",
+                            "text": " "
+                        },
+                        {
+                            "type": "broadcast",
+                            "range": "here",
+                            "style": {
+                                "bold": true,
+                                "italic": true,
+                                "underline": true
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "text": " test mention"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/normal_messages.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/normal_messages.json
@@ -7,7 +7,7 @@
         "channel_name": "random"
     },
     {
-        "text": "<@U061A5N1G>: hey!",
+        "text": "hey!",
         "user": "U061A1R2R",
         "ts": "1437868294.000006",
         "has_image": true,

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/thread_with_mention_syntax_in_topic_name.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/thread_with_mention_syntax_in_topic_name.json
@@ -1,17 +1,102 @@
 [
     {
-        "text": "<@U061A1R2R> please reply to this message",
         "user": "U061A5N1G",
-        "ts": "1437139200.000002",
-        "thread_ts": "1437139200.000002",
-        "channel_name": "random"
+        "type": "message",
+        "ts": "1776959516.007659",
+        "client_msg_id": "413a156a-ced0-4f52-bb06-de1b6185fd4f",
+        "text": "<@U061A1R2R> please reply to this message",
+        "team": "T06NRA6HM3P",
+        "user_team": "T06NRA6HM3P",
+        "source_team": "T06NRA6HM3P",
+        "user_profile": {
+            "avatar_hash": "112be04f818e",
+            "image_72": "https:\/\/avatars.slack-ed ge.com\/2024-03-10\/6773346635957_112be04f818e7bd093d5_72.png",
+            "first_name": "John",
+            "real_name": "John",
+            "display_name": "",
+            "team": "T06NRA6HM3P",
+            "name": "johndoe",
+            "is_restricted": false,
+            "is_ultra_restricted": false
+        },
+        "thread_ts": "1776959516.007659",
+        "reply_count": 1,
+        "reply_users_count": 1,
+        "channel_name": "random",
+        "latest_reply": "1776959526.566079",
+        "reply_users": [
+            "U061A1R2R"
+        ],
+        "replies": [
+            {
+                "user": "U061A1R2R",
+                "ts": "1776959526.566079"
+            }
+        ],
+        "is_locked": false,
+        "subscribed": true,
+        "last_read": "1776959526.566079",
+        "blocks": [
+            {
+                "type": "rich_text",
+                "block_id": "hzhfu",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [
+                            {
+                                "type": "user",
+                                "user_id": "U061A1R2R"
+                            },
+                            {
+                                "type": "text",
+                                "text": " please reply to this message"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
     },
     {
-        "text": "Yes?",
         "user": "U061A1R2R",
-        "ts": "1440869295.000008",
+        "type": "message",
+        "ts": "1776959526.566079",
+        "client_msg_id": "d8b51c97-6928-4cbc-95d1-7826c890ca52",
+        "text": "yes?",
+        "team": "T06NRA6HM3P",
+        "user_team": "T06NRA6HM3P",
+        "source_team": "T06NRA6HM3P",
+        "user_profile": {
+            "avatar_hash": "112be04f818e",
+            "image_72": "https:\/\/avatars.slack-edge.com\/2024-03-10\/6773346635957_112be04f818e7bd093d5_72.png",
+            "first_name": "Jane",
+            "real_name": "Jane",
+            "display_name": "",
+            "team": "T06NRA6HM3P",
+            "name": "janedoe",
+            "is_restricted": false,
+            "is_ultra_restricted": false
+        },
+        "thread_ts": "1776959516.007659",
+        "channel_name": "random",
         "parent_user_id": "U061A5N1G",
-        "thread_ts": "1437139200.000002",
-        "channel_name": "random"
+        "blocks": [
+            {
+                "type": "rich_text",
+                "block_id": "X9m+A",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [
+                            {
+                                "type": "text",
+                                "text": "yes?"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
     }
 ]

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -1273,7 +1273,7 @@ class SlackImporter(ZulipTestCase):
                 "channel_name": "random",
             },
             {
-                "text": "<@U061A5N1G>: hey!",
+                "text": "hey!",
                 "user": "U061A1R2R",
                 "ts": "1437868294.000006",
                 "has_image": True,
@@ -1416,7 +1416,7 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(conversion_result.reaction_list[0]["emoji_name"], reactions[0]["name"])
 
         # Message conversion already tested in tests.test_slack_message_conversion
-        self.assertEqual(zerver_message[0]["content"], "@**Jane**: hey!")
+        self.assertEqual(zerver_message[0]["content"], "hey!")
         self.assertEqual(zerver_message[0]["has_link"], False)
         self.assertEqual(zerver_message[2]["content"], "http://journals.plos.org/plosone/article")
         self.assertEqual(zerver_message[2]["has_link"], True)
@@ -1511,7 +1511,7 @@ class SlackImporter(ZulipTestCase):
         self.assert_length(attachment, 0)
 
         # Message conversion already tested in tests.test_slack_message_conversion
-        self.assertEqual(zerver_message[0]["content"], "@**Jane**: hey!")
+        self.assertEqual(zerver_message[0]["content"], "hey!")
         self.assertEqual(zerver_message[0]["has_link"], False)
         self.assertEqual(
             zerver_message[1]["recipient"],
@@ -1770,8 +1770,8 @@ message body text
 
         self.assert_length(zerver_message, 2)
         # Test mention syntax in thread topic name.
-        expected_thread_topic_name = "2015-07-17 @**Jon** please reply to this message"
-        thread_1_topic_link_syntax = get_stream_topic_link_syntax(
+        expected_thread_topic_name = "2026-04-23 @**Jon** please reply to this message"
+        thread_topic_link_syntax = get_stream_topic_link_syntax(
             slack_recipient_name_to_zulip_recipient_id["random"],
             "random",
             expected_thread_topic_name,
@@ -1780,8 +1780,9 @@ message body text
         expected_thread_message_1_content = f"""
 {original_thread_message_1_content}
 
-*1 reply in {thread_1_topic_link_syntax}*
+*1 reply in {thread_topic_link_syntax}*
 """.strip()
+
         self.assertEqual(zerver_message[0]["content"], expected_thread_message_1_content)
         self.assertEqual(zerver_message[0][EXPORT_TOPIC_NAME], MAIN_SLACK_IMPORT_TOPIC)
         self.assertEqual(zerver_message[1][EXPORT_TOPIC_NAME], expected_thread_topic_name)

--- a/zerver/tests/test_slack_message_conversion.py
+++ b/zerver/tests/test_slack_message_conversion.py
@@ -10,8 +10,7 @@ from zerver.data_import.slack_message_conversion import (
     LossyConversionError,
     RenderResult,
     UserMentionProcessorT,
-    convert_to_zulip_markdown,
-    get_user_full_name,
+    convert_slack_formatting,
     get_zulip_mention_for_slack_user,
     process_slack_block_and_attachment,
 )
@@ -51,96 +50,29 @@ class SlackMessageConversion(ZulipTestCase):
         for name, test in format_tests.items():
             # Check that there aren't any unexpected keys as those are often typos
             self.assert_length(set(test.keys()) - valid_keys, 0)
-            slack_user_map: dict[str, int] = {}
-            users: list[dict[str, Any]] = [{}]
-            channel_map: dict[str, tuple[str, int]] = {}
-            converted = convert_to_zulip_markdown(test["input"], users, channel_map, slack_user_map)
+            converted = convert_slack_formatting(test["input"])
             converted_text = converted[0]
             with self.subTest(slack_message_conversion=name):
                 self.assertEqual(converted_text, test["conversion_output"])
 
-    def test_mentioned_data(self) -> None:
-        slack_user_map = {"U08RGD1RD": 540, "U0CBK5KAT": 554, "U09TYF5SK": 571}
-        # For this test, only relevant keys are 'id', 'name', 'deleted'
-        # and 'real_name'
-        users = [
-            {
-                "id": "U0CBK5KAT",
-                "name": "aaron.anzalone",
-                "deleted": False,
-                "is_mirror_dummy": False,
-                "real_name": "",
-            },
-            {
-                "id": "U08RGD1RD",
-                "name": "john",
-                "deleted": False,
-                "is_mirror_dummy": False,
-                "real_name": "John Doe",
-            },
-            {
-                "id": "U09TYF5Sk",
-                "name": "Jane",
-                "is_mirror_dummy": False,
-                "deleted": True,  # Deleted users don't have 'real_name' key in Slack
-            },
-        ]
-        channel_map = {"general": ("C5Z73A7RA", 137)}
-        message = "Hi <@U08RGD1RD|john>: How are you? <#C5Z73A7RA|general>"
-        text, mentioned_users, _has_link = convert_to_zulip_markdown(
-            message, users, channel_map, slack_user_map
-        )
-        full_name = get_user_full_name(users[1])
-        self.assertEqual(full_name, "John Doe")
-        self.assertEqual(get_user_full_name(users[2]), "Jane")
-
-        self.assertEqual(text, f"Hi @**{full_name}**: How are you? #**general**")
-        self.assertEqual(mentioned_users, [540])
-
-        # multiple mentioning
-        message = "Hi <@U08RGD1RD|john>: How are you?<@U0CBK5KAT> asked."
-        text, mentioned_users, _has_link = convert_to_zulip_markdown(
-            message, users, channel_map, slack_user_map
-        )
-        self.assertEqual(text, "Hi @**John Doe**: How are you?@**aaron.anzalone** asked.")
-        self.assertEqual(mentioned_users, [540, 554])
-
-        # Check wrong mentioning
-        message = "Hi <@U08RGD1RD|jon>: How are you?"
-        text, mentioned_users, _has_link = convert_to_zulip_markdown(
-            message, users, channel_map, slack_user_map
-        )
-        self.assertEqual(text, message)
-        self.assertEqual(mentioned_users, [])
-
     def test_has_link(self) -> None:
-        slack_user_map: dict[str, int] = {}
-
         message = "<http://journals.plos.org/plosone/article>"
-        text, _mentioned_users, has_link = convert_to_zulip_markdown(
-            message, [], {}, slack_user_map
-        )
+        text, has_link = convert_slack_formatting(message)
         self.assertEqual(text, "http://journals.plos.org/plosone/article")
         self.assertEqual(has_link, True)
 
         message = "<http://chat.zulip.org/help/logging-in|Help logging in to CZO>"
-        text, _mentioned_users, has_link = convert_to_zulip_markdown(
-            message, [], {}, slack_user_map
-        )
+        text, has_link = convert_slack_formatting(message)
         self.assertEqual(text, "[Help logging in to CZO](http://chat.zulip.org/help/logging-in)")
         self.assertEqual(has_link, True)
 
         message = "<mailto:foo@foo.com>"
-        text, _mentioned_users, has_link = convert_to_zulip_markdown(
-            message, [], {}, slack_user_map
-        )
+        text, has_link = convert_slack_formatting(message)
         self.assertEqual(text, "mailto:foo@foo.com")
         self.assertEqual(has_link, True)
 
         message = "random message"
-        text, _mentioned_users, has_link = convert_to_zulip_markdown(
-            message, [], {}, slack_user_map
-        )
+        text, has_link = convert_slack_formatting(message)
         self.assertEqual(has_link, False)
 
 

--- a/zerver/tests/test_slack_message_conversion.py
+++ b/zerver/tests/test_slack_message_conversion.py
@@ -1,3 +1,4 @@
+import json
 import os
 from typing import Any
 
@@ -5,11 +6,18 @@ import orjson
 from typing_extensions import override
 
 from zerver.data_import.slack_message_conversion import (
+    ChannelMentionProcessorT,
+    LossyConversionError,
+    RenderResult,
+    UserMentionProcessorT,
     convert_to_zulip_markdown,
     get_user_full_name,
+    get_zulip_mention_for_slack_user,
+    process_slack_block_and_attachment,
 )
 from zerver.lib import mdiff
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.validator import to_wild_value
 
 
 class SlackMessageConversion(ZulipTestCase):
@@ -134,3 +142,305 @@ class SlackMessageConversion(ZulipTestCase):
             message, [], {}, slack_user_map
         )
         self.assertEqual(has_link, False)
+
+
+class SlackBlockAndAttachmentConversionTest(ZulipTestCase):
+    def check_converted_content(
+        self,
+        fixture_name: str,
+        channel_mention_processor: ChannelMentionProcessorT,
+        user_mention_processor: UserMentionProcessorT,
+        expected_result: RenderResult,
+    ) -> None:
+        raw_message = orjson.loads(
+            self.fixture_data(fixture_name, "slack_fixtures/exported_messages_fixtures")
+        )
+        result = process_slack_block_and_attachment(
+            (to_wild_value("message", json.dumps(raw_message))),
+            channel_mention_processor,
+            user_mention_processor,
+        )
+        self.assertEqual(expected_result.content, result.content)
+        self.assertEqual(expected_result.has_link, result.has_link)
+        self.assertEqual(expected_result.mentioned_user_ids, result.mentioned_user_ids)
+
+    def test_bold_italic_strike(self) -> None:
+        self.check_converted_content(
+            fixture_name="message_with_basic_formatting.json",
+            user_mention_processor=lambda id: None,
+            channel_mention_processor=lambda id: None,
+            expected_result=RenderResult(
+                content=(
+                    "Hello there, I am a basic rich text block!\n"
+                    "Hello there, **I am a bold rich text block!**\n"
+                    "Hello there, *I am an italic rich text block!*\n"
+                    "Hello there, ~~I am a strikethrough rich text block!~~"
+                ),
+                has_link=False,
+                mentioned_user_ids=[],
+            ),
+        )
+
+    def test_emojis(self) -> None:
+        self.check_converted_content(
+            fixture_name="message_with_emojis.json",
+            user_mention_processor=lambda id: None,
+            channel_mention_processor=lambda id: None,
+            expected_result=RenderResult(
+                content="Hello there! Here are some emojis :basketball: :snowboarder: :checkered_flag:",
+                has_link=False,
+                mentioned_user_ids=[],
+            ),
+        )
+
+    def test_links(self) -> None:
+        self.check_converted_content(
+            fixture_name="message_with_links.json",
+            user_mention_processor=lambda id: None,
+            channel_mention_processor=lambda id: None,
+            expected_result=RenderResult(
+                content="""
+[Text with a link](https://chat.zulip.org/)
+**[Text with a link](https://chat.zulip.org/)**
+*[Text with a link](https://chat.zulip.org/)*
+[Text with a link](https://chat.zulip.org/)
+~~[Text with a link](https://chat.zulip.org/)~~
+https://chat.zulip.org
+## [Public view of Zulip Community | Zulip team chat](https://chat.zulip.org/)
+
+Browse the publicly accessible channels in Zulip Community without logging in.
+""".strip(),
+                has_link=True,
+                mentioned_user_ids=[],
+            ),
+        )
+
+    def test_bullet_list(self) -> None:
+        self.check_converted_content(
+            fixture_name="message_with_bullet_list.json",
+            user_mention_processor=lambda id: None,
+            channel_mention_processor=lambda id: None,
+            expected_result=RenderResult(
+                content=(
+                    "Basic bullet list with rich elements\n\n"
+                    "- item 1: :basketball:\n"
+                    "- item 2: **this** is *a list* item\n"
+                    "- item 3: **[with a link](https://example.com/)**\n"
+                    "- item 4: we are near ~~the end~~\n"
+                    "- item 5: ~~***[this is the end](https://chat.zulip.org/)***~~"
+                ),
+                has_link=True,
+                mentioned_user_ids=[],
+            ),
+        )
+
+    def test_nested_unordered_list(self) -> None:
+        self.check_converted_content(
+            fixture_name="message_with_nested_unordered_list.json",
+            user_mention_processor=lambda id: None,
+            channel_mention_processor=lambda id: None,
+            expected_result=RenderResult(
+                content=(
+                    "unordered list with subitems:\n\n"
+                    "- main item 1\n"
+                    "   1. nested item 1\n"
+                    "   1. nested item 2\n"
+                    "   1. nested item 3\n"
+                    "- main item 2\n"
+                    "   1. nested item 1"
+                ),
+                has_link=False,
+                mentioned_user_ids=[],
+            ),
+        )
+
+    def test_nested_ordered_list(self) -> None:
+        self.check_converted_content(
+            fixture_name="message_with_nested_ordered_list.json",
+            user_mention_processor=lambda id: None,
+            channel_mention_processor=lambda id: None,
+            expected_result=RenderResult(
+                content=(
+                    "ordered list with subitems:\n\n"
+                    "1. main item 1\n"
+                    "   - nested item 1\n"
+                    "   - nested item 2\n"
+                    "   - nested item 3\n"
+                    "1. main item 2\n"
+                    "   1. nested item 1"
+                ),
+                has_link=False,
+                mentioned_user_ids=[],
+            ),
+        )
+
+    def test_inline_code(self) -> None:
+        self.check_converted_content(
+            fixture_name="message_with_inline_code.json",
+            user_mention_processor=lambda id: None,
+            channel_mention_processor=lambda id: None,
+            expected_result=RenderResult(
+                content="""
+Hello there, I am an `inline code`
+**Hello there, I am an** **`inline code`**
+ ~~***[Hello there, I am an](https://chat.zulip.org)***~~ ~~***`inline code`***~~
+## [Public view of Zulip Community | Zulip team chat](https://chat.zulip.org/)
+
+Browse the publicly accessible channels in Zulip Community without logging in.
+""".strip(),
+                has_link=True,
+                mentioned_user_ids=[],
+            ),
+        )
+
+    def test_code_block(self) -> None:
+        self.check_converted_content(
+            fixture_name="message_with_code_block.json",
+            user_mention_processor=lambda id: None,
+            channel_mention_processor=lambda id: None,
+            expected_result=RenderResult(
+                content="""
+```text
+# I'm a code block!
+
+def convert_slack_formatting(text: str) -> str:
+    return text
+```
+""".strip(),
+                has_link=False,
+                mentioned_user_ids=[],
+            ),
+        )
+
+    def test_quote_block(self) -> None:
+        self.check_converted_content(
+            fixture_name="message_with_quote_block.json",
+            user_mention_processor=lambda id: None,
+            channel_mention_processor=lambda id: None,
+            expected_result=RenderResult(
+                content="""
+```quote
+Hello there, I am a rich text section block!
+**Hello there, I am a rich text section block!**
+~~***`Hello there, I am a rich text section block!`***~~
+```
+""".strip(),
+                has_link=False,
+                mentioned_user_ids=[],
+            ),
+        )
+
+    def test_user_mentions(self) -> None:
+
+        slack_user_id_to_zulip_user_id = {"U06NU4E26M9": 1}
+        users = [
+            {
+                "id": "U06NU4E26M9",
+                "name": "john",
+                "is_mirror_dummy": False,
+                "real_name": "John Doe",
+                "profile": {
+                    "image_32": "",
+                    "email": "jon@gmail.com",
+                    "avatar_hash": "hash",
+                    "phone": "+1-123-456-77-868",
+                    "fields": {},
+                },
+            }
+        ]
+
+        def user_mention_processor(slack_user_id: str) -> tuple[str, int] | None:
+            if mention := get_zulip_mention_for_slack_user(slack_user_id, None, users):
+                return (mention, slack_user_id_to_zulip_user_id[slack_user_id])
+            else:
+                return None
+
+        self.check_converted_content(
+            fixture_name="message_with_user_mentions.json",
+            user_mention_processor=user_mention_processor,
+            channel_mention_processor=lambda id: None,
+            expected_result=RenderResult(
+                content="@**john** test user mention **#Unknown Slack user U074VRHQ11T**",
+                has_link=False,
+                mentioned_user_ids=[1],
+            ),
+        )
+
+    def test_channel_mentions(self) -> None:
+        slack_channel_id_to_name = {"C079A3FA12P": "general", "C0AHX20ADQQ": "issues"}
+
+        def channel_mention_processor(slack_channel_id: str) -> str | None:
+            if slack_channel_id in slack_channel_id_to_name:
+                return f"#**{slack_channel_id_to_name[slack_channel_id]}**"
+            else:
+                return None
+
+        self.check_converted_content(
+            fixture_name="message_with_channel_mentions.json",
+            user_mention_processor=lambda id: None,
+            channel_mention_processor=channel_mention_processor,
+            expected_result=RenderResult(
+                content="#**general** #**issues** **#Unknown Slack channel C06P6T3QGD7**",
+                has_link=False,
+                mentioned_user_ids=[],
+            ),
+        )
+
+    def test_workspace_mentions(self) -> None:
+        self.check_converted_content(
+            fixture_name="message_with_workspace_mentions.json",
+            user_mention_processor=lambda id: None,
+            channel_mention_processor=lambda id: None,
+            expected_result=RenderResult(
+                content="@**all** @**all** test mention",
+                has_link=False,
+                mentioned_user_ids=[],
+            ),
+        )
+
+    def test_variety_files_and_rich_text(self) -> None:
+        self.check_converted_content(
+            fixture_name="message_with_variety_files_and_rich_text.json",
+            user_mention_processor=lambda id: None,
+            channel_mention_processor=lambda id: None,
+            expected_result=RenderResult(
+                content="message with **files**  **#Unknown Slack user U074VRHQ11T**",
+                has_link=False,
+                mentioned_user_ids=[],
+            ),
+        )
+
+    def test_message_with_varying_block_types(self) -> None:
+        self.check_converted_content(
+            fixture_name="message_with_varying_block_types.json",
+            user_mention_processor=lambda id: None,
+            channel_mention_processor=lambda id: None,
+            expected_result=RenderResult(
+                content="""
+Hello there, I am a basic rich text block!
+Hello there, **I am a bold rich text block!**
+----
+This is a mrkdwn section block :ghost: **this is bold**, and ~~this is crossed out~~, and [this is a link](https://google.com)
+## This is a header block
+""".strip(),
+                has_link=True,
+                mentioned_user_ids=[],
+            ),
+        )
+
+    def test_unknown_rich_text_block(self) -> None:
+        with self.assertRaises(LossyConversionError) as e:
+            self.check_converted_content(
+                fixture_name="message_with_unknown_rich_text_block.json",
+                user_mention_processor=lambda id: None,
+                channel_mention_processor=lambda id: None,
+                expected_result=RenderResult(
+                    content="",
+                    has_link=False,
+                    mentioned_user_ids=[],
+                ),
+            )
+        self.assertEqual(
+            str(e.exception),
+            "Unknown rich_text block: unknown_block.\n{'type': 'unknown_block'}",
+        )

--- a/zerver/webhooks/slack/tests.py
+++ b/zerver/webhooks/slack/tests.py
@@ -320,7 +320,7 @@ class SlackWebhookTests(WebhookTestCase):
     def test_message_from_slack_integration_bot(self) -> None:
         message_body = """
 **Task status changed** from `complete` to `to do`
-**<https://app.clickup.com/t/25567147/86cw30wf2|asd>**
+**[asd](https://app.clickup.com/t/25567147/86cw30wf2)**
 
 [Cookie / The Goodiest of Cstdddddsdd / dds](https://search.clickup-au.com/media/app-icons/clickup/logo_alpha.png)
 

--- a/zerver/webhooks/slack/tests.py
+++ b/zerver/webhooks/slack/tests.py
@@ -197,7 +197,7 @@ class SlackWebhookTests(WebhookTestCase):
 
     @mock_slack_api_calls
     def test_message_with_bullet_points(self) -> None:
-        message_body = "• list three\n• list two"
+        message_body = "- list three\n- list two"
         expected_message = EXPECTED_MESSAGE.format(user=USER, message=message_body)
         self.check_webhook(
             "message_with_bullet_points",
@@ -208,7 +208,9 @@ class SlackWebhookTests(WebhookTestCase):
 
     @mock_slack_api_calls
     def test_message_with_channel_and_user_mentions(self) -> None:
-        message_body = "@**John Doe** **#general** message with both channel and user mentions"
+        message_body = (
+            "@**John Doe** **#Slack general** message with both channel and user mentions"
+        )
         expected_message = EXPECTED_MESSAGE.format(user=USER, message=message_body)
         self.check_webhook(
             "message_with_channel_and_user_mentions",
@@ -219,7 +221,7 @@ class SlackWebhookTests(WebhookTestCase):
 
     @mock_slack_api_calls
     def test_message_with_channel_mentions(self) -> None:
-        message_body = "**#zulip-mirror** **#general** message with channel mentions"
+        message_body = "**#Slack general** **#Slack general** message with channel mentions"
         expected_message = EXPECTED_MESSAGE.format(user=USER, message=message_body)
         self.check_webhook(
             "message_with_channel_mentions",
@@ -266,7 +268,13 @@ class SlackWebhookTests(WebhookTestCase):
 
     @mock_slack_api_calls
     def test_message_with_ordered_list(self) -> None:
-        message_body = "1. point one\n2. point two\n3. mix both\n4. pour water\n5. etc"
+        message_body = """
+1. point one
+1. point two
+1. mix both
+1. pour water
+1. etc
+""".strip()
         expected_message = EXPECTED_MESSAGE.format(user=USER, message=message_body)
         self.check_webhook(
             "message_with_ordered_list",
@@ -341,7 +349,18 @@ To Do""".strip()
 
     @mock_slack_api_calls
     def test_message_with_code_block(self) -> None:
-        message_body = """```def is_bot_message(payload: WildValue) -&gt; bool:\n    app_api_id = payload.get(\"api_app_id\").tame(check_none_or(check_string))\n    bot_app_id = (\n        payload.get(\"event\", {})\n        .get(\"bot_profile\", {})\n        .get(\"app_id\")\n        .tame(check_none_or(check_string))\n    )\n    return bot_app_id is not None and app_api_id == bot_app_id```"""
+        message_body = """
+```text
+def is_bot_message(payload: WildValue) -> bool:
+    app_api_id = payload.get("api_app_id").tame(check_none_or(check_string))
+    bot_app_id = (
+        payload.get("event", {})
+        .get("bot_profile", {})
+        .get("app_id")
+        .tame(check_none_or(check_string))
+    )
+    return bot_app_id is not None and app_api_id == bot_app_id
+```""".strip()
         expected_message = EXPECTED_MESSAGE.format(user=USER, message=message_body)
         self.check_webhook(
             "message_with_code_block",
@@ -363,7 +382,7 @@ To Do""".strip()
 
     @mock_slack_api_calls
     def test_message_with_complex_formatted_mentions(self) -> None:
-        message_body = "@**John Doe** **#general** ~~***@**all*****~~"
+        message_body = "@**John Doe** **#Slack general** @**all**"
         expected_message = EXPECTED_MESSAGE.format(user=USER, message=message_body)
         self.check_webhook(
             "message_with_complex_formatted_mentions",
@@ -374,7 +393,11 @@ To Do""".strip()
 
     @mock_slack_api_calls
     def test_message_with_quote_block(self) -> None:
-        message_body = "&gt; This is a quote"
+        message_body = """
+```quote
+This is a quote
+```
+""".strip()
         expected_message = EXPECTED_MESSAGE.format(user=USER, message=message_body)
         self.check_webhook(
             "message_with_quote_block",

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -104,7 +104,7 @@ def convert_slack_user_and_channel_mentions(text: str, app_token: str) -> str:
 # due to differences in the Slack import data and Slack webhook
 # payloads.
 def convert_to_zulip_markdown(text: str, slack_app_token: str) -> str:
-    text = convert_slack_formatting(text)
+    text, _ = convert_slack_formatting(text)
     text = convert_slack_workspace_mentions(text)
     text = convert_slack_user_and_channel_mentions(text, slack_app_token)
     return text
@@ -201,7 +201,7 @@ def api_slack_webhook(
             else:
                 raise RequestVariableMissingError(variable)
 
-        text = convert_slack_formatting(legacy_payload["text"])
+        text, _ = convert_slack_formatting(legacy_payload["text"])
         text = replace_links(text)
         text = get_message_body(text, legacy_payload["user_name"], [])
         handle_slack_webhook_message(

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -1,4 +1,3 @@
-import re
 from typing import Annotated, Any, TypeAlias
 
 from django.http import HttpRequest
@@ -8,9 +7,7 @@ from django.utils.translation import gettext as _
 from zerver.actions.message_send import send_rate_limited_pm_notification_to_bot_owner
 from zerver.data_import.slack import check_slack_token_access, get_slack_api_data
 from zerver.data_import.slack_message_conversion import (
-    SLACK_USERMENTION_REGEX,
     convert_slack_formatting,
-    convert_slack_workspace_mentions,
     process_slack_block_and_attachment,
     replace_links,
 )
@@ -70,44 +67,6 @@ def get_slack_sender_name(user_id: str, token: str) -> str:
         user=user_id,
     )
     return slack_user_data["real_name"]
-
-
-def convert_slack_user_and_channel_mentions(text: str, app_token: str) -> str:
-    tokens = text.split(" ")
-    for iterator in range(len(tokens)):
-        slack_usermention_match = re.search(SLACK_USERMENTION_REGEX, tokens[iterator], re.VERBOSE)
-        slack_channelmention_match = re.search(
-            SLACK_CHANNELMENTION_REGEX, tokens[iterator], re.MULTILINE
-        )
-        if slack_usermention_match:
-            # Convert Slack user mentions to a mention-like syntax since there
-            # is no way to map Slack and Zulip users.
-            slack_id = slack_usermention_match.group(2)
-            user_name = get_slack_sender_name(user_id=slack_id, token=app_token)
-            tokens[iterator] = "@**" + user_name + "**"
-        elif slack_channelmention_match:
-            # Convert Slack channel mentions to a mention-like syntax so that
-            # a mention isn't triggered for a Zulip channel with the same name.
-            channel_info: list[str] = slack_channelmention_match.group(0).split("|")
-            channel_id = channel_info[0]
-            channel_name = channel_info[1] if len(channel_info) > 1 else None
-            if channel_name:
-                tokens[iterator] = f"**#{channel_name}**"
-            else:
-                tokens[iterator] = f"**#[Slack channel {channel_id}]**"  # nocoverage
-    text = " ".join(tokens)
-    return text
-
-
-# This is a modified version of `convert_to_zulip_markdown` in
-# `slack_message_conversion.py`, which cannot be used directly
-# due to differences in the Slack import data and Slack webhook
-# payloads.
-def convert_to_zulip_markdown(text: str, slack_app_token: str) -> str:
-    text, _ = convert_slack_formatting(text)
-    text = convert_slack_workspace_mentions(text)
-    text = convert_slack_user_and_channel_mentions(text, slack_app_token)
-    return text
 
 
 def convert_raw_file_data(file_dict: WildValue) -> SlackFileListT:
@@ -280,8 +239,23 @@ def api_slack_webhook(
 
     raw_files = event_dict.get("files")
     files = convert_raw_file_data(raw_files) if raw_files else []
-    raw_text = process_slack_block_and_attachment(event_dict)
-    text = convert_to_zulip_markdown(raw_text, slack_app_token)
+
+    def channel_mention_processor(slack_channel_id: str) -> str:  # nocoverage
+        channel_name = get_slack_channel_name(channel_id=slack_channel_id, token=slack_app_token)
+        return f"**#{channel_name}**"
+
+    def user_mention_processor(slack_user_id: str) -> tuple[str, int]:  # nocoverage
+        user_name = get_slack_sender_name(user_id=slack_user_id, token=slack_app_token)
+        # The number 1 is just an arbitrary number, it's supposed to be the user ID, but
+        # that's not relevant here.
+        return ("@**" + user_name + "**", 1)
+
+    result = process_slack_block_and_attachment(
+        event_dict,
+        channel_mention_processor,
+        user_mention_processor,
+    )
+
     user_id = event_dict.get("user").tame(check_none_or(check_string))
     if user_id is None:
         # This is likely a Slack integration bot message. The sender of these
@@ -289,7 +263,7 @@ def api_slack_webhook(
         sender = event_dict["username"].tame(check_string)
     else:
         sender = get_slack_sender_name(user_id, slack_app_token)
-    content = get_message_body(text, sender, files)
+    content = get_message_body(result.content, sender, files)
 
     # channels_map_to_topics=0 is ported to use PresetUrlOption.CHANNEL_MAPPING
     # (map_to_channels).

--- a/zerver/webhooks/slack_incoming/view.py
+++ b/zerver/webhooks/slack_incoming/view.py
@@ -9,7 +9,6 @@ from django.utils.translation import gettext as _
 from typing_extensions import ParamSpec
 
 from zerver.data_import.slack_message_conversion import (
-    LossyConversionError,
     convert_slack_formatting,
     render_attachment,
     render_block,
@@ -83,15 +82,34 @@ def api_slack_incoming_webhook(
     if user_specified_topic is None:
         user_specified_topic = "(no topic)"
 
+    # We probably won't find many user/channel mentions in these payloads, if at
+    # all, since a major use case for this integration is to act as a bridge from
+    # third-party apps. So, these mention processor functions probably don't really
+    # matter much.
+    def channel_mention_processor(slack_channel_id: str) -> str | None:  # nocoverage
+        return f"#**Slack channel {slack_channel_id}**"
+
+    def user_mention_processor(slack_user_id: str) -> tuple[str, int] | None:  # nocoverage
+        return (f"@**Slack user {slack_user_id}**", 1)
+
     pieces: list[str] = []
     if payload.get("blocks"):
-        try:
-            pieces += map(render_block, payload["blocks"])
-        except LossyConversionError:  # nocoverage
-            pieces.append(payload.get("text", "").tame(check_string))
+        for block in payload["blocks"]:
+            result = render_block(
+                block,
+                channel_mention_processor,
+                user_mention_processor,
+            )
+            pieces.append(result.content)
 
     if payload.get("attachments"):
-        pieces += map(render_attachment, payload["attachments"])
+        for attachment in payload["attachments"]:
+            result = render_attachment(
+                attachment,
+                channel_mention_processor,
+                user_mention_processor,
+            )
+            pieces.append(result.content)
 
     body = "\n\n".join(piece.strip() for piece in pieces if piece.strip() != "")
 
@@ -99,9 +117,8 @@ def api_slack_incoming_webhook(
         if payload.get("icon_emoji"):
             body = payload["icon_emoji"].tame(check_string) + " "
         body += payload["text"].tame(check_string)
-        body = body.strip()
+        body, __ = convert_slack_formatting(replace_links(body.strip()))
 
     if body != "":
-        body, __ = convert_slack_formatting(replace_links(body).strip())
         check_send_webhook_message(request, user_profile, user_specified_topic, body)
     return json_success(request, data={"ok": True})

--- a/zerver/webhooks/slack_incoming/view.py
+++ b/zerver/webhooks/slack_incoming/view.py
@@ -102,6 +102,6 @@ def api_slack_incoming_webhook(
         body = body.strip()
 
     if body != "":
-        body = convert_slack_formatting(replace_links(body).strip())
+        body, __ = convert_slack_formatting(replace_links(body).strip())
         check_send_webhook_message(request, user_profile, user_specified_topic, body)
     return json_success(request, data={"ok": True})


### PR DESCRIPTION
This updates the Slack text processing methods to be able to properly convert `rich_text` blocks.


  | Slack| Before | After |
  |--------|--------|--------|
| <img width="725" height="551" alt="image" src="https://github.com/user-attachments/assets/50f8d549-a1fd-4ed4-9e91-a5da2ae20704" /><img width="726" height="582" alt="image" src="https://github.com/user-attachments/assets/8ca2a5a1-441a-4c35-8b3c-6f46cf6c2894" /><img width="731" height="401" alt="image" src="https://github.com/user-attachments/assets/298389a1-b3f4-4da3-8569-07dde3afcd40" /><img width="786" height="292" alt="image" src="https://github.com/user-attachments/assets/b18fad5f-7c6a-473a-9e62-84d023c71c5b" />| <img width="1101" height="2108" alt="image" src="https://github.com/user-attachments/assets/c37af129-25d7-46e7-9c1a-bb24ee3a887e" />| <img width="1101" height="2330" alt="image" src="https://github.com/user-attachments/assets/f7af9dfc-237f-4e51-8082-f0400b8a91c8" />|

The last message is composed of a combination of `rich_text` block and other `block` types, this is exactly the class of message that this PR mainly aim to support. Previously we can only partially process such message, we can only pass the raw content through `convert_to_zulip_markdown` and any other `block` types will be ignored, in this case, all `section`, `header`, `divider` formatting.

Other than that we have a nicer improvement on things like text for invalid mention, better conversion of lists (sub items are preserved), basic `rich_text` blocks are accurately converted now (first message) and other minor nits.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
