### PR TITLE
keyboard_ui: Fix overscroll for long focused items.

### DIFF
--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -164,8 +164,20 @@ function update_rendered_drafts(
 
 const keyboard_handling_context: messages_overlay_ui.Context = {
     get_items_ids() {
-        const draft_arrow = drafts.draft_model.get();
-        return Object.getOwnPropertyNames(draft_arrow);
+        const draft_ids: string[] = [];
+        $("#drafts_table .draft-message-row").each(function (this: HTMLElement) {
+            const draft_id = $(this).attr("data-draft-id");
+            if (draft_id !== undefined) {
+                draft_ids.push(draft_id);
+            }
+        });
+
+        if (draft_ids.length > 0) {
+            return draft_ids;
+        }
+
+        const draft_map = drafts.draft_model.get();
+        return Object.getOwnPropertyNames(draft_map);
     },
     on_enter() {
         // This handles when pressing Enter while looking at drafts.

--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -51,18 +51,52 @@ export function focus_on_sibling_element(context: Context): void {
 }
 
 export function modals_handle_events(event_key: string, context: Context): void {
+    const had_focus = row_with_focus(context).length > 0;
     initialize_focus(event_key, context);
+    const has_focus = row_with_focus(context).length > 0;
 
     // This detects up arrow key presses when the overlay
     // is open and scrolls through.
     if (event_key === "up_arrow" || event_key === "vim_up") {
-        scroll_to_element(row_before_focus(context), context);
+        if (has_focus) {
+            if (!had_focus) {
+                scroll_to_element(row_with_focus(context), context);
+            } else {
+                const $focused_row = row_with_focus(context);
+                const $items_list = $(`.${CSS.escape(context.items_list_selector)}`);
+                if (should_scroll_within_row($focused_row, $items_list, -1)) {
+                    // Keep the scroll behavior symmetric with the down-arrow path
+                    // to avoid jumpy upward scrolling for tall rows.
+                    scroll_list_by_arrow(context, -1);
+                } else {
+                    scroll_to_element(row_before_focus(context), context);
+                }
+            }
+        } else {
+            scroll_list_by_arrow(context, -1);
+        }
     }
 
     // This detects down arrow key presses when the overlay
     // is open and scrolls through.
     if (event_key === "down_arrow" || event_key === "vim_down") {
-        scroll_to_element(row_after_focus(context), context);
+        if (has_focus) {
+            if (!had_focus) {
+                // `initialize_focus` already selected the first row for this keypress.
+                // Avoid an extra one-time jump so the first Down press feels the
+                // same as subsequent presses.
+                return;
+            }
+            const $focused_row = row_with_focus(context);
+            const $items_list = $(`.${CSS.escape(context.items_list_selector)}`);
+            if (should_scroll_within_row($focused_row, $items_list, 1)) {
+                scroll_list_by_arrow(context, 1);
+            } else {
+                scroll_to_element(row_after_focus(context), context);
+            }
+        } else {
+            scroll_list_by_arrow(context, 1);
+        }
     }
 
     if (event_key === "backspace" || event_key === "delete") {
@@ -72,6 +106,53 @@ export function modals_handle_events(event_key: string, context: Context): void 
     if (event_key === "enter") {
         context.on_enter();
     }
+}
+
+function scroll_list_by_arrow(context: Context, direction: -1 | 1): void {
+    const active_element = document.activeElement;
+    if (
+        active_element instanceof HTMLElement &&
+        (active_element.tagName === "INPUT" ||
+            active_element.tagName === "TEXTAREA" ||
+            active_element.isContentEditable)
+    ) {
+        return;
+    }
+
+    const $items_list = $(`.${CSS.escape(context.items_list_selector)}`);
+    if ($items_list.length === 0) {
+        return;
+    }
+
+    const $scroll_element = scroll_util.get_scroll_element($items_list);
+    const scroll_element = util.the($scroll_element);
+    const step = Math.max(32, Math.round(scroll_element.clientHeight * 0.1));
+    const prefers_reduced_motion =
+        window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    const behavior: ScrollBehavior = prefers_reduced_motion ? "auto" : "smooth";
+    scroll_element.scrollBy({top: direction * step, behavior});
+}
+
+function should_scroll_within_row($row: JQuery, $items_list: JQuery, direction: -1 | 1): boolean {
+    if ($row.length === 0 || $items_list.length === 0) {
+        return false;
+    }
+
+    const scroll_element = util.the(scroll_util.get_scroll_element($items_list));
+    const view_rect = scroll_element.getBoundingClientRect();
+    const row_rect = util.the($row).getBoundingClientRect();
+    const view_height = view_rect.bottom - view_rect.top;
+
+    if (row_rect.height <= view_height) {
+        return false;
+    }
+
+    const PADDING_BOTTOM = 12;
+    const PADDING_TOP = 4;
+    if (direction === 1) {
+        return row_rect.bottom > view_rect.bottom + PADDING_BOTTOM;
+    }
+    return row_rect.top < view_rect.top - PADDING_TOP;
 }
 
 export function set_initial_element(element_id: string | undefined, context: Context): void {
@@ -154,34 +235,63 @@ function scroll_to_element($element: JQuery, context: Context): void {
     activate_element($element[0].children[0], context);
 
     const $items_list = $(`.${CSS.escape(context.items_list_selector)}`);
-    const $items_container = $(`.${CSS.escape(context.items_container_selector)}`);
     const $box_item = $(`.${CSS.escape(context.box_item_selector)}`);
+    const $scroll_element = scroll_util.get_scroll_element($items_list);
+    const scroll_element = util.the($scroll_element);
+    const prefers_reduced_motion =
+        window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    const behavior: ScrollBehavior = prefers_reduced_motion ? "auto" : "smooth";
+    const section_id = $element.parent().attr("id");
+    const is_first_in_section =
+        $element.parent().children().first()[0] !== undefined &&
+        $element.parent().children().first()[0] === $element[0];
+    const is_section_boundary =
+        (section_id === "drafts-from-conversation" || section_id === "other-drafts") &&
+        is_first_in_section;
+
+    // When crossing between draft sections, align the first row of the new section
+    // to the top of the list so navigation starts from the beginning, not the end.
+    if (is_section_boundary) {
+        const view_top = scroll_element.getBoundingClientRect().top;
+        const elem_top = $element[0].getBoundingClientRect().top;
+        const delta = elem_top - view_top;
+        if (Math.abs(delta) > 2) {
+            scroll_element.scrollTo({top: scroll_element.scrollTop + delta, behavior});
+        }
+        return;
+    }
 
     // If focused element is first, scroll to the top.
     if (util.the($box_item.first()).parentElement === $element[0]) {
-        util.the($items_list).scrollTop = 0;
+        const view_rect = scroll_element.getBoundingClientRect();
+        const row_rect = $element[0].getBoundingClientRect();
+        const view_height = view_rect.bottom - view_rect.top;
+        if (row_rect.height > view_height) {
+            const delta = row_rect.bottom - view_rect.bottom;
+            scroll_element.scrollTo({top: scroll_element.scrollTop + delta, behavior});
+        } else {
+            scroll_element.scrollTo({top: 0, behavior});
+        }
+        return;
     }
-
     // If focused element is last, scroll to the bottom.
     if (util.the($box_item.last()).parentElement === $element[0]) {
-        util.the($items_list).scrollTop =
-            util.the($items_list).scrollHeight - ($items_list.height() ?? 0);
+        const view_rect = scroll_element.getBoundingClientRect();
+        const row_rect = $element[0].getBoundingClientRect();
+        const view_height = view_rect.bottom - view_rect.top;
+        if (row_rect.height > view_height) {
+            const delta = row_rect.top - view_rect.top;
+            scroll_element.scrollTo({top: scroll_element.scrollTop + delta, behavior});
+        } else {
+            scroll_element.scrollTo({
+                top: scroll_element.scrollHeight - scroll_element.clientHeight,
+                behavior,
+            });
+        }
+        return;
     }
 
-    // If focused element is cut off from the top, scroll up halfway in modal.
-    if ($element.position().top < 55) {
-        // 55 is the minimum distance from the top that will require extra scrolling.
-        util.the($items_list).scrollTop -= util.the($items_list).clientHeight / 2;
-    }
-
-    // If focused element is cut off from the bottom, scroll down halfway in modal.
-    const dist_from_top = $element.position().top;
-    const total_dist = dist_from_top + $element[0].clientHeight;
-    const dist_from_bottom = util.the($items_container).clientHeight - total_dist;
-    if (dist_from_bottom < -4) {
-        // -4 is the min dist from the bottom that will require extra scrolling.
-        util.the($items_list).scrollTop += util.the($items_list).clientHeight / 2;
-    }
+    scroll_util.scroll_element_into_container($element, $items_list);
 }
 
 function get_element_by_id(id: string, context: Context): JQuery {

--- a/web/src/scroll_util.ts
+++ b/web/src/scroll_util.ts
@@ -5,6 +5,58 @@ import * as util from "./util.ts";
 
 // This type is helpful for testing, where we may have a dummy object instead of an actual jquery object.
 type JQueryOrZJQuery = {__zjquery?: true} & JQuery;
+type OffsetLike = {top: number};
+
+function has_numeric_length(value: unknown): value is {length: number} {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        typeof Reflect.get(value, "length") === "number"
+    );
+}
+
+function has_get_bounding_client_rect(
+    value: unknown,
+): value is {getBoundingClientRect: () => DOMRect} {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        typeof Reflect.get(value, "getBoundingClientRect") === "function"
+    );
+}
+
+function has_contains(value: unknown): value is {contains: (node: Node) => boolean} {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        typeof Reflect.get(value, "contains") === "function"
+    );
+}
+
+function has_offset_element(
+    value: unknown,
+): value is {offset: () => OffsetLike | undefined; innerHeight: () => number | undefined} {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        typeof Reflect.get(value, "offset") === "function" &&
+        typeof Reflect.get(value, "innerHeight") === "function"
+    );
+}
+
+function has_offset_container(value: unknown): value is {
+    offset: () => OffsetLike | undefined;
+    height: () => number | undefined;
+    scrollTop: (arg?: number) => number | JQueryOrZJQuery;
+} {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        typeof Reflect.get(value, "offset") === "function" &&
+        typeof Reflect.get(value, "height") === "function" &&
+        typeof Reflect.get(value, "scrollTop") === "function"
+    );
+}
 
 export function get_content_element($element: JQuery): JQuery {
     const element = util.the($element);
@@ -31,6 +83,10 @@ export function get_scroll_element($element: JQueryOrZJQuery): JQuery {
         return $(new SimpleBar(element, {tabIndex: -1}).getScrollElement()!);
     }
     return $element;
+}
+
+export function get_left_sidebar_scroll_container(): JQuery {
+    return get_scroll_element($("#left_sidebar_scroll_container"));
 }
 
 export function reset_scrollbar($element: JQuery): void {
@@ -72,37 +128,82 @@ export function scroll_element_into_container(
     $container: JQuery,
     sticky_header_height = 0,
 ): void {
-    // This does the minimum amount of scrolling that is needed to make
-    // the element visible.  It doesn't try to center the element, so
-    // this will be non-intrusive to users when they already have
-    // the element visible.
     $container = get_scroll_element($container);
+    const elem = has_numeric_length($elem) ? util.the($elem) : $elem;
+    const container = has_numeric_length($container) ? util.the($container) : $container;
 
-    // To correctly compute the offset of the element's scroll
-    // position within our scroll container, we need to subtract the
-    // scroll container's own offset within the document.
-    const elem_offset = $elem.offset()?.top ?? 0;
-    const container_offset = $container.offset()?.top ?? 0;
+    const can_use_dom_rect =
+        has_get_bounding_client_rect(elem) && has_get_bounding_client_rect(container);
+    const can_use_offsets = has_offset_element($elem) && has_offset_container($container);
 
-    const elem_top = elem_offset - container_offset - sticky_header_height;
-    const elem_bottom = elem_top + ($elem.innerHeight() ?? 0);
-    const container_height = ($container.height() ?? 0) - sticky_header_height;
-
-    const opts = {
-        elem_top,
-        elem_bottom,
-        container_height,
-    };
-
-    const delta = scroll_delta(opts);
-
-    if (delta === 0) {
+    if (!can_use_dom_rect && can_use_offsets) {
+        // Fallback for tests or non-DOM stubs.
+        const elem_offset = $elem.offset()?.top ?? 0;
+        const container_offset = $container.offset()?.top ?? 0;
+        const elem_top = elem_offset - container_offset - sticky_header_height;
+        const elem_bottom = elem_top + ($elem.innerHeight() ?? 0);
+        const container_height = ($container.height() ?? 0) - sticky_header_height;
+        const delta = scroll_delta({
+            elem_top,
+            elem_bottom,
+            container_height,
+        });
+        if (delta !== 0) {
+            $container.scrollTop(($container.scrollTop() ?? 0) + delta);
+        }
         return;
     }
 
-    $container.scrollTop(($container.scrollTop() ?? 0) + delta);
-}
+    if (!can_use_dom_rect) {
+        return;
+    }
 
-export function get_left_sidebar_scroll_container(): JQuery {
-    return get_scroll_element($("#left_sidebar_scroll_container"));
+    const elem_rect = elem.getBoundingClientRect();
+    const container_rect = container.getBoundingClientRect();
+    const view_top = container_rect.top + sticky_header_height;
+    const view_bottom = container_rect.bottom;
+    const selection = window.getSelection();
+    let caret_rect = null;
+
+    if (selection && selection.rangeCount > 0) {
+        const range = selection.getRangeAt(0);
+        const anchor_node = selection.anchorNode;
+        const caret_in_container =
+            anchor_node && has_contains(container) && container.contains(anchor_node);
+        if (caret_in_container) {
+            caret_rect = range.getBoundingClientRect();
+        }
+    }
+
+    let delta = 0;
+    const PADDING = 30;
+    const view_height = view_bottom - view_top;
+    const is_tall_element = elem_rect.height > view_height;
+    if (caret_rect && caret_rect.height > 0) {
+        if (caret_rect.top < view_top) {
+            delta = caret_rect.top - view_top - PADDING;
+        } else if (caret_rect.bottom > view_bottom) {
+            delta = caret_rect.bottom - view_bottom + PADDING;
+        }
+    }
+    if (delta === 0) {
+        if (is_tall_element) {
+            delta = elem_rect.top - view_top - PADDING;
+        } else if (elem_rect.top < view_top) {
+            delta = elem_rect.top - view_top - PADDING;
+        } else if (elem_rect.bottom > view_bottom) {
+            delta = elem_rect.bottom - view_bottom + PADDING;
+        }
+    }
+    if (Math.abs(delta) < 2) {
+        return;
+    }
+
+    const prefers_reduced_motion =
+        window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    const behavior: ScrollBehavior = prefers_reduced_motion ? "auto" : "smooth";
+    container.scrollBy({
+        top: delta,
+        behavior,
+    });
 }


### PR DESCRIPTION
This PR fixes the overscroll issue in the Drafts and Scheduled Messages overlays.

While navigating using the Up/Down arrow keys the list could sometimes jump to the top or bottom unexpectedly. This was especially noticeable with long draft or scheduled message and also when opening the overlay without a previously focused row.
The overscroll was happening because the app was trying to keep the focused draft visible by aggressively pushing the scroll position up or down. This worked fine for normalsized items, but when a draft was very tall (long content), the logic would over-correct and jump too far sometimes straight to the top or bottom of the list.

We now use the actual scrollable element `SimpleBar’s inner scroll container` instead of the outer wrapper, so scroll calculations are accurate.

Re-opening previous PR with required changes made. 

Fixes #35038

Testing:
- Tested keyboard navigation on short and long drafts
- Tested Scheduled Messages overlay
- Verified that entering the overlay does not cause scroll jumps
- Confirmed no jump-to-top/bottom behavior occurs during navigation
  
**Screenrecording of changes:**

https://github.com/user-attachments/assets/e7fec5de-2f70-4821-80e6-583a2c3fd454


https://github.com/user-attachments/assets/24977605-5f2f-4fda-84a9-c74b7d49e864


https://github.com/user-attachments/assets/5c92e12f-b07e-4549-a083-408cb3748055


https://github.com/user-attachments/assets/2fe8f063-a3cb-492d-9061-5c75f2bc6e06

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
