### PR TITLE
Left-sidebar: Keep 'Back to channels' button visible when scrolling

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -2291,6 +2291,20 @@ li.topic-list-item {
 }
 
 .zoom-in {
+    #topics_header {
+        display: grid !important;
+        top: calc(
+            var(--line-height-sidebar-row-prominent) + 1px + 2 *
+                var(--left-sidebar-direct-messages-bottom-divider-padding)
+        );
+    }
+
+    .direct-message-section-bottom-divider-container {
+        min-height: calc(
+            1px + 2 * var(--left-sidebar-direct-messages-bottom-divider-padding)
+        );
+    }
+
     .narrow-filter.hide {
         display: none;
     }
@@ -2303,7 +2317,9 @@ li.topic-list-item {
            variables for setting the space on the BACK TO CHANNELS
            grid row plus its top padding: */
         top: calc(
-            var(--line-height-sidebar-row-prominent) +
+            var(--line-height-sidebar-row-prominent) + 1px + 2 *
+                var(--left-sidebar-direct-messages-bottom-divider-padding) +
+                var(--line-height-sidebar-row-prominent) +
                 var(--left-sidebar-sections-vertical-gutter)
         );
         z-index: 2;


### PR DESCRIPTION
When viewing all topics in a channel (zoom-in view), the 'Back to channels' button now remains sticky at the top of the sidebar when scrolling through the topic list.

This ensures users can always navigate back without scrolling to the top first.

Fixes: https://chat.zulip.org/#narrow/channel/9-issues/topic/.22Back.20to.20channels.22.20button.20disappears.20when.20viewing.20all.20topics/with/2389524

**How changes were tested:**

Tested manually by:
1. Navigating to Browse channels in left sidebar
2. Selecting a channel with many topics (#design)
3. Clicking "Show all topics" at bottom
4. Scrolling down through the topic list
5. Verified "Back to channels" button remains visible at top

**Screenshots and screen captures:**

Before scrolling :
<img width="421" height="576" alt="image" src="https://github.com/user-attachments/assets/3fb47ea9-0a04-4662-8ba8-455d50e83e44" />

After scrolling down :
<img width="407" height="635" alt="image" src="https://github.com/user-attachments/assets/8a2eedf7-9b47-44c7-9401-883e8728c776" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
