### PR TITLE
docs: document bot_handler.react in interactive bots API

### DIFF
--- a/starlight_help/src/content/docs/interactive-bots-api.mdx
+++ b/starlight_help/src/content/docs/interactive-bots-api.mdx
@@ -129,6 +129,7 @@ bot_handler.update_message(dict(
     content=str(self.number), # string with which to update message with
 ))
 ```
+
 ## bot_handler.react
 
 `bot_handler.react(message, emoji_name)`: Add an emoji reaction to a


### PR DESCRIPTION
Adds documentation for the bot_handler.react method in the
Interactive Bots API page.

Inspired by #25444 and updated for the current MDX documentation
format after the Starlight docs migration.

Fixes #25443