### PR TITLE
populate-analytics: Delete attachments before realm and flushing cache.

### DIFF
--- a/analytics/management/commands/populate_analytics_db.py
+++ b/analytics/management/commands/populate_analytics_db.py
@@ -26,7 +26,7 @@ from zerver.lib.stream_subscription import create_stream_subscription
 from zerver.lib.streams import get_default_values_for_stream_permission_group_settings
 from zerver.lib.timestamp import floor_to_day
 from zerver.lib.upload import upload_message_attachment_from_request
-from zerver.models import Client, Realm, RealmAuditLog, Recipient, Stream, UserProfile
+from zerver.models import Attachment, Client, Realm, RealmAuditLog, Recipient, Stream, UserProfile
 from zerver.models.groups import NamedUserGroup, SystemGroups, UserGroupMembership
 from zerver.models.realm_audit_logs import AuditLogEventType
 
@@ -67,6 +67,10 @@ class Command(ZulipBaseCommand):
         # TODO: This should arguably only delete the objects
         # associated with the "analytics" realm.
         do_drop_all_analytics_tables()
+
+        # Delete attachment added for summary statistic before deleting
+        # the Realm object.
+        Attachment.objects.filter(realm__string_id="analytics").delete()
 
         # This also deletes any objects with this realm as a foreign key
         Realm.objects.filter(string_id="analytics").delete()


### PR DESCRIPTION
When this command is run in isolation, the attachment object added for the realm summary statistics needs to be deleted first, so that when the cache is flushed the `UserProfile` object for the realm owner still exists. See `flush_used_upload_space_cache`.

**Before**:
```console
$ ./manage.py populate_analytics_db
Traceback (most recent call last):
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/db/models/fields/related_descriptors.py", line 243, in __get__
    rel_obj = self.field.get_cached_value(instance)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/db/models/fields/mixins.py", line 37, in get_cached_value
    return instance._state.fields_cache[self.cache_name]
KeyError: 'owner'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/srv/zulip/./manage.py", line 154, in <module>
    execute_from_command_line(sys.argv)
  File "/srv/zulip/./manage.py", line 115, in execute_from_command_line
    utility.execute()
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/management/base.py", line 420, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/srv/zulip/zerver/lib/management.py", line 106, in execute
    super().execute(*args, **options)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/management/base.py", line 464, in execute
    output = self.handle(*args, **options)
  File "/srv/zulip/analytics/management/commands/populate_analytics_db.py", line 72, in handle
    Realm.objects.filter(string_id="analytics").delete()
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/db/models/query.py", line 1201, in delete
    num_deleted, num_deleted_per_model = collector.delete()
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/db/models/deletion.py", line 507, in delete
    signals.post_delete.send(
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/dispatch/dispatcher.py", line 189, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/srv/zulip/zerver/lib/cache.py", line 761, in flush_used_upload_space_cache
    cache_delete(get_realm_used_upload_space_cache_key(attachment.owner.realm_id))
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/db/models/fields/related_descriptors.py", line 261, in __get__
    rel_obj = self.get_object(instance)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/db/models/fields/related_descriptors.py", line 224, in get_object
    return qs.get(self.field.get_reverse_related_filter(instance))
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/db/models/query.py", line 635, in get
    raise self.model.DoesNotExist(
zerver.models.users.UserProfile.DoesNotExist: UserProfile matching query does not exist.

```

**After**:
```console
$ ./manage.py populate_analytics_db
2026-03-09 16:37:32.650 INFO [] Clearing memcached cache after migrations
2026-03-09 16:37:32.650 INFO [bmemcached.protocol] Flushing memcached

```

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
