### PR TITLE
[ai] buddy_list: Fix avatar preload background persisting after image load.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -332,6 +332,36 @@ export class BuddyList extends BuddyListConf {
         );
     }
 
+    // Attach load handlers to avatar images so that the preload
+    // background is removed once the image finishes loading. Also
+    // handles already-cached images by checking img.complete.
+    //
+    // By selecting only .avatar-preload-background containers, we
+    // skip images that have already been processed, avoiding duplicate
+    // handlers when this is called repeatedly (e.g., on scroll).
+    clear_avatar_preload_backgrounds(): void {
+        $("#user-list .avatar-preload-background img").each(function (this: HTMLElement) {
+            const $img = $(this);
+            const $picture = $img.closest(".avatar-preload-background");
+            $img.on("load", () => {
+                $picture.removeClass("avatar-preload-background");
+            });
+            // If the image is already cached, remove the preload
+            // background immediately.
+            // This fixes avatar-preload-background from briefly showing
+            // when reloading page.
+            if (
+                this instanceof HTMLImageElement &&
+                this.complete &&
+                // naturalWidth > 0 guard ensures broken images keep
+                // the preload background as a placeholder.
+                this.naturalWidth > 0
+            ) {
+                $picture.removeClass("avatar-preload-background");
+            }
+        });
+    }
+
     populate(opts: {all_user_ids: number[]}): void {
         this.render_count = 0;
         this.$participants_list.empty();
@@ -387,18 +417,6 @@ export class BuddyList extends BuddyListConf {
         background_task.run_async_function_without_await(
             this.update_empty_list_placeholders.bind(this),
         );
-
-        // `populate` always rerenders all user rows, so we need new load handlers.
-        // This logic only does something is a user has enabled the setting to
-        // view avatars in the buddy list, and otherwise the jQuery selector will
-        // always be the empty set.
-        $("#user-list .user-profile-picture img")
-            .off("load")
-            .on("load", function (this: HTMLElement) {
-                $(this)
-                    .closest(".user-profile-picture")
-                    .toggleClass("avatar-preload-background", false);
-            });
     }
 
     // We show "No matching users" if a section is empty during search.
@@ -1107,6 +1125,7 @@ export class BuddyList extends BuddyListConf {
         }
 
         this.display_or_hide_sections();
+        this.clear_avatar_preload_backgrounds();
         background_task.run_async_function_without_await(
             this.update_empty_list_placeholders.bind(this),
         );
@@ -1156,6 +1175,7 @@ export class BuddyList extends BuddyListConf {
             });
         }
         background_task.run_async_function_without_await(this.render_section_headers.bind(this));
+        this.clear_avatar_preload_backgrounds();
     }
 
     start_scroll_handler(): void {

--- a/web/tests/lib/buddy_list.cjs
+++ b/web/tests/lib/buddy_list.cjs
@@ -46,4 +46,7 @@ exports.stub_buddy_list_elements = () => {
     $(`#buddy-list-users-matching-view .empty-list-message`).remove = noop;
     $(`#buddy-list-other-users .empty-list-message`).remove = noop;
     $(`#buddy-list-participants .empty-list-message`).remove = noop;
+
+    // Simulate no avatar images for clear_avatar_preload_backgrounds.
+    $("#user-list .avatar-preload-background img").each = noop;
 };


### PR DESCRIPTION
discussion: [#issues > 🎯 avatar highlighted in right sidebar](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20avatar.20highlighted.20in.20right.20sidebar/with/2389221)

The `avatar-preload-background` CSS class, which shows a placeholder background while buddy list avatars lazy-load, was only cleared via a load handler attached in `populate()`. Images rendered later by `render_more()` (on scroll or section toggle) or inserted by `insert_or_move()` (new users, presence updates) never had load handlers attached, so the gray background persisted indefinitely.

Fix this by extracting a `clear_avatar_preload_backgrounds()` method that attaches load handlers and also handles already-cached images via `img.complete`. Call it from `fill_screen_with_content()` (which covers `populate`, scroll, and section toggles) and `insert_or_move`.

The method selects only `.avatar-preload-background img` (containers not yet processed), so repeated calls on scroll don't add duplicate handlers.


Reproducer:

### Reload after loading the page once.

Before:
[Screencast from 2026-03-03 12-12-38.webm](https://github.com/user-attachments/assets/1ec8fb9f-7cf9-4a38-8ef0-01506740bf69)

After:
 [Screencast from 2026-03-03 12-12-06.webm](https://github.com/user-attachments/assets/b5c87ac5-ff5e-4976-abf9-b9fcbb3248e9)

### Create a new user in a different tab



| before | after |
| --- | --- |
| <img width="403" height="83" alt="Screenshot from 2026-03-03 12-14-53" src="https://github.com/user-attachments/assets/f9e6ebc8-fc6a-4ce8-9f39-0eef62c7146e" /> | <img width="406" height="93" alt="Screenshot from 2026-03-03 12-16-02" src="https://github.com/user-attachments/assets/d0bc6272-0145-40f4-881b-4d19e9d19fc6" /> |