### PR TITLE
compose: Clear preview area in clear_compose_box instead of do_post_send_tasks.

### DIFF
--- a/web/src/compose.ts
+++ b/web/src/compose.ts
@@ -123,6 +123,7 @@ export function clear_compose_box(): void {
     if (compose_ui.is_expanded()) {
         compose_ui.make_compose_box_original_size();
     }
+    clear_preview_area();
     $("textarea#compose-textarea").val("").trigger("focus");
     compose_ui.compose_textarea_typeahead?.hide();
     compose_validate.check_overflow_text($("#send_message_form"));
@@ -400,7 +401,6 @@ export function rewire_finish(value: typeof finish): void {
 }
 
 export function do_post_send_tasks(): void {
-    clear_preview_area();
     // TODO: Do we want to perform below tasks even if the send failed due
     // to a server-side error?
     message_viewport.bottom_of_feed.reset();

--- a/web/src/compose_send_menu_popover.ts
+++ b/web/src/compose_send_menu_popover.ts
@@ -276,7 +276,6 @@ export function initialize(): void {
                 // time.
                 compose_state.prevent_draft_restoring();
                 compose.clear_compose_box();
-                compose.clear_preview_area();
                 popover_menus.hide_current_popover_if_visible(instance);
             });
         },

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -449,10 +449,18 @@ test_ui("handle_enter_key_with_preview_open", ({override, override_rewire}) => {
     override(realm, "realm_topics_policy", "allow_empty_topic");
 
     compose.handle_enter_key_with_preview_open();
-    fake_compose_box.assert_preview_mode_is_off();
+    // Preview mode should remain on after finish() returns, because
+    // clear_preview_area() is now called inside clear_compose_box(),
+    // which only runs when the server confirms the send.
+    fake_compose_box.assert_preview_mode_is_on();
 
     assert.ok(send_message_called);
     assert.ok(show_button_spinner_called);
+
+    // Verify that preview mode is cleared when the compose box is
+    // cleared, as would happen asynchronously on send success.
+    compose.clear_compose_box();
+    fake_compose_box.assert_preview_mode_is_off();
 
     override(user_settings, "enter_sends", false);
     fake_compose_box.blur_textarea();
@@ -519,8 +527,16 @@ test_ui("finish", ({override, override_rewire}) => {
 
         assert.ok(compose.finish());
 
-        fake_compose_box.assert_preview_mode_is_off();
+        // Preview mode should remain on after finish() returns, because
+        // clear_preview_area() is now called inside clear_compose_box(),
+        // which only runs when the server confirms the send.
+        fake_compose_box.assert_preview_mode_is_on();
         assert.ok(send_message_called);
+
+        // Verify that preview mode is cleared when the compose box is
+        // cleared, as would happen asynchronously on send success.
+        compose.clear_compose_box();
+        fake_compose_box.assert_preview_mode_is_off();
     })();
 });
 


### PR DESCRIPTION
## Summary

When sending a message from preview mode, the compose box would prematurely flip back to edit mode — briefly exposing raw markdown while the message was still being sent. Most noticeable with large messages, attachments, or on slow networks.

Fixes #33245

---

## Root Cause

`do_post_send_tasks()` called `clear_preview_area()` immediately after dispatching `send_message()`, regardless of whether the compose box had actually been cleared yet.

For non-locally-echoed messages (e.g. with attachments), `clear_compose_box()` only runs later in the async `send_message_success()` callback — so the user saw raw text flash in edit mode while waiting for the server response.

---

## Fix

Moved `clear_preview_area()` out of `do_post_send_tasks()` and into `clear_compose_box()`, so the preview area is only cleared when the compose box content is actually being emptied.

_As suggested by Tim Abbott in the [CZO thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20sending.20from.20preview.20mode.20flips.20to.20edit.20mode/near/2063372)._

Also removes a now-redundant `clear_preview_area()` call in `compose_send_menu_popover.ts`.

---

## Send Path Coverage

All send paths correctly call `clear_compose_box()`:

| Path | Where `clear_compose_box()` is called |
|---|---|
| Locally-echoed messages | Synchronously inside `send_message()` |
| Non-locally-echoed messages | Inside `send_message_success()` callback |
| Scheduled messages | Inside `schedule_message_to_custom_date()` success callback |
| zcommands | `finish()` calls it directly |
| Compose cancel / close | Compose-clear hook in `compose_setup.ts` |

---

## Demo

**Before**

https://github.com/user-attachments/assets/b6e19fdf-c5a5-4c94-a6f5-38cbb237e3ab

**After**

https://github.com/user-attachments/assets/4af744ed-6071-456d-943e-b24404d607dd