### PR TITLE
api-docs: Add note about order of message reactions array.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -27797,7 +27797,8 @@ components:
         reactions:
           type: array
           description: |
-            Data on any reactions to the message.
+            Data on any [reactions](/help/emoji-reactions) to the message,
+            ordered chronologically from oldest to newest reaction.
           items:
             $ref: "#/components/schemas/EmojiReaction"
         recipient_id:


### PR DESCRIPTION
As noted in the backend code, these reactions are ordered by ID, i.e., in chronological order from oldest to newest, which is useful information for clients to have when looking at this data.

Adds a link to the help center article on message emoji reactions.

[#api design > order of reactions](https://chat.zulip.org/#narrow/channel/378-api-design/topic/order.20of.20reactions/with/2292270)

---

[CODE LINK](https://github.com/zulip/zulip/blob/1df1ae12384aa1ef133a8c32bd1dec4a52e0a270/zerver/models/messages.py#L412-L437)
```python
class Reaction(AbstractReaction):
...
    @staticmethod
    def get_raw_db_rows(needed_ids: list[int]) -> list[dict[str, Any]]:
        fields = [
            "message_id",
            "emoji_name",
            "emoji_code",
            "reaction_type",
            "user_profile_id",
        ]
        # The ordering is important here, as it makes it convenient
        # for clients to display reactions in order without
        # client-side sorting code.
        return Reaction.objects.filter(message_id__in=needed_ids).values(*fields).order_by("id")
```

---

**Screenshots and screen captures:**

*Note that this is a shared schema in the API documentation, so it appears in multiple places. Only showing one example screenshot below from the `GET /events` endpoint.*

[Current message event documentation](https://zulip.com/api/get-events#message) - scroll down to `reactions` field
<img width="1472" height="1382" alt="Screenshot From 2026-03-04 17-47-10" src="https://github.com/user-attachments/assets/f03c7cd0-6507-4340-90bf-e3e050aedd1d" />


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
