### PR TITLE
[ai] drafts: Fix SimpleBar container not resizing on window resize.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -878,6 +878,10 @@ input.settings_text_input {
            so that the scrollbar appears to reach all the way
            to the bottom of the content. */
         padding-bottom: 0;
+        /* Override the `min-width: auto` default for grid
+           items so the SimpleBar container can shrink on
+           window resize. */
+        min-width: 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- Grid items default to `min-width: auto`, which prevents them from shrinking below their content's intrinsic width. This caused the SimpleBar-managed drafts list to retain its original width when the browser window was narrowed, overflowing its container.
- Adds `min-width: 0` to the `.overlay-messages-list` inside the grid-based `.drafts-container`.

| before | after |
| --- | --- |
|  <img width="1204" height="1425" alt="image" src="https://github.com/user-attachments/assets/d7066f57-3d8e-431b-93b2-a26151fe9d6b" /> |<img width="1204" height="1425" alt="Screenshot from 2026-03-05 16-21-54" src="https://github.com/user-attachments/assets/dee7afe7-e8ec-4034-b5a9-1996d67f2ef3" /> |



## Test plan
- [x] Open drafts overlay with several drafts
- [x] Resize the browser window narrower — the drafts list content now properly shrinks with the container
- [x] Resize back wider — content expands correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
