### PR TITLE
starred messages: Unstar messages when user loses channel access.

### DIFF
--- a/zerver/actions/message_flags.py
+++ b/zerver/actions/message_flags.py
@@ -155,6 +155,41 @@ def do_mark_stream_messages_as_read(
     return count
 
 
+@transaction.atomic(durable=True)
+def do_unstar_stream_messages(user_profile: UserProfile, stream_recipient_id: int) -> int:
+    query = (
+        UserMessage.select_for_update_query()
+        .filter(
+            user_profile=user_profile,
+            message__recipient_id=stream_recipient_id,
+        )
+        .extra(  # noqa: S610
+            where=[UserMessage.where_starred()],
+        )
+    )
+
+    message_ids = list(query.values_list("message_id", flat=True))
+
+    if len(message_ids) == 0:
+        return 0
+
+    count = query.update(
+        flags=F("flags").bitand(~UserMessage.flags.starred),
+    )
+
+    event = {
+        "type": "update_message_flags",
+        "op": "remove",
+        "operation": "remove",
+        "flag": "starred",
+        "messages": message_ids,
+        "all": False,
+    }
+    send_event_on_commit(user_profile.realm, event, [user_profile.id])
+
+    return count
+
+
 @transaction.atomic(savepoint=False)
 def do_mark_muted_user_messages_as_read(
     user_profile: UserProfile,

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -1005,6 +1005,17 @@ def send_subscription_remove_events(
             if inaccessible_streams:
                 send_stream_deletion_event(realm, [user_profile.id], inaccessible_streams)
 
+                queue_event_on_commit(
+                    "deferred_work",
+                    {
+                        "type": "unstar_inaccessible_stream_messages",
+                        "user_profile_id": user_profile.id,
+                        "stream_recipient_ids": [
+                            stream.recipient_id for stream in inaccessible_streams
+                        ],
+                    },
+                )
+
 
 def send_user_remove_events_on_removing_subscriptions(
     realm: Realm, altered_user_dict: dict[UserProfile, set[int]]

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -2137,6 +2137,107 @@ class MessageAccessTests(ZulipTestCase):
         self.assert_length(filtered_messages, 2)
 
 
+class UnstarStreamMessagesTest(ZulipTestCase):
+    def test_do_unstar_stream_messages(self) -> None:
+        """
+        Test that do_unstar_stream_messages removes the starred flag
+        from messages in a given stream and sends the appropriate event.
+        """
+        hamlet = self.example_user("hamlet")
+        stream_name = "private_stream"
+        stream = self.make_stream(stream_name, invite_only=True)
+        self.subscribe(hamlet, stream_name)
+
+        # Send messages and star them.
+        message_id1 = self.send_stream_message(hamlet, stream_name, "test 1")
+        message_id2 = self.send_stream_message(hamlet, stream_name, "test 2")
+        do_update_message_flags(hamlet, "add", "starred", [message_id1, message_id2])
+
+        # Verify messages are starred.
+        um1 = UserMessage.objects.get(user_profile=hamlet, message_id=message_id1)
+        um2 = UserMessage.objects.get(user_profile=hamlet, message_id=message_id2)
+        self.assertTrue(um1.flags.starred)
+        self.assertTrue(um2.flags.starred)
+
+        # Unstar all messages in this stream.
+        from zerver.actions.message_flags import do_unstar_stream_messages
+
+        assert stream.recipient_id is not None
+        with self.capture_send_event_calls(expected_num_events=1) as events:
+            count = do_unstar_stream_messages(hamlet, stream.recipient_id)
+
+        self.assertEqual(count, 2)
+
+        # Verify the event.
+        self.assertEqual(events[0]["event"]["type"], "update_message_flags")
+        self.assertEqual(events[0]["event"]["op"], "remove")
+        self.assertEqual(events[0]["event"]["flag"], "starred")
+        self.assertEqual(sorted(events[0]["event"]["messages"]), sorted([message_id1, message_id2]))
+
+        # Verify the flags are cleared in the database.
+        um1.refresh_from_db()
+        um2.refresh_from_db()
+        self.assertFalse(um1.flags.starred)
+        self.assertFalse(um2.flags.starred)
+
+    def test_do_unstar_stream_messages_no_starred(self) -> None:
+        """
+        Test that do_unstar_stream_messages is a no-op when there are
+        no starred messages in the stream.
+        """
+        hamlet = self.example_user("hamlet")
+        stream_name = "private_stream"
+        stream = self.make_stream(stream_name, invite_only=True)
+        self.subscribe(hamlet, stream_name)
+
+        # Send a message but don't star it.
+        self.send_stream_message(hamlet, stream_name, "test")
+
+        from zerver.actions.message_flags import do_unstar_stream_messages
+
+        assert stream.recipient_id is not None
+        with self.capture_send_event_calls(expected_num_events=0):
+            count = do_unstar_stream_messages(hamlet, stream.recipient_id)
+
+        self.assertEqual(count, 0)
+
+    def test_unsubscribe_private_stream_unstars_messages(self) -> None:
+        """
+        When a user unsubscribes from a private stream they can no
+        longer access, their starred messages in that stream should
+        be unstarred via a deferred work event.
+        """
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        stream_name = "private_stream"
+        stream = self.make_stream(stream_name, invite_only=True)
+        self.subscribe(hamlet, stream_name)
+        self.subscribe(cordelia, stream_name)
+
+        # Send a message and star it.
+        message_id = self.send_stream_message(hamlet, stream_name, "important message")
+        do_update_message_flags(hamlet, "add", "starred", [message_id])
+
+        # Verify the message is starred.
+        um = UserMessage.objects.get(user_profile=hamlet, message_id=message_id)
+        self.assertTrue(um.flags.starred)
+
+        # Unsubscribe hamlet from the private stream.
+        # This should queue a deferred work event to unstar messages.
+        with mock.patch("zerver.actions.streams.queue_event_on_commit") as mock_queue:
+            self.unsubscribe(hamlet, stream_name)
+
+        # Check that the unstar deferred work event was queued
+        # (along with the mark_stream_messages_as_read event).
+        queued_events = [call.args[1] for call in mock_queue.call_args_list]
+        unstar_events = [
+            e for e in queued_events if e["type"] == "unstar_inaccessible_stream_messages"
+        ]
+        self.assert_length(unstar_events, 1)
+        self.assertEqual(unstar_events[0]["user_profile_id"], hamlet.id)
+        self.assertEqual(unstar_events[0]["stream_recipient_ids"], [stream.recipient_id])
+
+
 class PersonalMessagesFlagTest(ZulipTestCase):
     def test_is_private_flag_not_leaked(self) -> None:
         """

--- a/zerver/worker/deferred_work.py
+++ b/zerver/worker/deferred_work.py
@@ -11,7 +11,7 @@ from django.utils.translation import override as override_language
 from typing_extensions import override
 
 from zerver.actions.data_import import import_slack_data
-from zerver.actions.message_flags import do_mark_stream_messages_as_read
+from zerver.actions.message_flags import do_mark_stream_messages_as_read, do_unstar_stream_messages
 from zerver.actions.message_send import internal_send_private_message
 from zerver.actions.realm_export import notify_realm_export
 from zerver.actions.realm_settings import scrub_deactivated_realm
@@ -59,6 +59,22 @@ class DeferredWorker(QueueProcessingWorker):
                 count = do_mark_stream_messages_as_read(user_profile, recipient_id)
                 logger.info(
                     "Marked %s messages as read for user %s, stream_recipient_id %s",
+                    count,
+                    user_profile.id,
+                    recipient_id,
+                )
+        elif event["type"] == "unstar_inaccessible_stream_messages":
+            user_profile = get_user_profile_by_id(event["user_profile_id"])
+            logger.info(
+                "Unstarring messages in inaccessible streams for user %s, stream_recipient_ids %s",
+                user_profile.id,
+                event["stream_recipient_ids"],
+            )
+
+            for recipient_id in event["stream_recipient_ids"]:
+                count = do_unstar_stream_messages(user_profile, recipient_id)
+                logger.info(
+                    "Unstarred %s messages for user %s, stream_recipient_id %s",
                     count,
                     user_profile.id,
                     recipient_id,


### PR DESCRIPTION
When a user is unsubscribed from a private channel they can no longer access, their starred messages in that channel remained starred. This caused the starred message count to include inaccessible messages, and clicking on them would fail.

This PR adds cleanup logic: when a non-admin user loses access to a channel, a deferred work event removes the starred flag from their messages in those channels and sends the standard `update_message_flags` event, so all clients update automatically. No frontend changes are needed.

Fixes: #38342

**How changes were tested:**

- Added unit test for `do_unstar_stream_messages` verifying flag removal, event generation, and correct message IDs.
- Added test for the no-op case (no starred messages).
- Added integration test for `unsubscribe_private_stream_unstars_messages` verifying the deferred work event is queued with correct parameters on unsubscribe.

**Screenshots and screen captures:**

This is a backend-only change with no visual UI modifications. The starred message count in the left sidebar will update automatically via the existing `update_message_flags` event handler.

<details>
<summary>Screenshots (add manually)</summary>

<!-- To add screenshots:
1. Open your Zulip dev environment
2. Star some messages in a private channel
3. Unsubscribe from that channel (or have an admin remove you)
4. Observe the starred count updates in the left sidebar

Use a Before/After table:
| Before | After |
| --- | --- |
| ![before](upload-url) | ![after](upload-url) |
-->

_Screenshots to be added after manual testing in dev environment._

</details>

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

### Technical decisions

- **Deferred work pattern**: Uses the same `queue_event_on_commit("deferred_work", ...)` pattern as `mark_stream_messages_as_read`, which already runs on unsubscribe. This avoids blocking the HTTP response for the potentially expensive database update.
- **Trigger point**: Hooks into the existing `inaccessible_streams` check in `send_subscription_remove_events` — this only fires for non-admin users who lose access, which is exactly the right condition.
- **No frontend changes**: The existing `update_message_flags` event handler on the frontend already handles `op: "remove", flag: "starred"`, so the `starred_ids` Set and sidebar count update automatically.

### Open question

- The issue mentions Tim Abbott's note: "I'm not sure we have the metadata to definitely know what channel the starred message is in when you lose access to it." This implementation resolves this by operating at the source — when the backend detects inaccessible streams, it already knows the recipient IDs, so we can directly query and clear starred flags for those specific channels.