### PR TITLE
docs: Restore lost link references on "reviewable prs" page.

### DIFF
--- a/docs/contributing/reviewable-prs.md
+++ b/docs/contributing/reviewable-prs.md
@@ -116,6 +116,10 @@ Once you've created a pull request on GitHub, you can use one of the [custom
 linkifiers][dev-community-linkifiers] in the development community to easily
 link to your pull request from the relevant conversation.
 
+[zulip-dev-community]: https://chat.zulip.org
+[link-to-message]: https://zulip.com/help/link-to-a-message-or-conversation#get-a-link-to-a-specific-message
+[dev-community-linkifiers]: https://zulip.com/development-community/#linking-to-github-issues-and-pull-requests
+
 ## Review your own work
 
 Before requesting a review for your pull request, follow our [review


### PR DESCRIPTION
It seems that the "reviewable prs" documentation has been revised and revised, each time taking [this section](https://zulip.readthedocs.io/en/latest/contributing/reviewable-prs.html#discussions-in-the-development-community) further from its link references, until finally (in ae316717687f2ddc2695e2296087653da657a307) these apparently lonely & dangling link references were removed, breaking the rendered markdown.

This PR adds them back to repair the docs, bundling them in the same subheading as the text (as appears to be the style) so as to reduce the likelihood that they'll get accidentally axed again. :)

Fixes: a problem of my own design :sweat_smile: 

**How changes were tested:**

I have yet to run `./tools/build-docs` locally, but I have tested the changes in the github markdown preview (it seemed suitable for such a simple change). I will update this PR if/as I build the docs locally and test them there.

**Screenshots and screen captures:**

[CURRENT DOC](https://zulip.readthedocs.io/en/latest/contributing/reviewable-prs.html#discussions-in-the-development-community)
[`reviewable-prs.md` on the commit previous this one](https://github.com/zulip/zulip/blob/75a23b3df4d87e8e38c9366fa49b07524e679b94/docs/contributing/reviewable-prs.md#discussions-in-the-development-community) (in an effort to support my case that viewing the github markdown preview is a reasonable way to test this PR)

<img width="958" height="916" alt="screenshot of github markdown preview of docs in this PR showing real links, not broken markdown" src="https://github.com/user-attachments/assets/6bb66052-b5fd-4361-87ae-3cf530c3ba3b" />


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

It seemed prudent to suggest this documentation change quickly, as an especially large number of people may be reading the "Submitting a Pull Request" documentation right now. I realize that by submitting a PR without having claimed an existing issue & been added as a collaborator to the repository I risk being perceived as someone who is trying to play a numbers game or otherwise make largely low-effort contributions; I welcome those perceptions of me as long as they result in an improvement to the docs. :')