### PR TITLE
delete_old_unclaimed_attachments: Add necessary atomic() block.

### DIFF
--- a/zerver/actions/uploads.py
+++ b/zerver/actions/uploads.py
@@ -92,14 +92,20 @@ def do_delete_old_unclaimed_attachments(weeks_ago: int) -> None:
     )
 
     with delete_message_attachments(delete_from=(ImageAttachment, Attachment)) as delete_one:
-        for path_id in old_unclaimed_attachments.values_list("path_id", flat=True).iterator():
+        for path_id in (
+            old_unclaimed_attachments.values_list("path_id", flat=True)
+            .select_for_update(of=("self",))
+            .iterator()
+        ):
             delete_one(path_id)
     with delete_message_attachments(
         delete_from=(ImageAttachment, ArchivedAttachment)
     ) as delete_one:
-        for path_id in old_unclaimed_archived_attachments.values_list(
-            "path_id", flat=True
-        ).iterator():
+        for path_id in (
+            old_unclaimed_archived_attachments.values_list("path_id", flat=True)
+            .select_for_update(of=("self",))
+            .iterator()
+        ):
             delete_one(path_id)
 
 

--- a/zerver/lib/attachments.py
+++ b/zerver/lib/attachments.py
@@ -235,7 +235,6 @@ def get_old_unclaimed_attachments(
             has_other_messages=False,
         )
         .order_by("id")
-        .select_for_update(of=("self",))
     )
     old_archived_attachments = (
         ArchivedAttachment.objects.alias(
@@ -251,7 +250,6 @@ def get_old_unclaimed_attachments(
             has_other_messages=False,
         )
         .order_by("id")
-        .select_for_update(of=("self",))
     )
 
     return old_attachments, old_archived_attachments


### PR DESCRIPTION
`get_old_unclaimed_attachments` needs to be called in a transaction, given that it calls `select_for_update()` as of
c22adaa12671a67e4db6953563a3327bb29173b3.

