### PR TITLE
reminders: Open inline media in reminders overlay lightbox.

### DIFF
--- a/web/src/reminders_overlay_ui.ts
+++ b/web/src/reminders_overlay_ui.ts
@@ -5,6 +5,7 @@ import render_reminder_list from "../templates/reminder_list.hbs";
 import render_reminders_overlay from "../templates/reminders_overlay.hbs";
 
 import * as browser_history from "./browser_history.ts";
+import * as lightbox from "./lightbox.ts";
 import * as message_reminder from "./message_reminder.ts";
 import type {Reminder} from "./message_reminder.ts";
 import * as messages_overlay_ui from "./messages_overlay_ui.ts";
@@ -129,6 +130,26 @@ export function remove_reminder_id(reminder_id: number): void {
 }
 
 export function initialize(): void {
+    $("body").on("click", ".reminder-row .restore-overlay-message", (e) => {
+        const $img = $(e.target).closest("img");
+        if ($img.length > 0) {
+            e.stopPropagation();
+            e.preventDefault();
+            overlays.close_overlay("reminders");
+            lightbox.handle_inline_media_element_click($img, true);
+            return;
+        }
+
+        const $video = $(e.target).closest("video");
+        if ($video.length > 0) {
+            e.stopPropagation();
+            e.preventDefault();
+            overlays.close_overlay("reminders");
+            lightbox.handle_inline_media_element_click($video, true);
+            return;
+        }
+    });
+
     $("body").on("click", ".reminder-row .delete-overlay-message", (e) => {
         const scheduled_msg_id = $(e.currentTarget)
             .closest(".reminder-row")


### PR DESCRIPTION
Fixes part of #35313.

Reminders overlay was the remaining place where clicking inline media in
restored message content did not open lightbox.

This PR adds delegated click handling for inline `img`/`video` inside
`.reminder-row .restore-overlay-message` so those clicks:
- prevent default navigation
- close the reminders overlay
- open the lightbox with overlay-style navigation behavior

This aligns reminders behavior with scheduled messages and message edit
history for inline media elements.

Scope note:
I tried rendering rendering the video previes in reminder overlay. But was not able to get it
While investigating the issue, I compared reminders with scheduled messages because scheduled messages were correctly rendering video previews, whereas reminders were not.
The difference is that reminders wrap the original message inside a `quote` block before rendering. Zulip markdown does not generate inline media previews for links inside blockquotes, so those video URLs remain plain links instead of <video> elements. As a result, they open normally and do not trigger the lightbox.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<details>

<summary> Screenshots and screen captures:</summary>


https://github.com/user-attachments/assets/af4bedb1-f2e4-45fc-adce-c3c1a5cba900




<img width="961" height="615" alt="image" src="https://github.com/user-attachments/assets/25aa4229-c7ec-4960-8384-e02715ea9bf2" />

After clicking on the Image Preview
<img width="1753" height="921" alt="image" src="https://github.com/user-attachments/assets/1a8375d8-d3e0-423f-90c4-0051a34929ca" />
</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
