### PR TITLE
[ai] Draft: Use django_hosts to differentiate URLS between different hosts.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,9 @@ prod = [
   # For querying recursive group membership
   "django-cte",
 
+  # Host-based URL routing
+  "django-hosts",
+
   # SCIM integration
   "django-scim2",
 
@@ -425,6 +428,7 @@ module = [
     "django_auth_ldap.*",
     "django_bmemcached.*",
     "django_cte.*",
+    "django_hosts.*",
     "django_otp.*",
     "django_scim.*",
     "fakeldap.*",

--- a/uv.lock
+++ b/uv.lock
@@ -1130,6 +1130,15 @@ wheels = [
 ]
 
 [[package]]
+name = "django-hosts"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/c0/cf2b37b6ef4dda89d00f040e69b4f8a3f52fa4f74b33141b68983c0fecce/django_hosts-7.0.0.tar.gz", hash = "sha256:08006bc09f5af69638721ced0657f24044835a22a608732ee1004adc9c95fb7c", size = 36858, upload-time = "2025-06-19T07:43:22.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/05/8056f3e631b0aee8ac99929a558d132634945d3cb16253fb2a2785b62dcf/django_hosts-7.0.0-py3-none-any.whl", hash = "sha256:93d3c941336463fd0c9377c1773d1c53a49606fa72656ed7ddfa474d2fe1f907", size = 27858, upload-time = "2025-06-19T07:43:33.953Z" },
+]
+
+[[package]]
 name = "django-otp"
 version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6386,6 +6395,7 @@ dev = [
     { name = "django-bitfield" },
     { name = "django-bmemcached" },
     { name = "django-cte" },
+    { name = "django-hosts" },
     { name = "django-scim2" },
     { name = "django-stubs" },
     { name = "django-stubs-ext" },
@@ -6528,6 +6538,7 @@ prod = [
     { name = "django-bitfield" },
     { name = "django-bmemcached" },
     { name = "django-cte" },
+    { name = "django-hosts" },
     { name = "django-scim2" },
     { name = "django-stubs-ext" },
     { name = "django-two-factor-auth", extra = ["call", "phonenumberslite", "sms"] },
@@ -6626,6 +6637,7 @@ dev = [
     { name = "django-bitfield" },
     { name = "django-bmemcached" },
     { name = "django-cte" },
+    { name = "django-hosts" },
     { name = "django-scim2" },
     { name = "django-stubs" },
     { name = "django-stubs-ext" },
@@ -6770,6 +6782,7 @@ prod = [
     { name = "django-bitfield" },
     { name = "django-bmemcached" },
     { name = "django-cte" },
+    { name = "django-hosts" },
     { name = "django-scim2" },
     { name = "django-stubs-ext" },
     { name = "django-two-factor-auth", extras = ["call", "phonenumberslite", "sms"] },

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 469
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (371, 0)  # bumped 2026-02-24 to upgrade JavaScript dependencies
+PROVISION_VERSION = (371, 1)  # bumped 2026-02-25 to add django-hosts dependency

--- a/zerver/lib/subdomains.py
+++ b/zerver/lib/subdomains.py
@@ -49,14 +49,6 @@ def is_subdomain_root_or_alias(request: HttpRequest) -> bool:
     return get_subdomain(request) == Realm.SUBDOMAIN_FOR_ROOT_DOMAIN
 
 
-def is_reserved_subdomain(subdomain: str) -> bool:
-    return subdomain in {
-        s
-        for s in [settings.SOCIAL_AUTH_SUBDOMAIN, settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN]
-        if s is not None
-    }
-
-
 def is_canonical_realm_host(request_host: str, realm: Realm) -> bool:
     host = request_host.lower()
     formal_host = realm.host

--- a/zerver/lib/subdomains.py
+++ b/zerver/lib/subdomains.py
@@ -49,6 +49,20 @@ def is_subdomain_root_or_alias(request: HttpRequest) -> bool:
     return get_subdomain(request) == Realm.SUBDOMAIN_FOR_ROOT_DOMAIN
 
 
+def is_reserved_subdomain(subdomain: str) -> bool:
+    return subdomain in {
+        s
+        for s in [settings.SOCIAL_AUTH_SUBDOMAIN, settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN]
+        if s is not None
+    }
+
+
+def is_canonical_realm_host(request_host: str, realm: Realm) -> bool:
+    host = request_host.lower()
+    formal_host = realm.host
+    return host == formal_host or host.startswith(formal_host + ":")
+
+
 def user_matches_subdomain(realm_subdomain: str, user_profile: UserProfile) -> bool:
     return user_profile.realm.subdomain == realm_subdomain
 

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -43,7 +43,7 @@ from zerver.lib.response import (
     json_unauthorized,
 )
 from zerver.lib.server_initialization import server_initialized
-from zerver.lib.subdomains import get_subdomain
+from zerver.lib.subdomains import get_subdomain, is_canonical_realm_host, is_reserved_subdomain
 from zerver.lib.typed_endpoint import INTENTIONALLY_UNDOCUMENTED, ApiParamConfig, typed_endpoint
 from zerver.lib.user_agent import parse_user_agent
 from zerver.models import Realm
@@ -555,6 +555,10 @@ class FlushDisplayRecipientCache(MiddlewareMixin):
         return response
 
 
+def should_skip_realm_lookup(path: str) -> bool:
+    return path.startswith(("/static/", "/api/", "/json/")) or path == "/health"
+
+
 class HostDomainMiddleware(MiddlewareMixin):
     def process_request(self, request: HttpRequest) -> HttpResponse | None:
         # Match against ALLOWED_HOSTS, which is rather permissive;
@@ -568,14 +572,11 @@ class HostDomainMiddleware(MiddlewareMixin):
         #
         # API authentication will end up checking for an invalid
         # realm, and throw a JSON-format error if appropriate.
-        if request.path.startswith(("/static/", "/api/", "/json/")) or request.path == "/health":
+        if should_skip_realm_lookup(request.path):
             return None
 
         subdomain = get_subdomain(request)
-        if subdomain in [
-            settings.SOCIAL_AUTH_SUBDOMAIN,
-            settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN,
-        ]:
+        if is_reserved_subdomain(subdomain):
             # Realms are not supposed to exist on these subdomains.
             return None
 
@@ -597,13 +598,10 @@ class HostDomainMiddleware(MiddlewareMixin):
         set_tag("realm", request_notes.realm.string_id)
 
         # Check that we're not using the non-canonical form of a REALM_HOSTS subdomain
-        if subdomain in settings.REALM_HOSTS:
-            host = request.get_host().lower()
-            formal_host = request_notes.realm.host
-            if host != formal_host and not host.startswith(formal_host + ":"):
-                return HttpResponseRedirect(
-                    urljoin(request_notes.realm.url, request.get_full_path())
-                )
+        if subdomain in settings.REALM_HOSTS and not is_canonical_realm_host(
+            request.get_host(), request_notes.realm
+        ):
+            return HttpResponseRedirect(urljoin(request_notes.realm.url, request.get_full_path()))
         return None
 
 

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -43,7 +43,7 @@ from zerver.lib.response import (
     json_unauthorized,
 )
 from zerver.lib.server_initialization import server_initialized
-from zerver.lib.subdomains import get_subdomain, is_canonical_realm_host, is_reserved_subdomain
+from zerver.lib.subdomains import get_subdomain, is_canonical_realm_host
 from zerver.lib.typed_endpoint import INTENTIONALLY_UNDOCUMENTED, ApiParamConfig, typed_endpoint
 from zerver.lib.user_agent import parse_user_agent
 from zerver.models import Realm
@@ -559,6 +559,14 @@ def should_skip_realm_lookup(path: str) -> bool:
     return path.startswith(("/static/", "/api/", "/json/")) or path == "/health"
 
 
+def should_skip_realm_lookup_for_reserved_subdomain(request: HttpRequest) -> bool:
+    # django-hosts has already selected the host-specific URLConf for reserved subdomains.
+    return getattr(request, "urlconf", None) in (
+        "zproject.auth_subdomain_urls",
+        "zproject.self_hosting_management_subdomain_urls",
+    )
+
+
 class HostDomainMiddleware(MiddlewareMixin):
     def process_request(self, request: HttpRequest) -> HttpResponse | None:
         # Match against ALLOWED_HOSTS, which is rather permissive;
@@ -575,10 +583,11 @@ class HostDomainMiddleware(MiddlewareMixin):
         if should_skip_realm_lookup(request.path):
             return None
 
-        subdomain = get_subdomain(request)
-        if is_reserved_subdomain(subdomain):
+        if should_skip_realm_lookup_for_reserved_subdomain(request):
             # Realms are not supposed to exist on these subdomains.
             return None
+
+        subdomain = get_subdomain(request)
 
         request_notes = RequestNotes.get_notes(request)
         try:

--- a/zerver/tests/test_urls.py
+++ b/zerver/tests/test_urls.py
@@ -2,6 +2,7 @@ import os
 from unittest import mock
 
 from django.test import Client
+from django.urls import Resolver404, resolve
 
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.url_redirects import (
@@ -175,6 +176,39 @@ class ErrorPageTest(ZulipTestCase):
             "/json/users", secure=True, HTTP_REFERER="https://somewhere", HTTP_HOST="$nonsense"
         )
         self.assertEqual(result.status_code, 400)
+
+
+class HostURLConfTest(ZulipTestCase):
+    def test_social_auth_urls_on_auth_subdomain(self) -> None:
+        urls_expected_on_auth_subdomain = [
+            "/",
+            "/login/",
+            "/accounts/login/",
+            "/compatibility",
+            "/complete/google/",
+            "/api/v1/server_settings",
+            "/health",
+        ]
+        for path in urls_expected_on_auth_subdomain:
+            resolve(path, urlconf="zproject.auth_subdomain_urls")
+
+    def test_social_auth_urls_not_on_root_host(self) -> None:
+        with self.assertRaises(Resolver404):
+            resolve("/complete/google/", urlconf="zproject.root_urls")
+
+    def test_self_hosting_urls_on_selfhosting_subdomain(self) -> None:
+        urls_expected_on_selfhosting_subdomain = [
+            "/",
+            "/login/",
+            "/self-hosted-billing/",
+            "/health",
+        ]
+        for path in urls_expected_on_selfhosting_subdomain:
+            resolve(path, urlconf="zproject.self_hosting_management_subdomain_urls")
+
+    def test_self_hosting_urls_not_on_root_host(self) -> None:
+        with self.assertRaises(Resolver404):
+            resolve("/self-hosted-billing/", urlconf="zproject.root_urls")
 
 
 class RedirectURLTest(ZulipTestCase):

--- a/zproject/auth_subdomain_urls.py
+++ b/zproject/auth_subdomain_urls.py
@@ -1,0 +1,19 @@
+from .urls import (
+    healthcheck_urls,
+    i18n_auth_urls,
+    i18n_landing_urls,
+    i18n_login_urls,
+    mobile_compatibility_urls,
+    social_auth_urls,
+    v1_api_mobile_urls,
+)
+
+urlpatterns = (
+    i18n_landing_urls
+    + i18n_login_urls
+    + i18n_auth_urls
+    + mobile_compatibility_urls
+    + social_auth_urls
+    + v1_api_mobile_urls
+    + healthcheck_urls
+)

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -236,6 +236,7 @@ ALLOWED_HOSTS += [EXTERNAL_HOST_WITHOUT_PORT, "." + EXTERNAL_HOST_WITHOUT_PORT]
 ALLOWED_HOSTS += REALM_HOSTS.values()
 
 MIDDLEWARE = [
+    "django_hosts.middleware.HostsRequestMiddleware",
     "zerver.middleware.TagRequests",
     "zerver.middleware.SetRemoteAddrFromRealIpHeader",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -256,6 +257,7 @@ MIDDLEWARE = [
     # Make sure 2FA middlewares come after authentication middleware.
     "django_otp.middleware.OTPMiddleware",  # Required by two factor auth.
     "two_factor.middleware.threadlocals.ThreadLocals",  # Required by Twilio
+    "django_hosts.middleware.HostsResponseMiddleware",
 ]
 
 AUTH_USER_MODEL = "zerver.UserProfile"
@@ -263,6 +265,9 @@ AUTH_USER_MODEL = "zerver.UserProfile"
 TEST_RUNNER = "zerver.lib.test_runner.Runner"
 
 ROOT_URLCONF = "zproject.urls"
+ROOT_HOSTCONF = "zproject.hosts"
+DEFAULT_HOST = "default"
+PARENT_HOST = EXTERNAL_HOST_WITHOUT_PORT
 
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = "zproject.wsgi.application"
@@ -275,6 +280,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.staticfiles",
     "confirmation",
+    "django_hosts",
     "zerver",
     "social_django",
     "django_scim",

--- a/zproject/hosts.py
+++ b/zproject/hosts.py
@@ -4,18 +4,24 @@ from django_hosts import host, patterns
 # Compatibility scaffold for a staged migration to django-hosts.
 # Requests that do not match a host pattern continue using ROOT_URLCONF.
 host_pattern_list = [
-    host(r"", "urls", name="default"),
+    host(r"", "root_urls", name="default"),
 ]
 
 if settings.SOCIAL_AUTH_SUBDOMAIN is not None:
-    host_pattern_list.append(host(settings.SOCIAL_AUTH_SUBDOMAIN, "urls", name="social-auth"))
+    host_pattern_list.append(
+        host(settings.SOCIAL_AUTH_SUBDOMAIN, "auth_subdomain_urls", name="social-auth")
+    )
 
 if settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN is not None:
     host_pattern_list.append(
-        host(settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN, "urls", name="self-hosting-management")
+        host(
+            settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN,
+            "self_hosting_management_subdomain_urls",
+            name="self-hosting-management",
+        )
     )
 
 # Keep this last: it matches any subdomain and would swallow reserved hosts above.
-host_pattern_list.append(host(r"[\w-]+", "urls", name="wildcard"))
+host_pattern_list.append(host(r"[\w-]+", "realm_urls", name="wildcard"))
 
 host_patterns = patterns("zproject", *host_pattern_list)

--- a/zproject/hosts.py
+++ b/zproject/hosts.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+from django_hosts import host, patterns
+
+# Compatibility scaffold for a staged migration to django-hosts.
+# Requests that do not match a host pattern continue using ROOT_URLCONF.
+host_pattern_list = [
+    host(r"", "urls", name="default"),
+]
+
+if settings.SOCIAL_AUTH_SUBDOMAIN is not None:
+    host_pattern_list.append(host(settings.SOCIAL_AUTH_SUBDOMAIN, "urls", name="social-auth"))
+
+if settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN is not None:
+    host_pattern_list.append(
+        host(settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN, "urls", name="self-hosting-management")
+    )
+
+# Keep this last: it matches any subdomain and would swallow reserved hosts above.
+host_pattern_list.append(host(r"[\w-]+", "urls", name="wildcard"))
+
+host_patterns = patterns("zproject", *host_pattern_list)

--- a/zproject/realm_urls.py
+++ b/zproject/realm_urls.py
@@ -1,0 +1,3 @@
+from .urls import urlpatterns as base_urlpatterns
+
+urlpatterns = list(base_urlpatterns)

--- a/zproject/realm_urls.py
+++ b/zproject/realm_urls.py
@@ -1,3 +1,5 @@
-from .urls import urlpatterns as base_urlpatterns
+from django.conf.urls.i18n import i18n_patterns
 
-urlpatterns = list(base_urlpatterns)
+from .urls import realm_host_i18n_urls, realm_host_urls
+
+urlpatterns = i18n_patterns(*realm_host_i18n_urls) + realm_host_urls

--- a/zproject/root_urls.py
+++ b/zproject/root_urls.py
@@ -1,3 +1,5 @@
-from .urls import urlpatterns as base_urlpatterns
+from django.conf.urls.i18n import i18n_patterns
 
-urlpatterns = list(base_urlpatterns)
+from .urls import i18n_urls, root_host_urls
+
+urlpatterns = i18n_patterns(*i18n_urls) + root_host_urls

--- a/zproject/root_urls.py
+++ b/zproject/root_urls.py
@@ -1,0 +1,3 @@
+from .urls import urlpatterns as base_urlpatterns
+
+urlpatterns = list(base_urlpatterns)

--- a/zproject/self_hosting_management_subdomain_urls.py
+++ b/zproject/self_hosting_management_subdomain_urls.py
@@ -1,0 +1,17 @@
+from .urls import (
+    extra_installed_app_urls,
+    healthcheck_urls,
+    i18n_landing_urls,
+    i18n_login_urls,
+    self_hosting_management_urls,
+    self_hosting_registration_urls,
+)
+
+urlpatterns = (
+    i18n_landing_urls
+    + i18n_login_urls
+    + self_hosting_management_urls
+    + self_hosting_registration_urls
+    + extra_installed_app_urls
+    + healthcheck_urls
+)

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -1,4 +1,5 @@
 import os
+from typing import cast
 
 from django.conf import settings
 from django.conf.urls import include
@@ -619,12 +620,56 @@ v1_api_and_json_patterns = [
 #
 # If you're adding a new page to the website (as opposed to a new
 # endpoint for use by code), you should add it here.
-i18n_urls = [
+i18n_realm_creation_urls = [
+    # Realm creation
+    path("json/antispam_challenge", get_challenge),
+    path("new/", create_realm),
+    path("new/demo/", create_demo_organization),
+    path("new/<confirmation_key>", create_realm, name="create_realm"),
+    # Realm reactivation
+    path("reactivate/", realm_reactivation, name="realm_reactivation"),
+    path("reactivate/<confirmation_key>", realm_reactivation_get, name="realm_reactivation_get"),
+]
+
+i18n_integrations_documentation_urls = [
+    # Integrations documentation
+    path(
+        "integrations/",
+        integrations_catalog,
+        {"category_slug": "all"},
+        name="integrations_home",
+    ),
+    path(
+        "integrations/category/<str:category_slug>",
+        integrations_catalog,
+        name="integrations_category",
+    ),
+    *INTEGRATION_CATEGORY_REDIRECT_PATHS,
+    path(
+        "integrations/doc/<str:integration_name>",
+        RedirectView.as_view(pattern_name="integration_doc", permanent=True, query_string=True),
+    ),
+    path(
+        "integrations/doc/<str:integration_name>/",
+        RedirectView.as_view(pattern_name="integration_doc", permanent=True, query_string=True),
+    ),
+    path(
+        "integrations/<str:integration_name>",
+        integrations_doc,
+        name="integration_doc",
+    ),
+]
+
+i18n_landing_urls = [
     path("", home, name="home"),
     # We have a desktop-specific landing page in case we change our /
     # to not log in in the future. We don't want to require a new
     # desktop app build for everyone in that case
     path("desktop_home/", desktop_home),
+    path("register/", accounts_home, name="register"),
+]
+
+i18n_auth_urls = [
     # Backwards-compatibility (legacy) Google auth URL for the mobile
     # apps; see https://github.com/zulip/zulip/issues/13081 for
     # background.  We can remove this once older versions of the
@@ -647,6 +692,15 @@ i18n_urls = [
     path("accounts/login/", login_page, {"template_name": "zerver/login.html"}, name="login_page"),
     path("accounts/login/", LoginView.as_view(template_name="zerver/login.html"), name="login"),
     path("accounts/logout/", logout_view),
+]
+
+i18n_login_urls = [
+    path("login/", login_page, {"template_name": "zerver/login.html"}, name="login_page"),
+]
+
+i18n_urls = [
+    *i18n_landing_urls,
+    *i18n_auth_urls,
     path("accounts/password/reset/", password_reset, name="password_reset"),
     path(
         "accounts/password/reset/done/",
@@ -730,7 +784,7 @@ i18n_urls = [
     path("reactivate/<confirmation_key>", realm_reactivation_get, name="realm_reactivation_get"),
     # Login/registration
     path("register/", accounts_home, name="register"),
-    path("login/", login_page, {"template_name": "zerver/login.html"}, name="login_page"),
+    *i18n_login_urls,
     path("join/<confirmation_key>/", accounts_home_from_multiuse_invite, name="join"),
     # Used to generate a Zoom video call URL
     path("calls/zoom/register", register_zoom_user),
@@ -770,10 +824,11 @@ i18n_urls = [
 urls: list[URLPattern | URLResolver] = list(i18n_urls)
 
 # Include the dual-use patterns twice
-urls += [
+dual_use_api_urls = [
     path("api/v1/", include(v1_api_and_json_patterns)),
     path("json/", include(v1_api_and_json_patterns)),
 ]
+urls += dual_use_api_urls
 
 # user_uploads -> zerver.views.upload.serve_file_backend
 #
@@ -861,12 +916,13 @@ urls += [
 ]
 
 # Mobile-specific authentication URLs
-urls += [
+mobile_compatibility_urls = [
     # Used as a global check by all mobile clients, which currently send
     # requests to https://zulip.com/compatibility almost immediately after
     # starting up.
     path("compatibility", check_global_compatibility),
 ]
+urls += mobile_compatibility_urls
 
 v1_api_mobile_patterns = [
     # This json format view used by the mobile apps lists which
@@ -889,11 +945,16 @@ v1_api_mobile_patterns = [
 
 # Include URL configuration files for site-specified extra installed
 # Django apps
+extra_installed_app_urls: list[URLPattern | URLResolver] = []
 for app_name in settings.EXTRA_INSTALLED_APPS:
     app_dir = os.path.join(settings.DEPLOY_ROOT, app_name)
     if os.path.exists(os.path.join(app_dir, "urls.py")):
-        urls += [path("", include(f"{app_name}.urls"))]
-        i18n_urls += import_string(f"{app_name}.urls.i18n_urlpatterns")
+        extra_installed_app_urls += [path("", include(f"{app_name}.urls"))]
+        i18n_urls += cast(
+            "list[URLPattern]",
+            import_string(f"{app_name}.urls.i18n_urlpatterns"),
+        )
+urls += extra_installed_app_urls
 
 # Used internally for communication between command-line, tusd, Django,
 # and Tornado processes
@@ -906,8 +967,11 @@ urls += [
 
 # Python Social Auth
 
-urls += [path("", include("social_django.urls", namespace="social"))]
-urls += [path("saml/metadata.xml", saml_sp_metadata)]
+social_auth_urls: list[URLPattern | URLResolver] = [
+    path("", include("social_django.urls", namespace="social")),
+    path("saml/metadata.xml", saml_sp_metadata),
+]
+urls += social_auth_urls
 
 
 # SCIM2
@@ -967,7 +1031,7 @@ urls += [
     path("doc-permalinks/<str:doc_id>", doc_permalinks_view),
 ]
 
-urls += [
+self_hosting_management_urls: list[URLPattern | URLResolver] = [
     path(
         "self-hosted-billing/",
         self_hosting_auth_redirect_endpoint,
@@ -982,13 +1046,15 @@ urls += [
         GET=self_hosting_auth_json_endpoint,
     ),
 ]
+urls += self_hosting_management_urls
 
-urls += [
+self_hosting_registration_urls: list[URLPattern | URLResolver] = [
     path(
         "api/v1/zulip-services/verify/<str:access_token>/",
         self_hosting_registration_transfer_challenge_verify,
     ),
 ]
+urls += self_hosting_registration_urls
 
 if not settings.CORPORATE_ENABLED:  # nocoverage
     # This conditional behavior cannot be tested directly, since
@@ -1007,12 +1073,12 @@ if settings.DEVELOPMENT:
     i18n_urls += dev_urls.i18n_urls
     v1_api_mobile_patterns += dev_urls.v1_api_mobile_patterns
 
-urls += [
-    path("api/v1/", include(v1_api_mobile_patterns)),
-]
+v1_api_mobile_urls = [path("api/v1/", include(v1_api_mobile_patterns))]
+urls += v1_api_mobile_urls
 
 # Healthcheck URL
-urls += [path("health", health)]
+healthcheck_urls = [path("health", health)]
+urls += healthcheck_urls
 
 # The sequence is important; if i18n URLs don't come first then
 # reverse URL mapping points to i18n URLs which causes the frontend

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -774,14 +774,7 @@ i18n_urls = [
     path("accounts/find/", find_account, name="find_account"),
     # Go to organization subdomain
     path("accounts/go/", realm_redirect, name="realm_redirect"),
-    # Realm creation
-    path("json/antispam_challenge", get_challenge),
-    path("new/", create_realm),
-    path("new/demo/", create_demo_organization),
-    path("new/<confirmation_key>", create_realm, name="create_realm"),
-    # Realm reactivation
-    path("reactivate/", realm_reactivation, name="realm_reactivation"),
-    path("reactivate/<confirmation_key>", realm_reactivation_get, name="realm_reactivation_get"),
+    *i18n_realm_creation_urls,
     # Login/registration
     path("register/", accounts_home, name="register"),
     *i18n_login_urls,
@@ -792,32 +785,7 @@ i18n_urls = [
     path("calls/zoom/deauthorize", deauthorize_zoom_user),
     # Used to join a BigBlueButton video call
     path("calls/bigbluebutton/join", join_bigbluebutton),
-    # Integrations documentation
-    path(
-        "integrations/",
-        integrations_catalog,
-        {"category_slug": "all"},
-        name="integrations_home",
-    ),
-    path(
-        "integrations/category/<str:category_slug>",
-        integrations_catalog,
-        name="integrations_category",
-    ),
-    *INTEGRATION_CATEGORY_REDIRECT_PATHS,
-    path(
-        "integrations/doc/<str:integration_name>",
-        RedirectView.as_view(pattern_name="integration_doc", permanent=True, query_string=True),
-    ),
-    path(
-        "integrations/doc/<str:integration_name>/",
-        RedirectView.as_view(pattern_name="integration_doc", permanent=True, query_string=True),
-    ),
-    path(
-        "integrations/<str:integration_name>",
-        integrations_doc,
-        name="integration_doc",
-    ),
+    *i18n_integrations_documentation_urls,
 ]
 
 # Make a copy of i18n_urls so that they appear without prefix for english
@@ -1079,6 +1047,9 @@ urls += v1_api_mobile_urls
 # Healthcheck URL
 healthcheck_urls = [path("health", health)]
 urls += healthcheck_urls
+
+realm_host_i18n_urls = i18n_urls
+realm_host_urls = urls
 
 # The sequence is important; if i18n URLs don't come first then
 # reverse URL mapping points to i18n URLs which causes the frontend

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -1051,6 +1051,14 @@ urls += healthcheck_urls
 realm_host_i18n_urls = i18n_urls
 realm_host_urls = urls
 
+# Remove URL groups that are served by their own reserved subdomain.
+reserved_subdomain_urls: list[URLPattern | URLResolver] = []
+if settings.SOCIAL_AUTH_SUBDOMAIN is not None:
+    reserved_subdomain_urls += social_auth_urls
+if settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN is not None:
+    reserved_subdomain_urls += self_hosting_management_urls + self_hosting_registration_urls
+root_host_urls = [url for url in urls if url not in reserved_subdomain_urls]
+
 # The sequence is important; if i18n URLs don't come first then
 # reverse URL mapping points to i18n URLs which causes the frontend
 # tests to fail


### PR DESCRIPTION
 This series introduces [django-hosts](https://django-hosts.readthedocs.io/) to route reserved subdomains (auth, self-hosting management) to dedicated, narrow URLConf
  modules instead of sharing the full URL namespace with realm hosts.

 Previously, every subdomain resolved against `zproject.urls`, relying on middleware and view-level checks to enforce host-specific behavior. With django-hosts, each reserved subdomain gets only the URL groups it needs, and the root host excludes routes that belong to reserved subdomains.


**How changes were tested:**
backend tests 

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

Draft state: Still need to manually review the code apart from a general glance + direction check.

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
