### PR TITLE
puppet: get_django_setting_slow returns nil if there are no deploy dirs.

### DIFF
--- a/puppet/zulip/lib/puppet/functions/get_django_setting_slow.rb
+++ b/puppet/zulip/lib/puppet/functions/get_django_setting_slow.rb
@@ -8,19 +8,18 @@ require "open3"
 
 Puppet::Functions.create_function(:get_django_setting_slow) do
   def get_django_setting_slow(name)
-    if File.exist?("/etc/zulip/settings.py")
-      if Dir.exist?("/home/zulip/deployments/current")
-        deploy_dir = "current"
-      else
-        # First puppet runs during install don't have a "current" yet, only a "next"
-        deploy_dir = "next"
-      end
-      output, _stderr, status = Open3.capture3("/home/zulip/deployments/#{deploy_dir}/scripts/get-django-setting", name)
-      if status.success?
-        output.strip
-      else
-        nil
-      end
+    return nil unless File.exist?("/etc/zulip/settings.py")
+    if Dir.exist?("/home/zulip/deployments/current")
+      deploy_dir = "current"
+    elsif Dir.exist?("/home/zulip/deployments/next")
+      # First puppet runs during install don't have a "current" yet, only a "next"
+      deploy_dir = "next"
+    else
+      return nil
+    end
+    output, _stderr, status = Open3.capture3("/home/zulip/deployments/#{deploy_dir}/scripts/get-django-setting", name)
+    if status.success?
+      output.strip
     else
       nil
     end


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
