### PR TITLE
user_profile: Include active tab in URL for back-button support

### DIFF
--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -459,3 +459,26 @@ export function get_link_hash(link: string): string {
         return "";
     }
 }
+
+const user_profile_tab_url_map: Record<string, string> = {
+    "profile-tab": "profile",
+    "user-profile-streams-tab": "channels",
+    "user-profile-groups-tab": "groups",
+    "manage-profile-tab": "manage",
+};
+
+const user_profile_url_tab_map: Record<string, string> = {
+    profile: "profile-tab",
+    channels: "user-profile-streams-tab",
+    groups: "user-profile-groups-tab",
+    manage: "manage-profile-tab",
+};
+
+export function user_profile_url(user_id: number, tab_key = "profile-tab"): string {
+    const tab_segment = user_profile_tab_url_map[tab_key] ?? "profile";
+    return `#user/${user_id}/${tab_segment}`;
+}
+
+export function user_profile_tab_key_from_url(tab_segment: string): string {
+    return user_profile_url_tab_map[tab_segment] ?? "profile-tab";
+}

--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -375,6 +375,12 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
             const right_side_tab = hash_parser.get_current_nth_hash_section(3);
             user_group_edit.change_state(section, undefined, right_side_tab);
         }
+        if (base === "user") {
+            const tab_segment = hash_parser.get_current_nth_hash_section(2);
+            const tab_key = hash_util.user_profile_tab_key_from_url(tab_segment);
+            user_profile.update_user_profile_tab(tab_key);
+            return;
+        }
 
         if (base === "settings") {
             if (!section) {
@@ -529,12 +535,18 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
     }
 
     if (base === "user") {
-        const user_id = Number.parseInt(hash_parser.get_current_hash_section(), 10);
+        const user_id = Number.parseInt(hash_parser.get_current_hash_section() ?? "", 10);
         if (!people.is_known_user_id(user_id)) {
             user_profile.show_user_profile_access_error_modal();
         } else {
             const user = people.get_by_user_id(user_id);
-            user_profile.show_user_profile(user);
+            const tab_segment = hash_parser.get_current_nth_hash_section(2);
+            const tab_key = hash_util.user_profile_tab_key_from_url(tab_segment);
+            if (user_profile.get_user_id_if_user_profile_modal_open() === user_id) {
+                user_profile.update_user_profile_tab(tab_key);
+            } else {
+                user_profile.show_user_profile(user, tab_key);
+            }
         }
         return;
     }
@@ -570,7 +582,11 @@ function hashchanged(
 
     if (hash_parser.is_overlay_hash(current_hash)) {
         browser_history.state.changing_hash = true;
-        modals.close_active_if_any();
+        const new_base = hash_parser.get_current_hash_category();
+        const old_base = hash_parser.get_hash_category(old_hash ?? "");
+        if (new_base !== old_base) {
+            modals.close_active_if_any();
+        }
         do_hashchange_overlay(old_hash);
         browser_history.state.changing_hash = false;
         return undefined;

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -33,6 +33,7 @@ import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import type {DropdownWidget, DropdownWidgetOptions} from "./dropdown_widget.ts";
 import {get_current_hash_category} from "./hash_parser.ts";
+import * as hash_parser from "./hash_parser.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t, $t_html} from "./i18n.ts";
 import type {InputPillContainer} from "./input_pill.ts";
@@ -41,6 +42,7 @@ import * as ListWidget from "./list_widget.ts";
 import type {ListWidget as ListWidgetType} from "./list_widget.ts";
 import * as loading from "./loading.ts";
 import * as modals from "./modals.ts";
+import * as overlays from "./overlays.ts";
 import * as peer_data from "./peer_data.ts";
 import * as people from "./people.ts";
 import type {User} from "./people.ts";
@@ -102,6 +104,13 @@ export function show_button_spinner($button: JQuery): void {
     $button.prop("disabled", true);
     loading.show_spinner($button, $spinner);
 }
+
+const USER_PROFILE_TAB_URL_MAP: Record<string, string> = {
+    "profile-tab": "profile",
+    "user-profile-streams-tab": "channels",
+    "user-profile-groups-tab": "groups",
+    "manage-profile-tab": "manage",
+};
 
 export function hide_button_spinner($button: JQuery): void {
     const $spinner = $button.find(".modal__spinner");
@@ -566,18 +575,19 @@ export function hide_user_profile(): void {
 }
 
 function on_user_profile_hide(): void {
-    const base = get_current_hash_category();
-    // After closing the user profile, if the hash consists of `#user`
-    // it means that it acts as an overlay rather than a modal (when
-    // no other overlay is in the background). Hence, we also need to
-    // update the hash when we close it.
-    if (base === "user") {
+    if (get_current_hash_category() === "user") {
         browser_history.exit_overlay();
     }
 }
 
 function show_manage_user_tab(target: string): void {
     toggler.goto(target);
+}
+
+export function update_user_profile_tab(tab_key: string): void {
+    if (toggler) {
+        toggler.goto(tab_key);
+    }
 }
 
 function initialize_user_type_fields(user: User): void {
@@ -588,6 +598,30 @@ function initialize_user_type_fields(user: User): void {
     } else {
         initialize_bot_owner("#user-profile-modal #content", user.user_id);
     }
+}
+
+function update_tab_in_url(key: string): void {
+    if (hash_parser.get_current_hash_category() !== "user") {
+        return;
+    }
+    const raw_section = hash_parser.get_current_hash_section();
+    if (!raw_section) {
+        return;
+    }
+
+    const [user_id_str] = raw_section.split("/");
+
+    if (!user_id_str) {
+        return;
+    }
+
+    const user_id = Number.parseInt(user_id_str, 10);
+    const tab_segment = USER_PROFILE_TAB_URL_MAP[key] ?? "profile";
+    const new_hash = `#user/${user_id}/${tab_segment}`;
+    if (window.location.hash === new_hash) {
+        return;
+    }
+    browser_history.update(new_hash);
 }
 
 export function show_user_profile_access_error_modal(): void {
@@ -747,16 +781,36 @@ export function show_user_profile(user: User, default_tab_key = "profile-tab"): 
     }
 
     $("#user-profile-modal-holder").html(render_user_profile_modal(args));
+    const user_profile_hash = `#user/${user.user_id}/${USER_PROFILE_TAB_URL_MAP[default_tab_key] ?? "profile"}`;
+
+    browser_history.set_hash_before_overlay(
+        hash_parser.get_current_hash_category() === "user"
+            ? browser_history.get_home_view_hash()
+            : window.location.hash,
+    );
     modals.open("user-profile-modal", {autoremove: true, on_hide: on_user_profile_hide});
+    if (!overlays.any_active()) {
+        if (hash_parser.get_current_hash_category() === "user") {
+            window.history.replaceState(null, "", user_profile_hash);
+        } else {
+            browser_history.update(user_profile_hash);
+        }
+    }
     $(".tabcontent").hide();
     $("#user-profile-modal .dialog_submit_button").prop("disabled", true);
 
     let default_tab = 0;
 
-    if (default_tab_key === "user-profile-streams-tab") {
-        default_tab = 1;
-    } else if (default_tab_key === "manage-profile-tab") {
-        default_tab = 3;
+    switch (default_tab_key) {
+        case "user-profile-streams-tab":
+            default_tab = 1;
+            break;
+        case "user-profile-groups-tab":
+            default_tab = 2;
+            break;
+        case "manage-profile-tab":
+            default_tab = 3;
+            break;
     }
 
     let has_initialized_user_type_fields = false;
@@ -775,6 +829,7 @@ export function show_user_profile(user: User, default_tab_key = "profile-tab"): 
             $("#user-profile-modal .manage-profile-tab-footer").removeClass(
                 "manage-profile-tab-active",
             );
+            update_tab_in_url(key);
             switch (key) {
                 case "profile-tab":
                     if (!has_initialized_user_type_fields) {
@@ -1677,8 +1732,14 @@ export function initialize(): void {
     $("body").on(
         "click",
         "#user-profile-modal .user-profile-channel-row, .user-profile-group-row",
-        () => {
+        (e) => {
+            e.preventDefault();
+            const href =
+                $(e.currentTarget).find("a").attr("href") ?? $(e.currentTarget).attr("href");
             hide_user_profile();
+            if (href) {
+                browser_history.go_to_location(href);
+            }
         },
     );
 


### PR DESCRIPTION
This PR adds support for tab aware URLs in the user profile modal using the `#user/{user_id}/{tab}` routing scheme.

Previously the active tab (Profile, Channels, User Groups, Manage Groups) was not included in the URL. As a result, the browser back button would not restore the correct tab state within the user profile modal.

Fixes: #38156
<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/70bc735e-291e-4a00-8b09-af5bb05a47d6" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/ec63650d-f288-42e8-9a77-35c737a7765d" width="400" controls></video> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
