### PR TITLE
bots: Add integration_name field to incoming webhook bots.

### DIFF
--- a/api_docs/unmerged.d/ZF-75c8e1.md
+++ b/api_docs/unmerged.d/ZF-75c8e1.md
@@ -1,3 +1,6 @@
 * `POST /bots` now requires the `service_name` parameter when `bot_type` is 2
   (incoming webhook bot). The value must match the name of an existing webhook
   integration.
+* [`GET /events`](/api/get-events), [`POST /register`](/api/register-queue):
+  Bot objects for incoming webhook bots now include an `integration_name`
+  field in `services`.

--- a/api_docs/unmerged.d/ZF-75c8e1.md
+++ b/api_docs/unmerged.d/ZF-75c8e1.md
@@ -1,0 +1,3 @@
+* `POST /bots` now requires the `service_name` parameter when `bot_type` is 2
+  (incoming webhook bot). The value must match the name of an existing webhook
+  integration.

--- a/web/src/bot_type_values.ts
+++ b/web/src/bot_type_values.ts
@@ -4,5 +4,6 @@ export const INCOMING_WEBHOOK_BOT_TYPE_INT = 2;
 export const OUTGOING_WEBHOOK_BOT_TYPE_INT = 3;
 
 // String forms used as HTML form values.
+export const INCOMING_WEBHOOK_BOT_TYPE = "2";
 export const OUTGOING_WEBHOOK_BOT_TYPE = "3";
 export const EMBEDDED_BOT_TYPE = "4";

--- a/web/src/bot_type_values.ts
+++ b/web/src/bot_type_values.ts
@@ -5,5 +5,6 @@ export const OUTGOING_WEBHOOK_BOT_TYPE_INT = 3;
 
 // String forms used as HTML form values.
 export const GENERIC_BOT_TYPE = "1";
+export const INCOMING_WEBHOOK_BOT_TYPE = "2";
 export const OUTGOING_WEBHOOK_BOT_TYPE = "3";
 export const EMBEDDED_BOT_TYPE = "4";

--- a/web/src/bot_types.ts
+++ b/web/src/bot_types.ts
@@ -18,9 +18,14 @@ const embedded_service_schema = z.object({
     service_name: z.string(),
 });
 
+const incoming_service_schema = z.object({
+    integration_name: z.string(),
+});
+
 export const services_schema = z.union([
     z.array(outgoing_service_schema),
     z.array(embedded_service_schema),
+    z.array(incoming_service_schema),
 ]);
 
 export const update_bot_schema = z.object({

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -45,6 +45,16 @@ const PresetUrlOption = {
     CHANNEL_MAPPING: "mapping",
 };
 
+export function get_options_for_integration_input_dropdown_widget(): Option[] {
+    const options = realm.realm_incoming_webhook_bots
+        .toSorted((a, b) => util.strcmp(a.display_name, b.display_name))
+        .map((bot) => ({
+            name: bot.display_name,
+            unique_id: bot.name,
+        }));
+    return options;
+}
+
 export function show_generate_integration_url_modal(api_key: string): void {
     const default_url_message = $t_html({defaultMessage: "Integration URL will appear here."});
     const streams = stream_data.subscribed_subs();
@@ -390,16 +400,6 @@ export function show_generate_integration_url_modal(api_key: string): void {
             unique_id_type: "string",
         });
         integration_input_dropdown_widget.setup();
-
-        function get_options_for_integration_input_dropdown_widget(): Option[] {
-            const options = realm.realm_incoming_webhook_bots
-                .toSorted((a, b) => util.strcmp(a.display_name, b.display_name))
-                .map((bot) => ({
-                    name: bot.display_name,
-                    unique_id: bot.name,
-                }));
-            return options;
-        }
 
         function integration_item_click_callback(
             event: JQuery.ClickEvent,

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -1,5 +1,6 @@
 import ClipboardJS from "clipboard";
 import $ from "jquery";
+import assert from "minimalistic-assert";
 import type * as tippy from "tippy.js";
 import * as z from "zod/mini";
 
@@ -9,6 +10,7 @@ import render_generate_integration_url_filter_branches_modal from "../templates/
 import render_generate_integration_url_modal from "../templates/settings/generate_integration_url_modal.hbs";
 import render_integration_events from "../templates/settings/integration_events.hbs";
 
+import * as bot_data from "./bot_data.ts";
 import {show_copied_confirmation} from "./copied_tooltip.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
@@ -55,7 +57,7 @@ export function get_options_for_integration_input_dropdown_widget(): Option[] {
     return options;
 }
 
-export function show_generate_integration_url_modal(api_key: string): void {
+export function show_generate_integration_url_modal(api_key: string, bot_id: number): void {
     const default_url_message = $t_html({defaultMessage: "Integration URL will appear here."});
     const streams = stream_data.subscribed_subs();
     const direct_messages_option = {
@@ -72,6 +74,11 @@ export function show_generate_integration_url_modal(api_key: string): void {
         max_topic_length: realm.max_topic_length,
         empty_string_topic_display_name: util.get_final_topic_display_name(""),
     });
+
+    const services = bot_data.get_services(bot_id);
+    const service = services?.[0];
+    assert(service !== undefined && "integration_name" in service);
+    const saved_integration = service.integration_name;
 
     const topics_named_after_slack_channels_option: Option = {
         name: $t_html({defaultMessage: "Topics named after Slack channels"}),
@@ -393,7 +400,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
             get_options: get_options_for_integration_input_dropdown_widget,
             item_click_callback: integration_item_click_callback,
             $events_container: $("#generate-integration-url-modal"),
-            default_id: "",
+            default_id: saved_integration,
             text_if_current_value_not_in_options: $t_html({
                 defaultMessage: "Select an integration",
             }),
@@ -590,6 +597,16 @@ export function show_generate_integration_url_modal(api_key: string): void {
             stream_input_dropdown_widget.render(direct_messages_option.unique_id);
             $config_container.empty();
             branch_pill_widget = undefined;
+        }
+
+        if (saved_integration) {
+            const saved_integration_data = realm.realm_incoming_webhook_bots.find(
+                (bot) => bot.name === saved_integration,
+            );
+            update_url();
+            if (saved_integration_data?.url_options) {
+                render_url_options(saved_integration_data.url_options);
+            }
         }
     }
 

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -1,5 +1,6 @@
 import ClipboardJS from "clipboard";
 import {$} from "jquery";
+import assert from "minimalistic-assert";
 import type * as tippy from "tippy.js";
 import * as z from "zod/mini";
 
@@ -9,6 +10,7 @@ import render_generate_integration_url_filter_branches_modal from "../templates/
 import render_generate_integration_url_modal from "../templates/settings/generate_integration_url_modal.hbs";
 import render_integration_events from "../templates/settings/integration_events.hbs";
 
+import * as bot_data from "./bot_data.ts";
 import {show_copied_confirmation} from "./copied_tooltip.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
@@ -55,7 +57,7 @@ export function get_options_for_integration_input_dropdown_widget(): Option[] {
     return options;
 }
 
-export function show_generate_integration_url_modal(api_key: string): void {
+export function show_generate_integration_url_modal(api_key: string, bot_id: number): void {
     const default_url_message = $t_html({defaultMessage: "Integration URL will appear here."});
     const streams = stream_data.subscribed_subs();
     const direct_messages_option = {
@@ -72,6 +74,11 @@ export function show_generate_integration_url_modal(api_key: string): void {
         max_topic_length: realm.max_topic_length,
         empty_string_topic_display_name: util.get_final_topic_display_name(""),
     });
+
+    const services = bot_data.get_services(bot_id);
+    const service = services?.[0];
+    assert(service !== undefined && "integration_name" in service);
+    const saved_integration = service.integration_name;
 
     const topics_named_after_slack_channels_option: Option = {
         name: $t_html({defaultMessage: "Topics named after Slack channels"}),
@@ -393,7 +400,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
             get_options: get_options_for_integration_input_dropdown_widget,
             item_click_callback: integration_item_click_callback,
             $events_container: $("#generate-integration-url-modal"),
-            default_id: "",
+            default_id: saved_integration,
             text_if_current_value_not_in_options: $t_html({
                 defaultMessage: "Select an integration",
             }),
@@ -590,6 +597,16 @@ export function show_generate_integration_url_modal(api_key: string): void {
             stream_input_dropdown_widget.render(direct_messages_option.unique_id);
             $config_container.empty();
             branch_pill_widget = undefined;
+        }
+
+        if (saved_integration) {
+            const saved_integration_data = realm.realm_incoming_webhook_bots.find(
+                (bot) => bot.name === saved_integration,
+            );
+            update_url();
+            if (saved_integration_data?.url_options) {
+                render_url_options(saved_integration_data.url_options);
+            }
         }
     }
 

--- a/web/src/settings_bots.ts
+++ b/web/src/settings_bots.ts
@@ -850,7 +850,7 @@ function set_up_bot_handlers($container: JQuery): void {
             if (!api_key) {
                 return;
             }
-            integration_url_modal.show_generate_integration_url_modal(api_key);
+            integration_url_modal.show_generate_integration_url_modal(api_key, bot_id);
         })();
     });
 }

--- a/web/src/settings_bots.ts
+++ b/web/src/settings_bots.ts
@@ -13,6 +13,7 @@ import * as bot_helper from "./bot_helper.ts";
 import {
     EMBEDDED_BOT_TYPE,
     GENERIC_BOT_TYPE,
+    INCOMING_WEBHOOK_BOT_TYPE,
     INCOMING_WEBHOOK_BOT_TYPE_INT,
     OUTGOING_WEBHOOK_BOT_TYPE,
     OUTGOING_WEBHOOK_BOT_TYPE_INT,
@@ -271,6 +272,7 @@ export function add_a_new_bot(): void {
     });
 
     let create_avatar_widget: UploadWidget;
+    let integration_input_dropdown_widget: dropdown_widget.DropdownWidget;
 
     function create_a_new_bot(): void {
         const bot_type = $<HTMLSelectOneElement>("select:not([multiple])#create_bot_type").val()!;
@@ -309,6 +311,11 @@ export function add_a_new_bot(): void {
                     config_data[key] = value;
                 });
                 formData.append("config_data", JSON.stringify(config_data));
+                break;
+            }
+            case INCOMING_WEBHOOK_BOT_TYPE: {
+                const integration_name = integration_input_dropdown_widget.value()!.toString();
+                formData.append("service_name", integration_name);
                 break;
             }
         }
@@ -353,16 +360,41 @@ export function add_a_new_bot(): void {
             demo_organizations_ui.show_configure_email_banner();
         }
 
+        integration_input_dropdown_widget = new dropdown_widget.DropdownWidget({
+            widget_name: "integration-name",
+            get_options: integration_url_modal.get_options_for_integration_input_dropdown_widget,
+            $events_container: $("#create_bot_form"),
+            default_id: "",
+            text_if_current_value_not_in_options: $t({
+                defaultMessage: "Select an integration",
+            }),
+            unique_id_type: "string",
+            item_click_callback(event: JQuery.ClickEvent, dropdown: tippy.Instance): void {
+                integration_input_dropdown_widget.render();
+                dropdown.hide();
+                event.preventDefault();
+                event.stopPropagation();
+            },
+        });
+        integration_input_dropdown_widget.setup();
+
         $("#create_bot_type").on("change", () => {
             const bot_type = $("#create_bot_type").val();
             // For "generic bot" or "incoming webhook" both these fields need not be displayed.
             $("#service_name_list").hide();
             $("#select_service_name").removeClass("required");
+            $("#integration-name_widget_container").hide();
+            $("#integration-name_widget_container").removeClass("required");
             $("#config_inputbox").hide();
 
             $("#payload_url_inputbox").hide();
             $("#create_payload_url").removeClass("required");
             switch (bot_type) {
+                case INCOMING_WEBHOOK_BOT_TYPE: {
+                    $("#integration-name_widget_container").show();
+                    $("#integration-name_widget_container").addClass("required");
+                    break;
+                }
                 case OUTGOING_WEBHOOK_BOT_TYPE: {
                     $("#payload_url_inputbox").show();
                     $("#create_payload_url").addClass("required");
@@ -388,6 +420,18 @@ export function add_a_new_bot(): void {
     }
 
     function validate_input(): boolean {
+        const bot_type = $("#create_bot_type").val()!;
+        if (bot_type === INCOMING_WEBHOOK_BOT_TYPE) {
+            const integration_name = integration_input_dropdown_widget.value()!.toString();
+            if (integration_name === "") {
+                ui_report.error(
+                    $t_html({defaultMessage: "Please select an integration"}),
+                    undefined,
+                    $("#dialog_error"),
+                );
+                return false;
+            }
+        }
         const bot_short_name = $<HTMLInputElement>("input#create_bot_short_name").val()!;
 
         if (bot_helper.validate_bot_short_name(bot_short_name)) {

--- a/web/src/settings_bots.ts
+++ b/web/src/settings_bots.ts
@@ -13,6 +13,7 @@ import * as bot_helper from "./bot_helper.ts";
 import {
     EMBEDDED_BOT_TYPE,
     GENERIC_BOT_TYPE_INT,
+    INCOMING_WEBHOOK_BOT_TYPE,
     INCOMING_WEBHOOK_BOT_TYPE_INT,
     OUTGOING_WEBHOOK_BOT_TYPE,
     OUTGOING_WEBHOOK_BOT_TYPE_INT,
@@ -271,6 +272,7 @@ export function add_a_new_bot(): void {
     });
 
     let create_avatar_widget: UploadWidget;
+    let integration_input_dropdown_widget: dropdown_widget.DropdownWidget;
 
     function create_a_new_bot(): void {
         const bot_type = $<HTMLSelectOneElement>("select:not([multiple])#create_bot_type").val()!;
@@ -309,6 +311,11 @@ export function add_a_new_bot(): void {
                     config_data[key] = value;
                 });
                 formData.append("config_data", JSON.stringify(config_data));
+                break;
+            }
+            case INCOMING_WEBHOOK_BOT_TYPE: {
+                const integration_name = integration_input_dropdown_widget.value()!.toString();
+                formData.append("service_name", integration_name);
                 break;
             }
         }
@@ -353,16 +360,41 @@ export function add_a_new_bot(): void {
             demo_organizations_ui.show_configure_email_banner();
         }
 
+        integration_input_dropdown_widget = new dropdown_widget.DropdownWidget({
+            widget_name: "integration-name",
+            get_options: integration_url_modal.get_options_for_integration_input_dropdown_widget,
+            $events_container: $("#create_bot_form"),
+            default_id: "",
+            text_if_current_value_not_in_options: $t({
+                defaultMessage: "Select an integration",
+            }),
+            unique_id_type: "string",
+            item_click_callback(event: JQuery.ClickEvent, dropdown: tippy.Instance): void {
+                integration_input_dropdown_widget.render();
+                dropdown.hide();
+                event.preventDefault();
+                event.stopPropagation();
+            },
+        });
+        integration_input_dropdown_widget.setup();
+
         $("#create_bot_type").on("change", () => {
             const bot_type = $("#create_bot_type").val();
             // For "generic bot" or "incoming webhook" both these fields need not be displayed.
             $("#service_name_list").hide();
             $("#select_service_name").removeClass("required");
+            $("#integration-name_widget_container").hide();
+            $("#integration-name_widget_container").removeClass("required");
             $("#config_inputbox").hide();
 
             $("#payload_url_inputbox").hide();
             $("#create_payload_url").removeClass("required");
             switch (bot_type) {
+                case INCOMING_WEBHOOK_BOT_TYPE: {
+                    $("#integration-name_widget_container").show();
+                    $("#integration-name_widget_container").addClass("required");
+                    break;
+                }
                 case OUTGOING_WEBHOOK_BOT_TYPE: {
                     $("#payload_url_inputbox").show();
                     $("#create_payload_url").addClass("required");
@@ -388,6 +420,18 @@ export function add_a_new_bot(): void {
     }
 
     function validate_input(): boolean {
+        const bot_type = $("#create_bot_type").val()!;
+        if (bot_type === INCOMING_WEBHOOK_BOT_TYPE) {
+            const integration_name = integration_input_dropdown_widget.value()!.toString();
+            if (integration_name === "") {
+                ui_report.error(
+                    $t_html({defaultMessage: "Please select an integration"}),
+                    undefined,
+                    $("#dialog_error"),
+                );
+                return false;
+            }
+        }
         const bot_short_name = $<HTMLInputElement>("input#create_bot_short_name").val()!;
 
         if (bot_helper.validate_bot_short_name(bot_short_name)) {

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -1114,7 +1114,7 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
                             .animate({scrollTop: 0}, "fast");
                         return;
                     }
-                    integration_url_modal.show_generate_integration_url_modal(api_key);
+                    integration_url_modal.show_generate_integration_url_modal(api_key, bot.user_id);
                 })();
             },
         );

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -1119,7 +1119,7 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
                             .animate({scrollTop: 0}, "fast");
                         return;
                     }
-                    integration_url_modal.show_generate_integration_url_modal(api_key);
+                    integration_url_modal.show_generate_integration_url_modal(api_key, bot.user_id);
                 })();
             },
         );

--- a/web/templates/settings/add_new_bot_form.hbs
+++ b/web/templates/settings/add_new_bot_form.hbs
@@ -22,6 +22,9 @@
                 {{/each}}
             </select>
         </div>
+        {{> ../dropdown_widget_with_label
+          widget_name="integration-name"
+          label=(t "Integration")}}
         <div class="input-group">
             <label for="create_bot_name" class="modal-field-label">{{t "Name" }}</label>
             <input type="text" name="bot_name" id="create_bot_name" class="required modal_text_input"

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -865,6 +865,15 @@ def get_service_dicts_for_bot(user_profile_id: int) -> list[dict[str, Any]]:
         # A ConfigError just means that there are no config entries for user_profile.
         except ConfigError:
             return []
+    elif user_profile.bot_type == UserProfile.INCOMING_WEBHOOK_BOT:
+        try:
+            return [{"integration_name": get_bot_config(user_profile).get("integration_id", "")}]
+        # The bot creation endpoint guarantees a valid integration is
+        # configured, but other callers like `do_change_bot_owner` can
+        # reach this with incoming webhook bots created before that
+        # requirement, which have no config data.
+        except ConfigError:
+            return [{"integration_name": ""}]
     else:
         return []
 
@@ -877,10 +886,12 @@ def get_service_dicts_for_bots(
     for service in Service.objects.filter(user_profile_id__in=bot_profile_ids):
         bot_services_by_uid[service.user_profile_id].append(service)
 
-    embedded_bot_ids = [
-        bot_dict["id"] for bot_dict in bot_dicts if bot_dict["bot_type"] == UserProfile.EMBEDDED_BOT
+    config_bot_ids = [
+        bot_dict["id"]
+        for bot_dict in bot_dicts
+        if bot_dict["bot_type"] in (UserProfile.EMBEDDED_BOT, UserProfile.INCOMING_WEBHOOK_BOT)
     ]
-    embedded_bot_configs = get_bot_configs(embedded_bot_ids)
+    bot_configs = get_bot_configs(config_bot_ids)
 
     service_dicts_by_uid: dict[int, list[dict[str, Any]]] = {}
     for bot_dict in bot_dicts:
@@ -888,7 +899,7 @@ def get_service_dicts_for_bots(
         bot_type = bot_dict["bot_type"]
         services = bot_services_by_uid[bot_profile_id]
         service_dicts: list[dict[str, Any]] = []
-        bot_config = embedded_bot_configs.get(bot_profile_id, {})
+        bot_config = bot_configs.get(bot_profile_id, {})
         if bot_type == UserProfile.OUTGOING_WEBHOOK_BOT:
             service_dicts = [
                 {
@@ -903,6 +914,12 @@ def get_service_dicts_for_bots(
                 {
                     "config_data": bot_config,
                     "service_name": services[0].name,
+                }
+            ]
+        elif bot_type == UserProfile.INCOMING_WEBHOOK_BOT:
+            service_dicts = [
+                {
+                    "integration_name": bot_config.get("integration_id", ""),
                 }
             ]
         service_dicts_by_uid[bot_profile_id] = service_dicts

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -888,6 +888,7 @@ def get_service_dicts_for_bots(
         bot_type = bot_dict["bot_type"]
         services = bot_services_by_uid[bot_profile_id]
         service_dicts: list[dict[str, Any]] = []
+        bot_config = embedded_bot_configs.get(bot_profile_id, {})
         if bot_type == UserProfile.OUTGOING_WEBHOOK_BOT:
             service_dicts = [
                 {
@@ -897,8 +898,7 @@ def get_service_dicts_for_bots(
                 }
                 for service in services
             ]
-        elif bot_type == UserProfile.EMBEDDED_BOT and bot_profile_id in embedded_bot_configs:
-            bot_config = embedded_bot_configs[bot_profile_id]
+        elif bot_type == UserProfile.EMBEDDED_BOT and bot_config:
             service_dicts = [
                 {
                     "config_data": bot_config,

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -861,6 +861,15 @@ def get_service_dicts_for_bot(user_profile_id: int) -> list[dict[str, Any]]:
         # A ConfigError just means that there are no config entries for user_profile.
         except ConfigError:
             return []
+    elif user_profile.bot_type == UserProfile.INCOMING_WEBHOOK_BOT:
+        try:
+            return [{"integration_name": get_bot_config(user_profile).get("integration_id", "")}]
+        # The bot creation endpoint guarantees a valid integration is
+        # configured, but other callers like `do_change_bot_owner` can
+        # reach this with incoming webhook bots created before that
+        # requirement, which have no config data.
+        except ConfigError:
+            return [{"integration_name": ""}]
     else:
         return []
 
@@ -873,10 +882,12 @@ def get_service_dicts_for_bots(
     for service in Service.objects.filter(user_profile_id__in=bot_profile_ids):
         bot_services_by_uid[service.user_profile_id].append(service)
 
-    embedded_bot_ids = [
-        bot_dict["id"] for bot_dict in bot_dicts if bot_dict["bot_type"] == UserProfile.EMBEDDED_BOT
+    config_bot_ids = [
+        bot_dict["id"]
+        for bot_dict in bot_dicts
+        if bot_dict["bot_type"] in (UserProfile.EMBEDDED_BOT, UserProfile.INCOMING_WEBHOOK_BOT)
     ]
-    embedded_bot_configs = get_bot_configs(embedded_bot_ids)
+    bot_configs = get_bot_configs(config_bot_ids)
 
     service_dicts_by_uid: dict[int, list[dict[str, Any]]] = {}
     for bot_dict in bot_dicts:
@@ -884,7 +895,7 @@ def get_service_dicts_for_bots(
         bot_type = bot_dict["bot_type"]
         services = bot_services_by_uid[bot_profile_id]
         service_dicts: list[dict[str, Any]] = []
-        bot_config = embedded_bot_configs.get(bot_profile_id, {})
+        bot_config = bot_configs.get(bot_profile_id, {})
         if bot_type == UserProfile.OUTGOING_WEBHOOK_BOT:
             service_dicts = [
                 {
@@ -899,6 +910,12 @@ def get_service_dicts_for_bots(
                 {
                     "config_data": bot_config,
                     "service_name": services[0].name,
+                }
+            ]
+        elif bot_type == UserProfile.INCOMING_WEBHOOK_BOT:
+            service_dicts = [
+                {
+                    "integration_name": bot_config.get("integration_id", ""),
                 }
             ]
         service_dicts_by_uid[bot_profile_id] = service_dicts

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -884,6 +884,7 @@ def get_service_dicts_for_bots(
         bot_type = bot_dict["bot_type"]
         services = bot_services_by_uid[bot_profile_id]
         service_dicts: list[dict[str, Any]] = []
+        bot_config = embedded_bot_configs.get(bot_profile_id, {})
         if bot_type == UserProfile.OUTGOING_WEBHOOK_BOT:
             service_dicts = [
                 {
@@ -893,8 +894,7 @@ def get_service_dicts_for_bots(
                 }
                 for service in services
             ]
-        elif bot_type == UserProfile.EMBEDDED_BOT and bot_profile_id in embedded_bot_configs:
-            bot_config = embedded_bot_configs[bot_profile_id]
+        elif bot_type == UserProfile.EMBEDDED_BOT and bot_config:
             service_dicts = [
                 {
                     "config_data": bot_config,

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -22,6 +22,7 @@ from zerver.lib.event_types import (
     AuthenticationData,
     BaseEvent,
     BotServicesEmbedded,
+    BotServicesIncoming,
     BotServicesOutgoing,
     ChannelFolderAddEvent,
     ChannelFolderReorderEvent,
@@ -410,6 +411,9 @@ def check_realm_bot_add(
     elif bot_type == UserProfile.EMBEDDED_BOT:
         assert len(services) == 1
         validate_with_model(services[0], BotServicesEmbedded)
+    elif bot_type == UserProfile.INCOMING_WEBHOOK_BOT:
+        assert len(services) == 1
+        validate_with_model(services[0], BotServicesIncoming)
     else:
         raise AssertionError(f"Unknown bot_type: {bot_type}")
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -403,12 +403,16 @@ class BotServicesEmbedded(BaseModel):
     config_data: dict[str, str]
 
 
+class BotServicesIncoming(BaseModel):
+    integration_name: str
+
+
 class Bot(BaseModel):
     user_id: int
     default_all_public_streams: bool
     default_events_register_stream: str | None
     default_sending_stream: str | None
-    services: list[BotServicesOutgoing | BotServicesEmbedded]
+    services: list[BotServicesOutgoing | BotServicesEmbedded | BotServicesIncoming]
 
 
 class RealmBotAddEvent(BaseEvent):
@@ -436,7 +440,7 @@ class BotTypeForUpdate(BotTypeForUpdateCore):
     default_all_public_streams: bool | None = None
     default_events_register_stream: str | None = None
     default_sending_stream: str | None = None
-    services: list[BotServicesOutgoing | BotServicesEmbedded] | None = None
+    services: list[BotServicesOutgoing | BotServicesEmbedded | BotServicesIncoming] | None = None
 
 
 class RealmBotUpdateEvent(BaseEvent):

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -27538,9 +27538,9 @@ components:
         services:
           type: array
           description: |
-            An array containing extra configuration fields only relevant for
-            outgoing webhook bots and embedded bots. This is always a single-element
-            array.
+            An array containing extra configuration fields for outgoing webhook
+            bots, incoming webhook bots, and embedded bots. This is always
+            a single-element array.
 
             We consider this part of the Zulip API to be unstable; it is used only
             for UI elements for administering bots and is likely to change.
@@ -27581,6 +27581,19 @@ components:
                       The name of the bot.
                   config_data:
                     $ref: "#/components/schemas/BotConfiguration"
+              - type: object
+                additionalProperties: false
+                description: |
+                  When the bot is an incoming webhook bot.
+                properties:
+                  integration_name:
+                    type: string
+                    description: |
+                      The name of the integration.
+
+                      **Changes**: New in Zulip 12.0 (feature level ZF-75c8e1).
+                required:
+                  - integration_name
     Bot:
       allOf:
         - $ref: "#/components/schemas/BasicBotBase"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -27981,9 +27981,9 @@ components:
         services:
           type: array
           description: |
-            An array containing extra configuration fields only relevant for
-            outgoing webhook bots and embedded bots. This is always a single-element
-            array.
+            An array containing extra configuration fields for outgoing webhook
+            bots, incoming webhook bots, and embedded bots. This is always
+            a single-element array.
 
             We consider this part of the Zulip API to be unstable; it is used only
             for UI elements for administering bots and is likely to change.
@@ -28024,6 +28024,19 @@ components:
                       The name of the bot.
                   config_data:
                     $ref: "#/components/schemas/BotConfiguration"
+              - type: object
+                additionalProperties: false
+                description: |
+                  When the bot is an incoming webhook bot.
+                properties:
+                  integration_name:
+                    type: string
+                    description: |
+                      The name of the integration.
+
+                      **Changes**: New in Zulip 12.0 (feature level ZF-75c8e1).
+                required:
+                  - integration_name
     Bot:
       allOf:
         - $ref: "#/components/schemas/BasicBotBase"

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -17,7 +17,7 @@ from zerver.actions.realm_settings import (
 from zerver.actions.streams import do_change_stream_permission
 from zerver.actions.user_groups import check_add_user_group
 from zerver.actions.users import do_change_can_create_users, do_change_user_role, do_deactivate_user
-from zerver.lib.bot_config import ConfigError, get_bot_config
+from zerver.lib.bot_config import get_bot_config
 from zerver.lib.bot_lib import get_bot_handler
 from zerver.lib.integrations import EMBEDDED_BOTS, IncomingWebhookIntegration
 from zerver.lib.request import RequestNotes
@@ -810,7 +810,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         self.login("hamlet")
         self.assert_num_bots_equal(0)
-        self.create_bot(bot_type=UserProfile.INCOMING_WEBHOOK_BOT)
+        self.create_bot(bot_type=UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld")
         self.assert_num_bots_equal(1)
 
         profile = get_user(bot_email, bot_realm)
@@ -830,13 +830,20 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_json_error(result, "Invalid bot type")
 
     def check_user_can_create_bot(
-        self, user: str, bot_name: str, bot_type: int, error_msg: Optional["str"] = None
+        self,
+        user: str,
+        bot_name: str,
+        bot_type: int,
+        error_msg: Optional["str"] = None,
+        service_name: Optional["str"] = None,
     ) -> None:
         bot_info = {
             "full_name": bot_name,
             "short_name": bot_name,
             "bot_type": bot_type,
         }
+        if bot_type == UserProfile.INCOMING_WEBHOOK_BOT:
+            bot_info["service_name"] = service_name
         bot_email = f"{bot_name}-bot@zulip.testserver"
         bot_realm = get_realm("zulip")
         self.login(user)
@@ -881,9 +888,15 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             acting_user=None,
         )
 
-        self.check_user_can_create_bot("hamlet", "testbot-1", UserProfile.INCOMING_WEBHOOK_BOT)
         self.check_user_can_create_bot(
-            "polonius", "testbot-2", UserProfile.INCOMING_WEBHOOK_BOT, "Not allowed for guest users"
+            "hamlet", "testbot-1", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
+        self.check_user_can_create_bot(
+            "polonius",
+            "testbot-2",
+            UserProfile.INCOMING_WEBHOOK_BOT,
+            "Not allowed for guest users",
+            "helloworld",
         )
 
         do_change_realm_permission_group_setting(
@@ -892,10 +905,18 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             moderators_system_group,
             acting_user=None,
         )
-        self.check_user_can_create_bot("shiva", "testbot-3", UserProfile.INCOMING_WEBHOOK_BOT)
-        self.check_user_can_create_bot("iago", "testbot-4", UserProfile.INCOMING_WEBHOOK_BOT)
         self.check_user_can_create_bot(
-            "hamlet", "testbot-5", UserProfile.INCOMING_WEBHOOK_BOT, "Insufficient permission"
+            "shiva", "testbot-3", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
+        self.check_user_can_create_bot(
+            "iago", "testbot-4", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
+        self.check_user_can_create_bot(
+            "hamlet",
+            "testbot-5",
+            UserProfile.INCOMING_WEBHOOK_BOT,
+            "Insufficient permission",
+            "helloworld",
         )
 
         do_change_realm_permission_group_setting(
@@ -904,9 +925,15 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             administrators_system_group,
             acting_user=None,
         )
-        self.check_user_can_create_bot("iago", "testbot-5", UserProfile.INCOMING_WEBHOOK_BOT)
         self.check_user_can_create_bot(
-            "shiva", "testbot-6", UserProfile.INCOMING_WEBHOOK_BOT, "Insufficient permission"
+            "iago", "testbot-5", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
+        self.check_user_can_create_bot(
+            "shiva",
+            "testbot-6",
+            UserProfile.INCOMING_WEBHOOK_BOT,
+            "Insufficient permission",
+            "helloworld",
         )
 
         # Test for checking setting for non-system user group.
@@ -918,16 +945,26 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         )
 
         # Hamlet and Cordelia are in the allowed user group, so can create bots.
-        self.check_user_can_create_bot("hamlet", "testbot-6", UserProfile.INCOMING_WEBHOOK_BOT)
-        self.check_user_can_create_bot("cordelia", "testbot-7", UserProfile.INCOMING_WEBHOOK_BOT)
+        self.check_user_can_create_bot(
+            "hamlet", "testbot-6", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
+        self.check_user_can_create_bot(
+            "cordelia", "testbot-7", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
 
         # Shiva is not in the allowed user group, so cannot create bots.
         self.check_user_can_create_bot(
-            "shiva", "testbot-8", UserProfile.INCOMING_WEBHOOK_BOT, "Insufficient permission"
+            "shiva",
+            "testbot-8",
+            UserProfile.INCOMING_WEBHOOK_BOT,
+            "Insufficient permission",
+            "helloworld",
         )
         # Iago is not in `can_create_write_only_bots_group` but is in `can_create_bots_group`,
         # so can create any bot.
-        self.check_user_can_create_bot("iago", "testbot-8", UserProfile.INCOMING_WEBHOOK_BOT)
+        self.check_user_can_create_bot(
+            "iago", "testbot-8", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
 
         # Test for checking the setting for anonymous user group.
         anonymous_user_group = self.create_or_update_anonymous_group_for_setting(
@@ -942,12 +979,20 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         )
 
         # Hamlet is the direct member of the anonymous user group, so can create bots.
-        self.check_user_can_create_bot("hamlet", "testbot-9", UserProfile.INCOMING_WEBHOOK_BOT)
+        self.check_user_can_create_bot(
+            "hamlet", "testbot-9", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
         # Iago is in the `administrators_system_group` subgroup, so can create bots.
-        self.check_user_can_create_bot("iago", "testbot-10", UserProfile.INCOMING_WEBHOOK_BOT)
+        self.check_user_can_create_bot(
+            "iago", "testbot-10", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
         # Shiva is not in the anonymous user group, so cannot create bots.
         self.check_user_can_create_bot(
-            "shiva", "testbot-11", UserProfile.INCOMING_WEBHOOK_BOT, "Insufficient permission"
+            "shiva",
+            "testbot-11",
+            UserProfile.INCOMING_WEBHOOK_BOT,
+            "Insufficient permission",
+            "helloworld",
         )
 
         do_change_realm_permission_group_setting(
@@ -959,19 +1004,27 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         # Iago is in `can_create_bots_group`, so can create any bot.
         self.check_user_can_create_bot("iago", "testbot-11", UserProfile.DEFAULT_BOT)
-        self.check_user_can_create_bot("iago", "testbot-12", UserProfile.INCOMING_WEBHOOK_BOT)
+        self.check_user_can_create_bot(
+            "iago", "testbot-12", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
         # Shiva is only in `can_create_write_only_bots_group`, so can only create
         # "INCOMING_WEBHOOK_BOT".
         self.check_user_can_create_bot(
             "shiva", "testbot-13", UserProfile.DEFAULT_BOT, "Insufficient permission"
         )
-        self.check_user_can_create_bot("shiva", "testbot-13", UserProfile.INCOMING_WEBHOOK_BOT)
+        self.check_user_can_create_bot(
+            "shiva", "testbot-13", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
         # Hamlet is in neither of the group, so cannot create any bot.
         self.check_user_can_create_bot(
             "hamlet", "testbot-14", UserProfile.DEFAULT_BOT, "Insufficient permission"
         )
         self.check_user_can_create_bot(
-            "hamlet", "testbot-14", UserProfile.INCOMING_WEBHOOK_BOT, "Insufficient permission"
+            "hamlet",
+            "testbot-14",
+            UserProfile.INCOMING_WEBHOOK_BOT,
+            "Insufficient permission",
+            "helloworld",
         )
 
     def test_can_create_bots_group(self) -> None:
@@ -2276,32 +2329,30 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         with self.assertRaises(UserProfile.DoesNotExist):
             UserProfile.objects.get(full_name="My Stripe Bot")
 
-    @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
     def test_create_incoming_webhook_bot_without_service_name(self) -> None:
-        self.login("hamlet")
-        bot_metadata = {
-            "full_name": "My Stripe Bot",
-            "short_name": "my-stripe",
-            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-        }
-        self.create_bot(**bot_metadata)
-        new_bot = UserProfile.objects.get(full_name="My Stripe Bot")
-        with self.assertRaises(ConfigError):
-            get_bot_config(new_bot)
+        self.fail_to_create_test_bot(
+            full_name="My Stripe Bot",
+            user_profile=self.example_user("hamlet"),
+            short_name="my-stripe",
+            bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+            assert_json_error_msg="Integration name is required for incoming webhook bots.",
+        )
 
-    @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
-    def test_create_incoming_webhook_bot_with_incorrect_service_name(self) -> None:
-        self.login("hamlet")
-        bot_metadata = {
-            "full_name": "My Stripe Bot",
-            "short_name": "my-stripe",
-            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-            "service_name": "stripes",
-        }
-        response = self.client_post("/json/bots", bot_metadata)
-        self.assertEqual(response.status_code, 400)
-        expected_error_message = "Invalid integration 'stripes'."
-        self.assertEqual(orjson.loads(response.content)["msg"], expected_error_message)
+        # Ensure bot is not created
+        with self.assertRaises(UserProfile.DoesNotExist):
+            UserProfile.objects.get(full_name="My Stripe Bot")
+
+    def test_create_incoming_webhook_bot_with_invalid_integration_name(self) -> None:
+        self.fail_to_create_test_bot(
+            short_name="my-stripe",
+            user_profile=self.example_user("hamlet"),
+            full_name="My Stripe Bot",
+            bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+            assert_json_error_msg="Invalid integration 'nonexistent_integration'.",
+            service_name="nonexistent_integration",
+        )
+
+        # Ensure bot is not created
         with self.assertRaises(UserProfile.DoesNotExist):
             UserProfile.objects.get(full_name="My Stripe Bot")
 

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -9,6 +9,7 @@ from django.test import override_settings
 from zulip_bots.custom_exceptions import ConfigValidationError
 
 from zerver.actions.bots import do_change_bot_owner, do_change_default_sending_stream
+from zerver.actions.create_user import do_create_user
 from zerver.actions.realm_settings import (
     do_change_realm_permission_group_setting,
     do_set_realm_property,
@@ -16,7 +17,13 @@ from zerver.actions.realm_settings import (
 )
 from zerver.actions.streams import do_change_stream_permission
 from zerver.actions.user_groups import check_add_user_group
-from zerver.actions.users import do_change_can_create_users, do_change_user_role, do_deactivate_user
+from zerver.actions.users import (
+    do_change_can_create_users,
+    do_change_user_role,
+    do_deactivate_user,
+    get_service_dicts_for_bot,
+    get_service_dicts_for_bots,
+)
 from zerver.lib.bot_config import get_bot_config
 from zerver.lib.bot_lib import get_bot_handler
 from zerver.lib.integrations import EMBEDDED_BOTS, IncomingWebhookIntegration
@@ -2355,6 +2362,25 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         # Ensure bot is not created
         with self.assertRaises(UserProfile.DoesNotExist):
             UserProfile.objects.get(full_name="My Stripe Bot")
+
+    def test_service_dicts_for_incoming_webhook_bot_without_integration(self) -> None:
+        realm = get_realm("zulip")
+        bot = do_create_user(
+            email="legacy-incoming-bot@zulip.com",
+            password=None,
+            realm=realm,
+            full_name="Legacy Incoming Bot",
+            bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+            bot_owner=self.example_user("hamlet"),
+            acting_user=None,
+        )
+
+        expected_service_dicts = [{"integration_name": ""}]
+        self.assertEqual(get_service_dicts_for_bot(bot.id), expected_service_dicts)
+
+        bot_dicts = [{"id": bot.id, "bot_type": bot.bot_type}]
+        service_dicts_by_uid = get_service_dicts_for_bots(bot_dicts, realm)
+        self.assertEqual(service_dicts_by_uid[bot.id], expected_service_dicts)
 
     def test_get_bot_api_key(self) -> None:
         self.login("hamlet")

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -9,6 +9,7 @@ from django.test import override_settings
 from zulip_bots.custom_exceptions import ConfigValidationError
 
 from zerver.actions.bots import do_change_bot_owner, do_change_default_sending_stream
+from zerver.actions.create_user import do_create_user
 from zerver.actions.realm_settings import (
     do_change_realm_permission_group_setting,
     do_set_realm_property,
@@ -16,7 +17,13 @@ from zerver.actions.realm_settings import (
 )
 from zerver.actions.streams import do_change_stream_permission
 from zerver.actions.user_groups import check_add_user_group
-from zerver.actions.users import do_change_can_create_users, do_change_user_role, do_deactivate_user
+from zerver.actions.users import (
+    do_change_can_create_users,
+    do_change_user_role,
+    do_deactivate_user,
+    get_service_dicts_for_bot,
+    get_service_dicts_for_bots,
+)
 from zerver.lib.bot_config import get_bot_config
 from zerver.lib.bot_lib import get_bot_handler
 from zerver.lib.integrations import EMBEDDED_BOTS, IncomingWebhookIntegration
@@ -2357,6 +2364,25 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         # Ensure bot is not created
         with self.assertRaises(UserProfile.DoesNotExist):
             UserProfile.objects.get(full_name="My Stripe Bot")
+
+    def test_service_dicts_for_incoming_webhook_bot_without_integration(self) -> None:
+        realm = get_realm("zulip")
+        bot = do_create_user(
+            email="legacy-incoming-bot@zulip.com",
+            password=None,
+            realm=realm,
+            full_name="Legacy Incoming Bot",
+            bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+            bot_owner=self.example_user("hamlet"),
+            acting_user=None,
+        )
+
+        expected_service_dicts = [{"integration_name": ""}]
+        self.assertEqual(get_service_dicts_for_bot(bot.id), expected_service_dicts)
+
+        bot_dicts = [{"id": bot.id, "bot_type": bot.bot_type}]
+        service_dicts_by_uid = get_service_dicts_for_bots(bot_dicts, realm)
+        self.assertEqual(service_dicts_by_uid[bot.id], expected_service_dicts)
 
     def test_get_bot_api_key(self) -> None:
         self.login("hamlet")

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -17,7 +17,7 @@ from zerver.actions.realm_settings import (
 from zerver.actions.streams import do_change_stream_permission
 from zerver.actions.user_groups import check_add_user_group
 from zerver.actions.users import do_change_can_create_users, do_change_user_role, do_deactivate_user
-from zerver.lib.bot_config import ConfigError, get_bot_config
+from zerver.lib.bot_config import get_bot_config
 from zerver.lib.bot_lib import get_bot_handler
 from zerver.lib.integrations import EMBEDDED_BOTS, IncomingWebhookIntegration
 from zerver.lib.request import RequestNotes
@@ -810,7 +810,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         self.login("hamlet")
         self.assert_num_bots_equal(0)
-        self.create_bot(bot_type=UserProfile.INCOMING_WEBHOOK_BOT)
+        self.create_bot(bot_type=UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld")
         self.assert_num_bots_equal(1)
 
         profile = get_user(bot_email, bot_realm)
@@ -830,13 +830,20 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_json_error(result, "Invalid bot type")
 
     def check_user_can_create_bot(
-        self, user: str, bot_name: str, bot_type: int, error_msg: Optional["str"] = None
+        self,
+        user: str,
+        bot_name: str,
+        bot_type: int,
+        error_msg: Optional["str"] = None,
+        service_name: Optional["str"] = None,
     ) -> None:
         bot_info = {
             "full_name": bot_name,
             "short_name": bot_name,
             "bot_type": bot_type,
         }
+        if bot_type == UserProfile.INCOMING_WEBHOOK_BOT:
+            bot_info["service_name"] = service_name
         bot_email = f"{bot_name}-bot@zulip.testserver"
         bot_realm = get_realm("zulip")
         self.login(user)
@@ -881,9 +888,15 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             acting_user=None,
         )
 
-        self.check_user_can_create_bot("hamlet", "testbot-1", UserProfile.INCOMING_WEBHOOK_BOT)
         self.check_user_can_create_bot(
-            "polonius", "testbot-2", UserProfile.INCOMING_WEBHOOK_BOT, "Not allowed for guest users"
+            "hamlet", "testbot-1", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
+        self.check_user_can_create_bot(
+            "polonius",
+            "testbot-2",
+            UserProfile.INCOMING_WEBHOOK_BOT,
+            "Not allowed for guest users",
+            "helloworld",
         )
 
         do_change_realm_permission_group_setting(
@@ -892,10 +905,18 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             moderators_system_group,
             acting_user=None,
         )
-        self.check_user_can_create_bot("shiva", "testbot-3", UserProfile.INCOMING_WEBHOOK_BOT)
-        self.check_user_can_create_bot("iago", "testbot-4", UserProfile.INCOMING_WEBHOOK_BOT)
         self.check_user_can_create_bot(
-            "hamlet", "testbot-5", UserProfile.INCOMING_WEBHOOK_BOT, "Insufficient permission"
+            "shiva", "testbot-3", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
+        self.check_user_can_create_bot(
+            "iago", "testbot-4", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
+        self.check_user_can_create_bot(
+            "hamlet",
+            "testbot-5",
+            UserProfile.INCOMING_WEBHOOK_BOT,
+            "Insufficient permission",
+            "helloworld",
         )
 
         do_change_realm_permission_group_setting(
@@ -904,9 +925,15 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             administrators_system_group,
             acting_user=None,
         )
-        self.check_user_can_create_bot("iago", "testbot-5", UserProfile.INCOMING_WEBHOOK_BOT)
         self.check_user_can_create_bot(
-            "shiva", "testbot-6", UserProfile.INCOMING_WEBHOOK_BOT, "Insufficient permission"
+            "iago", "testbot-5", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
+        self.check_user_can_create_bot(
+            "shiva",
+            "testbot-6",
+            UserProfile.INCOMING_WEBHOOK_BOT,
+            "Insufficient permission",
+            "helloworld",
         )
 
         # Test for checking setting for non-system user group.
@@ -918,16 +945,26 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         )
 
         # Hamlet and Cordelia are in the allowed user group, so can create bots.
-        self.check_user_can_create_bot("hamlet", "testbot-6", UserProfile.INCOMING_WEBHOOK_BOT)
-        self.check_user_can_create_bot("cordelia", "testbot-7", UserProfile.INCOMING_WEBHOOK_BOT)
+        self.check_user_can_create_bot(
+            "hamlet", "testbot-6", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
+        self.check_user_can_create_bot(
+            "cordelia", "testbot-7", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
 
         # Shiva is not in the allowed user group, so cannot create bots.
         self.check_user_can_create_bot(
-            "shiva", "testbot-8", UserProfile.INCOMING_WEBHOOK_BOT, "Insufficient permission"
+            "shiva",
+            "testbot-8",
+            UserProfile.INCOMING_WEBHOOK_BOT,
+            "Insufficient permission",
+            "helloworld",
         )
         # Iago is not in `can_create_write_only_bots_group` but is in `can_create_bots_group`,
         # so can create any bot.
-        self.check_user_can_create_bot("iago", "testbot-8", UserProfile.INCOMING_WEBHOOK_BOT)
+        self.check_user_can_create_bot(
+            "iago", "testbot-8", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
 
         # Test for checking the setting for anonymous user group.
         anonymous_user_group = self.create_or_update_anonymous_group_for_setting(
@@ -942,12 +979,20 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         )
 
         # Hamlet is the direct member of the anonymous user group, so can create bots.
-        self.check_user_can_create_bot("hamlet", "testbot-9", UserProfile.INCOMING_WEBHOOK_BOT)
+        self.check_user_can_create_bot(
+            "hamlet", "testbot-9", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
         # Iago is in the `administrators_system_group` subgroup, so can create bots.
-        self.check_user_can_create_bot("iago", "testbot-10", UserProfile.INCOMING_WEBHOOK_BOT)
+        self.check_user_can_create_bot(
+            "iago", "testbot-10", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
         # Shiva is not in the anonymous user group, so cannot create bots.
         self.check_user_can_create_bot(
-            "shiva", "testbot-11", UserProfile.INCOMING_WEBHOOK_BOT, "Insufficient permission"
+            "shiva",
+            "testbot-11",
+            UserProfile.INCOMING_WEBHOOK_BOT,
+            "Insufficient permission",
+            "helloworld",
         )
 
         do_change_realm_permission_group_setting(
@@ -959,19 +1004,27 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         # Iago is in `can_create_bots_group`, so can create any bot.
         self.check_user_can_create_bot("iago", "testbot-11", UserProfile.DEFAULT_BOT)
-        self.check_user_can_create_bot("iago", "testbot-12", UserProfile.INCOMING_WEBHOOK_BOT)
+        self.check_user_can_create_bot(
+            "iago", "testbot-12", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
         # Shiva is only in `can_create_write_only_bots_group`, so can only create
         # "INCOMING_WEBHOOK_BOT".
         self.check_user_can_create_bot(
             "shiva", "testbot-13", UserProfile.DEFAULT_BOT, "Insufficient permission"
         )
-        self.check_user_can_create_bot("shiva", "testbot-13", UserProfile.INCOMING_WEBHOOK_BOT)
+        self.check_user_can_create_bot(
+            "shiva", "testbot-13", UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld"
+        )
         # Hamlet is in neither of the group, so cannot create any bot.
         self.check_user_can_create_bot(
             "hamlet", "testbot-14", UserProfile.DEFAULT_BOT, "Insufficient permission"
         )
         self.check_user_can_create_bot(
-            "hamlet", "testbot-14", UserProfile.INCOMING_WEBHOOK_BOT, "Insufficient permission"
+            "hamlet",
+            "testbot-14",
+            UserProfile.INCOMING_WEBHOOK_BOT,
+            "Insufficient permission",
+            "helloworld",
         )
 
     def test_can_create_bots_group(self) -> None:
@@ -2278,32 +2331,30 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         with self.assertRaises(UserProfile.DoesNotExist):
             UserProfile.objects.get(full_name="My Stripe Bot")
 
-    @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
     def test_create_incoming_webhook_bot_without_service_name(self) -> None:
-        self.login("hamlet")
-        bot_metadata = {
-            "full_name": "My Stripe Bot",
-            "short_name": "my-stripe",
-            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-        }
-        self.create_bot(**bot_metadata)
-        new_bot = UserProfile.objects.get(full_name="My Stripe Bot")
-        with self.assertRaises(ConfigError):
-            get_bot_config(new_bot)
+        self.fail_to_create_test_bot(
+            full_name="My Stripe Bot",
+            user_profile=self.example_user("hamlet"),
+            short_name="my-stripe",
+            bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+            assert_json_error_msg="Integration name is required for incoming webhook bots.",
+        )
 
-    @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
-    def test_create_incoming_webhook_bot_with_incorrect_service_name(self) -> None:
-        self.login("hamlet")
-        bot_metadata = {
-            "full_name": "My Stripe Bot",
-            "short_name": "my-stripe",
-            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-            "service_name": "stripes",
-        }
-        response = self.client_post("/json/bots", bot_metadata)
-        self.assertEqual(response.status_code, 400)
-        expected_error_message = "Invalid integration 'stripes'."
-        self.assertEqual(orjson.loads(response.content)["msg"], expected_error_message)
+        # Ensure bot is not created
+        with self.assertRaises(UserProfile.DoesNotExist):
+            UserProfile.objects.get(full_name="My Stripe Bot")
+
+    def test_create_incoming_webhook_bot_with_invalid_integration_name(self) -> None:
+        self.fail_to_create_test_bot(
+            short_name="my-stripe",
+            user_profile=self.example_user("hamlet"),
+            full_name="My Stripe Bot",
+            bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+            assert_json_error_msg="Invalid integration 'nonexistent_integration'.",
+            service_name="nonexistent_integration",
+        )
+
+        # Ensure bot is not created
         with self.assertRaises(UserProfile.DoesNotExist):
             UserProfile.objects.get(full_name="My Stripe Bot")
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3527,6 +3527,15 @@ class NormalActionsTest(BaseAction):
             )
         check_realm_bot_add("events[3]", events[3], UserProfile.EMBEDDED_BOT)
 
+        with self.verify_action(num_events=4) as events:
+            self.create_bot(
+                "test_incoming_webhook",
+                full_name="Incoming Webhook Bot",
+                bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+                service_name="helloworld",
+            )
+        check_realm_bot_add("events[3]", events[3], UserProfile.INCOMING_WEBHOOK_BOT)
+
     def test_change_bot_full_name(self) -> None:
         bot = self.create_bot("test")
         with self.verify_action(num_events=1) as events:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3493,6 +3493,15 @@ class NormalActionsTest(BaseAction):
             )
         check_realm_bot_add("events[3]", events[3], UserProfile.EMBEDDED_BOT)
 
+        with self.verify_action(num_events=4) as events:
+            self.create_bot(
+                "test_incoming_webhook",
+                full_name="Incoming Webhook Bot",
+                bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+                service_name="helloworld",
+            )
+        check_realm_bot_add("events[3]", events[3], UserProfile.INCOMING_WEBHOOK_BOT)
+
     def test_change_bot_full_name(self) -> None:
         bot = self.create_bot("test")
         with self.verify_action(num_events=1) as events:

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -658,7 +658,7 @@ class HomeTest(ZulipTestCase):
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
         with (
-            self.assert_database_query_count(58),
+            self.assert_database_query_count(59),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page()

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -675,6 +675,8 @@ def add_bot_backend(
             raise JsonableError(_("Embedded bots are not enabled."))
         if service_name not in [bot.name for bot in EMBEDDED_BOTS]:
             raise JsonableError(_("Invalid embedded bot name."))
+    if bot_type == UserProfile.INCOMING_WEBHOOK_BOT and not service_name:
+        raise JsonableError(_("Integration name is required for incoming webhook bots."))
 
     if not form.is_valid():  # nocoverage
         # coverage note: The similar block above covers the most

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -676,6 +676,8 @@ def add_bot_backend(
             raise JsonableError(_("Embedded bots are not enabled."))
         if service_name not in [bot.name for bot in EMBEDDED_BOTS]:
             raise JsonableError(_("Invalid embedded bot name."))
+    if bot_type == UserProfile.INCOMING_WEBHOOK_BOT and not service_name:
+        raise JsonableError(_("Integration name is required for incoming webhook bots."))
 
     if not form.is_valid():  # nocoverage
         # coverage note: The similar block above covers the most


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This pr is a continuation of #33441 
Fixes part of #30139.

This PR adds support for selecting an integration for incoming webhook bots in the UI, saving that selection, and displaying it in the 'Generate integration URL' modal.

**How changes were tested:**
All the tests pass, verified maanually by creating bots.
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="685" height="585" alt="image" src="https://github.com/user-attachments/assets/8408a930-9f30-4ac0-b98d-105438e3fc54" />
<img width="690" height="560" alt="image" src="https://github.com/user-attachments/assets/a5f9b01e-e7d3-40a0-88f6-1e16d104da6e" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>