### PR TITLE
drafts: Replace dict[str, Any] with ValidatedDraftData dataclass.

### DIFF
--- a/zerver/lib/drafts.py
+++ b/zerver/lib/drafts.py
@@ -1,7 +1,9 @@
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
 from functools import wraps
-from typing import Annotated, Any, Concatenate, Literal
+from typing import Annotated, Concatenate, Literal
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -23,6 +25,14 @@ from zerver.tornado.django_api import send_event_on_commit
 ParamT = ParamSpec("ParamT")
 
 
+@dataclass
+class ValidatedDraftData:
+    recipient_id: int | None
+    topic: str
+    content: str
+    last_edit_time: datetime
+
+
 class DraftData(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -35,7 +45,7 @@ class DraftData(BaseModel):
 
 def further_validated_draft_dict(
     draft_dict: DraftData, user_profile: UserProfile
-) -> dict[str, Any]:
+) -> ValidatedDraftData:
     """Take a DraftData object that was already validated by the @typed_endpoint
     decorator then further sanitize, validate, and transform it.
     Ultimately return this "further validated" draft dict.
@@ -72,12 +82,12 @@ def further_validated_draft_dict(
         except ValidationError as e:  # nocoverage
             raise JsonableError(e.messages[0])
 
-    return {
-        "recipient_id": recipient_id,
-        "topic": topic_name,
-        "content": content,
-        "last_edit_time": last_edit_time,
-    }
+    return ValidatedDraftData(
+        recipient_id=recipient_id,
+        topic=topic_name,
+        content=content,
+        last_edit_time=last_edit_time,
+    )
 
 
 def draft_endpoint(
@@ -109,10 +119,10 @@ def do_create_drafts(drafts: list[DraftData], user_profile: UserProfile) -> list
         draft_objects.append(
             Draft(
                 user_profile=user_profile,
-                recipient_id=valid_draft_dict["recipient_id"],
-                topic=valid_draft_dict["topic"],
-                content=valid_draft_dict["content"],
-                last_edit_time=valid_draft_dict["last_edit_time"],
+                recipient_id=valid_draft_dict.recipient_id,
+                topic=valid_draft_dict.topic,
+                content=valid_draft_dict.content,
+                last_edit_time=valid_draft_dict.last_edit_time,
             )
         )
 
@@ -138,10 +148,10 @@ def do_edit_draft(draft_id: int, draft: DraftData, user_profile: UserProfile) ->
     except Draft.DoesNotExist:
         raise ResourceNotFoundError(_("Draft does not exist"))
     valid_draft_dict = further_validated_draft_dict(draft, user_profile)
-    draft_object.content = valid_draft_dict["content"]
-    draft_object.topic = valid_draft_dict["topic"]
-    draft_object.recipient_id = valid_draft_dict["recipient_id"]
-    draft_object.last_edit_time = valid_draft_dict["last_edit_time"]
+    draft_object.content = valid_draft_dict.content
+    draft_object.topic = valid_draft_dict.topic
+    draft_object.recipient_id = valid_draft_dict.recipient_id
+    draft_object.last_edit_time = valid_draft_dict.last_edit_time
 
     with transaction.atomic(durable=True):
         draft_object.save()


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Replaces `dict[str, Any]` with a typed `ValidatedDraftData` dataclass in zerver/lib/drafts.py. Updates `do_create_drafts()` and `do_edit_draft()`.

Fixes: <!-- Issue link, or clear description.-->
Part of the dict[str, Any] → dataclass migration

**How changes were tested:**
No test changes were required as all tests go through the HTTP endpoints and the JSON response shape is unchanged. `tools/run-mypy`,` tools/lint`, and `tools/test-backend zerver/tests/test_drafts.py` all pass (22/22 tests).

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
