### PR TITLE
compose: Remove stale "recipient not subscribed" banners.

### DIFF
--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -96,6 +96,9 @@ export function initialize(): void {
             if (recipient_widget_hidden) {
                 compose_validate.warn_if_topic_resolved(false);
             }
+            compose_validate.maybe_clear_stale_recipient_not_subscribed_warnings(
+                $<HTMLTextAreaElement>("textarea#compose-textarea").expectOne(),
+            );
             const compose_text_length = compose_validate.check_overflow_text(
                 $("#send_message_form"),
             );

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -371,6 +371,53 @@ export async function warn_if_mentioning_unsubscribed_user(
     }
 }
 
+// Called on every compose input event to remove any "recipient not
+// subscribed" banners whose mention is no longer in the compose text.
+// We check for the three mention syntaxes the markdown parser accepts
+// (@**Name**, @**Name|id**, @**|id**) rather than re-parsing markdown
+// on every input event.
+export function maybe_clear_stale_recipient_not_subscribed_warnings(
+    $textarea: JQuery<HTMLTextAreaElement>,
+): void {
+    const $banner_container = compose_banner.get_compose_banner_container($textarea);
+    const $existing_banners = $banner_container.find(
+        `.${CSS.escape(compose_banner.CLASSNAMES.recipient_not_subscribed)}`,
+    );
+    if ($existing_banners.length === 0) {
+        return;
+    }
+
+    const compose_text = $textarea.val() ?? "";
+    for (const banner of $existing_banners) {
+        const user_id = Number($(banner).attr("data-user-id"));
+        if (!user_id) {
+            $(banner).remove();
+            continue;
+        }
+
+        const user = people.maybe_get_user_by_id(user_id, true);
+        if (user === undefined) {
+            $(banner).remove();
+            continue;
+        }
+
+        // get_mention_syntax produces the canonical @**Name** form (or
+        // @**Name|id** for duplicate names), matching what the typeahead
+        // inserts.
+        const mention_syntax = people.get_mention_syntax(user.full_name, user_id, false);
+        const name_and_id_syntax = `@**${user.full_name}|${user_id}**`;
+        const id_only_syntax = `@**|${user_id}**`;
+
+        if (
+            !compose_text.includes(mention_syntax) &&
+            !compose_text.includes(name_and_id_syntax) &&
+            !compose_text.includes(id_only_syntax)
+        ) {
+            $(banner).remove();
+        }
+    }
+}
+
 export async function warn_if_mentioning_unsubscribed_group(
     mentioned_group: UserGroup,
     $textarea: JQuery<HTMLTextAreaElement>,

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -720,6 +720,117 @@ test_ui("warn_if_mentioning_unsubscribed_user", async ({override, mock_template}
     assert.ok(!new_banner_rendered);
 });
 
+test_ui("maybe_clear_stale_recipient_not_subscribed_warnings", () => {
+    const $textarea = $("<textarea>").attr("id", "compose-textarea");
+    stub_message_row($textarea);
+    const $banner_container = $("#compose_banners");
+
+    // Using a shared factory so the removal callback has a single
+    // source location — coverage is satisfied as long as any banner
+    // is actually removed across all test cases.
+    const removed_banners = new Set();
+    function make_banner(name, user_id_str) {
+        removed_banners.delete(name);
+        const $banner = $.create(name);
+        if (user_id_str !== undefined) {
+            $banner.attr("data-user-id", user_id_str);
+        }
+        $banner[0].remove = () => {
+            removed_banners.add(name);
+        };
+        return $banner;
+    }
+
+    // No banners present: function is a no-op.
+    $banner_container.set_find_results(".recipient_not_subscribed", []);
+    $textarea.val("text without any mention");
+    compose_validate.maybe_clear_stale_recipient_not_subscribed_warnings($textarea);
+
+    // Banner preserved when canonical @**Name** mention is present.
+    {
+        const $banner = make_banner("canonical", String(alice.user_id));
+        const mention = people.get_mention_syntax(alice.full_name, alice.user_id, false);
+        $banner_container.set_find_results(".recipient_not_subscribed", $banner);
+        $textarea.val(`Hello ${mention} here.`);
+        compose_validate.maybe_clear_stale_recipient_not_subscribed_warnings($textarea);
+        assert.ok(!removed_banners.has("canonical"));
+    }
+
+    // Banner removed when mention is deleted from compose text.
+    {
+        const $banner = make_banner("deleted", String(alice.user_id));
+        $banner_container.set_find_results(".recipient_not_subscribed", $banner);
+        $textarea.val("Hello, how are you?");
+        compose_validate.maybe_clear_stale_recipient_not_subscribed_warnings($textarea);
+        assert.ok(removed_banners.has("deleted"));
+    }
+
+    // Banner preserved for @**|user_id** form.
+    {
+        const $banner = make_banner("id-only", String(alice.user_id));
+        $banner_container.set_find_results(".recipient_not_subscribed", $banner);
+        $textarea.val(`Hello @**|${alice.user_id}** how are you?`);
+        compose_validate.maybe_clear_stale_recipient_not_subscribed_warnings($textarea);
+        assert.ok(!removed_banners.has("id-only"));
+    }
+
+    // Banner preserved for @**Name|user_id** form.
+    {
+        const $banner = make_banner("name-and-id", String(alice.user_id));
+        $banner_container.set_find_results(".recipient_not_subscribed", $banner);
+        $textarea.val(`Hello @**${alice.full_name}|${alice.user_id}** how are you?`);
+        compose_validate.maybe_clear_stale_recipient_not_subscribed_warnings($textarea);
+        assert.ok(!removed_banners.has("name-and-id"));
+    }
+
+    // Banner removed when only a silent mention is present, since
+    // the banner is not displayed for silent mentions.
+    {
+        const silent_mention = people.get_mention_syntax(alice.full_name, alice.user_id, true);
+        const $banner = make_banner("silent-only", String(alice.user_id));
+        $banner_container.set_find_results(".recipient_not_subscribed", $banner);
+        $textarea.val(`Hello ${silent_mention} here.`);
+        compose_validate.maybe_clear_stale_recipient_not_subscribed_warnings($textarea);
+        assert.ok(removed_banners.has("silent-only"));
+    }
+
+    // Banner removed when compose text is empty.
+    {
+        const $banner = make_banner("empty-text", String(alice.user_id));
+        $banner_container.set_find_results(".recipient_not_subscribed", $banner);
+        $textarea.val("");
+        compose_validate.maybe_clear_stale_recipient_not_subscribed_warnings($textarea);
+        assert.ok(removed_banners.has("empty-text"));
+    }
+
+    // Banner removed when mention syntax is incomplete.
+    {
+        const $banner = make_banner("incomplete", String(alice.user_id));
+        $banner_container.set_find_results(".recipient_not_subscribed", $banner);
+        $textarea.val(`Hello @**${alice.full_name} here.`);
+        compose_validate.maybe_clear_stale_recipient_not_subscribed_warnings($textarea);
+        assert.ok(removed_banners.has("incomplete"));
+    }
+
+    // Banner removed for unknown user_id.
+    {
+        const $banner = make_banner("unknown-user", "99999");
+        $banner_container.set_find_results(".recipient_not_subscribed", $banner);
+        $textarea.val("No mention here.");
+        compose_validate.maybe_clear_stale_recipient_not_subscribed_warnings($textarea);
+        assert.ok(removed_banners.has("unknown-user"));
+    }
+
+    // Banner removed when data-user-id attribute is missing.
+    {
+        const $banner = make_banner("no-user-id", undefined);
+        $banner_container.set_find_results(".recipient_not_subscribed", $banner);
+        $textarea.val("Some text.");
+        compose_validate.maybe_clear_stale_recipient_not_subscribed_warnings($textarea);
+        assert.ok(removed_banners.has("no-user-id"));
+    }
+});
+
 test_ui("test warn_if_topic_resolved", ({override, mock_template}) => {
     mock_banners();
     $.reset_selector("#compose_banners .topic_resolved");


### PR DESCRIPTION
Fixes #2007.

When composing a stream message, mentioning a user who is not subscribed to the stream shows a banner indicating that the user will be subscribed when the message is sent. Previously, if the mention was later removed from the compose text, the banner would remain visible, leaving stale UI in the compose area.

This change removes "recipient not subscribed" banners when the corresponding mention is no longer present in the compose text. To keep the check lightweight, the implementation looks for the mention syntaxes accepted by the markdown parser (`@**Name**`, `@**Name|user_id**`, and `@**|user_id**`) rather than re-running markdown parsing on every input event. Banners with unknown user IDs are treated as stale and removed.


## Videos

### Before: Banner remains stale

https://github.com/user-attachments/assets/7b7a5cc9-5031-4fbe-a244-1dc631321267


### After: Banner clears dynamically


https://github.com/user-attachments/assets/572d4352-9069-4358-9548-72d26cfbdb6c

## Relationship to other PRs

This addresses the same issue as #36729 but is an independent implementation. That PR attempted to detect mentions by parsing the compose text with a custom regex on each key event. This implementation instead reuses existing helpers used by the compose UI and checks for the mention syntaxes accepted by the markdown parser, avoiding duplicate parsing logic and potential performance regressions.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
