### PR TITLE
corporate: Add deactivation reason to remote server audit logs.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -64,6 +64,7 @@ from zilencer.models import (
     RemoteRealmAuditLog,
     RemoteRealmBillingUser,
     RemoteServerBillingUser,
+    RemoteServerDeactivationReasonType,
     RemoteZulipServer,
     RemoteZulipServerAuditLog,
     get_remote_realm_guest_and_non_guest_count,
@@ -5461,7 +5462,9 @@ class RemoteServerBillingSession(BillingSession):
         )
 
     @transaction.atomic(durable=True)
-    def do_deactivate_remote_server(self) -> None:
+    def do_deactivate_remote_server(
+        self, deactivation_reason: RemoteServerDeactivationReasonType = "owner_request"
+    ) -> None:
         if self.remote_server.deactivated:
             billing_logger.warning(
                 "Cannot deactivate remote server with ID %d, server has already been deactivated.",
@@ -5507,6 +5510,9 @@ class RemoteServerBillingSession(BillingSession):
             event_time=timezone_now(),
             acting_support_user=self.support_staff,
             acting_remote_user=self.remote_billing_user,
+            extra_data={
+                "deactivation_reason": deactivation_reason,
+            },
         )
 
 

--- a/corporate/lib/support.py
+++ b/corporate/lib/support.py
@@ -34,6 +34,7 @@ from zilencer.models import (
     RemoteRealm,
     RemoteRealmCount,
     RemoteServerBillingUser,
+    RemoteServerDeactivationReasonType,
     RemoteZulipServer,
     RemoteZulipServerAuditLog,
     get_remote_realm_guest_and_non_guest_count,
@@ -112,7 +113,7 @@ class DeactivationData:
     event_time: datetime
     acting_user: UserProfile | None
     billing_user: RemoteServerBillingUser | None
-    reason: RealmDeactivationReasonType | None
+    reason: RealmDeactivationReasonType | RemoteServerDeactivationReasonType | None
 
 
 @dataclass
@@ -486,6 +487,8 @@ def get_deactivation_data(audit_log: RealmAuditLog | RemoteZulipServerAuditLog) 
             billing_user = audit_log.acting_remote_user
         elif audit_log.acting_support_user:
             acting_user = audit_log.acting_support_user
+        if audit_log.extra_data:
+            reason = audit_log.extra_data.get("deactivation_reason", None)
 
     return DeactivationData(
         event_time=event_time,

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -669,6 +669,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
             "/activity/remote/support",
             {
                 "remote_server_id": f"{remote_server_with_upgrade.id}",
+                "remote_server_deactivation_reason": "tos_violation",
                 "remote_server_status": "deactivated",
             },
         )
@@ -687,6 +688,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
             "/activity/remote/support",
             {
                 "remote_server_id": f"{remote_server_no_upgrade.id}",
+                "remote_server_deactivation_reason": "tos_violation",
                 "remote_server_status": "deactivated",
             },
         )
@@ -708,6 +710,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
                 '<span class="remote-label">Remote server: deactivated</span>',
                 "♻️ Reactivate server:",
                 "<b>Acting user</b>: iago@zulip.com",
+                "<b>Deactivation reason</b>: tos_violation",
             ],
             result,
         )

--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -72,6 +72,7 @@ from zilencer.models import (
     RemoteRealm,
     RemoteRealmBillingUser,
     RemoteServerBillingUser,
+    RemoteServerDeactivationReasonType,
     RemoteZulipServer,
 )
 
@@ -784,6 +785,7 @@ def remote_servers_support(
     modify_plan: ModifyPlan | None = None,
     delete_fixed_price_next_plan: Json[bool] = False,
     remote_server_status: RemoteServerStatus | None = None,
+    remote_server_deactivation_reason: RemoteServerDeactivationReasonType | None = None,
     complimentary_access_plan: Annotated[
         str, AfterValidator(lambda x: check_date("complimentary_access_plan", x))
     ]
@@ -889,8 +891,11 @@ def remote_servers_support(
                 )
             else:
                 assert remote_server_status == "deactivated"
+                assert remote_server_deactivation_reason is not None
                 try:
-                    remote_server_status_billing_session.do_deactivate_remote_server()
+                    remote_server_status_billing_session.do_deactivate_remote_server(
+                        remote_server_deactivation_reason
+                    )
                     context["success_message"] = (
                         f"Remote server ({remote_server.hostname}) deactivated."
                     )
@@ -992,6 +997,7 @@ def remote_servers_support(
     )
     context["get_remote_realm_billing_user_emails"] = get_remote_realm_billing_user_emails_as_string
     context["SPONSORED_PLAN_TYPE"] = RemoteZulipServer.PLAN_TYPE_COMMUNITY
+    context["DEACTIVATION_REASONS"] = get_args(RemoteServerDeactivationReasonType)
     context["remote_support_view"] = True
 
     return render(

--- a/templates/corporate/support/deactivation_data.html
+++ b/templates/corporate/support/deactivation_data.html
@@ -16,12 +16,10 @@
         {% if deactivation_data.billing_user %}
         <li><b>Billing user</b>: {{ deactivation_data.billing_user.email}} (ID: {{ deactivation_data.billing_user.id }})</li>
         {% endif %}
-        {% if not remote_support_view %}
         {% if deactivation_data.reason %}
         <li><b>Deactivation reason</b>: {{ deactivation_data.reason }}</li>
         {% else %}
         <li><b>Deactivation reason</b>: Not in audit log data</li>
-        {% endif %}
         {% endif %}
     </ul>
     {% endif %}

--- a/templates/corporate/support/remote_server_support.html
+++ b/templates/corporate/support/remote_server_support.html
@@ -163,12 +163,26 @@
                     </form>
                 </div>
                 {% else %}
-                <form method="POST" class="deactivate-remote-server-form">
-                    {{ csrf_input }}
-                    <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />
-                    <input type="hidden" name="remote_server_status" value="deactivated" />
-                    <button class="deactivate-remote-server-button"><b>Deactivate</b>: {{ remote_server.hostname }}</button>
-                </form>
+                <div class="deactivation-information-container">
+                    <p class="support-section-header">⚠️ Deactivate remote server:</p>
+                    <form method="POST" class="deactivate-remote-server-form">
+                        {{ csrf_input }}
+                        <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />
+                        <input type="hidden" name="remote_server_status" value="deactivated" />
+                        <b>Deactivation reason</b>:<br />
+                        <select name="remote_server_deactivation_reason" id="remote_server_deactivation_reason">
+                            {% for reason in DEACTIVATION_REASONS %}
+                                {% if reason == "owner_request" %}
+                                    <option value="{{ reason }}" selected>{{ reason }}</option>
+                                {% else %}
+                                    <option value="{{ reason }}">{{ reason }}</option>
+                                {% endif %}
+                            {% endfor %}
+                        </select>
+                        <br />
+                        <button class="deactivate-remote-server-button"><b>Deactivate</b>: {{ remote_server.hostname }}</button>
+                    </form>
+                </div>
                 {% endif %}
             </div>
             <div class="remote-realms-section">

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -268,6 +268,10 @@ tr.admin td:first-child {
     }
 }
 
+.deactivate-remote-server-button {
+    margin-top: 6px;
+}
+
 .support-search-form {
     margin: 10px;
 }

--- a/zilencer/models.py
+++ b/zilencer/models.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import Literal
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -307,6 +308,12 @@ class PreregistrationRemoteServerBillingUser(AbstractRemoteServerBillingUser):
     next_page = models.TextField(null=True)
 
     created_user = models.ForeignKey(RemoteServerBillingUser, null=True, on_delete=models.SET_NULL)
+
+
+RemoteServerDeactivationReasonType = Literal[
+    "owner_request",
+    "tos_violation",
+]
 
 
 class RemoteZulipServerAuditLog(AbstractRealmAuditLog):


### PR DESCRIPTION
Adds a deactivation_reason to the audit logs created when a remote server is deactivated. The default reason is "owner_request". The only other implemented option is "tos_violation".

Updates the remote support view to allow for selecting a reason for deactivation and shows that reason (if it was recorded) in the support view for deactivated remote servers.

---

**Screenshots and screen captures:**

*Active remote server support view:*
| Before | After |
| --- | --- |
| <img width="1196" height="182" alt="Screenshot From 2026-03-04 15-50-29" src="https://github.com/user-attachments/assets/3c662c8a-d1e2-4f9d-bf47-4ec69fc5e29a" /> | <img width="1196" height="416" alt="Screenshot From 2026-03-04 15-49-32" src="https://github.com/user-attachments/assets/5e172862-903a-4c8b-8e2c-dacd5d87eef5" />

*Deactivated remote server support view:*
| Before | After |
| --- | --- |
| <img width="1196" height="482" alt="Screenshot From 2026-03-04 15-50-15" src="https://github.com/user-attachments/assets/56c308b6-8135-4165-a4cd-3bcb562e8f61" /> | <img width="1196" height="482" alt="Screenshot From 2026-03-04 15-49-46" src="https://github.com/user-attachments/assets/3cb0ebb7-803f-4552-a145-d35d81579264" />




---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
