### PR TITLE
web: Replace static display .css() calls with .hide() and .show().

### DIFF
--- a/web/src/billing/sponsorship.ts
+++ b/web/src/billing/sponsorship.ts
@@ -15,7 +15,7 @@ function show_submit_loading_indicator(): void {
 }
 
 function hide_submit_loading_indicator(): void {
-    $("#sponsorship-button .sponsorship-button-loader").css("display", "none");
+    $("#sponsorship-button .sponsorship-button-loader").hide();
     $("#sponsorship-button").prop("disabled", false);
     $("#sponsorship-button .sponsorship-button-text").show();
 }

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -81,7 +81,7 @@ export function toggle(opts: {
         if ($elem.hasClass("disabled")) {
             return false;
         }
-        if ($elem.css("display") === "none") {
+        if (!$elem.is(":visible")) {
             return false;
         }
 

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -507,7 +507,7 @@ export function update_placeholder_visibility(): void {
 export let update_compose_area_placeholder_text = (): void => {
     const $textarea: JQuery<HTMLTextAreaElement> = $("textarea#compose-textarea");
     // Change compose placeholder text only if compose box is open.
-    if ($(".message_comp").css("display") === "none") {
+    if (!$(".message_comp").is(":visible")) {
         return;
     }
     const message_type = compose_state.get_message_type();

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -1448,7 +1448,7 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
             let emoji_picker_reference;
             if (
                 $emoji_icon?.length !== 0 &&
-                $emoji_icon.closest(".message_control_button").css("display") !== "none"
+                $emoji_icon.closest(".message_control_button").is(":visible")
             ) {
                 emoji_picker_reference = util.the($emoji_icon);
             } else {

--- a/web/src/left_sidebar_tooltips.ts
+++ b/web/src/left_sidebar_tooltips.ts
@@ -208,7 +208,7 @@ export function initialize(): void {
         appendTo: () => document.body,
         onShow(instance) {
             let template = "show-left-sidebar-tooltip-template";
-            if ($("#left-sidebar-container").css("display") !== "none") {
+            if ($("#left-sidebar-container").is(":visible")) {
                 template = "hide-left-sidebar-tooltip-template";
             }
             $(instance.reference).attr("data-tooltip-template-id", template);

--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -96,7 +96,7 @@ function row_before_focus(context: Context): JQuery {
     if (
         $prev_row.length === 0 &&
         $focused_row.parent().attr("id") === "other-drafts" &&
-        $("#drafts-from-conversation").css("display") !== "none"
+        $("#drafts-from-conversation").is(":visible")
     ) {
         return $($("#drafts-from-conversation").children(".overlay-message-row").last());
     }
@@ -113,7 +113,7 @@ function row_after_focus(context: Context): JQuery {
     if (
         $next_row.length === 0 &&
         $focused_row.parent().attr("id") === "drafts-from-conversation" &&
-        $("#other-drafts").css("display") !== "none"
+        $("#other-drafts").is(":visible")
     ) {
         return $("#other-drafts").children(".overlay-message-row").first();
     }

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -226,7 +226,7 @@ export function get_actions_popover_content_context(message_id: number): ActionP
         assert(message_lists.current !== undefined);
         const $message_row = message_lists.current.get_row(message_id);
         const $reaction_button = $message_row.find(".message_controls .reaction_button");
-        return $reaction_button.length === 1 && $reaction_button.css("display") !== "none";
+        return $reaction_button.length === 1 && $reaction_button.is(":visible");
     }
 
     // Since we only display msg actions and star icons on windows smaller than

--- a/web/src/portico/email_log.ts
+++ b/web/src/portico/email_log.ts
@@ -8,19 +8,19 @@ $(() => {
     // This code will be executed when the user visits /emails in
     // development mode and email_log.html is rendered.
     $("#toggle").on("change", () => {
-        if ($(".email-text").css("display") === "none") {
+        if (!$(".email-text").is(":visible")) {
             $(".email-text").each(function () {
-                $(this).css("display", "block");
+                $(this).show();
             });
             $(".email-html").each(function () {
-                $(this).css("display", "none");
+                $(this).hide();
             });
         } else {
             $(".email-text").each(function () {
-                $(this).css("display", "none");
+                $(this).hide();
             });
             $(".email-html").each(function () {
-                $(this).css("display", "block");
+                $(this).show();
             });
         }
     });

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -122,9 +122,9 @@ $(() => {
         }
 
         // reset error message displays
-        $("#id_team_subdomain_error_client").css("display", "none");
+        $("#id_team_subdomain_error_client").hide();
         if ($(".team_subdomain_error_server").text() === "") {
-            $(".team_subdomain_error_server").css("display", "none");
+            $(".team_subdomain_error_server").hide();
         }
 
         $("#timezone").val(new Intl.DateTimeFormat().resolvedOptions().timeZone);
@@ -259,8 +259,8 @@ $(() => {
 
     let timer: number;
     $("#id_team_subdomain").on("input", () => {
-        $(".team_subdomain_error_server").text("").css("display", "none");
-        $("#id_team_subdomain_error_client").css("display", "none");
+        $(".team_subdomain_error_server").text("").hide();
+        $("#id_team_subdomain_error_client").hide();
         clearTimeout(timer);
         timer = setTimeout(check_subdomain_available, 250, $("#id_team_subdomain").val());
     });

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -32,7 +32,7 @@ export function get_stream_filters_max_height(): number {
     const GAP = 15;
 
     const $left_sidebar_search = $("#left-sidebar-search");
-    const is_search_visible = $left_sidebar_search.css("display") !== "none";
+    const is_search_visible = $left_sidebar_search.is(":visible");
 
     let stream_filters_max_height =
         viewport_height -

--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -108,7 +108,7 @@ function rerender_ui(): void {
     }
 
     if (unmatched_streams.length === 0) {
-        $unmatched_streams_table.css("display", "none");
+        $unmatched_streams_table.hide();
         $("#customize_stream_notifications_widget .dropdown_widget_value").text(
             $t({defaultMessage: "Customize a channel"}),
         );

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -74,7 +74,7 @@ export function hide_userlist_sidebar(): void {
 export function show_userlist_sidebar(): void {
     const $streamlist_sidebar = $(".app-main .column-left");
     const $userlist_sidebar = $(".app-main .column-right");
-    if ($userlist_sidebar.css("display") !== "none") {
+    if ($userlist_sidebar.is(":visible")) {
         // Return early if the right sidebar is already visible.
         return;
     }
@@ -113,7 +113,7 @@ export function show_streamlist_sidebar(): void {
 export function show_left_sidebar(): void {
     if (
         // Check if left column is a overlay and is not visible.
-        $("#streamlist-toggle").css("display") !== "none" &&
+        $("#streamlist-toggle").is(":visible") &&
         !left_sidebar_expanded_as_overlay
     ) {
         popovers.hide_all();

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -271,7 +271,7 @@ export function update_channel_folder_name(folder_id: number): void {
         return;
     }
 
-    if ($("#subscription_overlay .nothing-selected").css("display") !== "none") {
+    if ($("#subscription_overlay .nothing-selected").is(":visible")) {
         return;
     }
 
@@ -310,7 +310,7 @@ export function reset_dropdown_set_to_archived_folder(folder_id: number): void {
         return;
     }
 
-    if ($("#subscription_overlay .nothing-selected").css("display") !== "none") {
+    if ($("#subscription_overlay .nothing-selected").is(":visible")) {
         return;
     }
 

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -744,7 +744,7 @@ export function initialize(): void {
         appendTo: () => document.body,
         onShow(instance) {
             let template = "show-userlist-tooltip-template";
-            if ($("#right-sidebar-container").css("display") !== "none") {
+            if ($("#right-sidebar-container").is(":visible")) {
                 template = "hide-userlist-tooltip-template";
             }
             $(instance.reference).attr("data-tooltip-template-id", template);
@@ -1003,7 +1003,7 @@ export function initialize(): void {
                 instance.setContent(ui_util.parse_html(error_message));
                 // `display: flex` doesn't show the tooltip content inline when <i>general chat</i>
                 // is in the error message.
-                $(instance.popper).find(".tippy-content").css("display", "block");
+                $(instance.popper).find(".tippy-content").show();
                 return undefined;
             }
             return false;

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -865,7 +865,7 @@ export function viewport_is_visible_and_focused(): boolean {
         overlays.any_active() ||
         modals.any_active() ||
         !is_window_focused() ||
-        $("#message_feed_container").css("display") === "none"
+        $("#message_feed_container")!$element.is(":visible")
     ) {
         return false;
     }

--- a/web/src/upload.ts
+++ b/web/src/upload.ts
@@ -292,7 +292,7 @@ export let upload_files = (
     // We implement this transition through triggering a click on the
     // toggle button to take advantage of the existing plumbing for
     // handling the compose and edit UIs.
-    if (config.markdown_preview_hide_button().css("display") !== "none") {
+    if (config.markdown_preview_hide_button().is(":visible")) {
         config.markdown_preview_hide_button().trigger("click");
     }
 

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1754,7 +1754,7 @@ export function update_empty_left_panel_message(): void {
         FILTERS.ACTIVE_AND_DEACTIVATED_GROUPS;
 
     // When the dropdown menu is hidden.
-    if ($("#user-group-edit-filter-options").css("display") === "none") {
+    if ($("#user-group-edit-filter-options")!$element.is(":visible")) {
         current_group_filter = FILTERS.ACTIVE_AND_DEACTIVATED_GROUPS;
     }
 


### PR DESCRIPTION
This PR does not fix entire but some part of #18723 codebase audit, this commit manuallay replace `.css("display", "none")` and `.css("display", "block")` with `.hide()` and `.show()` methods.

Apart from this, it also replaces `.css("display") === "none"` state checks with `.is(":visible")` and `!$elt.is(":visible")`.

Note: `.css("display", "inline-block")` and other specific display values were intentionally left untouched, as replacing them with `.show()` could break layouts.

fixes #18723.



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
