### PR TITLE
[ai] stream_list: Rebuild topic widget before show-more-topics zoom.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -68,14 +68,20 @@ export function is_zoomed_in(): boolean {
     return zoomed_in;
 }
 
-function zoom_in(): void {
-    zoomed_in = true;
-    const stream_id = topic_list.active_stream_id();
+function zoom_in(stream_id?: number, $stream_li?: JQuery): void {
+    stream_id ??= topic_list.active_stream_id();
     assert(stream_id !== undefined);
 
+    $stream_li ??= get_stream_li(stream_id);
+    assert($stream_li !== undefined);
+
+    zoomed_in = true;
     popovers.hide_all();
     pm_list.close();
-    topic_list.zoom_in();
+    // topic_list.zoom_in requires an active widget for this stream, but
+    // sidebar rerenders can clear topic widgets before we reach this path.
+    topic_list.rebuild_left_sidebar($stream_li, stream_id);
+    topic_list.zoom_in(stream_id);
     zoom_in_topics(stream_id);
 }
 
@@ -1179,7 +1185,9 @@ export function handle_narrow_activated(
     const $stream_li = update_stream_sidebar_for_narrow(filter);
     if ($stream_li && !change_hash) {
         if (!is_zoomed_in() && show_more_topics) {
-            zoom_in();
+            const info = get_sidebar_stream_topic_info(filter);
+            assert(info.stream_id !== undefined);
+            zoom_in(info.stream_id, $stream_li);
         } else if (is_zoomed_in() && !show_more_topics) {
             zoom_out();
         }
@@ -1215,7 +1223,9 @@ export function initialize({
     set_event_handlers({show_channel_feed});
 
     $("#stream_filters").on("click", ".show-more-topics", (e) => {
-        zoom_in();
+        const $stream_li = $(e.target).parents("li.narrow-filter");
+        const stream_id = stream_id_for_elt($stream_li);
+        zoom_in(stream_id, $stream_li);
         // We define the focus behavior for the topic list search box
         // outside of the `zoom_in` method, since we want the focus
         // to only happen when the user clicks on the "SHOW ALL TOPICS"

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -493,23 +493,17 @@ export function left_sidebar_scroll_zoomed_in_topic_into_view(): void {
 
 // For zooming, we only do topic-list stuff here...let stream_list
 // handle hiding/showing the non-narrowed streams
-export function zoom_in(): void {
+export function zoom_in(stream_id: number): void {
     zoomed = true;
     previous_search_term = "";
     pre_search_scroll_position = 0;
     ui_util.disable_left_sidebar_search();
 
-    const stream_id = active_stream_id();
-    if (stream_id === undefined) {
-        blueslip.error("Cannot find widget for topic history zooming.");
-        return;
-    }
-
     const active_widget = active_widgets.get(stream_id);
     assert(active_widget !== undefined);
 
     function on_success(): void {
-        if (!active_widgets.has(stream_id!)) {
+        if (!active_widgets.has(stream_id)) {
             blueslip.warn("User re-narrowed before topic history was returned.");
             return;
         }

--- a/web/tests/stream_list.test.cjs
+++ b/web/tests/stream_list.test.cjs
@@ -730,3 +730,44 @@ test_ui("create_initial_sidebar_rows", ({override, override_rewire, mock_templat
     assert.equal(html_dict.get(1000), "<div>stub-html-devel");
     assert.equal(html_dict.get(5000), "<div>stub-html-Denmark");
 });
+
+test_ui("narrowing show_more_topics rebuilds after clear_topics", ({override_rewire}) => {
+    const calls = [];
+    let active_stream = carSub.stream_id;
+    topic_list.close = () => {
+        calls.push("close");
+        active_stream = undefined;
+    };
+    topic_list.rebuild_left_sidebar = (_$stream_li, stream_id) => {
+        calls.push(`rebuild:${stream_id}`);
+        active_stream = stream_id;
+    };
+    topic_list.setup_topic_search_typeahead = noop;
+    topic_list.active_stream_id = () => active_stream;
+    topic_list.zoom_out = noop;
+    override_rewire(stream_list, "scroll_stream_into_view", noop);
+    override_rewire(stream_list, "update_stream_section_mention_indicators", noop);
+    override_rewire(stream_list, "update_dom_with_unread_counts", noop);
+    override_rewire(stream_list, "get_section_id_for_stream_li", () => "normal");
+    override_rewire(stream_list, "maybe_hide_topic_bracket", noop);
+    override_rewire(left_sidebar_navigation_area, "update_dom_with_unread_counts", noop);
+    override_rewire(stream_list, "set_sections_states", noop);
+    $(".filter-topics").remove = noop;
+    $.create("#stream_filters li.narrow-filter", {children: []});
+    initialize_stream_data();
+    stream_list.build_stream_list(true);
+    calls.length = 0;
+
+    topic_list.zoom_in = (stream_id) => {
+        calls.push(`zoom:${stream_id}`);
+    };
+
+    const filter = new Filter([{operator: "channel", operand: develSub.stream_id.toString()}]);
+    stream_list.handle_narrow_activated(filter, false, true);
+    assert.deepEqual(calls, [
+        "close",
+        `rebuild:${develSub.stream_id}`,
+        `rebuild:${develSub.stream_id}`,
+        `zoom:${develSub.stream_id}`,
+    ]);
+});


### PR DESCRIPTION
A sidebar rerender can clear topic widgets before the show-more-topics zoom path reaches stream_list.zoom_in. In that state, zoom_in called topic_list.active_stream_id(), which returned undefined and triggered an assertion failure matching the Sentry report.

Fix this by having zoom_in accept explicit stream context, rebuilding the target stream's topic widget before calling topic_list.zoom_in. Both the narrow-activation path and the click handler now pass the stream_id and $stream_li directly.


<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**
I could not reproduce the issue locally so this was run before and after the change.

``` Typescript

test_ui("narrowing show_more_topics can assert with cleared topics", ({override_rewire}) => {
    topic_list.close = noop;
    topic_list.rebuild_left_sidebar = noop;
    topic_list.active_stream_id = () => undefined;
    override_rewire(stream_list, "scroll_stream_into_view", noop);
    override_rewire(stream_list, "update_stream_section_mention_indicators", noop);
    override_rewire(stream_list, "update_dom_with_unread_counts", noop);
    override_rewire(stream_list, "get_section_id_for_stream_li", () => "normal");
    override_rewire(stream_list, "maybe_hide_topic_bracket", noop);
    override_rewire(left_sidebar_navigation_area, "update_dom_with_unread_counts", noop);
    override_rewire(stream_list, "set_sections_states", noop);
    $(".filter-topics").remove = noop;
    $.create("#stream_filters li.narrow-filter", {children: []});

    initialize_stream_data();
    stream_list.build_stream_list(true);

    const filter = new Filter([{operator: "stream", operand: develSub.stream_id.toString()}]);
    assert.throws(() => {
        stream_list.handle_narrow_activated(filter, false, true);
    }, /Assertion failed/);
    stream_list.clear_topics();
});
```

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
