### PR TITLE
topic_list: Add is:followed filter to left sidebar

### DIFF
--- a/web/src/topic_filter_pill.ts
+++ b/web/src/topic_filter_pill.ts
@@ -31,6 +31,11 @@ export const filter_options: TopicFilterPill[] = [
     },
     {
         type: "topic_filter",
+        label: $t({defaultMessage: "followed"}),
+        syntax: "is:followed",
+    },
+    {
+        type: "topic_filter",
         label: $t({defaultMessage: "unfollowed"}),
         syntax: "-is:followed",
         match_prefix_required: "-is",


### PR DESCRIPTION
## Description
This PR adds the ability to filter topics by followed state in the left sidebar.

Adds `is:followed` as the third option in the is: filter suggestions. 
When selected, the pill appears as just "followed".

## Related Issue
Closes #36878