### PR TITLE
analytics-tests: Clean up create user helper in test_counts.

### DIFF
--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -126,12 +126,7 @@ class AnalyticsTestCase(ZulipTestCase):
         }
         for key, value in defaults.items():
             kwargs[key] = kwargs.get(key, value)
-        kwargs["delivery_email"] = kwargs["email"]
         with time_machine.travel(kwargs["date_joined"], tick=False):
-            pass_kwargs: dict[str, Any] = {}
-            if kwargs["is_bot"]:
-                pass_kwargs["bot_type"] = UserProfile.DEFAULT_BOT
-                pass_kwargs["bot_owner"] = None
             user = create_user(
                 kwargs["email"],
                 "password",
@@ -139,7 +134,7 @@ class AnalyticsTestCase(ZulipTestCase):
                 active=kwargs["is_active"],
                 full_name=kwargs["full_name"],
                 role=UserProfile.ROLE_REALM_ADMINISTRATOR,
-                **pass_kwargs,
+                bot_type=UserProfile.DEFAULT_BOT if kwargs["is_bot"] else None,
             )
             if not skip_auditlog:
                 RealmAuditLog.objects.create(


### PR DESCRIPTION
**Notes**:
- Since commit a352f2e10, the "delivery_email" field that's set here hasn't been used.
- The default value for bot_owner is None, so we don't need to set that here, and we can set the bot_type field directly as a param to create_user.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
