### PR TITLE
settings: Added padding to lock icons in settings sidebar.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1546,6 +1546,7 @@ label.preferences-radio-choice-label {
                 font-size: 1em;
                 text-align: center;
                 color: hsl(0deg 0% 62%);
+                padding-right: 0.6em;
             }
         }
 


### PR DESCRIPTION
Fixes: https://chat.zulip.org/#narrow/channel/137-feedback/topic/Settings.20sidebar.3A.20lock.20icons.20too.20close.20to.20scrollbar

In the settings sidebar, the lock icons were appearing too close to the scrollbar, making it look cramped especially when scrolling.

Added `padding-right: 0.6em` to the `.locked` class to give the icons breathing room from the scrollbar.

**Screenshots and screen captures:**
**Before** | **After**
-- | --
|<img width="750" height="1334" alt="before" src="https://github.com/user-attachments/assets/c1383f99-5377-4f28-a07a-7880723e97f0" />|<img width="750" height="1334" alt="after" src="https://github.com/user-attachments/assets/c95dc5e0-5ff1-44c8-8646-4730d7a0bd8e" />|
|<img width="378" height="863" alt="image" src="https://github.com/user-attachments/assets/8afbaed3-fb97-4805-8f17-00d74e894f41" /> | <img width="381" height="874" alt="image" src="https://github.com/user-attachments/assets/665e2bc4-543a-45e4-bb6e-51527585bc95" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
