### PR TITLE
api-tests: Remove comments about deactivate user curl example test.

### DIFF
--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -48,8 +48,7 @@ def test_generated_curl_examples_for_success(client: Client) -> None:
         extensions=[markdown_extension.makeExtension(api_url=realm.url + "/api")]
     )
 
-    # We run our curl tests in alphabetical order (except that we
-    # delay the deactivate-user test to the very end), since we depend
+    # We run our curl tests in alphabetical order since we depend
     # on "add" tests coming before "remove" tests in some cases.  We
     # should try to either avoid ordering dependencies or make them
     # very explicit.
@@ -90,8 +89,6 @@ def test_generated_curl_examples_for_success(client: Client) -> None:
             # example, and then run that to test it.
 
             # Set AUTHENTICATION_LINE to default_authentication_line.
-            # Set this every iteration, because deactivate_own_user
-            # will override this for its test.
             AUTHENTICATION_LINE[0] = default_authentication_line
 
             curl_command_html = md_engine.convert(line.strip())


### PR DESCRIPTION
The reordering of deactivate user to be last in the curl examples tested was removed in ba366244421.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
