### PR TITLE
settings: Fix mobile layout issues in users and code playgrounds from…

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -2208,6 +2208,12 @@ label.preferences-radio-choice-label {
             box-sizing: border-box;
         }
     }
+
+    .tab-switcher.org-user-settings-switcher {
+        gap: 0.5em;
+        display: flex;
+        flex-wrap: wrap;
+    }
 }
 
 @media (width < $ml_min) {


### PR DESCRIPTION
Fix mobile layout issues in users and code playgrounds from organization settings

**Changes made:**
- Users settings: Fixed "Invitations" tab having no spacing when stacked on mobile by adding gap and flex-wrap
- Code Playgrounds: Fixed missing gap between filter field and table header on mobile
- Code Playgrounds: Fixed "Add code playground" button overflowing outside the box on mobile

**How changes were tested:**
Tested on Chrome at 390px width (iPhone 12 Pro) in both dev and production environments.

**Screenshots and screen captures:**
| Before | After |
|--------|-------|
| <img width="373" height="486" alt="image" src="https://github.com/user-attachments/assets/5b09ce0a-ad65-40b6-b9c7-50fb6db13046" /> | <img width="868" height="930" alt="image" src="https://github.com/user-attachments/assets/b3a7e0d6-0759-432e-82bf-70c56d3261c5" /> |
|<img width="376" height="277" alt="image" src="https://github.com/user-attachments/assets/31552571-e7bb-415e-b177-3ef6029eb7ea" />|<img width="370" height="284" alt="image" src="https://github.com/user-attachments/assets/269032c3-215c-4c92-926b-c146998c9c86" />|

CZO thread: https://chat.zulip.org/#narrow/channel/6-frontend/topic/Mobile.20responsive.20issues.20in.20settings.20pages

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
