### PR TITLE
Expose communities data via api

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -196,3 +196,4 @@
 * [Create Nextcloud Talk video call](/api/create-nextcloud-talk-video-call)
 * [Create Webex video call](/api/create-webex-video-call)
 * [Outgoing webhook payloads](/api/outgoing-webhook-payload)
+* [Get open communities](/api/open_communities)

--- a/api_docs/unmerged.d/ZF-c2848d.md
+++ b/api_docs/unmerged.d/ZF-c2848d.md
@@ -1,0 +1,5 @@
+* [`GET /open_communities`](/api/open_communities): Returns a directory of public Zulip communities that have opted into being advertised.
+
+This endpoint is designed to provide API clients with the necessary data to build in-app community discovery.
+
+For more information on how organizations opt into this list, see our [`Help Center documentation on the Zulip communities directory`](https://zulip.com/help/communities-directory).

--- a/corporate/views/portico.py
+++ b/corporate/views/portico.py
@@ -21,8 +21,7 @@ from zerver.lib.github import (
     InvalidPlatformError,
     get_latest_github_release_download_link_for_platform,
 )
-from zerver.lib.realm_description import get_realm_text_description
-from zerver.lib.realm_icon import get_realm_icon_url
+from zerver.lib.portico import get_public_realms_that_want_to_be_advertised
 from zerver.lib.subdomains import is_subdomain_root_or_alias
 from zerver.lib.typed_endpoint import typed_endpoint
 from zerver.models import Realm
@@ -327,63 +326,7 @@ def hello_view(request: HttpRequest) -> HttpResponse:
 
 @add_google_analytics
 def communities_view(request: HttpRequest) -> HttpResponse:
-    eligible_realms = []
-    unique_org_type_ids = set()
-    want_to_be_advertised_realms = (
-        Realm.objects.filter(
-            want_advertise_in_communities_directory=True,
-        )
-        .exclude(
-            # Filter out realms who haven't changed their description from the default.
-            description="",
-        )
-        .exclude(
-            # Filter out demo organizations.
-            demo_organization_scheduled_deletion_date__isnull=False,
-        )
-        .order_by("name")
-    )
-    for realm in want_to_be_advertised_realms:
-        open_to_public = not realm.invite_required and not realm.emails_restricted_to_domains
-        if realm.allow_web_public_streams_access() or open_to_public:
-            [org_type] = (
-                org_type
-                for org_type in Realm.ORG_TYPES
-                if Realm.ORG_TYPES[org_type]["id"] == realm.org_type
-            )
-            eligible_realms.append(
-                {
-                    "name": realm.name,
-                    "realm_url": realm.url,
-                    "logo_url": get_realm_icon_url(realm),
-                    "description": get_realm_text_description(realm),
-                    "org_type_key": org_type,
-                }
-            )
-            unique_org_type_ids.add(realm.org_type)
-
-    # Custom list of org filters to show.
-    CATEGORIES_TO_OFFER = [
-        "opensource",
-        "research",
-        "community",
-    ]
-
-    # Remove org_types for which there are no open organizations.
-    org_types = dict()
-    for org_type in CATEGORIES_TO_OFFER:
-        org_type_info = Realm.ORG_TYPES[org_type]
-        if org_type_info["id"] in unique_org_type_ids:
-            org_types[org_type] = {"name": org_type_info["name"]}
-
-    # This code is not required right now, but could be useful in the
-    # future if we ever decide to show all the ORG_TYPES.
-    # Remove `Unspecified` ORG_TYPE
-    # org_types.pop("unspecified", None)
-
-    # Change display name of non-profit orgs.
-    # if org_types.get("nonprofit"):  # nocoverage
-    #    org_types["nonprofit"]["name"] = "Non-profit"
+    eligible_realms, org_types = get_public_realms_that_want_to_be_advertised()
 
     return TemplateResponse(
         request,

--- a/templates/corporate/communities.html
+++ b/templates/corporate/communities.html
@@ -62,7 +62,7 @@
                     <div class="eligible_realms">
                         {% for eligible_realm in eligible_realms %}
                             <a class="eligible_realm" data-org-type="{{ eligible_realm.org_type_key }}" href="{{ eligible_realm.realm_url }}">
-                                <img class="eligible_realm_logo" src="{{ eligible_realm.logo_url }}" alt="{{ eligible_realm.name }} logo"/>
+                                <img class="eligible_realm_icon" src="{{ eligible_realm.icon_url }}" alt="{{ eligible_realm.name }} logo"/>
                                 <div class="eligible_realm_details">
                                     <h3 class="eligible_realm_name">{{ eligible_realm.name }}</h3>
                                     <h4 class="eligible_realm_description">

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -861,7 +861,7 @@ html:has(.portico-landing.integrations) {
                 border-color: var(--color-integrations-card-border-hover);
             }
 
-            .eligible_realm_logo {
+            .eligible_realm_icon {
                 display: flex;
                 margin-right: 20px;
                 width: 60px;

--- a/zerver/lib/portico.py
+++ b/zerver/lib/portico.py
@@ -1,0 +1,79 @@
+from typing import TypedDict
+
+from zerver.lib.realm_description import get_realm_text_description
+from zerver.lib.realm_icon import get_realm_icon_url
+from zerver.models import Realm
+
+
+class RealmDict(TypedDict):
+    name: str
+    description: str
+    icon_url: str
+    realm_url: str
+    org_type_key: str
+
+
+def get_public_realms_that_want_to_be_advertised() -> tuple[
+    list[RealmDict], dict[str, dict[str, str]]
+]:
+    eligible_realms = []
+    unique_org_type_ids = set()
+    want_to_be_advertised_realms = (
+        Realm.objects.filter(
+            want_advertise_in_communities_directory=True,
+        )
+        .exclude(
+            # Filter out realms who haven't changed their description from the default.
+            description="",
+        )
+        .exclude(
+            # Filter out demo organizations.
+            demo_organization_scheduled_deletion_date__isnull=False,
+        )
+        .order_by("name")
+    )
+    for realm in want_to_be_advertised_realms:
+        open_to_public = not realm.invite_required and not realm.emails_restricted_to_domains
+        if realm.allow_web_public_streams_access() or open_to_public:
+            org_type_key = next(
+                (key for key in Realm.ORG_TYPES if Realm.ORG_TYPES[key]["id"] == realm.org_type),
+                None,
+            )
+
+            if org_type_key is None:
+                continue  # nocoverage
+
+            eligible_realms.append(
+                RealmDict(
+                    name=realm.name,
+                    description=get_realm_text_description(realm),
+                    icon_url=get_realm_icon_url(realm),
+                    realm_url=realm.url,
+                    org_type_key=org_type_key,
+                )
+            )
+            unique_org_type_ids.add(realm.org_type)
+
+    # Custom list of org filters to show.
+    CATEGORIES_TO_OFFER = [
+        "opensource",
+        "research",
+        "community",
+    ]
+
+    # Remove org_types for which there are no open organizations.
+    org_types = dict()
+    for org_type in CATEGORIES_TO_OFFER:
+        org_type_info = Realm.ORG_TYPES[org_type]
+        if org_type_info["id"] in unique_org_type_ids:
+            org_types[org_type] = {"name": org_type_info["name"]}
+
+    # This code is not required right now, but could be useful in the
+    # future if we ever decide to show all the ORG_TYPES.
+    # Remove `Unspecified` ORG_TYPE
+    # org_types.pop("unspecified", None)
+
+    # Change display name of non-profit orgs.
+    # if org_types.get("nonprofit"):  # nocoverage
+    #    org_types["nonprofit"]["name"] = "Non-profit"
+    return eligible_realms, org_types

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -27316,6 +27316,83 @@ paths:
                         "url": "https://example.constructor.app/groups/room/room-123",
                       }
 
+  /open_communities:
+    get:
+      tags: ["server_and_organizations"]
+      operationId: open_communities
+      summary: Get open communities
+      description: |
+        Get the Zulip communities are open to the public, and have opted in to be listed.
+
+        **Changes**: New in Zulip 12.0 (feature level ZF-c2848d).
+      parameters: []
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      realms:
+                        description: |
+                          The list of open communities that have opted for advertising.
+                        type: array
+                        items:
+                          type: object
+                          additionalProperties: false
+                          properties:
+                            name:
+                              type: string
+                              description: |
+                                The name of the organization.
+                            description:
+                              type: string
+                              description: |
+                                The description of the organization.
+                            icon_url:
+                              type: string
+                              description: |
+                                The URL of the organization's icon.
+                            realm_url:
+                              type: string
+                              description: |
+                                The URL of the organization.
+                            org_type_key:
+                              type: string
+                              description: |
+                                The organization type "key".
+                          example:
+                            [
+                              {
+                                "name": "Test Community",
+                                "description": "A great test community",
+                                "icon_url": "https://secure.gravatar.com/avatar/f4c91f821a38541d080a7f7314f5ce06?d=identicon",
+                                "realm_url": "https://example.zulipchat.com",
+                                "org_type_key": "opensource",
+                              },
+                            ]
+                    example:
+                      {
+                        "msg": "",
+                        "result": "success",
+                        "realms":
+                          [
+                            {
+                              "name": "Test Community",
+                              "description": "A great community",
+                              "icon_url": "https://secure.gravatar.com/avatar/b6c2e3c8b0f4e5d6a7b8c9d0e1f2a3b4?d=identicon",
+                              "realm_url": "https://example.zulipchat.com",
+                              "org_type_key": "opensource",
+                            },
+                          ],
+                      }
+
 components:
   #######################
   # Security definitions

--- a/zerver/tests/test_community_views.py
+++ b/zerver/tests/test_community_views.py
@@ -1,0 +1,163 @@
+from datetime import timedelta
+
+from django.utils.timezone import now as timezone_now
+from typing_extensions import override
+
+from zerver.actions.create_realm import do_create_realm
+from zerver.actions.realm_settings import do_set_realm_property
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.models import Realm
+from zerver.models.realms import get_realm
+
+
+class CommunitiesApiViewTest(ZulipTestCase):
+    """Tests for GET /api/v1/open_communities — the communities directory listing endpoint."""
+
+    @override
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = "/api/v1/open_communities"
+
+    def test_returns_empty_list_when_no_eligible_realms(self) -> None:
+        result = self.client_get(self.url)
+        self.assert_json_success(result)
+        data = result.json()
+        self.assertEqual(data["realms"], [])
+
+    def test_returns_eligible_realm(self) -> None:
+        realm = get_realm("zulip")
+        realm.want_advertise_in_communities_directory = True
+        realm.invite_required = False
+        realm.emails_restricted_to_domains = False
+        realm.save()
+        do_set_realm_property(realm, "description", "A great community", acting_user=None)
+
+        result = self.client_get(self.url)
+        self.assert_json_success(result)
+        data = result.json()
+        realm_urls = [r["realm_url"] for r in data["realms"]]
+        self.assertIn(realm.url, realm_urls)
+
+    def test_excludes_realm_with_empty_description(self) -> None:
+        realm = get_realm("zulip")
+        realm.want_advertise_in_communities_directory = True
+        realm.invite_required = False
+        realm.emails_restricted_to_domains = False
+        realm.save()
+        # Ensure description is empty (the default sentinel value).
+        do_set_realm_property(realm, "description", "", acting_user=None)
+
+        result = self.client_get(self.url)
+        self.assert_json_success(result)
+        data = result.json()
+        realm_urls = [r["realm_url"] for r in data["realms"]]
+        self.assertNotIn(realm.url, realm_urls)
+
+    def test_excludes_realm_not_wanting_to_advertise(self) -> None:
+        realm = get_realm("zulip")
+        realm.want_advertise_in_communities_directory = False
+        realm.invite_required = False
+        realm.emails_restricted_to_domains = False
+        realm.save()
+        do_set_realm_property(realm, "description", "A great community", acting_user=None)
+
+        result = self.client_get(self.url)
+        self.assert_json_success(result)
+        data = result.json()
+        realm_urls = [r["realm_url"] for r in data["realms"]]
+        self.assertNotIn(realm.url, realm_urls)
+
+    def test_excludes_demo_organization(self) -> None:
+        realm = get_realm("zulip")
+        realm.want_advertise_in_communities_directory = True
+        realm.invite_required = False
+        realm.emails_restricted_to_domains = False
+        realm.demo_organization_scheduled_deletion_date = timezone_now() + timedelta(days=15)
+        realm.save()
+        do_set_realm_property(realm, "description", "A great community", acting_user=None)
+
+        result = self.client_get(self.url)
+        self.assert_json_success(result)
+        data = result.json()
+        realm_urls = [r["realm_url"] for r in data["realms"]]
+        self.assertNotIn(realm.url, realm_urls)
+
+    def test_excludes_private_realm(self) -> None:
+        """A realm that requires invite and has no web-public streams should not appear."""
+        realm = get_realm("zulip")
+        realm.want_advertise_in_communities_directory = True
+        realm.invite_required = True
+        realm.emails_restricted_to_domains = True
+        realm.enable_spectator_access = False
+        realm.save(
+            update_fields=[
+                "want_advertise_in_communities_directory",
+                "invite_required",
+                "emails_restricted_to_domains",
+                "enable_spectator_access",
+            ]
+        )
+        do_set_realm_property(realm, "description", "A private community", acting_user=None)
+
+        result = self.client_get(self.url)
+        self.assert_json_success(result)
+        data = result.json()
+        realm_urls = [r["realm_url"] for r in data["realms"]]
+        self.assertNotIn(realm.url, realm_urls)
+
+    def test_realm_dict_has_expected_fields(self) -> None:
+        realm = get_realm("zulip")
+        realm.want_advertise_in_communities_directory = True
+        realm.invite_required = False
+        realm.emails_restricted_to_domains = False
+        realm.org_type = Realm.ORG_TYPES["community"]["id"]
+        realm.save()
+        do_set_realm_property(realm, "description", "A great community", acting_user=None)
+
+        result = self.client_get(self.url)
+        self.assert_json_success(result)
+        data = result.json()
+        realm_entry = next(r for r in data["realms"] if r["realm_url"] == realm.url)
+
+        self.assertIn("name", realm_entry)
+        self.assertIn("description", realm_entry)
+        self.assertIn("icon_url", realm_entry)
+        self.assertIn("realm_url", realm_entry)
+        self.assertIn("org_type_key", realm_entry)
+
+    def test_accessible_without_authentication(self) -> None:
+        """The endpoint must be accessible anonymously (needed for desktop/mobile clients)."""
+        result = self.client_get(self.url)
+        self.assert_json_success(result)
+
+    def test_multiple_eligible_realms(self) -> None:
+        realm1 = do_create_realm(
+            string_id="community_one",
+            name="Community One",
+            invite_required=False,
+            enable_read_receipts=False,
+        )
+        realm1.want_advertise_in_communities_directory = True
+        realm1.emails_restricted_to_domains = False
+        realm1.org_type = Realm.ORG_TYPES["community"]["id"]
+        realm1.save()
+        do_set_realm_property(realm1, "description", "First community", acting_user=None)
+
+        realm2 = do_create_realm(
+            string_id="community_two",
+            name="Community Two",
+            invite_required=False,
+            enable_read_receipts=False,
+        )
+        realm2.want_advertise_in_communities_directory = True
+        realm2.emails_restricted_to_domains = False
+        realm2.org_type = Realm.ORG_TYPES["research"]["id"]
+        realm2.save()
+        do_set_realm_property(realm2, "description", "Second community", acting_user=None)
+
+        result = self.client_get(self.url)
+        self.assert_json_success(result)
+        data = result.json()
+        realm_urls = [r["realm_url"] for r in data["realms"]]
+        self.assertIn(realm1.url, realm_urls)
+        self.assertIn(realm2.url, realm_urls)

--- a/zerver/views/communities.py
+++ b/zerver/views/communities.py
@@ -1,0 +1,15 @@
+from django.http import HttpRequest, HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_safe
+
+from zerver.lib.portico import get_public_realms_that_want_to_be_advertised
+from zerver.lib.response import json_success
+
+
+@require_safe
+@csrf_exempt
+def communities_api_view(
+    request: HttpRequest,
+) -> HttpResponse:
+    eligible_realms, _ = get_public_realms_that_want_to_be_advertised()
+    return json_success(request, data={"realms": eligible_realms})

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -44,6 +44,7 @@ from zerver.views.channel_folders import (
     reorder_realm_channel_folders,
     update_channel_folder,
 )
+from zerver.views.communities import communities_api_view
 from zerver.views.compatibility import check_global_compatibility
 from zerver.views.custom_profile_fields import (
     create_realm_custom_profile_field,
@@ -892,6 +893,7 @@ v1_api_mobile_patterns = [
     #  This view accepts a JWT containing an email and returns an API key
     #  and the details for a single user.
     path("jwt/fetch_api_key", jwt_fetch_api_key),
+    path("open_communities", communities_api_view),
 ]
 
 # Include URL configuration files for site-specified extra installed


### PR DESCRIPTION
### Issue Description
Expose the community directory data via API rather than rely on the current html page [here](https://zulip.com/communities)

The proposal and changes were discussed [here](https://chat.zulip.org/#narrow/channel/378-api-design/topic/expose.20communities.20directory.20data.20via.20api/with/2404804)

### Changes
Add endpoints to expose data for the organizations that enrolled for the communities directory.
Move functionality to get eligible_realms and org_types that are used by the template view: communities_view and the API view: communities_api_view to the get_public_realms_that_want_to_be_advertised in zerver/lib/portico.py

### Endpoints
1. GET /communities/ - Returns a list of all eligible realms.

### Data returned
 - name - The name of the organization.
 - description - The description of the 
 - icon_url - The URL of the organization's icon.
 - realm_url - The URL of the organization.
 - org_type_key -  The organization type key, e.g. "community", "opensource".

The endpoints can be accessed without authentication via /json/ but requires authentication at /api/v1/
While testing accessing at /api/v1/ seemed to fail for cross subdomain requests, the most reliable route is using /json/

### Bugs encountered
The html page that displayed communities was referencing the icon URL as logo_url which was confusing. I changed this to icon_url for clarity.

Fixes:  [#38021](https://github.com/zulip/zulip/issues/38021)

**How changes were tested:**
Added community API tests at corporate/tests/test_community_views.py.
The tests ensured
 - API endpoints returned the desired data.
 - API endpoints returned only eligible organizations i.e public organizations that want advertising.

**Screenshots**
<img width="1065" height="534" alt="zulip screen shot 1" src="https://github.com/user-attachments/assets/ccdbf625-c9f1-4d36-aaf4-6e15d3f27d39" />
<img width="1065" height="462" alt="zulip 2" src="https://github.com/user-attachments/assets/a8a84558-1d7c-4144-bde3-d8d9ceda0f9e" />
<img width="1066" height="522" alt="zulip 3" src="https://github.com/user-attachments/assets/d33c52c4-f1e3-4481-a350-f17d41d9b2d8" />
<img width="304" height="559" alt="zulip 4" src="https://github.com/user-attachments/assets/32d59ac4-676f-4a84-a6fd-6b6a79d37b58" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
