### PR TITLE
[ai] Use channel cards and group cards more

### DIFF
--- a/web/src/channel_folders_ui.ts
+++ b/web/src/channel_folders_ui.ts
@@ -16,7 +16,6 @@ import * as confirm_dialog from "./confirm_dialog.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import type {DropdownWidget, DropdownWidgetOptions} from "./dropdown_widget.ts";
-import * as hash_util from "./hash_util.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as ListWidget from "./list_widget.ts";
 import type {ListWidget as ListWidgetType} from "./list_widget.ts";
@@ -200,7 +199,6 @@ function format_channel_item_html(stream: StreamSubscription): string {
         stream_color: stream.color,
         invite_only: stream.invite_only,
         is_web_public: stream.is_web_public,
-        stream_edit_url: hash_util.channels_settings_edit_url(stream, "general"),
         can_manage_folder: settings_data.can_user_manage_folder(),
     });
 }

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -331,7 +331,6 @@ function format_user_group_list_item_html(group: UserGroup, user: User): string 
     return render_user_group_list_item({
         group_id: group.id,
         name: user_groups.get_display_group_name(group.name),
-        group_edit_url: hash_util.group_edit_url(group, "general"),
         is_guest: current_user.is_guest,
         is_direct_member,
         subgroups_name: subgroups_name.join(", "),
@@ -1672,14 +1671,6 @@ export function initialize(): void {
         hide_user_profile();
         browser_history.go_to_location("#settings/profile");
     });
-
-    $("body").on(
-        "click",
-        "#user-profile-modal .user-profile-channel-row, .user-profile-group-row",
-        () => {
-            hide_user_profile();
-        },
-    );
 
     bot_helper.initialize_bot_click_handlers();
 

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -309,7 +309,6 @@ function format_user_stream_list_item_html(stream: StreamSubscription, user: Use
         show_unsubscribe_button,
         show_private_stream_unsub_tooltip,
         show_last_user_in_private_stream_unsub_tooltip,
-        stream_edit_url: hash_util.channels_settings_edit_url(stream, "general"),
     });
 }
 

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -519,13 +519,13 @@
     .stream-row {
         display: flex;
         justify-content: space-between;
-        padding: 0.3125em 0.625em;
+        padding: 0 0.625em;
         align-items: center;
         text-decoration: none;
         border-bottom: none;
         border-radius: 4px;
         color: var(--color-dropdown-item);
-        cursor: pointer;
+        cursor: default;
 
         .user-group-list-item,
         .stream-row-content {
@@ -551,12 +551,22 @@
             outline-offset: -2px;
         }
 
+        /* Reset pill styling so stream names look like plain text,
+           while still matching the .pill[data-stream-id] selector
+           for the stream card popover. */
+        .pill {
+            all: unset;
+        }
+
         .user-group-name,
         .stream-name {
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
-            padding-right: 2px;
+            /* Vertical padding replaces the row-level padding so
+               the clickable area covers the full row height. */
+            padding: 0.3125em 2px 0.3125em 0;
+            cursor: pointer;
         }
     }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1084,6 +1084,12 @@ input[type="checkbox"] {
     max-height: calc(95vh - 280px);
 }
 
+#admin-default-channels-list .pill {
+    &:hover {
+        background-color: var(--color-background-input-pill-hover);
+    }
+}
+
 .edit_bot_form {
     font-size: 100%;
     padding: 0;

--- a/web/templates/settings/admin_default_streams_list.hbs
+++ b/web/templates/settings/admin_default_streams_list.hbs
@@ -1,8 +1,22 @@
 {{#with stream}}
 <tr class="default_stream_row hidden-remove-button-row" data-stream-id="{{stream_id}}">
     <td>
-        {{#if invite_only}}<i class="fa fa-lock" aria-hidden="true"></i>{{/if}}
-        <span class="default_stream_name">{{name}}</span>
+        <span class="pill-container display_only_pill">
+            <span class="pill" data-stream-id="{{stream_id}}" tabindex="0">
+                <span class="pill-label">
+                    <span class="pill-value">
+                        {{~#if invite_only~}}
+                        <i class="zulip-icon zulip-icon-lock channel-privacy-type-icon" aria-hidden="true"></i>
+                        {{~else if is_web_public~}}
+                        <i class="zulip-icon zulip-icon-globe channel-privacy-type-icon" aria-hidden="true"></i>
+                        {{~else~}}
+                        <i class="zulip-icon zulip-icon-hashtag channel-privacy-type-icon" aria-hidden="true"></i>
+                        {{~/if~}}
+                        {{name}}
+                    </span>
+                </span>
+            </span>
+        </span>
     </td>
     {{#if ../can_modify}}
     <td class="actions">

--- a/web/templates/stream_list_item.hbs
+++ b/web/templates/stream_list_item.hbs
@@ -1,10 +1,10 @@
 <li class="stream-list-item" role="presentation" data-stream-id="{{stream_id}}">
-    <a class="stream-row hidden-remove-button-row" href="{{stream_edit_url}}">
+    <div class="stream-row hidden-remove-button-row">
         <span class="stream-row-content">
             <span class="stream-privacy-original-color-{{stream_id}} stream-privacy filter-icon" style="color: {{stream_color}}">
                 {{> stream_privacy . }}
             </span>
-            <span class="stream-name">{{name}}</span>
+            <span class="pill stream-name" data-stream-id="{{stream_id}}" tabindex="0">{{name}}</span>
         </span>
         <div class="remove-button-wrapper">
             {{#if show_unsubscribe_button}}
@@ -20,5 +20,5 @@
                 {{> components/icon_button  icon="close" custom_classes="hidden-remove-button remove-button tippy-zulip-delayed-tooltip" intent="danger" aria-label=(t "Remove channel") data-tippy-content=(t "Remove channel") }}
             {{/if}}
         </div>
-    </a>
+    </div>
 </li>

--- a/web/templates/user_group_list_item.hbs
+++ b/web/templates/user_group_list_item.hbs
@@ -1,6 +1,6 @@
 <li class="group-list-item" role="presentation" data-group-id="{{group_id}}">
-    <a class="user-profile-group-row hidden-remove-button-row" href="{{group_edit_url}}">
-        <span class="user-group-name">
+    <div class="user-profile-group-row hidden-remove-button-row">
+        <span class="view_user_group user-group-name" data-user-group-id="{{group_id}}" tabindex="0">
             {{name}}
         </span>
         {{#if can_remove_members }}
@@ -14,5 +14,5 @@
                 {{/if}}
             </div>
         {{/if}}
-    </a>
+    </div>
 </li>


### PR DESCRIPTION
# Claude's description

Fixes: #38196.                                                                                                                           
   
  Clicking a channel or group name in settings pages now shows a card                                                                      
  popover instead of navigating directly to settings. This applies to:

  - Channel names in Organization settings > Default channels
  - Channel names in user profile modal (Channels tab)
  - Channel names in the folder management modal
  - Group names in user profile modal (User groups tab)

  The stream card popover is globally registered on
  `.pill[data-stream-id]`, so the channel changes just add matching
  markup. For groups, the existing `.view_user_group` click handler
  is reused similarly.

  In the default channels list, channel names become styled pills
  (with privacy icons). In the user profile and folder modals, the
  names keep their plain-text appearance (pill styling is reset with
  `all: unset`) since the row layout is different.

  **Screenshots:**

<details><summary>Screenshots</summary>
<p>

<img width="1400" height="937" alt="step-6-user-profile-group-popover" src="https://github.com/user-attachments/assets/28af6a2c-ffbf-43e9-bf91-c228c132591b" />

<img width="1400" height="937" alt="step-4-user-profile-channel-popover" src="https://github.com/user-attachments/assets/28a22840-ea4b-46fe-b811-02a3fe64bc97" />
<img width="1400" height="937" alt="step-2-default-channels-popover" src="https://github.com/user-attachments/assets/e9ada0c1-6886-483d-a01a-63c4adc53fc0" />


</p>
</details> 

  ## Test plan
  - [x] `./tools/lint` on all changed files — passes
  - [x] `./tools/test-js-with-node` — passes (pre-existing unrelated failure in `folder_dropdown_widget.test.cjs`)
  - [x] Puppeteer visual test covering all 6 states above
  - [ ] Verify popover works in folder management modal
  - [ ] Check dark theme

  ## Self-review checklist
  - [x] Each commit is a minimal coherent idea
  - [x] All relevant tests pass locally
  - [x] Code follows existing patterns in the codebase
  - [x] Names are clear and greppable
  - [x] Commit messages explain why, not just what
  - [x] No debugging code or unnecessary comments remain
  - [x] User-facing strings are tagged for translation (no new strings)
  - [x] No secrets or credentials are hardcoded
  - [x] Security: no XSS — popover content is rendered by existing trusted handlers