### PR TITLE
thumbnail: Remove message_lists dependency.

### DIFF
--- a/web/src/message_live_update.ts
+++ b/web/src/message_live_update.ts
@@ -1,5 +1,6 @@
 import * as message_lists from "./message_lists.ts";
 import * as message_store from "./message_store.ts";
+import * as thumbnail from "./thumbnail.ts";
 import type {UserStatusEmojiInfo} from "./user_status.ts";
 
 export function rerender_messages_view(): void {
@@ -89,4 +90,9 @@ export function update_user_status_emoji(
 ): void {
     message_store.update_status_emoji_info(user_id, status_emoji_info);
     rerender_messages_view_for_user(user_id);
+}
+
+export function update_thumbnails(): void {
+    thumbnail.set_media_preview_size_css_variable();
+    rerender_messages_view();
 }

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -93,7 +93,6 @@ import * as stream_ui_updates from "./stream_ui_updates.ts";
 import * as sub_store from "./sub_store.ts";
 import * as submessage from "./submessage.ts";
 import * as theme from "./theme.ts";
-import * as thumbnail from "./thumbnail.ts";
 import {group_setting_value_schema} from "./types.ts";
 import * as typing_events from "./typing_events.ts";
 import * as unread_ops from "./unread_ops.ts";
@@ -316,7 +315,7 @@ export function dispatch_normal_event(event) {
                 direct_message_permission_group: noop,
                 email_changes_disabled: settings_account.update_email_change_display,
                 disallow_disposable_email_addresses: noop,
-                media_preview_size: thumbnail.update_thumbnails,
+                media_preview_size: message_live_update.update_thumbnails,
                 inline_image_preview: noop,
                 inline_url_embed_preview: noop,
                 invite_required: noop,

--- a/web/src/thumbnail.ts
+++ b/web/src/thumbnail.ts
@@ -1,7 +1,6 @@
 import $ from "jquery";
 import type * as z from "zod/mini";
 
-import * as message_lists from "./message_lists.ts";
 import {realm} from "./state_data.ts";
 import type {thumbnail_format_schema} from "./state_data.ts";
 
@@ -21,13 +20,6 @@ export function set_media_preview_size_css_variable(): void {
 
 export function get_media_preview_size(): number {
     return (realm.realm_media_preview_size / 100) * DEFAULT_PREVIEW_SIZE_EM;
-}
-
-export function update_thumbnails(): void {
-    set_media_preview_size_css_variable();
-    for (const msg_list of message_lists.all_rendered_message_lists()) {
-        msg_list.rerender();
-    }
 }
 
 export function initialize(): void {

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -47,9 +47,6 @@ const message_events = mock_esm("../src/message_events", {
     update_current_view_for_topic_visibility: noop,
 });
 const message_lists = mock_esm("../src/message_lists");
-mock_esm("../src/thumbnail", {
-    update_thumbnails: noop,
-});
 const user_topics_ui = mock_esm("../src/user_topics_ui");
 const muted_users_ui = mock_esm("../src/muted_users_ui");
 const narrow_title = mock_esm("../src/narrow_title");


### PR DESCRIPTION
Commit abbb5d294094b48264a8ef7955ae614793afb3cf added message_lists.ts as a dependency to thumbnail.ts to support the update_thumbnails method.

However, this caused blueslip errors on showroom pages such as /devtools/banners because of the import chain templates > postprocess_content > thumbnail > message_lists, and eventually page_params.ts, which asserts if the page type is "home", which fails on showroom pages.

This PR moves the update_thumbnails method to message_live_update.ts which already has the required dependencies to rerender message views.

Fixes: [#issues > devtools/banners doesn't work](https://chat.zulip.org/#narrow/channel/9-issues/topic/devtools.2Fbanners.20doesn.27t.20work/with/2394774)

**How changes were tested:**
- Remove the `message_lists` dependency from  `web/src/thumbnail.ts`.
- Check if `devtools/banners` is being rendered successfully.
- Check for any blueslip errors in Inspect > Console.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| <img width="1131" height="394" alt="Screenshot 2026-03-10 at 6 38 06 PM" src="https://github.com/user-attachments/assets/d6e0b08d-a69b-432a-a887-c0ea9bfb83ae" /> | <img width="1131" height="394" alt="Screenshot 2026-03-10 at 6 37 05 PM" src="https://github.com/user-attachments/assets/462a72cf-76b6-4f14-a760-73a1e0fe679b" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
