### PR TITLE
[ai] puppeteer: Fix flaky drafts test click on compose button.

### DIFF
--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -51,8 +51,8 @@ async function test_restore_stream_message_draft_by_opening_compose_box(page: Pa
     // Wait for narrow to complete.
     const wait_for_change = true;
     await common.get_current_msg_list_id(page, wait_for_change);
-    await page.keyboard.press("Enter");
 
+    await page.waitForSelector("#left_bar_compose_reply_button_big", {visible: true});
     await page.click("#left_bar_compose_reply_button_big");
     await page.waitForSelector("#send_message_form", {visible: true});
 
@@ -75,6 +75,7 @@ async function create_private_message_draft(page: Page): Promise<void> {
 }
 
 async function test_restore_private_message_draft_by_opening_composebox(page: Page): Promise<void> {
+    await page.waitForSelector("#left_bar_compose_reply_button_big", {visible: true});
     await page.click("#left_bar_compose_reply_button_big");
     await page.waitForSelector("#private_message_recipient", {visible: true});
 


### PR DESCRIPTION
## Summary

- Remove a stale `keyboard.press("Enter")` in `test_restore_stream_message_draft_by_opening_compose_box` that was left over when 38e58ea3d6 added a second Enter press without removing the original from 4e87f35c7d. The leftover Enter fired into the message list after the narrow completed, sometimes opening compose and hiding the reply button.
- Add `waitForSelector` with `{visible: true}` before both clicks on `#left_bar_compose_reply_button_big`, following the pattern from 42a1bcf6ed.

## Test plan

- [x] `./tools/lint web/e2e-tests/drafts.test.ts`

---

User prompted to fix this flake from [CI error logs](https://github.com/zulip/zulip/actions/runs/22840491555/job/66245526174#step:17:1776).

🤖 Generated with [Claude Code](https://claude.com/claude-code)