### PR TITLE
search: Increased gap between pills in search box.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -73,7 +73,7 @@
         display: flex;
         padding: 0;
         flex-wrap: wrap;
-        gap: 0.125em; /* 2px at 16px em */
+        gap: 0.3571em; /* 5px at 14px em, matches pill spacing in typeahead dropdown */
         align-self: center;
     }
 


### PR DESCRIPTION
The gap between pills and text in the search box was too small, making it feel cramped. Increased the gap to match the spacing used in the typeahead dropdown (0.3571em, i.e., 5px at 14px em).

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**
Tested locally by adding multiple search filters and verifying the gap between pills looks consistent with typeahead spacing.

Discussed [here](https://chat.zulip.org/#narrow/channel/9-issues/topic/search.20pill.2Ftext.20spacing/with/2400125)

**Screenshots and screen captures:**
Before:
<img width="758" height="57" alt="image" src="https://github.com/user-attachments/assets/c390611f-76ad-4682-89bb-6cac377c88b6" />

After: 
<img width="880" height="60" alt="image" src="https://github.com/user-attachments/assets/d2d84aa7-e1f5-4333-b498-5174e01f8481" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
