### PR TITLE
topic-list-data: Show topics in list when recent MAX_TOPICS are all muted.

### DIFF
--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -45,7 +45,7 @@ function choose_topics(
     zoomed: boolean,
     topic_choice_state: TopicChoiceState,
 ): void {
-    for (const [idx, topic_name] of topic_names.entries()) {
+    for (const topic_name of topic_names) {
         const num_unread = unread.num_unread_for_topic(stream_id, topic_name);
         const is_active_topic = topic_choice_state.active_topic === topic_name.toLowerCase();
         const is_topic_muted = user_topics.is_topic_muted(stream_id, topic_name);
@@ -83,9 +83,9 @@ function choose_topics(
                     return false;
                 }
 
-                // We include the most recent MAX_TOPICS topics,
+                // We include the most recent, unmuted MAX_TOPICS topics,
                 // even if there are no unread messages.
-                if (idx < MAX_TOPICS && topics_selected < MAX_TOPICS) {
+                if (topics_selected < MAX_TOPICS) {
                     return true;
                 }
 
@@ -244,12 +244,11 @@ export function get_list_info(
         const unmuted_or_followed_topics = topic_names.filter((topic) =>
             user_topics.is_topic_unmuted_or_followed(stream_id, topic),
         );
-        choose_topics(stream_id, unmuted_or_followed_topics, zoomed, topic_choice_state);
-
         const other_topics = topic_names.filter(
             (topic) => !user_topics.is_topic_unmuted_or_followed(stream_id, topic),
         );
-        choose_topics(stream_id, other_topics, zoomed, topic_choice_state);
+        const reordered_topics = [...unmuted_or_followed_topics, ...other_topics];
+        choose_topics(stream_id, reordered_topics, zoomed, topic_choice_state);
     } else {
         choose_topics(stream_id, topic_names, zoomed, topic_choice_state);
     }

--- a/web/tests/topic_list_data.test.cjs
+++ b/web/tests/topic_list_data.test.cjs
@@ -346,8 +346,9 @@ test("get_list_info unreads", ({override}) => {
         ["topic 0", "topic 1", "topic 2", "topic 3", "topic 4", "topic 5"],
     );
 
-    // If the most recent topics in the channel are
-    // all muted, then we show no topics.
+    // We show the most recent, unmuted MAX_TOPICS
+    // topics in the channel, whether they have
+    // unread messages or not.
     override(user_topics, "is_topic_muted", (stream_id, topic_name) => {
         assert.equal(stream_id, general.stream_id);
         return ["topic 0", "topic 1", "topic 2", "topic 3", "topic 4", "topic 5"].includes(
@@ -356,13 +357,13 @@ test("get_list_info unreads", ({override}) => {
     });
 
     list_info = get_list_info();
-    assert.equal(list_info.items.length, 0);
+    assert.equal(list_info.items.length, 6);
     assert.equal(list_info.more_topics_unreads, 0);
     assert.equal(list_info.more_topics_have_unread_mention_messages, false);
     assert.equal(list_info.num_possible_topics, 16);
     assert.deepEqual(
         list_info.items.map((li) => li.topic_name),
-        [],
+        ["topic 6", "topic 7", "topic 8", "topic 9", "topic 10", "topic 11"],
     );
 
     override(user_topics, "is_topic_muted", () => false);


### PR DESCRIPTION
Currently, if a user has muted the most recent `MAX_TOPICS` (set to 6) in a channel, and all the messages are read in the channel, then no topics are shown in the left sidebar.

Updates the logic of generating that list to get the most recent, unmuted `MAX_TOPICS` in the channel, whether they have unread messages or not.

Extracted version of bug fix from #37904.

---

**Screenshots and screen captures:**

<details>
<summary>topic list view of channel for screenshots below</summary>

<img width="1344" height="1658" alt="Screenshot From 2026-02-24 19-54-59" src="https://github.com/user-attachments/assets/7ae14ee4-656b-4496-bcdf-4bd7e8c67ef0" />
</details>

| Before | After |
| --- | --- |
| <img width="686" height="976" alt="Screenshot From 2026-02-24 19-55-15" src="https://github.com/user-attachments/assets/2460559b-c85c-43a0-87ef-e763cc8019aa" /> | <img width="686" height="976" alt="Screenshot From 2026-02-24 19-55-26" src="https://github.com/user-attachments/assets/3dfb33e7-8dd4-4520-862f-cf916a257e65" /> |

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
