### PR TITLE
keyboard: Add shortcut to go to mentions.

### DIFF
--- a/starlight_help/src/content/docs/keyboard-shortcuts.mdx
+++ b/starlight_help/src/content/docs/keyboard-shortcuts.mdx
@@ -94,6 +94,7 @@ reference in the Zulip app to add more to your repertoire as needed.
 * **Go to inbox**: <kbd>Shift</kbd> + <kbd>I</kbd> — Shows conversations with unread messages.
 * **Go to recent conversations**: <kbd>T</kbd>
 * **Go to combined feed**: <kbd>A</kbd> — Shows all unmuted messages.
+* **Go to mentions**: <kbd data-mac-key="⌘">Ctrl</kbd> + <kbd>@</kbd>
 * **Go to starred messages**: <kbd>\*</kbd>
 * **Go to the conversation you are composing to**: <kbd>Ctrl</kbd> + <kbd>.</kbd>
 

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -141,12 +141,14 @@ const KEYDOWN_MAPPINGS: Record<string, Hotkey | Hotkey[]> = {
     "Cmd+Enter": {name: "action_with_enter", message_view_only: true},
     "Cmd+C": {name: "copy_with_c", message_view_only: false},
     "Cmd+K": {name: "search_with_k", message_view_only: false},
+    "Cmd+@": {name: "open_mentions_view", message_view_only: true},
     "Cmd+S": {name: "star_message", message_view_only: true},
     "Cmd+.": {name: "narrow_to_compose_target", message_view_only: true},
     "Cmd+'": {name: "open_saved_snippet_dropdown", message_view_only: true},
     "Ctrl+Enter": {name: "action_with_enter", message_view_only: true},
     "Ctrl+C": {name: "copy_with_c", message_view_only: false},
     "Ctrl+K": {name: "search_with_k", message_view_only: false},
+    "Ctrl+@": {name: "open_mentions_view", message_view_only: true},
     "Ctrl+S": {name: "star_message", message_view_only: true},
     "Ctrl+.": {name: "narrow_to_compose_target", message_view_only: true},
     "Ctrl+'": {name: "open_saved_snippet_dropdown", message_view_only: true},
@@ -1248,6 +1250,9 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
             return true;
         case "open_starred_message_view":
             browser_history.go_to_location("#narrow/is/starred");
+            return true;
+        case "open_mentions_view":
+            browser_history.go_to_location("#narrow/is/mentioned");
             return true;
         case "open_combined_feed":
             browser_history.go_to_location("#feed");

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -309,6 +309,10 @@
                     <td><span class="hotkey"><kbd>A</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'Go to mentions' }}</td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>@</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{{t 'Go to starred messages' }}</td>
                     <td><span class="hotkey"><kbd>*</kbd></span></td>
                 </tr>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -188,6 +188,7 @@
         <div>{{t 'Mentions' }}</div>
         <div class="tootlip-inner-content views-message-count italic"></div>
     </div>
+    {{tooltip_hotkey_hints "Ctrl" "@"}}
 </template>
 <template id="message-expander-tooltip-template">
     {{t 'Show more' }}

--- a/web/tests/hotkey.test.cjs
+++ b/web/tests/hotkey.test.cjs
@@ -195,6 +195,7 @@ run_test("mappings", () => {
     assert.equal(map_down("[", false, true).name, "escape");
     assert.equal(map_down("c", false, true).name, "copy_with_c");
     assert.equal(map_down("k", false, true).name, "search_with_k");
+    assert.equal(map_down("@", true, true).name, "open_mentions_view");
     assert.equal(map_down("s", false, true).name, "star_message");
     assert.equal(map_down(".", false, true).name, "narrow_to_compose_target");
 
@@ -234,6 +235,8 @@ run_test("mappings", () => {
     assert.equal(map_down("c", false, true, false), undefined);
     assert.equal(map_down("k", false, false, true).name, "search_with_k");
     assert.equal(map_down("k", false, true, false), undefined);
+    assert.equal(map_down("@", true, false, true).name, "open_mentions_view");
+    assert.equal(map_down("@", true, true, false), undefined);
     assert.equal(map_down("s", false, false, true).name, "star_message");
     assert.equal(map_down("s", false, true, false), undefined);
     assert.equal(map_down(".", false, false, true).name, "narrow_to_compose_target");
@@ -276,6 +279,7 @@ run_test("mappings non-latin keyboard", () => {
     assert.equal(map_down("х", "BracketLeft", false, true).name, "escape");
     assert.equal(map_down("с", "KeyC", false, true).name, "copy_with_c");
     assert.equal(map_down("л", "KeyK", false, true).name, "search_with_k");
+    assert.equal(map_down("@", "Digit2", true, true).name, "open_mentions_view");
     assert.equal(map_down("ы", "KeyS", false, true).name, "star_message");
     assert.equal(map_down("з", "KeyP", false, false, false, true).name, "toggle_compose_preview");
 
@@ -309,6 +313,8 @@ run_test("mappings non-latin keyboard", () => {
     assert.equal(map_down("с", "KeyC", false, true, false), undefined);
     assert.equal(map_down("л", "KeyK", false, false, true).name, "search_with_k");
     assert.equal(map_down("л", "KeyK", false, true, false), undefined);
+    assert.equal(map_down("@", "Digit2", true, false, true).name, "open_mentions_view");
+    assert.equal(map_down("@", "Digit2", true, true, false), undefined);
     assert.equal(map_down("ы", "KeyS", false, false, true).name, "star_message");
     assert.equal(map_down("ы", "KeyS", false, true, false), undefined);
     // Reset platform


### PR DESCRIPTION
Added new keyboard shortcut.We can now narrow to the  `mentions view` using `Ctrl/Cmd + @` 


<!-- Describe your pull request here.-->

Fixes #11098.

**How changes were tested:**
Updated the test and checked if all tests are passing. Also verified manually, Pressed `Ctrl + @` to open mention view

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/ab67a57c-2a59-44cd-8bbf-ca3904538bbd

<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/87b09b8c-79da-4cbf-9be0-5e934ae8f2d9" width="100%">
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/7ff46614-3a22-43c1-9dc5-ae231ceaae70" width="100%">
    </td>
  </tr>
</table>

<img width="814" height="142" alt="image" src="https://github.com/user-attachments/assets/43b3dd52-7386-43e8-b870-f5bb81d62962" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
