### PR TITLE
Search: Code highlighting gets in the way of searching for complex expressions in code blocks

### DIFF
--- a/puppet/zulip/files/postgresql/process_fts_updates
+++ b/puppet/zulip/files/postgresql/process_fts_updates
@@ -81,11 +81,13 @@ def update_fts_columns(conn: psycopg2.extensions.connection) -> int:
         if message_ids:
             if USING_PGROONGA:
                 update_sql = SQL(
-                    "search_pgroonga = escape_html(subject) || ' ' || rendered_content"
+                    "search_pgroonga = escape_html(subject) || ' '"
+                    " || regexp_replace(rendered_content, '</?span[^>]*>', '', 'g')"
                 )
             else:
                 update_sql = SQL(
-                    "search_tsvector = to_tsvector('zulip.english_us_search', subject || rendered_content)"
+                   "search_tsvector = to_tsvector('zulip.english_us_search',"
+                    " subject || regexp_replace(rendered_content, '</?span[^>]*>', '', 'g'))"
                 )
             cursor.execute(
                 SQL(

--- a/puppet/zulip/files/postgresql/process_fts_updates
+++ b/puppet/zulip/files/postgresql/process_fts_updates
@@ -82,12 +82,14 @@ def update_fts_columns(conn: psycopg2.extensions.connection) -> int:
             if USING_PGROONGA:
                 update_sql = SQL(
                     "search_pgroonga = escape_html(subject) || ' '"
-                    " || regexp_replace(rendered_content, '</?span[^>]*>', '', 'g')"
+                    " || regexp_replace(rendered_content,"
+                    " '<span class=\"[a-z]{1,3}\">([^<]*)</span>', '\\1', 'g')"
                 )
             else:
                 update_sql = SQL(
                     "search_tsvector = to_tsvector('zulip.english_us_search',"
-                    " subject || regexp_replace(rendered_content, '</?span[^>]*>', '', 'g'))"
+                    " subject || regexp_replace(rendered_content,"
+                    " '<span class=\"[a-z]{1,3}\">([^<]*)</span>', '\\1', 'g'))"
                 )
             cursor.execute(
                 SQL(

--- a/puppet/zulip/files/postgresql/process_fts_updates
+++ b/puppet/zulip/files/postgresql/process_fts_updates
@@ -86,7 +86,7 @@ def update_fts_columns(conn: psycopg2.extensions.connection) -> int:
                 )
             else:
                 update_sql = SQL(
-                   "search_tsvector = to_tsvector('zulip.english_us_search',"
+                    "search_tsvector = to_tsvector('zulip.english_us_search',"
                     " subject || regexp_replace(rendered_content, '</?span[^>]*>', '', 'g'))"
                 )
             cursor.execute(

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -758,10 +758,18 @@ class NarrowBuilder:
         query_extract_keywords = func.pgroonga_query_extract_keywords
         operand_escaped = func.escape_html(operand, type_=Text)
         keywords = query_extract_keywords(operand_escaped)
+        # Strip Pygments <span> tags so match positions align with the
+        # span-stripped content indexed in search_pgroonga.
+        # see process_fts_updates
+        stripped_content = func.regexp_replace(
+            column("rendered_content", Text),
+            literal("</?span[^>]*>"),
+            literal(""),
+            literal("g"),
+            type_=Text,
+        )
         query = query.add_columns(
-            match_positions_character(column("rendered_content", Text), keywords).label(
-                "content_matches"
-            ),
+            match_positions_character(stripped_content, keywords).label("content_matches"),
             match_positions_character(
                 func.escape_html(topic_column_sa(), type_=Text), keywords
             ).label("topic_matches"),
@@ -773,9 +781,19 @@ class NarrowBuilder:
         self, query: Select, operand: str, maybe_negate: ConditionTransform
     ) -> Select:
         tsquery = func.plainto_tsquery(literal("zulip.english_us_search"), literal(operand))
+        # Strip Pygments <span> tags before passing content to ts_headline.
+        # The search_tsvector is built from span-stripped content, see process_fts_updates
+        # so, ts_headline must operate on the same text
+        stripped_content = func.regexp_replace(
+            column("rendered_content", Text),
+            literal("</?span[^>]*>"),
+            literal(""),
+            literal("g"),
+            type_=Text,
+        )
         query = query.add_columns(
             ts_locs_array(
-                literal("zulip.english_us_search", Text), column("rendered_content", Text), tsquery
+                literal("zulip.english_us_search", Text), stripped_content, tsquery
             ).label("content_matches"),
             # We HTML-escape the topic in PostgreSQL to avoid doing a server round-trip
             ts_locs_array(

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -763,8 +763,8 @@ class NarrowBuilder:
         # see process_fts_updates
         stripped_content = func.regexp_replace(
             column("rendered_content", Text),
-            literal("</?span[^>]*>"),
-            literal(""),
+            literal('<span class="[a-z]{1,3}">([^<]*)</span>'),
+            literal(r"\1"),
             literal("g"),
             type_=Text,
         )
@@ -786,8 +786,8 @@ class NarrowBuilder:
         # so, ts_headline must operate on the same text
         stripped_content = func.regexp_replace(
             column("rendered_content", Text),
-            literal("</?span[^>]*>"),
-            literal(""),
+            literal('<span class="[a-z]{1,3}">([^<]*)</span>'),
+            literal(r"\1"),
             literal("g"),
             type_=Text,
         )

--- a/zerver/management/commands/audit_fts_indexes.py
+++ b/zerver/management/commands/audit_fts_indexes.py
@@ -14,8 +14,10 @@ class Command(ZulipBaseCommand):
                 """
                 UPDATE zerver_message
                 SET search_tsvector =
-                to_tsvector('zulip.english_us_search', subject || rendered_content)
-                WHERE to_tsvector('zulip.english_us_search', subject || rendered_content) != search_tsvector
+                to_tsvector('zulip.english_us_search',
+                    subject || regexp_replace(rendered_content, '</?span[^>]*>', '', 'g'))
+                WHERE to_tsvector('zulip.english_us_search',
+                    subject || regexp_replace(rendered_content, '</?span[^>]*>', '', 'g')) != search_tsvector
             """
             )
 

--- a/zerver/management/commands/audit_fts_indexes.py
+++ b/zerver/management/commands/audit_fts_indexes.py
@@ -15,10 +15,12 @@ class Command(ZulipBaseCommand):
                 UPDATE zerver_message
                 SET search_tsvector =
                 to_tsvector('zulip.english_us_search',
-                    subject || regexp_replace(rendered_content, '</?span[^>]*>', '', 'g'))
+                    subject || regexp_replace(rendered_content,
+                        '<span class="[a-z]{1,3}">([^<]*)</span>', '\1', 'g'))
                 WHERE to_tsvector('zulip.english_us_search',
-                    subject || regexp_replace(rendered_content, '</?span[^>]*>', '', 'g')) != search_tsvector
-            """
+                    subject || regexp_replace(rendered_content,
+                        '<span class="[a-z]{1,3}">([^<]*)</span>', '\1', 'g')) != search_tsvector
+                """
             )
 
             fixed_message_count = cursor.rowcount

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -609,7 +609,7 @@ class NarrowBuilderTest(ZulipTestCase):
         term = NarrowParameter(operator="search", operand='"french fries"')
         self._do_add_term_test(
             term,
-            "WHERE (content ILIKE %(content_1)s OR subject ILIKE %(subject_1)s AND is_channel_message) AND (search_tsvector @@ plainto_tsquery(%(param_4)s, %(param_5)s))",
+            "WHERE (content ILIKE %(content_1)s OR subject ILIKE %(subject_1)s AND is_channel_message) AND (search_tsvector @@ plainto_tsquery(%(param_7)s, %(param_8)s))",
         )
 
     @override_settings(USING_PGROONGA=False)
@@ -617,7 +617,7 @@ class NarrowBuilderTest(ZulipTestCase):
         term = NarrowParameter(operator="search", operand='"french fries"', negated=True)
         self._do_add_term_test(
             term,
-            "WHERE NOT (content ILIKE %(content_1)s OR subject ILIKE %(subject_1)s AND is_channel_message) AND NOT (search_tsvector @@ plainto_tsquery(%(param_4)s, %(param_5)s))",
+            "WHERE NOT (content ILIKE %(content_1)s OR subject ILIKE %(subject_1)s AND is_channel_message) AND NOT (search_tsvector @@ plainto_tsquery(%(param_7)s, %(param_8)s))",
         )
 
     @override_settings(USING_PGROONGA=True)
@@ -2912,9 +2912,10 @@ class GetOldMessagesTest(ZulipTestCase):
         with connection.cursor() as cursor:
             cursor.execute(
                 """
-            UPDATE zerver_message SET
-            search_tsvector = to_tsvector('zulip.english_us_search',
-            subject || rendered_content)
+                UPDATE zerver_message SET
+                search_tsvector = to_tsvector('zulip.english_us_search',
+                    subject || regexp_replace(rendered_content,
+                        '<span class="[a-z]{1,3}">([^<]*)</span>', '\\1', 'g'))
             """
             )
 
@@ -3359,6 +3360,126 @@ class GetOldMessagesTest(ZulipTestCase):
             special_search_result["messages"][0]["match_content"],
             '<p>James\' <span class="highlight">burger</span></p>',
         )
+
+    @override_settings(USING_PGROONGA=False)
+    def test_get_messages_with_search_in_code_block(self) -> None:
+        self.login("cordelia")
+        cordelia = self.example_user("cordelia")
+        next_message_id = self.get_last_message().id + 1
+
+        self.send_stream_message(
+            cordelia,
+            "Verona",
+            content="```javascript\nm.mount(document.body, App)\n```",
+            topic_name="code review",
+        )
+
+        self.send_stream_message(
+            cordelia,
+            "Verona",
+            content="```javascript\nborder-radius: 4px\n```",
+            topic_name="code review",
+        )
+
+        self.send_stream_message(
+            cordelia,
+            "Verona",
+            content="```\nm.mount(document.body, App)\n```",
+            topic_name="plain code",
+        )
+        self._update_tsvector_index()
+
+        narrow = [dict(operator="search", operand="m.mount")]
+        result: dict[str, Any] = self.get_and_check_messages(
+            dict(
+                narrow=orjson.dumps(narrow).decode(),
+                anchor=next_message_id,
+                num_before=0,
+                num_after=10,
+            )
+        )
+        self.assert_length(result["messages"], 2)
+
+        narrow = [dict(operator="search", operand="border-radius")]
+        result = self.get_and_check_messages(
+            dict(
+                narrow=orjson.dumps(narrow).decode(),
+                anchor=next_message_id,
+                num_before=0,
+                num_after=10,
+            )
+        )
+        self.assert_length(result["messages"], 1)
+
+    @override_settings(USING_PGROONGA=False)
+    def test_get_messages_with_search_in_inline_code(self) -> None:
+        self.login("cordelia")
+        cordelia = self.example_user("cordelia")
+        next_message_id = self.get_last_message().id + 1
+
+        self.send_stream_message(
+            cordelia,
+            "Verona",
+            content="Use `m.mount` to render your app.",
+            topic_name="inline code",
+        )
+        self._update_tsvector_index()
+
+        narrow = [dict(operator="search", operand="m.mount")]
+        result: dict[str, Any] = self.get_and_check_messages(
+            dict(
+                narrow=orjson.dumps(narrow).decode(),
+                anchor=next_message_id,
+                num_before=0,
+                num_after=10,
+            )
+        )
+        self.assert_length(result["messages"], 1)
+
+    @override_settings(USING_PGROONGA=True)
+    def test_get_messages_with_search_in_code_block_pgroonga(self) -> None:
+        self.login("cordelia")
+        cordelia = self.example_user("cordelia")
+        next_message_id = self.get_last_message().id + 1
+
+        self.send_stream_message(
+            cordelia,
+            "Verona",
+            content="```javascript\nm.mount(document.body, App)\n```",
+            topic_name="code review",
+        )
+        self.send_stream_message(
+            cordelia,
+            "Verona",
+            content="```\nm.mount(document.body, App)\n```",
+            topic_name="plain code",
+        )
+
+        # NOTE: There is no _update_pgroonga_index() helper in this test class.
+        # This raw SQL duplicates the formula in process_fts_updates and must
+        # be kept in sync manually if that formula changes.
+        # TODO: Extract a shared _update_pgroonga_index() helper when PGroonga
+        # testing infrastructure is improved.
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                UPDATE zerver_message SET
+                search_pgroonga = escape_html(subject) || ' '
+                || regexp_replace(rendered_content,
+                    '<span class="[a-z]{1,3}">([^<]*)</span>', '\\1', 'g')
+                """
+            )
+
+        narrow = [dict(operator="search", operand="m.mount")]
+        result: dict[str, Any] = self.get_and_check_messages(
+            dict(
+                narrow=orjson.dumps(narrow).decode(),
+                anchor=next_message_id,
+                num_before=0,
+                num_after=10,
+            )
+        )
+        self.assert_length(result["messages"], 2)
 
     @override_settings(USING_PGROONGA=False)
     def test_get_visible_messages_with_search(self) -> None:
@@ -5358,7 +5479,7 @@ WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.
         sql_template = """\
 SELECT anon_1.message_id, anon_1.flags, anon_1.escaped_topic_name, anon_1.rendered_content, anon_1.content_matches, anon_1.topic_matches \n\
 FROM (SELECT message_id, flags, escape_html(subject) AS escaped_topic_name, rendered_content, array((SELECT ARRAY[sum(length(anon_3) - 11) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) + 11, strpos(anon_3, '</ts-match>') - 1] AS anon_2 \n\
-FROM unnest(string_to_array(ts_headline('zulip.english_us_search', rendered_content, plainto_tsquery('zulip.english_us_search', 'jumping'), 'HighlightAll = TRUE, StartSel = <ts-match>, StopSel = </ts-match>'), '<ts-match>')) AS anon_3\n\
+FROM unnest(string_to_array(ts_headline('zulip.english_us_search', regexp_replace(rendered_content, '<span class=\"[a-z]{{1,3}}\">([^<]*)</span>', '\\1', 'g'), plainto_tsquery('zulip.english_us_search', 'jumping'), 'HighlightAll = TRUE, StartSel = <ts-match>, StopSel = </ts-match>'), '<ts-match>')) AS anon_3\n\
  LIMIT ALL OFFSET 1)) AS content_matches, array((SELECT ARRAY[sum(length(anon_5) - 11) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) + 11, strpos(anon_5, '</ts-match>') - 1] AS anon_4 \n\
 FROM unnest(string_to_array(ts_headline('zulip.english_us_search', escape_html(subject), plainto_tsquery('zulip.english_us_search', 'jumping'), 'HighlightAll = TRUE, StartSel = <ts-match>, StopSel = </ts-match>'), '<ts-match>')) AS anon_5\n\
  LIMIT ALL OFFSET 1)) AS topic_matches \n\
@@ -5378,7 +5499,7 @@ WHERE zerver_subscription.user_profile_id = {hamlet_id} AND zerver_subscription.
         sql_template = """\
 SELECT anon_1.message_id, anon_1.escaped_topic_name, anon_1.rendered_content, anon_1.content_matches, anon_1.topic_matches \n\
 FROM (SELECT id AS message_id, escape_html(subject) AS escaped_topic_name, rendered_content, array((SELECT ARRAY[sum(length(anon_3) - 11) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) + 11, strpos(anon_3, '</ts-match>') - 1] AS anon_2 \n\
-FROM unnest(string_to_array(ts_headline('zulip.english_us_search', rendered_content, plainto_tsquery('zulip.english_us_search', 'jumping'), 'HighlightAll = TRUE, StartSel = <ts-match>, StopSel = </ts-match>'), '<ts-match>')) AS anon_3\n\
+FROM unnest(string_to_array(ts_headline('zulip.english_us_search', regexp_replace(rendered_content, '<span class=\"[a-z]{{1,3}}\">([^<]*)</span>', '\\1', 'g'), plainto_tsquery('zulip.english_us_search', 'jumping'), 'HighlightAll = TRUE, StartSel = <ts-match>, StopSel = </ts-match>'), '<ts-match>')) AS anon_3\n\
  LIMIT ALL OFFSET 1)) AS content_matches, array((SELECT ARRAY[sum(length(anon_5) - 11) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) + 11, strpos(anon_5, '</ts-match>') - 1] AS anon_4 \n\
 FROM unnest(string_to_array(ts_headline('zulip.english_us_search', escape_html(subject), plainto_tsquery('zulip.english_us_search', 'jumping'), 'HighlightAll = TRUE, StartSel = <ts-match>, StopSel = </ts-match>'), '<ts-match>')) AS anon_5\n\
  LIMIT ALL OFFSET 1)) AS topic_matches \n\
@@ -5400,7 +5521,7 @@ WHERE realm_id = 2 AND recipient_id = {scotland_recipient} AND (search_tsvector 
         sql_template = """\
 SELECT anon_1.message_id, anon_1.flags, anon_1.escaped_topic_name, anon_1.rendered_content, anon_1.content_matches, anon_1.topic_matches \n\
 FROM (SELECT message_id, flags, escape_html(subject) AS escaped_topic_name, rendered_content, array((SELECT ARRAY[sum(length(anon_3) - 11) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) + 11, strpos(anon_3, '</ts-match>') - 1] AS anon_2 \n\
-FROM unnest(string_to_array(ts_headline('zulip.english_us_search', rendered_content, plainto_tsquery('zulip.english_us_search', '"jumping" quickly'), 'HighlightAll = TRUE, StartSel = <ts-match>, StopSel = </ts-match>'), '<ts-match>')) AS anon_3\n\
+FROM unnest(string_to_array(ts_headline('zulip.english_us_search', regexp_replace(rendered_content, '<span class=\"[a-z]{{1,3}}\">([^<]*)</span>', '\\1', 'g'), plainto_tsquery('zulip.english_us_search', '"jumping" quickly'), 'HighlightAll = TRUE, StartSel = <ts-match>, StopSel = </ts-match>'), '<ts-match>')) AS anon_3\n\
  LIMIT ALL OFFSET 1)) AS content_matches, array((SELECT ARRAY[sum(length(anon_5) - 11) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) + 11, strpos(anon_5, '</ts-match>') - 1] AS anon_4 \n\
 FROM unnest(string_to_array(ts_headline('zulip.english_us_search', escape_html(subject), plainto_tsquery('zulip.english_us_search', '"jumping" quickly'), 'HighlightAll = TRUE, StartSel = <ts-match>, StopSel = </ts-match>'), '<ts-match>')) AS anon_5\n\
  LIMIT ALL OFFSET 1)) AS topic_matches \n\

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Iterable
 from typing import Annotated
 
@@ -37,6 +38,12 @@ from zerver.lib.typed_endpoint import ApiParamConfig, typed_endpoint
 from zerver.models import UserMessage, UserProfile
 
 MAX_MESSAGES_PER_FETCH = 5000
+
+# Matches <span> tags inserted by Pygments syntax highlighting.
+# These are stripped before highlight_string applies match positions,
+# because match positions come from ts_locs_array which operates on
+# span-stripped content, matching the search_tsvector formula.
+_PYGMENTS_SPAN_RE = re.compile(r"</?span[^>]*>")
 
 
 def highlight_string(text: str, locs: Iterable[tuple[int, int]]) -> str:
@@ -295,8 +302,9 @@ def get_messages_backend(
             for row in rows:
                 message_id = row[0]
                 (escaped_topic_name, rendered_content, content_matches, topic_matches) = row[-4:]
+                stripped_content = _PYGMENTS_SPAN_RE.sub("", rendered_content)
                 search_fields[message_id] = get_search_fields(
-                    rendered_content, escaped_topic_name, content_matches, topic_matches
+                    stripped_content, escaped_topic_name, content_matches, topic_matches
                 )
 
         message_list = messages_for_ids(

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -43,7 +43,7 @@ MAX_MESSAGES_PER_FETCH = 5000
 # These are stripped before highlight_string applies match positions,
 # because match positions come from ts_locs_array which operates on
 # span-stripped content, matching the search_tsvector formula.
-_PYGMENTS_SPAN_RE = re.compile(r"</?span[^>]*>")
+_PYGMENTS_SPAN_RE = re.compile(r'<span class="[a-z]{1,3}">([^<]*)</span>')
 
 
 def highlight_string(text: str, locs: Iterable[tuple[int, int]]) -> str:
@@ -302,7 +302,7 @@ def get_messages_backend(
             for row in rows:
                 message_id = row[0]
                 (escaped_topic_name, rendered_content, content_matches, topic_matches) = row[-4:]
-                stripped_content = _PYGMENTS_SPAN_RE.sub("", rendered_content)
+                stripped_content = _PYGMENTS_SPAN_RE.sub(r"\1", rendered_content)
                 search_fields[message_id] = get_search_fields(
                     stripped_content, escaped_topic_name, content_matches, topic_matches
                 )


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: https://github.com/zulip/zulip/issues/22135
While working on this issue, I learned that when Zulip renders a code block with syntax highlighting, Pygments wraps each token in a span tag to apply colors. So something like m.mount ends up stored in rendered_content as three separate pieces

` <span class="nx">m</span><span class="o">.</span><span class="nx">mount</span>. `

When PostgreSQL builds the search index from that HTML, it sees `m`,` .`, and `mount` as three separate words, so searching for m.mount finds nothing even though the message is right there.

The fix is to strip those Pygments spans before the content is fed to the search indexer. 

I used `regexp_replace` with this pattern `<span class="[a-z]{1,3}">([^<]*)</span> `and the backreference `\1 ` to replace each span with just its text content. The reason I went with `\ 1` instead of replacing with an empty string is that empty string replacement required two separate passes and accidentally removed closing `</span> ` tags that belong to other spans like user mentions. 

**How changes were tested:**
I tested this fix in the dev environment. I on the zulip website, i sent a message with a JavaScript code block containing `m.mount`, searched for it, and confirmed it now shows up. 
I also checked that plain code blocks, inline backtick code, and messages with user mentions all still work correctly after the change.

I added three new tests

- `test_get_messages_with_search_in_code_block`  checks that `m.mount` and `border-radius` inside highlighted code blocks are now searchable
- `test_get_messages_with_search_in_inline_code`  makes sure inline code was not broken by the fix
- `test_get_messages_with_search_in_code_block_pgroonga`  same check but for the PGroonga path



**Screenshots and screen captures:**

Before fix,  searching `m.mount` returns no results for highlighted code block

<img width="1723" height="1057" alt="Screenshot 2026-03-10 at 15 16 33" src="https://github.com/user-attachments/assets/e080dfed-6216-424c-ac51-32285d877a73" />



After fix, searching `m.mount` finds the highlighted code block
<img width="1722" height="1094" alt="Screenshot 2026-03-10 at 15 09 45" src="https://github.com/user-attachments/assets/9c0fefdb-3484-4b3c-ba45-a6b9e5018fe7" />

<img width="1738" height="986" alt="Screenshot 2026-03-10 at 15 11 33" src="https://github.com/user-attachments/assets/2faae860-69b8-4973-8aaf-66df8c6a5933" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
