### PR TITLE
[ai] CLAUDE.md: Clarify issue linking in multi-commit PRs.

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -176,6 +176,8 @@ Fixes #123.
 
 - `Fixes #123.` - Automatically closes the issue
 - `Fixes part of #123.` - Does not close (for partial fixes)
+- In a multi-commit PR, use `Fixes part of #123.` in earlier commits
+  and `Fixes #123.` in the final commit.
 - Never: `Partially fixes #123.` (GitHub ignores "partially")
 
 ### Rebasing Commits (Non-Interactive)


### PR DESCRIPTION
In a multi-commit PR, earlier commits should use "Fixes part of #123." while only the final commit uses "Fixes #123." to auto-close the issue at the right time.

