### PR TITLE
tests: Add helper for creating message test objects.

### DIFF
--- a/web/tests/direct_message_group_data.test.cjs
+++ b/web/tests/direct_message_group_data.test.cjs
@@ -2,6 +2,7 @@
 
 const assert = require("node:assert/strict");
 
+const {make_direct_message} = require("./lib/example_message.cjs");
 const {make_user} = require("./lib/example_user.cjs");
 const {zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
@@ -54,11 +55,11 @@ run_test("direct_message_group_data.process_loaded_messages", () => {
     const old_timestamp = 1382479000;
 
     const messages = [
-        {
-            type: "private",
+        make_direct_message({
+            sender_id: me.user_id,
             display_recipient: [{id: jill.user_id}, {id: norbert.user_id}],
             timestamp: timestamp1,
-        },
+        }),
         {
             type: "stream",
         },

--- a/web/tests/example_message.test.cjs
+++ b/web/tests/example_message.test.cjs
@@ -1,0 +1,50 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {make_channel_message, make_direct_message} = require("./lib/example_message.cjs");
+const {make_stream} = require("./lib/example_stream.cjs");
+const {make_user} = require("./lib/example_user.cjs");
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const people = zrequire("people");
+const stream_data = zrequire("stream_data");
+
+run_test("make_channel_message: basic fields", () => {
+    const alice = make_user({email: "alice@zulip.com", user_id: 1, full_name: "Alice Smith"});
+    people.add_active_user(alice);
+
+    const denmark = make_stream({name: "Denmark", stream_id: 10});
+    stream_data.add_sub_for_tests(denmark);
+
+    const msg = make_channel_message({
+        stream_id: 10,
+        subject: "topic",
+        sender_id: 1,
+    });
+    assert.equal(msg.type, "stream");
+    assert.equal(msg.stream_id, 10);
+    assert.equal(msg.subject, "topic");
+    assert.equal(msg.sender_id, 1);
+    assert.equal(msg.sender_email, "alice@zulip.com");
+    assert.equal(msg.sender_full_name, "Alice Smith");
+    assert.equal(msg.display_recipient, "Denmark");
+    assert.ok(msg.id);
+});
+
+run_test("make_direct_message: basic fields", () => {
+    const alice = make_user({email: "alice@zulip.com", user_id: 1, full_name: "Alice Smith"});
+    people.add_active_user(alice);
+
+    const msg = make_direct_message({
+        sender_id: 1,
+        display_recipient: [{id: 1}, {id: 2}],
+    });
+    assert.equal(msg.type, "private");
+    assert.equal(msg.sender_id, 1);
+    assert.equal(msg.sender_email, "alice@zulip.com");
+    assert.equal(msg.sender_full_name, "Alice Smith");
+    assert.deepEqual(msg.display_recipient, [{id: 1}, {id: 2}]);
+    assert.ok(msg.id);
+});

--- a/web/tests/lib/example_message.cjs
+++ b/web/tests/lib/example_message.cjs
@@ -1,0 +1,54 @@
+"use strict";
+
+const {zrequire} = require("./namespace.cjs");
+
+// Generate message IDs that are random but strictly increasing.
+// This ensures tests get unique IDs automatically and preserves
+// ordering between messages when needed.
+let last_issued_message_id = 100000;
+
+const get_message_id = () => {
+    last_issued_message_id += 1 + Math.floor(Math.random() * 10);
+    return last_issued_message_id;
+};
+
+const base_message = (opts = {}) => {
+    const people = zrequire("people");
+
+    const sender_id = opts.sender_id;
+    const sender = people.get_by_user_id(sender_id);
+
+    return {
+        id: opts.id ?? get_message_id(),
+        sender_id,
+        sender_email: sender.email,
+        sender_full_name: sender.full_name,
+        content: opts.content ?? "<p>Test message</p>",
+        content_type: "text/html",
+        timestamp: opts.timestamp ?? Date.now(),
+        reactions: [],
+        submessages: [],
+        flags: [],
+    };
+};
+
+exports.make_channel_message = (opts = {}) => {
+    const stream_data = zrequire("stream_data");
+
+    const stream_id = opts.stream_id;
+    const sub = stream_data.get_sub_by_id(stream_id);
+
+    return {
+        ...base_message(opts),
+        type: "stream",
+        stream_id,
+        display_recipient: sub.name,
+        subject: opts.subject ?? "test-topic",
+    };
+};
+
+exports.make_direct_message = (opts = {}) => ({
+    ...base_message(opts),
+    type: "private",
+    display_recipient: opts.display_recipient ?? [],
+});


### PR DESCRIPTION
This PR introduces a helper for generating message objects in Node tests.

Adds `web/tests/lib/example_message.cjs` with:

- `make_channel_message()`
- `make_direct_message()`

These helpers create message objects by looking up sender details
from the `people` module and stream details from the `stream_data`
module, ensuring consistency with test data setup.

As a small demonstration, `direct_message_group_data.test.cjs` is
updated to use `make_direct_message()` instead of manually
constructing a message object.

Also adds `web/tests/example_message.test.cjs` to validate the
helper behavior.


**How changes were tested:**

Ran `tools/test-js-with-node`

All Node tests passed successfully.


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
