### PR TITLE
Fix spacing and dropdown sizing in channel folder selector

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1961,7 +1961,8 @@ textarea.new_message_textarea {
 }
 
 .saved_snippets-dropdown-list-container {
-    width: 17.8571em; /* 250px at 14px/em */
+    width: fit-content;
+    min-width: max-content;
 
     .dropdown-list .dropdown-list-item-common-styles {
         padding: 0.3571em 0.7143em; /* 5px 10px at 14px/em */

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2254,6 +2254,8 @@ body:not(.spectator-view) {
 
     .dropdown-list .dropdown-list-item-common-styles {
         display: grid;
+        min-height: 34px;
+        align-content: center;
         grid-template:
             "privacy-icon     item-label       " min-content
             "item-description item-description" minmax(0, min-content) / minmax(
@@ -2262,7 +2264,7 @@ body:not(.spectator-view) {
             )
             minmax(0, 1fr);
         color: var(--color-dropdown-item);
-        padding: 3px 10px 3px 8px;
+        padding: 3px 10px 3px 12px;
         font-weight: 400;
         white-space: normal;
         /* Keep the line-height stable, instead of using the


### PR DESCRIPTION
### Summary
This PR fixes spacing and dropdown sizing issues in the channel folder selector UI.

### What was fixed
- Corrected spacing inconsistencies in the channel folder selector.
- Adjusted dropdown height and sizing for better alignment.
- Improved overall UI consistency.

### Files changed
- web/styles/compose.css
- web/styles/zulip.css

### After fix
<img width="678" height="564" alt="Inbox - Zulip Dev - Zulip and 3 more pages - Personal - Microsoft​ Edge 07-03-2026 18_25_55" src="https://github.com/user-attachments/assets/69f9f11f-0fb9-4304-b8af-698bb08cc235" />

Fixes #37647
