### PR TITLE
hotkey: Support macOS Ctrl+N/P navigation in search menus.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -164,6 +164,7 @@ import {insertTextIntoField} from "text-field-edit";
 import getCaretCoordinates from "textarea-caret";
 import * as tippy from "tippy.js";
 
+import * as common from "./common.ts";
 import * as mouse_drag from "./mouse_drag.ts";
 import * as scroll_util from "./scroll_util.ts";
 import {get_string_diff, the} from "./util.ts";
@@ -256,6 +257,7 @@ export class Typeahead<ItemType extends string | object> {
     stopAdvance: boolean;
     advanceKeys: string[];
     non_tippy_parent_element: string | undefined;
+    enableMacCtrlNPNavigation: boolean;
     values: WeakMap<HTMLElement, ItemType>;
     instance: tippy.Instance | undefined;
     requireHighlight: boolean;
@@ -310,6 +312,7 @@ export class Typeahead<ItemType extends string | object> {
         this.tabIsEnter = options.tabIsEnter ?? true;
         this.helpOnEmptyStrings = options.helpOnEmptyStrings ?? false;
         this.non_tippy_parent_element = options.non_tippy_parent_element;
+        this.enableMacCtrlNPNavigation = options.enableMacCtrlNPNavigation ?? false;
         this.values = new WeakMap();
         this.requireHighlight = options.requireHighlight ?? true;
         this.shouldHighlightFirstResult = options.shouldHighlightFirstResult ?? (() => true);
@@ -725,7 +728,9 @@ export class Typeahead<ItemType extends string | object> {
             return;
         }
 
-        switch (e.key) {
+        const key = this.normalize_typeahead_nav_key(e);
+
+        switch (key) {
             case "Tab":
                 if (!this.tabIsEnter) {
                     return;
@@ -769,8 +774,9 @@ export class Typeahead<ItemType extends string | object> {
             e.preventDefault();
             this.select(e);
         }
+        const key = this.normalize_typeahead_nav_key(e);
         this.suppressKeyPressRepeat = !["ArrowDown", "ArrowUp", "Tab", "Enter", "Escape"].includes(
-            e.key,
+            key,
         );
         this.move(e);
     }
@@ -790,7 +796,9 @@ export class Typeahead<ItemType extends string | object> {
         // it did modify the query. For example, `Command + delete` on Mac
         // doesn't trigger a keyup event but when `Command` is released, it
         // triggers a keyup event which correctly updates the list.
-        switch (e.key) {
+        const key = this.normalize_typeahead_nav_key(e);
+
+        switch (key) {
             case "ArrowDown":
             case "ArrowUp":
                 break;
@@ -946,6 +954,28 @@ export class Typeahead<ItemType extends string | object> {
         // input position by asking popper to recompute your tooltip's position.
         void this.instance?.popperInstance?.update();
     }
+
+    private normalize_typeahead_nav_key(
+        e: JQuery.KeyDownEvent | JQuery.KeyPressEvent | JQuery.KeyUpEvent,
+    ): string {
+        if (!this.enableMacCtrlNPNavigation) {
+            return e.key;
+        }
+
+        // Support Ctrl+N/Ctrl+P as up/down navigation on macOS.
+        if (common.has_mac_keyboard() && e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
+            const key = e.key.toLowerCase();
+
+            if (key === "n") {
+                return "ArrowDown";
+            }
+            if (key === "p") {
+                return "ArrowUp";
+            }
+        }
+
+        return e.key;
+    }
 }
 
 /* TYPEAHEAD PLUGIN DEFINITION
@@ -972,6 +1002,7 @@ type TypeaheadOptions<ItemType> = {
     sorter: (items: ItemType[], query: string) => ItemType[];
     stopAdvance?: boolean;
     tabIsEnter?: boolean;
+    enableMacCtrlNPNavigation?: boolean;
     select_on_escape_condition?: () => boolean;
     trigger_selection?: (event: JQuery.KeyDownEvent) => boolean;
     updater?: (

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -353,6 +353,26 @@ export function get_keydown_hotkey(e: JQuery.KeyDownEvent): Hotkey | Hotkey[] | 
         }
     }
 
+    const is_message_or_gear_menu_open =
+        popover_menus.is_message_actions_popover_displayed() ||
+        popover_menus.is_gear_menu_popover_displayed();
+    if (
+        common.has_mac_keyboard() &&
+        e.ctrlKey &&
+        !e.metaKey &&
+        !e.altKey &&
+        !e.shiftKey &&
+        is_message_or_gear_menu_open
+    ) {
+        const lowercase_key = key.toLowerCase();
+        if (lowercase_key === "n") {
+            return KEYDOWN_MAPPINGS["ArrowDown"];
+        }
+        if (lowercase_key === "p") {
+            return KEYDOWN_MAPPINGS["ArrowUp"];
+        }
+    }
+
     if (common.has_mac_keyboard() && e.ctrlKey && key !== "[") {
         // On macOS, Cmd is used instead of Ctrl. Except 'Ctrl + ['.
         return undefined;

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -215,6 +215,7 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
         helpOnEmptyStrings: true,
         stopAdvance: true,
         requireHighlight: false,
+        enableMacCtrlNPNavigation: true,
         item_html(item: string, query: string): string {
             return search_pill.generate_pills_html(item, query);
         },

--- a/web/tests/hotkey.test.cjs
+++ b/web/tests/hotkey.test.cjs
@@ -83,6 +83,16 @@ const popovers = mock_esm("../src/user_card_popover", {
         is_open: () => false,
     },
 });
+const popover_menus = mock_esm("../src/popover_menus", {
+    get_visible_instance: () => undefined,
+    sidebar_menu_instance_handle_keyboard() {},
+    is_color_picker_popover_displayed: () => false,
+    is_stream_actions_popover_displayed: () => false,
+    is_message_actions_popover_displayed: () => false,
+    is_personal_menu_popover_displayed: () => false,
+    is_gear_menu_popover_displayed: () => false,
+    is_help_menu_popover_displayed: () => false,
+});
 const reactions = mock_esm("../src/reactions");
 const read_receipts = mock_esm("../src/read_receipts");
 const search = mock_esm("../src/search");
@@ -238,6 +248,21 @@ run_test("mappings", () => {
     assert.equal(map_down("s", false, true, false), undefined);
     assert.equal(map_down(".", false, false, true).name, "narrow_to_compose_target");
     assert.equal(map_down(".", false, true, false), undefined);
+    assert.equal(map_down("n", false, true, false), undefined);
+    assert.equal(map_down("p", false, true, false), undefined);
+
+    with_overrides(({override}) => {
+        override(popover_menus, "is_message_actions_popover_displayed", () => true);
+        assert.equal(map_down("n", false, true, false).name, "down_arrow");
+        assert.equal(map_down("p", false, true, false).name, "up_arrow");
+    });
+
+    with_overrides(({override}) => {
+        override(popover_menus, "is_message_actions_popover_displayed", () => false);
+        override(popover_menus, "is_gear_menu_popover_displayed", () => true);
+        assert.equal(map_down("n", false, true, false).name, "down_arrow");
+        assert.equal(map_down("p", false, true, false).name, "up_arrow");
+    });
     // Reset platform
     navigator.platform = "";
 
@@ -311,6 +336,21 @@ run_test("mappings non-latin keyboard", () => {
     assert.equal(map_down("л", "KeyK", false, true, false), undefined);
     assert.equal(map_down("ы", "KeyS", false, false, true).name, "star_message");
     assert.equal(map_down("ы", "KeyS", false, true, false), undefined);
+    assert.equal(map_down("т", "KeyN", false, true, false), undefined);
+    assert.equal(map_down("з", "KeyP", false, true, false), undefined);
+
+    with_overrides(({override}) => {
+        override(popover_menus, "is_message_actions_popover_displayed", () => true);
+        assert.equal(map_down("т", "KeyN", false, true, false).name, "down_arrow");
+        assert.equal(map_down("з", "KeyP", false, true, false).name, "up_arrow");
+    });
+
+    with_overrides(({override}) => {
+        override(popover_menus, "is_message_actions_popover_displayed", () => false);
+        override(popover_menus, "is_gear_menu_popover_displayed", () => true);
+        assert.equal(map_down("т", "KeyN", false, true, false).name, "down_arrow");
+        assert.equal(map_down("з", "KeyP", false, true, false).name, "up_arrow");
+    });
     // Reset platform
     navigator.platform = "";
 

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -82,6 +82,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
         assert.equal(opts.items, 999);
         assert.equal(opts.helpOnEmptyStrings, true);
         assert.equal(opts.matcher(), true);
+        assert.equal(opts.enableMacCtrlNPNavigation, true);
 
         return {
             lookup() {


### PR DESCRIPTION
dds macOS-style Ctrl+N / Ctrl+P navigation for the search typeahead, message actions dropdown (i), and gear dropdown (g) (Ctrl+N = down, Ctrl+P = up)

Fixes: https://github.com/zulip/zulip/issues/10884

How changes were tested:

Node tests (tools/test-js-with-node)
Manual testing (video)

**Screenshots and screen captures:**

- Before: 


https://github.com/user-attachments/assets/7f355859-2633-4735-b5f9-97b389a13503






<!-- attach/drag video here -->
- After: 



https://github.com/user-attachments/assets/c68871ae-5fd4-4658-a47a-438e81304933






 <!-- attach/drag video here -->

</details>

<details>
<summary>Implementation notes</summary>

- Added an `enableMacCtrlNPNavigation` option to `Typeahead` and used it to normalize navigation keys (`Ctrl+N`/`Ctrl+P` -> down/up) on macOS.
- Enabled this option only for the search bar typeahead in `search.ts` to keep typeahead behavior changes minimal.
- Added scoped hotkey handling in `hotkey.ts` so `Ctrl+N/P` also navigate the message actions (`i`) and gear (`g`) dropdowns when those popovers are open.
- Added/updated tests in `search.test.cjs` and `hotkey.test.cjs`.
</details>

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
      <!-- I used AI assistance for guidance on locating relevant code paths and drafting a minimal change. I reviewed and verified the final code and behavior myself. -->

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>

