### PR TITLE
search: Add channels:archived filter.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,16 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 489**
+
+* [`GET /messages`](/api/get-messages),
+  [`GET /messages/matches_narrow`](/api/check-messages-match-narrow),
+  [`POST /messages/flags/narrow`](/api/update-message-flags-for-narrow),
+  [`POST /register`](/api/register-queue): Added a new
+  [search/narrow filter](/api/construct-narrow), `channels:archived`,
+  that returns messages the current user received in channels that have
+  been [archived](/help/archive-a-channel).
+
 **Feature level 488**
 
 * [`GET /server_settings`](/api/get-server-settings): Added `discord` boolean

--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -58,6 +58,10 @@ as an empty string.
 
 ## Changes
 
+* In Zulip 12.0 (feature level 489), support was added for a new
+  filter, `channels:archived`, which returns messages the current user
+  received in channels that have been [archived](/help/archive-a-channel).
+
 * In Zulip 12.0 (feature level 446), add the `mentions` operator,
   matching messages that contain a direct personal mention of the
   specified user.

--- a/starlight_help/src/content/docs/search-for-messages.mdx
+++ b/starlight_help/src/content/docs/search-for-messages.mdx
@@ -97,12 +97,14 @@ Zulip offers the following filters based on the location of the message.
   between you, Bo, and Elena.
 * `dm-including:Bo Lin`: Search all direct message conversations
   (1-on-1 and group) that include you and Bo, as well as any other users.
+* `channels:archived`: Search the messages you received in [archived
+  channels](/help/archive-a-channel).
 
 ### Search shared history
 
 To avoid cluttering your search results, by default, Zulip searches just the
-messages you received. You can use `channels:` or `channel:` filters to search
-additional messages.
+messages you received. You can use the `channel:` filter, and some `channels:`
+filters, to search additional messages.
 
 * `channels:public`: Search messages in all
   [public](/help/channel-permissions#public-channels) and

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 488
+API_FEATURE_LEVEL = 489
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -66,7 +66,7 @@ type Part =
           is_empty_string_topic?: boolean;
       };
 
-const channels_operands = new Set(["public", "web-public"]);
+const channels_operands = new Set(["archived", "public", "web-public"]);
 
 function message_in_home(message: Message): boolean {
     // The home view contains messages not sent to muted channels,
@@ -175,6 +175,10 @@ function build_term_predicate(term: NarrowCanonicalTerm): ((message: Message) =>
                     return (message) =>
                         message.type === "stream" &&
                         stream_data.get_stream_privacy_policy(message.stream_id) === "web-public";
+                case "archived":
+                    return (message) =>
+                        message.type === "stream" &&
+                        stream_data.is_stream_archived_by_id(message.stream_id);
                 default:
                     return () => false;
             }
@@ -656,6 +660,8 @@ export class Filter {
         const levels = [
             "in",
             "channels-public",
+            "channels-archived",
+            "not-channels-archived",
             "channels-web-public",
             "channel",
             "topic",
@@ -879,6 +885,8 @@ export class Filter {
         switch (operand) {
             case "web-public":
                 return possible_prefix + "all web-public channels";
+            case "archived":
+                return possible_prefix + "archived channels";
             default:
                 return possible_prefix + "all public channels";
         }
@@ -1148,6 +1156,8 @@ export class Filter {
             "in-all",
             "channels-public",
             "not-channels-public",
+            "channels-archived",
+            "not-channels-archived",
             "channels-web-public",
             "not-channels-web-public",
             "near",
@@ -1230,6 +1240,10 @@ export class Filter {
             return true;
         }
 
+        if (_.isEqual(term_types, ["not-channels-archived"])) {
+            return true;
+        }
+
         if (_.isEqual(term_types, [])) {
             // Empty filters means we are displaying all possible messages.
             return true;
@@ -1259,6 +1273,9 @@ export class Filter {
             return true;
         }
         if (_.isEqual(term_types, ["channels-web-public"])) {
+            return true;
+        }
+        if (_.isEqual(term_types, ["channels-archived"])) {
             return true;
         }
         if (_.isEqual(term_types, ["sender"])) {
@@ -1339,6 +1356,10 @@ export class Filter {
                     return "/#narrow/is/mentioned";
                 case "channels-public":
                     return "/#narrow/channels/public";
+                case "channels-archived":
+                    return "/#narrow/channels/archived";
+                case "not-channels-archived":
+                    return "/#narrow/-channels/archived";
                 case "channels-web-public":
                     return "/#narrow/channels/web-public";
                 case "dm":
@@ -1529,6 +1550,10 @@ export class Filter {
                         });
                     }
                     return $t({defaultMessage: "Messages in all public channels"});
+                case "channels-archived":
+                    return $t({defaultMessage: "Messages in your archived channels"});
+                case "not-channels-archived":
+                    return $t({defaultMessage: "Messages not in archived channels"});
                 case "channels-web-public":
                     return $t({defaultMessage: "Messages in all web-public channels"});
                 case "is-starred":
@@ -1935,6 +1960,8 @@ export class Filter {
             "not-is-resolved",
             "channels-public",
             "not-channels-public",
+            "channels-archived",
+            "not-channels-archived",
             "channels-web-public",
             "not-channels-web-public",
             "is-muted",

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -344,6 +344,12 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
             // else fallthrough to default case
             break;
         }
+        case "channels": {
+            return {
+                title: $t({defaultMessage: "There are no messages here."}),
+                html: "",
+            };
+        }
         case "search": {
             // You are narrowed to empty search results.
             return empty_search_query_banner(current_filter);

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -31,13 +31,23 @@ type ChannelTopicEntry = {
 
 type TermPattern = Omit<NarrowTerm, "operand"> & Partial<Pick<NarrowTerm, "operand">>;
 
-const channel_incompatible_patterns: TermPattern[] = [
+const common_incompatible_patterns: TermPattern[] = [
     {operator: "is", operand: "dm"},
     {operator: "channel"},
     {operator: "dm-including"},
     {operator: "dm"},
     {operator: "in"},
+];
+
+const channel_incompatible_patterns: TermPattern[] = [
+    ...common_incompatible_patterns,
     {operator: "channels"},
+];
+
+const channels_public_incompatible_patterns: TermPattern[] = [
+    ...common_incompatible_patterns,
+    {operator: "channels", operand: "public"},
+    {operator: "channels", operand: "web-public"},
 ];
 
 // TODO: Expand this to support all available filters and its description.
@@ -65,6 +75,7 @@ type SearchFilter =
     | NarrowCanonicalOperator
     | "channels:public"
     | "channels:web-public"
+    | "channels:archived"
     | "is:resolved"
     | "-is:resolved"
     | "is:dm"
@@ -82,8 +93,12 @@ type SearchFilter =
 const incompatible_patterns: Record<SearchFilter, TermPattern[]> = {
     channel: channel_incompatible_patterns,
     channels: channel_incompatible_patterns,
-    "channels:public": channel_incompatible_patterns,
-    "channels:web-public": channel_incompatible_patterns,
+    "channels:public": channels_public_incompatible_patterns,
+    "channels:web-public": channels_public_incompatible_patterns,
+    "channels:archived": [
+        ...common_incompatible_patterns,
+        {operator: "channels", operand: "archived"},
+    ],
     topic: [
         {operator: "dm"},
         {operator: "is", operand: "dm"},
@@ -728,6 +743,7 @@ function get_channels_filter_suggestions(
     }
     const public_channels_search_string = "channels:public";
     const web_public_channels_search_string = "channels:web-public";
+    const archived_channels_search_string = "channels:archived";
     const suggestions: Suggestion[] = [];
 
     if (!page_params.is_spectator) {
@@ -740,6 +756,7 @@ function get_channels_filter_suggestions(
         );
     }
 
+    suggestions.push(...filter_suggestions_by_criteria(terms, [archived_channels_search_string]));
     return get_special_filter_suggestions(last, suggestions);
 }
 

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -77,6 +77,12 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">channels:archived</td>
+                        <td class="definition">
+                            {{t 'Search your archived channels.'}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">sender:<span class="operator_value">user</span></td>
                         <td class="definition">
                             {{#tr}}

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -341,6 +341,35 @@ test("basics", () => {
     assert.ok(filter.may_contain_multiple_conversations());
     assert.ok(!filter.has_exactly_channel_topic_operators());
 
+    terms = [{operator: "channels", operand: "archived", negated: true}];
+    filter = new Filter(terms);
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.has_operator("channels"));
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(filter.contains_no_partial_conversations());
+    assert.ok(filter.has_negated_operand("channels", "archived"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.is_channel_view());
+    assert.ok(filter.may_contain_multiple_conversations());
+    assert.ok(!filter.has_exactly_channel_topic_operators());
+
+    terms = [{operator: "channels", operand: "archived"}];
+    filter = new Filter(terms);
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(filter.has_operator("channels"));
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.contains_no_partial_conversations());
+    assert.ok(!filter.has_negated_operand("channels", "archived"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(filter.includes_full_stream_history());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.is_channel_view());
+    assert.ok(filter.may_contain_multiple_conversations());
+    assert.ok(!filter.has_exactly_channel_topic_operators());
+
     // "streams" was renamed to "channels"
     terms = [{operator: "streams", operand: "public"}];
     filter = new Filter(terms);
@@ -1146,6 +1175,7 @@ test("predicate_basics", ({override}) => {
     const old_sub_id = new_stream_id();
     const private_sub_id = new_stream_id();
     const web_public_sub_id = new_stream_id();
+    const archived_sub_id = new_stream_id();
     const old_sub = {
         name: "old-subscription",
         stream_id: old_sub_id,
@@ -1167,9 +1197,18 @@ test("predicate_basics", ({override}) => {
         invite_only: false,
         is_web_public: true,
     };
+    const archived_sub = {
+        name: "archived-subscription",
+        stream_id: archived_sub_id,
+        subscribed: true,
+        invite_only: false,
+        is_web_public: true,
+        is_archived: true,
+    };
     stream_data.add_sub_for_tests(old_sub);
     stream_data.add_sub_for_tests(private_sub);
     stream_data.add_sub_for_tests(web_public_sub);
+    stream_data.add_sub_for_tests(archived_sub);
     predicate = get_predicate([
         ["channel", old_sub_id.toString()],
         ["topic", "Bar"],
@@ -1193,7 +1232,11 @@ test("predicate_basics", ({override}) => {
     assert.ok(!predicate({type: stream_message, stream_id: private_sub_id}));
     assert.ok(predicate({type: stream_message, stream_id: web_public_sub_id}));
 
+    predicate = get_predicate([["channels", "archived"]]);
+    assert.ok(predicate({type: stream_message, stream_id: archived_sub_id}));
+
     predicate = get_predicate([["channels", "web-public"]]);
+    assert.ok(predicate({type: stream_message, stream_id: archived_sub_id}));
     assert.ok(predicate({type: stream_message, stream_id: web_public_sub_id}));
     assert.ok(!predicate({type: stream_message, stream_id: old_sub_id}));
 
@@ -1758,6 +1801,14 @@ test("describe", ({mock_template, override}) => {
 
     narrow = [{operator: "channels", operand: "public", negated: true}];
     string = "exclude all public channels";
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
+
+    narrow = [{operator: "channels", operand: "archived"}];
+    string = "archived channels";
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
+
+    narrow = [{operator: "channels", operand: "archived", negated: true}];
+    string = "exclude archived channels";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "channels", operand: "web-public"}];
@@ -2460,6 +2511,8 @@ test("navbar_helpers", ({override}) => {
     const is_resolved = [{operator: "is", operand: "resolved"}];
     const is_followed = [{operator: "is", operand: "followed"}];
     const channels_public = [{operator: "channels", operand: "public"}];
+    const channels_archived = [{operator: "channels", operand: "archived"}];
+    const not_channels_archived = [{operator: "channels", operand: "archived", negated: true}];
     const channels_web_public = [{operator: "channels", operand: "web-public"}];
     const channel_topic_terms = [
         {operator: "channel", operand: foo_stream_id.toString()},
@@ -2646,6 +2699,20 @@ test("navbar_helpers", ({override}) => {
             icon: undefined,
             title: "translated: Messages in all public channels",
             redirect_url_with_search: "/#narrow/channels/public",
+        },
+        {
+            terms: channels_archived,
+            is_common_narrow: true,
+            icon: undefined,
+            title: "translated: Messages in your archived channels",
+            redirect_url_with_search: "/#narrow/channels/archived",
+        },
+        {
+            terms: not_channels_archived,
+            is_common_narrow: true,
+            icon: undefined,
+            title: "translated: Messages not in archived channels",
+            redirect_url_with_search: "/#narrow/-channels/archived",
         },
         {
             terms: channels_web_public,
@@ -2964,6 +3031,7 @@ run_test("is_spectator_compatible", () => {
     assert.ok(!Filter.is_spectator_compatible([{operator: "is", operand: "starred"}]));
     assert.ok(!Filter.is_spectator_compatible([{operator: "is", operand: "dm"}]));
     assert.ok(Filter.is_spectator_compatible([{operator: "channels", operand: "public"}]));
+    assert.ok(Filter.is_spectator_compatible([{operator: "channels", operand: "archived"}]));
 
     // Malformed input not allowed
     assert.ok(!Filter.is_spectator_compatible([{operator: "has"}]));

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -668,6 +668,15 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
             "translated: You are not allowed to view messages in this private channel.",
         ),
     );
+    const channels_operands = ["archived", "public", "web-public"];
+    for (const operand of channels_operands) {
+        current_filter = set_filter([["channels", operand]]);
+        narrow_banner.show_empty_narrow_message(current_filter);
+        assert.equal(
+            $(".empty_feed_notice_main").html(),
+            empty_narrow_html("translated: There are no messages here."),
+        );
+    }
 });
 
 run_test("show_empty_narrow_message_with_search", ({mock_template, override}) => {

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -136,7 +136,7 @@ test("basic_get_suggestions_for_spectator", () => {
     stream_data.delete_sub(sub.stream_id);
     query = "channels:";
     suggestions = get_suggestions(query);
-    assert.deepEqual(suggestions, []);
+    assert.deepEqual(suggestions, ["channels:archived"]);
     page_params.is_spectator = false;
 });
 

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -47,6 +47,7 @@ from zerver.lib.streams import (
     access_stream_common,
     can_access_stream_history_by_id,
     can_access_stream_history_by_name,
+    get_archived_streams_queryset,
     get_public_streams_queryset,
     get_stream_by_narrow_operand_access_unchecked,
     get_web_public_streams_queryset,
@@ -492,6 +493,8 @@ class NarrowBuilder:
             recipient_queryset = get_public_streams_queryset(self.realm)
         elif operand == "web-public":
             recipient_queryset = get_web_public_streams_queryset(self.realm)
+        elif operand == "archived":
+            recipient_queryset = get_archived_streams_queryset(self.realm)
         else:
             raise BadNarrowOperatorError("unknown channels operand " + operand)
 

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -1027,6 +1027,10 @@ def get_public_streams_queryset(realm: Realm) -> QuerySet[Stream]:
     return Stream.objects.filter(realm=realm, invite_only=False, history_public_to_subscribers=True)
 
 
+def get_archived_streams_queryset(realm: Realm) -> QuerySet[Stream]:
+    return Stream.objects.filter(realm=realm, deactivated=True)
+
+
 def get_web_public_streams_queryset(realm: Realm) -> QuerySet[Stream]:
     # This should match the include_web_public code path in do_get_streams.
     return Stream.objects.filter(

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -228,6 +228,20 @@ class NarrowBuilderTest(ZulipTestCase):
             "WHERE (recipient_id NOT IN (__[POSTCOMPILE_recipient_id_1]))",
         )
 
+    def test_add_term_using_channels_operator_and_archived_operand(self) -> None:
+        term = NarrowParameter(operator="channels", operand="archived")
+        self._do_add_term_test(
+            term,
+            "WHERE recipient_id IN (__[POSTCOMPILE_recipient_id_1])",
+        )
+
+    def test_add_term_using_channels_operator_and_archived_operand_negated(self) -> None:
+        term = NarrowParameter(operator="channels", operand="archived", negated=True)
+        self._do_add_term_test(
+            term,
+            "WHERE (recipient_id NOT IN (__[POSTCOMPILE_recipient_id_1]))",
+        )
+
     def test_add_term_using_is_operator_and_dm_operand(self) -> None:
         term = NarrowParameter(operator="is", operand="dm")
         self._do_add_term_test(term, "WHERE (flags & %(flags_1)s) != %(param_1)s")
@@ -1330,6 +1344,9 @@ class NarrowLibraryTest(ZulipTestCase):
         self.assertTrue(
             is_spectator_compatible([NarrowParameter(operator="channels", operand="public")])
         )
+        self.assertTrue(
+            is_spectator_compatible([NarrowParameter(operator="channels", operand="archived")])
+        )
 
         # "is:private" is a legacy alias for "is:dm".
         self.assertFalse(
@@ -1397,6 +1414,17 @@ class IncludeHistoryTest(ZulipTestCase):
         # Negated -channels:web-public searches should not include history.
         narrow = [
             NarrowParameter(operator="channels", operand="web-public", negated=True),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+
+        # channels:archived searches should not include history,
+        # whether negated or not.
+        narrow = [
+            NarrowParameter(operator="channels", operand="archived"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+        narrow = [
+            NarrowParameter(operator="channels", operand="archived", negated=True),
         ]
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
 
@@ -1473,6 +1501,13 @@ class IncludeHistoryTest(ZulipTestCase):
         ]
         self.assertTrue(ok_to_include_history(narrow, user_profile, False))
 
+        # Search history for archived, public channel searches.
+        narrow = [
+            NarrowParameter(operator="channels", operand="public"),
+            NarrowParameter(operator="channels", operand="archived"),
+        ]
+        self.assertTrue(ok_to_include_history(narrow, user_profile, False))
+
         # simple True case
         narrow = [
             NarrowParameter(operator="channel", operand="public_channel"),
@@ -1494,6 +1529,14 @@ class IncludeHistoryTest(ZulipTestCase):
         # channels:public searches should not include history for guest members.
         narrow = [
             NarrowParameter(operator="channels", operand="public"),
+        ]
+        self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
+
+        # And archived, public channel searches should still not include history
+        # for guest members.
+        narrow = [
+            NarrowParameter(operator="channels", operand="public"),
+            NarrowParameter(operator="channels", operand="archived"),
         ]
         self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
 


### PR DESCRIPTION
This PR rebases #36021 and removes all conflicts.
<!-- Describe your pull request here.-->

Fixes: #32506<!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->
<details>
<summary>Screenshots and screen captures:</summary>
<img width="1045" height="214" alt="image" src="https://github.com/user-attachments/assets/95f5d707-7094-4876-8160-4ebfc57bd343" />
<img width="738" height="168" alt="image" src="https://github.com/user-attachments/assets/ca2a8039-f73a-4a67-b842-77968ffb7f14" />
<img width="834" height="128" alt="image" src="https://github.com/user-attachments/assets/7f2921ae-0216-478b-8c45-a1071c0b6049" />
<img width="514" height="106" alt="image" src="https://github.com/user-attachments/assets/ed82888f-85c7-4793-8d2c-4863c2fe89a9" />
<img width="1049" height="121" alt="image" src="https://github.com/user-attachments/assets/5efe03ef-1385-4761-8d3c-a7219b5104bc" />
<img width="958" height="721" alt="image" src="https://github.com/user-attachments/assets/76bb3230-ef0f-49cb-871e-35e82a25324d" />
<img width="1862" height="990" alt="image" src="https://github.com/user-attachments/assets/16968ab2-451f-41c3-9289-a49b4b80b592" />
<img width="1858" height="989" alt="image" src="https://github.com/user-attachments/assets/e10cb5a4-504a-405a-8c58-ae7e48c437e3" />

</details>
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
