### PR TITLE
puppet: Install logrotate package on Debian systems

### DIFF
--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -37,6 +37,8 @@ class zulip::profile::base {
         'apt-transport-https',
         # Needed for the cron jobs installed by Puppet
         'cron',
+        # Applies log rotation config installed by Puppet
+        'logrotate',
       ]
     }
     'RedHat': {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: https://github.com/zulip/docker-zulip/issues/263

The `logrotate` package is missing in the docker image, which makes use of this repo's puppet manifests to install dependencies. I presume that this does not break on Ubuntu/Debian VM installs because logrotate is generally installed by default on Ubuntu Server images, etc.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

Tested with: `podman build  --build-arg "ZULIP_GIT_URL=https://github.com/iofq/zulip.git" --build-arg "ZULIP_GIT_REF=main" .`

We can see the docker build installing logrotate now:

<img width="799" height="275" alt="image" src="https://github.com/user-attachments/assets/641efdab-7766-4baf-a408-49a2ce671d65" />

And indeed, logrotate is inside available inside the container, as well as the default daily cron entry for it:

<img width="782" height="442" alt="image" src="https://github.com/user-attachments/assets/8091825e-2a7a-48f6-b905-03aee5cfd5b0" />

I admit I'm not that familiar with zulip deployments so I don't have an actual server running to fully test this, however the verbose output of a manual `logrotate` looks like it's attempting to do the correct things at least. I would imagine this doesn't deviate from what a non-docker logrotate looks like:

[zulip_logrotate.txt](https://github.com/user-attachments/files/25582642/zulip_logrotate.txt)

Based on my understanding of the puppet infrastructure backing these zulip installers, the addition of this logrotate package requirement won't negatively affect VMs/servers that already have logrotate installed.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
