### PR TITLE
Fix channel and group card styling consistency.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -289,7 +289,7 @@
 .popover-group-menu-info {
     display: flex;
     flex-direction: column;
-    gap: 5px;
+    gap: 0;
     padding: 3px var(--user-group-popover-horizontal-padding);
 }
 
@@ -297,13 +297,19 @@
     display: flex;
     align-items: flex-start;
     gap: 5px;
-    /* 18px at 15px/1em */
-    font-size: 1.2em;
+    margin-bottom: 4px;
+    /* 15px at 15px/1em */
+    font-size: 1em;
     font-weight: 600;
-    /* 20px at 18px/1em */
+    /* 17px at 15px/1em */
     line-height: 1.1111em;
     color: var(--color-text-full-name);
     overflow-wrap: anywhere;
+
+    .popover-menu-icon {
+        /* Reset icon size to match channel icon (~17px) */
+        font-size: 0.8333em;
+    }
 }
 
 .popover-group-menu-description {


### PR DESCRIPTION
## Make group card popover styling consistent with channel card popover
<!-- Describe your pull request here.-->
The group card popover had two styling inconsistencies compared to the channel card popover:
- Font size: `.popover-group-menu-name-container` was set to font-size: 1.2em (~18px), making group names visibly larger than channel names which render at 1em (~15px). Reduced to 1em to match.
- Vertical spacing: `.popover-group-menu-info` had gap: 5px between the name and description, while the channel card uses margin-top: 4px on the name element instead. Removed the gap and added `margin-bottom`: 4px on `.popover-group-menu-name-container` to match the channel card's spacing approach.
- Icon size: Added font-size: 0.8333em on the group icon inside `.popover-group-menu-name-container` to match the channel privacy icon size (~17px).

**Additional difference flagged:** The group name uses var`--color-text-full-name` (full white) while the channel name uses rgba(255,255,255,0.8) (slightly dimmer). Left as-is for reviewer to decide

Fixes: #38200<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
### Before
<img width="391" height="322" alt="Screenshot 2026-03-12 121313" src="https://github.com/user-attachments/assets/ae67faa6-230e-4141-89e6-0abb82a87b4e" />
<img width="405" height="195" alt="Screenshot 2026-03-12 121152" src="https://github.com/user-attachments/assets/590f4beb-d0eb-4407-b681-80ad081fd3c6" />


### After 
<img width="393" height="322" alt="Screenshot 2026-03-12 201941" src="https://github.com/user-attachments/assets/58542558-b92d-4b19-ba70-7754319e20bb" />
<img width="395" height="187" alt="Screenshot 2026-03-12 201959" src="https://github.com/user-attachments/assets/2b4c5402-9841-4516-b7d0-2ae30257e871" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
