### PR TITLE
recent_view: Fix backfilled topic not inserted in recent view.

### DIFF
--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1033,17 +1033,37 @@ export function bulk_inplace_rerender(row_keys: string[]): void {
     // When doing bulk rerender, we assume that order of rows are not going
     // to change by default. Row insertion can still change the order but
     // we ensure the list remains sorted after insertion.
+    //
+    // Save whether all rows were rendered before updating the data,
+    // so we know if it's safe to use render() for new items below.
+    const was_all_rendered = topics_widget.all_rendered();
     topics_widget.replace_list_data(get_list_data_for_widget(), false);
     topics_widget.filter_and_sort();
-    // Iterate in the order of which the rows should be present so that
+    // Iterate in the order in which the rows should be present so that
     // we are not inserting rows without any rows being present around them.
+    let processed_count = 0;
     for (const topic_data of topics_widget.get_rendered_list()) {
+        if (processed_count >= row_keys.length) {
+            break;
+        }
         const msg = message_store.get(topic_data.last_msg_id);
         assert(msg !== undefined);
         const topic_key = recent_view_util.get_key_from_message(msg);
         if (row_keys.includes(topic_key)) {
             inplace_rerender(topic_key, true);
+            processed_count += 1;
         }
+    }
+    // New conversations from backfilled old messages sort at the end
+    // of the list, beyond the current render offset. Use render() to
+    // efficiently batch-append them in a single DOM operation, rather
+    // than inserting one at a time via insert_rendered_row.
+    //
+    // We can only use render() when the DOM already had all rows up
+    // to the render offset (was_all_rendered), ensuring new items
+    // start right at the offset boundary with no gap.
+    if (processed_count < row_keys.length && was_all_rendered) {
+        topics_widget.render(row_keys.length - processed_count);
     }
     setTimeout(revive_current_focus, 0);
 }


### PR DESCRIPTION
If all rows are rendered in recent view and we backfill a new topic row, it is not rendered in recent view due to us only checking `get_rendered_list` when inserting rows, which doesn't account for new rows being inserted.

To fix it, we insert the rows if all rows were rendered when we received the backfilled topic.


---

Used Claude Opus 4.6 to specify what changes to make.

---

To reproduce:

1. manage.py populate_db -n 5000 --max-topics=30
2. Apply this patch:
```
git apply <<'PATCH'
diff --git a/web/src/message_fetch.ts b/web/src/message_fetch.ts
index 052f55dd1b..31a0ebed48 100644
--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -79,26 +79,26 @@ const consts = {
     //
     // It's rare to have hundreds of unreads after the cursor, asking
     // for a larger number of messages after the cursor is cheap.
-    narrow_before: 60,
-    narrow_after: 150,
+    narrow_before: 1,
+    narrow_after: 10,
 
     // Batch sizes when at the top/bottom of a narrowed view.
-    narrowed_view_backward_batch_size: 100,
-    narrowed_view_forward_batch_size: 100,
+    narrowed_view_backward_batch_size: 1,
+    narrowed_view_forward_batch_size: 1,
 
     // Initial backfill parameters to populate message history.
-    initial_backfill_fetch_size: 1000,
-    catch_up_batch_size: 2000,
+    initial_backfill_fetch_size: 10,
+    catch_up_batch_size: 10,
     // We fetch at least minimum_initial_backfill_size messages of
     // history, but after that will stop fetching at either
     // maximum_initial_backfill_size messages or
     // target_days_of_history days, whichever comes first.
-    minimum_initial_backfill_size: 9000,
-    maximum_initial_backfill_size: 25000,
-    target_days_of_history: 180,
+    minimum_initial_backfill_size: 10,
+    maximum_initial_backfill_size: 100,
+    target_days_of_history: 1,
     // Delay in milliseconds after processing a catch-up request
     // before sending the next one.
-    catch_up_backfill_delay: 150,
+    catch_up_backfill_delay: 1,
 
     // Parameters for asking for more history in the recent view.
     recent_view_fetch_more_batch_size: 2000,
PATCH
```

3. Navigate to recent view to see only a few topic being preset without this PR, and a screen full (or more) of topics being present after this PR.