### PR TITLE
drafts: Fix draft-overlay layout when resizing window.

### DIFF
--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -378,7 +378,7 @@ function setup_bulk_actions_handlers(): void {
     });
 }
 
-function rerender_drafts(): void {
+export function rerender_drafts(): void {
     const {narrow_drafts, other_drafts, narrow_drafts_header} = get_formatted_drafts_data();
     render_widgets(narrow_drafts, other_drafts, narrow_drafts_header);
     setup_event_handlers();

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -756,6 +756,12 @@ export async function initialize_everything(state_data) {
     });
     drafts.initialize_ui();
     drafts_overlay_ui.initialize();
+    $(window).on("resize.drafts_overlay", () => {
+        if (!overlays.drafts_open()) {
+            return;
+        }
+        drafts_overlay_ui.rerender_drafts();
+    });
     // This needs to happen after activity_ui.initialize, so that user_filter
     // is defined. Also, must happen after people.initialize()
     onboarding_steps.initialize(state_data.onboarding_steps, {


### PR DESCRIPTION
When resizing the window from wide to narrow while the drafts overlay is open, the layout does not adjust correctly. This change adds a scoped resize listener in 'drafts_overlay_ui.ts' and re-renders the overlay only when it is active.

Fixes: [#issues > drafts overlay not resizing as expected](https://chat.zulip.org/#narrow/channel/9-issues/topic/drafts.20overlay.20not.20resizing.20as.20expected/with/2394511)

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|-------|
|<img width="1207" height="903" alt="Screenshot 2026-03-02 144202" src="https://github.com/user-attachments/assets/b2f36c10-a75a-4b97-8093-1b5a704c1e43" />|<img width="1208" height="903" alt="Screenshot 2026-03-02 144355" src="https://github.com/user-attachments/assets/c812c182-ead6-4696-bbeb-43cce0f7e785" />|


| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/19d4e9d2-d214-4c23-8d64-156872eb6566" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/9dd2a93b-ccf0-4978-be41-9f19e4de3f84" width="400" controls></video> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
