### PR TITLE
[ai] portico: Fix case studies menu overflow on low-height screens.

### DIFF
--- a/web/styles/portico/navbar.css
+++ b/web/styles/portico/navbar.css
@@ -293,6 +293,15 @@ details summary::-webkit-details-marker {
     );
 }
 
+/* Prevent background scrolling when the case studies dropdown
+   covers the full viewport height on narrower desktop screens.
+   Lower bound excludes widths where the desktop navbar is hidden. */
+@media (width > 1100px) and (width <= 1300px) {
+    body:has(#top-menu-tab-case-studies:checked) {
+        overflow: hidden;
+    }
+}
+
 .top-menu-tab .top-menu-tab-user-label {
     max-width: 140px;
     padding-right: 28px;


### PR DESCRIPTION
Fixes: #37091

wide = window width > 1300px
narrow = not wide

| before | after |
| --- | --- |
| wide |
| <img width="2038" height="713" alt="image" src="https://github.com/user-attachments/assets/f1ad5fb9-9b29-4e2d-b86e-1d3fbe99795f" />  |  <img width="2026" height="697" alt="image" src="https://github.com/user-attachments/assets/47a59be6-5fab-4589-a0b0-8a5a3c888d36" /> |
| narrow |
| <img width="1729" height="649" alt="image" src="https://github.com/user-attachments/assets/8a57aff3-161c-490f-9684-7c4c43776674" />  | <img width="1740" height="649" alt="image" src="https://github.com/user-attachments/assets/53869cc9-328a-4a5d-abde-1bfb48dbab38" /> |
| Tall  & narrow |
| <img width="1701" height="1577" alt="image" src="https://github.com/user-attachments/assets/8de960fc-5c9c-489f-9fbb-569f2692466d" /> | <img width="1752" height="1423" alt="image" src="https://github.com/user-attachments/assets/d3c2d54f-176d-4a0e-ace1-b26290baf7c5" /> |
| Tall & wide |
| <img width="1850" height="1727" alt="image" src="https://github.com/user-attachments/assets/c99353e2-aef1-4f2d-98ac-ed2c891839f9" />  |  <img width="2269" height="1448" alt="image" src="https://github.com/user-attachments/assets/3b594d4e-6a21-4ad6-8527-b98f6c68878e" /> |

---

First (minor refactoring) & last commits (asked to add visual effect to make it apparent that there is something to scroll there) are generated by Claude Opus 4.6.