### PR TITLE
compose: Preserve indentation when continuing lists.

### DIFF
--- a/web/src/bulleted_numbered_list_util.ts
+++ b/web/src/bulleted_numbered_list_util.ts
@@ -1,5 +1,7 @@
 export const get_last_line = (text: string): string => text.slice(text.lastIndexOf("\n") + 1);
 
+export const get_indent = (line: string): string => /^(\s*)/.exec(line)![1] ?? "";
+
 export const is_bulleted = (line: string): boolean =>
     line.startsWith("- ") || line.startsWith("* ") || line.startsWith("+ ");
 

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -276,29 +276,37 @@ function handle_bulleting_or_numbering(
     assert(val !== undefined);
     const before_text = split_at_cursor(val, $textarea)[0];
     const previous_line = bulleted_numbered_list_util.get_last_line(before_text);
+    const indent = bulleted_numbered_list_util.get_indent(previous_line);
+    const trimmed_previous_line = previous_line.slice(indent.length);
     let to_append = "";
     // if previous line was bulleted, automatically add a bullet to the new line
-    if (bulleted_numbered_list_util.is_bulleted(previous_line)) {
+    if (bulleted_numbered_list_util.is_bulleted(trimmed_previous_line)) {
         // if previous line had only bullet, remove it and stay on the same line
-        if (bulleted_numbered_list_util.strip_bullet(previous_line) === "") {
-            // below we select and replace the last 2 characters in the textarea before
-            // the cursor - the bullet syntax - with an empty string
-            util.the($textarea).setSelectionRange($textarea.caret() - 2, $textarea.caret());
+        if (bulleted_numbered_list_util.strip_bullet(trimmed_previous_line) === "") {
+            // below we select and replace the last few characters in the textarea before
+            // the cursor - the indentation and bullet syntax - with an empty string
+            util.the($textarea).setSelectionRange(
+                $textarea.caret() - indent.length - 2,
+                $textarea.caret(),
+            );
             compose_ui.insert_and_scroll_into_view("", $textarea);
             e.preventDefault();
             return;
         }
-        // use same bullet syntax as the previous line
-        to_append = previous_line.slice(0, 2);
-    } else if (bulleted_numbered_list_util.is_numbered(previous_line)) {
+        // use same indentation and bullet syntax as the previous line
+        to_append = indent + trimmed_previous_line.slice(0, 2);
+    } else if (bulleted_numbered_list_util.is_numbered(trimmed_previous_line)) {
         // if previous line was numbered, continue numbering with the new line
-        const previous_number_string = previous_line.slice(0, previous_line.indexOf("."));
+        const previous_number_string = trimmed_previous_line.slice(
+            0,
+            trimmed_previous_line.indexOf("."),
+        );
         // if previous line had only numbering, remove it and stay on the same line
-        if (bulleted_numbered_list_util.strip_numbering(previous_line) === "") {
+        if (bulleted_numbered_list_util.strip_numbering(trimmed_previous_line) === "") {
             // below we select then replaces the last few characters in the textarea before
-            // the cursor - the numbering syntax - with an empty string
+            // the cursor - the indentation and numbering syntax - with an empty string
             util.the($textarea).setSelectionRange(
-                $textarea.caret() - previous_number_string.length - 2,
+                $textarea.caret() - indent.length - previous_number_string.length - 2,
                 $textarea.caret(),
             );
             compose_ui.insert_and_scroll_into_view("", $textarea);
@@ -306,7 +314,7 @@ function handle_bulleting_or_numbering(
             return;
         }
         const previous_number = Number.parseInt(previous_number_string, 10);
-        to_append = previous_number + 1 + ". ";
+        to_append = indent + (previous_number + 1) + ". ";
     }
     // if previous line was neither numbered nor bulleted, only add
     // a new line to emulate default behaviour (to_append is blank)

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1799,6 +1799,50 @@ test("initialize", ({override, override_rewire, mock_template}) => {
     });
     $("form#send_message_form").trigger(event);
 
+    // Test automatic bulleting with indentation (sub-list).
+    $("textarea#compose-textarea").val("- Message 1\n  - Message 2");
+    $("textarea#compose-textarea")[0].selectionStart = 25;
+    $("textarea#compose-textarea")[0].selectionEnd = 25;
+    override(compose_ui, "insert_and_scroll_into_view", (content, _textarea) => {
+        assert.equal(content, "\n  - ");
+    });
+    $("form#send_message_form").trigger(event);
+
+    // Test removal of indented bullet.
+    $("textarea#compose-textarea").val("- Message 1\n  - Message 2\n  - ");
+    $("textarea#compose-textarea")[0].selectionStart = 30;
+    $("textarea#compose-textarea")[0].selectionEnd = 30;
+    $("textarea#compose-textarea")[0].setSelectionRange = (start, end) => {
+        assert.equal(start, 26);
+        assert.equal(end, 30);
+    };
+    override(compose_ui, "insert_and_scroll_into_view", (content, _textarea) => {
+        assert.equal(content, "");
+    });
+    $("form#send_message_form").trigger(event);
+
+    // Test automatic numbering with indentation (sub-list).
+    $("textarea#compose-textarea").val("- Message 1\n  1. Message 2");
+    $("textarea#compose-textarea")[0].selectionStart = 26;
+    $("textarea#compose-textarea")[0].selectionEnd = 26;
+    override(compose_ui, "insert_and_scroll_into_view", (content, _textarea) => {
+        assert.equal(content, "\n  2. ");
+    });
+    $("form#send_message_form").trigger(event);
+
+    // Test removal of indented numbering.
+    $("textarea#compose-textarea").val("- Message 1\n  1. Message 2\n  1. ");
+    $("textarea#compose-textarea")[0].selectionStart = 32;
+    $("textarea#compose-textarea")[0].selectionEnd = 32;
+    $("textarea#compose-textarea")[0].setSelectionRange = (start, end) => {
+        assert.equal(start, 27);
+        assert.equal(end, 32);
+    };
+    override(compose_ui, "insert_and_scroll_into_view", (content, _textarea) => {
+        assert.equal(content, "");
+    });
+    $("form#send_message_form").trigger(event);
+
     $("textarea#compose-textarea").val("A");
     $("textarea#compose-textarea")[0].selectionStart = 4;
     $("textarea#compose-textarea")[0].selectionEnd = 4;


### PR DESCRIPTION
Fixes: #37737

## Summary

When you press Shift+Return on an indented list item like `  - nested`, 
Zulip was producing a plain newline instead of continuing the list with 
another `  - `. The root cause is that `is_bulleted()` and `is_numbered()` 
check for markers at the very start of the line, so any leading whitespace 
silently broke detection. This fix strips the indent before checking, then 
re-prepends it to the new list item — so indented lists now continue exactly 
like top-level ones do.

## Demo

### Before

https://github.com/user-attachments/assets/7383be90-6f68-4095-90a0-6e5537da2882


### After
https://github.com/user-attachments/assets/ad2b63e4-02af-44b6-8470-a273c301536c

## Relation to #38093

PR #38093 by @MichaelJamesL tackles the same bug with a similar idea. 
The main differences here:

- The helper functions (`is_bulleted`, `is_numbered`, etc.) are kept pure — 
  indentation is stripped *before* calling them in `composebox_typeahead.ts`, 
  rather than teaching each helper about whitespace internally.
- The numbered empty-item removal uses `trimmed_previous_line.indexOf(".")` 
  instead of the untrimmed line, which fixes an off-by-one in the 
  `setSelectionRange` offset that #38093 still has.

## Testing

- [x] 4 new unit tests in `web/tests/composebox_typeahead.test.cjs` — 
  indented bullet continuation, indented bullet removal, indented numbered 
  continuation, indented numbered removal
- [x] `tsc --noEmit` passes on all changed files
- [x] Manually tested in the dev server (see demo above)

<details>
<summary>Self-review checklist</summary>


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>