### PR TITLE
compose: Introduce skinned compose box on topics, DMs.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -328,6 +328,20 @@ function hide_compose_box_and_maybe_display_missing_permissions_toast(trigger: s
     compose_fade.start_compose("stream");
 }
 
+export function update_skinned_compose_box_draft_preview(): void {
+    // If we have a draft, we'll display its first line in the
+    // skinned compose box's message area. This should also be
+    // called on the cancel() method so that the skinned textarea
+    // updates when the compose box goes to its closed state.
+    const narrow_drafts = drafts.get_last_restorable_draft_based_on_compose_state();
+    if (narrow_drafts?.content) {
+        $("#skinned-messagebox").text(narrow_drafts.content);
+    } else {
+        // Restore the default message
+        $("#skinned-messagebox").text($t({defaultMessage: "Write a message..."}));
+    }
+}
+
 export let start = (raw_opts: ComposeActionsStartOpts): void => {
     if (page_params.is_spectator) {
         spectators.login_to_access();
@@ -534,6 +548,7 @@ export let cancel = (): void => {
     compose_state.set_message_type(undefined);
     compose_pm_pill.clear();
     message_viewport.bottom_of_feed.reset();
+    update_skinned_compose_box_draft_preview();
     reload.maybe_reset_pending_reload_timeout("compose_end");
 };
 

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
+import render_decorated_channel_name from "../templates/decorated_channel_name.hbs";
 import render_reply_recipient_label from "../templates/reply_recipient_label.hbs";
 
 import * as compose_actions from "./compose_actions.ts";
@@ -13,6 +14,7 @@ import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as recent_view_util from "./recent_view_util.ts";
+import * as stream_color from "./stream_color.ts";
 import * as stream_data from "./stream_data.ts";
 import type {StreamSubscription} from "./sub_store.ts";
 import * as util from "./util.ts";
@@ -233,6 +235,71 @@ export function set_standard_text_for_reply_button(): void {
     $(".compose_reply_button").attr("disabled", null);
 }
 
+export function update_recipient_row_on_skinned_compose(
+    recipient_information?: ReplyRecipientInformation,
+): void {
+    // We're not currently working with ReplyRecipientInformation in the skinned
+    // compose box, as that isn't used inside of conversation views, but these
+    // lines make it so that we can cut over to that use in the future.
+    const stream_id =
+        recipient_information?.stream_id ?? narrow_state.stream_id(narrow_state.filter(), true);
+    const topic = recipient_information?.topic ?? narrow_state.topic();
+
+    const user_ids_string = narrow_state.pm_ids_string();
+    let user_ids: number[] = [];
+    let has_valid_user_ids = false;
+
+    if (recipient_information?.user_ids) {
+        user_ids = recipient_information?.user_ids;
+    } else if (typeof user_ids_string === "string") {
+        user_ids = people.user_ids_string_to_ids_array(user_ids_string);
+    }
+
+    has_valid_user_ids = people.is_valid_user_ids(user_ids);
+
+    if (stream_id !== undefined && topic !== undefined) {
+        // Update recipient row for stream/topic.
+        const stream = stream_data.get_sub_by_id(stream_id);
+        const has_empty_string_topic = topic === "";
+        const topic_display_name = util.get_final_topic_display_name(topic);
+
+        $("#skinned-channel-picker").html(
+            render_decorated_channel_name({stream, show_colored_icon: true}),
+        );
+        $("#skinned-topic-box-label").text(topic_display_name);
+
+        // Properly display *general chat*
+        if (has_empty_string_topic) {
+            $("#skinned-topic-box-label").addClass("empty-topic-display");
+        } else {
+            $("#skinned-topic-box-label").removeClass("empty-topic-display");
+        }
+
+        // Show adjusted colors as in the low-attention recipient row
+        // of the open compose box.
+        stream_color.adjust_stream_privacy_icon_colors(
+            stream_id,
+            "#skinned-channel-picker .channel-privacy-type-icon",
+        );
+    } else if (has_valid_user_ids) {
+        // Update recipient row for DMs.
+        const direct_message_label = $t({defaultMessage: "DM"});
+        const dm_label = get_direct_message_recipient_label(user_ids);
+
+        $("#skinned-channel-picker").html(
+            `<i class="zulip-icon zulip-icon-users channel-privacy-type-icon"></i>
+            <span class="decorated-channel-name">${direct_message_label}</span>`,
+        );
+        if (dm_label.label_text) {
+            $("#skinned-topic-box-label").text(dm_label.label_text);
+        }
+    } else {
+        // We had neither a stream_id or a valid set of user_ids, so we will
+        // fall back to displaying the legacy closed compose.
+        $("#compose").removeClass("composing-to-conversation-narrow");
+    }
+}
+
 export function update_reply_button_with_recipient_context(
     recipient_information?: ReplyRecipientInformation,
 ): void {
@@ -291,6 +358,36 @@ export function update_reply_button(recipient_information?: ReplyRecipientInform
     update_reply_button_state();
 }
 
+// Wrapper function to more gracefully handle updates across
+// the skinned and legacy closed compose boxes.
+export function update_skinned_or_closed_compose_recipient_display(
+    recipient_information?: ReplyRecipientInformation,
+): void {
+    const stream_id =
+        recipient_information?.stream_id ?? narrow_state.stream_id(narrow_state.filter(), true);
+    let user_can_post = true;
+
+    if (stream_id !== undefined) {
+        const stream = stream_data.get_sub_by_id(stream_id);
+        if (stream !== undefined) {
+            user_can_post = stream_data.can_post_messages_in_stream(stream);
+        }
+    }
+    // The skinned compose box doesn't yet support a state where
+    // we don't have a stream/topic or DM recipients.
+    if ($("#compose").hasClass("composing-to-conversation-narrow") && user_can_post) {
+        update_recipient_row_on_skinned_compose(recipient_information);
+    } else {
+        // If a user cannot post, then we want to fall back to displaying
+        // the legacy closed compose box
+        $("#compose").removeClass("composing-to-conversation-narrow");
+    }
+
+    // Follow the usual code path for the legacy closed compose
+    // without recipient information.
+    update_reply_button(recipient_information);
+}
+
 export function initialize(): void {
     update_closed_compose_box_class_by_narrow(narrow_state.is_message_feed_visible());
 
@@ -300,7 +397,7 @@ export function initialize(): void {
             // message_selected events can occur with Recent Conversations
             // open due to the combined feed view loading in the background,
             // so we only update if message feed is visible.
-            update_reply_button();
+            update_skinned_or_closed_compose_recipient_display();
         }
     });
 

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -377,6 +377,7 @@ export function update_skinned_or_closed_compose_recipient_display(
     // we don't have a stream/topic or DM recipients.
     if ($("#compose").hasClass("composing-to-conversation-narrow") && user_can_post) {
         update_recipient_row_on_skinned_compose(recipient_information);
+        compose_actions.update_skinned_compose_box_draft_preview();
     } else {
         // If a user cannot post, then we want to fall back to displaying
         // the legacy closed compose box

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -17,6 +17,17 @@ import * as stream_data from "./stream_data.ts";
 import type {StreamSubscription} from "./sub_store.ts";
 import * as util from "./util.ts";
 
+// This is likely a temporary function for supporting both the
+// new skinned compose box in conversation views and the legacy
+// closed compose box in home views, etc.
+export function update_closed_compose_box_class_by_narrow(is_conversation_narrow: boolean): void {
+    if (is_conversation_narrow) {
+        $("#compose").addClass("composing-to-conversation-narrow");
+    } else {
+        $("#compose").removeClass("composing-to-conversation-narrow");
+    }
+}
+
 type RecipientLabel = {
     label_text?: string;
     has_empty_string_topic?: boolean;
@@ -281,6 +292,8 @@ export function update_reply_button(recipient_information?: ReplyRecipientInform
 }
 
 export function initialize(): void {
+    update_closed_compose_box_class_by_narrow(narrow_state.is_message_feed_visible());
+
     // When the message selection changes, change the label on the Reply button.
     $(document).on("message_selected.zulip", () => {
         if (narrow_state.is_message_feed_visible()) {

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -382,6 +382,7 @@ export function update_skinned_or_closed_compose_recipient_display(
     // we don't have a stream/topic or DM recipients.
     if ($("#compose").hasClass("composing-to-conversation-narrow") && user_can_post) {
         update_recipient_row_on_skinned_compose(recipient_information);
+        compose_actions.update_skinned_compose_box_draft_preview();
     } else {
         // If a user cannot post, then we want to fall back to displaying
         // the legacy closed compose box

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -252,7 +252,6 @@ export function update_recipient_row_on_skinned_compose(
 
     const user_ids_string = narrow_state.pm_ids_string();
     let user_ids: number[] = [];
-    let has_valid_user_ids = false;
 
     if (recipient_information?.user_ids) {
         user_ids = recipient_information?.user_ids;
@@ -260,7 +259,7 @@ export function update_recipient_row_on_skinned_compose(
         user_ids = people.user_ids_string_to_ids_array(user_ids_string);
     }
 
-    has_valid_user_ids = people.is_valid_user_ids(user_ids);
+    const has_valid_user_ids = people.is_valid_user_ids(user_ids);
 
     if (stream_id !== undefined && topic !== undefined) {
         // Update recipient row for stream/topic.
@@ -293,7 +292,7 @@ export function update_recipient_row_on_skinned_compose(
 
         $("#skinned-channel-picker").html(
             `<i class="zulip-icon zulip-icon-users channel-privacy-type-icon"></i>
-            <span class="decorated-channel-name">${direct_message_label}</span>`,
+            <span class="decorated-dm-label">${direct_message_label}</span>`,
         );
         if (dm_label.label_text) {
             $("#skinned-topic-box-label").text(dm_label.label_text);

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -136,6 +136,17 @@ export function get_recipient_label(
     return undefined;
 }
 
+// This is likely a temporary function for supporting both the
+// new skinned compose box in conversation views and the legacy
+// closed compose box in home views, etc.
+export function update_closed_compose_box_class_by_narrow(is_conversation_narrow: boolean): void {
+    if (is_conversation_narrow) {
+        $("#compose").addClass("composing-to-conversation-narrow");
+    } else {
+        $("#compose").removeClass("composing-to-conversation-narrow");
+    }
+}
+
 // Exported for tests
 export let update_reply_button_state = (): void => {
     const $compose_reply_button_wrapper = $(
@@ -286,6 +297,8 @@ export function update_reply_button(recipient_information?: ReplyRecipientInform
 }
 
 export function initialize(): void {
+    update_closed_compose_box_class_by_narrow(narrow_state.is_message_feed_visible());
+
     // When the message selection changes, change the label on the Reply button.
     $(document).on("message_selected.zulip", () => {
         if (narrow_state.is_message_feed_visible()) {

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -1,6 +1,7 @@
 import {$} from "jquery";
 import assert from "minimalistic-assert";
 
+import render_decorated_channel_name from "../templates/decorated_channel_name.hbs";
 import render_reply_recipient_label from "../templates/reply_recipient_label.hbs";
 
 import * as compose_actions from "./compose_actions.ts";
@@ -13,6 +14,7 @@ import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as recent_view_util from "./recent_view_util.ts";
+import * as stream_color from "./stream_color.ts";
 import * as stream_data from "./stream_data.ts";
 import type {StreamSubscription} from "./sub_store.ts";
 import * as util from "./util.ts";
@@ -238,6 +240,71 @@ export function set_standard_text_for_reply_button(): void {
     $(".compose_reply_button").attr("disabled", null);
 }
 
+export function update_recipient_row_on_skinned_compose(
+    recipient_information?: ReplyRecipientInformation,
+): void {
+    // We're not currently working with ReplyRecipientInformation in the skinned
+    // compose box, as that isn't used inside of conversation views, but these
+    // lines make it so that we can cut over to that use in the future.
+    const stream_id =
+        recipient_information?.stream_id ?? narrow_state.stream_id(narrow_state.filter(), true);
+    const topic = recipient_information?.topic ?? narrow_state.topic();
+
+    const user_ids_string = narrow_state.pm_ids_string();
+    let user_ids: number[] = [];
+    let has_valid_user_ids = false;
+
+    if (recipient_information?.user_ids) {
+        user_ids = recipient_information?.user_ids;
+    } else if (typeof user_ids_string === "string") {
+        user_ids = people.user_ids_string_to_ids_array(user_ids_string);
+    }
+
+    has_valid_user_ids = people.is_valid_user_ids(user_ids);
+
+    if (stream_id !== undefined && topic !== undefined) {
+        // Update recipient row for stream/topic.
+        const stream = stream_data.get_sub_by_id(stream_id);
+        const has_empty_string_topic = topic === "";
+        const topic_display_name = util.get_final_topic_display_name(topic);
+
+        $("#skinned-channel-picker").html(
+            render_decorated_channel_name({stream, show_colored_icon: true}),
+        );
+        $("#skinned-topic-box-label").text(topic_display_name);
+
+        // Properly display *general chat*
+        if (has_empty_string_topic) {
+            $("#skinned-topic-box-label").addClass("empty-topic-display");
+        } else {
+            $("#skinned-topic-box-label").removeClass("empty-topic-display");
+        }
+
+        // Show adjusted colors as in the low-attention recipient row
+        // of the open compose box.
+        stream_color.adjust_stream_privacy_icon_colors(
+            stream_id,
+            "#skinned-channel-picker .channel-privacy-type-icon",
+        );
+    } else if (has_valid_user_ids) {
+        // Update recipient row for DMs.
+        const direct_message_label = $t({defaultMessage: "DM"});
+        const dm_label = get_direct_message_recipient_label(user_ids);
+
+        $("#skinned-channel-picker").html(
+            `<i class="zulip-icon zulip-icon-users channel-privacy-type-icon"></i>
+            <span class="decorated-channel-name">${direct_message_label}</span>`,
+        );
+        if (dm_label.label_text) {
+            $("#skinned-topic-box-label").text(dm_label.label_text);
+        }
+    } else {
+        // We had neither a stream_id or a valid set of user_ids, so we will
+        // fall back to displaying the legacy closed compose.
+        $("#compose").removeClass("composing-to-conversation-narrow");
+    }
+}
+
 export function update_reply_button_with_recipient_context(
     recipient_information?: ReplyRecipientInformation,
 ): void {
@@ -296,6 +363,36 @@ export function update_reply_button(recipient_information?: ReplyRecipientInform
     update_reply_button_state();
 }
 
+// Wrapper function to more gracefully handle updates across
+// the skinned and legacy closed compose boxes.
+export function update_skinned_or_closed_compose_recipient_display(
+    recipient_information?: ReplyRecipientInformation,
+): void {
+    const stream_id =
+        recipient_information?.stream_id ?? narrow_state.stream_id(narrow_state.filter(), true);
+    let user_can_post = true;
+
+    if (stream_id !== undefined) {
+        const stream = stream_data.get_sub_by_id(stream_id);
+        if (stream !== undefined) {
+            user_can_post = stream_data.can_post_messages_in_stream(stream);
+        }
+    }
+    // The skinned compose box doesn't yet support a state where
+    // we don't have a stream/topic or DM recipients.
+    if ($("#compose").hasClass("composing-to-conversation-narrow") && user_can_post) {
+        update_recipient_row_on_skinned_compose(recipient_information);
+    } else {
+        // If a user cannot post, then we want to fall back to displaying
+        // the legacy closed compose box
+        $("#compose").removeClass("composing-to-conversation-narrow");
+    }
+
+    // Follow the usual code path for the legacy closed compose
+    // without recipient information.
+    update_reply_button(recipient_information);
+}
+
 export function initialize(): void {
     update_closed_compose_box_class_by_narrow(narrow_state.is_message_feed_visible());
 
@@ -305,7 +402,7 @@ export function initialize(): void {
             // message_selected events can occur with Recent Conversations
             // open due to the combined feed view loading in the background,
             // so we only update if message feed is visible.
-            update_reply_button();
+            update_skinned_or_closed_compose_recipient_display();
         }
     });
 

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -876,4 +876,25 @@ export function initialize(): void {
     $("body").on("click", ".compose_reply_button", () => {
         respond_to_message({trigger: "reply button"});
     });
+
+    // Click handlers for skinned compose box
+    $("body").on("click", "#skinned-closed-compose-box", () => {
+        respond_to_message({trigger: "skinned closed compose"});
+    });
+
+    $("#skinned-closed-compose-box").on("click", "#skinned-topic-box-new-topic-button", (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        const stream_id = narrow_state.stream_id(narrow_state.filter(), true);
+        const topic = "";
+        const trigger = "clear topic button";
+
+        compose_actions.start({
+            message_type: "stream",
+            stream_id,
+            topic,
+            trigger,
+            keep_composebox_empty: true,
+        });
+    });
 }

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -940,4 +940,25 @@ export function initialize(): void {
     $("body").on("click", ".compose_reply_button", () => {
         respond_to_message({trigger: "reply button"});
     });
+
+    // Click handlers for skinned compose box
+    $("body").on("click", "#skinned-closed-compose-box", () => {
+        respond_to_message({trigger: "skinned closed compose"});
+    });
+
+    $("#skinned-closed-compose-box").on("click", "#skinned-topic-box-new-topic-button", (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        const stream_id = narrow_state.stream_id(narrow_state.filter(), true);
+        const topic = "";
+        const trigger = "clear topic button";
+
+        compose_actions.start({
+            message_type: "stream",
+            stream_id,
+            topic,
+            trigger,
+            keep_composebox_empty: true,
+        });
+    });
 }

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -322,6 +322,7 @@ function restore_inbox_view_state(): void {
 export function show(filter?: Filter): void {
     assert(hide_other_views_callback !== undefined);
     hide_other_views_callback();
+    compose_closed_ui.update_closed_compose_box_class_by_narrow(false);
     const was_inbox_already_visible = inbox_util.is_visible();
 
     // Check if we are already narrowed to the same channel view.

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -319,6 +319,7 @@ function restore_inbox_view_state(): void {
 export function show(filter?: Filter): void {
     assert(hide_other_views_callback !== undefined);
     hide_other_views_callback();
+    compose_closed_ui.update_closed_compose_box_class_by_narrow(false);
     const was_inbox_already_visible = inbox_util.is_visible();
 
     // Check if we are already narrowed to the same channel view.

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1616,6 +1616,8 @@ function handle_post_view_change(
     scheduled_messages_feed_ui.update_schedule_message_indicator();
     typing_events.render_notifications_for_narrow();
 
+    compose_closed_ui.update_closed_compose_box_class_by_narrow(filter.is_conversation_view());
+
     if (filter.contains_only_private_messages()) {
         compose_closed_ui.update_buttons("direct");
     } else if (filter.is_conversation_view() || filter.includes_full_stream_history()) {

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1626,6 +1626,7 @@ function handle_post_view_change(
         compose_closed_ui.update_buttons();
     }
 
+    compose_closed_ui.update_skinned_or_closed_compose_recipient_display();
     message_view_header.render_title_area();
 
     narrow_title.update_narrow_title(filter);

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1749,6 +1749,7 @@ function handle_post_view_change(
         compose_closed_ui.update_buttons();
     }
 
+    compose_closed_ui.update_skinned_or_closed_compose_recipient_display();
     message_view_header.render_title_area();
 
     narrow_title.update_narrow_title(filter);

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1739,6 +1739,8 @@ function handle_post_view_change(
     scheduled_messages_feed_ui.update_schedule_message_indicator();
     typing_events.render_notifications_for_narrow();
 
+    compose_closed_ui.update_closed_compose_box_class_by_narrow(filter.is_conversation_view());
+
     if (filter.contains_only_private_messages()) {
         compose_closed_ui.update_buttons("direct");
     } else if (filter.is_conversation_view() || filter.includes_full_stream_history()) {

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1815,6 +1815,7 @@ export function update_recent_view_rendered_time(): void {
 export function show(): void {
     assert(hide_other_views_callback !== undefined);
     hide_other_views_callback();
+    compose_closed_ui.update_closed_compose_box_class_by_narrow(false);
     // We remove event handler before hiding, so they need to
     // be attached again, checking for topics_widget to be defined
     // is a reliable solution to check if recent view was displayed earlier.

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1837,6 +1837,7 @@ export function update_recent_view_rendered_time(): void {
 export function show(): void {
     assert(hide_other_views_callback !== undefined);
     hide_other_views_callback();
+    compose_closed_ui.update_closed_compose_box_class_by_narrow(false);
     // We remove event handler before hiding, so they need to
     // be attached again, checking for topics_widget to be defined
     // is a reliable solution to check if recent view was displayed earlier.

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1360,6 +1360,11 @@
         color-mix(in srgb, hsl(0deg 0% 0%) 10%, hsl(232deg 20% 92%)),
         hsl(0deg 0% 0% / 80%)
     );
+    /* We do the same thing for the faux message box on the skinned
+       compose. */
+    --color-skinned-compose-messagebox-border: var(
+        --color-compose-recipient-box-border-color
+    );
     --color-compose-recipient-box-hover: light-dark(
         hsl(0deg 0% 69%),
         hsl(0deg 0% 100% / 12%)

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1369,6 +1369,11 @@
         color-mix(in srgb, hsl(0deg 0% 0%) 10%, hsl(232deg 20% 92%)),
         hsl(0deg 0% 0% / 80%)
     );
+    /* We do the same thing for the faux message box on the skinned
+       compose. */
+    --color-skinned-compose-messagebox-border: var(
+        --color-compose-recipient-box-border-color
+    );
     --color-compose-recipient-box-hover: light-dark(
         hsl(0deg 0% 69%),
         hsl(0deg 0% 100% / 12%)

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1255,8 +1255,128 @@ textarea.new_message_textarea {
     outline-color: transparent;
 }
 
+/* Display styles for skinned compose box. */
+
+#skinned-closed-compose-box {
+    /* The skinned compose box is effectively one big button
+       for clicking into its open state. */
+    cursor: pointer;
+    display: none;
+}
+
+#skinned-recipient-row {
+    padding-top: 0.25em; /* 4px at 16px/1em, eyeballed for better centering. */
+    display: grid;
+    /* The fit-content() syntax here is really slick, and probably
+       should be used more broadly in grid definitions across the
+       codebase.
+
+       TODO: Match this to what we allow in the actual channel picker.
+    */
+    grid-template-columns: fit-content(40%) auto minmax(0, 1fr);
+    grid-template-rows: 1.875em; /* 30px at 16px/1em */
+    align-items: baseline;
+}
+
+#skinned-channel-picker {
+    display: grid;
+    /* Grid based on the open-compose channel picker. */
+    grid-template:
+        "lefthand-offset privacy-icon privacy-icon-gap channel-name righthand-offset" auto / 0.35em [select-label-start] auto 0.2em minmax(
+            0,
+            1fr
+        )
+        [select-label-end]
+        0.35em;
+    align-items: baseline;
+
+    /* TODO: Add fiddly icon adjustments here. */
+    .channel-privacy-type-icon {
+        grid-area: privacy-icon;
+        font-size: 0.95em;
+        margin-top: -0.0579em; /* Eyeball work; 1.1px at 19px/1em */
+        align-self: center;
+        height: 1em;
+        width: 1em;
+        color: var(--privacy-icon-color-modified);
+    }
+
+    .decorated-channel-name {
+        grid-area: channel-name;
+        overflow-x: hidden;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+}
+
+#skinned-marker-container {
+    align-self: start;
+}
+
+#skinned-conversation-arrow {
+    font-size: 1.1429em; /* 16px / 14px em */
+    line-height: 1.3; /* Eyeball work. TODO: revisit alignment within grid. */
+    padding: 0 9px 0 2px;
+    margin: 0 3px;
+    color: var(--color-compose-chevron-arrow);
+    display: flex;
+    place-content: start center;
+}
+
+#skinned-topic-box {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+}
+
+#skinned-topic-box-label {
+    overflow-x: hidden;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#skinned-topic-box-controls-area {
+    margin-right: 1px;
+
+    .compose-new-recipient-button {
+        padding: 4px;
+    }
+}
+
+#skinned-messagebox {
+    height: calc(
+        var(--base-line-height-unitless) * var(--base-font-size-px) * 1.25
+    );
+    padding: 5px;
+    border-radius: 4px;
+    border: 1px solid var(--color-skinned-compose-messagebox-border);
+    background: var(--color-compose-message-content-background);
+    color: var(--color-text-placeholder);
+
+    /* TODO: More sensible variable names here. */
+    transition: var(--compose-recipient-row-transition);
+    transition-delay: var(--compose-recipient-row-transition-delay);
+    transition-property: border-color;
+}
+
+.composing-to-conversation-narrow #compose-content:hover {
+    #skinned-messagebox {
+        border-color: var(--color-message-content-container-border-focus);
+    }
+}
+
+.composing-to-conversation-narrow {
+    #legacy-closed-compose-box {
+        display: none;
+    }
+
+    #skinned-closed-compose-box {
+        display: block;
+    }
+}
+
 .compose-box-open {
-    #closed-compose-controls {
+    #skinned-closed-compose-box,
+    #legacy-closed-compose-box {
         display: none;
     }
 
@@ -1579,6 +1699,39 @@ textarea.new_message_textarea {
     }
 }
 
+.compose-new-recipient-button {
+    /* Set the border radius smaller, relative to the parent */
+    border-radius: 2px;
+    padding: 6px;
+    margin: 1px;
+    color: var(--color-compose-embedded-button-text-color);
+    font-size: inherit;
+
+    .zulip-icon {
+        display: block;
+    }
+
+    &:hover {
+        background-color: var(--color-compose-embedded-button-background-hover);
+        color: var(--color-compose-embedded-button-text-color-hover);
+    }
+
+    &:focus {
+        outline: 0;
+    }
+}
+
+#stream_message_recipient_topic,
+.compose-new-recipient-button {
+    background: none;
+    border: none;
+
+    &:disabled {
+        cursor: default;
+        opacity: 1;
+    }
+}
+
 #compose-recipient {
     /* Set a line-height equal to the font-size to
        make a compact, predictably tall recipient row. */
@@ -1598,41 +1751,6 @@ textarea.new_message_textarea {
       themselves, where necessary. */
     min-height: var(--compose-recipient-box-min-height);
     min-width: 0;
-
-    .compose-new-recipient-button {
-        /* Set the border radius smaller, relative to the parent */
-        border-radius: 2px;
-        padding: 6px;
-        margin: 1px;
-        color: var(--color-compose-embedded-button-text-color);
-        font-size: inherit;
-
-        .zulip-icon {
-            display: block;
-        }
-
-        &:hover {
-            background-color: var(
-                --color-compose-embedded-button-background-hover
-            );
-            color: var(--color-compose-embedded-button-text-color-hover);
-        }
-
-        &:focus {
-            outline: 0;
-        }
-    }
-
-    #stream_message_recipient_topic,
-    .compose-new-recipient-button {
-        background: none;
-        border: none;
-
-        &:disabled {
-            cursor: default;
-            opacity: 1;
-        }
-    }
 }
 
 .compose-control-buttons-container {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1356,6 +1356,9 @@ textarea.new_message_textarea {
     border: 1px solid var(--color-skinned-compose-messagebox-border);
     background: var(--color-compose-message-content-background);
     color: var(--color-text-placeholder);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     /* TODO: More sensible variable names here. */
     transition: var(--compose-recipient-row-transition);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1262,9 +1262,12 @@ textarea.new_message_textarea {
        for clicking into its open state. */
     cursor: pointer;
     display: none;
+    /* Maintain righthand space to match open compose. */
+    padding-right: 7px;
 }
 
 #skinned-recipient-row {
+    grid-area: skinned-recipient-row;
     padding-top: 0.25em; /* 4px at 16px/1em, eyeballed for better centering. */
     display: grid;
     /* The fit-content() syntax here is really slick, and probably
@@ -1343,9 +1346,11 @@ textarea.new_message_textarea {
 }
 
 #skinned-messagebox {
-    height: calc(
-        var(--base-line-height-unitless) * var(--base-font-size-px) * 1.25
-    );
+    grid-area: skinned-messagebox;
+    box-sizing: border-box;
+    /* Match the skinned messagebox height to the height
+       of the Send button. */
+    height: var(--compose-formatting-buttons-row-height);
     padding: 5px;
     border-radius: 4px;
     border: 1px solid var(--color-skinned-compose-messagebox-border);
@@ -1356,6 +1361,31 @@ textarea.new_message_textarea {
     transition: var(--compose-recipient-row-transition);
     transition-delay: var(--compose-recipient-row-transition-delay);
     transition-property: border-color;
+}
+
+#skinned-send-area {
+    grid-area: skinned-send-area;
+    display: flex;
+    /* Maintain lefthand space to match open compose,
+       which establishes this value on
+       #message-send-controls-container. */
+    margin-left: 6px;
+
+    @media (width < $sm_min), ((width >= $sm_min) and (width < $mc_min)) {
+        margin-left: 0;
+    }
+}
+
+#skinned-send-button {
+    flex: 0 0 auto !important;
+    align-self: end;
+    border-radius: 4px;
+    border: 0;
+    margin-bottom: 0;
+    color: var(--color-compose-send-button-icon-color);
+    background-color: var(--color-compose-send-button-background);
+    /* Always display as if disabled */
+    opacity: 0.5;
 }
 
 .composing-to-conversation-narrow #compose-content:hover {
@@ -1370,7 +1400,15 @@ textarea.new_message_textarea {
     }
 
     #skinned-closed-compose-box {
-        display: block;
+        display: grid;
+        /* This roughly approximates the grid on .messagebox */
+        grid-template: auto auto / minmax(0, 1fr) var(
+                --compose-send-controls-width
+            );
+        grid-template-areas:
+            "skinned-recipient-row .                "
+            "skinned-messagebox    skinned-send-area";
+        gap: 0 4px;
     }
 }
 
@@ -1546,6 +1584,7 @@ textarea.new_message_textarea {
     }
 }
 
+#skinned-send-button,
 #compose-send-button {
     width: 74px;
     height: var(--compose-formatting-buttons-row-height);
@@ -1577,6 +1616,7 @@ textarea.new_message_textarea {
 }
 
 @media (width < $sm_min), ((width >= $sm_min) and (width < $mc_min)) {
+    #skinned-send-button,
     #compose-send-button {
         /* Drop to a square button,
         and don't flex any wider. */

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1269,8 +1269,128 @@ textarea.new_message_textarea {
     outline-color: transparent;
 }
 
+/* Display styles for skinned compose box. */
+
+#skinned-closed-compose-box {
+    /* The skinned compose box is effectively one big button
+       for clicking into its open state. */
+    cursor: pointer;
+    display: none;
+}
+
+#skinned-recipient-row {
+    padding-top: 0.25em; /* 4px at 16px/1em, eyeballed for better centering. */
+    display: grid;
+    /* The fit-content() syntax here is really slick, and probably
+       should be used more broadly in grid definitions across the
+       codebase.
+
+       TODO: Match this to what we allow in the actual channel picker.
+    */
+    grid-template-columns: fit-content(40%) auto minmax(0, 1fr);
+    grid-template-rows: 1.875em; /* 30px at 16px/1em */
+    align-items: baseline;
+}
+
+#skinned-channel-picker {
+    display: grid;
+    /* Grid based on the open-compose channel picker. */
+    grid-template:
+        "lefthand-offset privacy-icon privacy-icon-gap channel-name righthand-offset" auto / 0.35em [select-label-start] auto 0.2em minmax(
+            0,
+            1fr
+        )
+        [select-label-end]
+        0.35em;
+    align-items: baseline;
+
+    /* TODO: Add fiddly icon adjustments here. */
+    .channel-privacy-type-icon {
+        grid-area: privacy-icon;
+        font-size: 0.95em;
+        margin-top: -0.0579em; /* Eyeball work; 1.1px at 19px/1em */
+        align-self: center;
+        height: 1em;
+        width: 1em;
+        color: var(--privacy-icon-color-modified);
+    }
+
+    .decorated-channel-name {
+        grid-area: channel-name;
+        overflow-x: hidden;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+}
+
+#skinned-marker-container {
+    align-self: start;
+}
+
+#skinned-conversation-arrow {
+    font-size: 1.1429em; /* 16px / 14px em */
+    line-height: 1.3; /* Eyeball work. TODO: revisit alignment within grid. */
+    padding: 0 9px 0 2px;
+    margin: 0 3px;
+    color: var(--color-compose-chevron-arrow);
+    display: flex;
+    place-content: start center;
+}
+
+#skinned-topic-box {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+}
+
+#skinned-topic-box-label {
+    overflow-x: hidden;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#skinned-topic-box-controls-area {
+    margin-right: 1px;
+
+    .compose-new-recipient-button {
+        padding: 4px;
+    }
+}
+
+#skinned-messagebox {
+    height: calc(
+        var(--base-line-height-unitless) * var(--base-font-size-px) * 1.25
+    );
+    padding: 5px;
+    border-radius: 4px;
+    border: 1px solid var(--color-skinned-compose-messagebox-border);
+    background: var(--color-compose-message-content-background);
+    color: var(--color-text-placeholder);
+
+    /* TODO: More sensible variable names here. */
+    transition: var(--compose-recipient-row-transition);
+    transition-delay: var(--compose-recipient-row-transition-delay);
+    transition-property: border-color;
+}
+
+.composing-to-conversation-narrow #compose-content:hover {
+    #skinned-messagebox {
+        border-color: var(--color-message-content-container-border-focus);
+    }
+}
+
+.composing-to-conversation-narrow {
+    #legacy-closed-compose-box {
+        display: none;
+    }
+
+    #skinned-closed-compose-box {
+        display: block;
+    }
+}
+
 .compose-box-open {
-    #closed-compose-controls {
+    #skinned-closed-compose-box,
+    #legacy-closed-compose-box {
         display: none;
     }
 
@@ -1595,6 +1715,39 @@ textarea.new_message_textarea {
     }
 }
 
+.compose-new-recipient-button {
+    /* Set the border radius smaller, relative to the parent */
+    border-radius: 2px;
+    padding: 6px;
+    margin: 1px;
+    color: var(--color-compose-embedded-button-text-color);
+    font-size: inherit;
+
+    .zulip-icon {
+        display: block;
+    }
+
+    &:hover {
+        background-color: var(--color-compose-embedded-button-background-hover);
+        color: var(--color-compose-embedded-button-text-color-hover);
+    }
+
+    &:focus {
+        outline: 0;
+    }
+}
+
+#stream_message_recipient_topic,
+.compose-new-recipient-button {
+    background: none;
+    border: none;
+
+    &:disabled {
+        cursor: default;
+        opacity: 1;
+    }
+}
+
 #compose-recipient {
     /* Set a line-height equal to the font-size to
        make a compact, predictably tall recipient row. */
@@ -1614,41 +1767,6 @@ textarea.new_message_textarea {
       themselves, where necessary. */
     min-height: var(--compose-recipient-box-min-height);
     min-width: 0;
-
-    .compose-new-recipient-button {
-        /* Set the border radius smaller, relative to the parent */
-        border-radius: 2px;
-        padding: 6px;
-        margin: 1px;
-        color: var(--color-compose-embedded-button-text-color);
-        font-size: inherit;
-
-        .zulip-icon {
-            display: block;
-        }
-
-        &:hover {
-            background-color: var(
-                --color-compose-embedded-button-background-hover
-            );
-            color: var(--color-compose-embedded-button-text-color-hover);
-        }
-
-        &:focus {
-            outline: 0;
-        }
-    }
-
-    #stream_message_recipient_topic,
-    .compose-new-recipient-button {
-        background: none;
-        border: none;
-
-        &:disabled {
-            cursor: default;
-            opacity: 1;
-        }
-    }
 }
 
 .compose-control-buttons-container {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1307,12 +1307,18 @@ textarea.new_message_textarea {
         0.35em;
     align-items: baseline;
 
-    /* TODO: Add fiddly icon adjustments here. */
+    /* TODO: Abstract the channel-picker CSS to avoid
+       the duplications here. */
+    .decorated-channel-name-wrapper {
+        display: grid;
+        grid-area: select-label;
+        grid-template-columns: subgrid;
+        gap: 0;
+    }
+
     .channel-privacy-type-icon {
         grid-area: privacy-icon;
-        font-size: 0.95em;
-        margin-top: -0.0579em; /* Eyeball work; 1.1px at 19px/1em */
-        align-self: center;
+        font-size: 0.9375em;
         height: 1em;
         width: 1em;
         color: var(--privacy-icon-color-modified);
@@ -1342,6 +1348,7 @@ textarea.new_message_textarea {
 
 #skinned-topic-box {
     display: grid;
+    align-self: start;
     grid-template-columns: minmax(0, 1fr) auto;
 }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1296,19 +1296,23 @@ textarea.new_message_textarea {
 }
 
 #skinned-channel-picker {
+    flex-grow: 1;
     display: grid;
-    /* Grid based on the open-compose channel picker. */
-    grid-template:
-        "lefthand-offset privacy-icon privacy-icon-gap channel-name righthand-offset" auto / 0.35em [select-label-start] auto 0.2em minmax(
-            0,
-            1fr
-        )
-        [select-label-end]
-        0.35em;
     align-items: baseline;
+    /* This is a bit of eyeball work, based on balancing
+       out the size and spatial relationships between the
+       privacy icon and the channel name, and the
+       surrounding negative space. */
+    /* 7px at 20px/1em; 4px at 20px/1em. */
+    grid-template:
+        "lefthand-offset privacy-icon privacy-icon-gap channel-name righthand-offset" auto
+        / 0.35em [select-label-start] auto var(
+            --dropdown-list-item-label-icon-gap
+        )
+        minmax(0, 1fr) [select-label-end] 0.35em;
 
     /* TODO: Abstract the channel-picker CSS to avoid
-       the duplications here. */
+       the duplications and various resets here. */
     .decorated-channel-name-wrapper {
         display: grid;
         grid-area: select-label;
@@ -1318,17 +1322,29 @@ textarea.new_message_textarea {
 
     .channel-privacy-type-icon {
         grid-area: privacy-icon;
-        font-size: 0.9375em;
-        height: 1em;
-        width: 1em;
+        font-size: 1em;
+        line-height: 0;
+        align-self: center;
         color: var(--privacy-icon-color-modified);
+
+        .zulip-icon {
+            position: static;
+            font-size: 1em;
+        }
     }
 
+    & > .channel-privacy-type-icon {
+        align-self: center;
+        line-height: 0;
+    }
+
+    .decorated-dm-label,
     .decorated-channel-name {
         grid-area: channel-name;
-        overflow-x: hidden;
-        text-wrap: nowrap;
+        overflow: hidden;
         text-overflow: ellipsis;
+        white-space: nowrap;
+        color: var(--color-text-default);
     }
 }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1296,7 +1296,9 @@ textarea.new_message_textarea {
             transition-property: background-color, border-color;
         }
 
-        #compose_select_recipient_widget .channel-privacy-type-icon {
+        #compose_select_recipient_widget
+            .channel-privacy-type-icon
+            .zulip-icon {
             transition: var(--compose-recipient-row-transition);
             transition-delay: var(--compose-recipient-row-transition-delay);
             transition-property: color;
@@ -1386,11 +1388,11 @@ textarea.new_message_textarea {
     }
 
     #compose_select_recipient_widget {
-        .channel-privacy-type-icon.zulip-icon {
+        .channel-privacy-type-icon .zulip-icon {
             color: var(--privacy-icon-color-modified);
         }
 
-        &:hover .channel-privacy-type-icon.zulip-icon {
+        &:hover .channel-privacy-type-icon .zulip-icon {
             color: var(--privacy-icon-color-original);
         }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1276,9 +1276,12 @@ textarea.new_message_textarea {
        for clicking into its open state. */
     cursor: pointer;
     display: none;
+    /* Maintain righthand space to match open compose. */
+    padding-right: 7px;
 }
 
 #skinned-recipient-row {
+    grid-area: skinned-recipient-row;
     padding-top: 0.25em; /* 4px at 16px/1em, eyeballed for better centering. */
     display: grid;
     /* The fit-content() syntax here is really slick, and probably
@@ -1357,9 +1360,11 @@ textarea.new_message_textarea {
 }
 
 #skinned-messagebox {
-    height: calc(
-        var(--base-line-height-unitless) * var(--base-font-size-px) * 1.25
-    );
+    grid-area: skinned-messagebox;
+    box-sizing: border-box;
+    /* Match the skinned messagebox height to the height
+       of the Send button. */
+    height: var(--compose-formatting-buttons-row-height);
     padding: 5px;
     border-radius: 4px;
     border: 1px solid var(--color-skinned-compose-messagebox-border);
@@ -1370,6 +1375,31 @@ textarea.new_message_textarea {
     transition: var(--compose-recipient-row-transition);
     transition-delay: var(--compose-recipient-row-transition-delay);
     transition-property: border-color;
+}
+
+#skinned-send-area {
+    grid-area: skinned-send-area;
+    display: flex;
+    /* Maintain lefthand space to match open compose,
+       which establishes this value on
+       #message-send-controls-container. */
+    margin-left: 6px;
+
+    @media (width < $sm_min), ((width >= $sm_min) and (width < $mc_min)) {
+        margin-left: 0;
+    }
+}
+
+#skinned-send-button {
+    flex: 0 0 auto !important;
+    align-self: end;
+    border-radius: 4px;
+    border: 0;
+    margin-bottom: 0;
+    color: var(--color-compose-send-button-icon-color);
+    background-color: var(--color-compose-send-button-background);
+    /* Always display as if disabled */
+    opacity: 0.5;
 }
 
 .composing-to-conversation-narrow #compose-content:hover {
@@ -1384,7 +1414,15 @@ textarea.new_message_textarea {
     }
 
     #skinned-closed-compose-box {
-        display: block;
+        display: grid;
+        /* This roughly approximates the grid on .messagebox */
+        grid-template: auto auto / minmax(0, 1fr) var(
+                --compose-send-controls-width
+            );
+        grid-template-areas:
+            "skinned-recipient-row .                "
+            "skinned-messagebox    skinned-send-area";
+        gap: 0 4px;
     }
 }
 
@@ -1562,6 +1600,7 @@ textarea.new_message_textarea {
     }
 }
 
+#skinned-send-button,
 #compose-send-button {
     width: 74px;
     height: var(--compose-formatting-buttons-row-height);
@@ -1593,6 +1632,7 @@ textarea.new_message_textarea {
 }
 
 @media (width < $sm_min), ((width >= $sm_min) and (width < $mc_min)) {
+    #skinned-send-button,
     #compose-send-button {
         /* Drop to a square button,
         and don't flex any wider. */

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1816,9 +1816,15 @@ textarea.new_message_textarea {
                DM picker, which does not participate in
                the subgrid above used for channel icons. */
             align-self: center;
+            /* Zero out line-height so that `align-self`
+               is respected without a `top` adjustment
+               (zeroed out below). */
+            line-height: 0;
 
             .zulip-icon {
                 color: var(--privacy-icon-color-original);
+                /* Let `align-self: center` do its thing. */
+                top: 0;
             }
         }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1370,6 +1370,9 @@ textarea.new_message_textarea {
     border: 1px solid var(--color-skinned-compose-messagebox-border);
     background: var(--color-compose-message-content-background);
     color: var(--color-text-placeholder);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     /* TODO: More sensible variable names here. */
     transition: var(--compose-recipient-row-transition);

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -13,6 +13,28 @@
         </div>
     </div>
     <div id="closed-compose-controls">
+        <div id="skinned-closed-compose-box">
+            <div id="skinned-recipient-row">
+                <div id="skinned-channel-picker"></div>
+
+                <div id="skinned-marker-container">
+                    <div id="skinned-conversation-arrow" class="zulip-icon zulip-icon-chevron-right"></div>
+                </div>
+
+                <div id="skinned-topic-box">
+                    <div id="skinned-topic-box-label"></div>
+
+                    <div id="skinned-topic-box-controls-area">
+                        <button id="skinned-topic-box-new-topic-button" class="compose-new-recipient-button tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'New conversation' }}">
+                            <i class="zulip-icon zulip-icon-square-plus"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div id="skinned-messagebox">
+                {{t 'Write a message...'}}
+            </div>
+        </div>
         <div id="legacy-closed-compose-box">
             <div class="reply_button_container">
                 <div class="compose-reply-button-wrapper" data-reply-button-type="selected_message">

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -34,6 +34,11 @@
             <div id="skinned-messagebox">
                 {{t 'Write a message...'}}
             </div>
+            <div id="skinned-send-area">
+                <div id="skinned-send-button">
+                    <i class="zulip-icon zulip-icon-send"></i>
+                </div>
+            </div>
         </div>
         <div id="legacy-closed-compose-box">
             <div class="reply_button_container">

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -95,6 +95,7 @@ const ListWidget = mock_esm("../src/list_widget", {
 });
 
 mock_esm("../src/compose_closed_ui", {
+    update_closed_compose_box_class_by_narrow: noop,
     set_standard_text_for_reply_button: noop,
     update_buttons: noop,
 });


### PR DESCRIPTION
This is a draft PR of the skinned compose box.

There are several known things here that I have yet to fix, including:
- [ ] Pixel-perfecting the recipient-row layout and new topic button to match the open compose box
- [ ] Getting the send button looking good at narrower viewports (currently too much lefthand space)
- [ ] Appeasing the linter (some empty selectors while I continue to draft, etc.)
- [ ] Adding tests and restoring full test coverage

I'll be working on those while awaiting feedback from @alya and an eventual #design discussion. Some matters I can already imagine needing to address:
- [ ] What the behavior and tooltip for the new-topic button should be in DM views; in the open compose, it's for adding more recipients. Right now, it just opens an empty compose box: [CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/always-open.20compose.20box/near/2390968)
- [x] Getting to a happy height-relationship between the skinned message area and the send button
- [x] Whether we want to include the send-buttton-adjacent vdots or not (I'm inclined towards No, as the skinned compose is meant to entice users to write a message, and not have a bunch of dummy elements that don't do anything in this state)
- [x] Archived channels > rendering, but the “Write a message…” string is misleading (we should just fall through to the legacy closed compose box)
- [x] Channels where a user is not allowed to post > the “Write a message…” string is misleading (again, fall through to the legacy closed compose box)

Follow-ups:
- [ ] #38219

<img width="2400" height="1600" alt="skinned-closed-compose-draft" src="https://github.com/user-attachments/assets/58206e0e-dfc6-4a14-9c24-333274a2208c" />

