### PR TITLE
buddy list: use ::before for status circle

### DIFF
--- a/web/styles/user_circles.css
+++ b/web/styles/user_circles.css
@@ -19,3 +19,18 @@
 .user-circle-deactivated {
     color: var(--color-user-circle-deactivated);
 }
+.user-circle::before {
+    content: "";
+    display: inline-block;
+    width: 0.6em;
+    height: 0.6em;
+    border-radius: 50%;
+}
+
+.user-circle-active::before {
+    background: var(--color-user-circle-active);
+}
+
+.user-circle-idle::before {
+    background: var(--gradient-user-circle-idle);
+}

--- a/web/templates/presence_row.hbs
+++ b/web/templates/presence_row.hbs
@@ -1,7 +1,7 @@
 <li data-user-id="{{user_id}}" data-name="{{name}}" class="user_sidebar_entry {{#if user_list_style.WITH_AVATAR}}with_avatar{{/if}} {{#if has_status_text}}with_status{{/if}} {{#if is_current_user}}user_sidebar_entry_me {{/if}} narrow-filter {{#if faded}} user-fade {{/if}}">
     <div class="selectable_sidebar_block">
         {{#if user_list_style.WITH_STATUS}}
-            <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
+            <span class="user-circle {{user_circle_class}}"></span>
             <a class="user-presence-link" href="{{href}}" draggable="false">
                 <div class="user-name-and-status-emoji">
                     {{> user_full_name .}}
@@ -13,7 +13,7 @@
             <div class="user-profile-picture-container">
                 <div class="user-profile-picture avatar-preload-background">
                     <img loading="lazy" src="{{profile_picture}}"/>
-                    <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
+                    <span class="user-circle {{user_circle_class}}"></span>
                 </div>
             </div>
             <a class="user-presence-link" href="{{href}}" draggable="false">
@@ -24,7 +24,7 @@
                 <span class="status-text">{{status_text}}</span>
             </a>
         {{else}}
-            <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
+            <span class="user-circle {{user_circle_class}}"></span>
             <a class="user-presence-link" href="{{href}}" draggable="false">
                 <div class="user-name-and-status-emoji">
                     {{> user_full_name .}}


### PR DESCRIPTION
Implements #37031

Use CSS ::before to render the status circle in the right sidebar.



**How changes were tested:**
Not tested locally (UI-only change); relying on CI.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
