### PR TITLE
stream_events: Update starred message count on unsubscribe

### DIFF
--- a/web/src/stream_events.ts
+++ b/web/src/stream_events.ts
@@ -15,6 +15,7 @@ import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_live_update from "./message_live_update.ts";
+import * as message_store from "./message_store.ts";
 import * as message_view from "./message_view.ts";
 import * as message_view_header from "./message_view_header.ts";
 import * as narrow_state from "./narrow_state.ts";
@@ -24,6 +25,8 @@ import * as people from "./people.ts";
 import * as recent_view_ui from "./recent_view_ui.ts";
 import * as settings_notifications from "./settings_notifications.ts";
 import * as settings_streams from "./settings_streams.ts";
+import * as starred_messages from "./starred_messages.ts";
+import * as starred_messages_ui from "./starred_messages_ui.ts";
 import {realm} from "./state_data.ts";
 import * as stream_color_events from "./stream_color_events.ts";
 import * as stream_create from "./stream_create.ts";
@@ -375,9 +378,18 @@ export function mark_unsubscribed(sub: StreamSubscription): void {
         activity_ui.build_user_sidebar();
     }
 
-    // Unread messages in the now-unsubscribe stream need to be
+    // Unread messages in the now-unsubscribed stream need to be
     // removed from global count totals.
     unread_ui.update_unread_counts();
+    // Remove starred messages from unsubscribed stream from the count.
+    const stream_message_ids = new Set(message_store.get_message_ids_in_stream(sub.stream_id));
+    const ids_to_remove = starred_messages
+        .get_starred_msg_ids()
+        .filter((id) => stream_message_ids.has(id));
+    if (ids_to_remove.length > 0) {
+        starred_messages.remove(ids_to_remove);
+        starred_messages_ui.rerender_ui();
+    }
 
     stream_list.remove_sidebar_row(sub.stream_id);
     stream_list.update_subscribe_to_more_streams_link();

--- a/web/tests/stream_events.test.cjs
+++ b/web/tests/stream_events.test.cjs
@@ -29,6 +29,11 @@ const stream_settings_ui = mock_esm("../src/stream_settings_ui", {
     update_settings_for_subscribed: noop,
     update_empty_left_panel_message: noop,
 });
+const message_store = mock_esm("../src/message_store", {
+    get_message_ids_in_stream: () => [],
+});
+const starred_messages = zrequire("starred_messages");
+const starred_messages_ui = mock_esm("../src/starred_messages_ui");
 const unread_ui = mock_esm("../src/unread_ui");
 const message_lists = mock_esm("../src/message_lists", {
     current: undefined,
@@ -645,6 +650,28 @@ test("mark_unsubscribed (render_title_area)", ({override, override_rewire}) => {
     assert.equal(message_view_header_stub.num_calls, 1);
 
     message_lists.current = undefined;
+});
+test("mark_unsubscribed (starred messages)", ({override, override_rewire}) => {
+    override_rewire(stream_data, "set_max_channel_width_css_variable", noop);
+    const sub = {...frontend, subscribed: true};
+    stream_data.add_sub_for_tests(sub);
+    override(message_view_header, "maybe_rerender_title_area_for_stream", noop);
+    const msg_id = 1001;
+    starred_messages.starred_ids.clear();
+    starred_messages.add([msg_id]);
+    override(stream_settings_ui, "update_settings_for_unsubscribed", noop);
+    override(stream_list, "remove_sidebar_row", noop);
+    override(message_store, "get_message_ids_in_stream", () => [msg_id]);
+    override(stream_list, "update_subscribe_to_more_streams_link", noop);
+    override(unread_ui, "update_unread_counts", noop);
+    override(user_profile, "update_user_profile_streams_list_for_users", noop);
+    override(starred_messages_ui, "rerender_ui", noop);
+
+    $.set_results("#channels_overlay_container .stream-row:not(.notdisplayed)", []);
+
+    assert.equal(starred_messages.get_count(), 1);
+    stream_events.mark_unsubscribed(sub);
+    assert.equal(starred_messages.get_count(), 0);
 });
 
 test("process_subscriber_update", ({override}) => {


### PR DESCRIPTION
When a user leaves a channel that has starred messages, 
the starred count in the sidebar was not updating.

The issue was that starred_ids still had message IDs 
from that channel, so get_count() returned the wrong number.

Fixed by filtering out those message IDs using 
message_store.get_message_ids_in_stream() and calling 
rerender_ui() to refresh the count.
