### PR TITLE
docs: Update links to Nextcloud Talk and Constructor Groups docs.

### DIFF
--- a/docs/production/video-calls.md
+++ b/docs/production/video-calls.md
@@ -9,8 +9,8 @@ supported by Zulip are:
   100% open source video conferencing solution.
 - [Zoom](https://zulip.com/integrations/zoom)
 - [BigBlueButton](https://zulip.com/integrations/big-blue-button)
-- [Constructor Groups](https://zulip.com/integrations/category/video-calling)
-- [Nextcloud Talk](https://zulip.com/integrations/category/video-calling)
+- [Constructor Groups](https://zulip.com/integrations/constructor-groups)
+- [Nextcloud Talk](https://zulip.com/integrations/nextcloud-talk)
 
 By default, Zulip uses the [cloud version of Jitsi Meet](https://meet.jit.si/)
 as its call provider. This page documents the configurations required to support
@@ -186,7 +186,7 @@ in the Zulip organizations where you want to use it.
 To use the [Constructor Groups](https://constructor.tech/products/learning/groups)
 video call integration on a self-hosted Zulip installation, you'll need to
 have a Constructor Groups account. See documentation to configure the Constructor
-Groups video call integration [here](https://zulip.com/integrations/category/video-calling).
+Groups video call integration [here](https://zulip.com/integrations/constructor-groups).
 
 ## Nextcloud Talk
 
@@ -194,4 +194,4 @@ To use the [Nextcloud Talk](https://nextcloud.com/talk/) video call
 integration on a self-hosted Zulip installation, you'll need to have access
 to a Nextcloud server (version 22+) with the Talk app enabled. See
 documentation to configure the Nextcloud Talk video call integration
-[here](https://zulip.com/integrations/category/video-calling).
+[here](https://zulip.com/integrations/nextcloud-talk).


### PR DESCRIPTION
Now that these integrations are up on the main zulip integrations doc page, we can link to them directly in the production docs:
- https://zulip.com/integrations/constructor-groups
- https://zulip.com/integrations/nextcloud-talk

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
