### PR TITLE
search: Avoid showing topic suggestions for non-id channel operands.

### DIFF
--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -569,6 +569,12 @@ function get_topic_suggestions(
         return [];
     }
 
+    // Avoid sending topic suggestions when the user is
+    // just trying to search through channels.
+    if (channel_id_or_operand_str?.length === 0 && last.operator === "channel") {
+        return [];
+    }
+
     // We don't want to show topic suggestions from negated channels
     const excluded_channel_ids = new Set(
         terms

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -834,6 +834,13 @@ test("topic_suggestions", ({override, override_rewire}) => {
     suggestions = get_suggestions("hello channel:foobar");
     expected = [];
     assert.deepEqual(suggestions, expected);
+
+    // We shouldn't see topic suggestions for an
+    // empty operand with channel as the operator for
+    // the last term.
+    suggestions = get_suggestions("hello channel:");
+    expected = ["hello channel:5", "hello channel:6"];
+    assert.deepEqual(suggestions, expected);
 });
 
 test("topic_suggestions (limits)", () => {


### PR DESCRIPTION
We avoid suggesting topics if the last query term
includes a channel operator whose operand is not a valid channel id.

Fixes: https://chat.zulip.org/#narrow/channel/9-issues/topic/unexpected.20search.20suggestion/with/2388550

| Before | After |
|-----|-----|
| <img width="1093" height="380" alt="image" src="https://github.com/user-attachments/assets/26b39d08-7ace-4abf-aa4d-0355ea640a17" />| <img width="1084" height="394" alt="image" src="https://github.com/user-attachments/assets/5b4d4f57-f5b9-48bc-b763-3dee19be22db" />|