### PR TITLE
message_fetch: Show server error messages for 400 responses

### DIFF
--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -28,6 +28,7 @@ import {narrow_operator_schema} from "./state_data.ts";
 import type {NarrowTerm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_list from "./stream_list.ts";
+import * as ui_report from "./ui_report.ts";
 import * as util from "./util.ts";
 
 export const response_schema = z.object({
@@ -443,12 +444,14 @@ export function load_messages(opts: MessageFetchOptions, attempt = 1): void {
                 // Bad request: We probably specified a narrow operator
                 // for a nonexistent stream or something.  We shouldn't
                 // retry or display a connection error.
-                //
-                // FIXME: This logic unconditionally ignores the actual JSON
-                // error in the xhr status. While we have empty narrow messages
-                // for many common errors, and those have nicer HTML formatting,
-                // we certainly don't for every possible 400 error.
                 message_feed_loading.hide_indicators();
+
+                const server_error_message_html = channel.xhr_error_message("", xhr);
+                if (server_error_message_html !== "") {
+                    narrow_banner.hide_empty_narrow_message();
+                    ui_report.generic_embed_error(server_error_message_html);
+                    return;
+                }
 
                 if (
                     message_lists.current !== undefined &&

--- a/web/tests/message_fetch.test.cjs
+++ b/web/tests/message_fetch.test.cjs
@@ -2,12 +2,19 @@
 
 const assert = require("node:assert/strict");
 
-const {zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {noop, run_test} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
 
+const message_feed_loading = mock_esm("../src/message_feed_loading");
+const narrow_banner = mock_esm("../src/narrow_banner");
+const popup_banners = mock_esm("../src/popup_banners");
+const ui_report = mock_esm("../src/ui_report");
+
+const channel = mock_esm("../src/channel");
 const {Filter} = zrequire("filter");
 const {MessageListData} = zrequire("message_list_data");
+const message_lists = zrequire("message_lists");
 const message_fetch = zrequire("message_fetch");
 
 run_test("get_parameters_for_message_fetch_api date anchor", () => {
@@ -38,3 +45,93 @@ run_test("get_parameters_for_message_fetch_api date anchor", () => {
     });
     assert.equal(missing_date.anchor_date, undefined);
 });
+
+run_test("load_messages: 400 surfaces server error message", ({disallow, override}) => {
+    const msg_list_data = new MessageListData({
+        excludes_muted_topics: false,
+        filter: new Filter([]),
+    });
+    let hide_indicators_called = false;
+    let error_message_html;
+
+    override(message_feed_loading, "hide_indicators", () => {
+        hide_indicators_called = true;
+    });
+    override(ui_report, "generic_embed_error", (message_html) => {
+        error_message_html = message_html;
+    });
+    override(narrow_banner, "hide_empty_narrow_message", noop);
+    disallow(narrow_banner, "show_empty_narrow_message");
+    override(popup_banners, "close_connection_error_popup_banner", noop);
+    override(channel, "get", (opts) => {
+        opts.error({
+            status: 400,
+            responseJSON: {msg: "Too many <messages> requested (maximum 5000)"},
+        });
+    });
+    override(
+        channel,
+        "xhr_error_message",
+        () => "Too many &lt;messages&gt; requested (maximum 5000)",
+    );
+
+    message_lists.set_current(undefined);
+    message_fetch.load_messages({
+        anchor: "newest",
+        num_before: 0,
+        num_after: 0,
+        msg_list_data,
+        cont: noop,
+    });
+
+    assert.equal(hide_indicators_called, true);
+    assert.equal(error_message_html, "Too many &lt;messages&gt; requested (maximum 5000)");
+});
+
+run_test(
+    "load_messages: 400 falls back to empty narrow when no server message",
+    ({disallow, override}) => {
+        const filter = new Filter([{operator: "search", operand: "zulip"}]);
+        const msg_list_data = new MessageListData({
+            excludes_muted_topics: false,
+            filter,
+        });
+        const msg_list = {
+            is_combined_feed_view: false,
+            visibly_empty: () => true,
+            data: {filter},
+        };
+        let hide_indicators_called = false;
+        let empty_narrow_banner_shown = false;
+
+        override(message_feed_loading, "hide_indicators", () => {
+            hide_indicators_called = true;
+        });
+        disallow(ui_report, "generic_embed_error");
+        override(narrow_banner, "show_empty_narrow_message", () => {
+            empty_narrow_banner_shown = true;
+        });
+        override(popup_banners, "close_connection_error_popup_banner", noop);
+        override(channel, "get", (opts) => {
+            opts.error({
+                status: 400,
+                responseJSON: {},
+            });
+        });
+        override(channel, "xhr_error_message", () => "");
+
+        message_lists.set_current(msg_list);
+        message_fetch.load_messages({
+            anchor: "newest",
+            num_before: 0,
+            num_after: 0,
+            msg_list,
+            msg_list_data,
+            cont: noop,
+        });
+        message_lists.set_current(undefined);
+
+        assert.equal(hide_indicators_called, true);
+        assert.equal(empty_narrow_banner_shown, true);
+    },
+);


### PR DESCRIPTION
Fixes: #38108

## Summary
This PR updates `message_fetch` handling for `400` responses from `/json/messages` to display server-provided error messages when available, instead of always showing the generic empty narrow banner.

Previously, this code path unconditionally ignored the server JSON error payload (as noted by the existing FIXME in `web/src/message_fetch.ts`), which hid actionable validation errors from users.

## What changed
- Updated `web/src/message_fetch.ts`:
  - Keep `400` as non-retryable and hide loading indicators.
  - Parse/display server message via `channel.xhr_error_message("", xhr)`.
  - If a server message is present:
    - hide empty narrow message,
    - show error with `ui_report.generic_embed_error(...)`,
    - return early.
  - If no usable server message exists:
    - preserve existing fallback behavior by showing `narrow_banner.show_empty_narrow_message(...)`.

- Added tests in `web/tests/message_fetch.test.cjs`:
  - `load_messages: 400 surfaces server error message`
  - `load_messages: 400 falls back to empty narrow when no server message`

## Why this approach
- Reuses existing, safe server-error extraction/escaping behavior (`channel.xhr_error_message`).
- Preserves current empty-narrow UX for known cases.
- Improves UX/debugging by surfacing specific API validation failures.

**How changes were tested:**
- `./tools/test-js-with-node web/tests/message_fetch.test.cjs`
- `./tools/lint --only=eslint web/src/message_fetch.ts web/tests/message_fetch.test.cjs`

**Screenshots and screen captures:**
- Not applicable (no visual design/layout change; behavior change in error-message selection path).

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
