### PR TITLE
[ai] Restore scroll position in recent view after clearning search.

### DIFF
--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -2185,6 +2185,10 @@ export function initialize({
         pre_search_topic_viewport_offset = undefined;
     });
 
+    $("body").on("click", "#recent-view-search-wrapper .input-close-filter-button", () => {
+        set_default_focus();
+    });
+
     $("body").on("click", "#recent-view-content-table .on_hover_topic_read", (e) => {
         e.stopPropagation();
         assert(e.currentTarget instanceof HTMLElement);


### PR DESCRIPTION
discussion: [#issues > reset scrolling when searching recent conversations](https://chat.zulip.org/#narrow/channel/9-issues/topic/reset.20scrolling.20when.20searching.20recent.20conversations/with/2282806)

The first commit is fix of the existing behaviour to scroll to top when searching something. It wasn't not working always.

Next 2 commits at logic to restore scroll position and focus when user clears search input.