### PR TITLE
user profile: Add phone number custom profile field feature.

### DIFF
--- a/api_docs/unmerged.d/ZF-fb3f81.md
+++ b/api_docs/unmerged.d/ZF-fb3f81.md
@@ -1,0 +1,4 @@
+* [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),
+  [`POST /realm/profile_fields`](/api/create-custom-profile-field),
+  [`GET /realm/profile_fields`](/api/get-custom-profile-fields): Added
+  phone number custom profile field type.

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -40,6 +40,7 @@ export function append_custom_profile_fields(element_id: string, user_id: number
         [all_field_types.EXTERNAL_ACCOUNT.id, "text"],
         [all_field_types.URL.id, "url"],
         [all_field_types.PRONOUNS.id, "text"],
+        [all_field_types.PHONE_NUMBER.id, "text"],
     ]);
 
     for (const field of all_custom_fields) {
@@ -73,6 +74,7 @@ export function append_custom_profile_fields(element_id: string, user_id: number
             is_date_field: field.type === all_field_types.DATE.id,
             is_url_field: field.type === all_field_types.URL.id,
             is_pronouns_field: field.type === all_field_types.PRONOUNS.id,
+            is_phone_number_field: field.type === all_field_types.PHONE_NUMBER.id,
             is_select_field,
             field_choices,
             for_manage_user_modal: element_id === "#edit-user-form .custom-profile-field-form",
@@ -102,7 +104,34 @@ function update_custom_profile_field(
     const $spinner_element = $(
         `.custom_user_field[data-field-id="${CSS.escape(field.id.toString())}"] .custom-field-status`,
     ).expectOne();
-    settings_ui.do_settings_change(method, "/json/users/me/profile_data", {data}, $spinner_element);
+    settings_ui.do_settings_change(
+        method,
+        "/json/users/me/profile_data",
+        {data},
+        $spinner_element,
+        {
+            success_continuation() {
+                const profile_field = realm.custom_profile_fields?.find((f) => f.id === field.id);
+
+                // If the user only changes the formatting of a phone number (e.g. +1 123 to +1123),
+                // the backend canonical value remains identical. Because the value didn't change,
+                // the server skips sending a WebSocket event. We manually reset the input box here
+                // to ensure the UI snaps to the canonical E.164 format.
+                if (profile_field?.type === realm.custom_profile_field_types.PHONE_NUMBER.id) {
+                    const canonical_value = people.get_custom_profile_data(
+                        current_user.user_id,
+                        field.id,
+                    )?.value;
+                    if (canonical_value !== undefined && typeof canonical_value === "string") {
+                        $spinner_element
+                            .closest(".custom_user_field")
+                            .find(".custom_user_field_value")
+                            .val(canonical_value);
+                    }
+                }
+            },
+        },
+    );
 }
 
 export function update_user_custom_profile_fields(

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -40,6 +40,7 @@ export function append_custom_profile_fields(element_id: string, user_id: number
         [all_field_types.EXTERNAL_ACCOUNT.id, "text"],
         [all_field_types.URL.id, "url"],
         [all_field_types.PRONOUNS.id, "text"],
+        [all_field_types.PHONE_NUMBER.id, "text"],
     ]);
 
     for (const field of all_custom_fields) {
@@ -73,6 +74,7 @@ export function append_custom_profile_fields(element_id: string, user_id: number
             is_date_field: field.type === all_field_types.DATE.id,
             is_url_field: field.type === all_field_types.URL.id,
             is_pronouns_field: field.type === all_field_types.PRONOUNS.id,
+            is_phone_number_field: field.type === all_field_types.PHONE_NUMBER.id,
             is_dropdown_field,
             field_choices,
             for_manage_user_modal: element_id === "#edit-user-form .custom-profile-field-form",
@@ -102,7 +104,34 @@ function update_custom_profile_field(
     const $spinner_element = $(
         `.custom_user_field[data-field-id="${CSS.escape(field.id.toString())}"] .custom-field-status`,
     ).expectOne();
-    settings_ui.do_settings_change(method, "/json/users/me/profile_data", {data}, $spinner_element);
+    settings_ui.do_settings_change(
+        method,
+        "/json/users/me/profile_data",
+        {data},
+        $spinner_element,
+        {
+            success_continuation() {
+                const profile_field = realm.custom_profile_fields?.find((f) => f.id === field.id);
+                assert(profile_field !== undefined);
+
+                // If the user only changes the formatting of a phone number (e.g. +1 123 to +1123),
+                // the backend canonical value remains identical. Because the value didn't change,
+                // the server skips sending a WebSocket event. We manually reset the input box here
+                // to ensure the UI snaps to the canonical E.164 format.
+                if (profile_field.type === realm.custom_profile_field_types.PHONE_NUMBER.id) {
+                    const canonical_value = people.get_custom_profile_data(
+                        current_user.user_id,
+                        field.id,
+                    )?.value;
+                    assert(typeof canonical_value === "string");
+                    $spinner_element
+                        .closest(".custom_user_field")
+                        .find(".custom_user_field_value")
+                        .val(canonical_value);
+                }
+            },
+        },
+    );
 }
 
 export function update_user_custom_profile_fields(

--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -994,3 +994,33 @@ export function set_up(): void {
         );
     });
 }
+
+export function update_custom_profile_field_ui(
+    user_id: number,
+    field: {id: number; value: string | null},
+): void {
+    const field_id = field.id;
+    const new_value = field.value ?? "";
+
+    if (user_id === people.my_current_user_id()) {
+        const $personal_input = $(
+            `#profile-settings .custom_user_field[data-field-id="${CSS.escape(field_id.toString())}"] .custom_user_field_value`,
+        );
+        if ($personal_input.length > 0) {
+            $personal_input.val(new_value);
+        }
+    }
+
+    const $manage_user_form = $("#edit-user-form");
+    if ($manage_user_form.length > 0) {
+        const modal_user_id = Number.parseInt($manage_user_form.attr("data-user-id")!, 10);
+        if (modal_user_id === user_id) {
+            const $modal_input = $manage_user_form.find(
+                `.custom_user_field[data-field-id="${CSS.escape(field_id.toString())}"] .custom_user_field_value`,
+            );
+            if ($modal_input.length > 0) {
+                $modal_input.val(new_value);
+            }
+        }
+    }
+}

--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -996,3 +996,50 @@ export function set_up(): void {
         );
     });
 }
+
+export function update_custom_profile_field_ui(
+    user_id: number,
+    field: {id: number; value: string | null},
+): void {
+    const field_id = field.id;
+    const new_value = field.value ?? "";
+
+    const profile_field = realm.custom_profile_fields?.find((f) => f.id === field_id);
+    if (profile_field === undefined) {
+        return;
+    }
+
+    const field_types = realm.custom_profile_field_types;
+    // For complex widget types (date pickers, user pills, dropdowns),
+    // .val() does not work; re-render the whole form instead.
+    if (
+        profile_field.type === field_types.DATE.id ||
+        profile_field.type === field_types.USER.id ||
+        profile_field.type === field_types.DROPDOWN.id
+    ) {
+        add_custom_profile_fields_to_settings();
+        return;
+    }
+
+    if (user_id === people.my_current_user_id()) {
+        const $personal_input = $(
+            `#profile-settings .custom_user_field[data-field-id="${CSS.escape(field_id.toString())}"] .custom_user_field_value`,
+        );
+        if ($personal_input.length > 0) {
+            $personal_input.val(new_value);
+        }
+    }
+
+    const $manage_user_form = $("#edit-user-form");
+    if ($manage_user_form.length > 0) {
+        const modal_user_id = Number.parseInt($manage_user_form.attr("data-user-id")!, 10);
+        if (modal_user_id === user_id) {
+            const $modal_input = $manage_user_form.find(
+                `.custom_user_field[data-field-id="${CSS.escape(field_id.toString())}"] .custom_user_field_value`,
+            );
+            if ($modal_input.length > 0) {
+                $modal_input.val(new_value);
+            }
+        }
+    }
+}

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -294,6 +294,15 @@ function update_form_for_field_type_selection(): void {
             $("#profile_field_hint").val("").prop("disabled", true);
             break;
         }
+        case field_types.PHONE_NUMBER.id: {
+            const default_label = $t({defaultMessage: "Phone number"});
+            const default_hint = $t({
+                defaultMessage: "What is your phone number?",
+            });
+            $("#profile_field_name").val(default_label);
+            $("#profile_field_hint").val(default_hint);
+            break;
+        }
         case field_types.PRONOUNS.id: {
             const default_label = $t({defaultMessage: "Pronouns"});
             const default_hint = $t({

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -296,6 +296,15 @@ function update_form_for_field_type_selection(): void {
             $("#profile_field_hint").val("").prop("disabled", true);
             break;
         }
+        case field_types.PHONE_NUMBER.id: {
+            const default_label = $t({defaultMessage: "Phone number"});
+            const default_hint = $t({
+                defaultMessage: "What is your phone number?",
+            });
+            $("#profile_field_name").val(default_label);
+            $("#profile_field_hint").val(default_hint);
+            break;
+        }
         case field_types.PRONOUNS.id: {
             const default_label = $t({defaultMessage: "Pronouns"});
             const default_hint = $t({

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -391,6 +391,7 @@ const custom_profile_field_types_schema = z.object({
     EXTERNAL_ACCOUNT: z.object({id: z.number(), name: z.string()}),
     USER: z.object({id: z.number(), name: z.string()}),
     PRONOUNS: z.object({id: z.number(), name: z.string()}),
+    PHONE_NUMBER: z.object({id: z.number(), name: z.string()}),
 });
 
 export type CustomProfileFieldTypes = z.infer<typeof custom_profile_field_types_schema>;

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -409,6 +409,7 @@ const custom_profile_field_types_schema = z.object({
     EXTERNAL_ACCOUNT: z.object({id: z.number(), name: z.string()}),
     USER: z.object({id: z.number(), name: z.string()}),
     PRONOUNS: z.object({id: z.number(), name: z.string()}),
+    PHONE_NUMBER: z.object({id: z.number(), name: z.string()}),
 });
 
 export type CustomProfileFieldTypes = z.infer<typeof custom_profile_field_types_schema>;

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -205,6 +205,7 @@ export const update_person = function update(event: UserUpdate): void {
     if ("custom_profile_field" in event) {
         people.set_custom_profile_field_data(event.user_id, event.custom_profile_field);
         user_profile.update_user_custom_profile_fields(user);
+        settings_account.update_custom_profile_field_ui(event.user_id, event.custom_profile_field);
         if (event.user_id === people.my_current_user_id()) {
             navbar_alerts.maybe_toggle_empty_required_profile_fields_banner();
 

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -214,6 +214,7 @@ export const update_person = function update(event: UserUpdate): void {
     if ("custom_profile_field" in event) {
         people.set_custom_profile_field_data(event.user_id, event.custom_profile_field);
         user_profile.update_user_custom_profile_fields(user);
+        settings_account.update_custom_profile_field_ui(event.user_id, event.custom_profile_field);
         if (event.user_id === people.my_current_user_id()) {
             navbar_alerts.maybe_toggle_empty_required_profile_fields_banner();
 

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -27,6 +27,8 @@
         <input id="id_custom_profile_field_input_{{ field.id }}" class="custom_user_field_value {{#if for_manage_user_modal}}modal_url_input{{else}}settings_url_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="2048" {{#unless editable_by_user}}disabled{{/unless}}/>
         {{else if is_pronouns_field}}
         <input id="id_custom_profile_field_input_{{ field.id }}" class="custom_user_field_value pronouns_type_field {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" {{#unless editable_by_user}}disabled{{/unless}}/>
+        {{else if is_phone_number_field}}
+        <input id="id_custom_profile_field_input_{{ field.id }}" class="custom_user_field_value phone_type_field {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" type="text" value="{{ field_value.value }}" maxlength="50" {{#unless editable_by_user}}disabled{{/unless}}/>
         {{else}}
         <input id="id_custom_profile_field_input_{{ field.id }}" class="custom_user_field_value {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" {{#unless editable_by_user}}disabled{{/unless}}/>
         {{/if}}

--- a/web/tests/user_events.test.cjs
+++ b/web/tests/user_events.test.cjs
@@ -19,6 +19,7 @@ const settings_account = mock_esm("../src/settings_account", {
     set_user_own_role_dropdown_value() {},
     add_or_remove_owner_from_role_dropdown() {},
     update_user_own_role_dropdown_state() {},
+    update_custom_profile_field_ui() {},
 });
 const settings_bots = mock_esm("../src/settings_bots", {
     redraw_your_bots_list() {},

--- a/web/tests/user_events.test.cjs
+++ b/web/tests/user_events.test.cjs
@@ -21,6 +21,7 @@ const settings_account = mock_esm("../src/settings_account", {
     set_user_own_role_dropdown_value() {},
     add_or_remove_owner_from_role_dropdown() {},
     update_user_own_role_dropdown_state() {},
+    update_custom_profile_field_ui() {},
 });
 const settings_preferences = mock_esm("../src/settings_preferences", {
     update_user_list_style_preview_name() {},

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -559,7 +559,7 @@ def validate_user_custom_profile_data(
             )
 
         try:
-            validate_user_custom_profile_field(realm_id, field, item["value"])
+            item["value"] = validate_user_custom_profile_field(realm_id, field, item["value"])
         except ValidationError as error:
             raise JsonableError(error.message)
 

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -561,7 +561,7 @@ def validate_user_custom_profile_data(
             )
 
         try:
-            validate_user_custom_profile_field(realm_id, field, item["value"])
+            item["value"] = validate_user_custom_profile_field(realm_id, field, item["value"])
         except ValidationError as error:
             raise JsonableError(error.message)
 

--- a/zerver/migrations/0001_squashed_0569.py
+++ b/zerver/migrations/0001_squashed_0569.py
@@ -1553,6 +1553,7 @@ class Migration(migrations.Migration):
                             (7, "External account"),
                             (5, "Link"),
                             (2, "Paragraph"),
+                            (9, "Phone number"),
                             (8, "Pronouns"),
                             (1, "Short text"),
                             (6, "Users"),

--- a/zerver/migrations/0417_alter_customprofilefield_field_type.py
+++ b/zerver/migrations/0417_alter_customprofilefield_field_type.py
@@ -19,6 +19,7 @@ class Migration(migrations.Migration):
                     (7, "External account"),
                     (5, "Link"),
                     (2, "Paragraph"),
+                    (9, "Phone number"),
                     (8, "Pronouns"),
                     (1, "Short text"),
                     (6, "Users"),

--- a/zerver/models/custom_profile_fields.py
+++ b/zerver/models/custom_profile_fields.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from typing import Any
 
 import orjson
+import phonenumbers
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import CASCADE, QuerySet
@@ -59,6 +60,27 @@ def check_valid_user_ids(realm_id: int, val: object, allow_deactivated: bool = F
     return user_ids
 
 
+def check_phone_number(var_name: str, val: object) -> str:
+    phone_number_str = check_short_string(var_name, val)
+
+    try:
+        # We default to 'US' for region as per CZO discussion.
+        # If the string starts with '+', phonenumbers ignores the 'US' default.
+        parsed_number = phonenumbers.parse(phone_number_str, "US")
+
+        if not phonenumbers.is_valid_number(parsed_number):
+            raise ValidationError(_("Invalid phone number."))
+
+        return phonenumbers.format_number(parsed_number, phonenumbers.PhoneNumberFormat.E164)
+    except phonenumbers.NumberParseException:
+        raise ValidationError(_("Invalid phone number format."))
+
+
+def format_phone_number(val: Any) -> str:
+    parsed_number = phonenumbers.parse(str(val), "US")
+    return phonenumbers.format_number(parsed_number, phonenumbers.PhoneNumberFormat.E164)
+
+
 class CustomProfileField(models.Model):
     """Defines a form field for the per-realm custom profile fields feature.
 
@@ -97,6 +119,7 @@ class CustomProfileField(models.Model):
     USER = 6
     EXTERNAL_ACCOUNT = 7
     PRONOUNS = 8
+    PHONE_NUMBER = 9
 
     # These are the fields whose validators require more than var_name
     # and value argument. i.e. DROPDOWN require field_data, USER require
@@ -129,6 +152,13 @@ class CustomProfileField(models.Model):
             "EXTERNAL_ACCOUNT",
         ),
         (PRONOUNS, gettext_lazy("Pronouns"), check_short_string, str, "PRONOUNS"),
+        (
+            PHONE_NUMBER,
+            gettext_lazy("Phone number"),
+            check_phone_number,
+            format_phone_number,
+            "PHONE_NUMBER",
+        ),
     ]
 
     ALL_FIELD_TYPES = sorted(

--- a/zerver/models/custom_profile_fields.py
+++ b/zerver/models/custom_profile_fields.py
@@ -1,7 +1,9 @@
+import re
 from collections.abc import Callable
 from typing import Any
 
 import orjson
+import phonenumbers
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import CASCADE, QuerySet
@@ -59,6 +61,26 @@ def check_valid_user_ids(realm_id: int, val: object, allow_deactivated: bool = F
     return user_ids
 
 
+def check_phone_number(var_name: str, val: object) -> str:
+    phone_number_str = check_short_string(var_name, val)
+
+    # Reject vanity numbers containing letters (e.g. +1-800-FLOWERS).
+    if re.search(r"[a-zA-Z]", phone_number_str):
+        raise ValidationError(_("Phone numbers must not contain letters."))
+
+    try:
+        # We default to 'US' for region as per CZO discussion.
+        # If the string starts with '+', phonenumbers ignores the 'US' default.
+        parsed_number = phonenumbers.parse(phone_number_str, "US")
+
+        if not phonenumbers.is_valid_number(parsed_number):
+            raise ValidationError(_("Invalid phone number."))
+
+        return phonenumbers.format_number(parsed_number, phonenumbers.PhoneNumberFormat.E164)
+    except phonenumbers.NumberParseException:
+        raise ValidationError(_("Invalid phone number format."))
+
+
 class CustomProfileField(models.Model):
     """Defines a form field for the per-realm custom profile fields feature.
 
@@ -97,6 +119,7 @@ class CustomProfileField(models.Model):
     USER = 6
     EXTERNAL_ACCOUNT = 7
     PRONOUNS = 8
+    PHONE_NUMBER = 9
 
     # These are the fields whose validators require more than var_name
     # and value argument. i.e. DROPDOWN require field_data, USER require
@@ -129,6 +152,13 @@ class CustomProfileField(models.Model):
             "EXTERNAL_ACCOUNT",
         ),
         (PRONOUNS, gettext_lazy("Pronouns"), check_short_string, str, "PRONOUNS"),
+        (
+            PHONE_NUMBER,
+            gettext_lazy("Phone number"),
+            check_phone_number,
+            str,
+            "PHONE_NUMBER",
+        ),
     ]
 
     ALL_FIELD_TYPES = sorted(

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14833,6 +14833,15 @@ paths:
                               "required": false,
                               "editable_by_user": true,
                             },
+                            {
+                              "id": 10,
+                              "name": "Alternate phone",
+                              "type": 9,
+                              "hint": "An alternate phone number",
+                              "order": 10,
+                              "required": false,
+                              "editable_by_user": true,
+                            },
                           ],
                       }
     patch:
@@ -14912,8 +14921,11 @@ paths:
                     - **6**: Users
                     - **7**: External account
                     - **8**: Pronouns
+                    - **9**: Phone number
 
-                    **Changes**: Field type `8` added in Zulip 6.0 (feature level 151).
+                    **Changes**: Field type `9` added in Zulip 10.0 (feature level ZF-fb3f81).
+
+                    Field type `8` added in Zulip 6.0 (feature level 151).
                   type: integer
                   example: 3
                 field_data:
@@ -17997,8 +18009,11 @@ paths:
                             - `EXTERNAL_ACCOUNT` for external accounts.
                             - `USER` for selecting a user for the field.
                             - `PRONOUNS` for a short text field with convenient typeahead for one's preferred pronouns.
+                            - `PHONE_NUMBER` for a short text field specifically formatted for phone numbers.
 
-                            **Changes**: `PRONOUNS` type added in Zulip 6.0 (feature level 151).
+                            **Changes**: `PHONE_NUMBER` type added in Zulip 10.0 (feature level ZF-fb3f81).
+
+                            `PRONOUNS` type added in Zulip 6.0 (feature level 151).
                           additionalProperties: false
                           properties:
                             id:
@@ -27366,8 +27381,11 @@ components:
             - **6**: Users
             - **7**: External account
             - **8**: Pronouns
+            - **9**: Phone number
 
-            **Changes**: Field type `8` added in Zulip 6.0 (feature level 151).
+            **Changes**: Field type `9` added in Zulip 10.0 (feature level ZF-fb3f81).
+
+            Field type `8` added in Zulip 6.0 (feature level 151).
         order:
           type: integer
           description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15344,6 +15344,15 @@ paths:
                               "required": false,
                               "editable_by_user": true,
                             },
+                            {
+                              "id": 10,
+                              "name": "Alternate phone",
+                              "type": 9,
+                              "hint": "An alternate phone number",
+                              "order": 10,
+                              "required": false,
+                              "editable_by_user": true,
+                            },
                           ],
                       }
     patch:
@@ -15417,8 +15426,11 @@ paths:
                     - **6**: Users
                     - **7**: External account
                     - **8**: Pronouns
+                    - **9**: Phone number
 
-                    **Changes**: Field type `8` added in Zulip 6.0 (feature level 151).
+                    **Changes**: Field type `9` added in Zulip 13.0 (feature level ZF-fb3f81).
+
+                    Field type `8` added in Zulip 6.0 (feature level 151).
                   type: integer
                   example: 3
                 hint:
@@ -18853,8 +18865,11 @@ paths:
                             - `EXTERNAL_ACCOUNT` for external accounts.
                             - `USER` for selecting a user for the field.
                             - `PRONOUNS` for a short text field with convenient typeahead for one's preferred pronouns.
+                            - `PHONE_NUMBER` for a short text field specifically formatted for phone numbers.
 
-                            **Changes**: `PRONOUNS` type added in Zulip 6.0 (feature level 151).
+                            **Changes**: `PHONE_NUMBER` type added in Zulip 13.0 (feature level ZF-fb3f81).
+
+                            `PRONOUNS` type added in Zulip 6.0 (feature level 151).
                           additionalProperties: false
                           properties:
                             id:
@@ -28261,8 +28276,11 @@ components:
             - **6**: Users
             - **7**: External account
             - **8**: Pronouns
+            - **9**: Phone number
 
-            **Changes**: Field type `8` added in Zulip 6.0 (feature level 151).
+            **Changes**: Field type `9` added in Zulip 13.0 (feature level ZF-fb3f81).
+
+            Field type `8` added in Zulip 6.0 (feature level 151).
         order:
           type: integer
           description: |

--- a/zerver/tests/fixtures/ldap/directory.json
+++ b/zerver/tests/fixtures/ldap/directory.json
@@ -11,7 +11,7 @@
         "mail": ["hamlet@zulip.com"],
         "userAccountControl": ["512"],
         "sn": ["Hamlet"],
-        "homePhone": ["123456789"],
+        "homePhone": ["+12345678900"],
         "birthDate": ["1900-09-08"],
         "jpegPhoto": "file:static/images/test-images/avatars/example_profile_picture.png"
     },

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3281,12 +3281,12 @@ class SAMLAuthBackendTest(SocialAuthBase):
         ).value
 
         idps_dict = copy.deepcopy(settings.SOCIAL_AUTH_SAML_ENABLED_IDPS)
-        idps_dict["test_idp"]["extra_attrs"] = ["mobilePhone", "zulip_role"]
+        idps_dict["test_idp"]["extra_attrs"] = ["favoriteFood", "zulip_role"]
 
         sync_custom_attrs_dict = {
             "zulip": {
                 "saml": {
-                    "custom__phone_number": "mobilePhone",
+                    "custom__favorite_food": "favoriteFood",
                     "role": "zulip_role",
                 }
             }
@@ -3305,7 +3305,7 @@ class SAMLAuthBackendTest(SocialAuthBase):
                 account_data_dict,
                 subdomain="zulip",
                 extra_attributes=dict(
-                    mobilePhone=["123412341234"], birthday=["2021-01-01"], zulip_role=["owner"]
+                    favoriteFood=["Pizza"], birthday=["2021-01-01"], zulip_role=["owner"]
                 ),
             )
         data = load_subdomain_token(result)
@@ -3314,13 +3314,13 @@ class SAMLAuthBackendTest(SocialAuthBase):
         self.assertEqual(data["subdomain"], "zulip")
         self.assertEqual(result.status_code, 302)
 
-        phone_field = CustomProfileField.objects.get(
-            realm=self.user_profile.realm, name="Phone number"
+        food_field = CustomProfileField.objects.get(
+            realm=self.user_profile.realm, name="Favorite food"
         )
-        phone_field_value = CustomProfileFieldValue.objects.get(
-            user_profile=self.user_profile, field=phone_field
+        food_field_value = CustomProfileFieldValue.objects.get(
+            user_profile=self.user_profile, field=food_field
         ).value
-        self.assertEqual(phone_field_value, "123412341234")
+        self.assertEqual(food_field_value, "Pizza")
 
         # Verify the Birthday field doesn't get synced - because it isn't configured for syncing.
         new_birthday_field_value = CustomProfileFieldValue.objects.get(
@@ -3369,16 +3369,16 @@ class SAMLAuthBackendTest(SocialAuthBase):
             result = self.social_auth_test(
                 account_data_dict,
                 subdomain="zulip",
-                extra_attributes=dict(mobilePhone=[""], zulip_role=[""]),
+                extra_attributes=dict(favoriteFood=[""], zulip_role=[""]),
             )
         data = load_subdomain_token(result)
         self.assertEqual(data["email"], self.email)
         self.user_profile.refresh_from_db()
         self.assertEqual(self.user_profile.role, UserProfile.ROLE_REALM_OWNER)
-        phone_field_value = CustomProfileFieldValue.objects.get(
-            user_profile=self.user_profile, field=phone_field
+        food_field_value = CustomProfileFieldValue.objects.get(
+            user_profile=self.user_profile, field=food_field
         ).value
-        self.assertEqual(phone_field_value, "123412341234")
+        self.assertEqual(food_field_value, "Pizza")
 
         # Verify with none of these attributes sent at all.
         with self.settings(
@@ -3395,10 +3395,10 @@ class SAMLAuthBackendTest(SocialAuthBase):
         self.assertEqual(data["email"], self.email)
         self.user_profile.refresh_from_db()
         self.assertEqual(self.user_profile.role, UserProfile.ROLE_REALM_OWNER)
-        phone_field_value = CustomProfileFieldValue.objects.get(
-            user_profile=self.user_profile, field=phone_field
+        food_field_value = CustomProfileFieldValue.objects.get(
+            user_profile=self.user_profile, field=food_field
         ).value
-        self.assertEqual(phone_field_value, "123412341234")
+        self.assertEqual(food_field_value, "Pizza")
 
         # Disable syncing of role in SOCIAL_AUTH_SYNC_ATTRS_DICT, while keeping
         # role in extra_attrs. This edge case means the attribute will be read from the
@@ -3432,21 +3432,21 @@ class SAMLAuthBackendTest(SocialAuthBase):
             result = self.social_auth_test(
                 account_data_dict,
                 subdomain="zulip",
-                extra_attributes=dict(mobilePhone=[long_value]),
+                extra_attributes=dict(favoriteFood=[long_value]),
             )
         data = load_subdomain_token(result)
         self.assertEqual(data["email"], self.email)
         self.assertIn(
             self.logger_output(
-                f"Truncated value for custom profile field phone_number of user {self.user_profile.id} to 50 characters.",
+                f"Truncated value for custom profile field favorite_food of user {self.user_profile.id} to 50 characters.",
                 type="warning",
             ),
             m.output,
         )
-        phone_field_value = CustomProfileFieldValue.objects.get(
-            user_profile=self.user_profile, field=phone_field
+        food_field_value = CustomProfileFieldValue.objects.get(
+            user_profile=self.user_profile, field=food_field
         ).value
-        self.assertEqual(phone_field_value, expected_value)
+        self.assertEqual(food_field_value, expected_value)
 
     def test_social_auth_group_sync(self) -> None:
         realm = get_realm("zulip")
@@ -8396,7 +8396,7 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
         with self.settings(
             AUTH_LDAP_USER_ATTR_MAP={
                 "full_name": "cn",
-                "custom_profile_field__phone_number": "homePhone",
+                "custom_profile_field__favorite_food": "homePhone",
                 "custom_profile_field__birthday": "birthDate",
             }
         ):
@@ -8404,7 +8404,7 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
         hamlet = self.example_user("hamlet")
         test_data = [
             {
-                "field_name": "Phone number",
+                "field_name": "Favorite food",
                 "expected_value": "123456789",
             },
             {
@@ -8477,7 +8477,7 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
             self.settings(
                 AUTH_LDAP_USER_ATTR_MAP={
                     "full_name": "cn",
-                    "custom_profile_field__phone_number": "homePhone",
+                    "custom_profile_field__favorite_food": "homePhone",
                 }
             ),
             self.assertLogs("zulip.ldap", "WARNING") as log_output,
@@ -8485,11 +8485,11 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
             self.perform_ldap_sync(self.example_user("hamlet"))
 
         hamlet = self.example_user("hamlet")
-        phone_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Phone number")
-        phone_value = CustomProfileFieldValue.objects.get(user_profile=hamlet, field=phone_field)
-        self.assertEqual(phone_value.value, expected_value)
+        food_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Favorite food")
+        food_value = CustomProfileFieldValue.objects.get(user_profile=hamlet, field=food_field)
+        self.assertEqual(food_value.value, expected_value)
         self.assertIn(
-            f"WARNING:zulip.ldap:Truncated value for custom profile field phone_number of user {hamlet.id} to 50 characters.",
+            f"WARNING:zulip.ldap:Truncated value for custom profile field favorite_food of user {hamlet.id} to 50 characters.",
             log_output.output,
         )
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -2439,6 +2439,13 @@ class SocialAuthBaseWithSyncAttrTest(SocialAuthBase, ABC):
         # Verify that values for text fields are truncated if they're too long.
         long_value = "x" * 60
         expected_value = "x" * 49 + "…"
+        truncation_sync_dict = {
+            "zulip": {
+                self.BACKEND_CLASS.name: {
+                    "custom__favorite_food": "favoriteFood",
+                }
+            }
+        }
         with (
             self.assertLogs(self.logger_string, level="WARNING") as m,
         ):
@@ -2446,23 +2453,26 @@ class SocialAuthBaseWithSyncAttrTest(SocialAuthBase, ABC):
             result = self.social_auth_test_with_sync_attrs(
                 account_data_dict,
                 subdomain="zulip",
-                extra_attrs=dict(mobilePhone=long_value),
-                sync_attrs_config=sync_custom_attrs_dict,
+                extra_attrs=dict(favoriteFood=long_value),
+                sync_attrs_config=truncation_sync_dict,
             )
 
         data = load_subdomain_token(result)
         self.assertEqual(data["email"], self.email)
         self.assertIn(
             self.logger_output(
-                f"Truncated value for custom profile field phone_number of user {self.user_profile.id} to 50 characters.",
+                f"Truncated value for custom profile field favorite_food of user {self.user_profile.id} to 50 characters.",
                 type="warning",
             ),
             m.output,
         )
-        phone_field_value = CustomProfileFieldValue.objects.get(
-            user_profile=self.user_profile, field=phone_field
+        food_field = CustomProfileField.objects.get(
+            realm=self.user_profile.realm, name="Favorite food"
+        )
+        food_field_value = CustomProfileFieldValue.objects.get(
+            user_profile=self.user_profile, field=food_field
         ).value
-        self.assertEqual(phone_field_value, expected_value)
+        self.assertEqual(food_field_value, expected_value)
 
     def test_social_auth_group_sync(self) -> None:
         realm = get_realm("zulip")
@@ -8943,7 +8953,7 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
             self.settings(
                 AUTH_LDAP_USER_ATTR_MAP={
                     "full_name": "cn",
-                    "custom_profile_field__phone_number": "homePhone",
+                    "custom_profile_field__favorite_food": "homePhone",
                 }
             ),
             self.assertLogs("zulip.ldap", "WARNING") as log_output,
@@ -8951,11 +8961,11 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
             self.perform_ldap_sync(self.example_user("hamlet"))
 
         hamlet = self.example_user("hamlet")
-        phone_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Phone number")
-        phone_value = CustomProfileFieldValue.objects.get(user_profile=hamlet, field=phone_field)
-        self.assertEqual(phone_value.value, expected_value)
+        food_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Favorite food")
+        food_value = CustomProfileFieldValue.objects.get(user_profile=hamlet, field=food_field)
+        self.assertEqual(food_value.value, expected_value)
         self.assertIn(
-            f"WARNING:zulip.ldap:Truncated value for custom profile field phone_number of user {hamlet.id} to 50 characters.",
+            f"WARNING:zulip.ldap:Truncated value for custom profile field favorite_food of user {hamlet.id} to 50 characters.",
             log_output.output,
         )
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -2334,7 +2334,9 @@ class SocialAuthBaseWithSyncAttrTest(SocialAuthBase, ABC):
         result = self.social_auth_test_with_sync_attrs(
             account_data_dict,
             subdomain="zulip",
-            extra_attrs=dict(mobilePhone="123412341234", birthday="2021-01-01", zulip_role="owner"),
+            extra_attrs=dict(
+                mobilePhone="+442079460959", birthday="2021-01-01", zulip_role="owner"
+            ),
             sync_attrs_config=sync_custom_attrs_dict,
         )
 
@@ -2350,7 +2352,7 @@ class SocialAuthBaseWithSyncAttrTest(SocialAuthBase, ABC):
         phone_field_value = CustomProfileFieldValue.objects.get(
             user_profile=self.user_profile, field=phone_field
         ).value
-        self.assertEqual(phone_field_value, "123412341234")
+        self.assertEqual(phone_field_value, "+442079460959")
 
         # Verify the Birthday field doesn't get synced - because it isn't configured for syncing.
         new_birthday_field_value = CustomProfileFieldValue.objects.get(
@@ -2402,7 +2404,7 @@ class SocialAuthBaseWithSyncAttrTest(SocialAuthBase, ABC):
         phone_field_value = CustomProfileFieldValue.objects.get(
             user_profile=self.user_profile, field=phone_field
         ).value
-        self.assertEqual(phone_field_value, "123412341234")
+        self.assertEqual(phone_field_value, "+442079460959")
 
         # Verify with none of these attributes sent at all.
         result = self.social_auth_test_with_sync_attrs(
@@ -2418,7 +2420,7 @@ class SocialAuthBaseWithSyncAttrTest(SocialAuthBase, ABC):
         phone_field_value = CustomProfileFieldValue.objects.get(
             user_profile=self.user_profile, field=phone_field
         ).value
-        self.assertEqual(phone_field_value, "123412341234")
+        self.assertEqual(phone_field_value, "+442079460959")
 
         # Disable syncing of role in SOCIAL_AUTH_SYNC_ATTRS_DICT, while keeping
         # role in extra_attrs. This edge case means the attribute will be read from the
@@ -2828,7 +2830,7 @@ class SocialAuthBaseWithSyncAttrTest(SocialAuthBase, ABC):
                 subdomain="zulip",
                 is_signup=True,
                 extra_attrs=dict(
-                    mobilePhone="123412341234",
+                    mobilePhone="+442079460959",
                     birthday="2021-01-01",
                     zulip_role="owner",
                     zulip_groups=["testgroup1", "samlgroup3", "samlgroup99"],
@@ -3044,7 +3046,7 @@ class SocialAuthBaseWithSyncAttrTest(SocialAuthBase, ABC):
                 account_data_dict,
                 subdomain="zulip",
                 extra_attrs=dict(
-                    mobilePhone="123412341234", title="some title", birthday="2021-01-01"
+                    mobilePhone="+442079460959", title="some title", birthday="2021-01-01"
                 ),
                 sync_attrs_config=sync_custom_attrs_dict,
             )
@@ -8134,7 +8136,7 @@ class TestLDAP(ZulipLDAPTestCase):
         new_external_auth_id = external_auth_ids[0]
         self.assertEqual(new_external_auth_id.realm_id, realm.id)
         self.assertEqual(new_external_auth_id.external_auth_method_name, "ldap")
-        self.assertEqual(new_external_auth_id.external_auth_id, "123456789")
+        self.assertEqual(new_external_auth_id.external_auth_id, "+12345678900")
 
     @override_settings(
         AUTHENTICATION_BACKENDS=("zproject.backends.ZulipLDAPAuthBackend",),
@@ -8881,7 +8883,7 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
         test_data = [
             {
                 "field_name": "Phone number",
-                "expected_value": "123456789",
+                "expected_value": "+12345678900",
             },
             {
                 "field_name": "Birthday",
@@ -9048,7 +9050,7 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
 
         external_auth_ids = list(ExternalAuthID.objects.filter(user=hamlet))
         self.assert_length(external_auth_ids, 1)
-        self.assertEqual(external_auth_ids[0].external_auth_id, "123456789")
+        self.assertEqual(external_auth_ids[0].external_auth_id, "+12345678900")
 
         # If unique_account_id is not configured, no ExternalAuthID should be created.
         ExternalAuthID.objects.filter(user=hamlet).delete()
@@ -9176,10 +9178,10 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
             sync_user_from_ldap(hamlet, mock.Mock())
 
         external_auth_id_obj = ExternalAuthID.objects.get(user=hamlet)
-        self.assertEqual(external_auth_id_obj.external_auth_id, "123456789")
+        self.assertEqual(external_auth_id_obj.external_auth_id, "+12345678900")
         self.assertIn(
             f"WARNING:zulip.auth.ldap:User {hamlet.id} had mismatched ExternalAuthID record. "
-            "Updating old_value => 123456789",
+            "Updating old_value => +12345678900",
             log_output.output,
         )
 

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -721,7 +721,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.login("iago")
         realm = get_realm("zulip")
 
-        field = CustomProfileField.objects.get(name="Phone number", realm=realm)
+        field = CustomProfileField.objects.get(name="Favorite food", realm=realm)
 
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
@@ -747,12 +747,12 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
             info={
-                "name": "Number",
+                "name": "Food",
             },
         )
 
         field.refresh_from_db()
-        self.assertEqual(field.name, "Number")
+        self.assertEqual(field.name, "Food")
         self.assertEqual(field.use_for_user_matching, True)
         self.assert_json_success(result)
 

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -388,6 +388,16 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         result = self.client_post("/json/realm/profile_fields", info=data)
         self.assert_json_success(result)
 
+    def test_create_field_of_type_phone_number(self) -> None:
+        self.login("iago")
+        data = {
+            "name": "Mobile number",
+            "hint": "What is your phone number?",
+            "field_type": CustomProfileField.PHONE_NUMBER,
+        }
+        result = self.client_post("/json/realm/profile_fields", info=data)
+        self.assert_json_success(result)
+
     def test_not_realm_admin(self) -> None:
         self.login("hamlet")
         result = self.client_post("/json/realm/profile_fields")
@@ -620,7 +630,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assertEqual(CustomProfileField.objects.count(), self.original_count)
         self.assertEqual(field.name, "New phone number")
         self.assertEqual(field.hint, "New contact number")
-        self.assertEqual(field.field_type, CustomProfileField.SHORT_TEXT)
+        self.assertEqual(field.field_type, CustomProfileField.PHONE_NUMBER)
         self.assertEqual(field.display_in_profile_summary, True)
         self.assertEqual(field.required, True)
         self.assertEqual(field.editable_by_user, False)
@@ -889,11 +899,39 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
             field_name, [invalid_user_id], f"Invalid user IDs: {invalid_user_id}"
         )
 
+    def test_update_phone_number_formatting(self) -> None:
+        self.login("iago")
+        realm = get_realm("zulip")
+        field = try_add_realm_custom_profile_field(realm, "Mobile", CustomProfileField.PHONE_NUMBER)
+        data = [
+            {
+                "id": field.id,
+                "value": "+1 234-567-8901",
+            }
+        ]
+        result = self.client_patch(
+            "/json/users/me/profile_data", {"data": orjson.dumps(data).decode()}
+        )
+        self.assert_json_success(result)
+        iago = self.example_user("iago")
+        for field_dict in iago.profile_data():
+            if field_dict["id"] == field.id:
+                self.assertEqual(field_dict["value"], "+12345678901")
+
+    def test_update_invalid_phone_number(self) -> None:
+        self.login("iago")
+        realm = get_realm("zulip")
+        field = try_add_realm_custom_profile_field(realm, "Mobile", CustomProfileField.PHONE_NUMBER)
+        self.assert_error_update_invalid_value(field.name, "abcdef", "Invalid phone number format.")
+        self.assert_error_update_invalid_value(
+            field.name, "+1 555-555-5555", "Invalid phone number."
+        )
+
     def test_update_profile_data_successfully(self) -> None:
         self.login("iago")
         realm = get_realm("zulip")
         fields: list[tuple[str, str | list[int]]] = [
-            ("Phone number", "*short* text data"),
+            ("Phone number", "+12345678999"),
             ("Biography", "~~short~~ **long** text data"),
             ("Favorite food", "long short text data"),
             ("Favorite editor", "0"),

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -388,6 +388,16 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         result = self.client_post("/json/realm/profile_fields", info=data)
         self.assert_json_success(result)
 
+    def test_create_field_of_type_phone_number(self) -> None:
+        self.login("iago")
+        data = {
+            "name": "Mobile number",
+            "hint": "What is your phone number?",
+            "field_type": CustomProfileField.PHONE_NUMBER,
+        }
+        result = self.client_post("/json/realm/profile_fields", info=data)
+        self.assert_json_success(result)
+
     def test_not_realm_admin(self) -> None:
         self.login("hamlet")
         result = self.client_post("/json/realm/profile_fields")
@@ -620,7 +630,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assertEqual(CustomProfileField.objects.count(), self.original_count)
         self.assertEqual(field.name, "New phone number")
         self.assertEqual(field.hint, "New contact number")
-        self.assertEqual(field.field_type, CustomProfileField.SHORT_TEXT)
+        self.assertEqual(field.field_type, CustomProfileField.PHONE_NUMBER)
         self.assertEqual(field.display_in_profile_summary, True)
         self.assertEqual(field.required, True)
         self.assertEqual(field.editable_by_user, False)
@@ -721,7 +731,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.login("iago")
         realm = get_realm("zulip")
 
-        field = CustomProfileField.objects.get(name="Phone number", realm=realm)
+        field = CustomProfileField.objects.get(name="Favorite food", realm=realm)
 
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
@@ -889,11 +899,42 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
             field_name, [invalid_user_id], f"Invalid user IDs: {invalid_user_id}"
         )
 
+    def test_update_phone_number_formatting(self) -> None:
+        self.login("iago")
+        realm = get_realm("zulip")
+        field = try_add_realm_custom_profile_field(realm, "Mobile", CustomProfileField.PHONE_NUMBER)
+        data = [
+            {
+                "id": field.id,
+                "value": "+1 234-567-8901",
+            }
+        ]
+        result = self.client_patch(
+            "/json/users/me/profile_data", {"data": orjson.dumps(data).decode()}
+        )
+        self.assert_json_success(result)
+        iago = self.example_user("iago")
+        for field_dict in iago.profile_data():
+            if field_dict["id"] == field.id:
+                self.assertEqual(field_dict["value"], "+12345678901")
+
+    def test_update_invalid_phone_number(self) -> None:
+        self.login("iago")
+        realm = get_realm("zulip")
+        field = try_add_realm_custom_profile_field(realm, "Mobile", CustomProfileField.PHONE_NUMBER)
+        self.assert_error_update_invalid_value(
+            field.name, "abcdef", "Phone numbers must not contain letters."
+        )
+        self.assert_error_update_invalid_value(
+            field.name, "+1 555-555-5555", "Invalid phone number."
+        )
+        self.assert_error_update_invalid_value(field.name, "***", "Invalid phone number format.")
+
     def test_update_profile_data_successfully(self) -> None:
         self.login("iago")
         realm = get_realm("zulip")
         fields: list[tuple[str, str | list[int]]] = [
-            ("Phone number", "*short* text data"),
+            ("Phone number", "+12345678999"),
             ("Biography", "~~short~~ **long** text data"),
             ("Favorite food", "long short text data"),
             ("Favorite editor", "0"),

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -847,7 +847,7 @@ class TestSCIMUser(SCIMTestCase):
             "userName": "newuser@zulip.com",
             "name": {"formatted": "New User"},
             "active": True,
-            "phoneNumber": "123456789",
+            "phoneNumber": "+12345678900",
             "birthday": "2000-01-01",
         }
 
@@ -862,7 +862,7 @@ class TestSCIMUser(SCIMTestCase):
 
         phone_field = CustomProfileField.objects.get(realm=new_user.realm, name="Phone number")
         phone_value = CustomProfileFieldValue.objects.get(user_profile=new_user, field=phone_field)
-        self.assertEqual(phone_value.value, "123456789")
+        self.assertEqual(phone_value.value, "+12345678900")
 
         birthday_field = CustomProfileField.objects.get(realm=new_user.realm, name="Birthday")
         birthday_value = CustomProfileFieldValue.objects.get(
@@ -872,7 +872,10 @@ class TestSCIMUser(SCIMTestCase):
 
         expected_response_schema = self.generate_user_schema(
             new_user,
-            expected_custom_profile_fields={"phoneNumber": "123456789", "birthday": "2000-01-01"},
+            expected_custom_profile_fields={
+                "phoneNumber": "+12345678900",
+                "birthday": "2000-01-01",
+            },
         )
         self.assertEqual(output_data, expected_response_schema)
 
@@ -885,7 +888,7 @@ class TestSCIMUser(SCIMTestCase):
             "userName": hamlet.delivery_email,
             "name": {"formatted": hamlet.full_name},
             "active": True,
-            "phoneNumber": "987654321",
+            "phoneNumber": "+12345678901",
         }
 
         with self.mock_custom_profile_field_map(field_map):
@@ -894,13 +897,13 @@ class TestSCIMUser(SCIMTestCase):
 
             output_data = orjson.loads(result.content)
             expected_response_schema = self.generate_user_schema(
-                hamlet, expected_custom_profile_fields={"phoneNumber": "987654321"}
+                hamlet, expected_custom_profile_fields={"phoneNumber": "+12345678901"}
             )
             self.assertEqual(output_data, expected_response_schema)
 
         phone_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Phone number")
         phone_value = CustomProfileFieldValue.objects.get(user_profile=hamlet, field=phone_field)
-        self.assertEqual(phone_value.value, "987654321")
+        self.assertEqual(phone_value.value, "+12345678901")
 
     def test_patch_custom_profile_fields(self) -> None:
         hamlet = self.example_user("hamlet")
@@ -910,7 +913,7 @@ class TestSCIMUser(SCIMTestCase):
         payload = {
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
             "Operations": [
-                {"op": "replace", "path": "phoneNumber", "value": "111222333"},
+                {"op": "replace", "path": "phoneNumber", "value": "+12345678902"},
             ],
         }
 
@@ -920,20 +923,20 @@ class TestSCIMUser(SCIMTestCase):
 
             output_data = orjson.loads(result.content)
             expected_response_schema = self.generate_user_schema(
-                hamlet, expected_custom_profile_fields={"phoneNumber": "111222333"}
+                hamlet, expected_custom_profile_fields={"phoneNumber": "+12345678902"}
             )
             self.assertEqual(output_data, expected_response_schema)
 
         phone_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Phone number")
         phone_value = CustomProfileFieldValue.objects.get(user_profile=hamlet, field=phone_field)
-        self.assertEqual(phone_value.value, "111222333")
+        self.assertEqual(phone_value.value, "+12345678902")
 
         # Now test the other PATCH form, without path, specifying
         # the attribute to modify in the value dict.
         payload = {
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
             "Operations": [
-                {"op": "replace", "value": {"phoneNumber": "444555666"}},
+                {"op": "replace", "value": {"phoneNumber": "+12345678903"}},
             ],
         }
 
@@ -943,12 +946,12 @@ class TestSCIMUser(SCIMTestCase):
 
             output_data = orjson.loads(result.content)
             expected_response_schema = self.generate_user_schema(
-                hamlet, expected_custom_profile_fields={"phoneNumber": "444555666"}
+                hamlet, expected_custom_profile_fields={"phoneNumber": "+12345678903"}
             )
             self.assertEqual(output_data, expected_response_schema)
 
         phone_value.refresh_from_db()
-        self.assertEqual(phone_value.value, "444555666")
+        self.assertEqual(phone_value.value, "+12345678903")
 
     def test_get_with_custom_profile_fields(self) -> None:
         hamlet = self.example_user("hamlet")
@@ -958,7 +961,7 @@ class TestSCIMUser(SCIMTestCase):
         CustomProfileFieldValue.objects.update_or_create(
             user_profile=hamlet,
             field=phone_field,
-            defaults={"value": "gettest123"},
+            defaults={"value": "+12345678904"},
         )
 
         with self.mock_custom_profile_field_map(field_map):
@@ -968,7 +971,7 @@ class TestSCIMUser(SCIMTestCase):
 
         # The response should include the standard schema plus the custom field.
         expected_response_schema = self.generate_user_schema(
-            hamlet, expected_custom_profile_fields={"phoneNumber": "gettest123"}
+            hamlet, expected_custom_profile_fields={"phoneNumber": "+12345678904"}
         )
         self.assertEqual(output_data, expected_response_schema)
 
@@ -1123,7 +1126,7 @@ class TestSCIMUser(SCIMTestCase):
             "userName": "newuser@zulip.com",
             "name": {"formatted": "New User"},
             "active": True,
-            "phoneNumber": "123456789",
+            "phoneNumber": "+12345678900",
         }
 
         result = self.client_post(

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -1024,7 +1024,7 @@ class TestSCIMUser(SCIMTestCase):
 
     def test_custom_profile_field_value_truncation(self) -> None:
         hamlet = self.example_user("hamlet")
-        field_map = {"phone_number": "phoneNumber", "biography": "biography"}
+        field_map = {"favorite_food": "phoneNumber", "biography": "biography"}
         long_short_value = "x" * 60
         expected_short_value = "x" * 49 + "…"
         long_long_value = "y" * 510
@@ -1048,14 +1048,14 @@ class TestSCIMUser(SCIMTestCase):
         self.assertEqual(
             log_output.output,
             [
-                f"WARNING:zerver.lib.scim:Truncated value for custom profile field phone_number of user {hamlet.id} to 50 characters.",
+                f"WARNING:zerver.lib.scim:Truncated value for custom profile field favorite_food of user {hamlet.id} to 50 characters.",
                 f"WARNING:zerver.lib.scim:Truncated value for custom profile field biography of user {hamlet.id} to 500 characters.",
             ],
         )
 
-        phone_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Phone number")
-        phone_value = CustomProfileFieldValue.objects.get(user_profile=hamlet, field=phone_field)
-        self.assertEqual(phone_value.value, expected_short_value)
+        food_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Favorite food")
+        food_value = CustomProfileFieldValue.objects.get(user_profile=hamlet, field=food_field)
+        self.assertEqual(food_value.value, expected_short_value)
 
         biography_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Biography")
         biography_value = CustomProfileFieldValue.objects.get(

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -849,7 +849,7 @@ class TestSCIMUser(SCIMTestCase):
             "userName": "newuser@zulip.com",
             "name": {"formatted": "New User"},
             "active": True,
-            "phoneNumber": "123456789",
+            "phoneNumber": "+12345678900",
             "birthday": "2000-01-01",
         }
 
@@ -864,7 +864,7 @@ class TestSCIMUser(SCIMTestCase):
 
         phone_field = CustomProfileField.objects.get(realm=new_user.realm, name="Phone number")
         phone_value = CustomProfileFieldValue.objects.get(user_profile=new_user, field=phone_field)
-        self.assertEqual(phone_value.value, "123456789")
+        self.assertEqual(phone_value.value, "+12345678900")
 
         birthday_field = CustomProfileField.objects.get(realm=new_user.realm, name="Birthday")
         birthday_value = CustomProfileFieldValue.objects.get(
@@ -874,7 +874,10 @@ class TestSCIMUser(SCIMTestCase):
 
         expected_response_schema = self.generate_user_schema(
             new_user,
-            expected_custom_profile_fields={"phoneNumber": "123456789", "birthday": "2000-01-01"},
+            expected_custom_profile_fields={
+                "phoneNumber": "+12345678900",
+                "birthday": "2000-01-01",
+            },
         )
         self.assertEqual(output_data, expected_response_schema)
 
@@ -887,7 +890,7 @@ class TestSCIMUser(SCIMTestCase):
             "userName": hamlet.delivery_email,
             "name": {"formatted": hamlet.full_name},
             "active": True,
-            "phoneNumber": "987654321",
+            "phoneNumber": "+12345678901",
         }
 
         with self.mock_custom_profile_field_map(field_map):
@@ -896,13 +899,13 @@ class TestSCIMUser(SCIMTestCase):
 
             output_data = orjson.loads(result.content)
             expected_response_schema = self.generate_user_schema(
-                hamlet, expected_custom_profile_fields={"phoneNumber": "987654321"}
+                hamlet, expected_custom_profile_fields={"phoneNumber": "+12345678901"}
             )
             self.assertEqual(output_data, expected_response_schema)
 
         phone_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Phone number")
         phone_value = CustomProfileFieldValue.objects.get(user_profile=hamlet, field=phone_field)
-        self.assertEqual(phone_value.value, "987654321")
+        self.assertEqual(phone_value.value, "+12345678901")
 
     def test_patch_custom_profile_fields(self) -> None:
         hamlet = self.example_user("hamlet")
@@ -912,7 +915,7 @@ class TestSCIMUser(SCIMTestCase):
         payload = {
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
             "Operations": [
-                {"op": "replace", "path": "phoneNumber", "value": "111222333"},
+                {"op": "replace", "path": "phoneNumber", "value": "+12345678902"},
             ],
         }
 
@@ -922,20 +925,20 @@ class TestSCIMUser(SCIMTestCase):
 
             output_data = orjson.loads(result.content)
             expected_response_schema = self.generate_user_schema(
-                hamlet, expected_custom_profile_fields={"phoneNumber": "111222333"}
+                hamlet, expected_custom_profile_fields={"phoneNumber": "+12345678902"}
             )
             self.assertEqual(output_data, expected_response_schema)
 
         phone_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Phone number")
         phone_value = CustomProfileFieldValue.objects.get(user_profile=hamlet, field=phone_field)
-        self.assertEqual(phone_value.value, "111222333")
+        self.assertEqual(phone_value.value, "+12345678902")
 
         # Now test the other PATCH form, without path, specifying
         # the attribute to modify in the value dict.
         payload = {
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
             "Operations": [
-                {"op": "replace", "value": {"phoneNumber": "444555666"}},
+                {"op": "replace", "value": {"phoneNumber": "+12345678903"}},
             ],
         }
 
@@ -945,12 +948,12 @@ class TestSCIMUser(SCIMTestCase):
 
             output_data = orjson.loads(result.content)
             expected_response_schema = self.generate_user_schema(
-                hamlet, expected_custom_profile_fields={"phoneNumber": "444555666"}
+                hamlet, expected_custom_profile_fields={"phoneNumber": "+12345678903"}
             )
             self.assertEqual(output_data, expected_response_schema)
 
         phone_value.refresh_from_db()
-        self.assertEqual(phone_value.value, "444555666")
+        self.assertEqual(phone_value.value, "+12345678903")
 
     def test_get_with_custom_profile_fields(self) -> None:
         hamlet = self.example_user("hamlet")
@@ -960,7 +963,7 @@ class TestSCIMUser(SCIMTestCase):
         CustomProfileFieldValue.objects.update_or_create(
             user_profile=hamlet,
             field=phone_field,
-            defaults={"value": "gettest123"},
+            defaults={"value": "+12345678904"},
         )
 
         with self.mock_custom_profile_field_map(field_map):
@@ -970,7 +973,7 @@ class TestSCIMUser(SCIMTestCase):
 
         # The response should include the standard schema plus the custom field.
         expected_response_schema = self.generate_user_schema(
-            hamlet, expected_custom_profile_fields={"phoneNumber": "gettest123"}
+            hamlet, expected_custom_profile_fields={"phoneNumber": "+12345678904"}
         )
         self.assertEqual(output_data, expected_response_schema)
 
@@ -1125,7 +1128,7 @@ class TestSCIMUser(SCIMTestCase):
             "userName": "newuser@zulip.com",
             "name": {"formatted": "New User"},
             "active": True,
-            "phoneNumber": "123456789",
+            "phoneNumber": "+12345678900",
         }
 
         result = self.client_post(

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -1026,7 +1026,7 @@ class TestSCIMUser(SCIMTestCase):
 
     def test_custom_profile_field_value_truncation(self) -> None:
         hamlet = self.example_user("hamlet")
-        field_map = {"phone_number": "phoneNumber", "biography": "biography"}
+        field_map = {"favorite_food": "favoriteFood", "biography": "biography"}
         long_short_value = "x" * 60
         expected_short_value = "x" * 49 + "…"
         long_long_value = "y" * 510
@@ -1037,7 +1037,7 @@ class TestSCIMUser(SCIMTestCase):
             "userName": hamlet.delivery_email,
             "name": {"formatted": hamlet.full_name},
             "active": True,
-            "phoneNumber": long_short_value,
+            "favoriteFood": long_short_value,
             "biography": long_long_value,
         }
 
@@ -1050,14 +1050,14 @@ class TestSCIMUser(SCIMTestCase):
         self.assertEqual(
             log_output.output,
             [
-                f"WARNING:zerver.lib.scim:Truncated value for custom profile field phone_number of user {hamlet.id} to 50 characters.",
+                f"WARNING:zerver.lib.scim:Truncated value for custom profile field favorite_food of user {hamlet.id} to 50 characters.",
                 f"WARNING:zerver.lib.scim:Truncated value for custom profile field biography of user {hamlet.id} to 500 characters.",
             ],
         )
 
-        phone_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Phone number")
-        phone_value = CustomProfileFieldValue.objects.get(user_profile=hamlet, field=phone_field)
-        self.assertEqual(phone_value.value, expected_short_value)
+        food_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Favorite food")
+        food_value = CustomProfileFieldValue.objects.get(user_profile=hamlet, field=food_field)
+        self.assertEqual(food_value.value, expected_short_value)
 
         biography_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Biography")
         biography_value = CustomProfileFieldValue.objects.get(

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2840,6 +2840,7 @@ class UserSignUpTest(ZulipTestCase):
         subdomain = "zulip"
 
         self.init_default_ldap_database()
+        self.change_ldap_user_attr("newuser", "homePhone", "+12345678900")
         ldap_user_attr_map = {
             "full_name": "cn",
             "custom_profile_field__phone_number": "homePhone",
@@ -2864,7 +2865,7 @@ class UserSignUpTest(ZulipTestCase):
             phone_number_field_value = CustomProfileFieldValue.objects.get(
                 user_profile=user_profile, field=phone_number_field
             )
-            self.assertEqual(phone_number_field_value.value, "a-new-number")
+            self.assertEqual(phone_number_field_value.value, "+12345678900")
 
     @override_settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipLDAPAuthBackend",))
     def test_ldap_auto_registration_on_login_invalid_email_in_directory(self) -> None:

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -859,7 +859,7 @@ class PermissionTest(ZulipTestCase):
 
         # Test for all type of data
         fields = {
-            "Phone number": "short text data",
+            "Phone number": "+12345678900",
             "Biography": "long text data",
             "Favorite food": "short text data",
             "Favorite editor": "0",
@@ -897,7 +897,7 @@ class PermissionTest(ZulipTestCase):
         # Map field names to their expected display values in the notification.
         # Some field types convert their stored values to human-readable display text.
         expected_display_values = {
-            "Phone number": "short text data",
+            "Phone number": "+12345678900",
             "Biography": "long text data",
             "Favorite food": "short text data",
             "Favorite editor": "Vim",  # SELECT field: "0" -> "Vim"
@@ -1002,6 +1002,8 @@ class PermissionTest(ZulipTestCase):
             value: str | None | list[Any] = ""
             if field.field_type == CustomProfileField.USER:
                 value = []
+            elif field.field_type == CustomProfileField.PHONE_NUMBER:
+                value = None
             empty_profile_data.append(
                 {
                     "id": field.id,

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -866,7 +866,7 @@ class PermissionTest(ZulipTestCase):
 
         # Test for all type of data
         fields = {
-            "Phone number": "short text data",
+            "Phone number": "+12345678900",
             "Biography": "long text data",
             "Favorite food": "short text data",
             "Favorite editor": "0",
@@ -904,7 +904,7 @@ class PermissionTest(ZulipTestCase):
         # Map field names to their expected display values in the notification.
         # Some field types convert their stored values to human-readable display text.
         expected_display_values = {
-            "Phone number": "short text data",
+            "Phone number": "+12345678900",
             "Biography": "long text data",
             "Favorite food": "short text data",
             "Favorite editor": "Vim",  # SELECT field: "0" -> "Vim"
@@ -1009,6 +1009,8 @@ class PermissionTest(ZulipTestCase):
             value: str | list[Any] | None = ""
             if field.field_type == CustomProfileField.USER:
                 value = []
+            elif field.field_type == CustomProfileField.PHONE_NUMBER:
+                value = None
             empty_profile_data.append(
                 {
                     "id": field.id,

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -79,7 +79,10 @@ def validate_use_for_user_matching_field(field_type: int, use_for_user_matching:
         return
 
     # Only SHORT_TEXT and EXTERNAL_ACCOUNT field types are supported for user matching.
-    if field_type not in (CustomProfileField.SHORT_TEXT, CustomProfileField.EXTERNAL_ACCOUNT):
+    if field_type not in (
+        CustomProfileField.SHORT_TEXT,
+        CustomProfileField.EXTERNAL_ACCOUNT,
+    ):
         raise JsonableError(_("Field type not supported for use for user matching."))
 
 

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -791,7 +791,7 @@ class Command(ZulipBaseCommand):
 
             # Create custom profile field data
             phone_number = try_add_realm_custom_profile_field(
-                zulip_realm, "Phone number", CustomProfileField.SHORT_TEXT, hint=""
+                zulip_realm, "Phone number", CustomProfileField.PHONE_NUMBER, hint=""
             )
             biography = try_add_realm_custom_profile_field(
                 zulip_realm,
@@ -853,7 +853,7 @@ class Command(ZulipBaseCommand):
             do_update_user_custom_profile_data_if_changed(
                 hamlet,
                 [
-                    {"id": phone_number.id, "value": "+0-11-23-456-7890"},
+                    {"id": phone_number.id, "value": "+44 20 7946 0958"},
                     {
                         "id": biography.id,
                         "value": "I am:\n* The prince of Denmark\n* Nephew to the usurping Claudius",

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -833,7 +833,7 @@ class Command(ZulipBaseCommand):
 
             # Create custom profile field data
             phone_number = try_add_realm_custom_profile_field(
-                zulip_realm, "Phone number", CustomProfileField.SHORT_TEXT, hint=""
+                zulip_realm, "Phone number", CustomProfileField.PHONE_NUMBER, hint=""
             )
             biography = try_add_realm_custom_profile_field(
                 zulip_realm,
@@ -895,7 +895,7 @@ class Command(ZulipBaseCommand):
             do_update_user_custom_profile_data_if_changed(
                 hamlet,
                 [
-                    {"id": phone_number.id, "value": "+0-11-23-456-7890"},
+                    {"id": phone_number.id, "value": "+44 20 7946 0958"},
                     {
                         "id": biography.id,
                         "value": "I am:\n* The prince of Denmark\n* Nephew to the usurping Claudius",

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1989,7 +1989,7 @@ def validate_custom_profile_field_data_for_sync(
             )
 
         try:
-            validate_user_custom_profile_field(realm_id, field, value)
+            value = validate_user_custom_profile_field(realm_id, field, value)
         except ValidationError as error:
             raise SyncUserError(f"Invalid data for {var_name} field: {error.message}")
         profile_data.append(


### PR DESCRIPTION
This PR implements the new "Phone number" custom profile field.

To keep our database clean and standardized, this also adds automatic formatting. Now, when a user types a phone number with messy spaces, brackets, or dashes, the backend intercepts it and converts it to the standard E.164 format
(using the `phonenumbers` library) right before
saving it to the database.

I also updated the API response and the frontend UI. Now, the moment a user clicks "Save," their input box instantly snaps to show the cleanly formatted number, giving them immediate visual feedback.

Fixes #23787.

<!-- Describe your pull request here.-->


**How changes were tested:**
* Manual UI Testing (Personal Settings): Navigated to Settings > Profile, entered a phone number with spaces and dashes (e.g., `+91 123 456 7890`). Verified that upon saving, the UI instantly updated the input field to `+911234567890`.
* Manual UI Testing (Admin Modal): Tested the same formatting behavior inside the "Manage Users" modal to ensure the core action layer (`do_update_user_custom_profile_data_if_changed`) correctly intercepts and formats the payload regardless of the endpoint used.
* Database Verification: Used `./manage.py shell` to query `CustomProfileFieldValue` and verified that the string is actually stored in the E.164 format without spaces.
* Automated Testing: Ran backend tests via `./tools/test-backend zerver.tests.test_custom_profile_data` to ensure no regressions and that the new phone number logic passes successfully.
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
1. The new "Phone number" option is now available in the custom profile field type dropdown
<img width="1100" height="900" alt="Screenshot 2026-03-10 at 9 04 07 PM" src="https://github.com/user-attachments/assets/dd2d1c48-c658-44c0-beab-1bd11fa4978e" />

2. Setting up the label and hint for the new phone number field.
<img width="590" height="492" alt="Screenshot 2026-03-10 at 9 04 20 PM" src="https://github.com/user-attachments/assets/2b9ad788-7739-4461-a106-0fa87378a76c" />

3. The phone number field successfully added to the organization's active custom profile fields.
<img width="872" height="125" alt="Screenshot 2026-03-10 at 9 04 31 PM" src="https://github.com/user-attachments/assets/a93be1e5-d6a9-4ef4-b5a4-f339ddb6e882" />

4. The new input box where users can enter their phone numbers (including spaces, dashes, etc.)
<img width="599" height="348" alt="Screenshot 2026-03-10 at 9 05 00 PM" src="https://github.com/user-attachments/assets/42887e87-6387-4f1e-8f35-f5463d46f4d7" />

5. The saved phone number successfully intercepted by the backend and displayed in the clean, standardized E.164 format on the user's profile.
<img width="444" height="273" alt="Screenshot 2026-03-10 at 9 06 38 PM" src="https://github.com/user-attachments/assets/9b3a6aff-ea9d-43b4-b13c-b6a9786a2dde" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
