### PR TITLE
supervisor: Add syslog output option for managed processes.

### DIFF
--- a/docs/production/system-configuration.md
+++ b/docs/production/system-configuration.md
@@ -219,6 +219,23 @@ with more than 24GB of RAM.
 Number of days of access logs to keep, for both nginx and the application.
 Defaults to 14 days.
 
+#### `supervisor_output`
+
+Controls where supervisor-managed Zulip processes send their output.
+Defaults to `file`, which writes logs to `/var/log/zulip/`.
+
+Set to `syslog` to redirect all supervisor-managed process output
+to syslog via supervisor's `stdout_syslog` directive. This is useful
+for deployments that forward logs to a centralized logging server
+via rsyslog or similar.
+
+:::{note}
+This only affects supervisor-managed output (process stdout/stderr).
+Application-level logs written by Django's logging framework
+(e.g., `errors.log`, `server.log`) are not affected by this
+setting and will continue to be written to `/var/log/zulip/`.
+:::
+
 #### `katex_server`
 
 Set to a false value to disable the separate service for [rendering math with

--- a/docs/production/troubleshooting.md
+++ b/docs/production/troubleshooting.md
@@ -102,6 +102,10 @@ isn't running. If you don't see relevant logs in
 `/etc/supervisor/conf.d/zulip.conf` for details. Logs only make it to
 `/var/log/zulip/errors.log` once a service has started fully.
 
+If you have configured `supervisor_output = syslog` in
+`/etc/zulip/zulip.conf`, check your syslog for supervisor-managed
+process output instead of the log files in `/var/log/zulip/`.
+
 ### Restarting services with `supervisorctl restart`
 
 After you change configuration in `/etc/zulip/settings.py` or fix a

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -199,6 +199,8 @@ class zulip::app_frontend_base {
   $katex_server = zulipconf('application_server', 'katex_server', true)
   $katex_server_port = zulipconf('application_server', 'katex_server_port', '9700')
 
+  $supervisor_output = zulipconf('application_server', 'supervisor_output', 'file')
+
   $tusd_server_listen = zulipconf('application_server', 'tusd_server_listen', '127.0.0.1')
 
   if $proxy_host != '' and $proxy_port != '' {

--- a/puppet/zulip/manifests/app_frontend_once.pp
+++ b/puppet/zulip/manifests/app_frontend_once.pp
@@ -11,6 +11,7 @@ class zulip::app_frontend_once {
   } else {
     $proxy = ''
   }
+  $supervisor_output = zulipconf('application_server', 'supervisor_output', 'file')
   file { "${zulip::common::supervisor_conf_dir}/zulip-once.conf":
     ensure  => file,
     require => [Package[supervisor], Exec['stage_updated_sharding']],

--- a/puppet/zulip/manifests/camo.pp
+++ b/puppet/zulip/manifests/camo.pp
@@ -37,6 +37,7 @@ class zulip::camo (String $listen_address = '0.0.0.0') {
 
   $zulip_version = $facts['zulip_version']
   $external_uri = pick(get_django_setting_slow('ROOT_DOMAIN_URI'), 'https://zulip.com')
+  $supervisor_output = zulipconf('application_server', 'supervisor_output', 'file')
   file { "${zulip::common::supervisor_conf_dir}/go-camo.conf":
     ensure  => file,
     require => [

--- a/puppet/zulip/manifests/local_mailserver.pp
+++ b/puppet/zulip/manifests/local_mailserver.pp
@@ -12,6 +12,7 @@ class zulip::local_mailserver {
       before => Service[$zulip::common::supervisor_service],
     }
   }
+  $supervisor_output = zulipconf('application_server', 'supervisor_output', 'file')
   file { "${zulip::common::supervisor_conf_dir}/email-mirror.conf":
     ensure  => file,
     require => [

--- a/puppet/zulip/manifests/process_fts_updates.pp
+++ b/puppet/zulip/manifests/process_fts_updates.pp
@@ -26,13 +26,14 @@ class zulip::process_fts_updates {
     source => 'puppet:///modules/zulip/postgresql/process_fts_updates',
   }
 
+  $supervisor_output = zulipconf('application_server', 'supervisor_output', 'file')
   file { "${zulip::common::supervisor_conf_dir}/zulip_db.conf":
     ensure  => file,
     require => [Package[supervisor], Package['python3-psycopg2']],
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    source  => 'puppet:///modules/zulip/supervisor/conf.d/zulip_db.conf',
+    content => template('zulip/supervisor/zulip_db.conf.erb'),
     notify  => Service[$zulip::common::supervisor_service],
   }
 }

--- a/puppet/zulip/manifests/smokescreen.pp
+++ b/puppet/zulip/manifests/smokescreen.pp
@@ -41,6 +41,7 @@ class zulip::smokescreen {
   $allow_ranges = split(zulipconf('http_proxy', 'allow_ranges', ''), ',')
   $deny_addresses = split(zulipconf('http_proxy', 'deny_addresses', ''), ',')
   $deny_ranges = split(zulipconf('http_proxy', 'deny_ranges', ''), ',')
+  $supervisor_output = zulipconf('application_server', 'supervisor_output', 'file')
 
   file { "${zulip::common::supervisor_conf_dir}/smokescreen.conf":
     ensure  => file,

--- a/puppet/zulip/templates/logrotate/zulip.template.erb
+++ b/puppet/zulip/templates/logrotate/zulip.template.erb
@@ -41,6 +41,7 @@
     create 644 zulip zulip
 }
 
+<% if @supervisor_output != 'syslog' -%>
 # Logfiles generated from supervisor _do not_ understand logrotate,
 # and thus must use copytruncate.  They also must not use supervisor's
 # built-in log rotation.
@@ -56,3 +57,4 @@
     notifempty
     copytruncate
 }
+<% end -%>

--- a/puppet/zulip/templates/supervisor/email-mirror.conf.template.erb
+++ b/puppet/zulip/templates/supervisor/email-mirror.conf.template.erb
@@ -8,7 +8,12 @@ stopsignal=TERM                ; signal used to kill process (default TERM)
 topwaitsecs=30                 ; max num secs to wait b4 SIGKILL (default 10)
 user=root                      ; setuid to this UNIX account to run the program
 redirect_stderr=true           ; redirect proc stderr to stdout (default false)
+<% if @supervisor_output == 'syslog' -%>
+stdout_syslog=true
+stdout_logfile=NONE
+<% else -%>
 stdout_logfile=/var/log/zulip/email_server.log         ; stdout log path, NONE for none; default AUTO
 stdout_logfile_maxbytes=20MB   ; max # logfile bytes b4 rotation (default 50MB)
 stdout_logfile_backups=3     ; # of stdout logfile backups (default 10)
+<% end -%>
 directory=/home/zulip/deployments/current/

--- a/puppet/zulip/templates/supervisor/go-camo.conf.erb
+++ b/puppet/zulip/templates/supervisor/go-camo.conf.erb
@@ -6,4 +6,9 @@ autostart=true
 autorestart=true
 user=zulip
 redirect_stderr=true
+<% if @supervisor_output == 'syslog' -%>
+stdout_syslog=true
+stdout_logfile=NONE
+<% else -%>
 stdout_logfile=/var/log/zulip/camo.log
+<% end -%>

--- a/puppet/zulip/templates/supervisor/smokescreen.conf.erb
+++ b/puppet/zulip/templates/supervisor/smokescreen.conf.erb
@@ -20,6 +20,11 @@ autostart=true
 autorestart=true
 user=zulip
 redirect_stderr=true
+<% if @supervisor_output == 'syslog' -%>
+stdout_syslog=true
+stdout_logfile=NONE
+<% else -%>
 stdout_logfile=/var/log/zulip/smokescreen.log
 stdout_logfile_maxbytes=0
 stdout_logfile_backups=0
+<% end -%>

--- a/puppet/zulip/templates/supervisor/zulip-once.conf.template.erb
+++ b/puppet/zulip/templates/supervisor/zulip-once.conf.template.erb
@@ -8,9 +8,14 @@ stopsignal=TERM                ; signal used to kill process (default TERM)
 topwaitsecs=30                ; max num secs to wait b4 SIGKILL (default 10)
 user=zulip                    ; setuid to this UNIX account to run the program
 redirect_stderr=true           ; redirect proc stderr to stdout (default false)
+<% if @supervisor_output == 'syslog' -%>
+stdout_syslog=true
+stdout_logfile=NONE
+<% else -%>
 stdout_logfile=/var/log/zulip/events_deliver_scheduled_emails.log         ; stdout log path, NONE for none; default AUTO
 stdout_logfile_maxbytes=20MB   ; max # logfile bytes b4 rotation (default 50MB)
 stdout_logfile_backups=3     ; # of stdout logfile backups (default 10)
+<% end -%>
 directory=/home/zulip/deployments/current/
 
 [program:zulip_deliver_scheduled_messages]
@@ -23,7 +28,12 @@ stopsignal=TERM                ; signal used to kill process (default TERM)
 topwaitsecs=30                ; max num secs to wait b4 SIGKILL (default 10)
 user=zulip                    ; setuid to this UNIX account to run the program
 redirect_stderr=true           ; redirect proc stderr to stdout (default false)
+<% if @supervisor_output == 'syslog' -%>
+stdout_syslog=true
+stdout_logfile=NONE
+<% else -%>
 stdout_logfile=/var/log/zulip/events_deliver_scheduled_messages.log         ; stdout log path, NONE for none; default AUTO
 stdout_logfile_maxbytes=20MB   ; max # logfile bytes b4 rotation (default 50MB)
 stdout_logfile_backups=3     ; # of stdout logfile backups (default 10)
+<% end -%>
 directory=/home/zulip/deployments/current/

--- a/puppet/zulip/templates/supervisor/zulip.conf.template.erb
+++ b/puppet/zulip/templates/supervisor/zulip.conf.template.erb
@@ -17,9 +17,14 @@ stopsignal=INT                 ; signal used to kill process (default TERM)
 stopwaitsecs=30                ; max num secs to wait b4 SIGKILL (default 10)
 user=zulip                    ; setuid to this UNIX account to run the program
 redirect_stderr=true           ; redirect proc stderr to stdout (default false)
+<% if @supervisor_output == 'syslog' -%>
+stdout_syslog=true
+stdout_logfile=NONE
+<% else -%>
 stdout_logfile=/var/log/zulip/django.log        ; stdout log path, NONE for none; default AUTO
 stdout_logfile_maxbytes=100MB   ; max # logfile bytes b4 rotation (default 50MB)
 stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
+<% end -%>
 stopasgroup=true              ; Without this, we leak processes every restart
 killasgroup=true              ; Without this, we leak processes every restart
 directory=/home/zulip/deployments/current/
@@ -34,9 +39,14 @@ stopsignal=INT                 ; signal used to kill process (default TERM)
 stopwaitsecs=30                ; max num secs to wait b4 SIGKILL (default 10)
 user=zulip                    ; setuid to this UNIX account to run the program
 redirect_stderr=true           ; redirect proc stderr to stdout (default false)
+<% if @supervisor_output == 'syslog' -%>
+stdout_syslog=true
+stdout_logfile=NONE
+<% else -%>
 stdout_logfile=/var/log/zulip/tusd.log        ; stdout log path, NONE for none; default AUTO
 stdout_logfile_maxbytes=0     ; Rotated by logrotate
 stdout_logfile_backups=0
+<% end -%>
 stopasgroup=true              ; Without this, we leak processes every restart
 killasgroup=true              ; Without this, we leak processes every restart
 directory=/home/zulip/deployments/current/
@@ -53,9 +63,14 @@ stopsignal=TERM                 ; signal used to kill process (default TERM)
 stopwaitsecs=30                ; max num secs to wait b4 SIGKILL (default 10)
 user=zulip                    ; setuid to this UNIX account to run the program
 redirect_stderr=true           ; redirect proc stderr to stdout (default false)
+<% if @supervisor_output == 'syslog' -%>
+stdout_syslog=true
+stdout_logfile=NONE
+<% else -%>
 stdout_logfile=/var/log/zulip/tornado-98%(process_num)02d.log         ; stdout log path, NONE for none; default AUTO
 stdout_logfile_maxbytes=0     ; Rotated by logrotate
 stdout_logfile_backups=0
+<% end -%>
 directory=/home/zulip/deployments/current/
 numprocs=<%= @tornado_ports.length %>
 <% else -%>
@@ -69,9 +84,14 @@ stopsignal=TERM                 ; signal used to kill process (default TERM)
 stopwaitsecs=30                ; max num secs to wait b4 SIGKILL (default 10)
 user=zulip                    ; setuid to this UNIX account to run the program
 redirect_stderr=true           ; redirect proc stderr to stdout (default false)
+<% if @supervisor_output == 'syslog' -%>
+stdout_syslog=true
+stdout_logfile=NONE
+<% else -%>
 stdout_logfile=/var/log/zulip/tornado.log         ; stdout log path, NONE for none; default AUTO
 stdout_logfile_maxbytes=0     ; Rotated by logrotate
 stdout_logfile_backups=0
+<% end -%>
 directory=/home/zulip/deployments/current/
 <% end -%>
 
@@ -93,12 +113,22 @@ directory=/home/zulip/deployments/current/
 <%- if numprocs > 1 -%>
 process_name=zulip_events_<%= queue %>_<%= term %>%(process_num)s
 command=nice -n10 /home/zulip/deployments/current/manage.py process_queue --queue_name=<%= queue %> --skip-checks --worker_num %(process_num)s
+<% if @supervisor_output == 'syslog' -%>
+stdout_syslog=true
+stdout_logfile=NONE
+<% else -%>
 stdout_logfile=/var/log/zulip/events_<%= queue %>_<%= term %>%(process_num)s.log         ; stdout log path, NONE for none; default AUTO
+<% end -%>
 numprocs=<%= numprocs %>
 numprocs_start=1
 <% else -%>
 command=nice -n10 /home/zulip/deployments/current/manage.py process_queue --queue_name=<%= queue %> --skip-checks
+<% if @supervisor_output == 'syslog' -%>
+stdout_syslog=true
+stdout_logfile=NONE
+<% else -%>
 stdout_logfile=/var/log/zulip/events_<%= queue %>.log         ; stdout log path, NONE for none; default AUTO
+<% end -%>
 <%end -%>
 environment=HTTP_proxy="<%= @proxy %>",HTTPS_proxy="<%= @proxy %>"<%= @ca_bundle %>
 priority=300                   ; the relative start priority (default 999)
@@ -108,8 +138,10 @@ stopsignal=TERM                 ; signal used to kill process (default TERM)
 stopwaitsecs=30                ; max num secs to wait b4 SIGKILL (default 10)
 user=zulip                    ; setuid to this UNIX account to run the program
 redirect_stderr=true           ; redirect proc stderr to stdout (default false)
+<% if @supervisor_output != 'syslog' -%>
 stdout_logfile_maxbytes=20MB   ; max # logfile bytes b4 rotation (default 50MB)
 stdout_logfile_backups=3     ; # of stdout logfile backups (default 10)
+<% end -%>
 directory=/home/zulip/deployments/current/
 <% end -%>
 <% else %>
@@ -123,9 +155,14 @@ stopsignal=TERM                 ; signal used to kill process (default TERM)
 stopwaitsecs=30                ; max num secs to wait b4 SIGKILL (default 10)
 user=zulip                    ; setuid to this UNIX account to run the program
 redirect_stderr=true           ; redirect proc stderr to stdout (default false)
+<% if @supervisor_output == 'syslog' -%>
+stdout_syslog=true
+stdout_logfile=NONE
+<% else -%>
 stdout_logfile=/var/log/zulip/events.log         ; stdout log path, NONE for none; default AUTO
 stdout_logfile_maxbytes=20MB   ; max # logfile bytes b4 rotation (default 50MB)
 stdout_logfile_backups=3     ; # of stdout logfile backups (default 10)
+<% end -%>
 directory=/home/zulip/deployments/current/
 stopasgroup=true              ; Without this, we leak processes every restart
 killasgroup=true              ; Without this, we leak processes every restart
@@ -154,9 +191,14 @@ stopsignal=TERM                 ; signal used to kill process (default TERM)
 stopwaitsecs=30                ; max num secs to wait b4 SIGKILL (default 10)
 user=zulip                    ; setuid to this UNIX account to run the program
 redirect_stderr=true           ; redirect proc stderr to stdout (default false)
+<% if @supervisor_output == 'syslog' -%>
+stdout_syslog=true
+stdout_logfile=NONE
+<% else -%>
 stdout_logfile=/var/log/zulip/katex.log         ; stdout log path, NONE for none; default AUTO
 stdout_logfile_maxbytes=20MB   ; max # logfile bytes b4 rotation (default 50MB)
 stdout_logfile_backups=3     ; # of stdout logfile backups (default 10)
+<% end -%>
 directory=/home/zulip/deployments/current/
 <% end %>
 

--- a/puppet/zulip/templates/supervisor/zulip_db.conf.erb
+++ b/puppet/zulip/templates/supervisor/zulip_db.conf.erb
@@ -7,4 +7,9 @@ stopsignal=TERM                ; signal used to kill process (default TERM)
 stopwaitsecs=30                ; max num secs to wait b4 SIGKILL (default 10)
 user=zulip                     ; setuid to this UNIX account to run the program
 redirect_stderr=true           ; redirect proc stderr to stdout (default false)
+<% if @supervisor_output == 'syslog' -%>
+stdout_syslog=true
+stdout_logfile=NONE
+<% else -%>
 stdout_logfile=/var/log/zulip/fts-updates.log         ; stdout log path, NONE for none; default AUTO
+<% end -%>


### PR DESCRIPTION
Fixes: #15973

Adds a supervisor_output setting under [application_server] in /etc/zulip/zulip.conf so administrators can forward supervisor-managed process output to syslog instead of log files. When set to syslog, templates use stdout_syslog=true and stdout_logfile=NONE. Defaults to file.

How changes were tested:

Tested with stdout_syslog=true on supervisor 4.2.1 and confirmed process output appears in /var/log/syslog. Also verified that stdout_logfile=NONE is needed to prevent supervisor from creating auto log files alongside syslog output.

```console
$ sudo grep test_syslog /var/log/syslog | tail -5
Feb 26 22:43:13 d70e92e84861 supervisord: test_syslog SYSLOG_VERIFIED_67890
Feb 26 23:57:36 d70e92e84861 supervisord: test_syslog TEST_RESTART_OUTPUT
Feb 26 23:57:39 d70e92e84861 supervisord: test_syslog TEST_RESTART_OUTPUT
```

**Screenshots and screen captures:**


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>