### PR TITLE
api_docs: Document POST /bots/{bot_id}/api_key/regenerate.

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -118,6 +118,7 @@
 * [Remove alert words](/api/remove-alert-words)
 * [Regenerate your API key](/api/regenerate-api-key)
 * [Get a bot's API key](/api/get-bot-api-key)
+* [Regenerate a bot's API key](/api/regenerate-bot-api-key)
 
 #### Invitations
 

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -447,3 +447,10 @@ def regenerate_api_key_test_user() -> dict[str, object]:
     # Change authentication line to allow test_client to regenerate its own key.
     AUTHENTICATION_LINE[0] = f"{test_user.email}:{test_user_api_key}"
     return {}
+
+
+@openapi_param_value_generator(["/bots/{bot_id}/api_key/regenerate:post"])
+def regenerate_bot_api_key_test() -> dict[str, object]:
+    bot = UserProfile.objects.filter(is_bot=True, realm=get_realm("zulip")).first()
+    assert bot is not None
+    return {"bot_id": bot.id}

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -25519,6 +25519,55 @@ paths:
                       }
                     description: |
                       An example JSON response when the bot ID is invalid:
+  /bots/{bot_id}/api_key/regenerate:
+    post:
+      operationId: regenerate-bot-api-key
+      summary: Regenerate a bot's API key
+      tags: ["users"]
+      description: |
+        Generate a new API key for a bot user. Only the bot's owner and
+        organization administrators have access to a bot's API key.
+      parameters:
+        - $ref: "#/components/parameters/BotId"
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      api_key:
+                        type: string
+                        description: |
+                          The new API key for the bot.
+                    example:
+                      {
+                        "msg": "",
+                        "result": "success",
+                        "api_key": "hkA04ZYcqXKalvYMA8OeXSfzUOLrtbZv",
+                      }
+
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - example:
+                      {
+                        "code": "BAD_REQUEST",
+                        "msg": "No such bot",
+                        "result": "error",
+                      }
+                    description: |
+                      An example JSON response when the bot ID is invalid:
   /real-time:
     # This entry is a hack; it exists to give us a place to put the text
     # documenting the parameters for call_on_each_event and friends.

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -240,7 +240,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/realm/domains/{domain}",
         "/bots",
         "/bots/{bot_id}",
-        "/bots/{bot_id}/api_key/regenerate",
         #### These "organization settings" endpoints have low value to document:
         "/realm/profile_fields/{field_id}",
         "/realm/icon",


### PR DESCRIPTION
This PR adds the missing documentation for the `POST /bots/{bot_id}/api_key/regenerate` endpoint and removes it from the pending endpoints list.

**Changes included:**
* **OpenAPI Schema:** Added the endpoint definition to `zerver/openapi/zulip.yaml`. It uses the `$ref` for `BotId` and includes both `200 Success` and `400 Bad Request` responses to perfectly match the structure of the existing `GET` bot API key endpoint.
* **cURL Test Generator:** Added a new Python parameter generator (`regenerate_bot_api_key_test`) in `zerver/openapi/curl_param_value_generators.py` to fetch a valid bot ID for the automated test suite.
* **Docs & Sidebar:** Added the endpoint to `api_docs/include/rest-endpoints.md` under the Users section.
* **Pending Tests:** Removed the endpoint from the `pending_endpoints` list in `zerver/tests/test_openapi.py`.

Fixes: Part of the ongoing effort to document all pending API endpoints in `zerver/tests/test_openapi.py`.

**How changes were tested:**
* Ran `tools/test-api` locally to verify the new cURL generator works and passes.
* Ran `tools/lint` locally to verify Python formatting and typing (passed).
* Ran `tools/check-openapi.ts` (Passed)
* Ran `tools/test-backend zerver/tests/test_openapi.py` (Passed)
* Checked the local development server (`tools/run-dev`) and manually verified the endpoint's visual rendering at `http://localhost:9991/api/regenerate-bot-api-key`, confirming both the 200 and 400 JSON responses and the dynamically generated cURL examples display correctly.

---

**Screenshots and screen captures:**

Sidebar showing the new "Regenerate a bot's API key" link:

<img width="233" height="150" alt="image" src="https://github.com/user-attachments/assets/53ec12df-4262-4002-9ab4-90bde491e03b" />


Rendered Documentation page:

<img width="1512" height="2320" alt="Screenshot From 2026-03-03 13-36-01" src="https://github.com/user-attachments/assets/be8597e7-6154-4a0f-8bd4-aeb9c1859179" />

---

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>