### PR TITLE
api-docs: Revise feature level 439 changelog entry and changes notes.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -330,7 +330,8 @@ element to plain escaped text.
 * [`GET /events`](/api/get-events): The deprecated `update_display_settings`
   and `update_global_notifications` event types are no longer sent to any
   clients. These legacy event types were deprecated in Zulip 5.0 (feature
-  level 89) and replaced by the `user_settings` event type.
+  level 89) and replaced by the [`user_settings` event
+  type](/api/get-events#user_settings-update).
 
 **Feature level 438**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -250,17 +250,15 @@ paths:
                                 }
                             - type: object
                               description: |
-                                Event sent to a user's clients when that user's settings
-                                have changed.
+                                Event sent to a user's clients when that user's settings have changed.
 
-                                **Changes**: The `update_display_settings` and `update_global_notifications`
-                                legacy event types that had been deprecated in Zulip 5.0 (feature level 89)
-                                were removed entirely in Zulip 12.0 (feature level 439). All clients should
-                                be using the `user_settings` event type to access user settings.
+                                **Changes**: In Zulip 12.0 (feature level 439), the deprecated, legacy
+                                `update_display_settings` and `update_global_notifications` event types
+                                were removed entirely. All clients should be using this event type for
+                                updates to a user's settings.
 
-                                New in Zulip 5.0 (feature level 89), replacing the
-                                previous `update_display_settings` and `update_global_notifications`
-                                event types, which are still present for backwards compatibility reasons.
+                                New in Zulip 5.0 (feature level 89), replaced and deprecated the
+                                `update_display_settings` and `update_global_notifications` event types.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -17017,20 +17015,22 @@ paths:
                       for backwards-compatibility; it will be required in a
                       future server release.
 
-                    - `user_settings_object`: Has no effect with modern servers. Previously, this
-                      was a boolean for whether the client supported the modern `user_settings` event type.
+                    - `user_settings_object`: Has no effect with modern servers. Previously,
+                      this was a boolean for whether the client supported the modern
+                      [`user_settings` event type](/api/get-events#user_settings-update) and
+                      the top-level `user_settings` object in this endpoint's response.
                       <br />
-                      **Changes**: Prior to Zulip 12.0 (feature level 439), if false, the server
-                      would additionally send the legacy `update_global_notifications` and
-                      `update_display_settings` event types if requested.
-
-                      New in Zulip 5.0 (feature level 89). Because the feature level 89 API changes
-                      were merged together, clients can safely make a request with this client
-                      capability and also request all three event types (`user_settings`,
-                      `update_display_settings`, `update_global_notifications`), and get exactly one
-                      copy of settings data on any server version. Clients can then use the
-                      `zulip_feature_level` in the `/register` response or the presence/absence of a
-                      `user_settings` key to determine where to look for the data.
+                      **Changes**: Prior to Zulip 12.0 (feature level 439), if false, the
+                      server would additionally send the legacy `update_global_notifications`
+                      and `update_display_settings` event types, if requested.
+                      <br />
+                      New in Zulip 5.0 (feature level 89). Because the feature level 89 API
+                      changes were merged together, clients could safely make a request with
+                      this client capability, and also request all three event types
+                      (`user_settings`, `update_display_settings`, and
+                      `update_global_notifications`), and then use the `zulip_feature_level`
+                      in this endpoint's response or the presence/absence of a `user_settings`
+                      key to determine where to look for the data.
 
                     - `linkifier_url_template`: Boolean for whether the client accepts
                       [linkifiers][help-linkifiers] that use [RFC 6570][rfc6570] compliant
@@ -18243,22 +18243,22 @@ paths:
 
                           A dictionary containing the user's personal settings.
 
-                          **Changes**: Removed duplicate copies of many of these settings from the
-                          top-level object in Zulip 12.0 (feature level 439). Previously,
-                          clients that did not include `user_settings_object` in their
-                          [`client_capabilities`][capabilities] and included
-                          `update_display_settings` or `update_global_notifications` in
-                          `fetch_event_types` would receive the settings that predated feature level
-                          89 in the top-level response.
+                          **Changes**: In Zulip 12.0 (feature level 439), removed deprecated,
+                          duplicate copies of many of these user settings from the top-level object.
+                          Previously, clients that did not include the `user_settings_object`
+                          [client capability][client-capabilities] and included `update_display_settings`
+                          or `update_global_notifications` in `fetch_event_types` would receive those
+                          user settings that predated feature level 89 in the top-level response.
 
-                          Removed `dense_mode` setting in Zulip 10.0 (feature level 364) as we now
-                          have `web_font_size_px` and `web_line_height_percent` settings for more
-                          control.
+                          In Zulip 10.0 (feature level 364), removed the `dense_mode` setting as we
+                          now have `web_font_size_px` and `web_line_height_percent` settings for
+                          more control.
 
-                          New in Zulip 5.0 (feature level 89). Previously, these
-                          settings appeared in the top-level object, where they are
-                          available for clients without the `user_settings_object` client
-                          capability for backwards-compatibility.
+                          New in Zulip 5.0 (feature level 89). Previously, user settings appeared
+                          in the top-level object; see the `user_settings_object`
+                          [client capability][client-capabilities] for backwards-compatibility.
+
+                          [client-capabilities]: /api/register-queue#parameter-client_capabilities
                         additionalProperties: false
                         properties:
                           twenty_four_hour_time:


### PR DESCRIPTION
**Notes**:
- Fixes and adds some links to these API feature level notes.
- Fixes the alignment of the paragraphs for the `user_settings_object` client capability description.
- Makes some revisions to these changes notes to make the more succinct.

**Screenshots and screen captures:**

[CURRENT DOC](https://zulip.com/api/changelog)
*Adds a link to the `user_settings` event type.*
| Before | After |
| --- | --- |
| <img width="1516" height="260" alt="Screenshot From 2026-03-09 19-32-37" src="https://github.com/user-attachments/assets/285655ac-f25d-4f83-9ccb-1ae670b09000" /> | <img width="1516" height="242" alt="Screenshot From 2026-03-09 19-32-59" src="https://github.com/user-attachments/assets/f77c5ff7-ceee-4776-a71c-f7ca2ee53dd8" />

[CURRENT DOC](https://zulip.com/api/register-queue#parameter-client_capabilities)
*Fixes alignment issue and revises text.*
| Before | After |
| --- | --- |
| <img width="1494" height="536" alt="Screenshot From 2026-03-09 19-30-55" src="https://github.com/user-attachments/assets/20b464e2-6af6-46b5-9b12-d602f14d4f97" /> | <img width="1494" height="512" alt="Screenshot From 2026-03-09 19-31-14" src="https://github.com/user-attachments/assets/efb94621-d429-497e-8e48-a6a954b72e8e" />

[CURRENT DOC](https://zulip.com/api/register-queue#response)
*Scroll down to `user_settings` key. Fixes broken reference links.*
| Before | After |
| --- | --- |
| <img width="1494" height="694" alt="Screenshot From 2026-03-09 19-30-38" src="https://github.com/user-attachments/assets/5cf880f0-797a-41ba-b2f8-ea1efe38688e" /> | <img width="1494" height="650" alt="Screenshot From 2026-03-09 19-31-28" src="https://github.com/user-attachments/assets/2d11a1aa-8db2-4ad1-ab6c-d08ae38399c4" />

[CURRENT DOC](https://zulip.com/api/get-events#user_settings-update)
| Before | After |
| --- | --- |
| <img width="1516" height="504" alt="Screenshot From 2026-03-09 19-32-12" src="https://github.com/user-attachments/assets/f60acf85-3b30-4c6d-9e89-2ce550910c0f" /> | <img width="1516" height="454" alt="Screenshot From 2026-03-09 19-31-52" src="https://github.com/user-attachments/assets/00be1d0b-e42c-4337-8b24-712030b69748" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
