### PR TITLE
settings: Auto-reload app when default language is changed.

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -402,20 +402,19 @@ async function test_alert_words_section(page: Page): Promise<void> {
     await test_alert_word_deletion(page, word);
 }
 
-async function change_language(page: Page, language_data_code: string): Promise<void> {
+async function change_language_and_reload(page: Page, language_data_code: string): Promise<void> {
     await page.waitForSelector("#default_language_widget", {
         visible: true,
     });
     await page.click("#default_language_widget");
     await page.waitForSelector(".dropdown-list", {visible: true});
     const language_selector = `li[data-unique-id="${CSS.escape(language_data_code)}"]`;
-    await page.click(language_selector);
-}
-
-async function check_language_setting_status(page: Page): Promise<void> {
-    await page.waitForSelector("#user-preferences .general-settings-status .reload_link", {
-        visible: true,
-    });
+    // Register the navigation listener before clicking to avoid a race
+    // condition where the page reloads before waitForNavigation is called.
+    await Promise.all([
+        page.waitForNavigation({waitUntil: "networkidle0"}),
+        page.click(language_selector),
+    ]);
 }
 
 async function assert_language_changed_to_chinese(page: Page): Promise<void> {
@@ -449,29 +448,16 @@ async function test_default_language_setting(page: Page): Promise<void> {
     await page.click(preferences_section);
 
     const chinese_language_data_code = "zh-hans";
-    await change_language(page, chinese_language_data_code);
-    // Check that the saved indicator appears
-    await check_language_setting_status(page);
-    await page.click(".reload_link");
-    await page.waitForSelector("#default_language_widget", {
-        visible: true,
-    });
+    await change_language_and_reload(page, chinese_language_data_code);
     await assert_language_changed_to_chinese(page);
     await test_i18n_language_precedence(page);
     await page.waitForSelector(preferences_section, {visible: true});
     await page.click(preferences_section);
 
     // Change the language back to English so that subsequent tests pass.
-    await change_language(page, "en");
-
-    // Check that the saved indicator appears
-    await check_language_setting_status(page);
-    await page.goto("http://zulip.zulipdev.com:9981/#settings"); // get back to normal language.
+    await change_language_and_reload(page, "en");
     await page.waitForSelector(preferences_section, {visible: true});
     await page.click(preferences_section);
-    await page.waitForSelector("#user-preferences .general-settings-status", {
-        visible: true,
-    });
     await page.waitForSelector("#default_language_widget", {
         visible: true,
     });

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -837,10 +837,6 @@ export function initialize(): void {
         settings_toggle.toggle_org_setting_collapse();
     });
 
-    $("body").on("click", ".reload_link", () => {
-        window.location.reload();
-    });
-
     // COMPOSE
 
     $("body").on("click", ".empty_feed_compose_stream", (e) => {

--- a/web/src/reload.ts
+++ b/web/src/reload.ts
@@ -148,6 +148,7 @@ function do_reload_app(
     send_after_reload: boolean,
     save_compose: boolean,
     reason: ReloadingReason,
+    show_reload_banner: boolean,
 ): void {
     if (reload_state.is_in_progress()) {
         blueslip.log("do_reload_app: Doing nothing since reload_in_progress");
@@ -162,7 +163,9 @@ function do_reload_app(
     }
 
     // TODO: We need a better API for showing messages.
-    popup_banners.open_reloading_application_banner(reason);
+    if (show_reload_banner) {
+        popup_banners.open_reloading_application_banner(reason);
+    }
     blueslip.log("Starting server requested page reload");
     reload_state.set_state_to_in_progress();
 
@@ -204,11 +207,13 @@ export function initiate({
     save_compose = true,
     send_after_reload = false,
     reason = "reload",
+    show_reload_banner = true,
 }: {
     immediate?: boolean;
     save_compose?: boolean;
     send_after_reload?: boolean;
     reason?: ReloadingReason;
+    show_reload_banner?: boolean;
 }): void {
     if (reload_state.is_in_progress()) {
         // If we're already attempting to reload, there's nothing to do.
@@ -223,7 +228,7 @@ export function initiate({
         // before any pending HTTP callbacks fire; channel.ts will
         // suppress those callbacks, preventing errors from processing
         // stale data.
-        do_reload_app(send_after_reload, save_compose, reason);
+        do_reload_app(send_after_reload, save_compose, reason, show_reload_banner);
         return;
     }
 
@@ -243,7 +248,7 @@ export function initiate({
         success() {
             server_reachable_check_failures = 0;
             if (immediate) {
-                do_reload_app(send_after_reload, save_compose, reason);
+                do_reload_app(send_after_reload, save_compose, reason, show_reload_banner);
                 // We don't expect do_reload_app to return, but if it
                 // does, the fallthrough logic seems fine.
             }
@@ -283,7 +288,7 @@ export function initiate({
             const basic_idle_timeout = 1000 * 60 * 1 + random_variance;
 
             function reload_from_idle(): void {
-                do_reload_app(false, save_compose, reason);
+                do_reload_app(false, save_compose, reason, show_reload_banner);
             }
 
             // Make sure we always do a reload eventually after
@@ -323,7 +328,13 @@ export function initiate({
                 server_reachable_check_failures,
             );
             setTimeout(() => {
-                initiate({immediate, save_compose, send_after_reload, reason});
+                initiate({
+                    immediate,
+                    save_compose,
+                    send_after_reload,
+                    reason,
+                    show_reload_banner,
+                });
             }, retry_delay_secs * 1000);
         },
     });

--- a/web/src/settings_preferences.ts
+++ b/web/src/settings_preferences.ts
@@ -16,6 +16,7 @@ import * as loading from "./loading.ts";
 import * as overlays from "./overlays.ts";
 import {page_params} from "./page_params.ts";
 import type {RealmDefaultSettings} from "./realm_user_settings_defaults.ts";
+import * as reload from "./reload.ts";
 import * as settings_components from "./settings_components.ts";
 import type {RequestOpts} from "./settings_ui.ts";
 import * as settings_ui from "./settings_ui.ts";
@@ -49,6 +50,25 @@ const meta = {
 
 export let user_settings_panel: SettingsPanel;
 let default_language_dropdown_widget: dropdown_widget.DropdownWidget;
+let default_language_feedback_timeout: ReturnType<typeof setTimeout> | undefined;
+let default_language_reload_timeout: ReturnType<typeof setTimeout> | undefined;
+let latest_default_language_request_id = 0;
+
+const saving_status_minimum_visible_time_ms = 500;
+const saved_status_remove_after_ms = 1000;
+const saved_status_fade_out_duration_ms = 400;
+
+function clear_default_language_timeouts(): void {
+    if (default_language_feedback_timeout !== undefined) {
+        clearTimeout(default_language_feedback_timeout);
+        default_language_feedback_timeout = undefined;
+    }
+
+    if (default_language_reload_timeout !== undefined) {
+        clearTimeout(default_language_reload_timeout);
+        default_language_reload_timeout = undefined;
+    }
+}
 
 function change_display_setting(
     data: Record<string, string | boolean | number>,
@@ -386,23 +406,73 @@ function language_select_callback(
 
     const current_value = widget.current_value;
     assert(current_value !== undefined);
+    if (current_value === user_settings.default_language) {
+        return;
+    }
     const data = {default_language: current_value};
-    change_display_setting(
+    const $status_el = $("#user-preferences").find(".general-settings-status");
+
+    latest_default_language_request_id += 1;
+    const request_id = latest_default_language_request_id;
+    const request_start_time = Date.now();
+
+    clear_default_language_timeouts();
+    $status_el.fadeTo(0, 1);
+    loading.make_indicator($status_el, {text: settings_ui.strings.saving});
+
+    void channel.patch({
+        url: "/json/settings",
         data,
-        $("#user-preferences").find(".general-settings-status"),
-        undefined,
-        undefined,
-        $t_html(
-            {
-                defaultMessage:
-                    "Saved. Please <z-link>reload</z-link> for the change to take effect.",
-            },
-            {
-                "z-link": (content_html) => `<a class='reload_link'>${content_html.join("")}</a>`,
-            },
-        ),
-        true,
-    );
+        success() {
+            if (request_id !== latest_default_language_request_id) {
+                return;
+            }
+
+            const remaining_delay = util.get_remaining_time(
+                request_start_time,
+                saving_status_minimum_visible_time_ms,
+            );
+
+            default_language_feedback_timeout = setTimeout(() => {
+                if (request_id !== latest_default_language_request_id) {
+                    return;
+                }
+
+                default_language_feedback_timeout = undefined;
+                ui_report.success(
+                    settings_ui.strings.success_html,
+                    $status_el,
+                    saved_status_remove_after_ms,
+                );
+                settings_ui.display_checkmark($status_el);
+
+                // Match the normal settings UX: allow "Saved" to auto-hide
+                // completely before reloading.
+                default_language_reload_timeout = setTimeout(() => {
+                    if (request_id !== latest_default_language_request_id) {
+                        return;
+                    }
+
+                    default_language_reload_timeout = undefined;
+                    reload.initiate({
+                        immediate: true,
+                        save_compose: true,
+                        // Keep the language-change flow focused on the settings
+                        // status area and avoid a flashing reload banner.
+                        show_reload_banner: false,
+                    });
+                }, saved_status_remove_after_ms + saved_status_fade_out_duration_ms);
+            }, remaining_delay);
+        },
+        error(xhr) {
+            if (request_id !== latest_default_language_request_id) {
+                return;
+            }
+
+            clear_default_language_timeouts();
+            ui_report.error(settings_ui.strings.failure_html, xhr, $status_el);
+        },
+    });
 }
 
 export function set_default_language(default_language: string): void {

--- a/web/tests/reload.test.cjs
+++ b/web/tests/reload.test.cjs
@@ -7,7 +7,7 @@ const {run_test, noop} = require("./lib/test.cjs");
 const $ = require("./lib/zjquery.cjs");
 
 const channel = mock_esm("../src/channel");
-mock_esm("../src/popup_banners", {
+const popup_banners = mock_esm("../src/popup_banners", {
     open_reloading_application_banner: noop,
 });
 
@@ -53,6 +53,8 @@ run_test("old_token_is_stale ", () => {
 });
 
 run_test("reload", () => {
+    reload_state.clear_for_testing();
+
     channel.get = (opts) => {
         assert.equal(opts.url, "/compatibility");
         opts.success();
@@ -87,4 +89,57 @@ run_test("immediate_reload_skips_compatibility_check", () => {
     reload.initiate({immediate: true, save_compose: true});
 
     assert.ok(reload_state.is_in_progress());
+});
+
+run_test("immediate_reload_shows_banner_by_default", () => {
+    reload_state.clear_for_testing();
+
+    let banner_reason;
+    let reload_calls = 0;
+
+    popup_banners.open_reloading_application_banner = (reason) => {
+        banner_reason = reason;
+    };
+    window.location.reload = () => {
+        reload_calls += 1;
+    };
+
+    channel.get = undefined;
+
+    reload.initiate({immediate: true});
+
+    assert.equal(banner_reason, "reload");
+    assert.equal(reload_calls, 1);
+});
+
+run_test("immediate_reload_can_skip_banner", () => {
+    reload_state.clear_for_testing();
+
+    let reload_calls = 0;
+
+    popup_banners.open_reloading_application_banner = assert.fail;
+    window.location.reload = () => {
+        reload_calls += 1;
+    };
+
+    channel.get = undefined;
+
+    reload.initiate({immediate: true, show_reload_banner: false});
+
+    assert.equal(reload_calls, 1);
+});
+
+run_test("delayed_reload_can_skip_banner", () => {
+    reload_state.clear_for_testing();
+
+    popup_banners.open_reloading_application_banner = assert.fail;
+
+    channel.get = (opts) => {
+        assert.equal(opts.url, "/compatibility");
+        opts.success();
+    };
+
+    reload.initiate({immediate: false, show_reload_banner: false});
+
+    assert.equal(reload_state.is_pending(), true);
 });


### PR DESCRIPTION
**Fixes:** #25552

**How changes were tested:**
* **Manual UI Testing:** Changed the default language and verified that the page automatically reloads using Zulip's internal reload pipeline.
* **State Preservation Test:** Verified that in-progress compose drafts are properly preserved across the auto-reload.
* **Automated Testing:** Ran the Puppeteer e2e test suite (`web/e2e-tests/settings.test.ts`). Fixed a race condition by utilizing `Promise.all` to register the navigation listener exactly before triggering the language change click.

**Description:**
Previously, changing the default language showed a success banner prompting the user to manually reload the page. As discussed by maintainers, it is a much cleaner user experience to automatically reload the application.

This PR updates the frontend to trigger an automatic reload upon a successful language change. Following the maintainers' feedback, this utilizes Zulip's internal `reload.initiate({immediate: true, save_compose: true})` API instead of a raw `window.location.reload()`. This ensures that user state (like in-progress compose drafts) is saved and server-side event queues are properly cleaned up before the navigation occurs.

Additionally, this PR handles the following:
* Prevents unnecessary API calls and reloads if the user re-selects their currently active language.
* Removes the now-orphaned `.reload_link` click handler from `click_handlers.ts`.
* Refactors the corresponding Puppeteer e2e tests to wait for network idle reliably without race conditions.

**Screenshots and screen captures:**

*As requested, here are the still screenshots of the UI state before and after the change (showing the new reloading confirmation banner).*

### Still Screenshots
| Before (Manual Reload Banner) | After (New Auto-Reloading Banner) |
| --- | --- |
| <img width="1914" height="952" alt="Before - Manual Reload Banner" src="https://github.com/user-attachments/assets/732ddfee-f8b2-40f8-9d3d-0fac0f1e0fd1" /> | <img width="1911" height="972" alt="After - Auto Reloading Banner" src="https://github.com/user-attachments/assets/5224801d-c94a-4076-8405-242bec3a109e" /> |

---

### Screen Captures (Videos)
**Before (Current Main)**  


https://github.com/user-attachments/assets/c745f0db-0efc-42fb-8701-9c9d7fd541ce




**After (This PR)**  


https://github.com/user-attachments/assets/35178ebc-41a6-4cf4-acd4-456496dd2328



---


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>