### PR TITLE
input_pill: Add in-place editing for pills

### DIFF
--- a/web/src/add_group_members_pill.ts
+++ b/web/src/add_group_members_pill.ts
@@ -187,6 +187,10 @@ export function set_up_handlers({
     */
     function callback(): void {
         const pill_widget = get_pill_widget();
+        // Resolve any in-flight pill edit before reading the member set.
+        if (!pill_widget.finalize_pending_edit()) {
+            return;
+        }
         void (async () => {
             loading.make_indicator($(".add-group-member-loading-spinner"), {
                 height: 56, // 4em at 14px / 1em

--- a/web/src/add_group_members_pill.ts
+++ b/web/src/add_group_members_pill.ts
@@ -15,13 +15,13 @@ import * as user_groups from "./user_groups.ts";
 import type {UserGroup} from "./user_groups.ts";
 import * as user_pill from "./user_pill.ts";
 
-async function get_pill_user_ids(pill_widget: CombinedPillContainer): Promise<number[]> {
+export async function get_pill_user_ids(pill_widget: CombinedPillContainer): Promise<number[]> {
     const user_ids = user_pill.get_user_ids(pill_widget);
     const stream_user_ids = await stream_pill.get_user_ids(pill_widget);
     return [...user_ids, ...stream_user_ids];
 }
 
-function get_pill_group_ids(pill_widget: CombinedPillContainer): number[] {
+export function get_pill_group_ids(pill_widget: CombinedPillContainer): number[] {
     const group_user_ids = user_group_pill.get_group_ids(pill_widget);
     return group_user_ids;
 }
@@ -187,6 +187,9 @@ export function set_up_handlers({
     */
     function callback(): void {
         const pill_widget = get_pill_widget();
+        if (!pill_widget.finalize_pending_edit()) {
+            return;
+        }
         void (async () => {
             loading.make_indicator($(".add-group-member-loading-spinner"), {
                 height: 56, // 4em at 14px / 1em

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -289,6 +289,10 @@ export function set_up_handlers({
     */
     function callback(): void {
         const pill_widget = get_pill_widget();
+        // Resolve any in-flight pill edit before reading the subscriber set.
+        if (!pill_widget.finalize_pending_edit()) {
+            return;
+        }
         void (async () => {
             loading.make_indicator($(".add-subscriber-loading-spinner"), {
                 height: 28, // 2em at 14px / 1em

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -79,6 +79,9 @@ export function set_up_pill_typeahead({
         opts.user_group_source = get_user_groups;
     }
     pill_typeahead.set_up_combined($pill_container.find(".input"), pill_widget, opts);
+    pill_widget.setSetupTypeahead(($edit) =>
+        pill_typeahead.set_up_combined($edit, pill_widget, opts),
+    );
 }
 
 export function get_display_value_from_item(item: CombinedPill): string {

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -291,6 +291,9 @@ export function set_up_handlers({
     */
     function callback(): void {
         const pill_widget = get_pill_widget();
+        if (!pill_widget.finalize_pending_edit()) {
+            return;
+        }
         void (async () => {
             loading.make_indicator($(".add-subscriber-loading-spinner"), {
                 height: 28, // 2em at 14px / 1em

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -697,23 +697,33 @@ export class Typeahead<ItemType extends string | object> {
                 this.blur(e);
             });
 
-        $(window).on("resize", this.resizeHandler.bind(this));
+        $(window).on("resize", this.resizeHandler);
     }
 
     unlisten(): void {
         this.hide();
         this.$container.remove();
-        const events = ["blur", "keydown", "keyup", "keypress", "click", "focus"];
+        const events = [
+            "blur",
+            "keydown",
+            "keyup",
+            "keypress",
+            "click",
+            "focus",
+            "typeahead.refreshPosition",
+        ];
         for (const event of events) {
             $(this.input_element.$element).off(event);
         }
+        $(window).off("resize", this.resizeHandler);
     }
 
-    resizeHandler(): void {
+    // An arrow function so `listen` and `unlisten` use the same reference.
+    resizeHandler = (): void => {
         if (this.shown) {
             this.show();
         }
-    }
+    };
 
     maybeStopAdvance(e: JQuery.KeyPressEvent | JQuery.KeyUpEvent | JQuery.KeyDownEvent): void {
         if (

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -693,23 +693,33 @@ export class Typeahead<ItemType extends string | object> {
                 this.blur(e);
             });
 
-        $(window).on("resize", this.resizeHandler.bind(this));
+        $(window).on("resize", this.resizeHandler);
     }
 
     unlisten(): void {
         this.hide();
         this.$container.remove();
-        const events = ["blur", "keydown", "keyup", "keypress", "click", "focus"];
+        const events = [
+            "blur",
+            "keydown",
+            "keyup",
+            "keypress",
+            "click",
+            "focus",
+            "typeahead.refreshPosition",
+        ];
         for (const event of events) {
             $(this.input_element.$element).off(event);
         }
+        $(window).off("resize", this.resizeHandler);
     }
 
-    resizeHandler(): void {
+    // An arrow function so `listen` and `unlisten` use the same reference.
+    resizeHandler = (): void => {
         if (this.shown) {
             this.show();
         }
-    }
+    };
 
     maybeStopAdvance(e: JQuery.KeyPressEvent | JQuery.KeyUpEvent | JQuery.KeyDownEvent): void {
         if (

--- a/web/src/compose.ts
+++ b/web/src/compose.ts
@@ -11,6 +11,7 @@ import render_wildcard_mention_not_allowed_error from "../templates/compose_bann
 import * as channel from "./channel.ts";
 import * as compose_banner from "./compose_banner.ts";
 import * as compose_notifications from "./compose_notifications.ts";
+import * as compose_pm_pill from "./compose_pm_pill.ts";
 import * as compose_state from "./compose_state.ts";
 import * as compose_ui from "./compose_ui.ts";
 import * as compose_validate from "./compose_validate.ts";
@@ -361,6 +362,15 @@ export let finish = (scheduling_message = false): boolean | undefined => {
         do_post_send_tasks();
         clear_compose_box();
         return undefined;
+    }
+
+    // Resolve any in-flight recipient pill edit before reading the
+    // recipient list; refuse to send if it can't be resolved.
+    if (
+        compose_state.get_message_type() === "private" &&
+        !compose_pm_pill.finalize_pending_edit()
+    ) {
+        return false;
     }
 
     compose_ui.show_compose_spinner();

--- a/web/src/compose.ts
+++ b/web/src/compose.ts
@@ -11,6 +11,7 @@ import render_wildcard_mention_not_allowed_error from "../templates/compose_bann
 import * as channel from "./channel.ts";
 import * as compose_banner from "./compose_banner.ts";
 import * as compose_notifications from "./compose_notifications.ts";
+import * as compose_pm_pill from "./compose_pm_pill.ts";
 import * as compose_state from "./compose_state.ts";
 import * as compose_ui from "./compose_ui.ts";
 import * as compose_validate from "./compose_validate.ts";
@@ -361,6 +362,13 @@ export let finish = (scheduling_message = false): boolean | undefined => {
         do_post_send_tasks();
         clear_compose_box();
         return undefined;
+    }
+
+    if (
+        compose_state.get_message_type() === "private" &&
+        !compose_pm_pill.finalize_pending_edit()
+    ) {
+        return false;
     }
 
     compose_ui.show_compose_spinner();

--- a/web/src/compose_pm_pill.ts
+++ b/web/src/compose_pm_pill.ts
@@ -81,6 +81,10 @@ export function get_user_ids(): number[] {
     return user_pill.get_user_ids(widget);
 }
 
+export function finalize_pending_edit(): boolean {
+    return widget.finalize_pending_edit();
+}
+
 export function has_unconverted_data(): boolean {
     return user_pill.has_unconverted_data(widget);
 }

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -633,7 +633,15 @@ export function filter_and_sort_mentions(
     }));
 }
 
-export function get_pm_people(query: string): (UserGroupPillData | UserPillData)[] {
+export function get_pm_people(query: string, include_groups: false): UserPillData[];
+export function get_pm_people(
+    query: string,
+    include_groups?: true,
+): (UserGroupPillData | UserPillData)[];
+export function get_pm_people(
+    query: string,
+    include_groups = true,
+): (UserGroupPillData | UserPillData)[] {
     const opts = {
         want_broadcast: false,
         filter_pills: true,
@@ -641,6 +649,7 @@ export function get_pm_people(query: string): (UserGroupPillData | UserPillData)
         topic: compose_state.topic(),
         filter_groups_for_dm: true,
         filter_by_dm_permission: true,
+        include_groups,
     };
     const suggestions = get_person_suggestions(query, opts, true);
     const current_user_ids = compose_pm_pill.get_user_ids();
@@ -674,6 +683,7 @@ type PersonSuggestionOpts = {
     filter_groups_for_mention?: boolean;
     allow_custom_profile_field_matching?: boolean;
     filter_by_dm_permission?: boolean;
+    include_groups?: boolean;
 };
 
 function filter_persons<T>(
@@ -787,7 +797,9 @@ export function get_person_suggestions(
     const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
     let groups: UserGroup[];
-    if (opts.filter_groups_for_mention) {
+    if (opts.include_groups === false) {
+        groups = [];
+    } else if (opts.filter_groups_for_mention) {
         groups = user_groups.get_user_groups_allowed_to_mention();
     } else if (opts.filter_groups_for_dm) {
         const can_access_all_users = settings_data.user_can_access_all_other_users();
@@ -1903,12 +1915,9 @@ export function initialize({
         },
     });
 
-    const private_message_typeahead_input: TypeaheadInputElement = {
-        $element: $("#private_message_recipient"),
-        type: "contenteditable",
-    };
-    private_message_recipient_typeahead = new Typeahead(private_message_typeahead_input, {
-        source: get_pm_people,
+    // Shared between the main PM input and editable pills.
+    const pm_recipient_typeahead_opts = {
+        source: (query: string) => get_pm_people(query),
         items: max_num_items,
         dropup: true,
         item_html(_query: string): (item: UserGroupPillData | UserPillData) => string {
@@ -1925,7 +1934,37 @@ export function initialize({
             set_recipient_from_typeahead(item);
         },
         stopAdvance: true, // Do not advance to the next field on a Tab or Enter
-    });
+    };
+
+    const private_message_typeahead_input: TypeaheadInputElement = {
+        $element: $("#private_message_recipient"),
+        type: "contenteditable",
+    };
+    private_message_recipient_typeahead = new Typeahead(
+        private_message_typeahead_input,
+        pm_recipient_typeahead_opts,
+    );
+    compose_pm_pill.widget.setSetupTypeahead(
+        ($edit) =>
+            new Typeahead(
+                {$element: $edit, type: "contenteditable"},
+                {
+                    ...pm_recipient_typeahead_opts,
+                    source(query: string): UserPillData[] {
+                        // Editing replaces one pill with one user pill, so only
+                        // show user suggestions when editing.
+                        return get_pm_people(query, false);
+                    },
+                    updater(item: UserGroupPillData | UserPillData): undefined {
+                        if (item.type === "user") {
+                            compose_pm_pill.widget.updatePillAfterEdit(
+                                user_pill.create_pill_data(item.user),
+                            );
+                        }
+                    },
+                },
+            ),
+    );
 
     initialize_compose_typeahead($("textarea#compose-textarea"));
 }

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -637,7 +637,15 @@ export function filter_and_sort_mentions(
     }));
 }
 
-export function get_pm_people(query: string): (UserGroupPillData | UserPillData)[] {
+export function get_pm_people(query: string, include_groups: false): UserPillData[];
+export function get_pm_people(
+    query: string,
+    include_groups?: true,
+): (UserGroupPillData | UserPillData)[];
+export function get_pm_people(
+    query: string,
+    include_groups = true,
+): (UserGroupPillData | UserPillData)[] {
     const opts = {
         want_broadcast: false,
         filter_pills: true,
@@ -645,6 +653,7 @@ export function get_pm_people(query: string): (UserGroupPillData | UserPillData)
         topic: compose_state.topic(),
         filter_groups_for_dm: true,
         filter_by_dm_permission: true,
+        include_groups,
     };
     const suggestions = get_person_suggestions(query, opts, true);
     const current_user_ids = compose_pm_pill.get_user_ids();
@@ -678,6 +687,7 @@ type PersonSuggestionOpts = {
     filter_groups_for_mention?: boolean;
     allow_custom_profile_field_matching?: boolean;
     filter_by_dm_permission?: boolean;
+    include_groups?: boolean;
 };
 
 function filter_persons<T>(
@@ -788,7 +798,9 @@ export function get_person_suggestions(
     query = typeahead.clean_query_lowercase(query);
 
     let groups: UserGroup[];
-    if (opts.filter_groups_for_mention) {
+    if (opts.include_groups === false) {
+        groups = [];
+    } else if (opts.filter_groups_for_mention) {
         groups = user_groups.get_user_groups_allowed_to_mention();
     } else if (opts.filter_groups_for_dm) {
         const can_access_all_users = settings_data.user_can_access_all_other_users();
@@ -1951,12 +1963,9 @@ export function initialize({
         },
     });
 
-    const private_message_typeahead_input: TypeaheadInputElement = {
-        $element: $("#private_message_recipient"),
-        type: "contenteditable",
-    };
-    private_message_recipient_typeahead = new Typeahead(private_message_typeahead_input, {
-        source: get_pm_people,
+    // Shared between the main PM input and editable pills.
+    const pm_recipient_typeahead_opts = {
+        source: (query: string) => get_pm_people(query),
         items: max_num_items,
         dropup: true,
         item_html(_query: string): (item: UserGroupPillData | UserPillData) => string {
@@ -1973,7 +1982,37 @@ export function initialize({
             set_recipient_from_typeahead(item);
         },
         stopAdvance: true, // Do not advance to the next field on a Tab or Enter
-    });
+    };
+
+    const private_message_typeahead_input: TypeaheadInputElement = {
+        $element: $("#private_message_recipient"),
+        type: "contenteditable",
+    };
+    private_message_recipient_typeahead = new Typeahead(
+        private_message_typeahead_input,
+        pm_recipient_typeahead_opts,
+    );
+    compose_pm_pill.widget.setSetupTypeahead(
+        ($edit) =>
+            new Typeahead(
+                {$element: $edit, type: "contenteditable"},
+                {
+                    ...pm_recipient_typeahead_opts,
+                    source(query: string): UserPillData[] {
+                        // Editing replaces one pill with one user pill, so only
+                        // show user suggestions when editing.
+                        return get_pm_people(query, false);
+                    },
+                    updater(item: UserGroupPillData | UserPillData): undefined {
+                        if (item.type === "user") {
+                            compose_pm_pill.widget.updatePillAfterEdit(
+                                user_pill.create_pill_data(item.user),
+                            );
+                        }
+                    },
+                },
+            ),
+    );
 
     initialize_compose_typeahead($("textarea#compose-textarea"));
 }

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -156,7 +156,12 @@ export function initialize_custom_user_type_fields(
             const pill_config = {
                 exclude_inaccessible_users: is_target_element_editable,
             };
-            const pills = user_pill.create_pills($pill_container, pill_config);
+            // We check and disable fields that this user doesn't have permission to edit.
+            const is_disabled = $pill_container.hasClass("disabled");
+            const is_editable = is_target_element_editable && !is_disabled;
+            const pills = user_pill.create_pills($pill_container, pill_config, {
+                disable_pill_editing: !is_editable,
+            });
 
             if (field_value_raw !== undefined) {
                 const field_value = user_value_schema.parse(JSON.parse(field_value_raw));
@@ -166,10 +171,7 @@ export function initialize_custom_user_type_fields(
                 }
             }
 
-            // We check and disable fields that this user doesn't have permission to edit.
-            const is_disabled = $pill_container.hasClass("disabled");
-
-            if (is_target_element_editable && !is_disabled) {
+            if (is_editable) {
                 const $input = $pill_container.children(".input");
                 pill_typeahead.set_up_user($input, pills, {exclude_bots: true});
                 if (pill_update_handler) {

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -174,6 +174,9 @@ export function initialize_custom_user_type_fields(
             if (is_editable) {
                 const $input = $pill_container.children(".input");
                 pill_typeahead.set_up_user($input, pills, {exclude_bots: true});
+                pills.setSetupTypeahead(($edit) =>
+                    pill_typeahead.set_up_user($edit, pills, {exclude_bots: true}),
+                );
                 if (pill_update_handler) {
                     pills.onPillCreate(() => {
                         pill_update_handler(field, pills);

--- a/web/src/group_setting_pill.ts
+++ b/web/src/group_setting_pill.ts
@@ -158,4 +158,7 @@ export function set_up_pill_typeahead({
         pill_widget,
         opts,
     );
+    pill_widget.setSetupTypeahead(($edit) =>
+        pill_typeahead.set_up_group_setting_typeahead($edit, pill_widget, opts),
+    );
 }

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -95,6 +95,11 @@ export type InputPillContainer<ItemType> = {
 
 export type RemovePillTrigger = "close" | "backspace" | "clear";
 
+function is_cursor_at_start(): boolean {
+    const selection = window.getSelection();
+    return selection !== null && selection.anchorOffset === 0 && !selection.toString();
+}
+
 export function create<ItemType extends {type: string}>(
     opts: InputPillCreateOptions<ItemType>,
 ): InputPillContainer<ItemType> {
@@ -390,11 +395,7 @@ export function create<ItemType extends {type: string}>(
             // If no text is selected, and the cursor is just to the
             // right of the last pill (with or without text in the
             // input), then backspace highlights or deletes the last pill.
-            if (
-                e.key === "Backspace" &&
-                (funcs.value(this).length === 0 ||
-                    (selection?.anchorOffset === 0 && selection?.toString()?.length === 0))
-            ) {
+            if (e.key === "Backspace" && (funcs.value(this).length === 0 || is_cursor_at_start())) {
                 e.preventDefault();
                 const pill = store.pills.at(-1);
                 // We focus the pill first first, as a signal that the pill

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -38,6 +38,7 @@ type InputPillCreateOptions<ItemType> = {
     ) => void;
     show_outline_on_invalid_input?: boolean;
     split_text_to_form_pills?: (pills: string) => string[];
+    disable_pill_editing?: boolean;
 };
 
 export type InputPill<ItemType> = {
@@ -65,6 +66,13 @@ type InputPillStore<ItemType> = {
     convert_to_pill_on_enter: boolean;
     show_outline_on_invalid_input: boolean;
     split_text_to_form_pills: InputPillCreateOptions<ItemType>["split_text_to_form_pills"];
+    setupTypeahead?: ($input: JQuery) => PillEditTypeahead | undefined;
+    disable_pill_editing: boolean;
+};
+
+export type PillEditTypeahead = {
+    shown: boolean;
+    unlisten: () => void;
 };
 
 // These are the functions that are exposed to other modules.
@@ -86,6 +94,9 @@ export type InputPillContainer<ItemType> = {
     onPillExpand: (callback: (pill: JQuery) => void) => void;
     onTextInputHook: (callback: () => void) => void;
     createPillonPaste: (callback: () => void) => void;
+    setSetupTypeahead: (callback: ($input: JQuery) => PillEditTypeahead | undefined) => void;
+    updatePillAfterEdit: (new_item: ItemType, triggered_by_blur?: boolean) => void;
+    finalize_pending_edit: () => boolean;
     clear: (quiet?: boolean) => void;
     clear_text: () => void;
     getCurrentText: () => string | null;
@@ -98,6 +109,21 @@ export type RemovePillTrigger = "close" | "backspace" | "clear";
 function is_cursor_at_start(): boolean {
     const selection = window.getSelection();
     return selection !== null && selection.anchorOffset === 0 && !selection.toString();
+}
+
+function is_cursor_at_end(element: HTMLElement): boolean {
+    const selection = window.getSelection();
+    if (!selection || selection.toString() || selection.rangeCount === 0) {
+        return false;
+    }
+    // Measure the text between the caret and the element's end, rather
+    // than comparing node offsets, so a trailing <br> (which browsers add
+    // to contenteditable) isn't counted as content after the caret.
+    const cursor = selection.getRangeAt(0);
+    const to_end = document.createRange();
+    to_end.selectNodeContents(element);
+    to_end.setStart(cursor.endContainer, cursor.endOffset);
+    return to_end.toString() === "";
 }
 
 export function create<ItemType extends {type: string}>(
@@ -119,7 +145,14 @@ export function create<ItemType extends {type: string}>(
         on_pill_exit: opts.on_pill_exit,
         show_outline_on_invalid_input: opts.show_outline_on_invalid_input ?? false,
         split_text_to_form_pills: opts.split_text_to_form_pills,
+        disable_pill_editing: opts.disable_pill_editing ?? false,
     };
+
+    // The pill being edited in place, along with its contenteditable input and
+    // typeahead; `$input` identifies stale blur callbacks.
+    let editing:
+        | {pill: InputPill<ItemType>; $input: JQuery; typeahead: PillEditTypeahead | undefined}
+        | undefined;
 
     // a dictionary of internal functions. Some of these are exposed as well,
     // and nothing in here should be assumed to be private (due to the passing)
@@ -152,7 +185,12 @@ export function create<ItemType extends {type: string}>(
         },
 
         create_item(text: string) {
-            const existing_items = funcs.items();
+            // Exclude the pill being edited so it can re-commit its own value
+            // without colliding with itself. This is the only reader that
+            // needs the exclusion; items() returns the full set.
+            const existing_items = store.pills
+                .filter((pill) => pill !== editing?.pill)
+                .map((pill) => pill.item);
             const item = store.create_item_from_text(text, existing_items, store.pill_config);
             if (!item) {
                 store.$input.addClass("shake");
@@ -174,6 +212,20 @@ export function create<ItemType extends {type: string}>(
                 display_value: store.get_display_value_from_item(item),
                 disabled,
             });
+        },
+
+        updatePillAfterEdit(new_item: ItemType, triggered_by_blur = false): void {
+            if (editing === undefined) {
+                return;
+            }
+            const {pill} = editing;
+            funcs.stop_editing();
+            funcs.updatePill(util.the(pill.$element), new_item);
+            store.onPillRemove?.(pill, "close");
+            store.onPillCreate?.();
+            if (!triggered_by_blur) {
+                store.$input.trigger("focus");
+            }
         },
 
         // This is generally called by typeahead logic, where we have all
@@ -236,6 +288,11 @@ export function create<ItemType extends {type: string}>(
                 if (store.pills[idx]!.disabled) {
                     return undefined;
                 }
+                // If this pill is mid-edit, end the edit so a pending
+                // blur-commit doesn't fire against a now-removed pill.
+                if (editing?.pill === store.pills[idx]) {
+                    funcs.stop_editing();
+                }
                 store.pills[idx]!.$element.remove();
                 const pill = util.the(store.pills.splice(idx, 1));
                 if (store.onPillRemove !== undefined) {
@@ -260,6 +317,10 @@ export function create<ItemType extends {type: string}>(
         // the pills.
         removeLastPill(trigger: RemovePillTrigger, quiet?: boolean) {
             const pill = store.pills.pop();
+
+            if (pill && editing?.pill === pill) {
+                funcs.stop_editing();
+            }
 
             if (pill && !pill.disabled) {
                 pill.$element.remove();
@@ -310,12 +371,13 @@ export function create<ItemType extends {type: string}>(
             return store.pills.find((pill) => pill.$element[0] === element);
         },
 
-        // This searches for a pill using a predicate function and returns it,
-        // or undefined if no pill matches.
+        // Returns the first matching pill, or undefined. Skips the pill being
+        // edited: callers are live-update handlers that call updatePill, which
+        // would replace the element and destroy the in-progress edit.
         getPillByPredicate(
             predicate: (item: ItemType) => boolean,
         ): InputPill<ItemType> | undefined {
-            return store.pills.find((pill) => predicate(pill.item));
+            return store.pills.find((pill) => pill !== editing?.pill && predicate(pill.item));
         },
 
         // Updates a pill's item data and refreshes its HTML representation in-place.
@@ -343,6 +405,9 @@ export function create<ItemType extends {type: string}>(
         },
 
         items() {
+            // Returns every pill's item, including the one being edited (as
+            // its pre-edit value). Submit paths that must not act on an
+            // unresolved edit call finalize_pending_edit() first.
             return store.pills.map((pill) => pill.item);
         },
 
@@ -352,6 +417,202 @@ export function create<ItemType extends {type: string}>(
                 return undefined;
             }
             return true;
+        },
+
+        startEditingPill(pill: InputPill<ItemType>, consume_enter_keypress = false): void {
+            if (pill.disabled) {
+                return;
+            }
+            if (editing !== undefined) {
+                return;
+            }
+
+            // Seed the edit box with the displayed text, not the internal
+            // text: e.g. a "role:administrators" system group shows as
+            // "Administrators". The unchanged check in commitEditingPill
+            // compares against the same value.
+            const text = store.get_display_value_from_item(pill.item);
+            const $edit = pill.$element.find(".pill-edit-input");
+            $edit.text(text);
+
+            pill.$element.addClass("editing");
+
+            ui_util.place_caret_at_end(util.the($edit));
+
+            let typeahead: PillEditTypeahead | undefined;
+            if (store.setupTypeahead !== undefined) {
+                if (consume_enter_keypress) {
+                    // Absorb the Enter keypress and keyup that triggered this edit,
+                    // so they don't commit the edit or select a typeahead suggestion.
+                    function block_enter(e: JQuery.KeyPressEvent | JQuery.KeyUpEvent): void {
+                        if (keydown_util.is_enter_event(e)) {
+                            e.preventDefault();
+                            e.stopImmediatePropagation();
+                        }
+                    }
+                    $edit.one("keypress", block_enter);
+                    $edit.one("keyup", block_enter);
+                }
+
+                typeahead = store.setupTypeahead($edit);
+            }
+
+            editing = {pill, $input: $edit, typeahead};
+
+            // Bound per edit, not delegated: the typeahead stops propagation of these keys.
+            $edit.on("keydown", (e) => {
+                // Stop keydown events from bubbling to the .pill keydown handler.
+                e.stopPropagation();
+                if (keydown_util.is_enter_event(e)) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    // While the menu is open, the typeahead's own keyup applies the suggestion.
+                    if ($edit.text().trim().length === 0 || typeahead?.shown !== true) {
+                        funcs.commitEditingPill($edit, false);
+                        // Otherwise this Enter's keyup submits the add-subscribers form.
+                        function block_enter_keyup(ev: JQuery.KeyUpEvent): void {
+                            if (keydown_util.is_enter_event(ev)) {
+                                ev.stopPropagation();
+                            }
+                        }
+                        store.$parent.one("keyup", block_enter_keyup);
+                    }
+                    return;
+                }
+                switch (e.key) {
+                    case "Escape": {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        funcs.cancelEditingPill($edit);
+                        break;
+                    }
+                    case "ArrowLeft": {
+                        if (is_cursor_at_start()) {
+                            const $prev = pill.$element.prev(".pill");
+                            if ($prev.length > 0) {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                funcs.cancelEditingPill($edit);
+                                $prev.trigger("focus");
+                            }
+                        }
+                        break;
+                    }
+                    case "ArrowRight": {
+                        if (is_cursor_at_end(util.the($edit))) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            const $next = pill.$element.next();
+                            funcs.cancelEditingPill($edit);
+                            if ($next.length > 0) {
+                                $next.trigger("focus");
+                            }
+                        }
+                        break;
+                    }
+                }
+            });
+
+            // Defer commit to allow a typeahead click to complete first.
+            const check_commit_on_blur = (): void => {
+                if (editing?.pill !== pill || editing?.$input !== $edit) {
+                    return;
+                }
+                if ($(".typeahead:hover").length > 0) {
+                    setTimeout(check_commit_on_blur, 100);
+                    return;
+                }
+                funcs.commitEditingPill($edit, true);
+            };
+
+            $edit.on("blur", () => {
+                setTimeout(check_commit_on_blur, 200);
+            });
+        },
+
+        // Resolves the active edit and reports whether it ended in a clean
+        // state: true if the pill was updated, deleted, or left unchanged;
+        // false if the text is invalid and the edit is still pending.
+        commitEditingPill($edit: JQuery, triggered_by_blur: boolean): boolean {
+            if (editing?.$input !== $edit) {
+                return true;
+            }
+
+            const text = $edit.text().trim();
+            if (text === store.get_display_value_from_item(editing.pill.item)) {
+                funcs.cancelEditingPill($edit);
+                return true;
+            }
+
+            if (text.length === 0) {
+                const {pill} = editing;
+                funcs.stop_editing();
+                const idx = store.pills.findIndex((p) => p.$element[0] === pill.$element[0]);
+                if (idx !== -1) {
+                    store.pills.splice(idx, 1);
+                }
+                pill.$element.remove();
+                store.onPillRemove?.(pill, "close");
+                if (!triggered_by_blur) {
+                    store.$input.trigger("focus");
+                }
+                return true;
+            }
+
+            // Use create_item directly to avoid comma-splitting via insertManyPills.
+            const item = funcs.create_item(text);
+
+            if (item !== undefined) {
+                funcs.updatePillAfterEdit(item, triggered_by_blur);
+                return true;
+            }
+
+            const {pill} = editing;
+            funcs.stop_editing();
+
+            // Redirect the invalid-input shake from the input to the pill.
+            store.$input.removeClass("shake");
+            if (store.show_outline_on_invalid_input) {
+                store.$parent.removeClass("invalid");
+            }
+            pill.$element.addClass("shake");
+            if (!triggered_by_blur) {
+                pill.$element.trigger("focus");
+            }
+            return false;
+        },
+
+        // Called by submit/save handlers before they read the pill set, to
+        // turn an in-flight edit into a real pill first. Returns false when
+        // the edit can't be resolved, so the caller can block the action.
+        finalize_pending_edit(): boolean {
+            if (editing === undefined) {
+                return true;
+            }
+            return funcs.commitEditingPill(editing.$input, true);
+        },
+
+        cancelEditingPill($edit: JQuery): void {
+            if (editing?.$input !== $edit) {
+                return;
+            }
+            const {pill} = editing;
+            funcs.stop_editing();
+
+            // Prevent focus from jumping to <body>.
+            pill.$element.trigger("focus");
+        },
+
+        // The edit element outlives a cancelled edit, so a later edit of the
+        // same pill would stack duplicates on it.
+        stop_editing(): void {
+            assert(editing !== undefined);
+            const {pill, $input, typeahead} = editing;
+            editing = undefined;
+            pill.$element.removeClass("editing");
+            $input.off("keydown");
+            $input.off("blur");
+            typeahead?.unlisten();
         },
     };
 
@@ -469,12 +730,36 @@ export function create<ItemType extends {type: string}>(
                     e.preventDefault();
                     break;
                 }
+                case "Enter": {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (!store.disable_pill_editing) {
+                        const pill = funcs.getByElement(util.the($pill));
+                        if (pill !== undefined) {
+                            funcs.startEditingPill(pill, true);
+                        }
+                    }
+                    break;
+                }
+            }
+        });
+
+        store.$parent.on("dblclick", ".pill", function (this: HTMLElement, e) {
+            if ($(e.target).closest(".exit, .expand").length > 0) {
+                return;
+            }
+            e.preventDefault();
+            if (!store.disable_pill_editing) {
+                const pill = funcs.getByElement(this);
+                if (pill !== undefined) {
+                    funcs.startEditingPill(pill);
+                }
             }
         });
 
         // when the shake animation is applied to the ".input" on invalid input,
         // we want to remove the class when finished automatically.
-        store.$parent.on("animationend", ".input", function () {
+        store.$parent.on("animationend", ".input, .pill", function () {
             $(this).removeClass("shake");
         });
 
@@ -534,6 +819,11 @@ export function create<ItemType extends {type: string}>(
         });
 
         store.$parent.on("copy", ".pill", function (this: HTMLElement, e) {
+            // Don't override the clipboard while editing: the selection is
+            // inside the edit box, so let the browser copy that text.
+            if ($(this).hasClass("editing")) {
+                return;
+            }
             const {item} = funcs.getByElement(this)!;
             assert(e.originalEvent instanceof ClipboardEvent);
             e.originalEvent.clipboardData?.setData("text/plain", store.get_text_from_item(item));
@@ -572,6 +862,13 @@ export function create<ItemType extends {type: string}>(
         createPillonPaste(callback) {
             store.createPillonPaste = callback;
         },
+
+        setSetupTypeahead(callback) {
+            store.setupTypeahead = callback;
+        },
+
+        updatePillAfterEdit: funcs.updatePillAfterEdit.bind(funcs),
+        finalize_pending_edit: funcs.finalize_pending_edit.bind(funcs),
 
         clear(quiet?: boolean) {
             funcs.removeAllPills.bind(funcs)("clear", quiet);

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -95,6 +95,11 @@ export type InputPillContainer<ItemType> = {
 
 export type RemovePillTrigger = "close" | "backspace" | "clear";
 
+function is_cursor_at_start(): boolean {
+    const selection = window.getSelection();
+    return selection !== null && selection.anchorOffset === 0 && !selection.toString();
+}
+
 export function create<ItemType extends {type: string}>(
     opts: InputPillCreateOptions<ItemType>,
 ): InputPillContainer<ItemType> {
@@ -390,11 +395,7 @@ export function create<ItemType extends {type: string}>(
             // If no text is selected, and the cursor is just to the
             // right of the last pill (with or without text in the
             // input), then backspace highlights or deletes the last pill.
-            if (
-                e.key === "Backspace" &&
-                (funcs.value(this).length === 0 ||
-                    (selection?.anchorOffset === 0 && selection?.toString()?.length === 0))
-            ) {
+            if (e.key === "Backspace" && (funcs.value(this).length === 0 || is_cursor_at_start())) {
                 e.preventDefault();
                 const pill = store.pills.at(-1);
                 // We focus the pill first, as a signal that the pill

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -38,6 +38,7 @@ type InputPillCreateOptions<ItemType> = {
     ) => void;
     show_outline_on_invalid_input?: boolean;
     split_text_to_form_pills?: (pills: string) => string[];
+    disable_pill_editing?: boolean;
 };
 
 export type InputPill<ItemType> = {
@@ -65,7 +66,19 @@ type InputPillStore<ItemType> = {
     convert_to_pill_on_enter: boolean;
     show_outline_on_invalid_input: boolean;
     split_text_to_form_pills: InputPillCreateOptions<ItemType>["split_text_to_form_pills"];
+    setupTypeahead?: ($input: JQuery) => PillEditTypeahead | undefined;
+    disable_pill_editing: boolean;
 };
+
+export type PillEditTypeahead = {
+    shown: boolean;
+    unlisten: () => void;
+};
+
+// How an edit ended. Only "user_action" moves focus, and only "blur"
+// discards invalid text, since a pill that isn't being edited has to
+// show a valid value.
+export type EditCommitTrigger = "user_action" | "blur" | "submit";
 
 // These are the functions that are exposed to other modules.
 export type InputPillContainer<ItemType> = {
@@ -86,6 +99,10 @@ export type InputPillContainer<ItemType> = {
     onPillExpand: (callback: (pill: JQuery) => void) => void;
     onTextInputHook: (callback: () => void) => void;
     createPillonPaste: (callback: () => void) => void;
+    setSetupTypeahead: (callback: ($input: JQuery) => PillEditTypeahead | undefined) => void;
+    updatePillAfterEdit: (new_item: ItemType, trigger?: EditCommitTrigger) => void;
+    finalize_pending_edit: () => boolean;
+    has_pending_edit: () => boolean;
     clear: (quiet?: boolean) => void;
     clear_text: () => void;
     getCurrentText: () => string | null;
@@ -98,6 +115,21 @@ export type RemovePillTrigger = "close" | "backspace" | "clear";
 function is_cursor_at_start(): boolean {
     const selection = window.getSelection();
     return selection !== null && selection.anchorOffset === 0 && !selection.toString();
+}
+
+function is_cursor_at_end(element: HTMLElement): boolean {
+    const selection = window.getSelection();
+    if (!selection || selection.toString() || selection.rangeCount === 0) {
+        return false;
+    }
+    // Measure the text between the caret and the element's end, rather
+    // than comparing node offsets, so a trailing <br> (which browsers add
+    // to contenteditable) isn't counted as content after the caret.
+    const cursor = selection.getRangeAt(0);
+    const to_end = document.createRange();
+    to_end.selectNodeContents(element);
+    to_end.setStart(cursor.endContainer, cursor.endOffset);
+    return to_end.toString() === "";
 }
 
 export function create<ItemType extends {type: string}>(
@@ -119,7 +151,14 @@ export function create<ItemType extends {type: string}>(
         on_pill_exit: opts.on_pill_exit,
         show_outline_on_invalid_input: opts.show_outline_on_invalid_input ?? false,
         split_text_to_form_pills: opts.split_text_to_form_pills,
+        disable_pill_editing: opts.disable_pill_editing ?? false,
     };
+
+    // The pill being edited in place, along with its contenteditable input and
+    // typeahead; `$input` identifies stale blur callbacks.
+    let editing:
+        | {pill: InputPill<ItemType>; $input: JQuery; typeahead: PillEditTypeahead | undefined}
+        | undefined;
 
     // a dictionary of internal functions. Some of these are exposed as well,
     // and nothing in here should be assumed to be private (due to the passing)
@@ -152,7 +191,12 @@ export function create<ItemType extends {type: string}>(
         },
 
         create_item(text: string) {
-            const existing_items = funcs.items();
+            // Exclude the pill being edited so it can re-commit its own value
+            // without colliding with itself. This is the only reader that
+            // needs the exclusion; items() returns the full set.
+            const existing_items = store.pills
+                .filter((pill) => pill !== editing?.pill)
+                .map((pill) => pill.item);
             const item = store.create_item_from_text(text, existing_items, store.pill_config);
             if (!item) {
                 store.$input.addClass("input-validation-shake");
@@ -174,6 +218,20 @@ export function create<ItemType extends {type: string}>(
                 display_value: store.get_display_value_from_item(item),
                 disabled,
             });
+        },
+
+        updatePillAfterEdit(new_item: ItemType, trigger: EditCommitTrigger = "user_action"): void {
+            if (editing === undefined) {
+                return;
+            }
+            const {pill} = editing;
+            funcs.stop_editing();
+            funcs.updatePill(util.the(pill.$element), new_item);
+            store.onPillRemove?.(pill, "close");
+            store.onPillCreate?.();
+            if (trigger === "user_action") {
+                store.$input.trigger("focus");
+            }
         },
 
         // This is generally called by typeahead logic, where we have all
@@ -236,6 +294,11 @@ export function create<ItemType extends {type: string}>(
                 if (store.pills[idx]!.disabled) {
                     return undefined;
                 }
+                // If this pill is mid-edit, end the edit so a pending
+                // blur-commit doesn't fire against a now-removed pill.
+                if (editing?.pill === store.pills[idx]) {
+                    funcs.stop_editing();
+                }
                 store.pills[idx]!.$element.remove();
                 const pill = util.the(store.pills.splice(idx, 1));
                 if (store.onPillRemove !== undefined) {
@@ -260,6 +323,10 @@ export function create<ItemType extends {type: string}>(
         // the pills.
         removeLastPill(trigger: RemovePillTrigger, quiet?: boolean) {
             const pill = store.pills.pop();
+
+            if (pill && editing?.pill === pill) {
+                funcs.stop_editing();
+            }
 
             if (pill && !pill.disabled) {
                 pill.$element.remove();
@@ -310,12 +377,13 @@ export function create<ItemType extends {type: string}>(
             return store.pills.find((pill) => pill.$element[0] === element);
         },
 
-        // This searches for a pill using a predicate function and returns it,
-        // or undefined if no pill matches.
+        // Returns the first matching pill, or undefined. Skips the pill being
+        // edited: callers are live-update handlers that call updatePill, which
+        // would replace the element and destroy the in-progress edit.
         getPillByPredicate(
             predicate: (item: ItemType) => boolean,
         ): InputPill<ItemType> | undefined {
-            return store.pills.find((pill) => predicate(pill.item));
+            return store.pills.find((pill) => pill !== editing?.pill && predicate(pill.item));
         },
 
         // Updates a pill's item data and refreshes its HTML representation in-place.
@@ -343,6 +411,9 @@ export function create<ItemType extends {type: string}>(
         },
 
         items() {
+            // Returns every pill's item, including the one being edited (as
+            // its pre-edit value). Submit paths that must not act on an
+            // unresolved edit call finalize_pending_edit() first.
             return store.pills.map((pill) => pill.item);
         },
 
@@ -352,6 +423,224 @@ export function create<ItemType extends {type: string}>(
                 return undefined;
             }
             return true;
+        },
+
+        startEditingPill(pill: InputPill<ItemType>, consume_enter_keypress = false): void {
+            if (pill.disabled) {
+                return;
+            }
+            if (editing !== undefined) {
+                if (editing.pill === pill) {
+                    return;
+                }
+                // The blur-commit from that click is deferred, so resolve the
+                // previous edit here instead of dropping this request.
+                funcs.commitEditingPill(editing.$input, "blur");
+                assert(editing === undefined);
+            }
+
+            // Seed the edit box with the displayed text, not the internal
+            // text: e.g. a "role:administrators" system group shows as
+            // "Administrators". The unchanged check in commitEditingPill
+            // compares against the same value.
+            const text = store.get_display_value_from_item(pill.item);
+            const $edit = pill.$element.find(".pill-edit-input");
+            $edit.text(text);
+
+            pill.$element.addClass("editing");
+
+            ui_util.place_caret_at_end(util.the($edit));
+
+            let typeahead: PillEditTypeahead | undefined;
+            if (store.setupTypeahead !== undefined) {
+                if (consume_enter_keypress) {
+                    // Absorb the Enter keypress and keyup that triggered this edit,
+                    // so they don't commit the edit or select a typeahead suggestion.
+                    function block_enter(e: JQuery.KeyPressEvent | JQuery.KeyUpEvent): void {
+                        if (keydown_util.is_enter_event(e)) {
+                            e.preventDefault();
+                            e.stopImmediatePropagation();
+                        }
+                    }
+                    $edit.one("keypress", block_enter);
+                    $edit.one("keyup", block_enter);
+                }
+
+                typeahead = store.setupTypeahead($edit);
+            }
+
+            editing = {pill, $input: $edit, typeahead};
+
+            // Bound per edit, not delegated: the typeahead stops propagation of these keys.
+            $edit.on("keydown", (e) => {
+                // Stop keydown events from bubbling to the .pill keydown handler.
+                e.stopPropagation();
+                if (keydown_util.is_enter_event(e)) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    // While the menu is open, the typeahead's own keyup applies the suggestion.
+                    if ($edit.text().trim().length === 0 || typeahead?.shown !== true) {
+                        funcs.commitEditingPill($edit, "user_action");
+                        // Otherwise this Enter's keyup submits the add-subscribers form.
+                        function block_enter_keyup(ev: JQuery.KeyUpEvent): void {
+                            if (keydown_util.is_enter_event(ev)) {
+                                ev.stopPropagation();
+                            }
+                        }
+                        store.$parent.one("keyup", block_enter_keyup);
+                    }
+                    return;
+                }
+                switch (e.key) {
+                    case "Escape": {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        funcs.cancelEditingPill($edit);
+                        break;
+                    }
+                    case "ArrowLeft": {
+                        if (is_cursor_at_start()) {
+                            const $prev = pill.$element.prev(".pill");
+                            if ($prev.length > 0) {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                funcs.cancelEditingPill($edit);
+                                $prev.trigger("focus");
+                            }
+                        }
+                        break;
+                    }
+                    case "ArrowRight": {
+                        if (is_cursor_at_end(util.the($edit))) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            const $next = pill.$element.next();
+                            funcs.cancelEditingPill($edit);
+                            if ($next.length > 0) {
+                                $next.trigger("focus");
+                            }
+                        }
+                        break;
+                    }
+                }
+            });
+
+            // Defer commit to allow a typeahead click to complete first.
+            const check_commit_on_blur = (): void => {
+                if (editing?.pill !== pill || editing?.$input !== $edit) {
+                    return;
+                }
+                // The typeahead refocuses its input when its menu is clicked,
+                // so the user is still editing; a later blur reschedules us.
+                if ($edit.is(":focus")) {
+                    return;
+                }
+                if ($(".typeahead:hover").length > 0) {
+                    setTimeout(check_commit_on_blur, 100);
+                    return;
+                }
+                funcs.commitEditingPill($edit, "blur");
+            };
+
+            $edit.on("blur", () => {
+                setTimeout(check_commit_on_blur, 200);
+            });
+        },
+
+        // Resolves the active edit and reports whether it ended in a clean
+        // state: true if the pill was updated, deleted, or left unchanged;
+        // false if the text is invalid and the edit is still unresolved.
+        commitEditingPill($edit: JQuery, trigger: EditCommitTrigger): boolean {
+            if (editing?.$input !== $edit) {
+                return true;
+            }
+
+            const text = $edit.text().trim();
+            if (text === store.get_display_value_from_item(editing.pill.item)) {
+                funcs.cancelEditingPill($edit, trigger);
+                return true;
+            }
+
+            if (text.length === 0) {
+                const {pill} = editing;
+                funcs.stop_editing();
+                const idx = store.pills.findIndex((p) => p.$element[0] === pill.$element[0]);
+                if (idx !== -1) {
+                    store.pills.splice(idx, 1);
+                }
+                pill.$element.remove();
+                store.onPillRemove?.(pill, "close");
+                if (trigger === "user_action") {
+                    store.$input.trigger("focus");
+                }
+                return true;
+            }
+
+            // Use create_item directly to avoid comma-splitting via insertManyPills.
+            const item = funcs.create_item(text);
+
+            if (item !== undefined) {
+                funcs.updatePillAfterEdit(item, trigger);
+                return true;
+            }
+
+            const {pill} = editing;
+
+            // Redirect the invalid-input shake from the input to the pill.
+            store.$input.removeClass("input-validation-shake");
+            if (store.show_outline_on_invalid_input) {
+                store.$parent.removeClass("invalid");
+            }
+            pill.$element.addClass("input-validation-shake");
+
+            if (trigger === "blur") {
+                // A pill that isn't being edited has to show a valid value.
+                funcs.stop_editing();
+                return false;
+            }
+
+            // Keep the text to fix, as the input does with a rejected pill.
+            $edit.trigger("focus");
+            return false;
+        },
+
+        // Called by submit/save handlers before they read the pill set, to
+        // turn an in-flight edit into a real pill first. Returns false when
+        // the edit can't be resolved, so the caller can block the action.
+        finalize_pending_edit(): boolean {
+            if (editing === undefined) {
+                return true;
+            }
+            return funcs.commitEditingPill(editing.$input, "submit");
+        },
+
+        has_pending_edit(): boolean {
+            return editing !== undefined;
+        },
+
+        cancelEditingPill($edit: JQuery, trigger: EditCommitTrigger = "user_action"): void {
+            if (editing?.$input !== $edit) {
+                return;
+            }
+            const {pill} = editing;
+            funcs.stop_editing();
+
+            if (trigger === "user_action") {
+                // Prevent focus from jumping to <body>.
+                pill.$element.trigger("focus");
+            }
+        },
+
+        // The edit element outlives a cancelled edit, so a later edit of the
+        // same pill would stack duplicates on it.
+        stop_editing(): void {
+            assert(editing !== undefined);
+            const {pill, $input, typeahead} = editing;
+            editing = undefined;
+            pill.$element.removeClass("editing");
+            $input.off("keydown");
+            $input.off("blur");
+            typeahead?.unlisten();
         },
     };
 
@@ -469,12 +758,36 @@ export function create<ItemType extends {type: string}>(
                     e.preventDefault();
                     break;
                 }
+                case "Enter": {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (!store.disable_pill_editing) {
+                        const pill = funcs.getByElement(util.the($pill));
+                        if (pill !== undefined) {
+                            funcs.startEditingPill(pill, true);
+                        }
+                    }
+                    break;
+                }
+            }
+        });
+
+        store.$parent.on("dblclick", ".pill", function (this: HTMLElement, e) {
+            if ($(e.target).closest(".exit, .expand").length > 0) {
+                return;
+            }
+            e.preventDefault();
+            if (!store.disable_pill_editing) {
+                const pill = funcs.getByElement(this);
+                if (pill !== undefined) {
+                    funcs.startEditingPill(pill);
+                }
             }
         });
 
         // when the shake animation is applied to the ".input" on invalid input,
         // we want to remove the class when finished automatically.
-        store.$parent.on("animationend", ".input", function () {
+        store.$parent.on("animationend", ".input, .pill", function () {
             $(this).removeClass("input-validation-shake");
         });
 
@@ -534,6 +847,11 @@ export function create<ItemType extends {type: string}>(
         });
 
         store.$parent.on("copy", ".pill", function (this: HTMLElement, e) {
+            // Don't override the clipboard while editing: the selection is
+            // inside the edit box, so let the browser copy that text.
+            if ($(this).hasClass("editing")) {
+                return;
+            }
             const {item} = funcs.getByElement(this)!;
             assert(e.originalEvent instanceof ClipboardEvent);
             e.originalEvent.clipboardData?.setData("text/plain", store.get_text_from_item(item));
@@ -572,6 +890,14 @@ export function create<ItemType extends {type: string}>(
         createPillonPaste(callback) {
             store.createPillonPaste = callback;
         },
+
+        setSetupTypeahead(callback) {
+            store.setupTypeahead = callback;
+        },
+
+        updatePillAfterEdit: funcs.updatePillAfterEdit.bind(funcs),
+        finalize_pending_edit: funcs.finalize_pending_edit.bind(funcs),
+        has_pending_edit: funcs.has_pending_edit.bind(funcs),
 
         clear(quiet?: boolean) {
             funcs.removeAllPills.bind(funcs)("clear", quiet);

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -104,6 +104,9 @@ export function show_generate_integration_url_modal(api_key: string): void {
 
         const clipboard = new ClipboardJS("#generate-integration-url-modal .dialog_submit_button", {
             text() {
+                // Commit any in-flight branch pill edit so the copied URL
+                // reflects it (committing re-runs update_url via onPillCreate).
+                branch_pill_widget?.finalize_pending_edit();
                 return $integration_url.text();
             },
         });

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -704,6 +704,17 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
     }
 
     function invite_users(): void {
+        // Resolve any in-flight pill edit before reading the invite fields;
+        // refuse to submit if it can't be resolved.
+        if (
+            !email_pill_widget.finalize_pending_edit() ||
+            !stream_pill_widget.finalize_pending_edit() ||
+            (user_group_pill_widget !== undefined &&
+                !user_group_pill_widget.finalize_pending_edit())
+        ) {
+            dialog_widget.hide_dialog_spinner();
+            return;
+        }
         const is_generate_invite_link =
             $(".invite_users_option_tabs").find(".selected").attr("data-tab-key") ===
             "invite-link-tab";

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -704,6 +704,15 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
     }
 
     function invite_users(): void {
+        if (
+            !email_pill_widget.finalize_pending_edit() ||
+            !stream_pill_widget.finalize_pending_edit() ||
+            (user_group_pill_widget !== undefined &&
+                !user_group_pill_widget.finalize_pending_edit())
+        ) {
+            dialog_widget.hide_dialog_spinner();
+            return;
+        }
         const is_generate_invite_link =
             $(".invite_users_option_tabs").find(".selected").attr("data-tab-key") ===
             "invite-link-tab";

--- a/web/src/invite_stream_picker_pill.ts
+++ b/web/src/invite_stream_picker_pill.ts
@@ -31,6 +31,7 @@ function set_up_pill_typeahead({pill_widget, $pill_container}: SetUpPillTypeahea
         invite_streams: true,
     };
     set_up_stream($pill_container.find(".input"), pill_widget, opts);
+    pill_widget.setSetupTypeahead(($edit) => set_up_stream($edit, pill_widget, opts));
 }
 
 export function add_default_stream_pills(pill_widget: stream_pill.StreamPillWidget): void {

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -44,13 +44,13 @@ export function set_up_user(
     opts: {
         exclude_bots?: boolean;
     },
-): void {
+): Typeahead<UserPillData> {
     const exclude_bots = opts.exclude_bots;
     const bootstrap_typeahead_input: TypeaheadInputElement = {
         $element: $input,
         type: "contenteditable",
     };
-    new Typeahead(bootstrap_typeahead_input, {
+    return new Typeahead(bootstrap_typeahead_input, {
         dropup: true,
         source(_query: string): UserPillData[] {
             return user_pill.typeahead_source(pills, exclude_bots);
@@ -72,9 +72,14 @@ export function set_up_user(
         },
         updater(item: UserPillData, _query: string): undefined {
             if (people.is_known_user_id(item.user.user_id)) {
-                user_pill.append_user(item.user, pills);
+                const is_editing_pill = $input.hasClass("pill-edit-input");
+                if (is_editing_pill) {
+                    pills.updatePillAfterEdit(user_pill.create_pill_data(item.user));
+                } else {
+                    user_pill.append_user(item.user, pills);
+                    $input.trigger("focus");
+                }
             }
-            $input.trigger("focus");
         },
         stopAdvance: true,
     });
@@ -88,13 +93,13 @@ export function set_up_stream(
         hide_on_empty_after_backspace?: boolean;
         invite_streams?: boolean;
     },
-): void {
+): Typeahead<StreamPillData> {
     const bootstrap_typeahead_input: TypeaheadInputElement = {
         $element: $input,
         type: "contenteditable",
     };
     opts.hide_on_empty_after_backspace ??= false;
-    new Typeahead(bootstrap_typeahead_input, {
+    return new Typeahead(bootstrap_typeahead_input, {
         dropup: true,
         helpOnEmptyStrings: () => opts.help_on_empty_strings ?? false,
         hideOnEmptyAfterBackspace: opts.hide_on_empty_after_backspace,
@@ -126,8 +131,16 @@ export function set_up_stream(
             return typeahead_helper.sort_streams_by_name(stream_matches, query);
         },
         updater(item: StreamPillData, _query: string): undefined {
-            stream_pill.append_stream(item, pills);
-            $input.trigger("focus");
+            const is_editing_pill = $input.hasClass("pill-edit-input");
+            if (is_editing_pill) {
+                pills.updatePillAfterEdit({
+                    type: "stream",
+                    stream_id: item.stream_id,
+                });
+            } else {
+                stream_pill.append_stream(item, pills);
+                $input.trigger("focus");
+            }
         },
         stopAdvance: true,
     });
@@ -139,12 +152,12 @@ export function set_up_user_group(
     opts: {
         user_group_source: () => UserGroup[];
     },
-): void {
+): Typeahead<UserGroupPillData> {
     const bootstrap_typeahead_input: TypeaheadInputElement = {
         $element: $input,
         type: "contenteditable",
     };
-    new Typeahead(bootstrap_typeahead_input, {
+    return new Typeahead(bootstrap_typeahead_input, {
         dropup: true,
         source(_query: string): UserGroupPillData[] {
             return opts
@@ -165,8 +178,17 @@ export function set_up_user_group(
             return typeahead_helper.sort_user_groups(matches, query);
         },
         updater(item: UserGroupPillData, _query: string): undefined {
-            user_group_pill.append_user_group(item, pills);
-            $input.trigger("focus");
+            const is_editing_pill = $input.hasClass("pill-edit-input");
+            if (is_editing_pill) {
+                pills.updatePillAfterEdit({
+                    type: "user_group",
+                    group_id: item.id,
+                    group_name: item.name,
+                });
+            } else {
+                user_group_pill.append_user_group(item, pills);
+                $input.trigger("focus");
+            }
         },
         stopAdvance: true,
         helpOnEmptyStrings: () => true,
@@ -182,12 +204,12 @@ export function set_up_group_setting_typeahead(
         setting_type: "realm" | "stream" | "group";
         group?: UserGroup | undefined;
     },
-): void {
+): Typeahead<GroupSettingTypeaheadItem> {
     const bootstrap_typeahead_input: TypeaheadInputElement = {
         $element: $input,
         type: "contenteditable",
     };
-    new Typeahead(bootstrap_typeahead_input, {
+    return new Typeahead(bootstrap_typeahead_input, {
         dropup: true,
         source(_query: string): GroupSettingTypeaheadItem[] {
             let source: GroupSettingTypeaheadItem[] = [];
@@ -249,13 +271,28 @@ export function set_up_group_setting_typeahead(
             });
         },
         updater(item: GroupSettingTypeaheadItem, _query: string): undefined {
+            const is_editing_pill = $input.hasClass("pill-edit-input");
             if (item.type === "user_group") {
-                user_group_pill.append_user_group(item, pills);
+                if (is_editing_pill) {
+                    pills.updatePillAfterEdit({
+                        type: "user_group",
+                        group_id: item.id,
+                        group_name: item.name,
+                    });
+                } else {
+                    user_group_pill.append_user_group(item, pills);
+                }
             } else if (item.type === "user" && people.is_known_user_id(item.user.user_id)) {
-                user_pill.append_user(item.user, pills);
+                if (is_editing_pill) {
+                    pills.updatePillAfterEdit(user_pill.create_pill_data(item.user));
+                } else {
+                    user_pill.append_user(item.user, pills);
+                }
             }
 
-            $input.trigger("focus");
+            if (!is_editing_pill) {
+                $input.trigger("focus");
+            }
         },
         stopAdvance: true,
         helpOnEmptyStrings: () => true,
@@ -275,10 +312,10 @@ export function set_up_combined(
         exclude_bots?: boolean;
         for_stream_subscribers: boolean;
     },
-): void {
+): Typeahead<TypeaheadItem> | undefined {
     if (!opts.user && !opts.user_group && !opts.stream) {
         blueslip.error("Unspecified possible item types");
-        return;
+        return undefined;
     }
     const include_streams = (query: string): boolean =>
         opts.stream !== undefined && query.trim().startsWith("#");
@@ -290,7 +327,7 @@ export function set_up_combined(
         $element: $input,
         type: "contenteditable",
     };
-    new Typeahead(bootstrap_typeahead_input, {
+    return new Typeahead(bootstrap_typeahead_input, {
         dropup: true,
         helpOnEmptyStrings: () => true,
         hideOnEmptyAfterBackspace: true,
@@ -423,22 +460,45 @@ export function set_up_combined(
             });
         },
         updater(item: TypeaheadItem, query: string): undefined {
+            const is_editing_pill = $input.hasClass("pill-edit-input");
             if (include_streams(query) && item.type === "stream") {
-                stream_pill.append_stream(item, pills);
+                if (is_editing_pill) {
+                    pills.updatePillAfterEdit({
+                        type: "stream",
+                        stream_id: item.stream_id,
+                    });
+                } else {
+                    stream_pill.append_stream(item, pills);
+                }
             } else if (include_user_groups && item.type === "user_group") {
                 const show_expand_button =
                     !opts.for_stream_subscribers &&
                     (item.members.size > 0 || item.direct_subgroup_ids.size > 0);
-                user_group_pill.append_user_group(item, pills, true, show_expand_button);
+                if (is_editing_pill) {
+                    pills.updatePillAfterEdit({
+                        type: "user_group",
+                        group_id: item.id,
+                        group_name: item.name,
+                        show_expand_button,
+                    });
+                } else {
+                    user_group_pill.append_user_group(item, pills, true, show_expand_button);
+                }
             } else if (
                 include_users &&
                 item.type === "user" &&
                 people.is_known_user_id(item.user.user_id)
             ) {
-                user_pill.append_user(item.user, pills);
+                if (is_editing_pill) {
+                    pills.updatePillAfterEdit(user_pill.create_pill_data(item.user));
+                } else {
+                    user_pill.append_user(item.user, pills);
+                }
             }
 
-            $input.trigger("focus");
+            if (!is_editing_pill) {
+                $input.trigger("focus");
+            }
         },
         stopAdvance: true,
     });

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -36,13 +36,13 @@ export function set_up_user(
     opts: {
         exclude_bots?: boolean;
     },
-): void {
+): Typeahead<UserPillData> {
     const exclude_bots = opts.exclude_bots;
     const bootstrap_typeahead_input: TypeaheadInputElement = {
         $element: $input,
         type: "contenteditable",
     };
-    new Typeahead(bootstrap_typeahead_input, {
+    return new Typeahead(bootstrap_typeahead_input, {
         dropup: true,
         source(_query: string): UserPillData[] {
             return user_pill.typeahead_source(pills, exclude_bots);
@@ -63,9 +63,14 @@ export function set_up_user(
         },
         updater(item: UserPillData, _query: string): undefined {
             if (people.is_known_user_id(item.user.user_id)) {
-                user_pill.append_user(item.user, pills);
+                const is_editing_pill = $input.hasClass("pill-edit-input");
+                if (is_editing_pill) {
+                    pills.updatePillAfterEdit(user_pill.create_pill_data(item.user));
+                } else {
+                    user_pill.append_user(item.user, pills);
+                    $input.trigger("focus");
+                }
             }
-            $input.trigger("focus");
         },
         stopAdvance: true,
     });
@@ -79,13 +84,13 @@ export function set_up_stream(
         hide_on_empty_after_backspace?: boolean;
         invite_streams?: boolean;
     },
-): void {
+): Typeahead<StreamPillData> {
     const bootstrap_typeahead_input: TypeaheadInputElement = {
         $element: $input,
         type: "contenteditable",
     };
     opts.hide_on_empty_after_backspace ??= false;
-    new Typeahead(bootstrap_typeahead_input, {
+    return new Typeahead(bootstrap_typeahead_input, {
         dropup: true,
         helpOnEmptyStrings: () => opts.help_on_empty_strings ?? false,
         hideOnEmptyAfterBackspace: opts.hide_on_empty_after_backspace,
@@ -117,8 +122,16 @@ export function set_up_stream(
             return typeahead_helper.sort_streams_by_name(stream_matches, query);
         },
         updater(item: StreamPillData, _query: string): undefined {
-            stream_pill.append_stream(item, pills);
-            $input.trigger("focus");
+            const is_editing_pill = $input.hasClass("pill-edit-input");
+            if (is_editing_pill) {
+                pills.updatePillAfterEdit({
+                    type: "stream",
+                    stream_id: item.stream_id,
+                });
+            } else {
+                stream_pill.append_stream(item, pills);
+                $input.trigger("focus");
+            }
         },
         stopAdvance: true,
     });
@@ -130,12 +143,12 @@ export function set_up_user_group(
     opts: {
         user_group_source: () => UserGroup[];
     },
-): void {
+): Typeahead<UserGroupPillData> {
     const bootstrap_typeahead_input: TypeaheadInputElement = {
         $element: $input,
         type: "contenteditable",
     };
-    new Typeahead(bootstrap_typeahead_input, {
+    return new Typeahead(bootstrap_typeahead_input, {
         dropup: true,
         source(_query: string): UserGroupPillData[] {
             return opts
@@ -153,8 +166,17 @@ export function set_up_user_group(
             return typeahead_helper.sort_user_groups(matches, query);
         },
         updater(item: UserGroupPillData, _query: string): undefined {
-            user_group_pill.append_user_group(item, pills);
-            $input.trigger("focus");
+            const is_editing_pill = $input.hasClass("pill-edit-input");
+            if (is_editing_pill) {
+                pills.updatePillAfterEdit({
+                    type: "user_group",
+                    group_id: item.id,
+                    group_name: item.name,
+                });
+            } else {
+                user_group_pill.append_user_group(item, pills);
+                $input.trigger("focus");
+            }
         },
         stopAdvance: true,
         helpOnEmptyStrings: () => true,
@@ -170,12 +192,12 @@ export function set_up_group_setting_typeahead(
         setting_type: "realm" | "stream" | "group";
         group?: UserGroup | undefined;
     },
-): void {
+): Typeahead<GroupSettingTypeaheadItem> {
     const bootstrap_typeahead_input: TypeaheadInputElement = {
         $element: $input,
         type: "contenteditable",
     };
-    new Typeahead(bootstrap_typeahead_input, {
+    return new Typeahead(bootstrap_typeahead_input, {
         dropup: true,
         source(_query: string): GroupSettingTypeaheadItem[] {
             return [
@@ -229,13 +251,28 @@ export function set_up_group_setting_typeahead(
             });
         },
         updater(item: GroupSettingTypeaheadItem, _query: string): undefined {
+            const is_editing_pill = $input.hasClass("pill-edit-input");
             if (item.type === "user_group") {
-                user_group_pill.append_user_group(item, pills);
+                if (is_editing_pill) {
+                    pills.updatePillAfterEdit({
+                        type: "user_group",
+                        group_id: item.id,
+                        group_name: item.name,
+                    });
+                } else {
+                    user_group_pill.append_user_group(item, pills);
+                }
             } else if (item.type === "user" && people.is_known_user_id(item.user.user_id)) {
-                user_pill.append_user(item.user, pills);
+                if (is_editing_pill) {
+                    pills.updatePillAfterEdit(user_pill.create_pill_data(item.user));
+                } else {
+                    user_pill.append_user(item.user, pills);
+                }
             }
 
-            $input.trigger("focus");
+            if (!is_editing_pill) {
+                $input.trigger("focus");
+            }
         },
         stopAdvance: true,
         helpOnEmptyStrings: () => true,
@@ -255,10 +292,10 @@ export function set_up_combined(
         exclude_bots?: boolean;
         for_stream_subscribers: boolean;
     },
-): void {
+): Typeahead<TypeaheadItem> | undefined {
     if (!opts.user && !opts.user_group && !opts.stream) {
         blueslip.error("Unspecified possible item types");
-        return;
+        return undefined;
     }
     const include_streams = (query: string): boolean =>
         opts.stream !== undefined && query.trimStart().startsWith("#");
@@ -270,7 +307,7 @@ export function set_up_combined(
         $element: $input,
         type: "contenteditable",
     };
-    new Typeahead(bootstrap_typeahead_input, {
+    return new Typeahead(bootstrap_typeahead_input, {
         dropup: true,
         helpOnEmptyStrings: () => true,
         hideOnEmptyAfterBackspace: true,
@@ -402,22 +439,45 @@ export function set_up_combined(
             });
         },
         updater(item: TypeaheadItem, query: string): undefined {
+            const is_editing_pill = $input.hasClass("pill-edit-input");
             if (include_streams(query) && item.type === "stream") {
-                stream_pill.append_stream(item, pills);
+                if (is_editing_pill) {
+                    pills.updatePillAfterEdit({
+                        type: "stream",
+                        stream_id: item.stream_id,
+                    });
+                } else {
+                    stream_pill.append_stream(item, pills);
+                }
             } else if (include_user_groups && item.type === "user_group") {
                 const show_expand_button =
                     !opts.for_stream_subscribers &&
                     (item.members.size > 0 || item.direct_subgroup_ids.size > 0);
-                user_group_pill.append_user_group(item, pills, true, show_expand_button);
+                if (is_editing_pill) {
+                    pills.updatePillAfterEdit({
+                        type: "user_group",
+                        group_id: item.id,
+                        group_name: item.name,
+                        show_expand_button,
+                    });
+                } else {
+                    user_group_pill.append_user_group(item, pills, true, show_expand_button);
+                }
             } else if (
                 include_users &&
                 item.type === "user" &&
                 people.is_known_user_id(item.user.user_id)
             ) {
-                user_pill.append_user(item.user, pills);
+                if (is_editing_pill) {
+                    pills.updatePillAfterEdit(user_pill.create_pill_data(item.user));
+                } else {
+                    user_pill.append_user(item.user, pills);
+                }
             }
 
-            $input.trigger("focus");
+            if (!is_editing_pill) {
+                $input.trigger("focus");
+            }
         },
         stopAdvance: true,
     });

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -362,6 +362,10 @@ export function create_pills($pill_container: JQuery): SearchPillWidget {
         get_text_from_item: get_search_string_from_item,
         split_text_on_comma: false,
         convert_to_pill_on_enter: false,
+        // In-place editing isn't supported for search pills (the
+        // typeahead doesn't work in the editable element), so we disable
+        // it and omit the .pill-edit-input element from their HTML.
+        disable_pill_editing: true,
         generate_pill_html(item) {
             switch (item.operator) {
                 case "dm":
@@ -376,14 +380,17 @@ export function create_pills($pill_container: JQuery): SearchPillWidget {
                             is_empty_string_topic: true,
                             sign: item.negated ? "-" : "",
                             topic_display_name: util.get_final_topic_display_name(""),
+                            read_only: true,
                         });
                     }
                     return render_input_pill({
                         display_value: get_search_string_from_item(item),
+                        read_only: true,
                     });
                 default:
                     return render_input_pill({
                         display_value: get_search_string_from_item(item),
+                        read_only: true,
                     });
             }
         },

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -365,6 +365,10 @@ export function create_pills($pill_container: JQuery): SearchPillWidget {
         get_text_from_item: get_search_string_from_item,
         split_text_on_comma: false,
         convert_to_pill_on_enter: false,
+        // In-place editing isn't supported for search pills (the
+        // typeahead doesn't work in the editable element), so we disable
+        // it and omit the .pill-edit-input element from their HTML.
+        disable_pill_editing: true,
         generate_pill_html(item) {
             switch (item.operator) {
                 case "dm":
@@ -379,14 +383,17 @@ export function create_pills($pill_container: JQuery): SearchPillWidget {
                             is_empty_string_topic: true,
                             sign: item.negated ? "-" : "",
                             topic_display_name: util.get_final_topic_display_name(""),
+                            read_only: true,
                         });
                     }
                     return render_input_pill({
                         display_value: get_search_string_from_item(item),
+                        read_only: true,
                     });
                 default:
                     return render_input_pill({
                         display_value: get_search_string_from_item(item),
+                        read_only: true,
                     });
             }
         },

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1103,6 +1103,7 @@ function get_request_data_for_org_join_restrictions(selected_val: string): {
 export function populate_data_for_realm_settings_request(
     $subsection_elem: JQuery,
 ): Record<string, string | boolean | number> {
+    finalize_group_setting_pill_edits();
     let data: Record<string, string | boolean | number> = {};
     const properties_elements = get_subsection_property_elements($subsection_elem);
     for (const input_elem of properties_elements) {
@@ -1189,6 +1190,7 @@ export function populate_data_for_stream_settings_request(
     $subsection_elem: JQuery,
     sub: StreamSubscription,
 ): Record<string, string | boolean | number> {
+    finalize_group_setting_pill_edits();
     let data: Record<string, string | boolean | number> = {};
     const properties_elements = get_subsection_property_elements($subsection_elem);
     for (const input_elem of properties_elements) {
@@ -1241,6 +1243,7 @@ export function populate_data_for_group_request(
     $subsection_elem: JQuery,
     group: UserGroup,
 ): Record<string, string | boolean | number> {
+    finalize_group_setting_pill_edits();
     const data: Record<string, string | boolean | number> = {};
     const properties_elements = get_subsection_property_elements($subsection_elem);
     for (const input_elem of properties_elements) {
@@ -1704,6 +1707,14 @@ export function get_group_setting_widget(setting_name: string): GroupSettingPill
     }
 
     return pill_widget;
+}
+
+export function finalize_group_setting_pill_edits(): void {
+    // Commit any in-flight group-setting pill edit before a save reads the
+    // pill values. At most one pill is ever mid-edit; the rest are no-ops.
+    for (const pill_widget of group_setting_widget_map.values()) {
+        pill_widget?.finalize_pending_edit();
+    }
 }
 
 export function set_group_setting_widget_value(

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1104,6 +1104,7 @@ function get_request_data_for_org_join_restrictions(selected_val: string): {
 export function populate_data_for_realm_settings_request(
     $subsection_elem: JQuery,
 ): Record<string, string | boolean | number> {
+    finalize_group_setting_pill_edits();
     let data: Record<string, string | boolean | number> = {};
     const properties_elements = get_subsection_property_elements($subsection_elem);
     for (const input_elem of properties_elements) {
@@ -1186,6 +1187,7 @@ export function populate_data_for_stream_settings_request(
     $subsection_elem: JQuery,
     sub: StreamSubscription,
 ): Record<string, string | boolean | number> {
+    finalize_group_setting_pill_edits();
     let data: Record<string, string | boolean | number> = {};
     const properties_elements = get_subsection_property_elements($subsection_elem);
     for (const input_elem of properties_elements) {
@@ -1238,6 +1240,7 @@ export function populate_data_for_group_request(
     $subsection_elem: JQuery,
     group: UserGroup,
 ): Record<string, string | boolean | number> {
+    finalize_group_setting_pill_edits();
     const data: Record<string, string | boolean | number> = {};
     const properties_elements = get_subsection_property_elements($subsection_elem);
     for (const input_elem of properties_elements) {
@@ -1701,6 +1704,14 @@ export function get_group_setting_widget(setting_name: string): GroupSettingPill
     }
 
     return pill_widget;
+}
+
+export function finalize_group_setting_pill_edits(): void {
+    // Commit any in-flight group-setting pill edit before a save reads the
+    // pill values. At most one pill is ever mid-edit; the rest are no-ops.
+    for (const pill_widget of group_setting_widget_map.values()) {
+        pill_widget?.finalize_pending_edit();
+    }
 }
 
 export function set_group_setting_widget_value(

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -552,6 +552,20 @@ export function show_new_stream_modal(): void {
 
 let group_setting_widgets: Record<string, GroupSettingPillContainer | undefined> = {};
 
+// Creating the channel must not act on a pill's pre-edit value.
+async function finalize_pending_pill_edits(): Promise<boolean> {
+    if (!(await stream_create_subscribers.finalize_pending_edit())) {
+        return false;
+    }
+    for (const pill_widget of Object.values(group_setting_widgets)) {
+        assert(pill_widget !== undefined);
+        if (!pill_widget.finalize_pending_edit()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 function set_up_group_setting_widgets(): void {
     for (const setting_name of Object.keys(realm.server_supported_permission_settings.stream)) {
         group_setting_widgets[setting_name] =
@@ -608,6 +622,15 @@ export function set_up_handlers(): void {
             return;
         }
 
+        void (async () => {
+            if (!(await finalize_pending_pill_edits())) {
+                return;
+            }
+            maybe_create_stream(stream_name);
+        })();
+    });
+
+    function maybe_create_stream(stream_name: string): void {
         const principals = stream_create_subscribers.get_principals();
         if (principals.length === 0) {
             stream_subscription_error.report_no_subs_to_stream();
@@ -643,7 +666,7 @@ export function set_up_handlers(): void {
         } else {
             create_stream();
         }
-    });
+    }
 
     function handle_channel_name_length_limit(): void {
         const $channel_input = $<HTMLInputElement>("input#create_stream_name");

--- a/web/src/stream_create_subscribers.ts
+++ b/web/src/stream_create_subscribers.ts
@@ -21,6 +21,19 @@ export function get_principals(): number[] {
     return stream_create_subscribers_data.get_principals();
 }
 
+export async function finalize_pending_edit(): Promise<boolean> {
+    if (!pill_widget.has_pending_edit()) {
+        return true;
+    }
+    if (!pill_widget.finalize_pending_edit()) {
+        return false;
+    }
+    // The pill hooks that sync our subscriber list run asynchronously, so a
+    // just-committed edit has not reached it before the caller reads it.
+    sync_user_ids(await add_subscribers_pill.get_pill_user_ids(pill_widget));
+    return true;
+}
+
 function redraw_subscriber_list(): void {
     all_users_list_widget.replace_list_data(stream_create_subscribers_data.sorted_user_ids());
 }

--- a/web/src/topic_filter_pill.ts
+++ b/web/src/topic_filter_pill.ts
@@ -129,10 +129,14 @@ export function create_pills(
         create_item_from_text: create_item_from_syntax,
         get_text_from_item: get_syntax_from_item,
         get_display_value_from_item: get_syntax_from_item,
+        // Picked from a fixed list, and the label ("resolved") isn't the text
+        // they're created from ("is:resolved").
+        disable_pill_editing: true,
         generate_pill_html(item: TopicFilterPill, disabled?: boolean) {
             return render_input_pill({
                 display_value: item.label,
                 disabled,
+                read_only: true,
             });
         },
     });

--- a/web/src/user_group_create.ts
+++ b/web/src/user_group_create.ts
@@ -44,6 +44,20 @@ export const group_setting_widget_map = new Map<string, GroupSettingPillContaine
     ["can_remove_members_group", null],
 ]);
 
+// Creating the group must not act on a pill's pre-edit value.
+async function finalize_pending_pill_edits(): Promise<boolean> {
+    if (!(await user_group_create_members.finalize_pending_edit())) {
+        return false;
+    }
+    for (const pill_widget of group_setting_widget_map.values()) {
+        assert(pill_widget !== null);
+        if (!pill_widget.finalize_pending_edit()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 export function maybe_update_error_message(): void {
     const group_name = $<HTMLInputElement>("input#create_user_group_name").val()!.trim();
     user_group_name_error.pre_validate(group_name);
@@ -270,6 +284,15 @@ export function set_up_handlers(): void {
             return;
         }
 
+        void (async () => {
+            if (!(await finalize_pending_pill_edits())) {
+                return;
+            }
+            maybe_create_user_group();
+        })();
+    });
+
+    function maybe_create_user_group(): void {
         const principals = user_group_create_members_data.get_principals();
         const subgroups = user_group_create_members_data.get_subgroups();
         if (principals.length === 0 && subgroups.length === 0) {
@@ -290,7 +313,7 @@ export function set_up_handlers(): void {
         }
 
         create_user_group();
-    });
+    }
 
     $container.on("input", "#create_user_group_name", () => {
         const user_group_name = $<HTMLInputElement>("input#create_user_group_name").val()!.trim();

--- a/web/src/user_group_create_members.ts
+++ b/web/src/user_group_create_members.ts
@@ -28,6 +28,22 @@ export function get_subgroups(): number[] {
     return user_group_create_members_data.get_subgroups();
 }
 
+export async function finalize_pending_edit(): Promise<boolean> {
+    if (!pill_widget.has_pending_edit()) {
+        return true;
+    }
+    if (!pill_widget.finalize_pending_edit()) {
+        return false;
+    }
+    // The pill hooks that sync our member list run asynchronously, so a
+    // just-committed edit has not reached it before the caller reads it.
+    sync_members(
+        await add_group_members_pill.get_pill_user_ids(pill_widget),
+        add_group_members_pill.get_pill_group_ids(pill_widget),
+    );
+    return true;
+}
+
 function redraw_member_list(): void {
     all_users_list_widget.replace_list_data(user_group_create_members_data.sorted_members());
 }

--- a/web/src/user_group_picker_pill.ts
+++ b/web/src/user_group_picker_pill.ts
@@ -65,6 +65,9 @@ function set_up_pill_typeahead(
         return user_group_pill.filter_taken_groups(groups_with_permission, pill_widget);
     };
     set_up_user_group($pill_container.find(".input"), pill_widget, {user_group_source});
+    pill_widget.setSetupTypeahead(($edit) =>
+        set_up_user_group($edit, pill_widget, {user_group_source}),
+    );
 }
 
 function get_display_value_from_item(item: UserGroupPill): string {

--- a/web/src/user_pill.ts
+++ b/web/src/user_pill.ts
@@ -222,6 +222,8 @@ export function generate_pill_html(item: UserPill, show_user_status_emoji = fals
 export function create_pills(
     $pill_container: JQuery,
     pill_config?: InputPillConfig,
+    // Some callers only display pills, with no way to add or remove them.
+    {disable_pill_editing = false}: {disable_pill_editing?: boolean} = {},
 ): input_pill.InputPillContainer<UserPill> {
     const pills = input_pill.create({
         $container: $pill_container,
@@ -230,6 +232,7 @@ export function create_pills(
         get_text_from_item: get_unique_full_name_from_item,
         get_display_value_from_item,
         generate_pill_html,
+        disable_pill_editing,
     });
     return pills;
 }

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -214,7 +214,9 @@ function initialize_bot_owner(
                 )}"] .pill-container`,
             )
             .expectOne();
-        const pills = user_pill.create_pills($pill_container);
+        const pills = user_pill.create_pills($pill_container, undefined, {
+            disable_pill_editing: true,
+        });
 
         user_pill.append_user(bot_owner, pills);
         user_pills.set(bot_owner.user_id, pills);

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -213,7 +213,9 @@ function initialize_bot_owner(
                 )}"] .pill-container`,
             )
             .expectOne();
-        const pills = user_pill.create_pills($pill_container);
+        const pills = user_pill.create_pills($pill_container, undefined, {
+            disable_pill_editing: true,
+        });
 
         user_pill.append_user(bot_owner, pills);
         user_pills.set(bot_owner.user_id, pills);

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -1350,6 +1350,12 @@ export function show_edit_user_info_modal(user_id: number, $container: JQuery): 
     // calls when the "Manage user" tab is opened multiple times.
     $("#user-profile-modal").off("click", ".dialog_submit_button");
     $("#user-profile-modal").on("click", ".dialog_submit_button", () => {
+        for (const field_pills of fields_user_pills.values()) {
+            if (!field_pills.finalize_pending_edit()) {
+                return;
+            }
+        }
+
         const role = Number.parseInt(
             $<HTMLSelectOneElement>("select:not([multiple])#user-role-select").val()!.trim(),
             10,
@@ -1651,6 +1657,10 @@ export function initialize(): void {
             ) {
                 $("#user-group-to-add .pill-container").addClass("invalid");
             }
+            return;
+        }
+
+        if (!user_group_pill_widget.finalize_pending_edit()) {
             return;
         }
 

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -220,12 +220,41 @@
         flex: 1 1 auto;
 
         outline: none;
+    }
 
-        &.shake {
-            animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
-            transform: translate3d(0, 0, 0);
-            backface-visibility: hidden;
-            perspective: 1000px;
+    .pill.shake,
+    .input.shake {
+        animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+        transform: translate3d(0, 0, 0);
+        backface-visibility: hidden;
+        perspective: 1000px;
+    }
+
+    .pill-edit-input {
+        display: none;
+    }
+
+    .pill.editing {
+        /* Match .pill:focus */
+        box-shadow: 0 0 0 1px var(--color-focus-outline-input-pill) inset;
+        cursor: text;
+
+        .pill-image,
+        .pill-image-border,
+        .pill-label,
+        .expand,
+        .exit {
+            display: none;
+        }
+
+        .pill-edit-input {
+            display: inline-block;
+            min-width: 2em;
+            padding: 0 var(--input-pill-side-padding);
+            overflow-wrap: normal;
+            white-space: nowrap;
+            line-height: var(--height-input-pill);
+            outline: none;
         }
     }
 

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -219,6 +219,36 @@
         outline: none;
     }
 
+    .pill-edit-input {
+        display: none;
+    }
+
+    .pill.editing {
+        /* Match .pill:focus */
+        box-shadow: 0 0 0 1px var(--color-focus-outline-input-pill) inset;
+        cursor: text;
+        /* Wrapped text must grow the pill, not paint outside it. */
+        height: auto;
+        min-height: var(--height-input-pill);
+
+        .pill-image,
+        .pill-image-border,
+        .pill-label,
+        .expand,
+        .exit {
+            display: none;
+        }
+
+        .pill-edit-input {
+            display: inline-block;
+            min-width: 2em;
+            padding: 0 var(--input-pill-side-padding);
+            overflow-wrap: anywhere;
+            line-height: var(--height-input-pill);
+            outline: none;
+        }
+    }
+
     &.not-editable-by-user {
         cursor: not-allowed;
         background-color: var(--color-background-pill-container-input-disabled);

--- a/web/templates/input_pill.hbs
+++ b/web/templates/input_pill.hbs
@@ -52,4 +52,7 @@
         <a role="button" class="zulip-icon zulip-icon-close pill-close-button" aria-label="{{t 'Remove' }}"></a>
     </div>
     {{/unless}}
+    {{#unless read_only}}
+    <span class="pill-edit-input" contenteditable="true" spellcheck="false"></span>
+    {{/unless}}
 </div>

--- a/web/templates/input_pill.hbs
+++ b/web/templates/input_pill.hbs
@@ -52,4 +52,7 @@
         <i role="button" class="zulip-icon zulip-icon-close pill-close-button" aria-label="{{t 'Remove' }}"></i>
     </div>
     {{/unless}}
+    {{#unless read_only}}
+    <span class="pill-edit-input" contenteditable="true" spellcheck="false"></span>
+    {{/unless}}
 </div>

--- a/web/templates/search_list_item.hbs
+++ b/web/templates/search_list_item.hbs
@@ -5,7 +5,7 @@
         {{else if (eq this.type "search_user")}}
             <span class="pill-container">{{> search_user_pill this}}</span>
         {{else}}
-            <span class="pill-container">{{> input_pill this}}</span>
+            <span class="pill-container">{{> input_pill this read_only=true}}</span>
         {{/if}}
     {{/each}}
     {{#if description_html}}<div class="description">{{{description_html}}}</div>{{/if}}

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -518,6 +518,7 @@ test_ui("finish", ({override, override_rewire}) => {
         override_rewire(compose_ui, "compose_spinner_visible", false);
         compose_state.set_message_type("private");
         override(compose_pm_pill, "get_user_ids", () => [bob.user_id]);
+        override(compose_pm_pill, "finalize_pending_edit", () => true);
         override(realm, "realm_direct_message_permission_group", everyone.id);
         override(realm, "realm_direct_message_initiator_group", everyone.id);
 

--- a/web/tests/compose_pm_pill.test.cjs
+++ b/web/tests/compose_pm_pill.test.cjs
@@ -298,3 +298,22 @@ run_test("update_user_pill_full_name", ({override_rewire}) => {
     compose_pm_pill.update_user_pill_full_name(1, "Othello the Moor");
     assert.ok(user_pill_function_called);
 });
+
+run_test("finalize_pending_edit", ({override_rewire}) => {
+    // The wrapper just delegates to the widget, returning its result so a
+    // submit path can block on an unresolved edit.
+    let called = false;
+    override_rewire(compose_pm_pill, "widget", {
+        finalize_pending_edit() {
+            called = true;
+            return true;
+        },
+    });
+    assert.equal(compose_pm_pill.finalize_pending_edit(), true);
+    assert.ok(called);
+
+    override_rewire(compose_pm_pill, "widget", {
+        finalize_pending_edit: () => false,
+    });
+    assert.equal(compose_pm_pill.finalize_pending_edit(), false);
+});

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1416,6 +1416,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
         items: () => pill_items,
         onPillCreate() {},
         onPillRemove() {},
+        setSetupTypeahead() {},
         appendValidatedData(item) {
             appended_names.push(user_pill.get_display_value_from_item(item));
         },

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1590,6 +1590,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
         items: () => pill_items,
         onPillCreate() {},
         onPillRemove() {},
+        setSetupTypeahead() {},
         appendValidatedData(item) {
             appended_names.push(user_pill.get_display_value_from_item(item));
         },

--- a/web/tests/input_pill.test.cjs
+++ b/web/tests/input_pill.test.cjs
@@ -16,6 +16,9 @@ mock_esm("../src/ui_util", {
 
 set_global("getSelection", () => ({
     anchorOffset: 0,
+    toString() {
+        return "";
+    },
 }));
 
 const input_pill = zrequire("input_pill");
@@ -514,7 +517,7 @@ run_test("misc things", () => {
     input_pill.create(info.config);
 
     // animation
-    const animation_end_handler = $container.get_on_handler("animationend", ".input");
+    const animation_end_handler = $container.get_on_handler("animationend", ".input, .pill");
 
     let shake_class_removed = false;
 
@@ -737,4 +740,577 @@ run_test("updatePill", ({mock_template}) => {
     // Blue pill data should remain unchanged
     assert.equal(blue_pill.item.color_name, "DARK BLUE");
     assert.equal(blue_pill.item.description, "color of the deep ocean");
+});
+
+function set_up_for_editing(mock_template, config_overrides = {}) {
+    mock_template("input_pill.hbs", true, (data, html) => {
+        $(html)[0] = `<pill-stub ${data.display_value}>`;
+        $(html).length = 1;
+        return html;
+    });
+
+    const info = set_up();
+    const {config, $container, $pill_input, items} = info;
+    Object.assign(config, config_overrides);
+
+    const widget = input_pill.create(config);
+    widget.appendValue("blue,red");
+
+    const pills = widget._get_pills_for_testing();
+    for (const [i, pill] of pills.entries()) {
+        pill.$element.remove = noop;
+        pill.$element.replaceWith = noop;
+        // Pre-render the edit span (normally rendered in input_pill.hbs).
+        const $edit = $.create(`pill-edit-input-${i}`);
+        pill.$element.find = (sel) => (sel === ".pill-edit-input" ? $edit : {length: 0});
+    }
+
+    return {widget, pills, $container, $pill_input, items};
+}
+
+function start_editing_pill_via_dblclick($container, pill) {
+    // The edit span is already inside the pill (pre-rendered in the template).
+    const $edit = pill.$element.find(".pill-edit-input");
+
+    const dblclick_handler = $container.get_on_handler("dblclick", ".pill");
+    dblclick_handler.call(pill.$element[0], {
+        target: {
+            to_$: () => ({
+                closest(_sel) {
+                    return {length: 0};
+                },
+            }),
+        },
+        preventDefault: noop,
+    });
+
+    return $edit;
+}
+
+run_test("dblclick starts in-place editing", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+
+    const blue_pill = pills[0];
+    assert.equal(blue_pill.item.color_name, "BLUE");
+
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+
+    assert.ok($edit !== undefined);
+    assert.equal(widget._get_pills_for_testing().length, 2);
+    assert.equal($edit.text(), "BLUE");
+});
+
+run_test("Enter key commits in-place edit", ({mock_template}) => {
+    const {widget, pills, $container, items} = set_up_for_editing(mock_template);
+
+    let pill_removed = false;
+    let pill_created = false;
+    widget.onPillRemove(() => {
+        pill_removed = true;
+    });
+    widget.onPillCreate(() => {
+        pill_created = true;
+    });
+
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+
+    let pill_replaced = false;
+    blue_pill.$element.replaceWith = () => {
+        pill_replaced = true;
+    };
+
+    $edit.text("yellow");
+
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    assert.ok(pill_replaced);
+    assert.ok(pill_removed);
+    assert.ok(pill_created);
+    // YELLOW replaces BLUE at index 0; store.pills must stay in DOM order.
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["YELLOW", "RED"],
+    );
+    assert.deepEqual(widget.items()[0], items.yellow);
+});
+
+run_test("empty edit deletes the pill", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+
+    let pill_removed = false;
+    widget.onPillRemove(() => {
+        pill_removed = true;
+    });
+
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+
+    $edit.remove = noop;
+
+    $edit.text("");
+
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["RED"],
+    );
+    assert.ok(pill_removed);
+});
+
+run_test("Escape cancels in-place edit", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+
+    $edit.remove = noop;
+
+    // Change the text to verify Escape truly cancels and reverts.
+    $edit.text("yellow");
+
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "Escape",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    // The pill stays in the DOM; editing class is removed on cancel.
+    assert.ok(!blue_pill.$element.hasClass("editing"));
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+});
+
+run_test("Enter on focused pill starts editing", ({mock_template}) => {
+    const {pills, $container} = set_up_for_editing(mock_template);
+
+    const blue_pill = pills[0];
+    const $edit = blue_pill.$element.find(".pill-edit-input");
+
+    // find(".pill:focus") is how the keydown handler locates the focused pill.
+    $container.set_find_results(".pill:focus", blue_pill.$element);
+
+    const pill_keydown = $container.get_on_handler("keydown", ".pill");
+    pill_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    assert.ok($edit !== undefined);
+    assert.equal($edit.text(), "BLUE");
+});
+
+run_test("unchanged edit cancels instead of validating", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+    // Trigger Enter without changing the text.
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+});
+
+run_test("edit box seeds and compares against the display value", ({mock_template}) => {
+    // Role-based system groups display a friendly name ("Administrators")
+    // that differs from their internal text ("role:administrators"). The edit
+    // box must show the display value, and committing it unchanged must cancel
+    // rather than validate the display string as new input.
+    const display_names = {BLUE: "Blue", RED: "Red"};
+    const {widget, pills, $container, $pill_input} = set_up_for_editing(mock_template, {
+        get_display_value_from_item: (item) => display_names[item.color_name] ?? item.color_name,
+    });
+
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+
+    // Seeded with the display value, not the internal "BLUE".
+    assert.equal($edit.text(), "Blue");
+
+    // Committing the unchanged display value cancels cleanly: no validation,
+    // no shake, pills intact.
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+    assert.ok(!$pill_input.hasClass("shake"));
+    assert.ok(!widget._get_pills_for_testing()[0].$element.hasClass("shake"));
+});
+
+run_test("invalid edit restores pill and applies shake", ({mock_template}) => {
+    const {widget, pills, $container, $pill_input} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+    $edit.text("invalid_color_name");
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+    // The validation shake should be redirected from the main input to the restored pill.
+    assert.ok(!$pill_input.hasClass("shake"));
+    assert.ok(widget._get_pills_for_testing()[0].$element.hasClass("shake"));
+});
+
+run_test("items() includes the pill being edited as its pre-edit value", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+
+    start_editing_pill_via_dblclick($container, blue_pill);
+
+    // items() still reports the edited pill (as its pre-edit value) so a
+    // submit read can't silently drop it; submit paths finalize first.
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+
+    // getPillByPredicate, used by live-update handlers that call updatePill,
+    // still skips the edited pill so a live update can't clobber the edit.
+    assert.equal(
+        widget.getPillByPredicate((item) => item.color_name === "BLUE"),
+        undefined,
+    );
+    assert.ok(widget.getPillByPredicate((item) => item.color_name === "RED"));
+});
+
+run_test("finalize_pending_edit is a no-op when not editing", ({mock_template}) => {
+    const {widget} = set_up_for_editing(mock_template);
+    assert.ok(widget.finalize_pending_edit());
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+});
+
+run_test("finalize_pending_edit commits a valid in-flight edit", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.text("yellow");
+
+    // A submit path calling this must see the committed value (YELLOW), not
+    // the pill's pre-edit value (BLUE).
+    assert.ok(widget.finalize_pending_edit());
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["YELLOW", "RED"],
+    );
+    // The edit is resolved, so a subsequent call is a no-op.
+    assert.ok(widget.finalize_pending_edit());
+});
+
+run_test("finalize_pending_edit blocks an unresolved invalid edit", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+    $edit.text("invalid_color_name");
+
+    // The submit must be blocked rather than fall back to the pill's
+    // stale, pre-edit value.
+    assert.ok(!widget.finalize_pending_edit());
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+    assert.ok(widget._get_pills_for_testing()[0].$element.hasClass("shake"));
+});
+
+run_test("typeahead selection updates pill in place", ({mock_template}) => {
+    const {widget, pills, $container, items} = set_up_for_editing(mock_template);
+
+    let pill_removed = false;
+    let pill_created = false;
+    widget.onPillRemove(() => {
+        pill_removed = true;
+    });
+    widget.onPillCreate(() => {
+        pill_created = true;
+    });
+    const blue_pill = pills[0];
+    start_editing_pill_via_dblclick($container, blue_pill);
+
+    let pill_replaced = false;
+    blue_pill.$element.replaceWith = () => {
+        pill_replaced = true;
+    };
+
+    // Simulate typeahead selecting "yellow": the updater calls updatePillAfterEdit
+    // directly, bypassing appendValidatedData.
+    widget.updatePillAfterEdit(items.yellow);
+
+    assert.ok(pill_replaced);
+    assert.ok(pill_removed);
+    assert.ok(pill_created);
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["YELLOW", "RED"],
+    );
+    assert.deepEqual(widget.items()[0], items.yellow);
+});
+
+run_test("ArrowRight at end of edit moves to next pill", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+
+    $edit.remove = noop;
+
+    // Mock getSelection to report cursor at end of the edit element.
+    const saved_get_selection = window.getSelection;
+    window.getSelection = () => ({
+        toString() {
+            return "";
+        },
+        rangeCount: 1,
+        getRangeAt() {
+            return {
+                endContainer: {},
+                endOffset: 0,
+            };
+        },
+    });
+    const saved_create_range = document.createRange;
+    document.createRange = () => ({
+        selectNodeContents: noop,
+        setStart: noop,
+        toString() {
+            return "";
+        },
+    });
+
+    // Provide a next sibling pill so the ArrowRight handler has something to focus.
+    const $next_pill = $.create("next-pill");
+    $next_pill.trigger = noop;
+    blue_pill.$element.next = () => $next_pill;
+
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "ArrowRight",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    // Edit is cancelled; pill stays in DOM with editing class removed.
+    assert.ok(!blue_pill.$element.hasClass("editing"));
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+
+    window.getSelection = saved_get_selection;
+    document.createRange = saved_create_range;
+});
+
+run_test("Enter leaves an open typeahead to handle itself", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+
+    // We ask this edit's own typeahead whether its menu is open, since the
+    // search typeahead leaves a highlighted row in the DOM even when hidden.
+    const typeahead_stub = {
+        shown: true,
+        unlisten: noop,
+    };
+    widget.setSetupTypeahead(() => typeahead_stub);
+
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+    $edit.text("yellow");
+
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    // The typeahead's keyup handler applies the suggestion, so the edit is
+    // still in flight.
+    assert.ok(blue_pill.$element.hasClass("editing"));
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+
+    typeahead_stub.shown = false;
+    edit_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["YELLOW", "RED"],
+    );
+});
+
+run_test("disable_pill_editing keeps pills read-only", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template, {
+        disable_pill_editing: true,
+    });
+    const blue_pill = pills[0];
+
+    start_editing_pill_via_dblclick($container, blue_pill);
+    assert.ok(!blue_pill.$element.hasClass("editing"));
+
+    // Enter on a focused pill must not start an edit either.
+    $container.set_find_results(".pill:focus", blue_pill.$element);
+    $container.get_on_handler(
+        "keydown",
+        ".pill",
+    )({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+    assert.ok(!blue_pill.$element.hasClass("editing"));
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+});
+
+run_test("editing a pill again with no typeahead", ({mock_template}) => {
+    // Invite emails and integration-URL branch pills have no typeahead.
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+    $edit.get_on_handler("keydown")({
+        key: "Escape",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    assert.equal(start_editing_pill_via_dblclick($container, blue_pill), $edit);
+    $edit.text("yellow");
+    $edit.get_on_handler("keydown")({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["YELLOW", "RED"],
+    );
+});
+
+run_test("editing a pill again tears down the previous edit", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+
+    // Every edit sets up its own typeahead, so every edit has to tear it down.
+    let typeaheads_set_up = 0;
+    let typeaheads_torn_down = 0;
+    widget.setSetupTypeahead(() => {
+        typeaheads_set_up += 1;
+        return {
+            shown: false,
+            unlisten() {
+                typeaheads_torn_down += 1;
+            },
+        };
+    });
+
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+    assert.equal(typeaheads_set_up, 1);
+    assert.equal(typeaheads_torn_down, 0);
+
+    $edit.get_on_handler("keydown")({
+        key: "Escape",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+    assert.equal(typeaheads_torn_down, 1);
+
+    // Editing it again reuses the same element, so nothing from the previous
+    // edit may still be attached: zjquery throws on a duplicate handler.
+    assert.equal(start_editing_pill_via_dblclick($container, blue_pill), $edit);
+    assert.equal(typeaheads_set_up, 2);
+    assert.equal(typeaheads_torn_down, 1);
+
+    // Committing replaces the pill element, but the typeahead is still ours.
+    $edit.text("yellow");
+    $edit.get_on_handler("keydown")({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["YELLOW", "RED"],
+    );
+    assert.equal(typeaheads_torn_down, 2);
+});
+
+run_test("ArrowLeft at start of edit cancels and restores pill", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+
+    $edit.remove = noop;
+
+    // Provide a previous sibling so the ArrowLeft handler finds a pill to focus.
+    const $prev_pill = $.create("prev-pill");
+    $prev_pill.trigger = noop;
+    blue_pill.$element.prev = (sel) => (sel === ".pill" ? $prev_pill : {length: 0});
+
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "ArrowLeft",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    // Edit is cancelled; pill stays in DOM with editing class removed.
+    assert.ok(!blue_pill.$element.hasClass("editing"));
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
 });

--- a/web/tests/input_pill.test.cjs
+++ b/web/tests/input_pill.test.cjs
@@ -16,7 +16,24 @@ mock_esm("../src/ui_util", {
 
 set_global("getSelection", () => ({
     anchorOffset: 0,
+    toString() {
+        return "";
+    },
 }));
+
+// The blur-commit of a pill edit is deferred, so tests run it explicitly.
+let deferred_callbacks = [];
+set_global("setTimeout", (f) => {
+    deferred_callbacks.push(f);
+});
+
+function run_deferred_callbacks() {
+    const callbacks = deferred_callbacks;
+    deferred_callbacks = [];
+    for (const callback of callbacks) {
+        callback();
+    }
+}
 
 const input_pill = zrequire("input_pill");
 
@@ -514,7 +531,7 @@ run_test("misc things", () => {
     input_pill.create(info.config);
 
     // animation
-    const animation_end_handler = $container.get_on_handler("animationend", ".input");
+    const animation_end_handler = $container.get_on_handler("animationend", ".input, .pill");
 
     let shake_class_removed = false;
 
@@ -737,4 +754,666 @@ run_test("updatePill", ({mock_template}) => {
     // Blue pill data should remain unchanged
     assert.equal(blue_pill.item.color_name, "DARK BLUE");
     assert.equal(blue_pill.item.description, "color of the deep ocean");
+});
+
+function set_up_for_editing(mock_template, config_overrides = {}) {
+    mock_template("input_pill.hbs", true, (data, html) => {
+        $(html)[0] = `<pill-stub ${data.display_value}>`;
+        $(html).length = 1;
+        return html;
+    });
+
+    // The deferred blur-commit waits while the typeahead menu is hovered.
+    $.set_results(".typeahead:hover", []);
+
+    const info = set_up();
+    const {config, $container, $pill_input, items} = info;
+    Object.assign(config, config_overrides);
+
+    const widget = input_pill.create(config);
+    widget.appendValue("blue,red");
+
+    const pills = widget._get_pills_for_testing();
+    for (const [i, pill] of pills.entries()) {
+        pill.$element.remove = noop;
+        pill.$element.replaceWith = noop;
+        // Pre-render the edit span (normally rendered in input_pill.hbs).
+        const $edit = $.create(`pill-edit-input-${i}`);
+        pill.$element.find = (sel) => (sel === ".pill-edit-input" ? $edit : {length: 0});
+    }
+
+    return {widget, pills, $container, $pill_input, items};
+}
+
+function start_editing_pill_via_dblclick($container, pill) {
+    // The edit span is already inside the pill (pre-rendered in the template).
+    const $edit = pill.$element.find(".pill-edit-input");
+
+    const dblclick_handler = $container.get_on_handler("dblclick", ".pill");
+    dblclick_handler.call(pill.$element[0], {
+        target: {
+            to_$: () => ({
+                closest(_sel) {
+                    return {length: 0};
+                },
+            }),
+        },
+        preventDefault: noop,
+    });
+
+    return $edit;
+}
+
+run_test("dblclick starts in-place editing", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+
+    const blue_pill = pills[0];
+    assert.equal(blue_pill.item.color_name, "BLUE");
+
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+
+    assert.ok($edit !== undefined);
+    assert.equal(widget._get_pills_for_testing().length, 2);
+    assert.equal($edit.text(), "BLUE");
+});
+
+run_test("Enter key commits in-place edit", ({mock_template}) => {
+    const {widget, pills, $container, items} = set_up_for_editing(mock_template);
+
+    let pill_removed = false;
+    let pill_created = false;
+    widget.onPillRemove(() => {
+        pill_removed = true;
+    });
+    widget.onPillCreate(() => {
+        pill_created = true;
+    });
+
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+
+    let pill_replaced = false;
+    blue_pill.$element.replaceWith = () => {
+        pill_replaced = true;
+    };
+
+    $edit.text("yellow");
+
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    assert.ok(pill_replaced);
+    assert.ok(pill_removed);
+    assert.ok(pill_created);
+    // YELLOW replaces BLUE at index 0; store.pills must stay in DOM order.
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["YELLOW", "RED"],
+    );
+    assert.deepEqual(widget.items()[0], items.yellow);
+});
+
+run_test("empty edit deletes the pill", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+
+    let pill_removed = false;
+    widget.onPillRemove(() => {
+        pill_removed = true;
+    });
+
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+
+    $edit.remove = noop;
+
+    $edit.text("");
+
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["RED"],
+    );
+    assert.ok(pill_removed);
+});
+
+run_test("Escape cancels in-place edit", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+
+    $edit.remove = noop;
+
+    // Change the text to verify Escape truly cancels and reverts.
+    $edit.text("yellow");
+
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "Escape",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    // The pill stays in the DOM; editing class is removed on cancel.
+    assert.ok(!blue_pill.$element.hasClass("editing"));
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+});
+
+run_test("Enter on focused pill starts editing", ({mock_template}) => {
+    const {pills, $container} = set_up_for_editing(mock_template);
+
+    const blue_pill = pills[0];
+    const $edit = blue_pill.$element.find(".pill-edit-input");
+
+    // find(".pill:focus") is how the keydown handler locates the focused pill.
+    $container.set_find_results(".pill:focus", blue_pill.$element);
+
+    const pill_keydown = $container.get_on_handler("keydown", ".pill");
+    pill_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    assert.ok($edit !== undefined);
+    assert.equal($edit.text(), "BLUE");
+});
+
+run_test("unchanged edit cancels instead of validating", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+    // Trigger Enter without changing the text.
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+});
+
+run_test("edit box seeds and compares against the display value", ({mock_template}) => {
+    // Role-based system groups display a friendly name ("Administrators")
+    // that differs from their internal text ("role:administrators"). The edit
+    // box must show the display value, and committing it unchanged must cancel
+    // rather than validate the display string as new input.
+    const display_names = {BLUE: "Blue", RED: "Red"};
+    const {widget, pills, $container, $pill_input} = set_up_for_editing(mock_template, {
+        get_display_value_from_item: (item) => display_names[item.color_name] ?? item.color_name,
+    });
+
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+
+    // Seeded with the display value, not the internal "BLUE".
+    assert.equal($edit.text(), "Blue");
+
+    // Committing the unchanged display value cancels cleanly: no validation,
+    // no shake, pills intact.
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+    assert.ok(!$pill_input.hasClass("input-validation-shake"));
+    assert.ok(!widget._get_pills_for_testing()[0].$element.hasClass("input-validation-shake"));
+});
+
+run_test("invalid edit shakes but keeps the typed text", ({mock_template}) => {
+    const {widget, pills, $container, $pill_input} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+    $edit.text("invalid_color_name");
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+    // The validation shake should be redirected from the main input to the pill.
+    assert.ok(!$pill_input.hasClass("input-validation-shake"));
+    assert.ok(blue_pill.$element.hasClass("input-validation-shake"));
+    // The edit stays open with the text, so it can be fixed, not retyped.
+    assert.ok(widget.has_pending_edit());
+    assert.ok(blue_pill.$element.hasClass("editing"));
+    assert.equal($edit.text(), "invalid_color_name");
+});
+
+run_test("invalid edit reverts once focus leaves the pill", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+    $edit.text("invalid_color_name");
+
+    // A pill that isn't being edited has to show a valid value, so this reverts.
+    $edit.get_on_handler("blur")();
+    run_deferred_callbacks();
+
+    assert.ok(!widget.has_pending_edit());
+    assert.ok(!blue_pill.$element.hasClass("editing"));
+    assert.ok(blue_pill.$element.hasClass("input-validation-shake"));
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+});
+
+run_test("blur ends an unchanged edit without taking focus", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+
+    // Pulling focus back would interrupt typing wherever the user went.
+    /* istanbul ignore next */
+    blue_pill.$element.trigger = () => {
+        throw new Error("ending an edit on blur must not take focus");
+    };
+
+    $edit.get_on_handler("blur")();
+    run_deferred_callbacks();
+
+    assert.ok(!widget.has_pending_edit());
+    assert.ok(!blue_pill.$element.hasClass("editing"));
+});
+
+run_test("deferred blur-commit bails once the edit box has focus again", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+    $edit.text("yellow");
+
+    // Clicking the typeahead menu blurs the edit box and then gives focus
+    // back, so the edit has to survive.
+    $edit.get_on_handler("blur")();
+    $edit.trigger("focus");
+    run_deferred_callbacks();
+
+    assert.ok(widget.has_pending_edit());
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+});
+
+run_test("editing another pill resolves the in-flight edit", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const [blue_pill, red_pill] = pills;
+    const $blue_edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $blue_edit.remove = noop;
+    $blue_edit.text("yellow");
+
+    // The blur-commit from that click is deferred, so it has to be resolved
+    // here or the click is swallowed.
+    $blue_edit.get_on_handler("blur")();
+    start_editing_pill_via_dblclick($container, red_pill);
+
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["YELLOW", "RED"],
+    );
+    assert.ok(!blue_pill.$element.hasClass("editing"));
+    assert.ok(red_pill.$element.hasClass("editing"));
+    assert.ok(widget.has_pending_edit());
+});
+
+run_test("items() includes the pill being edited as its pre-edit value", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+
+    start_editing_pill_via_dblclick($container, blue_pill);
+
+    // items() still reports the edited pill (as its pre-edit value) so a
+    // submit read can't silently drop it; submit paths finalize first.
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+
+    // getPillByPredicate, used by live-update handlers that call updatePill,
+    // still skips the edited pill so a live update can't clobber the edit.
+    assert.equal(
+        widget.getPillByPredicate((item) => item.color_name === "BLUE"),
+        undefined,
+    );
+    assert.ok(widget.getPillByPredicate((item) => item.color_name === "RED"));
+});
+
+run_test("finalize_pending_edit is a no-op when not editing", ({mock_template}) => {
+    const {widget} = set_up_for_editing(mock_template);
+    assert.ok(widget.finalize_pending_edit());
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+});
+
+run_test("finalize_pending_edit commits a valid in-flight edit", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.text("yellow");
+
+    // A submit path calling this must see the committed value (YELLOW), not
+    // the pill's pre-edit value (BLUE).
+    assert.ok(widget.finalize_pending_edit());
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["YELLOW", "RED"],
+    );
+    // The edit is resolved, so a subsequent call is a no-op.
+    assert.ok(widget.finalize_pending_edit());
+});
+
+run_test("finalize_pending_edit blocks an unresolved invalid edit", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+    $edit.text("invalid_color_name");
+
+    // The submit must be blocked rather than fall back to the pill's
+    // stale, pre-edit value, and the text stays for the user to fix.
+    assert.ok(!widget.finalize_pending_edit());
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+    assert.ok(widget._get_pills_for_testing()[0].$element.hasClass("input-validation-shake"));
+    assert.ok(widget.has_pending_edit());
+    assert.equal($edit.text(), "invalid_color_name");
+});
+
+run_test("typeahead selection updates pill in place", ({mock_template}) => {
+    const {widget, pills, $container, items} = set_up_for_editing(mock_template);
+
+    let pill_removed = false;
+    let pill_created = false;
+    widget.onPillRemove(() => {
+        pill_removed = true;
+    });
+    widget.onPillCreate(() => {
+        pill_created = true;
+    });
+    const blue_pill = pills[0];
+    start_editing_pill_via_dblclick($container, blue_pill);
+
+    let pill_replaced = false;
+    blue_pill.$element.replaceWith = () => {
+        pill_replaced = true;
+    };
+
+    // Simulate typeahead selecting "yellow": the updater calls updatePillAfterEdit
+    // directly, bypassing appendValidatedData.
+    widget.updatePillAfterEdit(items.yellow);
+
+    assert.ok(pill_replaced);
+    assert.ok(pill_removed);
+    assert.ok(pill_created);
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["YELLOW", "RED"],
+    );
+    assert.deepEqual(widget.items()[0], items.yellow);
+});
+
+run_test("ArrowRight at end of edit moves to next pill", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+
+    $edit.remove = noop;
+
+    // Mock getSelection to report cursor at end of the edit element.
+    const saved_get_selection = window.getSelection;
+    window.getSelection = () => ({
+        toString() {
+            return "";
+        },
+        rangeCount: 1,
+        getRangeAt() {
+            return {
+                endContainer: {},
+                endOffset: 0,
+            };
+        },
+    });
+    const saved_create_range = document.createRange;
+    document.createRange = () => ({
+        selectNodeContents: noop,
+        setStart: noop,
+        toString() {
+            return "";
+        },
+    });
+
+    // Provide a next sibling pill so the ArrowRight handler has something to focus.
+    const $next_pill = $.create("next-pill");
+    $next_pill.trigger = noop;
+    blue_pill.$element.next = () => $next_pill;
+
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "ArrowRight",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    // Edit is cancelled; pill stays in DOM with editing class removed.
+    assert.ok(!blue_pill.$element.hasClass("editing"));
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+
+    window.getSelection = saved_get_selection;
+    document.createRange = saved_create_range;
+});
+
+run_test("Enter leaves an open typeahead to handle itself", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+
+    // We ask this edit's own typeahead whether its menu is open, since the
+    // search typeahead leaves a highlighted row in the DOM even when hidden.
+    const typeahead_stub = {
+        shown: true,
+        unlisten: noop,
+    };
+    widget.setSetupTypeahead(() => typeahead_stub);
+
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+    $edit.text("yellow");
+
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    // The typeahead's keyup handler applies the suggestion, so the edit is
+    // still in flight.
+    assert.ok(blue_pill.$element.hasClass("editing"));
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+
+    typeahead_stub.shown = false;
+    edit_keydown({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["YELLOW", "RED"],
+    );
+});
+
+run_test("disable_pill_editing keeps pills read-only", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template, {
+        disable_pill_editing: true,
+    });
+    const blue_pill = pills[0];
+
+    start_editing_pill_via_dblclick($container, blue_pill);
+    assert.ok(!blue_pill.$element.hasClass("editing"));
+
+    // Enter on a focused pill must not start an edit either.
+    $container.set_find_results(".pill:focus", blue_pill.$element);
+    $container.get_on_handler(
+        "keydown",
+        ".pill",
+    )({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+    assert.ok(!blue_pill.$element.hasClass("editing"));
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
+});
+
+run_test("editing a pill again with no typeahead", ({mock_template}) => {
+    // Invite emails and integration-URL branch pills have no typeahead.
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+    $edit.get_on_handler("keydown")({
+        key: "Escape",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    assert.equal(start_editing_pill_via_dblclick($container, blue_pill), $edit);
+    $edit.text("yellow");
+    $edit.get_on_handler("keydown")({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["YELLOW", "RED"],
+    );
+});
+
+run_test("editing a pill again tears down the previous edit", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+
+    // Every edit sets up its own typeahead, so every edit has to tear it down.
+    let typeaheads_set_up = 0;
+    let typeaheads_torn_down = 0;
+    widget.setSetupTypeahead(() => {
+        typeaheads_set_up += 1;
+        return {
+            shown: false,
+            unlisten() {
+                typeaheads_torn_down += 1;
+            },
+        };
+    });
+
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+    $edit.remove = noop;
+    assert.equal(typeaheads_set_up, 1);
+    assert.equal(typeaheads_torn_down, 0);
+
+    $edit.get_on_handler("keydown")({
+        key: "Escape",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+    assert.equal(typeaheads_torn_down, 1);
+
+    // Editing it again reuses the same element, so nothing from the previous
+    // edit may still be attached: zjquery throws on a duplicate handler.
+    assert.equal(start_editing_pill_via_dblclick($container, blue_pill), $edit);
+    assert.equal(typeaheads_set_up, 2);
+    assert.equal(typeaheads_torn_down, 1);
+
+    // Committing replaces the pill element, but the typeahead is still ours.
+    $edit.text("yellow");
+    $edit.get_on_handler("keydown")({
+        key: "Enter",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["YELLOW", "RED"],
+    );
+    assert.equal(typeaheads_torn_down, 2);
+});
+
+run_test("ArrowLeft at start of edit cancels and restores pill", ({mock_template}) => {
+    const {widget, pills, $container} = set_up_for_editing(mock_template);
+    const blue_pill = pills[0];
+    const $edit = start_editing_pill_via_dblclick($container, blue_pill);
+
+    $edit.remove = noop;
+
+    // Provide a previous sibling so the ArrowLeft handler finds a pill to focus.
+    const $prev_pill = $.create("prev-pill");
+    $prev_pill.trigger = noop;
+    blue_pill.$element.prev = (sel) => (sel === ".pill" ? $prev_pill : {length: 0});
+
+    const edit_keydown = $edit.get_on_handler("keydown");
+    edit_keydown({
+        key: "ArrowLeft",
+        preventDefault: noop,
+        stopPropagation: noop,
+    });
+
+    // Edit is cancelled; pill stays in DOM with editing class removed.
+    assert.ok(!blue_pill.$element.hasClass("editing"));
+    assert.deepEqual(
+        widget.items().map((i) => i.color_name),
+        ["BLUE", "RED"],
+    );
 });

--- a/web/tests/pill_typeahead.test.cjs
+++ b/web/tests/pill_typeahead.test.cjs
@@ -226,6 +226,20 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
             assert.equal(number_of_pills(), 0);
             config.updater(me_item, person_query);
             assert.equal(number_of_pills(), 1);
+
+            // Test edit path: updatePillAfterEdit is called when the
+            // input has the pill-edit-input class.
+            $fake_input.addClass("pill-edit-input");
+            let replace_called = false;
+            $pill_widget.updatePillAfterEdit = (item) => {
+                replace_called = true;
+                assert.equal(item.user_id, me.user_id);
+            };
+            const pills_before = number_of_pills();
+            config.updater(me_item, person_query);
+            assert.ok(replace_called);
+            assert.equal(number_of_pills(), pills_before);
+            $fake_input.removeClass("pill-edit-input");
         })();
 
         // input_pill_typeahead_called is set true if
@@ -309,6 +323,19 @@ run_test("set_up_stream", ({mock_template, override, override_rewire}) => {
             assert.equal(number_of_pills(), 0);
             config.updater(denmark_item, stream_query);
             assert.equal(number_of_pills(), 1);
+
+            // Test edit path.
+            $fake_input.addClass("pill-edit-input");
+            let replace_called = false;
+            $pill_widget.updatePillAfterEdit = (item) => {
+                replace_called = true;
+                assert.equal(item.stream_id, denmark.stream_id);
+            };
+            const pills_before = number_of_pills();
+            config.updater(denmark_item, stream_query);
+            assert.ok(replace_called);
+            assert.equal(number_of_pills(), pills_before);
+            $fake_input.removeClass("pill-edit-input");
         })();
 
         // input_pill_typeahead_called is set true if
@@ -400,6 +427,19 @@ run_test("set_up_user_group", ({mock_template, override, override_rewire}) => {
             assert.equal(number_of_pills(), 0);
             config.updater(testers_item, "<rendered-group-stub>");
             assert.equal(number_of_pills(), 1);
+
+            // Test edit path.
+            $fake_input.addClass("pill-edit-input");
+            let replace_called = false;
+            $pill_widget.updatePillAfterEdit = (item) => {
+                replace_called = true;
+                assert.equal(item.group_id, testers.id);
+            };
+            const pills_before = number_of_pills();
+            config.updater(testers_item, "<rendered-group-stub>");
+            assert.ok(replace_called);
+            assert.equal(number_of_pills(), pills_before);
+            $fake_input.removeClass("pill-edit-input");
         })();
 
         input_pill_typeahead_called = true;
@@ -641,6 +681,20 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
                 // Clear pills for the next test.
                 mock_pill_removes($pill_widget);
                 $pill_widget.clear();
+
+                // Test edit path: all three item types.
+                $fake_input.addClass("pill-edit-input");
+                let replace_count = 0;
+                $pill_widget.updatePillAfterEdit = (_item) => {
+                    replace_count += 1;
+                };
+                const pills_before_edit = number_of_pills();
+                config.updater(denmark_item, stream_query);
+                config.updater(me_item, person_query);
+                config.updater(testers_item, group_query);
+                assert.equal(replace_count, 3);
+                assert.equal(number_of_pills(), pills_before_edit);
+                $fake_input.removeClass("pill-edit-input");
             }
         })();
 
@@ -844,6 +898,30 @@ run_test("set_up_group_setting_typeahead", ({mock_template, override, override_r
             assert.equal(number_of_pills(), 1);
             config.updater(testers_item, group_query);
             assert.equal(number_of_pills(), 2);
+
+            // Test edit path: user_group item.
+            $fake_input.addClass("pill-edit-input");
+            let replace_called = false;
+            $pill_widget.updatePillAfterEdit = (item) => {
+                replace_called = true;
+                assert.equal(item.group_id, testers.id);
+            };
+            const pills_before_group = number_of_pills();
+            config.updater(testers_item, group_query);
+            assert.ok(replace_called);
+            assert.equal(number_of_pills(), pills_before_group);
+
+            // Test edit path: user item.
+            replace_called = false;
+            $pill_widget.updatePillAfterEdit = (item) => {
+                replace_called = true;
+                assert.equal(item.user_id, me.user_id);
+            };
+            const pills_before_user = number_of_pills();
+            config.updater(me_item, person_query);
+            assert.ok(replace_called);
+            assert.equal(number_of_pills(), pills_before_user);
+            $fake_input.removeClass("pill-edit-input");
         })();
 
         input_pill_typeahead_called = true;

--- a/web/tests/pill_typeahead.test.cjs
+++ b/web/tests/pill_typeahead.test.cjs
@@ -226,6 +226,20 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
             assert.equal(number_of_pills(), 0);
             config.updater(me_item, person_query);
             assert.equal(number_of_pills(), 1);
+
+            // Test edit path: updatePillAfterEdit is called when the
+            // input has the pill-edit-input class.
+            $fake_input.addClass("pill-edit-input");
+            let replace_called = false;
+            $pill_widget.updatePillAfterEdit = (item) => {
+                replace_called = true;
+                assert.equal(item.user_id, me.user_id);
+            };
+            const pills_before = number_of_pills();
+            config.updater(me_item, person_query);
+            assert.ok(replace_called);
+            assert.equal(number_of_pills(), pills_before);
+            $fake_input.removeClass("pill-edit-input");
         })();
 
         // input_pill_typeahead_called is set true if
@@ -309,6 +323,19 @@ run_test("set_up_stream", ({mock_template, override, override_rewire}) => {
             assert.equal(number_of_pills(), 0);
             config.updater(denmark_item, stream_query);
             assert.equal(number_of_pills(), 1);
+
+            // Test edit path.
+            $fake_input.addClass("pill-edit-input");
+            let replace_called = false;
+            $pill_widget.updatePillAfterEdit = (item) => {
+                replace_called = true;
+                assert.equal(item.stream_id, denmark.stream_id);
+            };
+            const pills_before = number_of_pills();
+            config.updater(denmark_item, stream_query);
+            assert.ok(replace_called);
+            assert.equal(number_of_pills(), pills_before);
+            $fake_input.removeClass("pill-edit-input");
         })();
 
         // input_pill_typeahead_called is set true if
@@ -400,6 +427,19 @@ run_test("set_up_user_group", ({mock_template, override, override_rewire}) => {
             assert.equal(number_of_pills(), 0);
             config.updater(testers_item, "<rendered-group-stub>");
             assert.equal(number_of_pills(), 1);
+
+            // Test edit path.
+            $fake_input.addClass("pill-edit-input");
+            let replace_called = false;
+            $pill_widget.updatePillAfterEdit = (item) => {
+                replace_called = true;
+                assert.equal(item.group_id, testers.id);
+            };
+            const pills_before = number_of_pills();
+            config.updater(testers_item, "<rendered-group-stub>");
+            assert.ok(replace_called);
+            assert.equal(number_of_pills(), pills_before);
+            $fake_input.removeClass("pill-edit-input");
         })();
 
         input_pill_typeahead_called = true;
@@ -640,6 +680,20 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
                 // Clear pills for the next test.
                 mock_pill_removes($pill_widget);
                 $pill_widget.clear();
+
+                // Test edit path: all three item types.
+                $fake_input.addClass("pill-edit-input");
+                let replace_count = 0;
+                $pill_widget.updatePillAfterEdit = (_item) => {
+                    replace_count += 1;
+                };
+                const pills_before_edit = number_of_pills();
+                config.updater(denmark_item, stream_query);
+                config.updater(me_item, person_query);
+                config.updater(testers_item, group_query);
+                assert.equal(replace_count, 3);
+                assert.equal(number_of_pills(), pills_before_edit);
+                $fake_input.removeClass("pill-edit-input");
             }
         })();
 
@@ -842,6 +896,30 @@ run_test("set_up_group_setting_typeahead", ({mock_template, override, override_r
             assert.equal(number_of_pills(), 1);
             config.updater(testers_item, group_query);
             assert.equal(number_of_pills(), 2);
+
+            // Test edit path: user_group item.
+            $fake_input.addClass("pill-edit-input");
+            let replace_called = false;
+            $pill_widget.updatePillAfterEdit = (item) => {
+                replace_called = true;
+                assert.equal(item.group_id, testers.id);
+            };
+            const pills_before_group = number_of_pills();
+            config.updater(testers_item, group_query);
+            assert.ok(replace_called);
+            assert.equal(number_of_pills(), pills_before_group);
+
+            // Test edit path: user item.
+            replace_called = false;
+            $pill_widget.updatePillAfterEdit = (item) => {
+                replace_called = true;
+                assert.equal(item.user_id, me.user_id);
+            };
+            const pills_before_user = number_of_pills();
+            config.updater(me_item, person_query);
+            assert.ok(replace_called);
+            assert.equal(number_of_pills(), pills_before_user);
+            $fake_input.removeClass("pill-edit-input");
         })();
 
         input_pill_typeahead_called = true;

--- a/web/tests/stream_pill.test.cjs
+++ b/web/tests/stream_pill.test.cjs
@@ -154,6 +154,7 @@ run_test("generate_pill_html", () => {
             '    <div class="exit">\n' +
             '        <a role="button" class="zulip-icon zulip-icon-close pill-close-button" aria-label="translated: Remove"></a>\n' +
             "    </div>\n" +
+            '    <span class="pill-edit-input" contenteditable="true" spellcheck="false"></span>\n' +
             "</div>\n",
     );
 });

--- a/web/tests/stream_pill.test.cjs
+++ b/web/tests/stream_pill.test.cjs
@@ -154,6 +154,7 @@ run_test("generate_pill_html", () => {
             '    <div class="exit">\n' +
             '        <i role="button" class="zulip-icon zulip-icon-close pill-close-button" aria-label="translated: Remove"></i>\n' +
             "    </div>\n" +
+            '    <span class="pill-edit-input" contenteditable="true" spellcheck="false"></span>\n' +
             "</div>\n",
     );
 });

--- a/web/tests/user_group_pill.test.cjs
+++ b/web/tests/user_group_pill.test.cjs
@@ -165,6 +165,7 @@ run_test("generate_pill_html", () => {
             '    <div class="exit">\n' +
             '        <a role="button" class="zulip-icon zulip-icon-close pill-close-button" aria-label="translated: Remove"></a>\n' +
             "    </div>\n" +
+            '    <span class="pill-edit-input" contenteditable="true" spellcheck="false"></span>\n' +
             "</div>\n",
     );
 });

--- a/web/tests/user_group_pill.test.cjs
+++ b/web/tests/user_group_pill.test.cjs
@@ -165,6 +165,7 @@ run_test("generate_pill_html", () => {
             '    <div class="exit">\n' +
             '        <i role="button" class="zulip-icon zulip-icon-close pill-close-button" aria-label="translated: Remove"></i>\n' +
             "    </div>\n" +
+            '    <span class="pill-edit-input" contenteditable="true" spellcheck="false"></span>\n' +
             "</div>\n",
     );
 });


### PR DESCRIPTION
This PR adds in-place editing support for input pills.

Pills can now be edited by double-clicking them or by focusing them with the keyboard and pressing Enter. Editing replaces the pill with a contenteditable element containing the pill's current text. When editing is confirmed, the value is validated and the resulting pill is inserted back at the original position.

The implementation also wires the existing typeahead configurations into editable pills so suggestions behave the same way as in the normal input.

Fixes part of #29510.

## Screencasts

### *Basic Edit (Double-click):*
  

https://github.com/user-attachments/assets/cac5f8e5-7663-4053-8efd-d8b22645555d



### *Keyboard Accessibility (Enter):*

https://github.com/user-attachments/assets/8716b238-2eb7-4c81-8dc8-99db456d05b4



### *Cancel Edit (Escape):*

https://github.com/user-attachments/assets/50c90d11-2be9-417f-91f7-cdbdc1a49dd6



### *Invalid Edit (Validation shake redirected to pill):*

https://github.com/user-attachments/assets/32bd86df-b837-4195-816f-7c5d61d63096



### *Empty Text Deletion:*

https://github.com/user-attachments/assets/2a9001b7-8e2e-475b-ac7f-2fea13a666fc



### *Typeahead Wiring - stream editing:*
https://github.com/user-attachments/assets/dac78571-0b67-40a6-b7ae-cb0ef0f72515


## Relationship to other PRs

This PR is a fresh implementation of the editable input pills feature previously attempted in #29511.

It follows the same high-level goal but takes a different approach to better integrate with the existing input pill and typeahead architecture. In particular, editing is handled in-place while preserving pill ordering, and typeahead behavior is wired through a dedicated `addSetupTypeahead` hook rather than modifying shared input handlers.

This design avoids the issues identified in the earlier PR and keeps the editing lifecycle more localized and consistent with the existing pill system.
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>



