### PR TITLE
topic_list: Fix zoom to account for direct message header and divider.

### DIFF
--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -473,20 +473,27 @@ export function left_sidebar_scroll_zoomed_in_topic_into_view(): void {
         const topic_header_height =
             $("#streams_list.zoom-in #topics_header").outerHeight(true) ?? 0;
         sticky_header_height += stream_header_height + topic_header_height;
+    } else {
+        const channel_folder_header_height =
+            $selected_topic
+                .closest(".stream-list-section-container")
+                .find(".stream-list-subsection-header")
+                .outerHeight(true) ?? 0;
+        sticky_header_height += channel_folder_header_height;
     }
-    const channel_folder_header_height =
-        $selected_topic
-            .closest(".stream-list-section-container")
-            .find(".stream-list-subsection-header")
-            .outerHeight(true) ?? 0;
-    sticky_header_height += channel_folder_header_height;
-    const $topic_list = $selected_topic.closest(".topic-list");
-    const topic_list_height = $topic_list.outerHeight(true) ?? 0;
+    const direct_message_header_height =
+        $("#direct-messages-section-header").outerHeight(true) ?? 0;
+    const direct_message_divider_height =
+        $(".direct-message-section-bottom-divider-container").outerHeight(true) ?? 0;
+    sticky_header_height += direct_message_header_height + direct_message_divider_height;
+
+    const $channel_section = $selected_topic.closest(".stream-expanded");
+    const channel_section_height = $channel_section.outerHeight(true) ?? 0;
     const available_topic_height = ($container.height() ?? 0) - sticky_header_height;
 
     let $scroll_target = $selected_topic;
-    if (topic_list_height <= available_topic_height) {
-        $scroll_target = $topic_list;
+    if (channel_section_height <= available_topic_height) {
+        $scroll_target = $channel_section;
     }
     scroll_util.scroll_element_into_container($scroll_target, $container, sticky_header_height);
 }


### PR DESCRIPTION
Fixes incomplete #38123.

Testing navigating to a topic in a channel higher up than the currently viewed channel. Notice that Before cuts off the top of the channel box and After shows the channel name.

| Before | After |
| - | - |
| ![Kapture 2026-02-26 at 13 18 21](https://github.com/user-attachments/assets/0659e96b-b4b4-4bd7-bcf0-e7e16ea3dea5)  | ![Kapture 2026-02-26 at 13 16 19](https://github.com/user-attachments/assets/04f85061-7c8e-467e-8716-48d6636cfdb3) |
