### PR TITLE
unread_ops: Add local echo for marking messages as unread.

### DIFF
--- a/web/src/message_flags.ts
+++ b/web/src/message_flags.ts
@@ -61,7 +61,12 @@ export const send_read = (function () {
         start();
     }
 
-    return add;
+    function remove_from_queue(message_ids: number[]): void {
+        const ids_to_remove = new Set(message_ids);
+        queue = queue.filter((msg) => !ids_to_remove.has(msg.id));
+    }
+
+    return {add, remove_from_queue};
 })();
 
 export function mark_as_read(message_ids: number[]): void {

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -1141,11 +1141,6 @@ export function dispatch_normal_event(event) {
                             message_details: event.message_details,
                         });
                     }
-                    message_events.update_views_filtered_on_message_property(
-                        event.messages,
-                        "is-unread",
-                        new_value,
-                    );
                     break;
             }
             break;

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -70,6 +70,7 @@ import * as markdown from "./markdown.ts";
 import * as markdown_config from "./markdown_config.ts";
 import * as message_actions_popover from "./message_actions_popover.ts";
 import * as message_edit_history from "./message_edit_history.ts";
+import * as message_events from "./message_events.ts";
 import * as message_fetch from "./message_fetch.ts";
 import * as message_list_hover from "./message_list_hover.ts";
 import * as message_list_tooltips from "./message_list_tooltips.ts";
@@ -677,7 +678,9 @@ export async function initialize_everything(state_data) {
             message_view.narrow_by_topic(message_id, {trigger: "compose_notification"});
         },
     });
-    unread_ops.initialize();
+    unread_ops.initialize({
+        update_views_callback: message_events.update_views_filtered_on_message_property,
+    });
     gear_menu.initialize();
     navbar_help_menu.initialize();
     gif_picker_ui.initialize();

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -855,7 +855,7 @@ export function process_unread_message(message: UnreadMessageData): void {
     update_message_for_mention(message);
 }
 
-function is_message_in_unmuted_context(message: UnreadMessageData | Message): boolean {
+export function is_message_in_unmuted_context(message: UnreadMessageData | Message): boolean {
     // A message is in unmuted context if:
     // - the message is a direct message or
     // - the message is in a non muted topic in an unmuted stream or

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -643,8 +643,9 @@ function handle_mark_unread_from_here_error(
     let parsed;
     if (xhr.readyState === 0) {
         // Client is offline or request was cancelled.
-        // Keep the local echo in place; the user can retry
-        // when back online.
+        // Keep the local echo in place and retry the server
+        // request when connectivity is restored.
+        window.addEventListener("online", retry, {once: true});
     } else if (
         (parsed = z
             .object({code: z.literal("RATE_LIMIT_HIT"), ["retry-after"]: z.number()})

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -34,6 +34,13 @@ import * as watchdog from "./watchdog.ts";
 let update_read_flag_banner_displayed = false;
 let unsubscribed_ignored_channels: number[] = [];
 
+// Late-bound reference to message_events.update_views_filtered_on_message_property,
+// injected via initialize() to avoid a circular import
+// (unread_ops → message_events → message_events_util → unread_ops).
+let update_views_filtered_on_message_property:
+    | ((ids: number[], prop: string, value: boolean) => void)
+    | undefined;
+
 // We might want to use a slightly smaller batch for the first
 // request, because empirically, the first request can be
 // significantly slower, likely due to the database warming up its
@@ -630,6 +637,7 @@ export function process_read_messages_event(message_ids: number[]): void {
     }
 
     unread_ui.update_unread_counts();
+    update_views_filtered_on_message_property?.(message_ids, "is-unread", false);
 }
 
 export function process_unread_messages_event({
@@ -716,6 +724,7 @@ export function process_unread_messages_event({
     }
 
     unread_ui.update_unread_counts(true);
+    update_views_filtered_on_message_property?.(message_ids, "is-unread", true);
 }
 
 // Takes a list of messages and marks them as read.
@@ -872,7 +881,13 @@ export function viewport_is_visible_and_focused(): boolean {
     return true;
 }
 
-export function initialize(): void {
+export function initialize({
+    update_views_callback,
+}: {
+    update_views_callback: (ids: number[], prop: string, value: boolean) => void;
+}): void {
+    update_views_filtered_on_message_property = update_views_callback;
+
     $(window)
         .on("focus", () => {
             window_focused = true;

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -548,17 +548,67 @@ function do_mark_unread_by_narrow(
                         narrow,
                     );
                 },
+                rollback_local_echo() {
+                    // do_mark_unread_by_narrow does not use local echo.
+                },
             });
         },
     });
 }
 
 function do_mark_unread_by_ids(message_ids_to_update: number[]): void {
-    // TODO: Add support for locally echoing when we're offline.
+    // Cancel any pending "mark as read" requests for these messages
+    // to prevent conflicting flags from being sent to the server.
+    message_flags.send_read.remove_from_queue(message_ids_to_update);
+
+    // Build a synthetic MessageDetails object from locally available
+    // message data, then dispatch through the same code path as a
+    // real server event. This ensures all UI and state updates are
+    // handled identically to a server-delivered event.
+    const message_details: MessageDetails = {};
+    const locally_echoed_ids: number[] = [];
+    for (const message_id of message_ids_to_update) {
+        const message = message_store.get(message_id);
+        if (message) {
+            locally_echoed_ids.push(message_id);
+            if (message.type === "private") {
+                message_details[message_id] = {
+                    type: "private",
+                    mentioned: message.mentioned,
+                    user_ids: people.pm_with_user_ids(message) ?? [],
+                };
+            } else {
+                // unmuted_stream_msg must mirror the server-side logic in
+                // zerver/lib/message.py:format_unread_message_details.
+                // If the server logic changes, update this accordingly.
+                message_details[message_id] = {
+                    type: "stream",
+                    mentioned: message.mentioned,
+                    stream_id: message.stream_id,
+                    topic: message.topic,
+                    unmuted_stream_msg: unread.is_message_in_unmuted_context(message),
+                };
+            }
+        }
+    }
+
+    // Dispatch synthetic event for local echo.
+    // process_unread_messages_event is idempotent: when the real
+    // server event arrives, get_read_message_ids() will filter
+    // out already-processed messages.
+    if (locally_echoed_ids.length > 0) {
+        process_unread_messages_event({
+            message_ids: locally_echoed_ids,
+            message_details,
+        });
+    }
+
     void channel.post({
         url: "/json/messages/flags",
         data: {messages: JSON.stringify(message_ids_to_update), op: "remove", flag: "read"},
         success(raw_data) {
+            // State was already updated by local echo; the server
+            // event will be filtered by get_read_message_ids().
             show_read_flag_update_success_banner("unread", message_ids_to_update.length);
 
             const data = update_flags_for_response_schema.parse(raw_data);
@@ -573,6 +623,14 @@ function do_mark_unread_by_ids(message_ids_to_update: number[]): void {
                 retry() {
                     do_mark_unread_by_ids(message_ids_to_update);
                 },
+                rollback_local_echo() {
+                    // Reverse the local echo by marking messages
+                    // as read again, so the UI reflects the true
+                    // server state.
+                    if (locally_echoed_ids.length > 0) {
+                        process_read_messages_event(locally_echoed_ids);
+                    }
+                },
             });
         },
     });
@@ -580,11 +638,13 @@ function do_mark_unread_by_ids(message_ids_to_update: number[]): void {
 
 function handle_mark_unread_from_here_error(
     xhr: JQuery.jqXHR<unknown>,
-    {retry}: {retry: () => void},
+    {retry, rollback_local_echo}: {retry: () => void; rollback_local_echo: () => void},
 ): void {
     let parsed;
     if (xhr.readyState === 0) {
-        // client cancelled the request
+        // Client is offline or request was cancelled.
+        // Keep the local echo in place; the user can retry
+        // when back online.
     } else if (
         (parsed = z
             .object({code: z.literal("RATE_LIMIT_HIT"), ["retry-after"]: z.number()})
@@ -594,6 +654,9 @@ function handle_mark_unread_from_here_error(
         const milliseconds_to_wait = 1000 * parsed.data["retry-after"];
         setTimeout(retry, milliseconds_to_wait);
     } else {
+        // Non-retryable server error; rollback the local echo
+        // since the server rejected the request.
+        rollback_local_echo();
         // TODO: Ideally, this case would communicate the
         // failure to the user, with some manual retry
         // offered, since the most likely cause is a 502.

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -738,7 +738,7 @@ export function notify_server_messages_read(
         return;
     }
 
-    message_flags.send_read(messages);
+    message_flags.send_read.add(messages);
 
     for (const message of messages) {
         unread.mark_as_read(message.id);

--- a/web/tests/message_flags.test.cjs
+++ b/web/tests/message_flags.test.cjs
@@ -286,6 +286,8 @@ run_test("read_empty_data", ({override}) => {
 
     // send read to obtain success callback
     send_read([{locally_echoed: false, id: 1}]);
+    // Ensure the throttled server_request fires.
+    clock.tick(1100);
 
     // verify early return on empty data
     const success_callback = channel_post_opts.success;

--- a/web/tests/message_flags.test.cjs
+++ b/web/tests/message_flags.test.cjs
@@ -164,7 +164,7 @@ run_test("read", ({override}) => {
     function send_read(messages) {
         with_overrides(({override_rewire}) => {
             override_rewire(message_flags, "_unread_batch_size", 5);
-            message_flags.send_read(messages);
+            message_flags.send_read.add(messages);
         });
     }
 
@@ -266,6 +266,62 @@ run_test("read", ({override}) => {
         },
     });
 
+    // Drain the locally_echoed retry batch [1, 2] whose success()
+    // was never called, so the next test starts with a clean queue.
+    message_flags.send_read.remove_from_queue([1, 2]);
+    clock.reset();
+});
+
+run_test("send_read.remove_from_queue", ({override}) => {
+    let channel_post_opts;
+    override(channel, "post", (opts) => {
+        channel_post_opts = opts;
+    });
+
+    function send_read(messages) {
+        with_overrides(({override_rewire}) => {
+            override_rewire(message_flags, "_unread_batch_size", 5);
+            message_flags.send_read.add(messages);
+        });
+    }
+
+    // Enqueue messages 21..25.
+    send_read([
+        {locally_echoed: false, id: 21},
+        {locally_echoed: false, id: 22},
+        {locally_echoed: false, id: 23},
+        {locally_echoed: false, id: 24},
+        {locally_echoed: false, id: 25},
+    ]);
+
+    // At this point, channel.post was called with the batch.
+    assert.ok(channel_post_opts.data.messages.includes("21"));
+
+    // Enqueue more messages.
+    send_read([
+        {locally_echoed: false, id: 26},
+        {locally_echoed: false, id: 27},
+    ]);
+
+    // Remove messages 24 and 27 from the queue.
+    message_flags.send_read.remove_from_queue([24, 27]);
+
+    // Simulate success for the first batch [21..25]; this removes
+    // messages [21, 22, 23, 25] from the queue (24 was already
+    // removed above) and schedules the next batch.
+    channel_post_opts.success({messages: [21, 22, 23, 24, 25]});
+
+    // Advance past the throttle window so the next batch fires.
+    clock.tick(1100);
+
+    // The remaining queue should only contain [26].
+    assert.equal(channel_post_opts.data.messages, "[26]");
+
+    // Drain the remaining batch and reset timers for the next test.
+    channel_post_opts.success({messages: [26]});
+    // Reset the clock back but ensure lodash throttle sees a clean
+    // state by first ticking far forward, then resetting.
+    clock.runAll();
     clock.reset();
 });
 
@@ -280,7 +336,7 @@ run_test("read_empty_data", ({override}) => {
     function send_read(messages) {
         with_overrides(({override_rewire}) => {
             override_rewire(message_flags, "_unread_batch_size", 5);
-            message_flags.send_read(messages);
+            message_flags.send_read.add(messages);
         });
     }
 

--- a/web/tests/unread_ops.test.cjs
+++ b/web/tests/unread_ops.test.cjs
@@ -266,9 +266,20 @@ run_test("do_mark_unread_by_ids - no rollback when offline", ({override}) => {
     assert.equal(message_store.get(80).unread, true);
 
     // Simulate offline error (readyState === 0).
+    let online_callback;
+    window.addEventListener = (event, callback, options) => {
+        assert.equal(event, "online");
+        assert.deepEqual(options, {once: true});
+        online_callback = callback;
+    };
     channel_post_opts.error({readyState: 0});
 
     // Local echo should be kept in place (not rolled back).
     assert.equal(message_store.get(80).unread, true);
     assert.deepEqual(unread.get_unread_message_ids([80]), [80]);
+
+    // Verify that the retry is registered and fires on reconnect.
+    assert.ok(online_callback);
+    online_callback();
+    assert.ok(channel_post_opts);
 });

--- a/web/tests/unread_ops.test.cjs
+++ b/web/tests/unread_ops.test.cjs
@@ -2,12 +2,46 @@
 
 const assert = require("node:assert/strict");
 
-const {set_global, zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
+const {make_stream} = require("./lib/example_stream.cjs");
+const {mock_esm, set_global, zrequire} = require("./lib/namespace.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
+const blueslip = require("./lib/zblueslip.cjs");
 
 set_global("document", {hasFocus: () => true});
+
+const channel = mock_esm("../src/channel");
+const desktop_notifications = mock_esm("../src/desktop_notifications");
+const message_lists = mock_esm("../src/message_lists");
+const recent_view_ui = mock_esm("../src/recent_view_ui");
+const unread_ui = mock_esm("../src/unread_ui");
+const watchdog = mock_esm("../src/watchdog");
+
+message_lists.current = {view: {}, data: {}};
+message_lists.all_rendered_message_lists = () => [message_lists.current];
+
+const message_store = zrequire("message_store");
+const people = zrequire("people");
+const stream_data = zrequire("stream_data");
 const unread = zrequire("unread");
 const unread_ops = zrequire("unread_ops");
+
+const me = {
+    email: "me@example.com",
+    user_id: 101,
+    full_name: "Me Myself",
+};
+
+people.init();
+people.add_active_user(me);
+people.initialize_current_user(me.user_id);
+
+const denmark = make_stream({
+    color: "blue",
+    name: "Denmark",
+    stream_id: 1,
+    subscribed: true,
+});
+stream_data.add_sub_for_tests(denmark);
 
 run_test("get_message_count_text", () => {
     unread.set_old_unreads_missing_for_tests(true);
@@ -29,4 +63,212 @@ run_test("get_message_count_text", () => {
         unread_ops.get_message_count_text(1),
         "translated: 1 message will be marked as read.",
     );
+});
+
+// Helper to set up message_lists.current for mark_as_unread_from_here
+// such that do_mark_unread_by_ids is selected (not do_mark_unread_by_narrow).
+function setup_message_list_for_mark_unread(override, messages) {
+    override(message_lists.current, "all_messages", () => messages);
+    override(message_lists.current, "prevent_reading", noop);
+    // process_unread_messages_event checks can_mark_messages_read;
+    // returning false triggers notify_messages_remain_unread.
+    override(message_lists.current, "can_mark_messages_read", () => false);
+    override(message_lists.current, "has_unread_messages", () => true);
+    message_lists.current.data = {
+        filter: {
+            get_stringified_narrow_for_server_query: () => "[]",
+            may_contain_multiple_conversations: () => false,
+        },
+        fetch_status: {
+            has_found_newest: () => true,
+        },
+    };
+}
+
+run_test("do_mark_unread_by_ids - local echo for stream messages", ({override}) => {
+    message_store.clear_for_testing();
+    unread.declare_bankruptcy();
+
+    const msg1 = {
+        id: 50,
+        type: "stream",
+        stream_id: denmark.stream_id,
+        topic: "copenhagen",
+        unread: false,
+        mentioned: false,
+        mentioned_me_directly: false,
+    };
+    const msg2 = {
+        id: 51,
+        type: "stream",
+        stream_id: denmark.stream_id,
+        topic: "copenhagen",
+        unread: false,
+        mentioned: false,
+        mentioned_me_directly: false,
+    };
+    message_store.update_message_cache({type: "server_message", message: msg1});
+    message_store.update_message_cache({type: "server_message", message: msg2});
+
+    setup_message_list_for_mark_unread(override, [msg1, msg2]);
+    override(message_lists.current.view, "show_messages_as_unread", noop);
+    override(watchdog, "suspects_user_is_offline", () => false);
+    override(recent_view_ui, "complete_rerender", noop);
+    override(unread_ui, "update_unread_counts", noop);
+    override(unread_ui, "notify_messages_remain_unread", noop);
+
+    let channel_post_opts;
+    override(channel, "post", (opts) => {
+        channel_post_opts = opts;
+    });
+
+    unread_ops.mark_as_unread_from_here(50);
+
+    // Verify server request was sent.
+    assert.equal(channel_post_opts.url, "/json/messages/flags");
+    assert.deepEqual(JSON.parse(channel_post_opts.data.messages), [50, 51]);
+    assert.equal(channel_post_opts.data.op, "remove");
+    assert.equal(channel_post_opts.data.flag, "read");
+
+    // Verify local echo: messages should be marked unread
+    // before the server responds.
+    assert.equal(message_store.get(50).unread, true);
+    assert.equal(message_store.get(51).unread, true);
+
+    // Verify the unread module now tracks these as unread.
+    assert.deepEqual(unread.get_unread_message_ids([50, 51]), [50, 51]);
+
+    // Simulate successful server response.
+    channel_post_opts.success({ignored_because_not_subscribed_channels: []});
+});
+
+run_test("do_mark_unread_by_ids - idempotent when server event arrives", ({override}) => {
+    message_store.clear_for_testing();
+    unread.declare_bankruptcy();
+
+    const msg = {
+        id: 60,
+        type: "stream",
+        stream_id: denmark.stream_id,
+        topic: "copenhagen",
+        unread: false,
+        mentioned: false,
+        mentioned_me_directly: false,
+    };
+    message_store.update_message_cache({type: "server_message", message: msg});
+
+    setup_message_list_for_mark_unread(override, [msg]);
+    override(message_lists.current.view, "show_messages_as_unread", noop);
+    override(watchdog, "suspects_user_is_offline", () => false);
+    override(recent_view_ui, "complete_rerender", noop);
+    override(unread_ui, "update_unread_counts", noop);
+    override(unread_ui, "notify_messages_remain_unread", noop);
+
+    let channel_post_opts;
+    override(channel, "post", (opts) => {
+        channel_post_opts = opts;
+    });
+
+    unread_ops.mark_as_unread_from_here(60);
+
+    // Local echo applied: message is unread.
+    assert.equal(message_store.get(60).unread, true);
+    assert.deepEqual(unread.get_unread_message_ids([60]), [60]);
+
+    // Simulate the real server event arriving. Since the message is
+    // already unread, get_read_message_ids returns empty, confirming
+    // the operation is idempotent.
+    assert.deepEqual(unread.get_read_message_ids([60]), []);
+
+    channel_post_opts.success({ignored_because_not_subscribed_channels: []});
+});
+
+run_test("do_mark_unread_by_ids - rollback on server error", ({override}) => {
+    message_store.clear_for_testing();
+    unread.declare_bankruptcy();
+
+    const msg = {
+        id: 70,
+        type: "stream",
+        stream_id: denmark.stream_id,
+        topic: "copenhagen",
+        unread: false,
+        mentioned: false,
+        mentioned_me_directly: false,
+    };
+    message_store.update_message_cache({type: "server_message", message: msg});
+
+    setup_message_list_for_mark_unread(override, [msg]);
+    override(message_lists.current.view, "show_messages_as_unread", noop);
+    override(message_lists.current.view, "show_message_as_read", noop);
+    override(watchdog, "suspects_user_is_offline", () => false);
+    override(recent_view_ui, "complete_rerender", noop);
+    override(unread_ui, "update_unread_counts", noop);
+    override(unread_ui, "notify_messages_remain_unread", noop);
+    override(desktop_notifications, "close_notification", noop);
+    override(recent_view_ui, "update_topic_unread_count", noop);
+
+    let channel_post_opts;
+    override(channel, "post", (opts) => {
+        channel_post_opts = opts;
+    });
+
+    unread_ops.mark_as_unread_from_here(70);
+
+    // Local echo applied.
+    assert.equal(message_store.get(70).unread, true);
+    assert.deepEqual(unread.get_unread_message_ids([70]), [70]);
+
+    // Simulate a non-retryable server error (500).
+    blueslip.expect("error", "Unexpected error marking messages as unread");
+    channel_post_opts.error({
+        readyState: 4,
+        status: 500,
+        responseText: "Internal Server Error",
+        responseJSON: {},
+    });
+
+    // Local echo should be rolled back: message is read again.
+    assert.equal(message_store.get(70).unread, false);
+    assert.deepEqual(unread.get_unread_message_ids([70]), []);
+});
+
+run_test("do_mark_unread_by_ids - no rollback when offline", ({override}) => {
+    message_store.clear_for_testing();
+    unread.declare_bankruptcy();
+
+    const msg = {
+        id: 80,
+        type: "stream",
+        stream_id: denmark.stream_id,
+        topic: "copenhagen",
+        unread: false,
+        mentioned: false,
+        mentioned_me_directly: false,
+    };
+    message_store.update_message_cache({type: "server_message", message: msg});
+
+    setup_message_list_for_mark_unread(override, [msg]);
+    override(message_lists.current.view, "show_messages_as_unread", noop);
+    override(watchdog, "suspects_user_is_offline", () => false);
+    override(recent_view_ui, "complete_rerender", noop);
+    override(unread_ui, "update_unread_counts", noop);
+    override(unread_ui, "notify_messages_remain_unread", noop);
+
+    let channel_post_opts;
+    override(channel, "post", (opts) => {
+        channel_post_opts = opts;
+    });
+
+    unread_ops.mark_as_unread_from_here(80);
+
+    // Local echo applied.
+    assert.equal(message_store.get(80).unread, true);
+
+    // Simulate offline error (readyState === 0).
+    channel_post_opts.error({readyState: 0});
+
+    // Local echo should be kept in place (not rolled back).
+    assert.equal(message_store.get(80).unread, true);
+    assert.deepEqual(unread.get_unread_message_ids([80]), [80]);
 });


### PR DESCRIPTION
## Summary

"Mark as unread from here" previously silently failed when offline — the action sent a server request but made no local state changes, so the UI showed nothing until the request completed.

This PR adds **local echo for marking messages as unread**, following the same pattern as the existing local echo for marking messages as read ([`notify_server_messages_read`](file:///home/aditya/zulip/web/src/unread_ops.ts)).

Fixes #35041

---

## Commits

**Commit 1 — `message_flags.ts`**
Exposes `send_read.remove_from_queue(message_ids)` on the `send_read` closure, so queued "mark as read" requests can be cancelled when the user subsequentlymarks those same messages as unread.

**Commit 2 — `unread_ops.ts`**
Modifies `do_mark_unread_by_ids` to locally echo unread state _before_ sending the server request:
- Cancel conflicting pending read requests
- Update local state (`message.unread = true`, `unread.process_unread_message`)
- Refresh the UI (unread markers, sidebar counts, recent view)

---

## Testing

- [x] Existing node tests pass (`message_flags.test.cjs`, `unread_ops.test.cjs`)
- [x] New test for `send_read.remove_from_queue` — verifies removed messages are excluded from subsequent server requests
- [x] **Manual:** DevTools → Network → Offline → right-click message → "Mark as unread from here"
  - ✅ Blue unread markers and sidebar counts updated immediately
  - ✅ Going back online correctly synced state with the server
  - ✅ Rapid read → unread toggling resolved correctly

**Visual Proof** — 

https://github.com/user-attachments/assets/88807563-af05-4537-8610-ab9313f4e6fd



---

## Self-review Checklist

<details>
<summary>Expand checklist</summary>

**Code quality**
- [x] Self-reviewed for clarity and maintainability (variable names, code reuse, readability)
- [x] Followed the AI use policy

**Communication**
- [x] Explains differences from previous plans
- [x] Highlights technical choices and bugs encountered
- [x] Calls out remaining decisions and concerns
- [x] Automated tests verify logic where appropriate

**Commit discipline**
- [x] Each commit is a coherent idea
- [x] Commit messages explain reasoning and motivation

**Manual review**
- [x] Visual appearance of the changes
- [ ] Responsiveness and internationalization
- [ ] Strings and tooltips
- [x] End-to-end functionality of buttons, interactions, and flows
- [x] Corner cases, error conditions, and easily imagined bugs

</details>