### PR TITLE
emoji settings: Add "Show only my emojis" filter

### DIFF
--- a/web/src/settings_emoji.ts
+++ b/web/src/settings_emoji.ts
@@ -134,7 +134,21 @@ export function populate_emoji(): void {
                 .closest(".settings-section")
                 .find<HTMLInputElement>("input.search"),
             predicate(item, value) {
-                return item.name.toLowerCase().includes(value);
+                // check if the emoji name matches the search input
+                const matches_search = item.name.toLowerCase().includes(value);
+
+                const checkbox = $("#show-my-emojis-only")[0];
+
+                let show_only_my_emojis = false;
+
+                if (checkbox instanceof HTMLInputElement) {
+                    show_only_my_emojis = checkbox.checked;
+                }
+
+                if (show_only_my_emojis) {
+                    return matches_search && people.is_my_user_id(item.author_id);
+                }
+                return matches_search;
             },
             onupdate() {
                 scroll_util.reset_scrollbar($emoji_table);
@@ -317,6 +331,11 @@ export function set_up(): void {
 
     // Populate emoji table
     populate_emoji();
+
+    // Re-render the emoji table whenever the "Show only my emojis" checkbox is toggled
+    $("#emoji-settings").on("change", "#show-my-emojis-only", () => {
+        populate_emoji();
+    });
 
     $(".admin_emoji_table").on("click", ".delete", function (e) {
         e.preventDefault();

--- a/web/templates/settings/admin_emoji_list.hbs
+++ b/web/templates/settings/admin_emoji_list.hbs
@@ -1,5 +1,5 @@
 {{#with emoji}}
-<tr class="emoji_row" id="emoji_{{name}}" data-emoji-name="{{name}}">
+<tr class="emoji_row" id="emoji_{{name}}" data-emoji-name="{{name}}" data-author-id="{{author.user_id}}">
     <td>
         <span class="emoji_name">{{display_name}}</span>
         {{#if is_overriding_default}}

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -3,7 +3,7 @@
         <div class="tip">{{t "You do not have permission to add custom emoji."}}</div>
     </div>
     <p class="add-emoji-text {{#unless can_add_emojis}}hide{{/unless}}">
-        {{t "Add extra emoji for members of the {realm_name} organization." }}
+        {{t "Add extra emoji for members of the {realm_name} organization."}}
     </p>
     {{> ../components/action_button
       id="add-custom-emoji-button"
@@ -12,23 +12,30 @@
       label=(t "Add a new emoji")
       hidden=(not can_add_emojis)
       }}
-
     <div class="settings_panel_list_header">
         <h3>{{t "Custom emoji"}}</h3>
-        {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter emoji')}}
+        {{> filter_text_input placeholder=(t "Filter") aria_label=(t "Filter emoji")}}
+        {{!-- checkbox to filter and show only emojis created by current user --}}
+        <div class="emoji-filter-container inline-block ml-3">
+            <label class="checkbox">
+                <input type="checkbox" id="show-my-emojis-only" />
+                <span></span>
+                {{t "Show only my emojis"}}
+            </label>
+        </div>
     </div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table admin_emoji_table">
             <thead class="table-sticky-headers">
                 <tr>
-                    <th class="active" data-sort="alphabetic" data-sort-prop="name">{{t "Name" }}
+                    <th class="active" data-sort="alphabetic" data-sort-prop="name">{{t "Name"}}
                         <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                     </th>
-                    <th class="image">{{t "Image" }}</th>
-                    <th class="image" data-sort="author_full_name">{{t "Author" }}
+                    <th class="image">{{t "Image"}}</th>
+                    <th class="image" data-sort="author_full_name">{{t "Author"}}
                         <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                     </th>
-                    <th class="actions">{{t "Actions" }}</th>
+                    <th class="actions">{{t "Actions"}}</th>
                 </tr>
             </thead>
             <tbody id="admin_emoji_table" data-empty="{{t 'There are no custom emoji.' }}" data-search-results-empty="{{t 'No custom emojis match your current filter.' }}"></tbody>


### PR DESCRIPTION
Summary : 
Added a "Show only my emojis" filter in the Organization Emoji settings. This allows users to quickly filter the custom emoji list to see only the ones they have uploaded.

Changes :
1. Logic : Added filter functionality in `web/src/settings_emoji.ts` to toggle between all emojis and user-uploaded emojis.
2.  UI : Updated `web/templates/settings/emoji_settings_admin.hbs` and `web/templates/settings/admin_emoji_list.hbs` to include the checkbox/filter UI.
3.  Formatting : Ensured all code follows Zulip's linting and Prettier standards.

Screenshots :
| Before (All Emojis) | After (Filtered) |
<img width="1900" height="1001" alt="image" src="https://github.com/user-attachments/assets/838d5ad3-0c5a-4894-92b4-b605ddae7443" />
<img width="1913" height="944" alt="image" src="https://github.com/user-attachments/assets/7aa2e2c3-b0b9-4b69-9725-9607491025ba" />

Testing :
1. Verified the filter works correctly in the development environment.
2. Checked that the list updates dynamically without page refresh.
3. Verified the "No results" state when a user has no uploaded emojis.

Fixes #8170