### PR TITLE
settings: Show privacy icons in 'Add default channels' dropdown.

### DIFF
--- a/web/src/settings_streams.ts
+++ b/web/src/settings_streams.ts
@@ -16,6 +16,7 @@ import * as scroll_util from "./scroll_util.ts";
 import * as settings_profile_fields from "./settings_profile_fields.ts";
 import {current_user} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
+import type {StreamSubscription} from "./sub_store";
 import * as sub_store from "./sub_store.ts";
 import * as ui_report from "./ui_report.ts";
 
@@ -46,11 +47,11 @@ function create_choice_row(): void {
     $container.append($(row_html));
 
     // List of non-default streams that are not yet selected.
-    function get_options(): {name: string; unique_id: number}[] {
+    function get_options(): {name: string; unique_id: number; stream: StreamSubscription}[] {
         const chosen_default_streams = get_chosen_default_streams();
 
         return stream_data
-            .get_non_default_stream_names()
+            .get_default_stream_options()
             .filter((e) => !chosen_default_streams.has(e.unique_id));
     }
 

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -337,16 +337,20 @@ export function delete_sub(stream_id: number): void {
     stream_info.delete(stream_id);
 }
 
-export function get_non_default_stream_names(): {name: string; unique_id: number}[] {
+export function get_default_stream_options(): {
+    name: string;
+    unique_id: number;
+    stream: StreamSubscription;
+}[] {
     let subs = [...stream_info.values()];
     subs = subs.filter(
         (sub) => !is_default_stream_id(sub.stream_id) && !sub.invite_only && !sub.is_archived,
     );
-    const names = subs.map((sub) => ({
+    return subs.map((sub) => ({
         name: sub.name,
         unique_id: sub.stream_id,
+        stream: sub,
     }));
-    return names;
 }
 
 export function get_unsorted_subs(): StreamSubscription[] {

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -944,8 +944,8 @@ test("default_stream_names", () => {
     stream_data.add_sub_for_tests(private_stream);
     stream_data.add_sub_for_tests(general);
 
-    const names = stream_data.get_non_default_stream_names();
-    assert.deepEqual(names, [{name: "public", unique_id: 102}]);
+    const names = stream_data.get_default_stream_options();
+    assert.deepEqual(names, [{name: "public", stream: public_stream, unique_id: 102}]);
 
     const default_stream_ids = stream_data.get_default_stream_ids();
     assert.deepEqual(default_stream_ids.toSorted(), [announce.stream_id, general.stream_id]);


### PR DESCRIPTION
Previously, the "Add default channels" dropdown only showed channel names without their privacy status. 

This PR updates the `get_options` function in `settings_streams.ts` to fetch and pass the full stream object to the DropdownWidget. This allows the widget DropdownWidget to automatically render the appropriate privacy icons (lock, hash, or globe) in the "Add default channels" modal

Fixes: #38202

**How changes were tested:**

Ran ./tools/test-js-with-node stream_data settings_data and confirmed all relevant tests pass.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Before:
<img width="621" height="346" alt="image" src="https://github.com/user-attachments/assets/d0815dca-1654-44e3-a134-5a0c92e61082" />
After:
<img width="742" height="335" alt="image" src="https://github.com/user-attachments/assets/e8b80c47-0bc4-4af8-92eb-a32c2cdc1874" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
