### PR TITLE
user_status: Allow bots with role=admin to change user status. 

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 473**
+
+- [`POST /users/{user_id}/status`](/api/update-status-for-user): Bots
+  with administrator permissions can now use this endpoint.
+
 **Feature level 472**
 
 * [`GET /attachments`](/api/get-attachments), [`GET /events`](/api/get-events):

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 472
+API_FEATURE_LEVEL = 473
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/user_status.py
+++ b/zerver/lib/user_status.py
@@ -1,8 +1,12 @@
+from dataclasses import dataclass
 from typing import TypedDict
 
 from django.db.models import Q
 from django.utils.timezone import now as timezone_now
+from django.utils.translation import gettext as _
 
+from zerver.lib.emoji import check_emoji_request, get_emoji_data
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.users import check_user_can_access_all_users, get_accessible_user_ids
 from zerver.models import Realm, UserProfile, UserStatus
 
@@ -132,3 +136,66 @@ def get_user_status(user_profile: UserProfile) -> UserInfoDict:
     if not status_set_by_user:
         return {}
     return format_user_status(status_set_by_user)
+
+
+@dataclass
+class NewUserStatus:
+    status_text: str | None
+    emoji_name: str | None
+    emoji_code: str | None
+    reaction_type: str | None
+
+
+def check_update_user_status(
+    realm: Realm,
+    *,
+    away: bool | None = None,
+    status_text: str | None = None,
+    emoji_name: str | None = None,
+    emoji_code: str | None = None,
+    emoji_type: str | None = None,
+) -> NewUserStatus:
+    if status_text is not None:
+        status_text = status_text.strip()
+
+    if (away is None) and (status_text is None) and (emoji_name is None):
+        raise JsonableError(_("Client did not pass any new values."))
+
+    if emoji_name == "":
+        # Reset the emoji_code and reaction_type if emoji_name is empty.
+        # This should clear the user's configured emoji.
+        emoji_code = ""
+        emoji_type = UserStatus.UNICODE_EMOJI
+
+    elif emoji_name is not None:
+        if emoji_code is None or emoji_type is None:
+            emoji_data = get_emoji_data(realm.id, emoji_name)
+            if emoji_code is None:
+                # The emoji_code argument is only required for rare corner
+                # cases discussed in the long block comment below.  For simple
+                # API clients, we allow specifying just the name, and just
+                # look up the code using the current name->code mapping.
+                emoji_code = emoji_data.emoji_code
+
+            if emoji_type is None:
+                emoji_type = emoji_data.reaction_type
+
+    elif emoji_type or emoji_code:
+        raise JsonableError(
+            _("Client must pass emoji_name if they pass either emoji_code or reaction_type.")
+        )
+
+    # If we're asking to set an emoji (not clear it ("") or not adjust
+    # it (None)), we need to verify the emoji is valid.
+    if emoji_name not in ["", None]:
+        assert emoji_name is not None
+        assert emoji_code is not None
+        assert emoji_type is not None
+        check_emoji_request(realm, emoji_name, emoji_code, emoji_type)
+
+    return NewUserStatus(
+        status_text=status_text,
+        emoji_name=emoji_name,
+        emoji_code=emoji_code,
+        reaction_type=emoji_type,
+    )

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10807,7 +10807,11 @@ paths:
         Administrator endpoint for changing the [status](/help/status-and-availability) of
         another user.
 
-        **Changes**: New in Zulip 11.0 (feature level 407).
+        **Changes**: Prior to Zulip 12.0 (feature level 473), only
+        bots could not access this API endpoint, regardless of the
+        role of the bot.
+
+        New in Zulip 11.0 (feature level 407).
       x-requires-administrator: true
       requestBody:
         required: false

--- a/zerver/tests/test_user_status.py
+++ b/zerver/tests/test_user_status.py
@@ -4,6 +4,7 @@ import orjson
 import time_machine
 from django.utils.timezone import now as timezone_now
 
+from zerver.actions.users import do_change_user_role
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.user_status import (
     UserInfoDict,
@@ -546,3 +547,30 @@ class UserStatusTest(ZulipTestCase):
                 reaction_type=UserStatus.UNICODE_EMOJI,
             ),
         )
+
+        # Bot with admin privileges can set status for another user.
+        bot = self.create_test_bot("iago-bot", iago)
+        do_change_user_role(
+            bot, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=iago, notify=False
+        )
+
+        update_status_url = f"/api/v1/users/{hamlet.id}/status"
+
+        with self.capture_send_event_calls(expected_num_events=1) as events:
+            result = self.api_post(bot, update_status_url, {"status_text": "status by bot"})
+        self.assert_json_success(result)
+        self.assertEqual(
+            events[0]["event"],
+            dict(type="user_status", user_id=hamlet.id, status_text="status by bot"),
+        )
+        self.assertEqual(
+            user_status_info(hamlet)["status_text"],
+            "status by bot",
+        )
+
+        # Bot with non-admin privileges can't set status for another user.
+        do_change_user_role(bot, UserProfile.ROLE_MEMBER, acting_user=iago, notify=False)
+
+        with self.capture_send_event_calls(expected_num_events=0) as events:
+            result = self.api_post(bot, update_status_url, {"status_text": "new status by bot"})
+        self.assert_json_error(result, "Insufficient permission")

--- a/zerver/views/presence.py
+++ b/zerver/views/presence.py
@@ -9,16 +9,15 @@ from pydantic import Json, StringConstraints
 from zerver.actions.presence import update_user_presence
 from zerver.actions.user_status import do_update_user_status
 from zerver.decorator import human_users_only
-from zerver.lib.emoji import check_emoji_request, get_emoji_data
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.presence import get_presence_for_user, get_presence_response
 from zerver.lib.request import RequestNotes
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.typed_endpoint import ApiParamConfig, PathOnly, typed_endpoint
-from zerver.lib.user_status import get_user_status
+from zerver.lib.user_status import check_update_user_status, get_user_status
 from zerver.lib.users import access_user_by_id, check_can_access_user
-from zerver.models import UserPresence, UserProfile, UserStatus
+from zerver.models import UserPresence, UserProfile
 from zerver.models.users import get_active_user, get_active_user_profile_by_id_in_realm
 
 
@@ -93,60 +92,30 @@ def update_user_status_backend(
         str | None, StringConstraints(strip_whitespace=True, max_length=60)
     ] = None,
 ) -> HttpResponse:
-    if status_text is not None:
-        status_text = status_text.strip()
-
-    if (away is None) and (status_text is None) and (emoji_name is None):
-        raise JsonableError(_("Client did not pass any new values."))
-
-    if emoji_name == "":
-        # Reset the emoji_code and reaction_type if emoji_name is empty.
-        # This should clear the user's configured emoji.
-        emoji_code = ""
-        emoji_type = UserStatus.UNICODE_EMOJI
-
-    elif emoji_name is not None:
-        if emoji_code is None or emoji_type is None:
-            emoji_data = get_emoji_data(user_profile.realm_id, emoji_name)
-            if emoji_code is None:
-                # The emoji_code argument is only required for rare corner
-                # cases discussed in the long block comment below.  For simple
-                # API clients, we allow specifying just the name, and just
-                # look up the code using the current name->code mapping.
-                emoji_code = emoji_data.emoji_code
-
-            if emoji_type is None:
-                emoji_type = emoji_data.reaction_type
-
-    elif emoji_type or emoji_code:
-        raise JsonableError(
-            _("Client must pass emoji_name if they pass either emoji_code or reaction_type.")
-        )
-
-    # If we're asking to set an emoji (not clear it ("") or not adjust
-    # it (None)), we need to verify the emoji is valid.
-    if emoji_name not in ["", None]:
-        assert emoji_name is not None
-        assert emoji_code is not None
-        assert emoji_type is not None
-        check_emoji_request(user_profile.realm, emoji_name, emoji_code, emoji_type)
+    user_status = check_update_user_status(
+        user_profile.realm,
+        away=away,
+        status_text=status_text,
+        emoji_name=emoji_name,
+        emoji_code=emoji_code,
+        emoji_type=emoji_type,
+    )
 
     client = RequestNotes.get_notes(request).client
     assert client is not None
     do_update_user_status(
         user_profile=user_profile,
         away=away,
-        status_text=status_text,
+        status_text=user_status.status_text,
         client_id=client.id,
-        emoji_name=emoji_name,
-        emoji_code=emoji_code,
-        reaction_type=emoji_type,
+        emoji_name=user_status.emoji_name,
+        emoji_code=user_status.emoji_code,
+        reaction_type=user_status.reaction_type,
     )
 
     return json_success(request)
 
 
-@human_users_only
 @typed_endpoint
 def update_user_status_admin(
     request: HttpRequest,
@@ -161,14 +130,28 @@ def update_user_status_admin(
     emoji_type: Annotated[str | None, ApiParamConfig("reaction_type")] = None,
 ) -> HttpResponse:
     target_user = access_user_by_id(user_profile, user_id, allow_bots=False, for_admin=True)
-    return update_user_status_backend(
-        request,
-        user_profile=target_user,
+
+    user_status = check_update_user_status(
+        target_user.realm,
         status_text=status_text,
         emoji_name=emoji_name,
         emoji_code=emoji_code,
         emoji_type=emoji_type,
     )
+
+    client = RequestNotes.get_notes(request).client
+    assert client is not None
+    do_update_user_status(
+        user_profile=target_user,
+        away=None,
+        status_text=user_status.status_text,
+        client_id=client.id,
+        emoji_name=user_status.emoji_name,
+        emoji_code=user_status.emoji_code,
+        reaction_type=user_status.reaction_type,
+    )
+
+    return json_success(request)
 
 
 @human_users_only


### PR DESCRIPTION
CZO: [#issues > Change the user’s status from a bot. @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/Change.20the.20user.E2.80.99s.20status.20from.20a.20bot.2E/near/2385493)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
