### PR TITLE
[ai] muted_users: Re-render typing notifications on mute state change.

### DIFF
--- a/web/src/muted_users_ui.ts
+++ b/web/src/muted_users_ui.ts
@@ -7,6 +7,7 @@ import * as pm_list from "./pm_list.ts";
 import * as popovers from "./popovers.ts";
 import * as recent_view_ui from "./recent_view_ui.ts";
 import * as settings_muted_users from "./settings_muted_users.ts";
+import * as typing_events from "./typing_events.ts";
 
 export function rerender_for_muted_user(): void {
     for (const msg_list of message_lists.all_rendered_message_lists()) {
@@ -19,6 +20,8 @@ export function rerender_for_muted_user(): void {
 
     activity_ui.redraw();
     pm_list.update_private_messages();
+
+    typing_events.render_notifications_for_narrow();
 
     // If a user is (un)muted, we want to update their avatars on the Recent Conversations
     // participants column.


### PR DESCRIPTION
When a user is muted while they are actively typing, the typing
indicator ("user is typing...") at the bottom of the message feed
is not removed.

The typing data layer (`typing_data.ts`) already filters out muted
users via `muted_users.filter_muted_user_ids()` in its getter
functions. The fix is to call `render_notifications_for_narrow()`
in `rerender_for_muted_user()` so that typing notifications are
refreshed when mute state changes. This also correctly restores
typing notifications when a user is unmuted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)