### PR TITLE
Fix message divider for moved messages.

### DIFF
--- a/web/src/message_list.ts
+++ b/web/src/message_list.ts
@@ -115,7 +115,6 @@ export class MessageList {
     near_view_reading_gate_pending: boolean;
 
     // TODO: Clean up these monkey-patched properties somehow.
-    last_message_historical?: boolean;
     should_trigger_message_selected_event?: boolean;
 
     constructor(opts: {
@@ -537,10 +536,14 @@ export class MessageList {
             return;
         }
 
+        const last_message_historical =
+            this.view.get_boundary_message_info_with_meaningful_historical("newest")
+                ?.message_container.msg.historical;
+
         if (
             sub &&
             sub.subscribed &&
-            !this.last_message_historical &&
+            !last_message_historical &&
             !page_params.is_spectator &&
             !force_render
         ) {
@@ -554,7 +557,11 @@ export class MessageList {
         const is_web_public = sub?.is_web_public;
         if (sub === undefined || sub.is_archived) {
             deactivated = true;
-        } else if (!subscribed && !this.last_message_historical && !this.empty()) {
+        } else if (!subscribed && last_message_historical === false && !this.empty()) {
+            // `=== false`, not `!...`: an undefined flag (no rendered message
+            // has a meaningful historical flag, e.g. the newest messages were
+            // all moved here from another channel) doesn't tell us the user
+            // unsubscribed, so we don't claim they did.
             just_unsubscribed = true;
         }
 

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -195,6 +195,16 @@ function clear_message_divider(message_container: MessageContainer): void {
     message_container.date_divider_html = undefined;
 }
 
+function wants_subscription_divider(
+    prev_historical: boolean | undefined,
+    message: Message,
+): boolean {
+    // A continuation message shows an inline subscription divider when its
+    // `historical` flag differs from the previous one, i.e. the user
+    // (un)subscribed between them.
+    return prev_historical !== undefined && prev_historical !== message.historical;
+}
+
 function update_message_divider(opts: {
     prev_msg_container: MessageContainer | undefined;
     curr_msg_container: MessageContainer;
@@ -221,11 +231,10 @@ function get_message_divider_data(opts: {
     const prev_message = opts.prev_message;
     const curr_message = opts.curr_message;
     const display_year = opts.display_year;
-    let want_subscription_status_divider = false;
-
-    if (prev_message) {
-        want_subscription_status_divider = prev_message?.historical !== curr_message.historical;
-    }
+    const want_subscription_status_divider = wants_subscription_divider(
+        prev_message?.historical,
+        curr_message,
+    );
 
     if (!prev_message || same_day(curr_message, prev_message)) {
         return {

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -137,6 +137,11 @@ type RenderingPlan = {
     append_messages: MessageContainer[];
 };
 
+type BoundaryMessageContainerInfo = {
+    message_group: MessageGroup;
+    message_container: MessageContainer;
+};
+
 function same_day(earlier_msg: Message | undefined, later_msg: Message | undefined): boolean {
     if (earlier_msg === undefined || later_msg === undefined) {
         return false;
@@ -196,14 +201,37 @@ function clear_message_divider(message_container: MessageContainer): void {
     message_container.date_divider_html = undefined;
 }
 
+function was_moved_from_another_channel(message: Message): boolean {
+    // A moved message's `historical` flag reflects the channel it was
+    // originally sent to, so it says nothing about the user's
+    // subscription history in the current channel.
+    if (message.type !== "stream") {
+        return false;
+    }
+    // edit_history is newest-first, so the oldest stream-move entry's
+    // prev_stream is the original channel; a message moved back there
+    // has a meaningful flag again.
+    const original_stream_id = message.edit_history?.findLast(
+        (entry) => entry.prev_stream !== undefined,
+    )?.prev_stream;
+    return original_stream_id !== undefined && original_stream_id !== message.stream_id;
+}
+
 function wants_subscription_divider(
     prev_historical: boolean | undefined,
     message: Message,
+    message_was_moved: boolean,
 ): boolean {
     // A continuation message shows an inline subscription divider when its
-    // `historical` flag differs from the previous one, i.e. the user
-    // (un)subscribed between them.
-    return prev_historical !== undefined && prev_historical !== message.historical;
+    // `historical` flag differs from the previous meaningful one, i.e. the
+    // user (un)subscribed between them. A moved message's flag is
+    // meaningless here, so it never shows one; callers pass the
+    // already-computed moved status to avoid recomputing it.
+    return (
+        !message_was_moved &&
+        prev_historical !== undefined &&
+        prev_historical !== message.historical
+    );
 }
 
 function update_date_divider(opts: {
@@ -685,10 +713,12 @@ export class MessageListView {
         group: MessageGroup,
         prev_historical: boolean | undefined,
         first_message: Message,
+        first_message_was_moved: boolean,
     ): void {
         const markers = this.get_possible_group_subscription_markers(
             prev_historical,
             first_message,
+            first_message_was_moved,
         );
         if (markers) {
             Object.assign(group, markers);
@@ -698,6 +728,7 @@ export class MessageListView {
     get_possible_group_subscription_markers(
         prev_historical: boolean | undefined,
         first_message: Message,
+        first_message_was_moved: boolean,
     ): SubscriptionMarkers | undefined {
         // The `historical` flag is present on messages which were
         // sent a time when the current user was not subscribed to the
@@ -710,7 +741,11 @@ export class MessageListView {
         if (!this.list.data.filter.has_operator("channel")) {
             return undefined;
         }
-        if (prev_historical === undefined) {
+        // A moved message's flag reflects its original channel, so a
+        // boundary involving one tells us nothing about subscription
+        // changes here. prev_historical already skips moved messages;
+        // guard the group's first message too.
+        if (prev_historical === undefined || first_message_was_moved) {
             return undefined;
         }
 
@@ -739,26 +774,95 @@ export class MessageListView {
         return undefined;
     }
 
-    update_oldest_rendered_subscription_representation(prev_historical: boolean): void {
-        // Set the oldest rendered container's divider and marker against
-        // the prepended messages; the set_subscription_representation pass over
-        // the new groups did not cover this boundary.
-        const oldest_rendered_group = this._message_groups[0];
-        const oldest_rendered_container = this._message_groups[0]?.message_containers[0];
-        if (oldest_rendered_group !== undefined && oldest_rendered_container !== undefined) {
-            this.maybe_add_subscription_marker_to_group(
-                oldest_rendered_group,
-                prev_historical,
-                oldest_rendered_container.msg,
-            );
-            // The oldest rendered group may merge with the prepended content, so
-            // set the divider speculatively; merge_message_groups() clears it if
-            // the merge does not happen.
-            oldest_rendered_container.want_subscription_status_divider = wants_subscription_divider(
-                prev_historical,
-                oldest_rendered_container.msg,
-            );
+    get_boundary_message_info_with_meaningful_historical(
+        position: "oldest" | "newest",
+    ): BoundaryMessageContainerInfo | undefined {
+        // Returns the oldest or newest rendered message container info whose
+        // `historical` flag is meaningful in the current channel, or
+        // undefined if there is none.
+        //
+        // Moved messages are skipped because their `historical` flag does not
+        // represent the subscription state of this channel. This method is
+        // used when prepending/appending messages, so it walks from the
+        // requested boundary rather than flattening all rendered containers;
+        // in the common case it finds a meaningful message immediately.
+        const message_groups =
+            position === "oldest" ? this._message_groups : this._message_groups.toReversed();
+
+        for (const message_group of message_groups) {
+            const meaningful_container =
+                position === "oldest"
+                    ? message_group.message_containers.find(
+                          (message_container) =>
+                              !was_moved_from_another_channel(message_container.msg),
+                      )
+                    : message_group.message_containers.findLast(
+                          (message_container) =>
+                              !was_moved_from_another_channel(message_container.msg),
+                      );
+
+            if (meaningful_container !== undefined) {
+                return {
+                    message_container: meaningful_container,
+                    message_group,
+                };
+            }
         }
+
+        return undefined;
+    }
+
+    update_oldest_rendered_subscription_representation(prev_historical: boolean): void {
+        // Set the oldest rendered meaningful container's divider/marker against
+        // the prepended messages; the walk over the new groups did not cover
+        // this boundary.
+        //
+        // The container is meaningful, hence never moved, so it passes `false`
+        // for message_was_moved below.
+        const boundary_message_container_info =
+            this.get_boundary_message_info_with_meaningful_historical("oldest");
+        if (boundary_message_container_info === undefined) {
+            return;
+        }
+        const {message_group, message_container} = boundary_message_container_info;
+
+        const is_first_container_in_group =
+            message_group.message_containers[0] === message_container;
+
+        if (!is_first_container_in_group) {
+            // A continuation within its group: shown as an inline divider.
+            message_container.want_subscription_status_divider = wants_subscription_divider(
+                prev_historical,
+                message_container.msg,
+                false,
+            );
+            return;
+        }
+
+        // Starts its group: the change is shown as a group marker.
+        this.maybe_add_subscription_marker_to_group(
+            message_group,
+            prev_historical,
+            message_container.msg,
+            false,
+        );
+
+        const is_oldest_rendered_group = message_group === this._message_groups[0];
+
+        if (!is_oldest_rendered_group) {
+            // This group can't merge with the prepended content, so no divider.
+            message_container.want_subscription_status_divider = false;
+            return;
+        }
+
+        // The oldest rendered group may merge with the prepended content, so
+        // set the divider speculatively; merge_message_groups() clears it if
+        // the merge does not happen.
+        message_container.want_subscription_status_divider = wants_subscription_divider(
+            prev_historical,
+            message_container.msg,
+            false,
+        );
     }
 
     set_subscription_dividers_and_markers(
@@ -768,38 +872,62 @@ export class MessageListView {
         // Walk the newly built groups in order, setting each container's
         // inline subscription-status divider and each group's bookend marker.
         // Both mark the same thing -- the `historical` flag flipping between
-        // two adjacent messages, i.e. the user (un)subscribed
+        // two adjacent meaningful messages, i.e. the user (un)subscribed
         // between them -- shown inline between two messages or as a bookend
         // at a group boundary.
         //
-        // prev_historical stores the previous message's flag as we walk.
+        // prev_historical holds the last meaningful flag as we walk. A message
+        // moved here from another channel carries its original channel's flag,
+        // so it is skipped and does not advance prev_historical, preserving a
+        // real transition around a moved message rather than hiding it.
         //
         // The boundary against the already-rendered messages is handled after
         // the loop, since that container may merge into a neighbouring group.
 
         const is_prepend = where === "top";
-        let prev_historical = is_prepend ? undefined : this.list.last_message_historical;
+        let prev_historical = is_prepend
+            ? undefined
+            : this.get_boundary_message_info_with_meaningful_historical("newest")?.message_container
+                  .msg.historical;
+        const newest_rendered_historical = is_prepend ? undefined : prev_historical;
+
+        // The first new container is the boundary against the already-rendered
+        // messages when appending; cache whether it was moved during the walk
+        // so the post-loop boundary step need not recompute it.
+        const first_message_container = new_message_groups[0]?.message_containers[0];
+        let first_message_was_moved = false;
 
         // Record a container's subscription change as a bookend marker when it
         // starts its group, or as an inline divider when it is a continuation,
-        // then advance prev_historical.
+        // then advance prev_historical past meaningful messages.
         const set_subscription_representation = (
             group: MessageGroup,
             message_container: MessageContainer,
             starts_message_group: boolean,
         ): void => {
             const message = message_container.msg;
+            const message_was_moved = was_moved_from_another_channel(message);
+            if (message_container === first_message_container) {
+                first_message_was_moved = message_was_moved;
+            }
             if (starts_message_group) {
-                this.maybe_add_subscription_marker_to_group(group, prev_historical, message);
+                this.maybe_add_subscription_marker_to_group(
+                    group,
+                    prev_historical,
+                    message,
+                    message_was_moved,
+                );
                 message_container.want_subscription_status_divider = false;
             } else {
                 message_container.want_subscription_status_divider = wants_subscription_divider(
                     prev_historical,
                     message,
+                    message_was_moved,
                 );
             }
-
-            prev_historical = message.historical;
+            if (!message_was_moved) {
+                prev_historical = message.historical;
+            }
         };
 
         for (const message_group of new_message_groups) {
@@ -820,15 +948,12 @@ export class MessageListView {
         // speculative: merge_message_groups() clears it if no merge takes place.
         if (is_prepend && prev_historical !== undefined) {
             this.update_oldest_rendered_subscription_representation(prev_historical);
-        } else {
-            const first_message_container = new_message_groups[0]?.message_containers[0];
-            if (first_message_container !== undefined) {
-                first_message_container.want_subscription_status_divider =
-                    wants_subscription_divider(
-                        this.list.last_message_historical,
-                        first_message_container.msg,
-                    );
-            }
+        } else if (first_message_container !== undefined) {
+            first_message_container.want_subscription_status_divider = wants_subscription_divider(
+                newest_rendered_historical,
+                first_message_container.msg,
+                first_message_was_moved,
+            );
         }
     }
 

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1498,12 +1498,6 @@ export class MessageListView {
 
         restore_scroll_position();
 
-        const last_message_group = this._message_groups.at(-1);
-        if (last_message_group !== undefined) {
-            list.last_message_historical =
-                last_message_group.message_containers.at(-1)!.msg.historical;
-        }
-
         list.update_trailing_bookend();
 
         if (list === message_lists.current) {
@@ -1682,7 +1676,6 @@ export class MessageListView {
         if (clear_table) {
             this.clear_table();
         }
-        this.list.last_message_historical = false;
 
         this._render_win_start = 0;
         this._render_win_end = 0;

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -401,7 +401,6 @@ export function populate_group_from_message(
     message: Message,
     date_unchanged: boolean,
     year_changed: boolean,
-    subscription_markers: SubscriptionMarkers | undefined,
 ): MessageGroup {
     const is_stream = message.is_stream;
     const is_private = message.is_private;
@@ -426,7 +425,6 @@ export function populate_group_from_message(
             is_stream,
             ...get_topic_edit_properties(message),
             user_can_resolve_topic: stream_data.can_resolve_topics(sub),
-            ...subscription_markers,
             date_html,
             display_recipient,
             date_unchanged,
@@ -977,10 +975,6 @@ export class MessageListView {
                 message_for_next_group,
                 same_day(message_for_next_group, prev_message),
                 !same_year(message_for_next_group, prev_message),
-                // Subscription-status bookends are filled in afterward by
-                // set_subscription_dividers_and_markers, which also needs the
-                // boundary against already-rendered messages.
-                undefined,
             );
         };
 
@@ -1846,7 +1840,6 @@ export class MessageListView {
                 group.message_containers[0]!.msg,
                 group.date_unchanged,
                 group.message_containers[0]!.year_changed,
-                undefined,
             ),
             // We don't want `populate_group_from_message` to generate a
             // new id. We also preserve the message containers, since this

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -189,7 +189,7 @@ function clear_group_date(group: MessageGroup): void {
 
 function clear_message_divider(message_container: MessageContainer): void {
     // want_date_divider is set by update_date_divider and
-    // want_subscription_status_divider by set_subscription_dividers;
+    // want_subscription_status_divider by set_subscription_dividers_and_markers;
     // reset both here.
     message_container.want_date_divider = false;
     message_container.want_subscription_status_divider = false;
@@ -683,17 +683,20 @@ export class MessageListView {
 
     maybe_add_subscription_marker_to_group(
         group: MessageGroup,
-        last_message: Message | undefined,
+        prev_historical: boolean | undefined,
         first_message: Message,
     ): void {
-        const markers = this.get_possible_group_subscription_markers(last_message, first_message);
+        const markers = this.get_possible_group_subscription_markers(
+            prev_historical,
+            first_message,
+        );
         if (markers) {
             Object.assign(group, markers);
         }
     }
 
     get_possible_group_subscription_markers(
-        last_message: Message | undefined,
+        prev_historical: boolean | undefined,
         first_message: Message,
     ): SubscriptionMarkers | undefined {
         // The `historical` flag is present on messages which were
@@ -707,11 +710,11 @@ export class MessageListView {
         if (!this.list.data.filter.has_operator("channel")) {
             return undefined;
         }
-        if (last_message === undefined) {
+        if (prev_historical === undefined) {
             return undefined;
         }
 
-        const last_subscribed = !last_message.historical;
+        const last_subscribed = !prev_historical;
         const first_subscribed = !first_message.historical;
         assert(first_message.type === "stream");
         const stream_id = first_message.stream_id;
@@ -736,15 +739,38 @@ export class MessageListView {
         return undefined;
     }
 
-    set_subscription_dividers(new_message_groups: MessageGroup[], where: "top" | "bottom"): void {
+    update_oldest_rendered_subscription_representation(prev_historical: boolean): void {
+        // Set the oldest rendered container's divider and marker against
+        // the prepended messages; the set_subscription_representation pass over
+        // the new groups did not cover this boundary.
+        const oldest_rendered_group = this._message_groups[0];
+        const oldest_rendered_container = this._message_groups[0]?.message_containers[0];
+        if (oldest_rendered_group !== undefined && oldest_rendered_container !== undefined) {
+            this.maybe_add_subscription_marker_to_group(
+                oldest_rendered_group,
+                prev_historical,
+                oldest_rendered_container.msg,
+            );
+            // The oldest rendered group may merge with the prepended content, so
+            // set the divider speculatively; merge_message_groups() clears it if
+            // the merge does not happen.
+            oldest_rendered_container.want_subscription_status_divider = wants_subscription_divider(
+                prev_historical,
+                oldest_rendered_container.msg,
+            );
+        }
+    }
+
+    set_subscription_dividers_and_markers(
+        new_message_groups: MessageGroup[],
+        where: "top" | "bottom",
+    ): void {
         // Walk the newly built groups in order, setting each container's
-        // inline subscription-status divider, which marks -- the `historical`
-        // flag flipping between two adjacent messages, i.e. the user (un)subscribed
-        // between them -- shown inline between two messages.
-        //
-        // A flip at the first container of a group is shown as a group
-        // bookend rather than an inline divider, so those containers are
-        // skipped here.
+        // inline subscription-status divider and each group's bookend marker.
+        // Both mark the same thing -- the `historical` flag flipping between
+        // two adjacent messages, i.e. the user (un)subscribed
+        // between them -- shown inline between two messages or as a bookend
+        // at a group boundary.
         //
         // prev_historical stores the previous message's flag as we walk.
         //
@@ -754,16 +780,19 @@ export class MessageListView {
         const is_prepend = where === "top";
         let prev_historical = is_prepend ? undefined : this.list.last_message_historical;
 
-        // Record a container's subscription change as an inline divider
-        // when it isn't the first container of its message group, and
+        // Record a container's subscription change as a bookend marker when it
+        // starts its group, or as an inline divider when it is a continuation,
         // then advance prev_historical.
         const set_subscription_representation = (
+            group: MessageGroup,
             message_container: MessageContainer,
             starts_message_group: boolean,
         ): void => {
             const message = message_container.msg;
-
-            if (!starts_message_group) {
+            if (starts_message_group) {
+                this.maybe_add_subscription_marker_to_group(group, prev_historical, message);
+                message_container.want_subscription_status_divider = false;
+            } else {
                 message_container.want_subscription_status_divider = wants_subscription_divider(
                     prev_historical,
                     message,
@@ -775,7 +804,7 @@ export class MessageListView {
 
         for (const message_group of new_message_groups) {
             for (const [index, message_container] of message_group.message_containers.entries()) {
-                set_subscription_representation(message_container, index === 0);
+                set_subscription_representation(message_group, message_container, index === 0);
             }
         }
 
@@ -783,27 +812,22 @@ export class MessageListView {
         // may be merged into a single group by merge_message_groups():
         //
         // * when prepending, the oldest rendered container may merge into the
-        //   last new group, so update (divider) against the incoming messages;
+        //   last new group, so update (divider/marker) against the incoming messages;
         // * when appending, the first new container may merge into the newest
         //   rendered group, so set its divider against the newest rendered flag.
         //
         // Update the subscription representation at the boundary. Either is
         // speculative: merge_message_groups() clears it if no merge takes place.
-        if (is_prepend) {
-            // Set the oldest rendered container's divider against
-            // the prepended messages; the set_subscription_representation pass over
-            // the new groups did not cover this boundary.
-            const oldest_rendered_container = this._message_groups[0]?.message_containers[0];
-            if (oldest_rendered_container !== undefined) {
-                oldest_rendered_container.want_subscription_status_divider =
-                    wants_subscription_divider(prev_historical, oldest_rendered_container.msg);
-            }
+        if (is_prepend && prev_historical !== undefined) {
+            this.update_oldest_rendered_subscription_representation(prev_historical);
         } else {
-            prev_historical = this.list.last_message_historical;
             const first_message_container = new_message_groups[0]?.message_containers[0];
-            if (first_message_container) {
+            if (first_message_container !== undefined) {
                 first_message_container.want_subscription_status_divider =
-                    wants_subscription_divider(prev_historical, first_message_container.msg);
+                    wants_subscription_divider(
+                        this.list.last_message_historical,
+                        first_message_container.msg,
+                    );
             }
         }
     }
@@ -828,7 +852,10 @@ export class MessageListView {
                 message_for_next_group,
                 same_day(message_for_next_group, prev_message),
                 !same_year(message_for_next_group, prev_message),
-                this.get_possible_group_subscription_markers(prev_message, message_for_next_group),
+                // Subscription-status bookends are filled in afterward by
+                // set_subscription_dividers_and_markers, which also needs the
+                // boundary against already-rendered messages.
+                undefined,
             );
         };
 
@@ -931,8 +958,7 @@ export class MessageListView {
         second_group: MessageGroup | undefined,
     ): boolean {
         // join_message_groups will combine groups if they have the
-        // same_recipient and the view supports collapsing, otherwise
-        // it may add a subscription_marker if required.  It returns
+        // same_recipient and the view supports collapsing. It returns
         // true if the two groups were joined in to one and the
         // second_group should be ignored.
         if (first_group === undefined || second_group === undefined) {
@@ -959,13 +985,6 @@ export class MessageListView {
             ];
             return true;
         }
-
-        // We may need to add a subscription marker after merging the groups.
-        this.maybe_add_subscription_marker_to_group(
-            second_group,
-            last_msg_container?.msg,
-            first_msg_container.msg,
-        );
 
         return false;
     }
@@ -1247,7 +1266,7 @@ export class MessageListView {
 
         const new_message_groups = this.build_message_groups(messages);
         const message_containers = new_message_groups.flatMap((group) => group.message_containers);
-        this.set_subscription_dividers(new_message_groups, where);
+        this.set_subscription_dividers_and_markers(new_message_groups, where);
         const message_actions = this.merge_message_groups(new_message_groups, where);
         const new_dom_elements = [];
         let $rendered_groups;

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -188,8 +188,9 @@ function clear_group_date(group: MessageGroup): void {
 }
 
 function clear_message_divider(message_container: MessageContainer): void {
-    // see update_message_divider for how
-    // these get set
+    // want_date_divider is set by update_date_divider and
+    // want_subscription_status_divider by set_subscription_dividers;
+    // reset both here.
     message_container.want_date_divider = false;
     message_container.want_subscription_status_divider = false;
     message_container.date_divider_html = undefined;
@@ -205,13 +206,13 @@ function wants_subscription_divider(
     return prev_historical !== undefined && prev_historical !== message.historical;
 }
 
-function update_message_divider(opts: {
+function update_date_divider(opts: {
     prev_msg_container: MessageContainer | undefined;
     curr_msg_container: MessageContainer;
 }): void {
     Object.assign(
         opts.curr_msg_container,
-        get_message_divider_data({
+        get_date_divider_data({
             prev_message: opts.prev_msg_container?.msg,
             curr_message: opts.curr_msg_container.msg,
             display_year: !same_year(opts.curr_msg_container.msg, opts.prev_msg_container?.msg),
@@ -219,27 +220,21 @@ function update_message_divider(opts: {
     );
 }
 
-function get_message_divider_data(opts: {
+function get_date_divider_data(opts: {
     prev_message: Message | undefined;
     curr_message: Message;
     display_year: boolean;
 }): {
     want_date_divider: boolean;
-    want_subscription_status_divider: boolean;
     date_divider_html: string | undefined;
 } {
     const prev_message = opts.prev_message;
     const curr_message = opts.curr_message;
     const display_year = opts.display_year;
-    const want_subscription_status_divider = wants_subscription_divider(
-        prev_message?.historical,
-        curr_message,
-    );
 
     if (!prev_message || same_day(curr_message, prev_message)) {
         return {
             want_date_divider: false,
-            want_subscription_status_divider,
             date_divider_html: undefined,
         };
     }
@@ -247,7 +242,6 @@ function get_message_divider_data(opts: {
 
     return {
         want_date_divider: true,
-        want_subscription_status_divider,
         date_divider_html: timerender.render_date(curr_time, display_year).outerHTML,
     };
 }
@@ -742,6 +736,78 @@ export class MessageListView {
         return undefined;
     }
 
+    set_subscription_dividers(new_message_groups: MessageGroup[], where: "top" | "bottom"): void {
+        // Walk the newly built groups in order, setting each container's
+        // inline subscription-status divider, which marks -- the `historical`
+        // flag flipping between two adjacent messages, i.e. the user (un)subscribed
+        // between them -- shown inline between two messages.
+        //
+        // A flip at the first container of a group is shown as a group
+        // bookend rather than an inline divider, so those containers are
+        // skipped here.
+        //
+        // prev_historical stores the previous message's flag as we walk.
+        //
+        // The boundary against the already-rendered messages is handled after
+        // the loop, since that container may merge into a neighbouring group.
+
+        const is_prepend = where === "top";
+        let prev_historical = is_prepend ? undefined : this.list.last_message_historical;
+
+        // Record a container's subscription change as an inline divider
+        // when it isn't the first container of its message group, and
+        // then advance prev_historical.
+        const set_subscription_representation = (
+            message_container: MessageContainer,
+            starts_message_group: boolean,
+        ): void => {
+            const message = message_container.msg;
+
+            if (!starts_message_group) {
+                message_container.want_subscription_status_divider = wants_subscription_divider(
+                    prev_historical,
+                    message,
+                );
+            }
+
+            prev_historical = message.historical;
+        };
+
+        for (const message_group of new_message_groups) {
+            for (const [index, message_container] of message_group.message_containers.entries()) {
+                set_subscription_representation(message_container, index === 0);
+            }
+        }
+
+        // The boundary between new and already-rendered messages
+        // may be merged into a single group by merge_message_groups():
+        //
+        // * when prepending, the oldest rendered container may merge into the
+        //   last new group, so update (divider) against the incoming messages;
+        // * when appending, the first new container may merge into the newest
+        //   rendered group, so set its divider against the newest rendered flag.
+        //
+        // Update the subscription representation at the boundary. Either is
+        // speculative: merge_message_groups() clears it if no merge takes place.
+        if (is_prepend) {
+            // Set the oldest rendered container's divider against
+            // the prepended messages; the set_subscription_representation pass over
+            // the new groups did not cover this boundary.
+            const oldest_rendered_container = this._message_groups[0]?.message_containers[0];
+            if (oldest_rendered_container !== undefined) {
+                oldest_rendered_container.want_subscription_status_divider =
+                    wants_subscription_divider(prev_historical, oldest_rendered_container.msg);
+            }
+        } else {
+            prev_historical = this.list.last_message_historical;
+            const first_message_container = new_message_groups[0]?.message_containers[0];
+            if (first_message_container) {
+                first_message_container.want_subscription_status_divider =
+                    wants_subscription_divider(prev_historical, first_message_container.msg);
+            }
+        }
+    }
+
     build_message_groups(messages: Message[]): MessageGroup[] {
         const new_message_groups: MessageGroup[] = [];
 
@@ -787,7 +853,7 @@ export class MessageListView {
             let include_sender;
             let want_date_divider;
             let date_divider_html;
-            let want_subscription_status_divider = false;
+            const want_subscription_status_divider = false;
             const year_changed = !same_year(message, prev_message_container?.msg);
 
             if (
@@ -795,13 +861,12 @@ export class MessageListView {
                 util.same_recipient(prev_message_container.msg, message) &&
                 this.collapse_messages
             ) {
-                const divider_data = get_message_divider_data({
+                const divider_data = get_date_divider_data({
                     prev_message: prev_message_container.msg,
                     curr_message: message,
                     display_year: year_changed,
                 });
                 want_date_divider = divider_data.want_date_divider;
-                want_subscription_status_divider = divider_data.want_subscription_status_divider;
                 date_divider_html = divider_data.date_divider_html;
             } else {
                 finish_group();
@@ -945,7 +1010,7 @@ export class MessageListView {
 
         const was_joined = this.join_message_groups(first_group, second_group);
         if (was_joined) {
-            update_message_divider({
+            update_date_divider({
                 prev_msg_container,
                 curr_msg_container,
             });
@@ -1182,6 +1247,7 @@ export class MessageListView {
 
         const new_message_groups = this.build_message_groups(messages);
         const message_containers = new_message_groups.flatMap((group) => group.message_containers);
+        this.set_subscription_dividers(new_message_groups, where);
         const message_actions = this.merge_message_groups(new_message_groups, where);
         const new_dom_elements = [];
         let $rendered_groups;

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1129,7 +1129,7 @@ export class MessageListView {
 
     render(
         messages: Message[],
-        where: string,
+        where: "top" | "bottom",
         messages_are_new = false,
     ): {need_user_to_scroll: boolean} | undefined {
         // This function processes messages into chunks with separators between them,

--- a/web/src/message_report.ts
+++ b/web/src/message_report.ts
@@ -58,7 +58,7 @@ function register_message_preview_click_handlers(
 function get_message_group_for_message_preview(message: Message): MessageGroup {
     // This creates a simpler recipient_row without element like the
     // topic menu and topic visibility policy menu.
-    const message_group = populate_group_from_message(message, false, false, undefined);
+    const message_group = populate_group_from_message(message, false, false);
     if (message_group.is_stream) {
         message_group.user_can_resolve_topic = false;
         message_group.is_topic_editable = false;

--- a/web/tests/message_list.test.cjs
+++ b/web/tests/message_list.test.cjs
@@ -37,6 +37,7 @@ function MessageListView() {
         prepend: noop,
         clear_rendering_state: noop,
         is_current_message_list: () => true,
+        get_boundary_message_info_with_meaningful_historical: () => undefined,
     };
 }
 mock_esm("../src/message_list_view", {
@@ -389,7 +390,14 @@ run_test("bookend", ({override}) => {
         assert.equal(bookend.just_unsubscribed, false);
     }
 
-    list.last_message_historical = false;
+    list.view.get_boundary_message_info_with_meaningful_historical = () => ({
+        message_container: {
+            msg: {
+                historical: false,
+            },
+        },
+    });
+
     is_subscribed = false;
 
     {
@@ -411,7 +419,14 @@ run_test("bookend", ({override}) => {
         assert.equal(bookend.just_unsubscribed, false);
     }
 
-    list.last_message_historical = false;
+    list.view.get_boundary_message_info_with_meaningful_historical = () => ({
+        message_container: {
+            msg: {
+                historical: false,
+            },
+        },
+    });
+
     is_subscribed = false;
     list.empty = () => false;
 
@@ -456,7 +471,37 @@ run_test("bookend", ({override}) => {
         assert.equal(bookend.just_unsubscribed, true);
     }
 
-    list.last_message_historical = true;
+    list.view.get_boundary_message_info_with_meaningful_historical = () => ({
+        message_container: {
+            msg: {
+                historical: true,
+            },
+        },
+    });
+
+    {
+        const stub = make_stub();
+        list.view.render_trailing_bookend = stub.f;
+        list.update_trailing_bookend();
+        assert.equal(stub.num_calls, 1);
+        const bookend = stub.get_args(
+            "stream_id",
+            "stream_name",
+            "subscribed",
+            "deactivated",
+            "just_unsubscribed",
+        );
+        assert.equal(bookend.stream_id, 5);
+        assert.equal(bookend.stream_name, "IceCream");
+        assert.equal(bookend.subscribed, false);
+        assert.equal(bookend.deactivated, false);
+        assert.equal(bookend.just_unsubscribed, false);
+    }
+
+    // When no rendered message has a meaningful `historical` flag
+    // (e.g., they were all moved from another channel), we don't know
+    // whether the user just unsubscribed, so we don't claim they did.
+    list.view.get_boundary_message_info_with_meaningful_historical = () => undefined;
 
     {
         const stub = make_stub();

--- a/web/tests/message_list_view.test.cjs
+++ b/web/tests/message_list_view.test.cjs
@@ -544,6 +544,13 @@ test("merge_message_groups", ({mock_template}) => {
         view._message_groups = message_groups;
         view.list.unsubscribed_bookend_content = noop;
         view.list.subscribed_bookend_content = noop;
+        // render() records the historical status of the last rendered
+        // message so subsequent appends can compute the subscription
+        // divider against it; mirror that here for the merge tests.
+        const last_group = message_groups.at(-1);
+        if (last_group !== undefined) {
+            view.list.last_message_historical = last_group.message_containers.at(-1).msg.historical;
+        }
         return view;
     }
 
@@ -663,6 +670,7 @@ test("merge_message_groups", ({mock_template}) => {
         const message_group2 = build_message_group([message2]);
 
         const list = build_list([message_group1]);
+        list.set_subscription_dividers([message_group2], "bottom");
         const result = list.merge_message_groups([message_group2], "bottom");
 
         // Flipping historical flag should not split the message group
@@ -682,6 +690,7 @@ test("merge_message_groups", ({mock_template}) => {
         const message3 = build_message_context({historical: false, topic: "test"});
         const message_group3 = build_message_group([message3]);
 
+        list.set_subscription_dividers([message_group3], "bottom");
         const result2 = list.merge_message_groups([message_group3]);
 
         assert.ok(message_group3.bookend_top);
@@ -799,6 +808,7 @@ test("merge_message_groups", ({mock_template}) => {
 
         const list = build_list([message_group1]);
         list.$list[0].prepend = noop;
+        list.set_subscription_dividers([message_group2], "top");
         const result = list.merge_message_groups([message_group2], "top");
 
         assert.equal(message_group1.bookend_top, undefined);
@@ -817,6 +827,7 @@ test("merge_message_groups", ({mock_template}) => {
         const message3 = build_message_context({historical: false, topic: "test"});
         const message_group3 = build_message_group([message3]);
 
+        list.set_subscription_dividers([message_group3], "top");
         const result2 = list.merge_message_groups([message_group3], "top");
 
         assert.ok(message_group2.bookend_top);

--- a/web/tests/message_list_view.test.cjs
+++ b/web/tests/message_list_view.test.cjs
@@ -544,25 +544,15 @@ test("merge_message_groups", ({mock_template}) => {
         view._message_groups = message_groups;
         view.list.unsubscribed_bookend_content = noop;
         view.list.subscribed_bookend_content = noop;
-        // render() records the historical status of the last rendered
-        // message so subsequent appends can compute the subscription
-        // divider against it; mirror that here for the merge tests.
-        const last_group = message_groups.at(-1);
-        if (last_group !== undefined) {
-            view.list.last_message_historical = last_group.message_containers.at(-1).msg.historical;
-        }
         return view;
     }
 
-    // Mirror the order in which render() computes subscription dividers and
-    // markers, merges the new groups, and records the last rendered
-    // message's historical status for the next batch.
+    // Mirror the order in which render() computes subscription-status
+    // dividers and markers on the new groups before merging them into
+    // the rendered list.
     function add_message_groups(list, new_message_groups, where) {
         list.set_subscription_dividers_and_markers(new_message_groups, where);
-        const result = list.merge_message_groups(new_message_groups, where);
-        const last_group = list._message_groups.at(-1);
-        list.list.last_message_historical = last_group.message_containers.at(-1).msg.historical;
-        return result;
+        return list.merge_message_groups(new_message_groups, where);
     }
 
     function extract_message_ids(lst) {
@@ -851,6 +841,396 @@ test("merge_message_groups", ({mock_template}) => {
         assert.ok(!list._message_groups[1].message_containers[0].want_subscription_status_divider);
         assert.ok(list._message_groups[1].message_containers[1].want_subscription_status_divider);
     })();
+
+    // Messages moved here from another channel carry a `historical` flag
+    // that is meaningless in this channel, so they must not trigger
+    // subscription-status dividers or bookends.
+    function build_moved_message_context(message = {}) {
+        // prev_stream differs from the default stream_id (2), marking the
+        // message as moved here from another channel.
+        return build_message_context({
+            edit_history: [{prev_stream: 999}],
+            ...message,
+        });
+    }
+
+    (function test_append_moved_message_skips_subscription_divider() {
+        const moved_message = build_moved_message_context({historical: true});
+        const message_group1 = build_message_group([moved_message]);
+
+        const message2 = build_message_context({historical: false});
+        const message_group2 = build_message_group([message2]);
+
+        const list = build_list([message_group1]);
+        add_message_groups(list, [message_group2], "bottom");
+
+        assert.ok(!message2.want_subscription_status_divider);
+        assert_message_groups_list_equal(list._message_groups, [
+            build_message_group([moved_message, message2]),
+        ]);
+    })();
+
+    (function test_moved_message_never_gets_subscription_divider() {
+        const message1 = build_message_context({historical: false});
+        const message_group1 = build_message_group([message1]);
+
+        const moved_message = build_moved_message_context({historical: true});
+        const message_group2 = build_message_group([moved_message]);
+
+        const list = build_list([message_group1]);
+        add_message_groups(list, [message_group2], "bottom");
+
+        // Assert the groups joined, so the divider check can't pass
+        // vacuously on an unset field.
+        assert_message_groups_list_equal(list._message_groups, [
+            build_message_group([message1, moved_message]),
+        ]);
+        assert.equal(moved_message.want_subscription_status_divider, false);
+    })();
+
+    (function test_moved_last_message_skips_subscription_bookend() {
+        // When the groups do not join (different topic), the transition is
+        // shown as a group bookend; a moved message must not trigger it.
+        const moved_message = build_moved_message_context({historical: true});
+        const message_group1 = build_message_group([moved_message]);
+
+        const message2 = build_message_context({historical: false, topic: "Test topic 2"});
+        const message_group2 = build_message_group([message2]);
+
+        const list = build_list([message_group1]);
+        add_message_groups(list, [message_group2], "bottom");
+
+        assert.equal(message_group2.bookend_top, undefined);
+        assert.equal(message_group2.subscribed, undefined);
+        assert.equal(message_group2.just_unsubscribed, undefined);
+    })();
+
+    (function test_moved_first_message_skips_subscription_bookend() {
+        const message1 = build_message_context({historical: false});
+        const message_group1 = build_message_group([message1]);
+
+        const moved_message = build_moved_message_context({
+            historical: true,
+            topic: "Test topic 2",
+        });
+        const message_group2 = build_message_group([moved_message]);
+
+        const list = build_list([message_group1]);
+        add_message_groups(list, [message_group2], "bottom");
+
+        assert.equal(message_group2.bookend_top, undefined);
+        assert.equal(message_group2.just_unsubscribed, undefined);
+    })();
+
+    (function test_message_moved_back_to_original_channel() {
+        // A message moved away and then back to its current channel carries
+        // a meaningful historical flag, so it is treated as a normal message.
+        const moved_back_message = build_message_context({
+            historical: true,
+            edit_history: [{prev_stream: 2}],
+        });
+        const message_group1 = build_message_group([moved_back_message]);
+
+        const message2 = build_message_context({historical: false});
+        const message_group2 = build_message_group([message2]);
+
+        const list = build_list([message_group1]);
+        add_message_groups(list, [message_group2], "bottom");
+
+        assert.ok(message2.want_subscription_status_divider);
+    })();
+
+    (function test_prepend_moved_message_skips_subscription_bookend() {
+        const message1 = build_message_context({historical: false});
+        const message_group1 = build_message_group([message1]);
+
+        const moved_message = build_moved_message_context({
+            historical: true,
+            topic: "Test topic 2",
+        });
+        const message_group2 = build_message_group([moved_message]);
+
+        const list = build_list([message_group1]);
+        add_message_groups(list, [message_group2], "top");
+
+        // The bookend, if any, is added to the existing (lower) group.
+        assert.equal(message_group1.bookend_top, undefined);
+        assert.equal(message_group1.subscribed, undefined);
+    })();
+
+    (function test_divider_shown_across_moved_message_in_batch() {
+        // A moved message between two messages with meaningful flags must
+        // not hide the real transition between them: the divider belongs
+        // on the first meaningful message after the flip.
+        const message1 = build_message_context({historical: true});
+        const message_group1 = build_message_group([message1]);
+
+        const moved_message = build_moved_message_context({historical: true});
+        const message2 = build_message_context({historical: false});
+        const message_group2 = build_message_group([moved_message, message2]);
+
+        const list = build_list([message_group1]);
+        add_message_groups(list, [message_group2], "bottom");
+
+        assert_message_groups_list_equal(list._message_groups, [
+            build_message_group([message1, moved_message, message2]),
+        ]);
+        assert.ok(!moved_message.want_subscription_status_divider);
+        assert.ok(message2.want_subscription_status_divider);
+    })();
+
+    (function test_divider_shown_when_newest_rendered_message_was_moved() {
+        // Likewise when the moved message was already rendered: the new
+        // message is compared with the newest meaningful flag, not with
+        // the moved message just above it.
+        const message1 = build_message_context({historical: true});
+        const moved_message = build_moved_message_context({historical: true});
+        const message_group1 = build_message_group([message1, moved_message]);
+
+        const message2 = build_message_context({historical: false});
+        const message_group2 = build_message_group([message2]);
+
+        const list = build_list([message_group1]);
+        add_message_groups(list, [message_group2], "bottom");
+
+        assert_message_groups_list_equal(list._message_groups, [
+            build_message_group([message1, moved_message, message2]),
+        ]);
+        assert.ok(message2.want_subscription_status_divider);
+    })();
+
+    (function test_prepend_divider_shown_across_moved_message() {
+        const message1 = build_message_context({historical: false});
+        const message_group1 = build_message_group([message1]);
+
+        const message2 = build_message_context({historical: true});
+        const moved_message = build_moved_message_context({historical: true});
+        const message_group2 = build_message_group([message2, moved_message]);
+
+        const list = build_list([message_group1]);
+        add_message_groups(list, [message_group2], "top");
+
+        // The existing message joins below the prepended group; its
+        // divider reflects the flip from message2's flag, not the moved
+        // message's.
+        assert_message_groups_list_equal(list._message_groups, [
+            build_message_group([message2, moved_message, message1]),
+        ]);
+        assert.ok(message1.want_subscription_status_divider);
+        assert.ok(!moved_message.want_subscription_status_divider);
+    })();
+
+    (function test_prepend_marker_when_oldest_rendered_group_was_moved() {
+        // The oldest rendered group consists only of a message moved here from
+        // another channel, so the first meaningful rendered message starts a
+        // later group that the prepended messages can never merge into. A
+        // subscription change at that boundary belongs on the group as a
+        // bookend, not as an inline divider on its first message.
+        const moved_message = build_moved_message_context({
+            historical: true,
+            topic: "Moved topic",
+        });
+        const moved_group = build_message_group([moved_message]);
+
+        const message1 = build_message_context({historical: true, topic: "Subscribed topic"});
+        const message_group1 = build_message_group([message1]);
+
+        const message2 = build_message_context({historical: false, topic: "New topic"});
+        const message_group2 = build_message_group([message2]);
+
+        const list = build_list([moved_group, message_group1]);
+        add_message_groups(list, [message_group2], "top");
+
+        // No merge happens (distinct topics), so the flip from subscribed
+        // (message2) to unsubscribed (message1) shows as a bookend on
+        // message1's group, and message1 keeps no inline divider.
+        assert.ok(message_group1.bookend_top);
+        assert.equal(message_group1.just_unsubscribed, true);
+        assert.ok(!message1.want_subscription_status_divider);
+    })();
+
+    (function test_prepend_inline_divider_when_oldest_rendered_group_starts_with_moved() {
+        // The oldest rendered group starts with a moved message but
+        // continues with a meaningful one. The boundary against the
+        // prepended messages is shown as an inline divider on that
+        // meaningful continuation message, since the moved message above it
+        // in the same group makes it a continuation rather than the group's
+        // first message.
+        const moved_message = build_moved_message_context({historical: true});
+        const message1 = build_message_context({historical: true});
+        // Same recipient, so both messages live in one rendered group.
+        const rendered_group = build_message_group([moved_message, message1]);
+
+        const message2 = build_message_context({historical: false, topic: "New topic"});
+        const message_group2 = build_message_group([message2]);
+
+        const list = build_list([rendered_group]);
+        add_message_groups(list, [message_group2], "top");
+
+        // No merge happens (distinct topics), so the flip from message2
+        // (subscribed) to message1 (unsubscribed) is shown inline on
+        // message1, not on the moved message above it.
+        assert.ok(message1.want_subscription_status_divider);
+        assert.ok(!moved_message.want_subscription_status_divider);
+    })();
+
+    (function test_prepend_no_boundary_update_when_all_rendered_messages_moved() {
+        // Every already-rendered message was moved here from another
+        // channel, so none has a meaningful flag. The prepended-boundary
+        // update finds no container to mark and leaves the rendered content
+        // untouched.
+        const moved_message = build_moved_message_context({historical: true});
+        const rendered_group = build_message_group([moved_message]);
+
+        const message1 = build_message_context({historical: false, topic: "New topic"});
+        const message_group1 = build_message_group([message1]);
+
+        const list = build_list([rendered_group]);
+        add_message_groups(list, [message_group1], "top");
+
+        assert.ok(!moved_message.want_subscription_status_divider);
+        assert.equal(rendered_group.bookend_top, undefined);
+        assert.equal(rendered_group.subscribed, undefined);
+        assert.equal(rendered_group.just_unsubscribed, undefined);
+    })();
+
+    (function test_no_subscription_marker_without_historical_flip() {
+        // Two non-merging groups in the same subscription state produce no
+        // bookend: there is no historical-flag flip between them.
+        const message1 = build_message_context({historical: false});
+        const message_group1 = build_message_group([message1]);
+
+        const message2 = build_message_context({historical: false, topic: "New topic"});
+        const message_group2 = build_message_group([message2]);
+
+        const list = build_list([message_group1]);
+        add_message_groups(list, [message_group2], "bottom");
+
+        assert.equal(message_group2.bookend_top, undefined);
+        assert.equal(message_group2.subscribed, undefined);
+        assert.equal(message_group2.just_unsubscribed, undefined);
+        assert.ok(!message2.want_subscription_status_divider);
+    })();
+});
+
+test("get_boundary_message_info_with_meaningful_historical", () => {
+    // get_boundary_message_info_with_meaningful_historical("newest")
+    // feeds the trailing bookend, which must infer subscription status from the newest
+    // message whose `historical` flag is meaningful in this channel, skipping
+    // messages moved here from another channel.
+    function build_message_container(message = {}) {
+        return {
+            msg: {
+                id: _.uniqueId("test_message_"),
+                type: "stream",
+                stream_id: 2,
+                ...message,
+            },
+        };
+    }
+
+    function build_list(message_groups) {
+        const list = new MessageListView({id: 1}, true, true);
+        list._message_groups = message_groups;
+        return list;
+    }
+
+    // The newest message's flag is used directly when it is meaningful.
+    let list = build_list([
+        {
+            message_containers: [
+                build_message_container({historical: false}),
+                build_message_container({historical: true}),
+            ],
+        },
+    ]);
+    assert.equal(
+        list.get_boundary_message_info_with_meaningful_historical("newest")?.message_container.msg
+            .historical,
+        true,
+    );
+
+    // Moved messages are skipped, across group boundaries.
+    list = build_list([
+        {message_containers: [build_message_container({historical: false})]},
+        {
+            message_containers: [
+                build_message_container({historical: true, edit_history: [{prev_stream: 999}]}),
+            ],
+        },
+    ]);
+    assert.equal(
+        list.get_boundary_message_info_with_meaningful_historical("newest")?.message_container.msg
+            .historical,
+        false,
+    );
+
+    // A message moved back to its original channel has a meaningful flag.
+    list = build_list([
+        {
+            message_containers: [
+                build_message_container({historical: true, edit_history: [{prev_stream: 2}]}),
+            ],
+        },
+    ]);
+    assert.equal(
+        list.get_boundary_message_info_with_meaningful_historical("newest")?.message_container.msg
+            .historical,
+        true,
+    );
+
+    // With no meaningful flag at all, the status is unknown.
+    list = build_list([
+        {
+            message_containers: [
+                build_message_container({historical: true, edit_history: [{prev_stream: 999}]}),
+            ],
+        },
+    ]);
+    assert.equal(
+        list.get_boundary_message_info_with_meaningful_historical("newest")?.message_container.msg
+            .historical,
+        undefined,
+    );
+
+    list = build_list([]);
+    assert.equal(
+        list.get_boundary_message_info_with_meaningful_historical("newest")?.message_container.msg
+            .historical,
+        undefined,
+    );
+});
+
+test("set_subscription_dividers_and_markers ignores non-channel narrows", () => {
+    // Subscription-status dividers and bookends only make sense in a
+    // single-channel narrow. In other narrows (e.g. direct messages) the
+    // pass must run without adding any divider or bookend, and a non-stream
+    // message is never treated as moved.
+    const filter = new Filter([{operator: "is", operand: "dm"}]);
+    const list = new message_list.MessageList({
+        data: new MessageListData({excludes_muted_topics: false, filter}),
+        is_node_test: true,
+    });
+    const view = new MessageListView(list, true, true);
+
+    const dm1 = {include_sender: true, msg: {id: 1, type: "private", to_user_ids: "5"}};
+    const dm2 = {include_sender: true, msg: {id: 2, type: "private", to_user_ids: "5"}};
+    const rendered_group = {message_containers: [dm1], message_group_id: "dm-group-1"};
+    const new_group = {message_containers: [dm2], message_group_id: "dm-group-2"};
+    view._message_groups = [rendered_group];
+
+    view.set_subscription_dividers_and_markers([new_group], "bottom");
+
+    assert.ok(!dm2.want_subscription_status_divider);
+    assert.equal(new_group.bookend_top, undefined);
+    assert.equal(new_group.subscribed, undefined);
+    assert.equal(new_group.just_unsubscribed, undefined);
+
+    // Appending no new groups is a no-op: there is no boundary container to
+    // mark.
+    assert.doesNotThrow(() => {
+        view.set_subscription_dividers_and_markers([], "bottom");
+    });
 });
 
 test("render_windows", ({mock_template}) => {

--- a/web/tests/message_list_view.test.cjs
+++ b/web/tests/message_list_view.test.cjs
@@ -554,6 +554,17 @@ test("merge_message_groups", ({mock_template}) => {
         return view;
     }
 
+    // Mirror the order in which render() computes subscription dividers and
+    // markers, merges the new groups, and records the last rendered
+    // message's historical status for the next batch.
+    function add_message_groups(list, new_message_groups, where) {
+        list.set_subscription_dividers_and_markers(new_message_groups, where);
+        const result = list.merge_message_groups(new_message_groups, where);
+        const last_group = list._message_groups.at(-1);
+        list.list.last_message_historical = last_group.message_containers.at(-1).msg.historical;
+        return result;
+    }
+
     function extract_message_ids(lst) {
         return lst.map((item) => item.msg.id);
     }
@@ -670,12 +681,12 @@ test("merge_message_groups", ({mock_template}) => {
         const message_group2 = build_message_group([message2]);
 
         const list = build_list([message_group1]);
-        list.set_subscription_dividers([message_group2], "bottom");
-        const result = list.merge_message_groups([message_group2], "bottom");
+        const result = add_message_groups(list, [message_group2], "bottom");
 
-        // Flipping historical flag should not split the message group
-        // if the message recipient is same
-        assert.equal(message_group2.bookend_top, undefined);
+        // Flipping the historical flag should not split the message group
+        // when the recipient is the same: the change is shown as an inline
+        // divider on message2 rather than as a bookend on the joined group.
+        assert.equal(list._message_groups[0].bookend_top, undefined);
         assert.equal(message2.want_subscription_status_divider, true);
         assert_message_groups_list_equal(list._message_groups, [
             build_message_group([message1, message2]),
@@ -690,8 +701,7 @@ test("merge_message_groups", ({mock_template}) => {
         const message3 = build_message_context({historical: false, topic: "test"});
         const message_group3 = build_message_group([message3]);
 
-        list.set_subscription_dividers([message_group3], "bottom");
-        const result2 = list.merge_message_groups([message_group3]);
+        const result2 = add_message_groups(list, [message_group3], "bottom");
 
         assert.ok(message_group3.bookend_top);
         assert_message_groups_list_equal(list._message_groups, [
@@ -808,10 +818,9 @@ test("merge_message_groups", ({mock_template}) => {
 
         const list = build_list([message_group1]);
         list.$list[0].prepend = noop;
-        list.set_subscription_dividers([message_group2], "top");
-        const result = list.merge_message_groups([message_group2], "top");
+        const result = add_message_groups(list, [message_group2], "top");
 
-        assert.equal(message_group1.bookend_top, undefined);
+        assert.equal(list._message_groups[0].bookend_top, undefined);
         assert_message_groups_list_equal(list._message_groups, [
             build_message_group([message2, message1]),
         ]);
@@ -827,8 +836,7 @@ test("merge_message_groups", ({mock_template}) => {
         const message3 = build_message_context({historical: false, topic: "test"});
         const message_group3 = build_message_group([message3]);
 
-        list.set_subscription_dividers([message_group3], "top");
-        const result2 = list.merge_message_groups([message_group3], "top");
+        const result2 = add_message_groups(list, [message_group3], "top");
 
         assert.ok(message_group2.bookend_top);
         assert_message_groups_list_equal(list._message_groups, [


### PR DESCRIPTION
Currently, message subscription status dividers are calculated by checking whether the subscription status flips between two consecutive messages in a message list. However, some messages may have been moved from a different channel and still carry the historical subscription flag for that original channel. These moved messages do not provide meaningful information when calculating the subscription status for the current channel.

This PR identifies and excludes such moved messages when computing subscription status.

Computation logic:

The subscription status change computation is consolidated into a single function that assigns both:

- inline subscription status dividers between messages, and
- subscription status bookend markers at message group boundaries.

The function tracks the most recent meaningful historical value while walking messages. Messages moved from another channel are skipped, preventing their inherited historical value from affecting divider or bookend generation.

Special case:

We need to update the divider/marker at the boundary where `new_message_groups` and the `this._message_groups` are merged by `merge_message_groups()`.

Fixes: [#issues > 📂 Incorrect "You subscribed / unsubscribed to" bookend @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20Incorrect.20.22You.20subscribed.20.2F.20unsubscribed.20to.22.20bookend/near/2362124)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

|After|
|-|
|<img width="926" height="445" alt="Screenshot from 2026-06-11 15-45-23" src="https://github.com/user-attachments/assets/e43e5dd9-a448-46c5-a470-87fb165f7f27" />|
|<img width="927" height="370" alt="Screenshot from 2026-06-18 01-16-45" src="https://github.com/user-attachments/assets/e61672df-838e-4da0-85ac-4b07c3c5f4da" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
