### PR TITLE
left_sidebar: hide drafts menu icon when there are no drafts.

### DIFF
--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -24,6 +24,7 @@ import * as util from "./util.ts";
 export function set_count(count: number): void {
     const $drafts_li = $(".top_left_drafts");
     ui_util.update_unread_count_in_dom($drafts_li, count);
+    $(".drafts-sidebar-menu-icon").toggleClass("hide", count === 0);
 }
 
 function getTimestamp(): number {

--- a/web/src/left_sidebar_navigation_area_popovers.ts
+++ b/web/src/left_sidebar_navigation_area_popovers.ts
@@ -134,7 +134,12 @@ export function initialize(): void {
         onShow(instance) {
             popovers.hide_all();
 
+            if (drafts.draft_model.getDraftCount() === 0) {
+                return false;
+            }
+
             instance.setContent(ui_util.parse_html(render_left_sidebar_drafts_popover({})));
+            return undefined;
         },
         onHidden(instance) {
             instance.destroy();


### PR DESCRIPTION
Previously, the “Delete all drafts” option was always visible in the left sidebar drafts popover even when no drafts were saved. Clicking it in that state had no effect.

This PR updates the popover to show the “Delete all drafts” option only when at least one draft exists. If there are no drafts the option is hidden. This prevents users from seeing a non-functional action.

Fixes: [#issues > Unexpected behavior in "Delete All drafts" option](https://chat.zulip.org/#narrow/channel/9-issues/topic/Unexpected.20behavior.20in.20.22Delete.20All.20drafts.22.20option/with/2393737)
<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/aeee2ad5-99b5-4027-a78e-842c3411389f" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/b16138b8-e0c0-4bf4-a483-0eae28e47bc1" width="400" controls></video> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
