### PR TITLE
api docs: Add documentation for JWT API key fetch endpoint.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -3033,8 +3033,9 @@ No changes; feature level used for Zulip 7.0 release.
 
 **Feature level 160**
 
-* `POST /api/v1/jwt/fetch_api_key`: Added new endpoint to fetch API
-  keys using JSON Web Token (JWT) authentication.
+* [`POST /api/v1/jwt/fetch_api_key`](/api/jwt-fetch-api-key): Added
+  new endpoint to fetch API keys using JSON Web Token (JWT)
+  authentication.
 * `accounts/login/jwt/`: Adjusted format of requests to undocumented,
   optional endpoint for JWT authentication log in support.
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -162,6 +162,7 @@
 
 * [Fetch an API key (production)](/api/fetch-api-key)
 * [Fetch an API key (development only)](/api/dev-fetch-api-key)
+* [Fetch an API key (JWT)](/api/jwt-fetch-api-key)
 * [Register a logged-in device](/api/register-client-device)
 * [Remove a registered device](/api/remove-client-device)
 * [Send an E2EE test notification to mobile device(s)](/api/e2ee-test-notify)

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -275,7 +275,11 @@ def generate_curl_example(
     operation_entry = openapi_spec.openapi()["paths"][endpoint][method.lower()]
     global_security = openapi_spec.openapi()["security"]
 
-    insecure_operations = ["/dev_fetch_api_key:post", "/fetch_api_key:post"]
+    insecure_operations = [
+        "/dev_fetch_api_key:post",
+        "/fetch_api_key:post",
+        "/jwt/fetch_api_key:post",
+    ]
     lines = []
     if operation in insecure_operations:
         lines.append("```curl")

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -25,6 +25,8 @@ from zerver.openapi.curl_param_value_generators import (
 from zerver.openapi.openapi import get_endpoint_from_operationid
 
 UNTESTED_GENERATED_CURL_EXAMPLES = {
+    # Requires organization-specific JWT_AUTH_KEYS configuration.
+    "jwt-fetch-api-key",
     # Would need push notification bouncer set up to test the
     # generated curl example for the following three endpoints.
     "e2ee-test-notify",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -104,6 +104,114 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiKeyResponse"
+  /jwt/fetch_api_key:
+    post:
+      operationId: jwt-fetch-api-key
+      summary: Fetch an API key (JWT)
+      tags: ["authentication"]
+      description: |
+        This API endpoint is used by clients to implement JSON Web Token
+        (JWT) authentication. Given a JWT identifying a Zulip user, it
+        returns a Zulip API key that the client can use to make requests
+        as the user.
+
+        !!! warn ""
+
+            **Note:** This endpoint is only useful for Zulip servers/organizations
+            with [JSON web token authentication][prod-jwt-auth] enabled.
+
+        See the [API keys](/api/api-keys) documentation for more details
+        on how to manage API keys manually.
+
+        **Changes**: New in Zulip 7.0 (feature level 160).
+
+        [prod-jwt-auth]: https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#json-web-tokens-jwt
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                token:
+                  description: |
+                    A JSON Web Token for the target user.
+
+                    The token payload must contain a custom `email` claim with the target
+                    user's email address, e.g., `{"email": "<target user email>"}`.
+                  type: string
+                  example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImhhbWxldEB6dWxpcC5jb20ifQ.EsHxSVt54zPR-ywgPH54TB1FYmrGKsfq7hsQEhp_9w0"
+                include_profile:
+                  type: boolean
+                  default: false
+                  example: false
+                  description: |
+                    Whether to include a `user` object containing the target
+                    user's profile details in the response.
+              required:
+                - token
+      security: []
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - required:
+                      - api_key
+                      - email
+                    additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      api_key:
+                        type: string
+                        description: |
+                          The API key that can be used to authenticate as the requested user.
+                      email:
+                        type: string
+                        description: |
+                          The email address of the user who owns the API key.
+                      user:
+                        description: |
+                          Only present if `include_profile` parameter was set to `true`.
+
+                          A dictionary with data on the target user.
+                        allOf:
+                          - $ref: "#/components/schemas/UserBase"
+                          - additionalProperties: false
+                            properties:
+                              user_id: {}
+                              delivery_email:
+                                nullable: true
+                              email: {}
+                              full_name: {}
+                              date_joined: {}
+                              is_active: {}
+                              is_owner: {}
+                              is_admin: {}
+                              is_guest: {}
+                              is_bot: {}
+                              bot_type:
+                                nullable: true
+                              bot_owner_id:
+                                nullable: true
+                              role: {}
+                              timezone: {}
+                              avatar_url:
+                                nullable: true
+                              avatar_version: {}
+                              is_imported_stub: {}
+                    example:
+                      {
+                        "api_key": "gjA04ZYcqXKalvYMA8OeXSfzUOLrtbZv",
+                        "email": "hamlet@zulip.com",
+                        "msg": "",
+                        "result": "success",
+                      }
   /dev_fetch_api_key:
     post:
       operationId: dev-fetch-api-key

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -259,7 +259,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/rest-error-handling",
         # Zulip outgoing webhook payload
         "/zulip-outgoing-webhook",
-        "/jwt/fetch_api_key",
         #### Bouncer endpoints
         # Higher priority to document
         "/remotes/push/e2ee/notify",
@@ -278,6 +277,7 @@ class OpenAPIArgumentsTest(ZulipTestCase):
     documented_post_only_endpoints = {
         "fetch_api_key",
         "dev_fetch_api_key",
+        "jwt/fetch_api_key",
     }
 
     # Endpoints where the documentation is currently failing our


### PR DESCRIPTION
Fixes: #24278

Adds API documentation for the `POST /api/v1/jwt/fetch_api_key` endpoint that was introduced in #24199 but was never documented in the `/api` documentation site.

Changes:
- Add OpenAPI spec for `/jwt/fetch_api_key` in `zulip.yaml`, including a new `JwtApiKeyResponse` schema (differs from `ApiKeyResponse` by having an optional `user` field instead of `user_id`).
- Register the endpoint in `insecure_operations` in `markdown_extension.py` so curl examples render correctly.
- Add the endpoint to `UNTESTED_GENERATED_CURL_EXAMPLES` since testing requires organization-specific `JWT_AUTH_KEYS` setup.

**How changes were tested:**
- Ran `tools/test-backend zerver.tests.test_openapi` 
- Verified the rendered page visually at
  `http://localhost:9991/api/jwt-fetch-api-key` in the dev server.

---

**Screenshots and screen captures:**

<img width="1516" height="1934" alt="Screenshot From 2026-03-12 17-28-33" src="https://github.com/user-attachments/assets/b0c2c586-fbc6-4ec1-8dd9-ade0f24f851b" />
<img width="1516" height="2074" alt="Screenshot From 2026-03-12 17-28-46" src="https://github.com/user-attachments/assets/0db5dba6-dac6-4439-916b-85cdfaa22ad6" />
<img width="1516" height="2066" alt="Screenshot From 2026-03-12 17-28-57" src="https://github.com/user-attachments/assets/1ce498e2-bdcf-49bb-bb1e-c80734f4fcf4" />
<img width="1516" height="1626" alt="Screenshot From 2026-03-12 17-29-14" src="https://github.com/user-attachments/assets/f866ff44-e344-4533-825b-2f8abf04ead8" />

---

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>