### PR TITLE
lightbox: Fix video not working when using lightbox carousel.

### DIFF
--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -735,6 +735,9 @@ export function initialize(): void {
         const media_element = $original_media_element[0];
         if (media_element instanceof HTMLImageElement) {
             open_image($(media_element));
+        } else {
+            assert(media_element instanceof HTMLMediaElement);
+            open_video($(media_element));
         }
 
         if (!$(".image-list .image.selected").hasClass("lightbox_video") || !is_video) {


### PR DESCRIPTION
The left and right arrow buttons with the carousel did not work when the previous or next media was a video instead of an image. Also, selecting a video from the carousel did not work.

This PR fixes both the above bugs. It was happening due to code for handling videos being missed in 0c1a55f.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->https://chat.zulip.org/#narrow/channel/9-issues/topic/selecting.20videos.20from.20the.20lightbox.20carousel.20doesn't.20work/with/2390128


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

[Screencast from 2026-02-25 12-59-15.webm](https://github.com/user-attachments/assets/580a5b32-afd3-440f-a4b9-2a3601b7c0ce)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
