### PR TITLE
Show all DMs in zoomed DMs view.

### DIFF
--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -13,6 +13,7 @@ import type {PMNode} from "./pm_list_dom.ts";
 import * as resize from "./resize.ts";
 import * as scroll_util from "./scroll_util.ts";
 import * as ui_util from "./ui_util.ts";
+import * as unread from "./unread.ts";
 import type {FullUnreadCountsData} from "./unread.ts";
 import * as util from "./util.ts";
 import * as vdom from "./vdom.ts";
@@ -66,6 +67,10 @@ export function _build_direct_messages_list(opts: {
     );
     const pm_list_info = pm_list_data.get_list_info(zoomed, opts.search_term);
     const more_conversations_unread_count = pm_list_info.more_conversations_unread_count;
+
+    if (zoomed) {
+        pm_list_nodes.unshift(pm_list_dom.all_dms_li(unread.get_counts().direct_message_count));
+    }
 
     if (!opts.all_conversations_shown) {
         pm_list_nodes.push(

--- a/web/src/pm_list_dom.ts
+++ b/web/src/pm_list_dom.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 
 import render_more_private_conversations from "../templates/more_pms.hbs";
+import render_pm_list_all_dms from "../templates/pm_list_all_dms.hbs";
 import render_pm_list_item from "../templates/pm_list_item.hbs";
 
 import * as vdom from "./vdom.ts";
@@ -18,6 +19,10 @@ export type PMNode =
     | {
           type: "more_items";
           more_conversations_unread_count: number;
+      }
+    | {
+          type: "all_dms";
+          unread_count: number;
       };
 
 export function keyed_pm_li(conversation: PMListConversation): vdom.Node<PMNode> {
@@ -58,6 +63,23 @@ export function more_private_conversations_li(
         eq,
         type: "more_items",
         more_conversations_unread_count,
+    };
+}
+
+export function all_dms_li(unread_count: number): vdom.Node<PMNode> {
+    const render = (): string => render_pm_list_all_dms({unread_count});
+
+    const eq = (other: PMNode): boolean =>
+        other.type === "all_dms" && unread_count === other.unread_count;
+
+    const key = "all_dms";
+
+    return {
+        key,
+        type: "all_dms",
+        unread_count,
+        render,
+        eq,
     };
 }
 

--- a/web/templates/more_pms.hbs
+++ b/web/templates/more_pms.hbs
@@ -1,5 +1,5 @@
 <li id="show-more-direct-messages" class="dm-list-item dm-box bottom_left_row {{#if (eq more_conversations_unread_count 0)}}zero-dm-unreads{{/if}}">
-    <a class="dm-name trigger-click-on-enter" tabindex="0">{{t "more conversations" }}</a>
+    <a class="dm-name trigger-click-on-enter" tabindex="0">{{t "Show all DMs" }}</a>
     <span class="unread_count {{#if (eq more_conversations_unread_count 0)}}zero_count{{/if}}">
         {{more_conversations_unread_count}}
     </span>

--- a/web/templates/pm_list_all_dms.hbs
+++ b/web/templates/pm_list_all_dms.hbs
@@ -1,0 +1,13 @@
+<li class="dm-list-item dm-box bottom_left_row" id="show-all-direct-messages">
+    <a href="#narrow/is/dm" draggable="false" class="dm-box dm-user-status show-all-direct-messages" tabindex="0">
+        <span class="conversation-partners-icon zulip-icon zulip-icon-all-messages"></span>
+        <span class="conversation-partners">
+            <span class="conversation-partners-list">{{t "All DMs" }}</span>
+        </span>
+        <div class="dm-markers-and-unreads">
+            <span class="unread_count {{#if (eq unread_count 0)}}zero_count{{/if}}">
+                {{unread_count}}
+            </span>
+        </div>
+    </a>
+</li>


### PR DESCRIPTION
DESCRIPTION: 
Renamed the "more conversations" link in the Direct Messages sidebar to "Show all DMs" and added an "All DMs" row at the top of the zoomed DMs view.

The "All DMs" row links to #narrow/is/dm and displays the total unread direct message count, matching the behavior of "Show all topics" in the topics view.

Fixes: 
https://github.com/zulip/zulip/issues/37976

Started the Zulip development server locally.
Verified the sidebar now displays "Show all DMs" instead of "more conversations".
Clicked "Show all DMs" and confirmed the zoomed DMs view opens.
Verified that "All DMs" appears as the first row in the zoomed view.
Confirmed that the unread count displays correctly.
Clicked "All DMs" and verified navigation to #narrow/is/dm.
Confirmed there are no console errors in the browser.
Frontend and backend tests pass locally. 

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures
<img width="2880" height="1800" alt="Screenshot (173)" src="https://github.com/user-attachments/assets/50f31992-652e-4efc-bab5-d9baddb20a52" />
<img width="2880" height="1800" alt="Screenshot (174)" src="https://github.com/user-attachments/assets/a6d2a12f-128f-4c7f-9302-915dc8cb3dab" />
:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
