### PR TITLE
compose_reply: Fix forward message generating invalid topic link.

### DIFF
--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -326,6 +326,7 @@ export function quote_message(opts: {
             const topic_link_syntax = topic_link_util.get_stream_topic_link_syntax(
                 channel_name,
                 message.topic,
+                true,
             );
             // Final message looks like:
             //     @_**Iago|5** [said](link to message) in [#channel > topic](link to topic):

--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -126,6 +126,7 @@ export function get_fallback_markdown_link(
     stream_name: string,
     topic_name?: string,
     message_id?: string,
+    only_link_syntax = false,
 ): string {
     // Helper that should only be called by other methods in this file.
 
@@ -137,17 +138,23 @@ export function get_fallback_markdown_link(
         topic_name,
         message_id,
     });
-    return as_markdown_link_syntax(label_text_markdown, url);
+    return only_link_syntax
+        ? label_text_markdown
+        : as_markdown_link_syntax(label_text_markdown, url);
 }
 
-export function get_stream_topic_link_syntax(stream_name: string, topic_name: string): string {
-    // If the topic name is such that it will generate an invalid #**stream>topic** syntax,
-    // we revert to generating the normal markdown syntax for a link.
+export function get_stream_topic_link_syntax(
+    stream_name: string,
+    topic_name: string,
+    only_link_syntax = false,
+): string {
+    // If the topic/stream name would produce an invalid #**stream>topic** syntax, fall back
+    // to markdown link syntax. If only_link_syntax is true, only the link label is returned.
     if (
         will_produce_broken_stream_topic_link(topic_name) ||
         will_produce_broken_stream_topic_link(stream_name)
     ) {
-        return get_fallback_markdown_link(stream_name, topic_name);
+        return get_fallback_markdown_link(stream_name, topic_name, undefined, only_link_syntax);
     }
     return `#**${stream_name}>${topic_name}**`;
 }

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -20,6 +20,8 @@ const $ = require("./lib/zjquery.cjs");
 const {set_current_user} = zrequire("state_data");
 const user_groups = zrequire("user_groups");
 const {initialize_user_settings} = zrequire("user_settings");
+const {will_produce_broken_stream_topic_link} = zrequire("topic_link_util");
+
 initialize_user_settings({
     user_settings: {
         default_language: "en",
@@ -879,6 +881,43 @@ test("quote_message", ({disallow, override, override_rewire}) => {
         message_id: selected_message.id,
         forward_message: true,
     };
+    replaced = false;
+    override(message_lists.current, "get", (id) =>
+        id === selected_message.id ? selected_message : undefined,
+    );
+    quote_message(opts);
+    assert.ok(replaced);
+
+    const topic_with_invalid_characters = "[zulip/zulip>topic]";
+    assert.ok(will_produce_broken_stream_topic_link(topic_with_invalid_characters));
+
+    selected_message = {
+        type: "stream",
+        stream_id: denmark_stream.stream_id,
+        topic: topic_with_invalid_characters,
+        sender_full_name: steve.full_name,
+        sender_id: steve.user_id,
+        raw_content: "test invalid topic",
+        id: 11,
+    };
+    opts = {
+        reply_type: "personal",
+        forward_message: true,
+        message_id: selected_message.id,
+    };
+
+    const html_entity_encoded_topic_name = "&#91;zulip/zulip&gt;topic&#93;";
+    const url_encoded_topic_name = ".5Bzulip.2Fzulip.3Etopic.5D";
+
+    const near_url = `http://zulip.zulipdev.com/#narrow/channel/${selected_message.stream_id}-${channel_object.name}/topic/${url_encoded_topic_name}/near/${selected_message.id}`;
+    const with_url = `#narrow/channel/${selected_message.stream_id}-${channel_object.name}/topic/${url_encoded_topic_name}/with/${selected_message.id}`;
+    const topic_link_syntax = `[#${channel_object.name} > ${html_entity_encoded_topic_name}](${with_url})`;
+
+    const fence = "```";
+    expected_replacement = `translated: @_**${selected_message.sender_full_name}|${selected_message.sender_id}** [said](${near_url}) in ${topic_link_syntax}:
+${fence}quote
+${selected_message.raw_content}
+${fence}`;
     replaced = false;
     override(message_lists.current, "get", (id) =>
         id === selected_message.id ? selected_message : undefined,


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: [#issues > 🎯 topic &#91;&#93;s mess up link formatting in forwarded message](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20topic.20.5B.5Ds.20mess.20up.20link.20formatting.20in.20forwarded.20message/with/2392506)

**How changes were tested:**
 
- Invalid topic:

  | Before | After |
  |--------|--------|
  | <img width="1085" height="146" alt="image" src="https://github.com/user-attachments/assets/ce2376ef-2e6b-4247-92d8-2a12d198cf5a" />| <img width="1085" height="121" alt="image" src="https://github.com/user-attachments/assets/fc059f31-cc15-4c12-bf92-63b662f5a5a9" />|

- Invalid channel:

  | Before | After |
  |--------|--------|
  | <img width="1085" height="205" alt="image" src="https://github.com/user-attachments/assets/e9b18819-116f-4568-9d89-f0d5aef11928" />| <img width="1085" height="210" alt="image" src="https://github.com/user-attachments/assets/ca24b87d-c866-4d87-a3f4-8da8a5428942" />|

- Invalid topic and channel:

  | Before | After |
  |--------|--------|
  | <img width="1085" height="116" alt="image" src="https://github.com/user-attachments/assets/6ba29485-bec7-4955-a7dd-087b3964300e" />| <img width="1085" height="86" alt="image" src="https://github.com/user-attachments/assets/9f7cb4d6-aba5-4d4e-a51b-da2aa193fc86" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
