### PR TITLE
 Allow channel-specific wildcard_mentions_notify to override channel muting 

### DIFF
--- a/starlight_help/src/content/docs/dm-mention-alert-notifications.mdx
+++ b/starlight_help/src/content/docs/dm-mention-alert-notifications.mdx
@@ -41,8 +41,10 @@ mentions (**@all**, **@everyone**, **@channel**) and **@topic** mentions
 separately from personal @-mentions.
 
 <ZulipTip>
-  These mentions don't trigger notifications in muted channels or topics,
-  unlike personal mentions.
+  These mentions don't trigger notifications in muted topics, unlike
+  personal mentions. In muted channels, they are suppressed by default,
+  but you can override this by enabling wildcard mention notifications
+  for a specific channel in your [Channel settings](/help/channel-notifications).
 </ZulipTip>
 
 <FlattenedSteps>

--- a/web/src/message_notifications.ts
+++ b/web/src/message_notifications.ts
@@ -11,6 +11,7 @@ import * as message_view from "./message_view.ts";
 import * as people from "./people.ts";
 import * as spoilers from "./spoilers.ts";
 import * as stream_data from "./stream_data.ts";
+import * as sub_store from "./sub_store.ts";
 import * as ui_util from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
 import * as user_topics from "./user_topics.ts";
@@ -244,7 +245,8 @@ export function message_is_notifiable(message: Message | TestNotificationMessage
     }
 
     // @-<username> mentions take precedence over muted-ness. Note
-    // that @all mentions are still suppressed by muting.
+    // that @all mentions are still suppressed by muting unless the
+    // channel-specific wildcard_mentions_notify setting is enabled.
     if (message.mentioned_me_directly) {
         return true;
     }
@@ -263,7 +265,18 @@ export function message_is_notifiable(message: Message | TestNotificationMessage
         stream_data.is_muted(message.stream_id) &&
         !user_topics.is_topic_unmuted(message.stream_id, message.topic)
     ) {
-        return false;
+        // Channel-specific wildcard_mentions_notify=true overrides channel
+        // muting for wildcard mentions (but not topic muting, checked above).
+        const sub = sub_store.get(message.stream_id);
+        if (
+            !(
+                message.mentioned &&
+                !message.mentioned_me_directly &&
+                sub?.wildcard_mentions_notify === true
+            )
+        ) {
+            return false;
+        }
     }
 
     if (message.type === "stream" && user_topics.is_topic_muted(message.stream_id, message.topic)) {

--- a/web/tests/notifications.test.cjs
+++ b/web/tests/notifications.test.cjs
@@ -238,6 +238,28 @@ test("message_is_notifiable", ({override}) => {
     assert.equal(message_notifications.should_send_audible_notification(message), true);
     assert.equal(message_notifications.message_is_notifiable(message), false);
 
+    // Case 7a: If a message is in a muted stream
+    //  and has a wildcard mention with channel-specific wildcard_mentions_notify=true,
+    //  DO notify the user (channel-specific setting overrides channel muting)
+    muted.wildcard_mentions_notify = true;
+    message = {
+        id: 50,
+        content: "message number 5a",
+        sent_by_me: false,
+        notification_sent: false,
+        mentioned: true,
+        mentioned_me_directly: false,
+        type: "stream",
+        stream_id: muted.stream_id,
+        topic: "whatever",
+    };
+    assert.equal(message_notifications.message_is_notifiable(message), true);
+    assert.equal(message_notifications.should_send_desktop_notification(message), true);
+    assert.equal(message_notifications.should_send_audible_notification(message), true);
+
+    // Reset state
+    muted.wildcard_mentions_notify = null;
+
     // Case 8: If a message is in a muted stream
     //  and does mention the user DIRECTLY,
     //  DO notify the user

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -338,7 +338,9 @@ def get_recipient_info(
 
         user_id_to_visibility_policy = stream_topic.user_id_to_visibility_policy_dict()
 
-        def notification_recipients(setting: str) -> set[int]:
+        def notification_recipients(
+            setting: str, *, channel_specific_overrides_mute: bool = False
+        ) -> set[int]:
             return {
                 row["user_profile_id"]
                 for row in subscription_rows
@@ -349,6 +351,7 @@ def get_recipient_info(
                     ),
                     row[setting],
                     row["user_profile_" + setting],
+                    channel_specific_overrides_mute=channel_specific_overrides_mute,
                 )
             }
 
@@ -377,7 +380,9 @@ def get_recipient_info(
             # This is important so as to avoid unnecessarily sending huge user ID lists with
             # thousands of elements to the event queue (which can happen because these settings
             # are `True` by default for new users.)
-            wildcard_mentions_notify_user_ids = notification_recipients("wildcard_mentions_notify")
+            wildcard_mentions_notify_user_ids = notification_recipients(
+                "wildcard_mentions_notify", channel_specific_overrides_mute=True
+            )
             followed_topic_wildcard_mentions_notify_user_ids = (
                 followed_topic_notification_recipients("wildcard_mentions_notify")
             )

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -294,15 +294,27 @@ def user_allows_notifications_in_StreamTopic(
     visibility_policy: int,
     stream_specific_setting: bool | None,
     global_setting: bool,
+    *,
+    channel_specific_overrides_mute: bool = False,
 ) -> bool:
     """
     Captures the hierarchy of notification settings, where visibility policy is considered first,
     followed by stream-specific settings, and the global-setting in the UserProfile is the fallback.
+
+    When channel_specific_overrides_mute is True (used for wildcard mention notifications),
+    an explicit channel-specific setting of True will override channel muting, but not
+    topic muting. This allows users who opt into wildcard notifications for a specific
+    channel to receive them even when the channel is muted.
     """
-    if stream_is_muted and visibility_policy != UserTopic.VisibilityPolicy.UNMUTED:
+    # Muted topics always suppress notifications, regardless of other settings.
+    if visibility_policy == UserTopic.VisibilityPolicy.MUTED:
         return False
 
-    if visibility_policy == UserTopic.VisibilityPolicy.MUTED:
+    if stream_is_muted and visibility_policy != UserTopic.VisibilityPolicy.UNMUTED:
+        # For wildcard mentions, an explicit channel-specific opt-in overrides
+        # channel muting. The global/org-wide setting does not override muting.
+        if channel_specific_overrides_mute and stream_specific_setting is True:
+            return True
         return False
 
     if stream_specific_setting is not None:

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -427,6 +427,52 @@ class MissedMessageHookTest(ZulipTestCase):
                 already_notified={"email_notified": False, "push_notified": False},
             )
 
+    def test_stream_wildcard_mention_in_muted_stream_with_channel_specific_setting(self) -> None:
+        # When wildcard_mentions_notify is explicitly True for the channel,
+        # it should override channel muting and still notify.
+        self.change_subscription_properties({"is_muted": True, "wildcard_mentions_notify": True})
+        msg_id = self.send_stream_message(self.iago, "Denmark", content="@**all** what's up?")
+        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
+            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            mock_enqueue.assert_called_once()
+            args_dict = mock_enqueue.call_args_list[0][1]
+
+            self.assert_maybe_enqueue_notifications_call_args(
+                args_dict=args_dict,
+                stream_wildcard_mention_email_notify=True,
+                stream_wildcard_mention_push_notify=True,
+                message_id=msg_id,
+                user_id=self.user_profile.id,
+                already_notified={"email_notified": True, "push_notified": True},
+            )
+
+    def test_stream_wildcard_mention_in_muted_topic_with_channel_specific_setting(self) -> None:
+        # Even with channel-specific wildcard_mentions_notify=True,
+        # muted topics should still suppress notifications.
+        self.change_subscription_properties({"wildcard_mentions_notify": True})
+        do_set_user_topic_visibility_policy(
+            self.user_profile,
+            get_stream("Denmark", self.user_profile.realm),
+            "mutingtest",
+            visibility_policy=UserTopic.VisibilityPolicy.MUTED,
+        )
+        msg_id = self.send_stream_message(
+            self.iago, "Denmark", topic_name="mutingtest", content="@**all** what's up?"
+        )
+        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
+            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            mock_enqueue.assert_called_once()
+            args_dict = mock_enqueue.call_args_list[0][1]
+
+            self.assert_maybe_enqueue_notifications_call_args(
+                args_dict=args_dict,
+                stream_wildcard_mention_email_notify=False,
+                stream_wildcard_mention_push_notify=False,
+                message_id=msg_id,
+                user_id=self.user_profile.id,
+                already_notified={"email_notified": False, "push_notified": False},
+            )
+
     def test_stream_wildcard_mention_in_muted_topic(self) -> None:
         # stream wildcard mentions in muted topics don't notify.
         do_set_user_topic_visibility_policy(


### PR DESCRIPTION
Fixes #37973.

When a user has explicitly enabled `wildcard_mentions_notify` for a
specific channel, that per-channel setting now overrides the channel
being muted for wildcard and group mentions (`@all`, `@everyone`,
`@channel`).

However, it does **not** override a specific topic being muted, and
org-wide notification settings still do **not** override channel muting.

**Behavior matrix:**

| Scenario | Before | After |
|---|---|---|
| Muted channel, channel-specific `wildcard_mentions_notify=True` | No notify | **Notifies** |
| Muted channel, only global `wildcard_mentions_notify=True` | No notify | No notify |
| Muted topic, any wildcard setting | No notify | No notify |

**Changes:**

- `zerver/lib/notification_data.py`: Added `channel_specific_overrides_mute`
  parameter to `user_allows_notifications_in_StreamTopic` so that an
  explicit per-channel setting can override a muted channel (but not a
  muted topic).
- `zerver/actions/message_send.py`: Pass
  `channel_specific_overrides_mute=True` only for
  `wildcard_mentions_notify` in `notification_recipients()`.
- `web/src/message_notifications.ts`: Check
  `sub.wildcard_mentions_notify` before suppressing wildcard mentions
  in muted channels.
- `zerver/tests/test_event_queue.py`: Added two new test cases for
  muted channel (should notify) and muted topic (should not notify)
  with channel-specific wildcard setting.
- `web/tests/notifications.test.cjs`: Added test case for muted
  stream with channel-specific `wildcard_mentions_notify=true`.
- `help/dm-mention-alert-notifications.md`: Updated documentation to
  reflect the new override behavior.