### PR TITLE
starred messages: Unstar messages after channel unsubscription.

### DIFF
--- a/zerver/actions/message_flags.py
+++ b/zerver/actions/message_flags.py
@@ -154,6 +154,41 @@ def do_mark_stream_messages_as_read(
     return count
 
 
+@transaction.atomic(durable=True)
+def do_unstar_stream_messages(user_profile: UserProfile, stream_recipient_id: int) -> int:
+    query = (
+        UserMessage.select_for_update_query()
+        .filter(
+            user_profile=user_profile,
+            message__recipient_id=stream_recipient_id,
+        )
+        .extra(  # noqa: S610
+            where=[UserMessage.where_starred()],
+        )
+    )
+
+    message_ids = list(query.values_list("message_id", flat=True))
+
+    if len(message_ids) == 0:
+        return 0
+
+    count = query.update(
+        flags=F("flags").bitand(~UserMessage.flags.starred),
+    )
+
+    event = {
+        "type": "update_message_flags",
+        "op": "remove",
+        "operation": "remove",
+        "flag": "starred",
+        "messages": message_ids,
+        "all": False,
+    }
+    send_event_on_commit(user_profile.realm, event, [user_profile.id])
+
+    return count
+
+
 @transaction.atomic(savepoint=False)
 def do_mark_muted_user_messages_as_read(
     user_profile: UserProfile,

--- a/zerver/actions/message_flags.py
+++ b/zerver/actions/message_flags.py
@@ -1,5 +1,6 @@
 import time
 from collections import defaultdict
+from collections.abc import Collection
 from dataclasses import asdict, dataclass, field
 
 from django.db import transaction
@@ -16,9 +17,20 @@ from zerver.lib.message import (
 )
 from zerver.lib.queue import mobile_notifications_queue_name, queue_event_on_commit
 from zerver.lib.stream_subscription import get_subscribed_stream_recipient_ids_for_user
+from zerver.lib.streams import user_has_content_access
 from zerver.lib.topic import filter_by_topic_name_via_message
+from zerver.lib.user_groups import UserGroupMembershipDetails
 from zerver.lib.user_message import DEFAULT_HISTORICAL_FLAGS, create_historical_user_messages
-from zerver.models import Device, Message, PushDeviceToken, Recipient, UserMessage, UserProfile
+from zerver.models import (
+    Device,
+    Message,
+    PushDeviceToken,
+    Recipient,
+    Stream,
+    Subscription,
+    UserMessage,
+    UserProfile,
+)
 from zerver.tornado.django_api import send_event_on_commit, send_event_rollback_unsafe
 
 
@@ -151,6 +163,70 @@ def do_mark_stream_messages_as_read(
         event_time,
         increment=min(1, count),
     )
+    return count
+
+
+def do_unstar_inaccessible_stream_messages(
+    user_profile: UserProfile, stream_recipient_ids: Collection[int]
+) -> int:
+    streams = list(
+        Stream.objects.filter(
+            realm=user_profile.realm,
+            recipient_id__in=stream_recipient_ids,
+        )
+    )
+    subscribed_recipient_ids = set(
+        Subscription.objects.filter(
+            user_profile=user_profile,
+            recipient_id__in=stream_recipient_ids,
+            active=True,
+        ).values_list("recipient_id", flat=True)
+    )
+    user_group_membership_details = UserGroupMembershipDetails(user_recursive_group_ids=None)
+    inaccessible_recipient_ids: list[int] = []
+    for stream in streams:
+        assert stream.recipient_id is not None
+        if not user_has_content_access(
+            user_profile,
+            stream,
+            user_group_membership_details,
+            is_subscribed=stream.recipient_id in subscribed_recipient_ids,
+        ):
+            inaccessible_recipient_ids.append(stream.recipient_id)
+
+    if len(inaccessible_recipient_ids) == 0:
+        return 0
+
+    with transaction.atomic(durable=True):
+        query = (
+            UserMessage.select_for_update_query()
+            .filter(
+                user_profile=user_profile,
+                message__recipient_id__in=inaccessible_recipient_ids,
+            )
+            .extra(  # noqa: S610
+                where=[UserMessage.where_starred()],
+            )
+        )
+        message_ids = list(query.values_list("message_id", flat=True))
+
+        if len(message_ids) == 0:
+            return 0
+
+        count = query.update(
+            flags=F("flags").bitand(~UserMessage.flags.starred),
+        )
+
+        event = {
+            "type": "update_message_flags",
+            "op": "remove",
+            "operation": "remove",
+            "flag": "starred",
+            "messages": message_ids,
+            "all": False,
+        }
+        send_event_on_commit(user_profile.realm, event, [user_profile.id])
+
     return count
 
 

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -38,7 +38,6 @@ from zerver.lib.stream_subscription import (
 from zerver.lib.stream_traffic import get_streams_traffic
 from zerver.lib.streams import (
     can_access_stream_metadata_user_ids,
-    check_basic_stream_access,
     get_anonymous_group_membership_dict_for_streams,
     get_stream_permission_policy_key,
     get_stream_post_policy_value_based_on_group_setting,
@@ -47,11 +46,14 @@ from zerver.lib.streams import (
     send_stream_creation_event,
     send_stream_deletion_event,
     stream_to_dict,
+    user_has_content_access,
+    user_has_metadata_access,
 )
 from zerver.lib.subscription_info import bulk_get_subscriber_peer_info, get_subscribers_query
 from zerver.lib.topic import get_topic_display_name
 from zerver.lib.types import APISubscriptionDict, UserGroupMembersData
 from zerver.lib.user_groups import (
+    UserGroupMembershipDetails,
     convert_to_user_group_members_dict,
     get_group_setting_value_for_api,
     get_group_setting_value_for_audit_log_data,
@@ -998,17 +1000,39 @@ def send_subscription_remove_events(
         }
         queue_event_on_commit("deferred_work", event)
 
-        if not user_profile.is_realm_admin:
-            inaccessible_streams = [
-                stream
-                for stream in streams_by_user[user_profile.id]
-                if not check_basic_stream_access(
-                    user_profile, stream, is_subscribed=False, require_content_access=False
-                )
-            ]
+        user_group_membership_details = UserGroupMembershipDetails(user_recursive_group_ids=None)
+        streams_losing_content_access: list[Stream] = []
+        inaccessible_streams: list[Stream] = []
+        for stream in streams_by_user[user_profile.id]:
+            if not user_has_content_access(
+                user_profile,
+                stream,
+                user_group_membership_details,
+                is_subscribed=False,
+            ):
+                streams_losing_content_access.append(stream)
+            if not user_profile.is_realm_admin and not user_has_metadata_access(
+                user_profile,
+                stream,
+                user_group_membership_details,
+                is_subscribed=False,
+            ):
+                inaccessible_streams.append(stream)
 
-            if inaccessible_streams:
-                send_stream_deletion_event(realm, [user_profile.id], inaccessible_streams)
+        if streams_losing_content_access:
+            queue_event_on_commit(
+                "deferred_work",
+                {
+                    "type": "unstar_inaccessible_stream_messages",
+                    "user_profile_id": user_profile.id,
+                    "stream_recipient_ids": [
+                        stream.recipient_id for stream in streams_losing_content_access
+                    ],
+                },
+            )
+
+        if inaccessible_streams:
+            send_stream_deletion_event(realm, [user_profile.id], inaccessible_streams)
 
 
 def send_user_remove_events_on_removing_subscriptions(

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -38,7 +38,6 @@ from zerver.lib.stream_subscription import (
 from zerver.lib.stream_traffic import get_streams_traffic
 from zerver.lib.streams import (
     can_access_stream_metadata_user_ids,
-    check_basic_stream_access,
     get_anonymous_group_membership_dict_for_streams,
     get_stream_permission_policy_key,
     get_stream_post_policy_value_based_on_group_setting,
@@ -47,11 +46,14 @@ from zerver.lib.streams import (
     send_stream_creation_event,
     send_stream_deletion_event,
     stream_to_dict,
+    user_has_content_access,
+    user_has_metadata_access,
 )
 from zerver.lib.subscription_info import bulk_get_subscriber_peer_info, get_subscribers_query
 from zerver.lib.topic import get_topic_display_name
 from zerver.lib.types import APISubscriptionDict, UserGroupMembersData
 from zerver.lib.user_groups import (
+    UserGroupMembershipDetails,
     convert_to_user_group_members_dict,
     get_group_setting_value_for_api,
     get_group_setting_value_for_audit_log_data,
@@ -998,17 +1000,52 @@ def send_subscription_remove_events(
         }
         queue_event_on_commit("deferred_work", event)
 
-        if not user_profile.is_realm_admin:
-            inaccessible_streams = [
-                stream
-                for stream in streams_by_user[user_profile.id]
-                if not check_basic_stream_access(
-                    user_profile, stream, is_subscribed=False, require_content_access=False
-                )
-            ]
+        user_group_membership_details = UserGroupMembershipDetails(user_recursive_group_ids=None)
+        streams_losing_content_access: list[Stream] = []
+        inaccessible_streams: list[Stream] = []
+        for stream in streams_by_user[user_profile.id]:
+            if user_profile.is_realm_admin:
+                # Realm admins always have metadata access to streams in
+                # the realm, so only check for content access.
+                if not user_has_content_access(
+                    user_profile,
+                    stream,
+                    user_group_membership_details,
+                    is_subscribed=False,
+                ):
+                    streams_losing_content_access.append(stream)
+            elif not user_has_metadata_access(
+                user_profile,
+                stream,
+                user_group_membership_details,
+                is_subscribed=False,
+            ):
+                # A user without metadata access to a stream cannot have
+                # content access to it either.
+                streams_losing_content_access.append(stream)
+                inaccessible_streams.append(stream)
+            elif not user_has_content_access(
+                user_profile,
+                stream,
+                user_group_membership_details,
+                is_subscribed=False,
+            ):
+                streams_losing_content_access.append(stream)
 
-            if inaccessible_streams:
-                send_stream_deletion_event(realm, [user_profile.id], inaccessible_streams)
+        if streams_losing_content_access:
+            queue_event_on_commit(
+                "deferred_work",
+                {
+                    "type": "unstar_inaccessible_stream_messages",
+                    "user_profile_id": user_profile.id,
+                    "stream_recipient_ids": [
+                        stream.recipient_id for stream in streams_losing_content_access
+                    ],
+                },
+            )
+
+        if inaccessible_streams:
+            send_stream_deletion_event(realm, [user_profile.id], inaccessible_streams)
 
 
 def send_user_remove_events_on_removing_subscriptions(

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -6,7 +6,7 @@ from django.db import connection
 from django.test import override_settings
 from typing_extensions import override
 
-from zerver.actions.message_flags import do_update_message_flags
+from zerver.actions.message_flags import do_unstar_stream_messages, do_update_message_flags
 from zerver.actions.streams import do_change_stream_group_based_setting, do_change_stream_permission
 from zerver.actions.user_groups import check_add_user_group
 from zerver.actions.user_settings import do_change_user_setting
@@ -28,6 +28,7 @@ from zerver.lib.message import (
 from zerver.lib.message_cache import MessageDict
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import get_subscription
+from zerver.lib.types import UserGroupMembersData
 from zerver.lib.user_message import DEFAULT_HISTORICAL_FLAGS, create_historical_user_messages
 from zerver.models import (
     Device,
@@ -2135,6 +2136,153 @@ class MessageAccessTests(ZulipTestCase):
             bulk_access_stream_messages_query_count=1,
         )
         self.assert_length(filtered_messages, 2)
+
+
+class UnstarStreamMessagesTest(ZulipTestCase):
+    def test_do_unstar_stream_messages(self) -> None:
+        """
+        Test that do_unstar_stream_messages removes the starred flag
+        from messages in a given stream and sends the appropriate event.
+        """
+        hamlet = self.example_user("hamlet")
+        stream_name = "private_stream"
+        stream = self.make_stream(stream_name, invite_only=True)
+        self.subscribe(hamlet, stream_name)
+
+        # Send messages and star them.
+        message_id1 = self.send_stream_message(hamlet, stream_name, "test 1")
+        message_id2 = self.send_stream_message(hamlet, stream_name, "test 2")
+        do_update_message_flags(hamlet, "add", "starred", [message_id1, message_id2])
+
+        # Verify messages are starred.
+        um1 = UserMessage.objects.get(user_profile=hamlet, message_id=message_id1)
+        um2 = UserMessage.objects.get(user_profile=hamlet, message_id=message_id2)
+        self.assertTrue(um1.flags.starred)
+        self.assertTrue(um2.flags.starred)
+
+        assert stream.recipient_id is not None
+        with self.capture_send_event_calls(expected_num_events=1) as events:
+            count = do_unstar_stream_messages(hamlet, stream.recipient_id)
+
+        self.assertEqual(count, 2)
+
+        # Verify the event.
+        self.assertEqual(events[0]["event"]["type"], "update_message_flags")
+        self.assertEqual(events[0]["event"]["op"], "remove")
+        self.assertEqual(events[0]["event"]["flag"], "starred")
+        self.assertEqual(sorted(events[0]["event"]["messages"]), sorted([message_id1, message_id2]))
+
+        # Verify the flags are cleared in the database.
+        um1.refresh_from_db()
+        um2.refresh_from_db()
+        self.assertFalse(um1.flags.starred)
+        self.assertFalse(um2.flags.starred)
+
+    def test_do_unstar_stream_messages_no_starred(self) -> None:
+        """
+        Test that do_unstar_stream_messages is a no-op when there are
+        no starred messages in the stream.
+        """
+        hamlet = self.example_user("hamlet")
+        stream_name = "private_stream"
+        stream = self.make_stream(stream_name, invite_only=True)
+        self.subscribe(hamlet, stream_name)
+
+        # Send a message but don't star it.
+        self.send_stream_message(hamlet, stream_name, "test")
+
+        assert stream.recipient_id is not None
+        with self.capture_send_event_calls(expected_num_events=0):
+            count = do_unstar_stream_messages(hamlet, stream.recipient_id)
+
+        self.assertEqual(count, 0)
+
+    def test_unsubscribe_private_stream_unstars_messages(self) -> None:
+        """
+        When a user unsubscribes from a private stream they can no
+        longer access, their starred messages in that stream should
+        be unstarred via a deferred work event.
+        """
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        stream_name = "private_stream"
+        stream = self.make_stream(stream_name, invite_only=True)
+        self.subscribe(hamlet, stream_name)
+        self.subscribe(cordelia, stream_name)
+
+        # Send a message and star it.
+        message_id = self.send_stream_message(hamlet, stream_name, "important message")
+        do_update_message_flags(hamlet, "add", "starred", [message_id])
+
+        # Verify the message is starred.
+        um = UserMessage.objects.get(user_profile=hamlet, message_id=message_id)
+        self.assertTrue(um.flags.starred)
+
+        # Unsubscribe hamlet from the private stream.
+        # This should queue a deferred work event to unstar messages.
+        with mock.patch("zerver.actions.streams.queue_event_on_commit") as mock_queue:
+            self.unsubscribe(hamlet, stream_name)
+
+        # Check that the unstar deferred work event was queued
+        # (along with the mark_stream_messages_as_read event).
+        queued_events = [call.args[1] for call in mock_queue.call_args_list]
+        unstar_events = [
+            e for e in queued_events if e["type"] == "unstar_inaccessible_stream_messages"
+        ]
+        self.assert_length(unstar_events, 1)
+        self.assertEqual(unstar_events[0]["user_profile_id"], hamlet.id)
+        self.assertEqual(unstar_events[0]["stream_recipient_ids"], [stream.recipient_id])
+
+    def test_unsubscribe_private_stream_unstars_messages_for_realm_admin(self) -> None:
+        iago = self.example_user("iago")
+        stream_name = "private_stream"
+        stream = self.make_stream(stream_name, invite_only=True)
+        self.subscribe(iago, stream_name)
+
+        message_id = self.send_stream_message(iago, stream_name, "important message")
+        do_update_message_flags(iago, "add", "starred", [message_id])
+
+        with mock.patch("zerver.actions.streams.queue_event_on_commit") as mock_queue:
+            self.unsubscribe(iago, stream_name)
+
+        queued_events = [call.args[1] for call in mock_queue.call_args_list]
+        unstar_events = [
+            e for e in queued_events if e["type"] == "unstar_inaccessible_stream_messages"
+        ]
+        self.assert_length(unstar_events, 1)
+        self.assertEqual(unstar_events[0]["user_profile_id"], iago.id)
+        self.assertEqual(unstar_events[0]["stream_recipient_ids"], [stream.recipient_id])
+
+    def test_unsubscribe_private_stream_unstars_for_channel_admin(self) -> None:
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+        stream_name = "private_stream"
+        stream = self.make_stream(stream_name, invite_only=True)
+        self.subscribe(hamlet, stream_name)
+        do_change_stream_group_based_setting(
+            stream,
+            "can_administer_channel_group",
+            UserGroupMembersData(direct_members=[hamlet.id], direct_subgroups=[]),
+            acting_user=iago,
+        )
+
+        message_id = self.send_stream_message(hamlet, stream_name, "important message")
+        do_update_message_flags(hamlet, "add", "starred", [message_id])
+
+        with (
+            mock.patch("zerver.actions.streams.queue_event_on_commit") as mock_queue,
+            mock.patch("zerver.actions.streams.send_stream_deletion_event") as mock_delete,
+        ):
+            self.unsubscribe(hamlet, stream_name)
+
+        queued_events = [call.args[1] for call in mock_queue.call_args_list]
+        unstar_events = [
+            e for e in queued_events if e["type"] == "unstar_inaccessible_stream_messages"
+        ]
+        self.assert_length(unstar_events, 1)
+        self.assertEqual(unstar_events[0]["user_profile_id"], hamlet.id)
+        self.assertEqual(unstar_events[0]["stream_recipient_ids"], [stream.recipient_id])
+        mock_delete.assert_not_called()
 
 
 class PersonalMessagesFlagTest(ZulipTestCase):

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -28,6 +28,7 @@ from zerver.lib.message import (
 from zerver.lib.message_cache import MessageDict
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import get_subscription
+from zerver.lib.types import UserGroupMembersData
 from zerver.lib.user_message import DEFAULT_HISTORICAL_FLAGS, create_historical_user_messages
 from zerver.models import (
     Device,
@@ -43,6 +44,7 @@ from zerver.models.groups import NamedUserGroup
 from zerver.models.realms import get_realm
 from zerver.models.recipients import get_or_create_direct_message_group
 from zerver.models.streams import get_stream
+from zerver.worker.deferred_work import DeferredWorker
 
 if TYPE_CHECKING:
     from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
@@ -2135,6 +2137,153 @@ class MessageAccessTests(ZulipTestCase):
             bulk_access_stream_messages_query_count=1,
         )
         self.assert_length(filtered_messages, 2)
+
+
+class UnstarStreamMessagesTest(ZulipTestCase):
+    def test_unsubscribe_unstars_inaccessible_starred_messages(self) -> None:
+        """
+        Test that unsubscribing a user from a channel they lose content
+        access to unstars their starred messages in that channel, while
+        users retaining content access keep their stars.
+        """
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+        othello = self.example_user("othello")
+        cordelia = self.example_user("cordelia")
+        prospero = self.example_user("prospero")
+        polonius = self.example_user("polonius")  # Guest user.
+
+        # A regular user unsubscribed from a private stream loses
+        # content access to it.
+        self.make_stream("private_stream", invite_only=True)
+        self.subscribe(hamlet, "private_stream")
+        private_message_id = self.send_stream_message(hamlet, "private_stream", "test message")
+        do_update_message_flags(hamlet, "add", "starred", [private_message_id])
+
+        # A realm admin unsubscribed from a private stream keeps metadata
+        # access but loses content access.
+        self.make_stream("admin_stream", invite_only=True)
+        self.subscribe(iago, "admin_stream")
+        admin_message_id = self.send_stream_message(iago, "admin_stream", "test message")
+        do_update_message_flags(iago, "add", "starred", [admin_message_id])
+
+        # A channel admin (via can_administer_channel_group) unsubscribed
+        # from a private stream keeps metadata access but loses content
+        # access.
+        channel_admin_stream = self.make_stream("channel_admin_stream", invite_only=True)
+        self.subscribe(othello, "channel_admin_stream")
+        do_change_stream_group_based_setting(
+            channel_admin_stream,
+            "can_administer_channel_group",
+            UserGroupMembersData(direct_members=[othello.id], direct_subgroups=[]),
+            acting_user=iago,
+        )
+        channel_admin_message_id = self.send_stream_message(
+            othello, "channel_admin_stream", "test message"
+        )
+        do_update_message_flags(othello, "add", "starred", [channel_admin_message_id])
+
+        # A user in can_subscribe_group unsubscribed from a private
+        # stream retains content access.
+        can_subscribe_stream = self.make_stream("can_subscribe_stream", invite_only=True)
+        self.subscribe(cordelia, "can_subscribe_stream")
+        do_change_stream_group_based_setting(
+            can_subscribe_stream,
+            "can_subscribe_group",
+            UserGroupMembersData(direct_members=[cordelia.id], direct_subgroups=[]),
+            acting_user=iago,
+        )
+        can_subscribe_message_id = self.send_stream_message(
+            cordelia, "can_subscribe_stream", "test message"
+        )
+        do_update_message_flags(cordelia, "add", "starred", [can_subscribe_message_id])
+
+        # A user unsubscribed from a private stream with no starred
+        # messages has nothing to unstar.
+        self.make_stream("no_starred_stream", invite_only=True)
+        self.subscribe(prospero, "no_starred_stream")
+        self.send_stream_message(prospero, "no_starred_stream", "test message")
+
+        # A regular user unsubscribed from a public stream retains
+        # content access to it, but a guest loses content access.
+        self.make_stream("public_stream")
+        self.subscribe(hamlet, "public_stream")
+        self.subscribe(polonius, "public_stream")
+        public_message_id = self.send_stream_message(hamlet, "public_stream", "test message")
+        do_update_message_flags(hamlet, "add", "starred", [public_message_id])
+        do_update_message_flags(polonius, "add", "starred", [public_message_id])
+
+        # The unstar work is queued on commit and processed by the
+        # deferred work worker.
+        with self.captureOnCommitCallbacks(execute=True):
+            self.unsubscribe(hamlet, "private_stream")
+            self.unsubscribe(iago, "admin_stream")
+            self.unsubscribe(othello, "channel_admin_stream")
+            self.unsubscribe(cordelia, "can_subscribe_stream")
+            self.unsubscribe(prospero, "no_starred_stream")
+            self.unsubscribe(hamlet, "public_stream")
+            self.unsubscribe(polonius, "public_stream")
+
+        # Users who lost content access have their starred messages unstarred.
+        self.assertFalse(
+            UserMessage.objects.get(
+                user_profile=hamlet, message_id=private_message_id
+            ).flags.starred
+        )
+        self.assertFalse(
+            UserMessage.objects.get(user_profile=iago, message_id=admin_message_id).flags.starred
+        )
+        self.assertFalse(
+            UserMessage.objects.get(
+                user_profile=othello, message_id=channel_admin_message_id
+            ).flags.starred
+        )
+        self.assertFalse(
+            UserMessage.objects.get(
+                user_profile=polonius, message_id=public_message_id
+            ).flags.starred
+        )
+
+        # Users who retained content access keep their stars.
+        self.assertTrue(
+            UserMessage.objects.get(
+                user_profile=cordelia, message_id=can_subscribe_message_id
+            ).flags.starred
+        )
+        self.assertTrue(
+            UserMessage.objects.get(user_profile=hamlet, message_id=public_message_id).flags.starred
+        )
+
+    def test_deferred_unstar_rechecks_content_access(self) -> None:
+        """
+        Starred messages are not unstarred if the user regains content
+        access to the channel before the queued unstar work runs.
+        """
+        hamlet = self.example_user("hamlet")
+        stream_name = "private_stream"
+        self.make_stream(stream_name, invite_only=True)
+        self.subscribe(hamlet, stream_name)
+
+        message_id = self.send_stream_message(hamlet, stream_name, "important message")
+        do_update_message_flags(hamlet, "add", "starred", [message_id])
+        um = UserMessage.objects.get(user_profile=hamlet, message_id=message_id)
+
+        with mock.patch("zerver.actions.streams.queue_event_on_commit") as mock_queue:
+            self.unsubscribe(hamlet, stream_name)
+
+        unstar_events = [
+            call.args[1]
+            for call in mock_queue.call_args_list
+            if call.args[1]["type"] == "unstar_inaccessible_stream_messages"
+        ]
+        self.assert_length(unstar_events, 1)
+
+        self.subscribe(hamlet, stream_name)
+        with self.capture_send_event_calls(expected_num_events=0):
+            DeferredWorker().consume(unstar_events[0])
+
+        um.refresh_from_db()
+        self.assertTrue(um.flags.starred)
 
 
 class PersonalMessagesFlagTest(ZulipTestCase):

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3170,7 +3170,7 @@ class StreamAdminTest(ZulipTestCase):
         are on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=18,
+            query_count=19,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3187,7 +3187,7 @@ class StreamAdminTest(ZulipTestCase):
         streams you aren't on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=18,
+            query_count=19,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=False,
@@ -4590,8 +4590,8 @@ class SubscriptionAPITest(ZulipTestCase):
         # Sends 5 peer-remove events, 2 unsubscribe events
         # and 2 stream delete events for private streams.
         with (
-            self.assert_database_query_count(27),
-            self.assert_memcached_count(5),
+            self.assert_database_query_count(29),
+            self.assert_memcached_count(7),
             self.capture_send_event_calls(expected_num_events=9) as events,
         ):
             bulk_remove_subscriptions(

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3170,7 +3170,7 @@ class StreamAdminTest(ZulipTestCase):
         are on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=18,
+            query_count=22,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3187,7 +3187,7 @@ class StreamAdminTest(ZulipTestCase):
         streams you aren't on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=18,
+            query_count=22,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=False,
@@ -4590,8 +4590,8 @@ class SubscriptionAPITest(ZulipTestCase):
         # Sends 5 peer-remove events, 2 unsubscribe events
         # and 2 stream delete events for private streams.
         with (
-            self.assert_database_query_count(27),
-            self.assert_memcached_count(5),
+            self.assert_database_query_count(35),
+            self.assert_memcached_count(7),
             self.capture_send_event_calls(expected_num_events=9) as events,
         ):
             bulk_remove_subscriptions(

--- a/zerver/worker/deferred_work.py
+++ b/zerver/worker/deferred_work.py
@@ -11,7 +11,7 @@ from django.utils.translation import override as override_language
 from typing_extensions import override
 
 from zerver.actions.data_import import import_slack_data
-from zerver.actions.message_flags import do_mark_stream_messages_as_read
+from zerver.actions.message_flags import do_mark_stream_messages_as_read, do_unstar_stream_messages
 from zerver.actions.message_send import internal_send_private_message
 from zerver.actions.realm_export import notify_realm_export
 from zerver.actions.realm_settings import scrub_deactivated_realm
@@ -59,6 +59,22 @@ class DeferredWorker(QueueProcessingWorker):
                 count = do_mark_stream_messages_as_read(user_profile, recipient_id)
                 logger.info(
                     "Marked %s messages as read for user %s, stream_recipient_id %s",
+                    count,
+                    user_profile.id,
+                    recipient_id,
+                )
+        elif event["type"] == "unstar_inaccessible_stream_messages":
+            user_profile = get_user_profile_by_id(event["user_profile_id"])
+            logger.info(
+                "Unstarring messages in inaccessible streams for user %s, stream_recipient_ids %s",
+                user_profile.id,
+                event["stream_recipient_ids"],
+            )
+
+            for recipient_id in event["stream_recipient_ids"]:
+                count = do_unstar_stream_messages(user_profile, recipient_id)
+                logger.info(
+                    "Unstarred %s messages for user %s, stream_recipient_id %s",
                     count,
                     user_profile.id,
                     recipient_id,

--- a/zerver/worker/deferred_work.py
+++ b/zerver/worker/deferred_work.py
@@ -11,7 +11,10 @@ from django.utils.translation import override as override_language
 from typing_extensions import override
 
 from zerver.actions.data_import import import_slack_data
-from zerver.actions.message_flags import do_mark_stream_messages_as_read
+from zerver.actions.message_flags import (
+    do_mark_stream_messages_as_read,
+    do_unstar_inaccessible_stream_messages,
+)
 from zerver.actions.message_send import internal_send_private_message
 from zerver.actions.realm_export import notify_realm_export
 from zerver.actions.realm_settings import scrub_deactivated_realm
@@ -63,6 +66,22 @@ class DeferredWorker(QueueProcessingWorker):
                     user_profile.id,
                     recipient_id,
                 )
+        elif event["type"] == "unstar_inaccessible_stream_messages":
+            user_profile = get_user_profile_by_id(event["user_profile_id"])
+            logger.info(
+                "Unstarring messages in inaccessible streams for user %s, stream_recipient_ids %s",
+                user_profile.id,
+                event["stream_recipient_ids"],
+            )
+
+            count = do_unstar_inaccessible_stream_messages(
+                user_profile, event["stream_recipient_ids"]
+            )
+            logger.info(
+                "Unstarred %s messages for user %s",
+                count,
+                user_profile.id,
+            )
         elif event["type"] == "clear_push_device_tokens":
             logger.info(
                 "Clearing push device tokens for user_profile_id %s",


### PR DESCRIPTION
When removing a channel subscription causes a user to lose content access, starred messages from that channel remain in the user's starred-message state. The left sidebar therefore counts messages that the user can no longer open, while the **Starred messages** view appears empty.

Queue deferred cleanup for channels that become inaccessible after subscription removal. Before removing any flags, the worker rechecks current subscription and group-based content access so that a stale event does not remove valid stars after access has been restored. It processes affected channels together, updates messages in bounded batches, and sends the standard `update_message_flags` event so active clients update automatically.

This PR handles only the channel-unsubscription case. Other access-loss paths in #38342, including channel privacy, permission-group, and role changes, remain follow-up work.

Fixes: Part of #38342

**How changes were tested:**

- Added backend tests for flag removal and the no-op case.
- Tested deferred-worker execution and its `update_message_flags` event.
- Tested restoring access before deferred work runs.
- Tested retained content access through `can_subscribe_group`.
- Tested realm administrators, channel administrators, and bounded batching.
- Manually starred two messages as Hamlet in a private channel, then removed Hamlet from the channel as Iago. The starred count dropped from 2 to 0.

**Screenshots and screen captures:**

**King Hamlet** is a regular user. **Iago** is an organization administrator.

### Setup

| Subscribing Hamlet to private channel | Removing Hamlet from channel |
| --- | --- |
| <img width="713" alt="Subscribing Hamlet to the private channel" src="https://github.com/user-attachments/assets/bc624edc-fe22-41fd-964c-5041aeb15ef0" /> | <img width="713" alt="Removing Hamlet from the private channel" src="https://github.com/user-attachments/assets/09b37a5f-1bc1-4b0e-92d1-27f86cfe1a93" /> |

### Starred message count: Before / After

| Before (2 starred messages) | After (Hamlet removed from channel) |
| --- | --- |
| <img width="760" alt="Starred message count before removing Hamlet" src="https://github.com/user-attachments/assets/fb403608-061f-4e5c-a994-2f1d33a8509a" /> | <img width="760" alt="Starred message count after removing Hamlet" src="https://github.com/user-attachments/assets/36605fa3-b507-41cc-9cc2-4b91f2040b97" /> |

Before removal, the sidebar shows two starred messages. After removal, the count drops to zero and the view shows **You have no starred messages.**

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization. *(No UI, template, or string changes.)*
- [x] Strings and tooltips. *(No new user-facing strings.)*
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

CZO thread: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20update.20of.20starred.20message.20count.20after.20user.20unsubscribed/with/2376750
