### PR TITLE
compose: Add Ctrl+]/[ shortcuts for list indent/unindent

### DIFF
--- a/starlight_help/astro.config.mjs
+++ b/starlight_help/astro.config.mjs
@@ -327,6 +327,7 @@ export default defineConfig({
                         "paragraph-and-section-formatting",
                         "bulleted-lists",
                         "numbered-lists",
+                        "indent-a-list-item",
                         "tables",
                         "code-blocks",
                         "latex",

--- a/starlight_help/src/content/docs/format-your-message-using-markdown.mdx
+++ b/starlight_help/src/content/docs/format-your-message-using-markdown.mdx
@@ -18,6 +18,8 @@ import EmphasisExamples from "../include/_EmphasisExamples.mdx";
 import EmphasisIntro from "../include/_EmphasisIntro.mdx";
 import GlobalTimesExamples from "../include/_GlobalTimesExamples.mdx";
 import GlobalTimesIntro from "../include/_GlobalTimesIntro.mdx";
+import IndentingListItemsExamples from "../include/_IndentingListItemsExamples.mdx";
+import IndentingListItemsIntro from "../include/_IndentingListItemsIntro.mdx";
 import LatexExamples from "../include/_LatexExamples.mdx";
 import LatexIntro from "../include/_LatexIntro.mdx";
 import LinksExamples from "../include/_LinksExamples.mdx";
@@ -73,6 +75,7 @@ below.
 * [Text emphasis](#text-emphasis)
 * [Bulleted lists](#bulleted-lists)
 * [Numbered lists](#numbered-lists)
+* [Indenting list items](#indenting-list-items)
 * [Links](#links)
 * [Code blocks](#code-blocks)
 * [LaTeX](#latex)
@@ -121,6 +124,17 @@ below.
   You can also use the **numbered list** (<OrderedListIcon />)
   button in the compose box to insert numbered list formatting.
   [Learn more](/help/numbered-lists).
+</ZulipTip>
+
+## Indenting list items
+
+<IndentingListItemsIntro />
+
+<IndentingListItemsExamples />
+
+<ZulipTip>
+  You can indent bulleted and numbered list items using keyboard
+  shortcuts. [Learn more](/help/indent-a-list-item).
 </ZulipTip>
 
 ## Links

--- a/starlight_help/src/content/docs/indent-a-list-item.mdx
+++ b/starlight_help/src/content/docs/indent-a-list-item.mdx
@@ -1,0 +1,31 @@
+---
+title: Indent a list item
+---
+
+import FlattenedSteps from "../../components/FlattenedSteps.astro";
+import IndentingListItemsExamples from "../include/_IndentingListItemsExamples.mdx";
+import IndentingListItemsIntro from "../include/_IndentingListItemsIntro.mdx";
+import StartComposing from "../include/_StartComposing.mdx";
+
+<IndentingListItemsIntro />
+
+## How to indent a list item
+
+<FlattenedSteps>
+  <StartComposing />
+
+  1. Place your cursor on a list item, or select multiple list items.
+  1. Press <kbd data-mac-key="Cmd">Ctrl</kbd> + <kbd>]</kbd> to increase
+     indentation, or <kbd data-mac-key="Cmd">Ctrl</kbd> + <kbd>\[</kbd> to
+     reduce indentation.
+</FlattenedSteps>
+
+## Examples
+
+<IndentingListItemsExamples />
+
+## Related articles
+
+* [Bulleted lists](/help/bulleted-lists)
+* [Numbered lists](/help/numbered-lists)
+* [Message formatting](/help/format-your-message-using-markdown)

--- a/starlight_help/src/content/include/_IndentingListItemsExamples.mdx
+++ b/starlight_help/src/content/include/_IndentingListItemsExamples.mdx
@@ -1,0 +1,4 @@
+* Press <kbd data-mac-key="Cmd">Ctrl</kbd> + <kbd>]</kbd> to increase the
+  indentation of the current list item.
+* Press <kbd data-mac-key="Cmd">Ctrl</kbd> + <kbd>\[</kbd> to reduce the
+  indentation of the current list item.

--- a/starlight_help/src/content/include/_IndentingListItemsIntro.mdx
+++ b/starlight_help/src/content/include/_IndentingListItemsIntro.mdx
@@ -1,0 +1,2 @@
+In Zulip, you can increase or reduce the indentation of a list item using
+keyboard shortcuts in the compose box.

--- a/web/src/bulleted_numbered_list_util.ts
+++ b/web/src/bulleted_numbered_list_util.ts
@@ -12,3 +12,8 @@ export const is_numbered = (line: string): boolean => /^\d+\. /.test(line);
 export const strip_bullet = (line: string): string => line.slice(2);
 
 export const strip_numbering = (line: string): string => line.slice(line.indexOf(" ") + 1);
+
+export const is_list_item = (line: string): boolean => {
+    const trimmed = line.trimStart();
+    return is_bulleted(trimmed) || is_numbered(trimmed);
+};

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -584,6 +584,67 @@ export function handle_scrolling_formatting_buttons(event: JQuery.ScrollEvent): 
     }
 }
 
+export function handle_list_indent(
+    $textarea: JQuery<HTMLTextAreaElement>,
+    increase: boolean,
+): boolean {
+    const elem = $textarea[0]!;
+    const val = elem.value;
+    const start = elem.selectionStart;
+    const end = elem.selectionEnd;
+
+    const line_start = val.lastIndexOf("\n", start - 1) + 1;
+    const line_end_idx = val.indexOf("\n", end);
+    const line_end = line_end_idx === -1 ? val.length : line_end_idx;
+    const selected_block = val.slice(line_start, line_end);
+    const original_lines = selected_block.split("\n");
+    const lines = [...original_lines];
+    let changed = false;
+    let changed_count = 0;
+    let is_list_context = false;
+
+    for (let i = 0; i < lines.length; i += 1) {
+        const line = lines[i]!;
+        if (!bulleted_numbered_list_util.is_list_item(line)) {
+            continue;
+        }
+        is_list_context = true;
+        if (increase) {
+            lines[i] = "  " + line;
+            changed = true;
+            changed_count += 1;
+        } else if (line.startsWith(" ")) {
+            lines[i] = line.startsWith("  ") ? line.slice(2) : line.slice(1);
+            changed = true;
+            changed_count += line.startsWith("  ") ? 2 : 1;
+        }
+    }
+
+    if (!changed) {
+        return is_list_context;
+    }
+
+    const new_block = lines.join("\n");
+    const new_val = val.slice(0, line_start) + new_block + val.slice(line_end);
+    setFieldText(elem, new_val);
+
+    let start_offset = 0;
+    if (lines[0] !== original_lines[0]) {
+        if (increase) {
+            start_offset = 2;
+        } else {
+            start_offset = original_lines[0]!.startsWith("  ") ? -2 : -1;
+        }
+    }
+    const end_offset = increase ? changed_count * 2 : -changed_count;
+
+    elem.setSelectionRange(
+        Math.max(line_start, start + start_offset),
+        Math.max(line_start, end + end_offset),
+    );
+    return true;
+}
+
 export function handle_keydown(
     event: JQuery.KeyboardEventBase,
     $textarea: JQuery<HTMLTextAreaElement>,
@@ -614,6 +675,15 @@ export function handle_keydown(
         format_text($textarea, type);
         autosize_textarea($textarea);
         event.preventDefault();
+    }
+
+    if (isCmdOrCtrl && (key === "]" || key === "[")) {
+        if (handle_list_indent($textarea, key === "]")) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+
+        return;
     }
 }
 

--- a/web/src/info_overlay.ts
+++ b/web/src/info_overlay.ts
@@ -108,6 +108,16 @@ const markdown_help_rows = [
 1. ${$t({defaultMessage: "Coffee"})}`,
     },
     {
+        markdown: "",
+        usage_html: `<kbd>Ctrl</kbd> + <kbd>]</kbd>`,
+        output_html: $t({defaultMessage: "Increase list indentation"}),
+    },
+    {
+        markdown: "",
+        usage_html: `<kbd>Ctrl</kbd> + <kbd>[</kbd>`,
+        output_html: $t({defaultMessage: "Reduce list indentation"}),
+    },
+    {
         markdown: `> ${$t({defaultMessage: "Quoted"})}`,
     },
     {

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -1475,3 +1475,57 @@ run_test("get_focus_area", ({override, override_rewire}) => {
         "input#stream_message_recipient_topic",
     );
 });
+
+run_test("handle_list_indent", ({override}) => {
+    override(text_field_edit, "setFieldText", (elt, val) => {
+        elt.value = val;
+    });
+    function make_list_textarea(val, selectionStart, selectionEnd) {
+        const elem = {
+            value: val,
+            selectionStart,
+            selectionEnd,
+            setSelectionRange(start, end) {
+                this.selectionStart = start;
+                this.selectionEnd = end;
+            },
+        };
+        return {length: 1, 0: elem, trigger: noop};
+    }
+
+    {
+        const $t = make_list_textarea("- Item 1\n- Item 2", 9, 9);
+        assert.ok(compose_ui.handle_list_indent($t, true));
+        assert.equal($t[0].value, "- Item 1\n  - Item 2");
+    }
+
+    {
+        const $t = make_list_textarea("- Item 1\n  - Item 2", 11, 11);
+        assert.ok(compose_ui.handle_list_indent($t, false));
+        assert.equal($t[0].value, "- Item 1\n- Item 2");
+    }
+
+    {
+        const $t = make_list_textarea("Hello world", 5, 5);
+        assert.equal(compose_ui.handle_list_indent($t, true), false);
+        assert.equal($t[0].value, "Hello world");
+    }
+
+    {
+        const $t = make_list_textarea("- Item 1", 3, 3);
+        assert.equal(compose_ui.handle_list_indent($t, false), true);
+    }
+
+    {
+        const val = "- Item 1\n- Item 2\n- Item 3";
+        const $t = make_list_textarea(val, 0, val.length);
+        assert.ok(compose_ui.handle_list_indent($t, true));
+        assert.equal($t[0].value, "  - Item 1\n  - Item 2\n  - Item 3");
+    }
+
+    {
+        const $t = make_list_textarea("1. Item 1", 0, 0);
+        assert.ok(compose_ui.handle_list_indent($t, true));
+        assert.equal($t[0].value, "  1. Item 1");
+    }
+});


### PR DESCRIPTION
Add keyboard shortcuts to increase or decrease the indentation level of Markdown list items in the compose textarea.

Pressing `Ctrl+]` / `Cmd+]` increases indentation and `Ctrl+[` / `Cmd+[` decreases indentation for the current line or all selected lines if they are valid list items Non-list lines are ignored.

Fixes: #37738

**Changes made:**
- Added `is_list_item()` helper in `bulleted_numbered_list_util.ts`
- Added `handle_list_indent()` function in `compose_ui.ts`
- Added `Ctrl+]` and `Ctrl+[` keyboard event handlers in `handle_keydown()`
- Updated keyboard shortcuts UI (`keyboard_shortcuts.hbs`)
- Updated help documentation (`keyboard-shortcuts.mdx`)
- Added tests for the new functionality


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

**Update the "Message formatting" panel**

| Before | After |
|--------|-------|
|<img width="1052" height="671" alt="Screenshot 2026-03-26 145812" src="https://github.com/user-attachments/assets/140add2e-d639-46f3-90b1-0e764ba6f684" />|<img width="1056" height="650" alt="Screenshot 2026-03-26 145646" src="https://github.com/user-attachments/assets/e2440894-0307-4ea2-b2df-b25f9b81428e" />|

**Update the `help/format-your-message-using-markdown` section**

| Before | After |
|--------|-------|
|<img width="1919" height="880" alt="Screenshot 2026-03-26 145937" src="https://github.com/user-attachments/assets/c9c412f4-0f7b-4c67-8ac9-a1e29cf2cd89" />|<img width="1919" height="844" alt="Screenshot 2026-03-26 150040" src="https://github.com/user-attachments/assets/23221e60-91ff-42e6-84ab-480e472ec09f" />|

**Add sidebar entry for `Indent a list item`.**

| Before | After |
|--------|-------|
|<img width="400" height="596" alt="Screenshot 2026-04-01 221538" src="https://github.com/user-attachments/assets/ec9b46a3-0842-4ee4-9aa6-be98df678b35" />|<img width="393" height="653" alt="Screenshot 2026-04-01 221433" src="https://github.com/user-attachments/assets/598c0226-091a-43c0-9fe5-ee05f6640a96" />|

**`Ctrl+]` increases indentation**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/37a8c330-806b-4db9-907d-ed05f233e4ca" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/a7b813d7-5cfd-4a4b-843a-67a3ad1b0e1a" width="400" controls></video> |

**`Ctrl+[` decreases indentation**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/37a8c330-806b-4db9-907d-ed05f233e4ca" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/bb1b161c-6a92-4e05-83ee-aace5ba508e6" width="400" controls></video> |




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
