### PR TITLE
markdown: Restore table-scrolling with explanatory comments.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -215,7 +215,18 @@
         padding-right: 10px;
         margin: 0 5px var(--markdown-interelement-space-px);
         max-width: fit-content;
+        /* The `display: block` property is critical, given the
+           current markup, to allowing oversize tables to scroll.
+           It's possible that in the future we'll want to wrap
+           a `<div>` element around tables and allow it to handle
+           overscroll, allowing the table to take its normal
+           `display: table` property. */
+        display: block;
         overflow-x: auto;
+        /* Firefox's devtools will report that this property has
+           no effect because of `display: block`, but that is
+           incorrect. Without this, cells separate in ways we
+           do not want. */
         border-collapse: collapse;
     }
 


### PR DESCRIPTION
This PR restores the ability to scroll wide tables in rendered markdown.

CSS has been annotated with comments that better explain the properties we set on tables, and why, so as to avoid these types of well-intentioned regressions in the future.

Fixes:
* [#issues > 🎯 Long table not scrolling to the right](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Long.20table.20not.20scrolling.20to.20the.20right/with/2394646)
* [#feedback > main pane width &amp; oversized formatted tables](https://chat.zulip.org/#narrow/channel/137-feedback/topic/main.20pane.20width.20.26.20oversized.20formatted.20tables/with/2389432)


**Screenshots and screen captures:**

![restrored-table-scrolling](https://github.com/user-attachments/assets/dd80baff-f79e-4a30-9104-1043c89a3c35)

| Before | After |
| --- | --- |
| <img width="1160" height="1600" alt="tables-scrolling-before" src="https://github.com/user-attachments/assets/a7bae0b7-14cd-4273-addd-bc70401c026c" /> | <img width="1160" height="1600" alt="tables-scrolling-after" src="https://github.com/user-attachments/assets/0a712c4b-9710-4438-955f-1d83bde421d7" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>