### PR TITLE
integrations: Improve Jira's comment-event notification.

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -755,6 +755,10 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
         "jira",
         ["project-management"],
         [WebhookScreenshotConfig("issue_created_with_assignee.json")],
+        url_options=[
+            WebhookUrlOption(name="email", label="Your Jira email", input_type="text"),
+            WebhookUrlOption(name="jira_api_token", label="Your Jira API token", input_type="text"),
+        ],
     ),
     IncomingWebhookIntegration(
         "jotform", ["productivity"], [WebhookScreenshotConfig("screenshot_response.multipart")]

--- a/zerver/webhooks/jira/doc.md
+++ b/zerver/webhooks/jira/doc.md
@@ -6,7 +6,16 @@ Get Zulip notifications for your Jira projects!
 
 1. {!create-an-incoming-webhook.md!}
 
-1. {!generate-webhook-url-basic.md!}
+1. Decide where to send {{ integration_display_name }} notifications, and
+   [generate the integration URL](/help/generate-integration-url). To
+   generate a Jira API token, follow
+   [Atlassian's documentation](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/).
+
+    !!! tip ""
+
+        If you also configure **Your Jira email** and **Your Jira API
+        token**, this integration will show display names for users
+        mentioned in Jira comments, instead of the `[~accountid:ACCOUNT_ID]`.
 
 1. Go to your Jira **Site administration** page. Click on the menu icon
    ( <i class="fa fa-ellipsis-h"></i> ) under **Actions** for your
@@ -20,6 +29,7 @@ Get Zulip notifications for your Jira projects!
    to be notified about, and click **Create**.
 
 {end_tabs}
+
 
 {!congrats.md!}
 

--- a/zerver/webhooks/jira/fixtures/comment_created_with_account_mention.json
+++ b/zerver/webhooks/jira/fixtures/comment_created_with_account_mention.json
@@ -1,0 +1,94 @@
+{
+  "timestamp": 1722411493985,
+  "webhookEvent": "comment_created",
+  "comment": {
+    "self": "https://peteririri.atlassian.net/rest/api/2/issue/10002/comment/10003",
+    "id": "10003",
+    "author": {
+      "self": "https://peteririri.atlassian.net/rest/api/2/user?accountId=619a4432ebce470067f20384",
+      "accountId": "619a4432ebce470067f20384",
+      "avatarUrls": {
+        "48x48": "https://secure.gravatar.com/avatar/338c91613dac07cd4bd32682a494fe66?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FP-5.png",
+        "24x24": "https://secure.gravatar.com/avatar/338c91613dac07cd4bd32682a494fe66?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FP-5.png",
+        "16x16": "https://secure.gravatar.com/avatar/338c91613dac07cd4bd32682a494fe66?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FP-5.png",
+        "32x32": "https://secure.gravatar.com/avatar/338c91613dac07cd4bd32682a494fe66?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FP-5.png"
+      },
+      "displayName": "Peter",
+      "active": true,
+      "timeZone": "Asia/Jakarta",
+      "accountType": "atlassian"
+    },
+    "body": "[~accountid:619a4432ebce470067f20384] [~accountid:63a22fb348b367d78a14c15b] [~accountid:63a22fb348b367d78a14c15b] ",
+    "updateAuthor": {
+      "self": "https://peteririri.atlassian.net/rest/api/2/user?accountId=619a4432ebce470067f20384",
+      "accountId": "619a4432ebce470067f20384",
+      "avatarUrls": {
+        "48x48": "https://secure.gravatar.com/avatar/338c91613dac07cd4bd32682a494fe66?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FP-5.png",
+        "24x24": "https://secure.gravatar.com/avatar/338c91613dac07cd4bd32682a494fe66?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FP-5.png",
+        "16x16": "https://secure.gravatar.com/avatar/338c91613dac07cd4bd32682a494fe66?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FP-5.png",
+        "32x32": "https://secure.gravatar.com/avatar/338c91613dac07cd4bd32682a494fe66?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FP-5.png"
+      },
+      "displayName": "Peter",
+      "active": true,
+      "timeZone": "Asia/Jakarta",
+      "accountType": "atlassian"
+    },
+    "created": "2024-07-31T14:38:13.985+0700",
+    "updated": "2024-07-31T14:38:13.985+0700",
+    "jsdPublic": true
+  },
+  "issue": {
+    "id": "10002",
+    "self": "https://peteririri.atlassian.net/rest/api/2/10002",
+    "key": "SB-1",
+    "fields": {
+      "summary": "asdasd",
+      "issuetype": {
+        "self": "https://peteririri.atlassian.net/rest/api/2/issuetype/10002",
+        "id": "10002",
+        "description": "Functionality or a feature expressed as a user goal.",
+        "iconUrl": "https://peteririri.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium",
+        "name": "Story",
+        "subtask": false,
+        "avatarId": 10315,
+        "hierarchyLevel": 0
+      },
+      "project": {
+        "self": "https://peteririri.atlassian.net/rest/api/2/project/10001",
+        "id": "10001",
+        "key": "SB",
+        "name": "scrum board",
+        "projectTypeKey": "software",
+        "simplified": false,
+        "avatarUrls": {
+          "48x48": "https://peteririri.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10401",
+          "24x24": "https://peteririri.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10401?size=small",
+          "16x16": "https://peteririri.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10401?size=xsmall",
+          "32x32": "https://peteririri.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10401?size=medium"
+        }
+      },
+      "assignee": null,
+      "priority": {
+        "self": "https://peteririri.atlassian.net/rest/api/2/priority/3",
+        "iconUrl": "https://peteririri.atlassian.net/images/icons/priorities/medium.svg",
+        "name": "Medium",
+        "id": "3"
+      },
+      "status": {
+        "self": "https://peteririri.atlassian.net/rest/api/2/status/10007",
+        "description": "",
+        "iconUrl": "https://peteririri.atlassian.net/",
+        "name": "To Do",
+        "id": "10007",
+        "statusCategory": {
+          "self": "https://peteririri.atlassian.net/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      }
+    }
+  },
+  "eventType": "primaryAction"
+}

--- a/zerver/webhooks/jira/tests.py
+++ b/zerver/webhooks/jira/tests.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import responses
+
 from zerver.lib.test_classes import WebhookTestCase
 
 
@@ -114,6 +116,67 @@ Leonardo Franchi [Administrator] created [TEST-4: Test Created Assignee](https:/
         self.check_webhook(
             "comment_created_no_issue_details", expected_topic_name, expected_message
         )
+
+    @responses.activate
+    def test_comment_event_comment_created_with_account_mention(self) -> None:
+        expected_topic_name = "SB-1: asdasd"
+        expected_message = """Peter commented on [SB-1: asdasd](https://peteririri.atlassian.net/browse/SB-1)\n``` quote\n**Peter** **Alice** **Alice** \n```"""
+        self.url = self.build_webhook_url(
+            email="test@example.com",
+            jira_api_token="test-token",
+        )
+        responses.add(
+            responses.GET,
+            "https://peteririri.atlassian.net/rest/api/2/user",
+            match=[
+                responses.matchers.query_param_matcher({"accountId": "619a4432ebce470067f20384"})
+            ],
+            json={"displayName": "Peter"},
+        )
+        responses.add(
+            responses.GET,
+            "https://peteririri.atlassian.net/rest/api/2/user",
+            match=[
+                responses.matchers.query_param_matcher({"accountId": "63a22fb348b367d78a14c15b"})
+            ],
+            json={"displayName": "Alice"},
+        )
+        self.check_webhook(
+            "comment_created_with_account_mention",
+            expected_topic_name,
+            expected_message,
+        )
+        self.assert_length(responses.calls, 2)
+
+    def test_comment_event_comment_created_with_account_mention_no_credentials(self) -> None:
+        expected_topic_name = "SB-1: asdasd"
+        expected_message = """Peter commented on [SB-1: asdasd](https://peteririri.atlassian.net/browse/SB-1)\n``` quote\n[~accountid:619a4432ebce470067f20384] [~accountid:63a22fb348b367d78a14c15b] [~accountid:63a22fb348b367d78a14c15b] \n```"""
+        self.check_webhook(
+            "comment_created_with_account_mention",
+            expected_topic_name,
+            expected_message,
+        )
+
+    @responses.activate
+    def test_comment_event_comment_created_with_account_mention_api_failure(self) -> None:
+        expected_topic_name = "SB-1: asdasd"
+        expected_message = """Peter commented on [SB-1: asdasd](https://peteririri.atlassian.net/browse/SB-1)\n``` quote\n**unknown Jira user (619a4432...)** **unknown Jira user (63a22fb3...)** **unknown Jira user (63a22fb3...)** \n```"""
+        self.url = self.build_webhook_url(
+            email="test@example.com",
+            jira_api_token="test-token",
+        )
+        responses.add(
+            responses.GET,
+            "https://peteririri.atlassian.net/rest/api/2/user",
+            status=401,
+        )
+        with self.assertLogs("zerver.lib.webhooks.common", level="WARNING") as cm:
+            self.check_webhook(
+                "comment_created_with_account_mention",
+                expected_topic_name,
+                expected_message,
+            )
+        self.assert_length(cm.output, 2)
 
     def test_comment_updated(self) -> None:
         expected_topic_name = "SP-1: Add support for newer format Jira issue comment events"

--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -1,8 +1,12 @@
 # Webhooks for external integrations.
+import base64
 import re
 import string
 from collections.abc import Callable
+from dataclasses import dataclass
+from urllib.parse import unquote, urlsplit, urlunsplit
 
+import requests
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.http import HttpRequest, HttpResponse
@@ -13,9 +17,16 @@ from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
 from zerver.lib.validator import WildValue, check_none_or, check_string
-from zerver.lib.webhooks.common import check_send_webhook_message
+from zerver.lib.webhooks.common import check_send_webhook_message, get_service_api_data
 from zerver.models import Realm, UserProfile
 from zerver.models.users import get_user_by_delivery_email
+
+
+@dataclass
+class JiraAuth:
+    email: str
+    api_token: str
+
 
 IGNORED_EVENTS = [
     "attachment_created",
@@ -82,8 +93,10 @@ def convert_jira_markup(content: str, realm: Realm) -> str:
 
     # Try to convert a Jira user mention of format [~username] into a
     # Zulip user mention. We don't know the email, just the Jira username,
-    # so we naively guess at their Zulip account using this
-    mention_re = re.compile(r"\[~(.*?)\]")
+    # so we naively guess at their Zulip account using this.
+    # Skip [~accountid:...] mentions, which are handled separately via
+    # the Jira API in get_comment_content.
+    mention_re = re.compile(r"\[~(?!accountid:)(.*?)\]")
     for username in mention_re.findall(content):
         # Try to look up username
         user_profile = guess_zulip_user_from_jira(username, realm)
@@ -127,6 +140,22 @@ def get_issue_string(
         return f"[{text}]({base_url.group(1)}/browse/{issue_id})"
     else:
         return text
+
+
+def get_jira_api_data(
+    jira_api_url: str, get_param: str, auth: JiraAuth, account_id: str
+) -> str | None:
+    credentials = base64.b64encode(f"{auth.email}:{auth.api_token}".encode()).decode()
+    try:
+        response = get_service_api_data(
+            jira_api_url,
+            "jira",
+            headers={"Authorization": f"Basic {credentials}"},
+            params={"accountId": account_id},
+        )
+        return response.json().get(get_param)
+    except (requests.RequestException, ValueError):
+        return None
 
 
 def get_assignee_mention(assignee_email: str, realm: Realm) -> str:
@@ -264,46 +293,71 @@ def normalize_comment(comment: str, realm: Realm) -> str:
     return normalized_comment
 
 
-def handle_comment_created_event(payload: WildValue, user_profile: UserProfile) -> str:
+def get_comment_content(payload: WildValue, realm: Realm, auth: JiraAuth | None = None) -> str:
+    comment = normalize_comment(payload["comment"]["body"].tame(check_string), realm)
+    if auth is None:
+        return comment
+
+    author_url = payload["comment"]["author"]["self"].tame(check_string)
+    parsed = urlsplit(author_url)
+    jira_api_url = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+
+    # Replace each [~accountid:xxx] mention with the user's display name.
+    for account_id in set(re.findall(r"\[~accountid:([\w\-:]+)\]", comment)):
+        display_name = get_jira_api_data(jira_api_url, "displayName", auth, account_id)
+        replacement = (
+            f"**{display_name}**"
+            if display_name is not None
+            else f"**unknown Jira user ({account_id[:8]}...)**"
+        )
+        comment = comment.replace(f"[~accountid:{account_id}]", replacement)
+    return comment
+
+
+def handle_comment_created_event(
+    payload: WildValue, user_profile: UserProfile, auth: JiraAuth | None = None
+) -> str:
     return "{author} commented on {issue_string}\
 \n``` quote\n{comment}\n```\n".format(
         author=payload["comment"]["author"]["displayName"].tame(check_string),
         issue_string=get_issue_string(payload, with_title=True),
-        comment=normalize_comment(
-            payload["comment"]["body"].tame(check_string), user_profile.realm
-        ),
+        comment=get_comment_content(payload, user_profile.realm, auth),
     )
 
 
-def handle_comment_updated_event(payload: WildValue, user_profile: UserProfile) -> str:
+def handle_comment_updated_event(
+    payload: WildValue, user_profile: UserProfile, auth: JiraAuth | None = None
+) -> str:
     return "{author} updated their comment on {issue_string}\
 \n``` quote\n{comment}\n```\n".format(
         author=payload["comment"]["author"]["displayName"].tame(check_string),
         issue_string=get_issue_string(payload, with_title=True),
-        comment=normalize_comment(
-            payload["comment"]["body"].tame(check_string), user_profile.realm
-        ),
+        comment=get_comment_content(payload, user_profile.realm, auth),
     )
 
 
-def handle_comment_deleted_event(payload: WildValue, user_profile: UserProfile) -> str:
+def handle_comment_deleted_event(
+    payload: WildValue, user_profile: UserProfile, auth: JiraAuth | None = None
+) -> str:
     return "{author} deleted their comment on {issue_string}\
 \n``` quote\n~~{comment}~~\n```\n".format(
         author=payload["comment"]["author"]["displayName"].tame(check_string),
         issue_string=get_issue_string(payload, with_title=True),
-        comment=normalize_comment(
-            payload["comment"]["body"].tame(check_string), user_profile.realm
-        ),
+        comment=get_comment_content(payload, user_profile.realm, auth),
     )
 
 
-JIRA_CONTENT_FUNCTION_MAPPER: dict[str, Callable[[WildValue, UserProfile], str] | None] = {
-    "jira:issue_created": handle_created_issue_event,
-    "jira:issue_deleted": handle_deleted_issue_event,
-    "jira:issue_updated": handle_updated_issue_event,
+COMMENT_EVENT_FUNCTION_MAPPER: dict[str, Callable[..., str]] = {
     "comment_created": handle_comment_created_event,
     "comment_updated": handle_comment_updated_event,
     "comment_deleted": handle_comment_deleted_event,
+}
+
+JIRA_CONTENT_FUNCTION_MAPPER: dict[str, Callable[..., str] | None] = {
+    "jira:issue_created": handle_created_issue_event,
+    "jira:issue_deleted": handle_deleted_issue_event,
+    "jira:issue_updated": handle_updated_issue_event,
+    **COMMENT_EVENT_FUNCTION_MAPPER,
 }
 
 ALL_EVENT_TYPES = list(JIRA_CONTENT_FUNCTION_MAPPER.keys())
@@ -316,6 +370,8 @@ def api_jira_webhook(
     user_profile: UserProfile,
     *,
     payload: JsonBodyPayload[WildValue],
+    email: str | None = None,
+    jira_api_token: str | None = None,
 ) -> HttpResponse:
     event = payload.get("webhookEvent").tame(check_none_or(check_string))
     if event in IGNORED_EVENTS:
@@ -324,14 +380,21 @@ def api_jira_webhook(
     if event is None:
         raise AnomalousWebhookPayloadError
 
-    if event is not None:
-        content_func = JIRA_CONTENT_FUNCTION_MAPPER.get(event)
+    content_func = JIRA_CONTENT_FUNCTION_MAPPER.get(event)
 
     if content_func is None:
         raise UnsupportedWebhookEventTypeError(event)
 
+    auth: JiraAuth | None = None
+    if email and jira_api_token:
+        auth = JiraAuth(email=unquote(email), api_token=unquote(jira_api_token))
+
     topic_name = get_issue_topic(payload)
-    content: str = content_func(payload, user_profile)
+
+    if event in COMMENT_EVENT_FUNCTION_MAPPER:
+        content = content_func(payload, user_profile, auth)
+    else:
+        content = content_func(payload, user_profile)
 
     check_send_webhook_message(
         request, user_profile, topic_name, content, event, unquote_url_parameters=True


### PR DESCRIPTION
This PR fixes the Jira integration's "comment" event notifications by replacing `[~accountid:...]` mentions with the user's actual display name.

<!-- Describe your pull request here.-->

- When a user provides their Jira email and API token via the webhook URL configoptions, the integration calls Jira's `/rest/api/2/user` API to resolve each account ID to a display name, replacing it with `**Display Name**` in the notification. 
- If credentials are not provided, the raw `[~accountid:...]` is shown as before . If the API call fails, `**accountId` is shown so the notification still delivers.

Fixes #32646 

**Before** (no credentials):
<img width="912" height="152" alt="Screenshot From 2026-03-22 13-26-23" src="https://github.com/user-attachments/assets/703d6bc0-f795-41d2-ae7f-423f027886fe" />


**After** (with credentials):
<img width="1139" height="166" alt="Screenshot From 2026-04-02 10-46-58" src="https://github.com/user-attachments/assets/a1614de9-376d-4d48-8dcc-849d5298e152" />


Bad Credentials:
<img width="1139" height="195" alt="Screenshot From 2026-04-02 10-41-38" src="https://github.com/user-attachments/assets/db7aa4ae-5726-415e-ac37-41e364af0429" />


Integration Docs:
<img width="1293" height="837" alt="Screenshot From 2026-04-02 10-26-25" src="https://github.com/user-attachments/assets/69c46bed-62b6-4ed9-98e0-feec803f0a01" />


Generate-integration-URL modal:
<img width="589" height="645" alt="Screenshot From 2026-03-19 16-16-40" src="https://github.com/user-attachments/assets/428c7fdd-44f8-46cc-80e9-309cda38c82c" />

**How changes were tested:**

- Manual end-to-end test using ngrok + real Jira Cloud instance + real API token

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>