### PR TITLE
views_util: Consider open view popovers.

### DIFF
--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -160,11 +160,17 @@ export function is_in_focus(): boolean {
     let can_current_view_steal_focus = true;
     const focused_element = document.activeElement;
 
-    // If current view has focus we don't need to check anything else.
+    // If current view has focus and there's not a visibility or
+    // vdots popover with focus, we don't need to check anything else.
     if (
         focused_element instanceof HTMLElement &&
         (focused_element.closest("#recent_view") !== null ||
-            focused_element.closest("#inbox-view") !== null)
+            focused_element.closest("#inbox-view") !== null) &&
+        !(
+            focused_element.classList.contains("visibility-policy-indicator") ||
+            focused_element.classList.contains("inbox-action-button") ||
+            focused_element.classList.contains("recent_topic_actions")
+        )
     ) {
         return true;
     }


### PR DESCRIPTION
This tries to correct for a regression introduced in 25fb8faf45474a18d4c502e3be709f06284917db that caused the state of an open Inbox or Recents popover to be disregarded, which meant those popovers failed to receive focus, with or without the compose box open.

CZO Issue: [#issues > 🎯 keyboard navigation for topic notifications menu](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20keyboard.20navigation.20for.20topic.20notifications.20menu/with/2391007)

<!-- Describe your pull request here.-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>