### PR TITLE
api-docs: Move changes note for feature level 328.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -27503,12 +27503,8 @@ components:
               description: |
                 The ID of the user who added the reaction.
 
-                **Changes**: New in Zulip 3.0 (feature level 2). The `user`
-                object is deprecated and will be removed in the future.
-
-                In Zulip 10.0 (feature level 328), the deprecated `user` object
-                was removed which contained the following properties: `id`, `email`,
-                `full_name` and `is_mirror_dummy`.
+                **Changes**: New in Zulip 3.0 (feature level 2), which
+                deprecated the `user` object.
     EmojiBase:
       type: object
       properties:
@@ -27835,6 +27831,11 @@ components:
           description: |
             Data on any [reactions](/help/emoji-reactions) to the message,
             ordered chronologically from oldest to newest reaction.
+
+            **Changes**: In Zulip 10.0 (feature level 328), the deprecated `user`
+            object was removed from the data for each reaction. It contained the
+            following information about the user who added the reaction: `id`,
+            `email`, `full_name` and `is_mirror_dummy`.
           items:
             $ref: "#/components/schemas/EmojiReaction"
         recipient_id:


### PR DESCRIPTION
Moves the changes note about the removal of the deprecated `user` object from the data for an emoji reaction to the description of the reactions array.

**Notes**:
- Noted when working on #38298.
- The original feature level 328 changes are in commit 143ca5065e.
  - Those changes were partially reverted in commit e487a5c8c7, but the changes to reactions array in message objects was not reverted.
- I'm not sure if it's really useful to have the fields from the removed `user` object listed, but I kept them in these changes.

---

**Screenshots and screen captures:**

[CURRENT DOC](https://zulip.com/api/get-events#message) - scroll down to `reactions` array.

| Before | After |
| --- | --- |
| <img width="1472" height="1392" alt="Screenshot From 2026-03-04 18-11-44" src="https://github.com/user-attachments/assets/c66eaefe-daa0-4e91-bf8d-338529540b71" /> | <img width="1428" height="1388" alt="Screenshot From 2026-03-06 13-40-40" src="https://github.com/user-attachments/assets/e627ea42-bbfc-4332-8d9e-22f1ef7a5aab" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
