### PR TITLE
Make selection boxes blue.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2402,12 +2402,9 @@
     );
 
     /* Shared button CSS variables */
-    --color-outline-button-focus: light-dark(
-        hsl(0deg 0% 0%),
-        hsl(0deg 0% 100%)
-    );
     --outline-width-button-focus: 1.5px;
     --outline-offset-button-focus: 0;
+    --outline-offset-action-button-focus: 1px;
     /* Actions buttons */
     --color-inner-shadow-action-button: light-dark(
         color-mix(in oklch, hsl(0deg 0% 0%) 20%, transparent),

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1599,10 +1599,6 @@
         hsl(0deg 0% 97%),
         hsl(0deg 0% 21%)
     );
-    --color-outline-user-profile-list-item: light-dark(
-        hsl(0deg 0% 0%),
-        hsl(0deg 0% 100%)
-    );
 
     /* Link colors */
     --color-text-link: light-dark(hsl(210deg 94% 42%), hsl(200deg 100% 50%));

--- a/web/styles/buttons.css
+++ b/web/styles/buttons.css
@@ -45,14 +45,14 @@
     &:focus-visible {
         /* Override common button outline style set in zulip.css and dark_theme.css */
         outline: var(--outline-width-button-focus) solid
-            var(--color-outline-button-focus) !important;
-        outline-offset: var(--outline-offset-button-focus);
+            var(--color-outline-focus) !important;
+        outline-offset: var(--outline-offset-action-button-focus);
         clip-path: inset(
             calc(
                     -1 *
                         (
                             var(--outline-width-button-focus) +
-                                var(--outline-offset-button-focus)
+                                var(--outline-offset-action-button-focus)
                         )
                 )
                 round 4px
@@ -450,7 +450,7 @@
     &:focus-visible {
         /* Override common button outline style set in zulip.css and dark_theme.css */
         outline: var(--outline-width-button-focus) solid
-            var(--color-outline-button-focus) !important;
+            var(--color-outline-focus) !important;
         outline-offset: var(--outline-offset-button-focus);
         clip-path: inset(
             calc(

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1491,12 +1491,6 @@ textarea.new_message_textarea {
             align-self: center;
             font-size: inherit;
 
-            &:focus {
-                outline: 1px dotted hsl(0deg 0% 20%);
-                outline: 5px auto -webkit-focus-ring-color;
-                outline-offset: -2px;
-            }
-
             &:checked
                 + .enter_sends_choice_text_container
                 .popover-menu-hotkey-hint {

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -547,7 +547,7 @@
         }
 
         &:focus-visible {
-            outline: 1px solid var(--color-outline-user-profile-list-item);
+            outline: 1px solid var(--color-outline-focus);
             outline-offset: -2px;
         }
 

--- a/web/templates/popovers/send_later_popover.hbs
+++ b/web/templates/popovers/send_later_popover.hbs
@@ -3,7 +3,7 @@
         <li role="none" class="popover-menu-list-item">
             <div role="group" class="enter_sends_choices" aria-label="{{t 'Enter to send choices' }}">
                 <label role="menuitemradio" class="enter_sends_choice" tabindex="0">
-                    <input type="radio" class="enter_sends_choice_radio" name="enter_sends_choice" value="true"{{#if enter_sends_true }} checked{{/if}} />
+                    <input type="radio" class="enter_sends_choice_radio" name="enter_sends_choice" value="true"{{#if enter_sends_true }} checked{{/if}} tabindex="-1" />
                     <span class="enter_sends_choice_text_container">
                         <span class="enter_sends_major enter_sends_choice_text">
                             {{#tr}}
@@ -20,7 +20,7 @@
                     </span>
                 </label>
                 <label role="menuitemradio" class="enter_sends_choice" tabindex="0">
-                    <input type="radio" class="enter_sends_choice_radio" name="enter_sends_choice" value="false"{{#unless enter_sends_true }} checked{{/unless}} />
+                    <input type="radio" class="enter_sends_choice_radio" name="enter_sends_choice" value="false"{{#unless enter_sends_true }} checked{{/unless}} tabindex="-1" />
                     <span class="enter_sends_choice_text_container">
                         <span class="enter_sends_major enter_sends_choice_text">
                             {{#tr}}


### PR DESCRIPTION
Consolidates outline colors to `--color-outline-focus` for icon-button/action-button & channel/group list container.

Fixes: zulip#38040.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

|Before|After|
|-|-|
|<img width="674" height="326" alt="image" src="https://github.com/user-attachments/assets/7e1b0a45-c7fd-40ae-b96f-e1d07157a492" />|<img width="678" height="320" alt="image" src="https://github.com/user-attachments/assets/c5ef2ece-59fd-4310-a45c-4857842d1ff6" />|
|<img width="674" height="326" alt="image" src="https://github.com/user-attachments/assets/0491e855-9896-44f5-bad5-380d99b48d46" />|<img width="678" height="320" alt="image" src="https://github.com/user-attachments/assets/b3a166ee-71bc-47ae-b1e7-986764a835bd" />|
|zoomed page||
|<img width="1050" height="644" alt="image" src="https://github.com/user-attachments/assets/8adb1d76-3617-4ab2-bd7c-060ad7e048f8" />|<img width="1050" height="644" alt="image" src="https://github.com/user-attachments/assets/11d5089e-f011-42fb-a7b0-393f7351f181" />|
|<img width="1050" height="644" alt="image" src="https://github.com/user-attachments/assets/8b730227-02e7-4c5a-883f-417a77846f37" />|<img width="1050" height="644" alt="image" src="https://github.com/user-attachments/assets/afb667f1-f3f0-48b2-ab2e-3fb912f9e487" />|
|<img width="586" height="145" alt="Screenshot from 2026-03-17 03-02-29" src="https://github.com/user-attachments/assets/2448d7c1-40c7-46b7-be0e-ff6c8f5a71bd" />|<img width="586" height="145" alt="image" src="https://github.com/user-attachments/assets/d0c6906a-21aa-42b2-acd8-445114dc9806" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
