### PR TITLE
Add Snap and Flatpak custom certificate instructions

### DIFF
--- a/starlight_help/src/content/docs/custom-certificates.mdx
+++ b/starlight_help/src/content/docs/custom-certificates.mdx
@@ -81,6 +81,37 @@ browser.
 
     You will need to restart the Zulip Desktop application to pick up the
     new certificate.
+
+    #### Snap
+
+    For installations via Snap, the certificate must be added to a Snap
+    specific `nss` database. Once the `nss` tools are installed, the command to
+    trust the certificate is:
+
+    ```bash "path/to/certificate.pem"
+    certutil \
+      -d sql:$(echo 'echo $SNAP_USER_DATA' | snap run --shell zulip)/.pki/nssdb \
+      -A -t "P,," -n zulip -i path/to/certificate.pem
+    ```
+
+    You will need to restart the Zulip Desktop application to pick up the
+    new certificate.
+
+    #### Flatpak
+
+    For installations via Flatpak, the certificate must be added to the system
+    certificate database and the `p11-kit` tools be installed. The steps to do
+    so vary by distribution.
+
+    On Ubuntu or Debian the commands are as follows:
+
+    ```bash "path/to/certificate.pem"
+    sudo cp path/to/certificate.pem /usr/local/share/ca-certificates/zulip.crt
+    sudo update-ca-certificates
+    ```
+
+    You will need to restart the Zulip Desktop application to pick up the
+    new certificate.
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
This PR adds instructions for adding a custom certificate to the Zulip desktop app on Linux, when installed via Snap or Flatpak. The current instructions don't work, seemingly due to sandboxing features of the two formats.

Fixes: https://chat.zulip.org/#narrow/channel/16-desktop/topic/Flatpak.20custom.20certificate.20troubles/near/2390438

**How changes were tested:**

By following the instructions in a clean environment.

**Screenshots and screen captures:**

Before:

<img width="720" height="272" alt="before" src="https://github.com/user-attachments/assets/c172dc27-a520-4f52-84d4-2dc3ed481d6e" />

After:

<img width="480" height="570" alt="after" src="https://github.com/user-attachments/assets/61fa3198-93c8-4052-a1ae-9a68b5f01ebf" />

The Snap directory that contains the `nss` database of interest for the Zulip desktop app is in most cases located `$HOME/snap/zulip/current`, however it seems this isn't always the case. See, for instance, https://forum.snapcraft.io/t/28509.

As a result, a rather convoluted command seems to be needed to reliably get the location of the directory in question. It makes use of the `SNAP_USER_DATA` environment variable available via opening a shell as the snap, see https://snapcraft.io/docs/reference/development/environment-variables/. This is the best way I found. I might very well have missed a great solution, though!

An alternative to writing to the Snap specific `nss` database _might_ be to allow the Snap access to `$HOME/.pki/nssdb`. I believe this was the approach taken in the one similar seeming case I was able to find: https://forum.snapcraft.io/t/44643

I didn't test this approach though, as I don't how to. Also, I'm not convinced that it _is_ the preferred approach. It seems rather discouraged: https://snapcraft.io/docs/reference/interfaces/personal-files-interface/

<details>
<summary>Self-review checklist</summary>

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

