### PR TITLE
tests: Remove unused real_jquery

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -325,7 +325,6 @@ EXEMPT_FILES = make_set(
         "web/src/zulip_test.ts",
         # Test library code isn't always fully used.
         "web/tests/lib/mdiff.cjs",
-        "web/tests/lib/real_jquery.cjs",
         "web/tests/lib/zjquery_element.cjs",
         "web/tests/lib/zpage_billing_params.cjs",
         # There are some important functions which are not called right now but will

--- a/web/tests/lib/namespace.cjs
+++ b/web/tests/lib/namespace.cjs
@@ -19,7 +19,6 @@ const used_module_mocks = new Set();
 const used_templates = new Set();
 
 const jquery_path = require.resolve("jquery");
-const real_jquery_path = require.resolve("./real_jquery.cjs");
 
 let in_mid_render = false;
 let jquery_function;
@@ -34,7 +33,7 @@ function load(request, parent, isMain) {
     } else if (filename.endsWith(".hbs") && filename.startsWith(template_path + path.sep)) {
         const actual_render = actual_load(request, parent, isMain);
         return template_stub({filename, actual_render});
-    } else if (filename === jquery_path && parent.filename !== real_jquery_path) {
+    } else if (filename === jquery_path) {
         return jquery_function || $;
     }
 

--- a/web/tests/lib/real_jquery.cjs
+++ b/web/tests/lib/real_jquery.cjs
@@ -1,9 +1,0 @@
-"use strict";
-
-const jquery = require("jquery");
-
-// so the tests can mock jQuery
-// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-delete require.cache[require.resolve("jquery")];
-
-module.exports = jquery;


### PR DESCRIPTION
If this is ever needed again, it can be replaced by `require("jquery/factory")` in jQuery 4.0.0.