### PR TITLE
[ai] slack import: Log invalid token at info level instead of error.

### DIFF
--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1814,7 +1814,7 @@ def check_slack_token_access(token: str, required_scopes: set[str]) -> None:
         if not data.json()["ok"]:
             error = data.json()["error"]
             if error != "missing_scope":
-                logging.error("Slack token is invalid: %s", error)
+                logging.info("Slack token is invalid: %s", error)
                 raise ValueError(f"Invalid token: {token}")
         has_scopes = set(data.headers.get("x-oauth-scopes", "").split(","))
         missing_scopes = required_scopes - has_scopes

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -445,7 +445,7 @@ class SlackImporter(ZulipTestCase):
             "Invalid token. Valid tokens start with xoxb-.",
         )
 
-        with self.assertLogs(level="ERROR"):
+        with self.assertLogs(level="INFO"):
             self.assertEqual(
                 exception_for("xoxb-invalid-token"),
                 "Invalid token: xoxb-invalid-token",


### PR DESCRIPTION
An invalid Slack token is purely a user error, not a server-side issue
requiring operator attention. Logging it at error level triggers
Sentry notifications unnecessarily. This changes the log level to
info.

---

Prompted claude to use logging.info instead of logging.error here, didn't do any additional testing.
