### PR TITLE
ui: Correct alignment of radio icons in compose menu.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1462,8 +1462,11 @@ textarea.new_message_textarea {
     color: var(--color-text-popover-menu);
 
     .enter_sends_choice {
-        padding: 4px 10px;
-        gap: 0 8px;
+        /* Adjust padding and gap to match popover-menu-link
+           (schedule message / view schedule messages) to ensure consistent
+           vertical alignment. */
+        padding: 0.2em 0.7em;
+        gap: 5px;
         display: grid;
         /* 1em and 1.5em were chosen from playing around with different values
            and picking some that looked reasonable. */


### PR DESCRIPTION
This PR corrects the alignment of the radio icons in the compose menu with their neighboring elements.

Fixes: #39090 

**How changes were tested:**
- [x] Manual UI testing across font sizes 12px–20px.

---

## Screenshots

### Default font size

| | Before | After |
|---|---|---|
| With ruler | <img width="300" height="220" alt="before-ruler" src="https://github.com/user-attachments/assets/c454fbc9-da10-4fe8-9537-9df656fb66f4" /> | <img width="300" height="220" alt="after-ruler" src="https://github.com/user-attachments/assets/566b99cc-669b-4402-8408-130a4be6d398" /> |
| Without ruler | <img width="300" height="220" alt="before" src="https://github.com/user-attachments/assets/e19a168d-9332-4f1b-be5a-1a735a04dce5" /> | <img width="300" height="220" alt="after" src="https://github.com/user-attachments/assets/1f608bba-7d1a-418b-a0f2-be274834980c" /> |

---

### Font size comparison (12px – 20px)

| Font Size | Before | After |
|-----------|--------|-------|
| **12px** | <img width="300" height="220" alt="12px-before" src="https://github.com/user-attachments/assets/f8cac125-9808-495e-87af-08a3fe8307e9" /> | <img width="300" height="220" alt="12px-after" src="https://github.com/user-attachments/assets/6fb0d34d-0641-4dde-9a10-ad50aa6cbc6a" /> |
| **13px** | <img width="300" height="220" alt="13px-before" src="https://github.com/user-attachments/assets/47502d4a-6094-4538-bae0-a4e6f53aac0a" /> | <img width="300" height="220" alt="13px-after" src="https://github.com/user-attachments/assets/563d113c-234c-4de2-aa83-5585dad04fe5" /> |
| **14px** | <img width="300" height="220" alt="image" src="https://github.com/user-attachments/assets/fb4dc8dd-37a6-4a7b-ab8c-2a4ccd84592a" /> | <img width="300" height="220" alt="14px-after" src="https://github.com/user-attachments/assets/bdee0b5d-61b9-41c5-a6cf-e2e42111e6b7" /> |
| **15px** | <img width="300" height="220" alt="15px-before" src="https://github.com/user-attachments/assets/9eadbefd-1bca-42dc-8975-2f0ff62484f4" /> | <img width="300" height="220" alt="15px-after" src="https://github.com/user-attachments/assets/6fe8eb79-062d-4d57-837d-403d66a05d6a" /> |
| **16px** | <img width="300" height="220" alt="16px-before" src="https://github.com/user-attachments/assets/2b4c0eee-cb71-4eb0-91dc-6b5eed0b1db2" /> | <img width="300" height="220" alt="16px-after" src="https://github.com/user-attachments/assets/6aa0300a-3631-494a-82a5-e6e0731e9a83" /> |
| **17px** | <img width="300" height="220" alt="17px-before" src="https://github.com/user-attachments/assets/ad2d7b65-5747-46ac-a8c0-42c02c5388f3" /> | <img width="300" height="220" alt="17px-after" src="https://github.com/user-attachments/assets/cb76be4c-4680-4fc7-8d05-6102095b3c15" /> |
| **18px** | <img width="300" height="220" alt="18px-before" src="https://github.com/user-attachments/assets/4519316b-bbb5-4283-bda0-17fd65f866e2" /> | <img width="300" height="220" alt="18px-after" src="https://github.com/user-attachments/assets/16dab061-77a4-4361-9dc9-caffeadb2d11" /> |
| **19px** | <img width="300" height="220" alt="19px-before" src="https://github.com/user-attachments/assets/bb7cbabe-d772-4b07-b653-4d5c7004e532" /> | <img width="300" height="220" alt="19px-after" src="https://github.com/user-attachments/assets/7a6b6f9e-8a82-4ce3-ac84-2b6b7c211815" /> |
| **20px** | <img width="300" height="220" alt="20px-before" src="https://github.com/user-attachments/assets/a9038b66-13d9-4e19-bdda-4b58ab4f3967" /> | <img width="300" height="220" alt="20px-after" src="https://github.com/user-attachments/assets/4449c86e-2c29-413b-87db-25e557556080" /> |
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
