### PR TITLE
help: document roles tab flows in user roles

### DIFF
--- a/starlight_help/src/content/docs/user-roles.mdx
+++ b/starlight_help/src/content/docs/user-roles.mdx
@@ -20,34 +20,69 @@ You can also manage permissions with [custom user groups](/help/user-groups).
 
 ## Roles
 
-* **Organization owner**: Can manage users, public channels, organization
+- **Organization owner**: Can manage users, public channels, organization
   settings, and billing. Organization owners can do anything that an
   organization administrator can do.
-* **Organization administrator**: Can manage users, public channels, and
+- **Organization administrator**: Can manage users, public channels, and
   organization settings. Cannot make someone an owner, or change an existing
   owner's role.
-* **Moderator**: Can do anything that members can do, plus additional
+- **Moderator**: Can do anything that members can do, plus additional
   permissions [configured](/help/manage-permissions) by
   your organization.
-* **Member**: This is the default role for most users. Members have access to
+- **Member**: This is the default role for most users. Members have access to
   all public channels. You can [configure different
   permissions](/help/restrict-permissions-of-new-members) for **new members**
   and **full members**, which is especially useful for [moderating open
   organizations](/help/moderating-open-organizations). New members automatically
   become full members after a configurable waiting period.
-* **Guest**: Can view and send messages in channels they have been subscribed to.
+- **Guest**: Can view and send messages in channels they have been subscribed to.
   Guests cannot see other channels, unless they have been specifically subscribed
   to the channel. See [guest users documentation](/help/guest-users) for additional
   details and configuration options.
-* **Billing administrator**: The user who upgrades the organization to
+- **Billing administrator**: The user who upgrades the organization to
   a paid plan is, in addition to their normal role, a billing
-  administrator.  Billing administrators can manage billing for the organization.
+  administrator. Billing administrators can manage billing for the organization.
   For example, someone from your billing department can be a **billing
   administrator**, but not an **administrator** for the organization.
 
 ## View users by role
 
-<ViewUsersByRole />
+<Tabs>
+  <TabItem label="Via organization settings">
+    <ViewUsersByRole />
+  </TabItem>
+
+  <TabItem label="Via group settings">
+    <FlattenedSteps>
+      <NavigationSteps target="relative/gear/group-settings" />
+
+      1. Select **Roles** in the upper left.
+      1. Select a role.
+      1. Select the **Members** tab on the right.
+    </FlattenedSteps>
+
+  </TabItem>
+</Tabs>
+
+## Review and remove permissions assigned to a role
+
+You can review which permissions are assigned to a role, and remove permissions
+as needed.
+
+<Tabs>
+  <TabItem label="Desktop/Web">
+    <FlattenedSteps>
+      <NavigationSteps target="relative/gear/group-settings" />
+
+      1. Select **Roles** in the upper left.
+      1. Select a role.
+      1. Select the **Permissions** tab on the right.
+      1. Toggle the checkboxes next to any permissions you'd like to remove.
+      1. Click **Save changes**.
+    </FlattenedSteps>
+
+  </TabItem>
+</Tabs>
 
 ## Change a user's role
 
@@ -68,6 +103,7 @@ existing owner's role.
     </FlattenedSteps>
 
     <ManageUserTabTip />
+
   </TabItem>
 
   <TabItem label="Via organization settings">
@@ -80,6 +116,7 @@ existing owner's role.
       1. Under **User role**, select a [role](#roles).
       1. Click **Save changes**. The new permissions will take effect immediately.
     </FlattenedSteps>
+
   </TabItem>
 </Tabs>
 
@@ -93,13 +130,13 @@ restriction that administrators cannot make themselves owners.
 <FlattenedSteps>
   <NavigationSteps target="settings/account-and-privacy" />
 
-  1. Under **Account**, select a [role](#roles) from the **Roles** dropdown.
-</FlattenedSteps>
+1. Under **Account**, select a [role](#roles) from the **Roles** dropdown.
+    </FlattenedSteps>
 
 ## Related articles
 
-* [Guest users](/help/guest-users)
-* [User groups](/help/user-groups)
-* [Manage permissions](/help/manage-permissions)
-* [Manage a user](/help/manage-a-user)
-* [Deactivate or reactivate a user](/help/deactivate-or-reactivate-a-user)
+- [Guest users](/help/guest-users)
+- [User groups](/help/user-groups)
+- [Manage permissions](/help/manage-permissions)
+- [Manage a user](/help/manage-a-user)
+- [Deactivate or reactivate a user](/help/deactivate-or-reactivate-a-user)


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR updates the **user roles documentation** to include instructions for viewing users by role via **group settings**, in addition to the existing method via organization settings.


Fixes:  #38306<!-- Issue link, or clear description.-->

**How changes were tested:**

- Ran the Zulip development server locally using `tools/run-dev.py`.
- Verified that the documentation renders correctly at `/help/user-roles`.
- Confirmed that the navigation steps match the UI flow:

Settings → Organization settings → User groups → Roles

### Changes
- Added alternative instructions under **View users by role** for accessing roles via **User groups → Roles**.
- Added a new section **"Review and remove permissions assigned to a role"**, similar to the documentation for user groups.



<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="1246" height="932" alt="image" src="https://github.com/user-attachments/assets/1f69f8e0-10a1-4ad0-b772-43fae4b9fe9f" />


Screenshot attached showing the **Roles section in User groups settings**, verifying the navigation path used in the documentation.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
