### PR TITLE
alert_words: highlight alert words in channel/topic links.

### DIFF
--- a/web/src/alert_words.ts
+++ b/web/src/alert_words.ts
@@ -41,12 +41,8 @@ const alert_regex_replacements = new Map<string, string>([
     ["'", "(?:'|&#39;)"],
 ]);
 
-export function process_message(message: Message): void {
-    // Parsing for alert words is expensive, so we rely on the host
-    // to tell us there any alert words to even look for.
-    if (!message.alerted) {
-        return;
-    }
+export function highlight_alert_words(content: string): string {
+    let updated_content = content;
 
     for (const word of my_alert_words) {
         const clean = _.escapeRegExp(word).replaceAll(
@@ -57,7 +53,7 @@ export function process_message(message: Message): void {
         const after_punctuation = "(?=\\s)|$|<|[\\)\\\"\\?!:.,';\\]!]";
 
         const regex = new RegExp(`(${before_punctuation})(${clean})(${after_punctuation})`, "ig");
-        const updated_content = message.content.replace(
+        updated_content = updated_content.replace(
             regex,
             (
                 match: string,
@@ -82,8 +78,20 @@ export function process_message(message: Message): void {
                 return before + "<span class='alert-word'>" + word + "</span>" + after;
             },
         );
-        message_store.update_message_content(message, updated_content);
     }
+
+    return updated_content;
+}
+
+export function process_message(message: Message): void {
+    // Parsing for alert words is expensive, so we rely on the host
+    // to tell us if there are any alert words to even look for.
+    if (!message.alerted) {
+        return;
+    }
+
+    const updated_content = highlight_alert_words(message.content);
+    message_store.update_message_content(message, updated_content);
 }
 
 export function notifies(message: Message): boolean {

--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -632,10 +632,11 @@ function handleStreamTopic({
         return undefined;
     }
     const href = stream_topic_hash(stream.stream_id, topic);
+    const topic_display_name_html = _.escape(util.get_final_topic_display_name(topic));
     return render_topic_link({
         channel_id: stream.stream_id,
         channel_name: stream.name,
-        topic_display_name: util.get_final_topic_display_name(topic),
+        topic_display_name_html,
         is_empty_string_topic: topic === "",
         href,
     });
@@ -664,9 +665,10 @@ function handleStreamTopicMessage({
         return undefined;
     }
     const href = stream_topic_hash(stream.stream_id, topic) + "/near/" + message_id;
+    const topic_display_name_html = _.escape(util.get_final_topic_display_name(topic));
     return render_channel_message_link({
         channel_name: stream.name,
-        topic_display_name: util.get_final_topic_display_name(topic),
+        topic_display_name_html,
         is_empty_string_topic: topic === "",
         href,
     });

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -1,6 +1,7 @@
 import ClipboardJS from "clipboard";
 import {isValid, parseISO} from "date-fns";
 import $ from "jquery";
+import _ from "lodash";
 import assert from "minimalistic-assert";
 
 import render_channel_message_link from "../templates/channel_message_link.hbs";
@@ -11,6 +12,7 @@ import render_markdown_timestamp from "../templates/markdown_timestamp.hbs";
 import render_mention_content_wrapper from "../templates/mention_content_wrapper.hbs";
 import render_topic_link from "../templates/topic_link.hbs";
 
+import * as alert_words from "./alert_words.ts";
 import * as blueslip from "./blueslip.ts";
 import {show_copied_confirmation} from "./copied_tooltip.ts";
 import * as hash_util from "./hash_util.ts";
@@ -77,12 +79,17 @@ export function update_topic_or_message_link_element(
     stream_info: StreamInfo,
     topic_name: string,
     narrow_url: string,
+    message?: Message,
 ): void {
-    const topic_display_name = util.get_final_topic_display_name(topic_name);
+    let topic_display_name = _.escape(util.get_final_topic_display_name(topic_name));
+
+    if (message?.alerted) {
+        topic_display_name = alert_words.highlight_alert_words(topic_display_name);
+    }
 
     const context = {
         channel_name: stream_info.name,
-        topic_display_name,
+        topic_display_name_html: topic_display_name,
         is_empty_string_topic: topic_name === "",
         href: narrow_url,
     };
@@ -288,11 +295,13 @@ export const update_elements = ($content: JQuery): void => {
             // TODO: Ideally, we should NOT skip this if only topic is highlighted,
             // but we are doing so currently.
             assert(channel_topic.topic_name !== undefined);
+            message ??= get_message_for_message_content($content);
             update_topic_or_message_link_element(
                 $(this),
                 sub,
                 channel_topic.topic_name,
                 narrow_url,
+                message,
             );
         }
     });

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -157,6 +157,7 @@ export function set_name_in_mention_element(
 }
 
 export const update_elements = ($content: JQuery): void => {
+    let message: Message | undefined;
     // Set the rtl class if the text has an rtl direction
     if (rtl.get_direction($content.text()) === "rtl") {
         $content.addClass("rtl");
@@ -182,7 +183,7 @@ export const update_elements = ($content: JQuery): void => {
     // personal and stream wildcard mentions
     $content.find(".user-mention").each(function (): void {
         const user_id = get_user_id_for_mention_button(this);
-        const message = get_message_for_message_content($content);
+        message ??= get_message_for_message_content($content);
         const user_is_bot =
             user_id !== undefined && user_id !== "*" && people.is_valid_bot_user(user_id);
         // We give special highlights to the mention buttons
@@ -223,7 +224,7 @@ export const update_elements = ($content: JQuery): void => {
     });
 
     $content.find(".topic-mention").each(function (): void {
-        const message = get_message_for_message_content($content);
+        message ??= get_message_for_message_content($content);
 
         if (message?.topic_wildcard_mentioned) {
             $(this).addClass("user-mention-me");

--- a/web/templates/channel_message_link.hbs
+++ b/web/templates/channel_message_link.hbs
@@ -5,7 +5,7 @@
     {{~> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}
     {{~else~}}
     #{{channel_name}}
-    {{~/if}} &gt; <span class="empty-topic-display">{{topic_display_name}}</span> @ 💬
+    {{~/if}} &gt; <span class="empty-topic-display">{{{topic_display_name_html}}}</span> @ 💬
     {{~!-- squash whitespace --~}}
 </a>
 {{~else}}
@@ -15,7 +15,7 @@
     {{~> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}
     {{~else~}}
     #{{channel_name}}
-    {{~/if}} &gt; {{topic_display_name}} @ 💬
+    {{~/if}} &gt; {{{topic_display_name_html}}} @ 💬
     {{~!-- squash whitespace --~}}
 </a>
 {{~/if}}

--- a/web/templates/topic_link.hbs
+++ b/web/templates/topic_link.hbs
@@ -5,7 +5,7 @@
     {{~> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}
     {{~else~}}
     #{{channel_name}}
-    {{~/if}} &gt; <span class="empty-topic-display">{{topic_display_name}}</span>
+    {{~/if}} &gt; <span class="empty-topic-display">{{{topic_display_name_html}}}</span>
     {{~!-- squash whitespace --~}}
 </a>
 {{~else}}
@@ -15,7 +15,7 @@
     {{~> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}
     {{~else~}}
     #{{channel_name}}
-    {{~/if}} &gt; {{topic_display_name}}
+    {{~/if}} &gt; {{{topic_display_name_html}}}
     {{~!-- squash whitespace --~}}
 </a>
 {{~/if}}

--- a/web/tests/rendered_markdown.test.cjs
+++ b/web/tests/rendered_markdown.test.cjs
@@ -29,6 +29,7 @@ mock_cjs("clipboard", Clipboard);
 const realm_playground = mock_esm("../src/realm_playground");
 const copied_tooltip = mock_esm("../src/copied_tooltip");
 
+const alert_words = zrequire("alert_words");
 const rm = zrequire("rendered_markdown");
 const people = zrequire("people");
 const user_groups = zrequire("user_groups");
@@ -472,11 +473,100 @@ run_test("stream-links", ({mock_template}) => {
         channel_id: stream.stream_id,
         stream,
         channel_name: stream.name,
-        topic_display_name: "topic name > still the topic name",
+        topic_display_name_html: "topic name &gt; still the topic name",
         is_empty_string_topic: false,
         href: `/#narrow/channel/${stream.stream_id}-random/topic/topic.20name.20.3E.20still.20the.20topic.20name`,
     });
     assert.ok(!topic_link_rendered_html.includes("empty-topic-display"));
+});
+
+run_test("stream-links alert words", ({mock_template}) => {
+    // Setup
+    const $content = get_content_element();
+    const $stream = $.create("a.stream");
+    $stream.set_find_results(".highlight", []);
+    $stream.attr("data-stream-id", stream.stream_id);
+
+    const $stream_topic = $.create("a.stream-topic");
+    $stream_topic.set_find_results(".highlight", []);
+    $stream_topic.attr(
+        "href",
+        `/#narrow/channel/${stream.stream_id}-test/topic/important.20alert.20topic`,
+    );
+
+    $stream_topic[0].replaceWith = noop;
+    $stream_topic.addClass("stream-topic");
+    $stream_topic.text("#test alert > important alert topic");
+
+    $content.set_find_results("a.stream", $stream);
+    $content.set_find_results("a.stream-topic, a.message-link", $stream_topic);
+
+    let stream_name_context;
+    mock_template("decorated_channel_name.hbs", true, (data, html) => {
+        stream_name_context = data;
+        return html;
+    });
+
+    let topic_link_context;
+    mock_template("topic_link.hbs", true, (data, html) => {
+        topic_link_context = data;
+        return html;
+    });
+
+    const message = {alerted: true};
+    set_message_for_message_content($content, message);
+    alert_words.set_words(["alert"]);
+
+    rm.update_elements($content);
+
+    // Verify decorated_channel_name was called with the correct stream.
+    assert.ok(stream_name_context, "decorated_channel_name should be called");
+    assert.equal(stream_name_context.stream.stream_id, stream.stream_id);
+    assert.equal(stream_name_context.stream.name, stream.name);
+
+    assert.deepEqual(topic_link_context, {
+        channel_id: stream.stream_id,
+        stream,
+        channel_name: stream.name,
+        topic_display_name_html: "important <span class='alert-word'>alert</span> topic",
+        is_empty_string_topic: false,
+        href: `/#narrow/channel/${stream.stream_id}-test/topic/important.20alert.20topic`,
+    });
+
+    alert_words.set_words([]);
+});
+
+run_test("message-link alert words", ({mock_template}) => {
+    // Setup
+    const $content = get_content_element();
+    const $message_link = $.create("a.message-link(alert)");
+    $message_link.set_find_results(".highlight", []);
+    $message_link.attr("href", `/#narrow/channel/${stream.stream_id}-random/topic/alert/near/123`);
+    $message_link.addClass("message-link");
+    $message_link[0].replaceWith = noop;
+    $content.set_find_results("a.stream-topic, a.message-link", $message_link);
+
+    let channel_message_link_context;
+    mock_template("channel_message_link.hbs", true, (data, html) => {
+        channel_message_link_context = data;
+        return html;
+    });
+
+    const message = {alerted: true};
+    set_message_for_message_content($content, message);
+    alert_words.set_words(["alert"]);
+
+    rm.update_elements($content);
+
+    assert.deepEqual(channel_message_link_context, {
+        channel_name: stream.name,
+        topic_display_name_html: "<span class='alert-word'>alert</span>",
+        is_empty_string_topic: false,
+        href: `/#narrow/channel/${stream.stream_id}-random/topic/alert/near/123`,
+        stream,
+    });
+
+    alert_words.set_words([]);
 });
 
 run_test("topic-link (empty string topic)", ({mock_template}) => {
@@ -508,7 +598,7 @@ run_test("topic-link (empty string topic)", ({mock_template}) => {
         channel_id: stream.stream_id,
         stream,
         channel_name: stream.name,
-        topic_display_name: `translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}`,
+        topic_display_name_html: `translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}`,
         is_empty_string_topic: true,
         href: `/#narrow/channel/${stream.stream_id}-random/topic/`,
     });
@@ -547,7 +637,7 @@ run_test("message-links", ({mock_template}) => {
     // Final asserts
     assert.deepEqual(channel_message_link_context, {
         channel_name: stream.name,
-        topic_display_name: `translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}`,
+        topic_display_name_html: `translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}`,
         is_empty_string_topic: true,
         href: `/#narrow/channel/${stream.stream_id}-test/topic//near/123`,
         stream,


### PR DESCRIPTION
Enable highlighting of configured alert words in channel and topic links when they appear in message text.

Fixes: #37830.
CZO: [#issues > 📂 Inconsistent alert word highlight](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20Inconsistent.20alert.20word.20highlight/with/2370615)

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/68e74af8-c3dc-4f73-aa7a-b5220a19d4aa) | ![image-after](https://github.com/user-attachments/assets/76545926-8b30-4036-a159-79dddadd5742)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
