### PR TITLE
streams : Add PERMISSION_DENIED error for stream creation.

### DIFF
--- a/api_docs/unmerged.d/ZF-e65a6c.md
+++ b/api_docs/unmerged.d/ZF-e65a6c.md
@@ -1,0 +1,9 @@
+* [`POST /users/me/subscriptions`](/api/subscribe),
+  [`POST /channels/create`](/api/create-channel),
+  [`PATCH /streams/{stream_id}`](/api/update-stream): Added the
+  `PERMISSION_DENIED` error code (HTTP status 403), returned when a
+  channel name collides with an existing channel the user cannot
+  access, instead of revealing the channel's existence. For
+  [`POST /users/me/subscriptions`](/api/subscribe), this replaces the
+  previous `BAD_REQUEST` error (HTTP status 400) whose message named
+  the conflicting channel.

--- a/api_docs/unmerged.d/ZF-e65a6c.md
+++ b/api_docs/unmerged.d/ZF-e65a6c.md
@@ -1,0 +1,12 @@
+* [`POST /users/me/subscriptions`](/api/subscribe),
+  [`POST /channels/create`](/api/create-channel),
+  [`PATCH /streams/{stream_id}`](/api/update-stream): Added the
+  `PERMISSION_DENIED` error code (HTTP status 403), returned when a
+  channel name collides with an existing channel the user cannot
+  access, so that the channel's name and whether it is private or
+  archived are not revealed. Previously these requests returned an
+  error that named the conflicting channel: a `BAD_REQUEST` (HTTP
+  status 400) on [`POST /users/me/subscriptions`](/api/subscribe), and
+  `CHANNEL_ALREADY_EXISTS` (HTTP status 409) on
+  [`POST /channels/create`](/api/create-channel) and
+  [`PATCH /streams/{stream_id}`](/api/update-stream).

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -415,16 +415,15 @@ function create_stream(): void {
             // The rest of the work is done via the subscribe event we will get
         },
         error(xhr): void {
-            const error_message = z.object({msg: z.optional(z.string())}).parse(xhr.responseJSON);
-            if (error_message?.msg?.includes("access")) {
-                // If we can't access the stream, we can safely
-                // assume it's a duplicate stream that we are not invited to.
-                //
-                // BUG: This check should be using error codes, not
-                // parsing the error string, so it works correctly
-                // with i18n.  And likely we should be reporting the
-                // error text directly rather than turning it into
-                // "Error creating channel"?
+            const parsed_error = z
+                .object({code: z.optional(z.string())})
+                .safeParse(xhr.responseJSON);
+
+            if (parsed_error.success && parsed_error.data.code === "PERMISSION_DENIED") {
+                // If we can't access the stream, we can safely assume it's a
+                // duplicate channel we cannot access (private or archived). We
+                // don't know whether it's archived, so we use the generic
+                // non-archived copy to avoid leaking that information.
                 const rendered_error = render_channel_name_conflict_error({
                     stream_id: undefined,
                     is_archived: false,

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -179,9 +179,15 @@ export function save_stream_info(): void {
 
     dialog_widget.submit_api_request(channel.patch, url, data, {
         error_continuation(xhr) {
-            const {code} = z.object({code: z.string()}).parse(xhr.responseJSON);
+            const parsed_error = z
+                .object({code: z.optional(z.string())})
+                .safeParse(xhr.responseJSON);
+            if (!parsed_error.success) {
+                return;
+            }
+            const {code} = parsed_error.data;
 
-            if (code === "CHANNEL_ALREADY_EXISTS") {
+            if (code === "CHANNEL_ALREADY_EXISTS" || code === "PERMISSION_DENIED") {
                 $("#dialog_error").hide().empty();
 
                 assert(data.new_name !== undefined);

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -821,6 +821,19 @@ class CannotAdministerChannelError(JsonableError):
         return _("You do not have permission to administer this channel.")
 
 
+class PermissionDeniedError(JsonableError):
+    code = ErrorCode.PERMISSION_DENIED
+    http_status_code = 403
+
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _("Permission denied.")
+
+
 class CannotManageDefaultChannelError(JsonableError):
     def __init__(self) -> None:
         pass

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -18,6 +18,7 @@ from zerver.lib.exceptions import (
     JsonableError,
     MissingAuthenticationError,
     OrganizationOwnerRequiredError,
+    PermissionDeniedError,
 )
 from zerver.lib.stream_subscription import (
     get_guest_user_ids_for_streams,
@@ -1049,13 +1050,26 @@ def get_web_public_streams_queryset(realm: Realm) -> QuerySet[Stream]:
     )
 
 
-def check_stream_name_available(realm: Realm, name: str) -> None:
+def check_stream_name_available(acting_user: UserProfile, name: str) -> None:
     check_stream_name(name)
     try:
-        get_stream(name, realm)
-        raise ChannelExistsError(name)
+        stream = get_stream(name, acting_user.realm)
     except Stream.DoesNotExist:
-        pass
+        return
+
+    assert stream.recipient_id is not None
+    try:
+        sub: Subscription | None = Subscription.objects.get(
+            user_profile=acting_user, recipient_id=stream.recipient_id, active=True
+        )
+    except Subscription.DoesNotExist:
+        sub = None
+
+    if check_basic_stream_access(
+        acting_user, stream, is_subscribed=sub is not None, require_content_access=False
+    ):
+        raise ChannelExistsError(name)
+    raise PermissionDeniedError
 
 
 def access_stream_by_name(

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -18,6 +18,7 @@ from zerver.lib.exceptions import (
     JsonableError,
     MissingAuthenticationError,
     OrganizationOwnerRequiredError,
+    PermissionDeniedError,
 )
 from zerver.lib.stream_subscription import (
     get_guest_user_ids_for_streams,
@@ -1049,13 +1050,23 @@ def get_web_public_streams_queryset(realm: Realm) -> QuerySet[Stream]:
     )
 
 
-def check_stream_name_available(realm: Realm, name: str) -> None:
+def check_stream_name_available(acting_user: UserProfile, name: str) -> None:
     check_stream_name(name)
     try:
-        get_stream(name, realm)
-        raise ChannelExistsError(name)
+        stream = get_stream(name, acting_user.realm)
     except Stream.DoesNotExist:
-        pass
+        return
+
+    assert stream.recipient_id is not None
+    is_subscribed = Subscription.objects.filter(
+        user_profile=acting_user, recipient_id=stream.recipient_id, active=True
+    ).exists()
+
+    if check_basic_stream_access(
+        acting_user, stream, is_subscribed=is_subscribed, require_content_access=False
+    ):
+        raise ChannelExistsError(name)
+    raise PermissionDeniedError
 
 
 def access_stream_by_name(

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -210,8 +210,8 @@ def test_authorization_errors_fatal(client: Client, nonadmin_client: Client) -> 
         ],
         authorization_errors_fatal=True,
     )
-    assert_error_response(result)
-    validate_against_openapi_schema(result, "/users/me/subscriptions", "post", "400")
+    assert_error_response(result, code="PERMISSION_DENIED")
+    validate_against_openapi_schema(result, "/users/me/subscriptions", "post", "403")
 
 
 @openapi_test_function("/realm/presence:get")

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13357,17 +13357,41 @@ paths:
           content:
             application/json:
               schema:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                BadRequest:
+                  value:
+                    result: error
+                    msg: Bad request.
+                    code: BAD_REQUEST
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
                 allOf:
                   - $ref: "#/components/schemas/CodedError"
-                  - example:
-                      {
-                        "msg": "Unable to access channel (private).",
-                        "result": "error",
-                        "code": "BAD_REQUEST",
-                      }
+                  - type: object
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - PERMISSION_DENIED
                     description: |
-                      An example JSON response for when the requesting user does not have
-                      access to a private channel and `"authorization_errors_fatal": true`:
+                      Returned when the request references a channel name that
+                      collides with an existing channel the user cannot access.
+                      The error is intentionally generic, so it does not reveal
+                      the channel's name or whether it is private or archived.
+
+                      **Changes**: New in Zulip 13.0 (feature level ZF-e65a6c).
+                      Previously, this was a `BAD_REQUEST` error (HTTP status 400)
+                      whose message named the conflicting channel.
+              examples:
+                PermissionDenied:
+                  value:
+                    result: error
+                    msg: Permission denied.
+                    code: PERMISSION_DENIED
     patch:
       operationId: update-subscriptions
       summary: Update subscriptions
@@ -24951,6 +24975,57 @@ paths:
                         description: |
                           An example JSON response for when trying to set moderation request channel to
                           be public:
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - type: object
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - PERMISSION_DENIED
+                    description: |
+                      Returned when the new name collides with an existing channel
+                      the user cannot access. The error is intentionally generic,
+                      so it does not reveal the channel's name or whether it is
+                      private or archived.
+
+                      **Changes**: New in Zulip 13.0 (feature level ZF-e65a6c).
+                      Previously, all name collisions returned a
+                      `CHANNEL_ALREADY_EXISTS` error (HTTP status 409); that error
+                      is now returned only when the user can access the existing
+                      channel.
+              examples:
+                PermissionDenied:
+                  value:
+                    result: error
+                    msg: Permission denied.
+                    code: PERMISSION_DENIED
+        "409":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - example:
+                      {
+                        result: "error",
+                        msg: "Channel 'Denmark' already exists",
+                        code: "CHANNEL_ALREADY_EXISTS",
+                      }
+                    description: |
+                      Returned when the new name collides with an existing
+                      channel the user can access.
+
+                      **Changes**: Prior to Zulip 13.0 (feature level ZF-e65a6c),
+                      this error was also returned when the existing channel was
+                      one the user could not access; that case now returns a
+                      `PERMISSION_DENIED` error instead.
   /streams/{stream_id}/email_address:
     get:
       operationId: get-stream-email-address
@@ -25554,6 +25629,36 @@ paths:
                         type: integer
                         description: "The ID of the newly created channel."
                 example: {"result": "success", "msg": "", "id": 50}
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - type: object
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - PERMISSION_DENIED
+                    description: |
+                      Returned when the submitted name collides with an existing
+                      channel the user cannot access. The error is intentionally
+                      generic, so it does not reveal the channel's name or whether
+                      it is private or archived.
+
+                      **Changes**: New in Zulip 13.0 (feature level ZF-e65a6c).
+                      Previously, all name collisions returned a
+                      `CHANNEL_ALREADY_EXISTS` error (HTTP status 409); that error
+                      is now returned only when the user can access the existing
+                      channel.
+              examples:
+                PermissionDenied:
+                  value:
+                    result: error
+                    msg: Permission denied.
+                    code: PERMISSION_DENIED
         "409":
           description: Bad request.
           content:
@@ -25570,6 +25675,11 @@ paths:
                     description: |
                       An example JSON error response for when a channel with the submitted
                       name already exists.
+
+                      **Changes**: Prior to Zulip 13.0 (feature level ZF-e65a6c),
+                      this error was also returned when the existing channel was
+                      one the user could not access; that case now returns a
+                      `PERMISSION_DENIED` error instead.
   /user_groups/create:
     post:
       operationId: create-user-group

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13357,17 +13357,39 @@ paths:
           content:
             application/json:
               schema:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                BadRequest:
+                  value:
+                    result: error
+                    msg: Bad request.
+                    code: BAD_REQUEST
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
                 allOf:
                   - $ref: "#/components/schemas/CodedError"
-                  - example:
-                      {
-                        "msg": "Unable to access channel (private).",
-                        "result": "error",
-                        "code": "BAD_REQUEST",
-                      }
+                  - type: object
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - PERMISSION_DENIED
                     description: |
-                      An example JSON response for when the requesting user does not have
-                      access to a private channel and `"authorization_errors_fatal": true`:
+                      Returned when the request references a channel name that
+                      collides with an existing channel the user cannot access,
+                      so that the channel's existence is not revealed.
+
+                      **Changes**: New in Zulip 13.0 (feature level ZF-e65a6c).
+                      Previously, this was a `BAD_REQUEST` error (HTTP status 400) whose message named the conflicting channel.
+              examples:
+                PermissionDenied:
+                  value:
+                    result: error
+                    msg: Permission denied.
+                    code: PERMISSION_DENIED
     patch:
       operationId: update-subscriptions
       summary: Update subscriptions
@@ -24951,6 +24973,31 @@ paths:
                         description: |
                           An example JSON response for when trying to set moderation request channel to
                           be public:
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - type: object
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - PERMISSION_DENIED
+                    description: |
+                      Returned when the new name collides with a channel the user
+                      cannot access, so that the channel's existence is not
+                      revealed.
+
+                      **Changes**: New in Zulip 13.0 (feature level ZF-e65a6c).
+              examples:
+                PermissionDenied:
+                  value:
+                    result: error
+                    msg: Permission denied.
+                    code: PERMISSION_DENIED
   /streams/{stream_id}/email_address:
     get:
       operationId: get-stream-email-address
@@ -25554,6 +25601,31 @@ paths:
                         type: integer
                         description: "The ID of the newly created channel."
                 example: {"result": "success", "msg": "", "id": 50}
+        "403":
+          description: Permission denied.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - type: object
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - PERMISSION_DENIED
+                    description: |
+                      Returned when the submitted name collides with a channel
+                      the user cannot access, so that the channel's existence is
+                      not revealed.
+
+                      **Changes**: New in Zulip 13.0 (feature level ZF-e65a6c).
+              examples:
+                PermissionDenied:
+                  value:
+                    result: error
+                    msg: Permission denied.
+                    code: PERMISSION_DENIED
         "409":
           description: Bad request.
           content:
@@ -25570,6 +25642,11 @@ paths:
                     description: |
                       An example JSON error response for when a channel with the submitted
                       name already exists.
+
+                      **Changes**: Prior to Zulip 13.0 (feature level ZF-e65a6c),
+                      this error was also returned when the existing channel was
+                      one the user could not access; that case now returns a
+                      `PERMISSION_DENIED` error instead.
   /user_groups/create:
     post:
       operationId: create-user-group

--- a/zerver/tests/test_channel_permissions.py
+++ b/zerver/tests/test_channel_permissions.py
@@ -405,7 +405,7 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
             {"principals": orjson.dumps([invitee_user_id]).decode()},
             allow_fail=True,
         )
-        self.assert_json_error(result, "Unable to access channel (private_stream).")
+        self.assert_json_error(result, "Permission denied.", status_code=403)
 
     def test_stream_settings_for_subscribing(self) -> None:
         realm = get_realm("zulip")
@@ -416,14 +416,16 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
             name=SystemGroups.NOBODY, realm_for_sharding=realm, is_system_group=True
         )
 
-        def check_user_can_subscribe(user: UserProfile, error_msg: str | None = None) -> None:
+        def check_user_can_subscribe(
+            user: UserProfile, error_msg: str | None = None, status_code: int = 400
+        ) -> None:
             result = self.subscribe_via_post(
                 user,
                 [stream.name],
                 allow_fail=error_msg is not None,
             )
             if error_msg:
-                self.assert_json_error(result, error_msg)
+                self.assert_json_error(result, error_msg, status_code=status_code)
                 return
 
             self.assertTrue(
@@ -487,10 +489,10 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
 
         stream = self.subscribe(self.example_user("iago"), "private_stream", invite_only=True)
 
-        check_user_can_subscribe(desdemona, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(shiva, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(hamlet, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(othello, f"Unable to access channel ({stream.name}).")
+        check_user_can_subscribe(desdemona, "Permission denied.", status_code=403)
+        check_user_can_subscribe(shiva, "Permission denied.", status_code=403)
+        check_user_can_subscribe(hamlet, "Permission denied.", status_code=403)
+        check_user_can_subscribe(othello, "Permission denied.", status_code=403)
 
         owners_group = NamedUserGroup.objects.get(
             name=SystemGroups.OWNERS, realm_for_sharding=realm, is_system_group=True
@@ -499,9 +501,9 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
             stream, "can_subscribe_group", owners_group, acting_user=othello
         )
 
-        check_user_can_subscribe(shiva, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(hamlet, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(othello, f"Unable to access channel ({stream.name}).")
+        check_user_can_subscribe(shiva, "Permission denied.", status_code=403)
+        check_user_can_subscribe(hamlet, "Permission denied.", status_code=403)
+        check_user_can_subscribe(othello, "Permission denied.", status_code=403)
         check_user_can_subscribe(desdemona)
 
         hamletcharacters_group = NamedUserGroup.objects.get(
@@ -510,9 +512,9 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         do_change_stream_group_based_setting(
             stream, "can_subscribe_group", hamletcharacters_group, acting_user=othello
         )
-        check_user_can_subscribe(shiva, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(desdemona, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(othello, f"Unable to access channel ({stream.name}).")
+        check_user_can_subscribe(shiva, "Permission denied.", status_code=403)
+        check_user_can_subscribe(desdemona, "Permission denied.", status_code=403)
+        check_user_can_subscribe(othello, "Permission denied.", status_code=403)
         check_user_can_subscribe(hamlet)
 
         setting_group_member_dict = UserGroupMembersData(
@@ -521,8 +523,8 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         do_change_stream_group_based_setting(
             stream, "can_subscribe_group", setting_group_member_dict, acting_user=othello
         )
-        check_user_can_subscribe(shiva, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(hamlet, f"Unable to access channel ({stream.name}).")
+        check_user_can_subscribe(shiva, "Permission denied.", status_code=403)
+        check_user_can_subscribe(hamlet, "Permission denied.", status_code=403)
         check_user_can_subscribe(othello)
         check_user_can_subscribe(desdemona)
 
@@ -533,8 +535,8 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         do_change_stream_group_based_setting(
             stream, "can_add_subscribers_group", setting_group_member_dict, acting_user=othello
         )
-        check_user_can_subscribe(shiva, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(hamlet, f"Unable to access channel ({stream.name}).")
+        check_user_can_subscribe(shiva, "Permission denied.", status_code=403)
+        check_user_can_subscribe(hamlet, "Permission denied.", status_code=403)
         check_user_can_subscribe(othello)
         check_user_can_subscribe(desdemona)
 
@@ -546,10 +548,10 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         do_change_stream_group_based_setting(
             stream, "can_administer_channel_group", setting_group_member_dict, acting_user=othello
         )
-        check_user_can_subscribe(shiva, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(hamlet, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(othello, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(desdemona, f"Unable to access channel ({stream.name}).")
+        check_user_can_subscribe(shiva, "Permission denied.", status_code=403)
+        check_user_can_subscribe(hamlet, "Permission denied.", status_code=403)
+        check_user_can_subscribe(othello, "Permission denied.", status_code=403)
+        check_user_can_subscribe(desdemona, "Permission denied.", status_code=403)
 
     def test_can_remove_subscribers_group(self) -> None:
         realm = get_realm("zulip")
@@ -1554,3 +1556,76 @@ class ChannelAdministerPermissionTest(ZulipTestCase):
                 "property": "default_push_notifications",
             },
         )
+
+
+class ChannelNameCollisionLeakTest(ZulipTestCase):
+    def test_create_channel_name_collision_hides_inaccessible_channel(self) -> None:
+        realm = get_realm("zulip")
+        othello = self.example_user("othello")
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+
+        private_stream = self.make_stream("private", realm, invite_only=True)
+        self.subscribe(othello, "private")
+
+        result = self.create_channel_via_post(hamlet, name="private")
+        self.assert_json_error(result, "Permission denied.", status_code=403)
+
+        result = self.create_channel_via_post(othello, name="private")
+        self.assert_json_error(result, "Channel 'private' already exists", status_code=409)
+
+        do_change_stream_group_based_setting(
+            private_stream,
+            "can_add_subscribers_group",
+            UserGroupMembersData(direct_members=[hamlet.id], direct_subgroups=[]),
+            acting_user=iago,
+        )
+        result = self.create_channel_via_post(hamlet, name="private")
+        self.assert_json_error(result, "Channel 'private' already exists", status_code=409)
+
+        result = self.create_channel_via_post(iago, name="private")
+        self.assert_json_error(result, "Channel 'private' already exists", status_code=409)
+
+    def test_create_channel_without_permission_does_not_leak_collision(self) -> None:
+        realm = get_realm("zulip")
+        othello = self.example_user("othello")
+        hamlet = self.example_user("hamlet")
+
+        self.make_stream("private", realm, invite_only=True)
+        self.subscribe(othello, "private")
+
+        admins_group = NamedUserGroup.objects.get(
+            name=SystemGroups.ADMINISTRATORS, realm_for_sharding=realm, is_system_group=True
+        )
+        do_change_realm_permission_group_setting(
+            realm, "can_create_public_channel_group", admins_group, acting_user=None
+        )
+
+        result = self.create_channel_via_post(hamlet, name="private")
+        self.assert_json_error(result, "Insufficient permission")
+        result = self.create_channel_via_post(hamlet, name="brand-new-channel")
+        self.assert_json_error(result, "Insufficient permission")
+
+    def test_rename_channel_name_collision_hides_inaccessible_channel(self) -> None:
+        realm = get_realm("zulip")
+        othello = self.example_user("othello")
+        cordelia = self.example_user("cordelia")
+
+        self.make_stream("private", realm, invite_only=True)
+        self.subscribe(othello, "private")
+
+        source_stream = self.make_stream("cordelia-channel", realm)
+        self.subscribe(cordelia, "cordelia-channel")
+        do_change_stream_group_based_setting(
+            source_stream,
+            "can_administer_channel_group",
+            UserGroupMembersData(direct_members=[cordelia.id], direct_subgroups=[]),
+            acting_user=othello,
+        )
+        self.login_user(cordelia)
+
+        result = self.client_patch(f"/json/streams/{source_stream.id}", {"new_name": "private"})
+        self.assert_json_error(result, "Permission denied.", status_code=403)
+
+        result = self.client_patch(f"/json/streams/{source_stream.id}", {"new_name": "Denmark"})
+        self.assert_json_error(result, "Channel 'Denmark' already exists", status_code=409)

--- a/zerver/tests/test_channel_permissions.py
+++ b/zerver/tests/test_channel_permissions.py
@@ -405,7 +405,7 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
             {"principals": orjson.dumps([invitee_user_id]).decode()},
             allow_fail=True,
         )
-        self.assert_json_error(result, "Unable to access channel (private_stream).")
+        self.assert_json_error(result, "Permission denied.", status_code=403)
 
     def test_stream_settings_for_subscribing(self) -> None:
         realm = get_realm("zulip")
@@ -416,14 +416,16 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
             name=SystemGroups.NOBODY, realm_for_sharding=realm, is_system_group=True
         )
 
-        def check_user_can_subscribe(user: UserProfile, error_msg: str | None = None) -> None:
+        def check_user_can_subscribe(
+            user: UserProfile, error_msg: str | None = None, status_code: int = 400
+        ) -> None:
             result = self.subscribe_via_post(
                 user,
                 [stream.name],
                 allow_fail=error_msg is not None,
             )
             if error_msg:
-                self.assert_json_error(result, error_msg)
+                self.assert_json_error(result, error_msg, status_code=status_code)
                 return
 
             self.assertTrue(
@@ -487,10 +489,10 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
 
         stream = self.subscribe(self.example_user("iago"), "private_stream", invite_only=True)
 
-        check_user_can_subscribe(desdemona, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(shiva, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(hamlet, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(othello, f"Unable to access channel ({stream.name}).")
+        check_user_can_subscribe(desdemona, "Permission denied.", status_code=403)
+        check_user_can_subscribe(shiva, "Permission denied.", status_code=403)
+        check_user_can_subscribe(hamlet, "Permission denied.", status_code=403)
+        check_user_can_subscribe(othello, "Permission denied.", status_code=403)
 
         owners_group = NamedUserGroup.objects.get(
             name=SystemGroups.OWNERS, realm_for_sharding=realm, is_system_group=True
@@ -499,9 +501,9 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
             stream, "can_subscribe_group", owners_group, acting_user=othello
         )
 
-        check_user_can_subscribe(shiva, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(hamlet, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(othello, f"Unable to access channel ({stream.name}).")
+        check_user_can_subscribe(shiva, "Permission denied.", status_code=403)
+        check_user_can_subscribe(hamlet, "Permission denied.", status_code=403)
+        check_user_can_subscribe(othello, "Permission denied.", status_code=403)
         check_user_can_subscribe(desdemona)
 
         hamletcharacters_group = NamedUserGroup.objects.get(
@@ -510,9 +512,9 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         do_change_stream_group_based_setting(
             stream, "can_subscribe_group", hamletcharacters_group, acting_user=othello
         )
-        check_user_can_subscribe(shiva, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(desdemona, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(othello, f"Unable to access channel ({stream.name}).")
+        check_user_can_subscribe(shiva, "Permission denied.", status_code=403)
+        check_user_can_subscribe(desdemona, "Permission denied.", status_code=403)
+        check_user_can_subscribe(othello, "Permission denied.", status_code=403)
         check_user_can_subscribe(hamlet)
 
         setting_group_member_dict = UserGroupMembersData(
@@ -521,8 +523,8 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         do_change_stream_group_based_setting(
             stream, "can_subscribe_group", setting_group_member_dict, acting_user=othello
         )
-        check_user_can_subscribe(shiva, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(hamlet, f"Unable to access channel ({stream.name}).")
+        check_user_can_subscribe(shiva, "Permission denied.", status_code=403)
+        check_user_can_subscribe(hamlet, "Permission denied.", status_code=403)
         check_user_can_subscribe(othello)
         check_user_can_subscribe(desdemona)
 
@@ -533,8 +535,8 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         do_change_stream_group_based_setting(
             stream, "can_add_subscribers_group", setting_group_member_dict, acting_user=othello
         )
-        check_user_can_subscribe(shiva, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(hamlet, f"Unable to access channel ({stream.name}).")
+        check_user_can_subscribe(shiva, "Permission denied.", status_code=403)
+        check_user_can_subscribe(hamlet, "Permission denied.", status_code=403)
         check_user_can_subscribe(othello)
         check_user_can_subscribe(desdemona)
 
@@ -546,10 +548,10 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
         do_change_stream_group_based_setting(
             stream, "can_administer_channel_group", setting_group_member_dict, acting_user=othello
         )
-        check_user_can_subscribe(shiva, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(hamlet, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(othello, f"Unable to access channel ({stream.name}).")
-        check_user_can_subscribe(desdemona, f"Unable to access channel ({stream.name}).")
+        check_user_can_subscribe(shiva, "Permission denied.", status_code=403)
+        check_user_can_subscribe(hamlet, "Permission denied.", status_code=403)
+        check_user_can_subscribe(othello, "Permission denied.", status_code=403)
+        check_user_can_subscribe(desdemona, "Permission denied.", status_code=403)
 
     def test_can_remove_subscribers_group(self) -> None:
         realm = get_realm("zulip")
@@ -1554,3 +1556,118 @@ class ChannelAdministerPermissionTest(ZulipTestCase):
                 "property": "default_push_notifications",
             },
         )
+
+
+class ChannelNameCollisionLeakTest(ZulipTestCase):
+    def test_create_channel_name_collision_hides_inaccessible_channel(self) -> None:
+        realm = get_realm("zulip")
+        othello = self.example_user("othello")
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+
+        private_stream = self.make_stream("private", realm, invite_only=True)
+        self.subscribe(othello, "private")
+
+        result = self.create_channel_via_post(hamlet, name="private")
+        self.assert_json_error(result, "Permission denied.", status_code=403)
+
+        result = self.create_channel_via_post(othello, name="private")
+        self.assert_json_error(result, "Channel 'private' already exists", status_code=409)
+
+        do_change_stream_group_based_setting(
+            private_stream,
+            "can_add_subscribers_group",
+            UserGroupMembersData(direct_members=[hamlet.id], direct_subgroups=[]),
+            acting_user=iago,
+        )
+        result = self.create_channel_via_post(hamlet, name="private")
+        self.assert_json_error(result, "Channel 'private' already exists", status_code=409)
+
+        result = self.create_channel_via_post(iago, name="private")
+        self.assert_json_error(result, "Channel 'private' already exists", status_code=409)
+
+    def test_create_channel_without_permission_does_not_leak_collision(self) -> None:
+        realm = get_realm("zulip")
+        othello = self.example_user("othello")
+        hamlet = self.example_user("hamlet")
+
+        self.make_stream("private", realm, invite_only=True)
+        self.subscribe(othello, "private")
+
+        admins_group = NamedUserGroup.objects.get(
+            name=SystemGroups.ADMINISTRATORS, realm_for_sharding=realm, is_system_group=True
+        )
+        do_change_realm_permission_group_setting(
+            realm, "can_create_public_channel_group", admins_group, acting_user=None
+        )
+
+        result = self.create_channel_via_post(hamlet, name="private")
+        self.assert_json_error(result, "Insufficient permission")
+        result = self.create_channel_via_post(hamlet, name="brand-new-channel")
+        self.assert_json_error(result, "Insufficient permission")
+
+    def test_rename_channel_name_collision_hides_inaccessible_channel(self) -> None:
+        realm = get_realm("zulip")
+        othello = self.example_user("othello")
+        cordelia = self.example_user("cordelia")
+
+        self.make_stream("private", realm, invite_only=True)
+        self.subscribe(othello, "private")
+
+        target_stream = self.make_stream("cordelia-channel", realm)
+        self.subscribe(cordelia, "cordelia-channel")
+        do_change_stream_group_based_setting(
+            target_stream,
+            "can_administer_channel_group",
+            UserGroupMembersData(direct_members=[cordelia.id], direct_subgroups=[]),
+            acting_user=othello,
+        )
+        self.login_user(cordelia)
+
+        result = self.client_patch(f"/json/streams/{target_stream.id}", {"new_name": "private"})
+        self.assert_json_error(result, "Permission denied.", status_code=403)
+
+        result = self.client_patch(f"/json/streams/{target_stream.id}", {"new_name": "Denmark"})
+        self.assert_json_error(result, "Channel 'Denmark' already exists", status_code=409)
+
+    def test_create_channel_permission_check_precedes_collision_check(self) -> None:
+        realm = get_realm("zulip")
+        othello = self.example_user("othello")
+        hamlet = self.example_user("hamlet")
+
+        self.make_stream("private", realm, invite_only=True)
+        self.subscribe(othello, "private")
+
+        for name in ("private", "brand-new-channel"):
+            result = self.create_channel_via_post(
+                hamlet, name=name, extra_post_data={"default_push_notifications": "true"}
+            )
+            self.assert_json_error(result, "Insufficient permission")
+
+    def test_create_channel_subscriber_check_precedes_collision_check(self) -> None:
+        realm = get_realm("zulip")
+        othello = self.example_user("othello")
+        hamlet = self.example_user("hamlet")
+
+        self.make_stream("private", realm, invite_only=True)
+        self.subscribe(othello, "private")
+
+        for name in ("private", "brand-new-channel"):
+            result = self.create_channel_via_post(hamlet, name=name, subscribers=[10000000])
+            self.assert_json_error(result, "No such user")
+
+    def test_create_channel_name_collision_hides_archived_channel(self) -> None:
+        realm = get_realm("zulip")
+        othello = self.example_user("othello")
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+
+        archived_stream = self.make_stream("archived", realm, invite_only=True)
+        self.subscribe(othello, "archived")
+        do_deactivate_stream(archived_stream, acting_user=othello)
+
+        result = self.create_channel_via_post(hamlet, name="archived")
+        self.assert_json_error(result, "Permission denied.", status_code=403)
+
+        result = self.create_channel_via_post(iago, name="archived")
+        self.assert_json_error(result, "Channel 'archived' already exists", status_code=409)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3066,8 +3066,7 @@ class StreamAdminTest(ZulipTestCase):
         if expect_can_subscribe:
             self.assert_json_success(result)
         else:
-            self.assert_json_error(result, "Unable to access channel (privstream).")
-
+            self.assert_json_error(result, "Permission denied.", status_code=403)
             # now grant content access
             setting_group_member_dict = UserGroupMembersData(
                 direct_members=[hamlet.id], direct_subgroups=[]
@@ -5698,8 +5697,7 @@ class InviteOnlyStreamTest(ZulipTestCase):
         # Subscribing oneself to an invite-only stream is not allowed
         self.login_user(othello)
         result = self.subscribe_via_post(othello, [stream_name], allow_fail=True)
-        self.assert_json_error(result, "Unable to access channel (Saxony).")
-
+        self.assert_json_error(result, "Permission denied.", status_code=403)
         # authorization_errors_fatal=False works
         self.login_user(othello)
         result = self.subscribe_via_post(

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -59,6 +59,7 @@ from zerver.lib.exceptions import (
     CannotManageDefaultChannelError,
     JsonableError,
     OrganizationOwnerRequiredError,
+    PermissionDeniedError,
 )
 from zerver.lib.mention import MentionBackend, silent_mention_syntax_for_user
 from zerver.lib.message import bulk_access_stream_messages_query
@@ -465,7 +466,7 @@ def update_stream_backend(
         if stream.name.lower() != new_name.lower():
             # Check that the stream name is available (unless we are
             # are only changing the casing of the stream name).
-            check_stream_name_available(user_profile.realm, new_name)
+            check_stream_name_available(user_profile, new_name)
         do_rename_stream(stream, new_name, user_profile)
 
     if not isinstance(folder_id, MissingType):
@@ -714,8 +715,6 @@ def create_channel(
     realm = user_profile.realm
     request_settings_dict = locals()
 
-    check_stream_name_available(realm, name)
-
     folder: ChannelFolder | None = None
     if folder_id is not None:
         folder = get_channel_folder_by_id(folder_id, realm)
@@ -743,6 +742,8 @@ def create_channel(
         is_web_public=is_web_public,
         message_retention_days=parsed_message_retention_days,
     )
+
+    check_stream_name_available(user_profile, name)
 
     stream_group_settings_map, anonymous_group_membership = (
         access_requested_group_permissions_for_streams(
@@ -916,11 +917,7 @@ def add_subscriptions_backend(
     )
 
     if len(unauthorized_streams) > 0 and authorization_errors_fatal:
-        raise JsonableError(
-            _("Unable to access channel ({channel_name}).").format(
-                channel_name=unauthorized_streams[0].name,
-            )
-        )
+        raise PermissionDeniedError
     if len(streams_to_which_user_cannot_add_subscribers) > 0:
         raise JsonableError(_("Insufficient permission"))
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -59,6 +59,7 @@ from zerver.lib.exceptions import (
     CannotManageDefaultChannelError,
     JsonableError,
     OrganizationOwnerRequiredError,
+    PermissionDeniedError,
 )
 from zerver.lib.mention import MentionBackend, silent_mention_syntax_for_user
 from zerver.lib.message import bulk_access_stream_messages_query
@@ -465,7 +466,7 @@ def update_stream_backend(
         if stream.name.lower() != new_name.lower():
             # Check that the stream name is available (unless we are
             # are only changing the casing of the stream name).
-            check_stream_name_available(user_profile.realm, new_name)
+            check_stream_name_available(user_profile, new_name)
         do_rename_stream(stream, new_name, user_profile)
 
     if not isinstance(folder_id, MissingType):
@@ -714,8 +715,6 @@ def create_channel(
     realm = user_profile.realm
     request_settings_dict = locals()
 
-    check_stream_name_available(realm, name)
-
     folder: ChannelFolder | None = None
     if folder_id is not None:
         folder = get_channel_folder_by_id(folder_id, realm)
@@ -756,6 +755,15 @@ def create_channel(
     if default_push_notifications and not user_profile.is_realm_admin:
         raise JsonableError(_("Insufficient permission"))
 
+    new_subscribers: set[UserProfile] = set()
+    if len(subscribers) > 0:
+        new_subscribers = bulk_principals_to_user_profiles(subscribers, user_profile)
+
+    # Checked last, just before creating the channel, so that a user who
+    # would fail any other permission or validation check cannot use the
+    # collision error to detect a channel they cannot access.
+    check_stream_name_available(user_profile, name)
+
     group_settings_map = stream_group_settings_map[name]
     new_channel, created = create_stream_if_needed(
         realm,
@@ -793,7 +801,6 @@ def create_channel(
             data={"id": new_channel.id},
         )
 
-    new_subscribers = bulk_principals_to_user_profiles(subscribers, user_profile)
     bulk_add_subscriptions(
         realm,
         [new_channel],
@@ -916,11 +923,11 @@ def add_subscriptions_backend(
     )
 
     if len(unauthorized_streams) > 0 and authorization_errors_fatal:
-        raise JsonableError(
-            _("Unable to access channel ({channel_name}).").format(
-                channel_name=unauthorized_streams[0].name,
-            )
-        )
+        # This is returned even to a user with metadata access to the
+        # channel (rather than a "already exists" error), so that we do
+        # not confirm the channel's name to a user without content
+        # access to it.
+        raise PermissionDeniedError
     if len(streams_to_which_user_cannot_add_subscribers) > 0:
         raise JsonableError(_("Insufficient permission"))
 


### PR DESCRIPTION
Fixes #32138.

When a user tries to use a channel name that already belongs to a channel they cannot access, Zulip previously returned an error that revealed the conflicting channel either by name (`"Unable to access channel (private)."`) or, on the create path, via a `CHANNEL_ALREADY_EXISTS` error naming the channel. That leaks the existence (and archived status) of channels the user has no access to.

This replaces those leaky errors with a generic `PermissionDeniedError` HTTP 403, code `PERMISSION_DENIED`, message no data fields), following the design agreed on in [CZO](https://chat.zulip.org/#narrow/channel/378-api-design/topic/Error.20codes.20when.20creating.20channel/near/2035458) and earlier #32725:  a generic base `PermissionDeniedError(JsonableError)` rather than a channel-specific class, so the "channel access denied" specifically.

The clearer `Channel '...' already exists` error (409) is still returned, but **only** to a user who can already see the conflicting channel (metadata access), so it never reveals a channel the user couldn't otherwise know about.

**Endpoints covered**

* `POST /users/me/subscriptions` (`/api/subs
  authorization-error path in `add_subscriptions_backend` now raises
  the generic `PermissionDeniedError` instea
  channel.
* `POST /channels/create` (`/api/create-chan
  checking is now access-gated — `PERMISSION_DENIED` (403) when the
  conflicting channel is inaccessible, `CHAN
  otherwise. The create-permission check was reordered to run *before*
  the name-availability check, so a user who
  can't distinguish "name taken by a hidden channel" from "name free."
* `PATCH /streams/{stream_id}` (`/api/update
  channel onto an inaccessible channel's name now returns
  `PERMISSION_DENIED` (403) instead of naming it.

Takes references from #https://github.com/zulip/zulip/pull/32725.

Relevant CZOs
[#api design > coded error when not allowed to post](https://chat.zulip.org/#narrow/channel/378-api-design/topic/coded.20error.20when.20not.20allowed.20to.20post/with/2032777)
<!-- Describe your pull request here.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
