### PR TITLE
Fixes Emoji sometimes cut off in left sidebar #38264

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1830,8 +1830,8 @@ li.active-sub-filter {
            we set the top space with padding. But to make the
            line-clamp effect work, we set the bottom space
            with margin. */
-        padding-top: var(--spacing-top-bottom-sidebar-topic-inner);
-        margin: 0 0 var(--spacing-top-bottom-sidebar-topic-inner) 0;
+        padding-top: calc(var(--spacing-top-bottom-sidebar-topic-inner) + 2px);
+        margin: 0 0 calc(var(--spacing-top-bottom-sidebar-topic-inner) + 2px) 0;
     }
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1831,7 +1831,7 @@ li.active-sub-filter {
            line-clamp effect work, we set the bottom space
            with margin. */
         padding-top: calc(var(--spacing-top-bottom-sidebar-topic-inner) + 2px);
-        margin: 0 0 calc(var(--spacing-top-bottom-sidebar-topic-inner) + 2px) 0;
+        margin: 0 0 calc(var(--spacing-top-bottom-sidebar-topic-inner) + 2px);
     }
 }
 


### PR DESCRIPTION
Emoji glyphs in topic names were sometimes visually clipped in the left sidebar, particularly on external monitors and high-DPI displays. The `.sidebar-topic-name-inner` element uses `overflow: hidden` (required for `-webkit-line-clamp`) which hard-clips anything outside the computed content box. Since emoji render outside the standard text em-box - protruding above the ascender and below the descender - they were being cut off at the top or bottom.

The fix increases `padding-top` and `margin-bottom` on `.sidebar-topic-name-inner` by 2px using `calc()`, keeping the values proportional to the existing design token `--spacing-top-bottom-sidebar-topic-inner` across all information-density settings.

Fixes: #38264

**How changes were tested:**
Tested locally on a laptop display where the clipping was not reproducible. The root cause is well understood - `overflow: hidden` clips emoji glyphs that render outside the standard em-box, and this is more pronounced on external monitors and high-DPI displays due to sub-pixel rounding. The fix adds 2px of vertical breathing room via `calc()` on the existing spacing token, which directly addresses the clipping boundary. I was unable to verify the fix visually on an external monitor and would appreciate confirmation from a reviewer who can test on the affected display setup.

**Screenshots and screen captures:**
**Before**
<img width="562" height="121" alt="Screenshot 2026-03-16 142856" src="https://github.com/user-attachments/assets/832cbd23-92b1-45c9-8cf5-811acecd1b83" />
**After**
<img width="1128" height="571" alt="Screenshot 2026-03-15 193850" src="https://github.com/user-attachments/assets/cad8e5b7-a168-4f93-bdca-fcb1a48d08fa" />
<img width="3699" height="1785" alt="Screenshot 2026-03-15 194253" src="https://github.com/user-attachments/assets/f21b6fa0-e16f-48ba-aa48-7694687979ad" />



<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
- [ ] Visual appearance of the changes. *(Could not reproduce on laptop; external monitor needed)*
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>