### PR TITLE
css: Update markdown link colors to Zulip blue.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1777,15 +1777,32 @@
         var(--color-markdown-pre-border)
     );
     --color-markdown-link: light-dark(
-        hsl(200deg 100% 40%),
-        var(--color-text-generic-link)
+        hsl(200deg 100% 36%),
+        hsl(200deg 100% 50%)
+    );
+    --color-markdown-link-decoration: light-dark(
+        hsl(200deg 100% 36% / 30%),
+        hsl(200deg 100% 50% / 30%)
     );
     --color-markdown-code-link: var(--color-markdown-link);
     --color-markdown-link-hover: light-dark(
-        hsl(200deg 100% 25%),
-        var(--color-text-generic-link-interactive)
+        hsl(200deg 100% 33%),
+        hsl(200deg 100% 66%)
+    );
+    --color-markdown-link-decoration-hover: light-dark(
+        hsl(200deg 100% 33% / 70%),
+        hsl(200deg 100% 66% / 70%)
     );
     --color-markdown-code-link-hover: var(--color-markdown-link-hover);
+    --color-markdown-link-active: light-dark(
+        hsl(200deg 100% 30%),
+        hsl(200deg 100% 55%)
+    );
+    --color-markdown-link-decoration-active: light-dark(
+        hsl(200deg 100% 30%),
+        hsl(200deg 100% 50% / 70%)
+    );
+    --color-markdown-code-link-active: var(--color-markdown-link-active);
     --color-background-image-thumbnail: light-dark(
         hsl(0deg 0% 0% / 3%),
         hsl(0deg 0% 100% / 3%)

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -801,9 +801,10 @@
         }
     }
 
-    & a:not(.icon-button) {
+    & a:not(.icon-button, .media-anchor-element) {
         color: var(--color-markdown-link);
-        text-decoration: none;
+        text-decoration: underline solid var(--color-markdown-link-decoration);
+        text-underline-offset: 2px;
 
         & code {
             color: var(--color-markdown-code-link);
@@ -812,10 +813,21 @@
         &:hover,
         &:focus {
             color: var(--color-markdown-link-hover);
-            text-decoration: underline;
+            text-decoration: underline solid
+                var(--color-markdown-link-decoration-hover);
 
             & code {
                 color: var(--color-markdown-code-link-hover);
+            }
+        }
+
+        &:active {
+            color: var(--color-markdown-link-active);
+            text-decoration: underline solid
+                var(--color-markdown-link-decoration-active);
+
+            & code {
+                color: var(--color-markdown-code-link-active);
             }
         }
     }


### PR DESCRIPTION
Fixes #24877.

**Description:**
This PR implements a permanent, subtle underline for links in the message view to improve accessibility and visual contrast against colorful backgrounds like mentions and private messages. Following the lead designer's guidance, these styles are strictly scoped to the message feed to avoid regressions in UI icons or banners.

**Key Changes:**
* Added new global CSS variables for link decorations using the `light-dark()` syntax in `app_variables.css`.
* Applied a permanent transparent underline with a `2px` offset to markdown links in `rendered_markdown.css`.
* Implemented a **less transparent (darker) underline on hover** for better user feedback.

**Scope Control:**
Ensured that error banners and UI buttons (like the close **"X"** icon) remain completely unaffected.

---

## Visual Comparison 

### 1. Light Mode

| Before | After |
|------|------|
| <img width="1914" height="968" alt="before-light" src="https://github.com/user-attachments/assets/b1b55603-f3e7-44cd-ad8f-c8d0593c5634"> | <img width="1917" height="946" alt="after-light" src="https://github.com/user-attachments/assets/21b72d3e-9a2f-405b-a786-e464793f776a"> |

---

### 2. Dark Mode

| Before | After |
|------|------|
| <img width="1917" height="961" alt="before-dark" src="https://github.com/user-attachments/assets/7b6f5ff7-2b57-48c2-a680-677e4673ce07"> | *<img width="1919" height="899" alt="Screenshot 2026-03-05 152823" src="https://github.com/user-attachments/assets/dd04f755-1c75-47bf-8fe4-e4ce0c43aa26" />* |

---

## Interaction (Hover State)

**Before (Current Main)**  

https://github.com/user-attachments/assets/f1c95fce-ee40-4139-ae5d-b89c09eb5348


**After (This PR)**  

https://github.com/user-attachments/assets/6dab0092-395a-4b4e-a869-c343ab8037d4



---

## How changes were tested
* Verified contrast improvements on highlight backgrounds in both Light and Dark themes.
* Confirmed that the **"X" close button** and compose banners do not show an underline.
* Ran `./tools/lint` to ensure code style consistency and followed commit discipline guidelines.

---

<details>
<summary><strong>Self-review checklist</strong></summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Followed the AI use policy.
- [x] Explains technical choices (scoped strictly to message feed).
- [x] Individual commits are ready for review (followed commit discipline).
- [x] Visual appearance of the changes is verified.

</details>