### PR TITLE
left sidebar: Add padding to avoid clipping emoji in topic rows.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -330,13 +330,14 @@
     --line-height-sidebar-topic-inner: 1.2em;
     /* This spacing value is to compensate for the
        additional space of the prominent row-height
-       from within the inner topic value. */
+       from within the inner topic value. The extra 2px
+       provides breathing room to avoid clipping emoji. */
     --spacing-top-bottom-sidebar-topic-inner: calc(
         (
                 var(--line-height-sidebar-row-prominent) -
                     var(--line-height-sidebar-topic-inner)
             ) /
-            2
+            2 + 2px
     );
 
     /* Right sidebar */


### PR DESCRIPTION
As alya said [here](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20emoji.20display.20in.20left.20sidebar/near/2237036) clipping is issue is noticable in external monitors . This pr Increases the` --spacing-top-bottom-sidebar-topic-inner` variable by 2px to give emoji in topic names enough vertical breathing room to avoid being clipped by `overflow: hidden.`

Fixes #38264.


**How changes were tested:**
Using before and  after screenshots 

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Before:
<img width="593" height="218" alt="image" src="https://github.com/user-attachments/assets/288a5f1f-3bdd-48bc-811a-204f72af10f9" />




After:
<img width="593" height="218" alt="image" src="https://github.com/user-attachments/assets/c7955fb9-4dde-44c6-a724-3aa3a3ebbdcd" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
