### PR TITLE
populate_db: Add links and attachment to generated message data.

### DIFF
--- a/tools/rebuild-test-database
+++ b/tools/rebuild-test-database
@@ -33,7 +33,8 @@ create_zulip_test
 # This next line can be simplified to "-n0" once we fix our app (and tests) with 0 messages.
 ./manage.py populate_db --test-suite -n30 --threads=1 \
     --max-topics=3 \
-    --direct-message-groups=0 --personals=0 --percent-direct-message-groups=0 --percent-personals=0
+    --direct-message-groups=0 --personals=0 --percent-direct-message-groups=0 --percent-personals=0 \
+    --percent-attachments=0
 
 ./manage.py dumpdata \
     zerver.UserProfile zerver.Stream zerver.Recipient \

--- a/zerver/lib/generate_test_data.py
+++ b/zerver/lib/generate_test_data.py
@@ -6,6 +6,7 @@ from typing import Any
 import orjson
 
 from scripts.lib.zulip_tools import get_or_create_dev_uuid_var_path
+from zerver.lib.message import truncate_topic
 from zerver.lib.topic import RESOLVED_TOPIC_PREFIX
 
 
@@ -16,7 +17,7 @@ def load_config() -> dict[str, Any]:
     return config
 
 
-def generate_topics(num_topics: int) -> list[str]:
+def generate_topics(num_topics: int, percent_topic_links: float = 0) -> list[str]:
     config = load_config()["gen_fodder"]
 
     # Make single word topics account for 30% of total topics.
@@ -44,14 +45,14 @@ def generate_topics(num_topics: int) -> list[str]:
     else:
         resolved_topic_probability = 0.05
 
-    return [
-        (
-            RESOLVED_TOPIC_PREFIX + topic_name
-            if random.random() < resolved_topic_probability
-            else topic_name
-        )
-        for topic_name in topic_names
-    ]
+    results = []
+    for topic_name in topic_names:
+        if percent_topic_links > 0 and random.random() < percent_topic_links / 100.0:
+            topic_name = add_link_to_topic(topic_name)
+        if random.random() < resolved_topic_probability:
+            topic_name = truncate_topic(RESOLVED_TOPIC_PREFIX + topic_name)
+        results.append(topic_name)
+    return results
 
 
 def load_generators(config: dict[str, Any]) -> dict[str, Any]:
@@ -181,6 +182,11 @@ def add_link(text: str, link: str) -> str:
     vals[start] = vals[start] + " " + link + " "
 
     return " ".join(vals)
+
+
+def add_link_to_topic(topic: str) -> str:
+    url = random.choice(config["gen_fodder"]["topic-links"])
+    return truncate_topic(f"{url} {topic}")
 
 
 def remove_line_breaks(fh: Any) -> list[str]:

--- a/zerver/tests/fixtures/config.generate_data.json
+++ b/zerver/tests/fixtures/config.generate_data.json
@@ -25,6 +25,13 @@
          "https://zulip.readthedocs.io/en/latest/subsystems/client.html",
          "https://zulip.readthedocs.io/en/latest/subsystems/logging.html",
          "https://zulip.readthedocs.io/en/latest/subsystems/dependencies.html"],
+      "topic-links": [
+        "https://example.com",
+        "https://zulip.com",
+        "https://chat.zulip.org",
+        "https://github.com/zulip",
+        "https://wikipedia.org"
+      ],
       "inline-code": [
         "`(reduce (fn [m [k v]] (assoc m v k)) {} {:b 2 :a 1 :c 3})`" ,
         "`select id, first-name, last-name from users where active = 1;`",

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -302,6 +302,13 @@ class Command(ZulipBaseCommand):
         )
 
         parser.add_argument(
+            "--percent-topic-links",
+            type=float,
+            default=5,
+            help="The percent of topics with links in them.",
+        )
+
+        parser.add_argument(
             "--stickiness",
             type=float,
             default=20,
@@ -1309,7 +1316,9 @@ def generate_and_send_messages(
         else:
             num_topics = options["max_topics"]
 
-        possible_topic_names[stream_id] = generate_topics(num_topics)
+        possible_topic_names[stream_id] = generate_topics(
+            num_topics, options["percent_topic_links"]
+        )
 
     message_batch_size = options["batch_size"]
     num_messages = 0

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -1,3 +1,4 @@
+import io
 import itertools
 import os
 import random
@@ -11,6 +12,7 @@ import orjson
 from django.conf import settings
 from django.contrib.sessions.models import Session
 from django.core.files.base import File
+from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.management import call_command
 from django.core.management.base import CommandParser
 from django.core.validators import validate_email
@@ -53,6 +55,7 @@ from zerver.lib.storage import static_path
 from zerver.lib.stream_color import STREAM_ASSIGNMENT_COLORS
 from zerver.lib.stream_subscription import bulk_create_stream_subscriptions
 from zerver.lib.types import AnalyticsDataUploadLevel, ProfileFieldData
+from zerver.lib.upload import upload_message_attachment_from_request
 from zerver.lib.users import add_service
 from zerver.lib.utils import generate_api_key
 from zerver.models import (
@@ -197,6 +200,31 @@ def subscribe_users_to_streams(realm: Realm, stream_dict: dict[str, dict[str, An
     RealmAuditLog.objects.bulk_create(all_subscription_logs)
 
 
+def create_attachment(user: UserProfile) -> tuple[str, str]:
+    if random.random() < 0.5:
+        filename = "attachment.txt"
+        content_type = "text/plain"
+        content = b"temporary test attachment file. Hello, World!"
+    else:
+        filename = "README.md"
+        content_type = "text/markdown"
+        content = (
+            b"# Project README\n\nThis is a **sample** markdown file.\n\n"
+            b"## Getting started\n\n- Step 1\n- Step 2\n- Step 3\n"
+        )
+    file_obj = io.BytesIO(content)
+    upload = InMemoryUploadedFile(
+        file=file_obj,
+        field_name=None,
+        name=filename,
+        content_type=content_type,
+        size=len(content),
+        charset=None,
+    )
+    locator, _ = upload_message_attachment_from_request(upload, user)
+    return locator, filename
+
+
 def create_alert_words(realm_id: int) -> None:
     user_ids = UserProfile.objects.filter(
         realm_id=realm_id,
@@ -306,6 +334,13 @@ class Command(ZulipBaseCommand):
             type=float,
             default=5,
             help="The percent of topics with links in them.",
+        )
+
+        parser.add_argument(
+            "--percent-attachments",
+            type=float,
+            default=3,
+            help="The percent of messages to have attachments.",
         )
 
         parser.add_argument(
@@ -1333,6 +1368,10 @@ def generate_and_send_messages(
     recipients: dict[int, tuple[str, int, dict[str, Any]]] = {}
     messages: list[Message] = []
     while num_messages < tot_messages:
+        has_attachment = (
+            options["percent_attachments"] > 0
+            and random.random() < options["percent_attachments"] / 100.0
+        )
         saved_data: dict[str, Any] = {}
         message = Message(realm=realm)
         message.sending_client = get_client("ZulipDataImport")
@@ -1388,6 +1427,10 @@ def generate_and_send_messages(
             ).user_profile
             message.subject = random.choice(possible_topic_names[message.recipient.id])
             saved_data["subject"] = message.subject
+
+        if has_attachment:
+            locator, filename = create_attachment(message.sender)
+            message.content += f"\n[{filename}]({locator})"
 
         message.is_channel_message = msg_type == MSG_TYPE_STREAM
         message.date_sent = choose_date_sent(


### PR DESCRIPTION
 This completes the remaining items from #14991 by adding two missing components to the data generated by `populate_db`:     
                                                                 
  - **Links in topic names:** 5% of stream message topics now include a URL, exercising topic link rendering.              
  - **Attachments in messages:** 3% of messages now include a text file attachment created via the upload API, exercising attachment rendering and storage.                            

  Both features are disabled when `--test-suite` is used, to keep the backend test fixture data stable.The percentages are configurable via `--percent-topic-links` and `--percent-attachments`.

  **How changes were tested:**
  -  Ran `./manage.py populate_db --percent-attachments 50` and verified attachments and topic links appear in messages.

 Fixes part of: #14991.       

**Screenshots and Screen captures:**
<img width="1119" height="241" alt="Screenshot From 2026-03-07 15-23-57" src="https://github.com/user-attachments/assets/105e34f8-5488-471f-8117-a7eb1c6060a5" />

  <details>
  <summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy and-guidelines). Communicate decisions, questions, and potential concerns.
- [x] Explains differences from previous plans (e.g., issue description).
  - [x] Highlights technical choices and bugs encountered.
  - [ ] Calls out remaining decisions and concerns.
  - [x] Automated tests verify logic where appropriate.

  Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing
  /commit-discipline.html)).
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for
  changes.

  Completed manual review and testing of the following:

  - [x] End-to-end functionality of buttons, interactions and flows.
  - [x] Corner cases, error conditions, and easily imagined bugs.
  </details>