### PR TITLE
notifications: Channel wildcard notification setting overrides muting.

### DIFF
--- a/starlight_help/src/content/docs/dm-mention-alert-notifications.mdx
+++ b/starlight_help/src/content/docs/dm-mention-alert-notifications.mdx
@@ -41,8 +41,10 @@ mentions (**@all**, **@everyone**, **@channel**) and **@topic** mentions
 separately from personal @-mentions.
 
 <ZulipTip>
-  These mentions don't trigger notifications in muted channels or topics,
-  unlike personal mentions.
+  These mentions don't trigger notifications in muted topics, unlike
+  personal mentions. In muted channels, they are suppressed by default,
+  but you can override this by [enabling](/help/channel-notifications#configure-notifications-for-a-single-channel)
+  wildcard mention notifications in the specific channels where you'd like to receive them.
 </ZulipTip>
 
 <FlattenedSteps>

--- a/web/src/message_notifications.ts
+++ b/web/src/message_notifications.ts
@@ -11,6 +11,7 @@ import * as message_view from "./message_view.ts";
 import * as people from "./people.ts";
 import * as spoilers from "./spoilers.ts";
 import * as stream_data from "./stream_data.ts";
+import * as sub_store from "./sub_store.ts";
 import * as ui_util from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
 import * as user_topics from "./user_topics.ts";
@@ -232,6 +233,12 @@ export function message_is_notifiable(message: Message | TestNotificationMessage
     // Independent of the user's notification settings, are there
     // properties of the message that unconditionally mean we
     // shouldn't notify about it.
+    //
+    // NOTE: The muted channel block below checks
+    // wildcard_mentions_notify setting for maintainability, keeping the
+    // muting override logic in one place rather than duplicating it
+    // across should_send_*_notification. This should not be taken
+    // as precedent for adding other notification settings here.
 
     if (message.sent_by_me) {
         return false;
@@ -244,7 +251,8 @@ export function message_is_notifiable(message: Message | TestNotificationMessage
     }
 
     // @-<username> mentions take precedence over muted-ness. Note
-    // that @all mentions are still suppressed by muting.
+    // that @all mentions are still suppressed by muting unless the
+    // channel-specific wildcard_mentions_notify setting is enabled.
     if (message.mentioned_me_directly) {
         return true;
     }
@@ -257,17 +265,22 @@ export function message_is_notifiable(message: Message | TestNotificationMessage
         return true;
     }
 
+    if (message.type === "stream" && user_topics.is_topic_muted(message.stream_id, message.topic)) {
+        return false;
+    }
+
     // Messages to unmuted topics in muted streams may generate desktop notifications.
     if (
         message.type === "stream" &&
         stream_data.is_muted(message.stream_id) &&
         !user_topics.is_topic_unmuted(message.stream_id, message.topic)
     ) {
-        return false;
-    }
-
-    if (message.type === "stream" && user_topics.is_topic_muted(message.stream_id, message.topic)) {
-        return false;
+        // Now, only way a message can notify is if it's a wildcard mention
+        // with channel-specific wildcard_mentions_notify=true.
+        const sub = sub_store.get(message.stream_id);
+        if (!(message.mentioned && sub?.wildcard_mentions_notify === true)) {
+            return false;
+        }
     }
 
     // Everything else is on the table; next filter based on notification

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -7,7 +7,7 @@
             {{/if}}
             {{> settings_save_discard_widget section_name="general-notify-settings" show_save_discard_buttons=for_realm_settings show_saving_indicator=true }}
         </div>
-        <p>{{t "Configure how Zulip notifies you about new messages. In muted channels, channel notification settings apply only to unmuted topics." }}</p>
+        <p>{{t "Configure how Zulip notifies you about new messages." }}</p>
         <table class="notification-table table table-bordered wrapped-table">
             <thead>
                 <tr>

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -101,7 +101,6 @@
                     <h4 class="stream_setting_subsection_title">{{t "Notification settings" }}</h4>
                     <div class="stream_change_property_status alert-notification"></div>
                 </div>
-                <p>{{t "In muted channels, channel notification settings apply only to unmuted topics." }}</p>
                 <div class="input-group">
                     {{> ../components/action_button
                       label=(t "Reset to default notifications")

--- a/web/tests/notifications.test.cjs
+++ b/web/tests/notifications.test.cjs
@@ -239,6 +239,28 @@ test("message_is_notifiable", ({override}) => {
     assert.equal(message_notifications.message_is_notifiable(message), false);
 
     // Case 8: If a message is in a muted stream
+    //  and has a wildcard mention with channel-specific wildcard_mentions_notify=true,
+    //  DO notify the user (channel-specific setting overrides channel muting)
+    muted.wildcard_mentions_notify = true;
+    message = {
+        id: 50,
+        content: "message number 5a",
+        sent_by_me: false,
+        notification_sent: false,
+        mentioned: true,
+        mentioned_me_directly: false,
+        type: "stream",
+        stream_id: muted.stream_id,
+        topic: "whatever",
+    };
+    assert.equal(message_notifications.message_is_notifiable(message), true);
+    assert.equal(message_notifications.should_send_desktop_notification(message), true);
+    assert.equal(message_notifications.should_send_audible_notification(message), true);
+
+    // Reset state
+    muted.wildcard_mentions_notify = null;
+
+    // Case 9: If a message is in a muted stream
     //  and does mention the user DIRECTLY,
     //  DO notify the user
     message = {
@@ -256,7 +278,7 @@ test("message_is_notifiable", ({override}) => {
     assert.equal(message_notifications.should_send_audible_notification(message), true);
     assert.equal(message_notifications.message_is_notifiable(message), true);
 
-    // Case 9: If a message is in a muted topic
+    // Case 10: If a message is in a muted topic
     //  and does not mention the user DIRECTLY (i.e. wildcard mention),
     //  DO NOT notify the user
     message = {
@@ -274,7 +296,25 @@ test("message_is_notifiable", ({override}) => {
     assert.equal(message_notifications.should_send_audible_notification(message), true);
     assert.equal(message_notifications.message_is_notifiable(message), false);
 
-    // Case 10:
+    // Case 11:
+    // For wildcard mentions, even with channel-specific
+    // wildcard_mentions_notify=True, muted topics suppress notifications.
+    message = {
+        id: 50,
+        content: "message number 6",
+        sent_by_me: false,
+        notification_sent: false,
+        mentioned: true,
+        mentioned_me_directly: false,
+        type: "stream",
+        stream_id: general.stream_id,
+        topic: "muted topic",
+    };
+    assert.equal(message_notifications.message_is_notifiable(message), false);
+    assert.equal(message_notifications.should_send_desktop_notification(message), true);
+    assert.equal(message_notifications.should_send_audible_notification(message), true);
+
+    // Case 12:
     // Wildcard mentions in a followed topic with 'wildcard_mentions_notify',
     // 'enable_followed_topic_desktop_notifications',
     // 'enable_followed_topic_audible_notifications' disabled and
@@ -310,7 +350,7 @@ test("message_is_notifiable", ({override}) => {
     override(user_settings, "enable_followed_topic_audible_notifications", true);
     override(user_settings, "enable_followed_topic_wildcard_mentions_notify", true);
 
-    // Case 11: If `None` is selected as the notification sound, send no
+    // Case 13: If `None` is selected as the notification sound, send no
     // audible notification, no matter what other user configurations are.
     message = {
         id: 50,

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -338,7 +338,9 @@ def get_recipient_info(
 
         user_id_to_visibility_policy = stream_topic.user_id_to_visibility_policy_dict()
 
-        def notification_recipients(setting: str) -> set[int]:
+        def notification_recipients(
+            setting: str, *, channel_specific_setting_overrides_mute: bool = False
+        ) -> set[int]:
             return {
                 row["user_profile_id"]
                 for row in subscription_rows
@@ -349,6 +351,7 @@ def get_recipient_info(
                     ),
                     row[setting],
                     row["user_profile_" + setting],
+                    channel_specific_setting_overrides_mute,
                 )
             }
 
@@ -377,7 +380,9 @@ def get_recipient_info(
             # This is important so as to avoid unnecessarily sending huge user ID lists with
             # thousands of elements to the event queue (which can happen because these settings
             # are `True` by default for new users.)
-            wildcard_mentions_notify_user_ids = notification_recipients("wildcard_mentions_notify")
+            wildcard_mentions_notify_user_ids = notification_recipients(
+                "wildcard_mentions_notify", channel_specific_setting_overrides_mute=True
+            )
             followed_topic_wildcard_mentions_notify_user_ids = (
                 followed_topic_notification_recipients("wildcard_mentions_notify")
             )

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -294,15 +294,23 @@ def user_allows_notifications_in_StreamTopic(
     visibility_policy: int,
     stream_specific_setting: bool | None,
     global_setting: bool,
+    channel_specific_setting_overrides_mute: bool,
 ) -> bool:
     """
     Captures the hierarchy of notification settings, where visibility policy is considered first,
     followed by stream-specific settings, and the global-setting in the UserProfile is the fallback.
+
+    When `channel_specific_setting_overrides_mute` is True (currently used for
+    `wildcard_mentions_notify` setting), `stream_specific_setting` overrides
+    channel mute, but not topic mute.
     """
-    if stream_is_muted and visibility_policy != UserTopic.VisibilityPolicy.UNMUTED:
+    # Muted topics always suppress notifications, regardless of other settings.
+    if visibility_policy == UserTopic.VisibilityPolicy.MUTED:
         return False
 
-    if visibility_policy == UserTopic.VisibilityPolicy.MUTED:
+    if stream_is_muted and visibility_policy != UserTopic.VisibilityPolicy.UNMUTED:
+        if channel_specific_setting_overrides_mute and stream_specific_setting is not None:
+            return stream_specific_setting
         return False
 
     if stream_specific_setting is not None:

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -427,8 +427,54 @@ class MissedMessageHookTest(ZulipTestCase):
                 already_notified={"email_notified": False, "push_notified": False},
             )
 
+    def test_wildcard_mentions_notify_stream_specific_setting_in_muted_stream(self) -> None:
+        # If wildcard_mentions_notify=True for a muted channel,
+        # it overrides channel muting and notifies user.
+        self.change_subscription_properties({"is_muted": True, "wildcard_mentions_notify": True})
+        msg_id = self.send_stream_message(self.iago, "Denmark", content="@**all** what's up?")
+        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
+            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            mock_enqueue.assert_called_once()
+            args_dict = mock_enqueue.call_args_list[0][1]
+
+            self.assert_maybe_enqueue_notifications_call_args(
+                args_dict=args_dict,
+                stream_wildcard_mention_email_notify=True,
+                stream_wildcard_mention_push_notify=True,
+                message_id=msg_id,
+                user_id=self.user_profile.id,
+                already_notified={"email_notified": True, "push_notified": True},
+            )
+
     def test_stream_wildcard_mention_in_muted_topic(self) -> None:
         # stream wildcard mentions in muted topics don't notify.
+        do_set_user_topic_visibility_policy(
+            self.user_profile,
+            get_stream("Denmark", self.user_profile.realm),
+            "mutingtest",
+            visibility_policy=UserTopic.VisibilityPolicy.MUTED,
+        )
+        msg_id = self.send_stream_message(
+            self.iago, "Denmark", topic_name="mutingtest", content="@**all** what's up?"
+        )
+        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
+            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            mock_enqueue.assert_called_once()
+            args_dict = mock_enqueue.call_args_list[0][1]
+
+            self.assert_maybe_enqueue_notifications_call_args(
+                args_dict=args_dict,
+                stream_wildcard_mention_email_notify=False,
+                stream_wildcard_mention_push_notify=False,
+                message_id=msg_id,
+                user_id=self.user_profile.id,
+                already_notified={"email_notified": False, "push_notified": False},
+            )
+
+    def test_wildcard_mentions_notify_stream_specific_setting_in_muted_topic(self) -> None:
+        # Even with channel-specific wildcard_mentions_notify=True,
+        # muted topics should still suppress notifications.
+        self.change_subscription_properties({"wildcard_mentions_notify": True})
         do_set_user_topic_visibility_policy(
             self.user_profile,
             get_stream("Denmark", self.user_profile.realm),


### PR DESCRIPTION
PR to replace https://github.com/zulip/zulip/pull/38261

Fixes #37973.


**How changes were tested:**

Tests + manual testing.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
