### PR TITLE
puppeteer: Fix flaky user-deactivation test.

### DIFF
--- a/web/e2e-tests/user-deactivation.test.ts
+++ b/web/e2e-tests/user-deactivation.test.ts
@@ -44,6 +44,9 @@ async function test_reactivation_confirmation_modal(page: Page, fullname: string
 async function test_deactivate_user(page: Page): Promise<void> {
     const cordelia_user_row = await user_row(page, common.fullname.cordelia);
     await page.waitForSelector(cordelia_user_row, {visible: true});
+    // Wait for the presence-data fetch in `settings_users.populate_users`
+    // to complete and the table to re-render.
+    await page.waitForSelector(cordelia_user_row + " .loading-placeholder", {hidden: true});
     await page.waitForSelector(cordelia_user_row + " .zulip-icon-user-x");
     await page.click(cordelia_user_row + " .deactivate");
     await common.wait_for_micromodal_to_open(page);


### PR DESCRIPTION
PR to fix: https://github.com/zulip/zulip/actions/runs/22711968254/job/65852017082#step:17:7052

Took help of Opus to debug.

---

The `test_deactivate_user` test was intermittently failing with "Error: Node is detached from document" when clicking the deactivate button for a user row.

The root cause is that `settings_users.populate_users` renders the admin user list twice: once synchronously (with a loading placeholder in the "Last active" column), and again when the presence-data fetch (`POST /json/users/me/presence`) completes.

The second render destroys the older DOM row - clicking on older DOM row results in error.

Fix this by waiting for the loading placeholder to disappear from the row before clicking, which ensures the presence-data re-render has completed.



**How changes were tested:**

Running the test 20 times in loop.




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
