### PR TITLE
Fix broken message_feed_divider stream status content.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -736,6 +736,14 @@
     --input-vertical-padding: 4px;
     --input-border-width: 1px;
 
+    /* Message date divider variables */
+    --date-divider-text-padding: 12px;
+    --date-divider-line-gap: 4px;
+    --date-divider-right-edge-offset: 2px;
+    --date-divider-line-inset: calc(
+        var(--date-divider-text-padding) - var(--date-divider-line-gap)
+    );
+
     /* Colors used across the app */
     --color-date: light-dark(hsl(0deg 0% 15% / 75%), hsl(0deg 0% 100% / 75%));
     --color-background-private-message-header: light-dark(

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1160,7 +1160,7 @@
 .message_feed_divider {
     display: grid;
     grid-area: message_feed_divider_content;
-    grid-template: auto / minmax(20px, 1fr) auto max-content;
+    grid-template: auto / minmax(20px, 1fr) auto minmax(max-content, 1fr);
     grid-template-areas: "left_divider_content middle_divider_content right_divider_content";
     align-items: center;
     padding: 8px 0;
@@ -1201,46 +1201,48 @@
         }
     }
 
-    .timerender-content {
+    .date-divider-content {
+        position: relative;
         grid-area: right_divider_content;
         display: flex;
         align-items: center;
         justify-content: end;
         white-space: nowrap;
         letter-spacing: 0.04em;
-        /* Right padding matches time in message row and date in recipient row. */
-        padding-right: 6px;
 
         &::before {
+            position: relative;
             min-width: 20px;
             width: 100%;
-            right: 0.25em;
+            right: calc(-1 * var(--date-divider-line-inset));
             margin-left: -50%;
         }
 
         &::after {
-            width: 6px;
-            left: 0.25em;
-            /* Align date with message time and recipient bar date. */
-            margin-right: -1px;
+            position: absolute;
+            right: var(--date-divider-right-edge-offset);
+            width: calc(
+                var(--date-divider-line-inset) -
+                    var(--date-divider-right-edge-offset)
+            );
         }
 
         &::before,
         &::after {
-            position: relative;
             content: " ";
             height: 0;
             border-bottom: 1px solid
                 var(--color-border-message-group-spacer-line);
         }
 
-        &.date_row_text {
+        .date_row_text {
+            padding: 0 var(--date-divider-text-padding);
             cursor: pointer;
         }
     }
 
     .stream-status,
-    .timerender-content {
+    .date-divider-content {
         overflow: hidden;
         text-transform: uppercase;
         font-size: calc(12em / 14);

--- a/web/templates/single_message.hbs
+++ b/web/templates/single_message.hbs
@@ -20,9 +20,11 @@
         </span>
         {{/if}}
         {{#if want_date_divider}}
-            <span class="scroll-to-time" role="button" tabindex="0">
-                {{{date_divider_html}}}
-            </span>
+            <div class="date-divider-content">
+                <span class="scroll-to-time" role="button" tabindex="0">
+                    {{{date_divider_html}}}
+                </span>
+            </div>
         {{/if}}
     </div>
     {{/if}}


### PR DESCRIPTION
In 2761f96587e32b0c1595a0081b09dec3fd7fd776, date_divider was fixed to max-content, which means on shorter dates, the stream_status divider would shift right side as the third column of the divider becomes small. We instead use `date-divider-content` div to calculate divider column while keeping `scroll-to-time` only max width of `timerender-content` for mouse hover and popover click area.

Came across this while working on moved message divider. I have opened as separate PR since we would probably want to get this merged quickly.

**How changes were tested:**

|Before|After|
|-|-|
|<img width="799" height="374" alt="image" src="https://github.com/user-attachments/assets/ebfb7de2-3d72-49fd-b7f3-c5cdfd9d6a96" />|<img width="799" height="374" alt="image" src="https://github.com/user-attachments/assets/533c5a77-a907-4fed-9c17-cc97ebc29836" />|

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
