### PR TITLE
api docs: Document POST /default_stream_groups/create.

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -130,6 +130,7 @@
 
 #### Server & organizations
 
+* [Create a default channel group](/api/create-default-stream-group)
 * [Get server settings](/api/get-server-settings)
 * [Get linkifiers](/api/get-linkifiers)
 * [Add a linkifier](/api/add-linkifier)

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -431,6 +431,17 @@ def get_temporary_url_for_uploaded_file() -> dict[str, object]:
     return {"realm_id_str": realm_id, "filename": filename}
 
 
+@openapi_param_value_generator(["/default_stream_groups/create:post"])
+def create_default_stream_group_data() -> dict[str, object]:
+    helpers.subscribe(helpers.example_user("iago"), "new_test_stream")
+
+    return {
+        "group_name": "Marketing",
+        "description": "Default channels for the marketing team.",
+        "stream_names": ["new_test_stream"],
+    }
+
+
 @openapi_param_value_generator(["/users/me/api_key/regenerate:post"])
 def regenerate_api_key_test_user() -> dict[str, object]:
     test_user_email = "regenerate-api-key-test@zulip.com"

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -883,6 +883,29 @@ def update_stream(client: Client, stream_id: int) -> None:
     validate_against_openapi_schema(result, "/streams/{stream_id}", "patch", "200")
 
 
+@openapi_test_function("/default_stream_groups/create:post")
+def create_default_stream_group(client: Client) -> None:
+    client.call_endpoint(
+        url="/users/me/subscriptions",
+        method="POST",
+        request={"subscriptions": '[{"name": "new_test_stream"}]'},
+    )
+
+    # {code_example|start}
+    request = {
+        "group_name": "Engineering",
+        "description": "Default channels for the engineering team.",
+        "stream_names": json.dumps(["new_test_stream"]),
+    }
+    result = client.call_endpoint(
+        url="/default_stream_groups/create",
+        method="POST",
+        request=request,
+    )
+    # {code_example|end}
+    print(result)
+
+
 @openapi_test_function("/user_groups:get")
 def get_user_groups(client: Client) -> int:
     # {code_example|start}
@@ -2160,6 +2183,7 @@ def test_server_organizations(client: Client) -> None:
     export_realm(client)
     get_realm_exports(client)
     get_realm_export_consents(client)
+    create_default_stream_group(client)
 
 
 def test_errors(client: Client) -> None:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8068,6 +8068,62 @@ paths:
                   - $ref: "#/components/schemas/InvalidChannelError"
                   - description: |
                       A typical failed JSON response for when an invalid channel ID is passed:
+  /default_stream_groups/create:
+    post:
+      summary: Create a default channel group
+      description: |
+        Create a new default channel group.
+
+        Default channel groups allow organizations to group channels together
+        so that users can be easily subscribed to multiple channels at once.
+      tags:
+        - server_and_organizations
+      operationId: create-default-stream-group
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                group_name:
+                  description: The name of the default channel group.
+                  type: string
+                  example: "Engineering"
+                description:
+                  description: A description for the default channel group.
+                  type: string
+                  example: "Default channels for the engineering team."
+                stream_names:
+                  description: A JSON-encoded array of channel names to include in the group.
+                  type: array
+                  items:
+                    type: string
+                  example:
+                    - "new_test_stream"
+              required:
+                - group_name
+                - description
+                - stream_names
+            encoding:
+              stream_names:
+                contentType: application/json
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                    example: {"result": "success", "msg": ""}
+
   /messages:
     get:
       operationId: get-messages

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -216,7 +216,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         # Delete a data export.
         "/export/realm/{export_id}",
         # Manage default streams and default stream groups
-        "/default_stream_groups/create",
         "/default_stream_groups/{group_id}",
         "/default_stream_groups/{group_id}/streams",
         # Single-stream settings alternative to the bulk endpoint


### PR DESCRIPTION
This PR adds the missing documentation for the `POST /default_stream_groups/create` endpoint and removes it from the `pending_endpoints` list.

**Changes included:**

* **OpenAPI Schema**: Added the endpoint definition to `zerver/openapi/zulip.yaml`.
* **Python Code Example**: Added the test example using `@openapi_test_function`. Used the API client to dynamically create an isolated stream group to prevent testing suite database errors.
* **cURL Test**: Patched the curl parameter generator in `curl_param_value_generators.py` to use an isolated stream group name ('Marketing') to avoid database collision errors during the automated test suite.
* **Docs & Changelog**: Added the endpoint to `rest-endpoints.md` for the sidebar.

Fixes: Part of the pending documentation endpoints in `zerver/tests/test_openapi.py` (No specific issue number).

**How changes were tested:**

* Ran `tools/check-openapi.ts` (Passed)
* Ran the full `tools/test-api` suite (Passed)
* Manually verified the UI rendering locally at `http://localhost:9991/api/create-default-stream-group`


**Screenshots and screen captures:**

**After (New Page): python examples**
<img width="983" height="1213" alt="image" src="https://github.com/user-attachments/assets/00a1c948-7c2a-4f7c-97f6-3eb51a63ea9a" />

**After (New Page): cURL examples**
<img width="992" height="1043" alt="image" src="https://github.com/user-attachments/assets/5d18da5c-e145-42cc-ad0f-e7e66e14c41f" />
<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>