### PR TITLE
user_status_ui: Add up/down arrow navigation for status picker.

### DIFF
--- a/web/src/user_status_ui.ts
+++ b/web/src/user_status_ui.ts
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import assert from "minimalistic-assert";
 
 import render_set_status_overlay from "../templates/set_status_overlay.hbs";
 import render_status_emoji_selector from "../templates/status_emoji_selector.hbs";
@@ -165,6 +166,16 @@ function user_status_post_render(): void {
         update_button();
     });
 
+    $("#set-user-status-modal").on("keydown", "input.user-status, .user-status-value", (event) => {
+        if (event.key !== "ArrowUp" && event.key !== "ArrowDown") {
+            return;
+        }
+
+        event.preventDefault();
+        assert(event.currentTarget instanceof HTMLElement);
+        navigate_status_options($(event.currentTarget), event.key);
+    });
+
     input_field().on("keydown", (event) => {
         if (keydown_util.is_enter_event(event)) {
             event.preventDefault();
@@ -183,6 +194,15 @@ function user_status_post_render(): void {
         set_selected_emoji_info({});
         update_button();
     });
+}
+
+function navigate_status_options($focused_element: JQuery, key: "ArrowUp" | "ArrowDown"): void {
+    const $navigable_elements = input_field().add("#set-user-status-modal .user-status-value");
+    const current_index = $navigable_elements.index($focused_element);
+    const offset = key === "ArrowDown" ? 1 : -1;
+    const next_index =
+        (current_index + offset + $navigable_elements.length) % $navigable_elements.length;
+    $navigable_elements.eq(next_index).trigger("focus");
 }
 
 export function initialize(): void {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Earlier we couldnt navigate through status picker using up or down arrows. Only tab does the navigation.
Users can now
- Move focus from input field to the first status using down arrow.
- Move focus from input field to the last status using up arrow.
- Navigate inside statuses using up/down arrow

Fixes #35178.

**How changes were tested:**
I tested the chnage manually by navigating using the arrows.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**



https://github.com/user-attachments/assets/61a2a49a-7131-44fb-ac81-297ef2a4d3f8






<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
