### PR TITLE
[ai] recent_view: Fix filter borders clipped at fractional zoom levels.

### DIFF
--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -177,6 +177,13 @@
     #recent-view-search-wrapper {
         flex-grow: 1;
         margin-bottom: var(--recent-topics-filters-gap);
+        /* Prevent the search input outline from being clipped
+           by the overflow:hidden ancestor at fractional browser
+           zoom levels. Applied on both sides because this
+           element can wrap to its own line at narrow widths.
+           2px because 1px can round to 0 device pixels at
+           certain fractional zoom levels (e.g., 80%). */
+        margin-inline: 2px;
     }
 
     .button-recent-filters {
@@ -655,6 +662,11 @@
 #recent-view-filter_widget {
     display: inline-flex;
     width: 10.7142em; /* 150px at 14px em */
+    /* Prevent the outline from being clipped by the
+       overflow:hidden ancestor at fractional browser
+       zoom levels. 2px because 1px can round to 0
+       device pixels at certain zoom levels (e.g., 80%). */
+    margin-left: 2px;
     /* 1.5px 6px at 16px/1em */
     padding: 0 0.375em;
     /* Matching to the height of the filter search box. */


### PR DESCRIPTION
At fractional browser zoom levels (e.g., 80%), the filter dropdown's left border and the search input's right border in Recent Conversations were clipped. This happened because their outlines sat exactly at the edge of the overflow:hidden ancestor, leaving no room for subpixel rounding.

Add a 2px margin to the filter dropdown widget (left side) and the search input wrapper (both sides, since it can wrap to its own line at narrow widths) to prevent clipping.

discussion: [#issues > Filter boxes cut off atop Recent conversations](https://chat.zulip.org/#narrow/channel/9-issues/topic/Filter.20boxes.20cut.20off.20atop.20Recent.20conversations/with/2393630)

| before | after |
| --- | --- |
| <img width="2185" height="443" alt="Screenshot from 2026-02-28 12-51-58" src="https://github.com/user-attachments/assets/abf24616-feea-4bef-8585-dbd8dafd9016" /> |  <img width="2185" height="443" alt="Screenshot from 2026-02-28 12-51-46" src="https://github.com/user-attachments/assets/0e2696fa-4616-4123-8f3e-2908a8eaca70" /> |
