### PR TITLE
[ai] markdown: Skip thread-based timeout in tests.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2699,7 +2699,15 @@ def do_convert(
         # extremely inefficient in corner cases) as well as user
         # errors (e.g. a linkifier that makes some syntax
         # infinite-loop).
-        rendering_result.rendered_content = unsafe_timeout(5, lambda: md_engine.convert(content))
+        if settings.TEST_SUITE:
+            # Don't use the thread-based timeout in tests, because
+            # coverage.py is not thread-safe and flakes with
+            # "Set changed size during iteration" errors.
+            rendering_result.rendered_content = md_engine.convert(content)
+        else:
+            rendering_result.rendered_content = unsafe_timeout(
+                5, lambda: md_engine.convert(content)
+            )
 
         # Post-process the result with the rendered image previews:
         if user_upload_previews is not None:


### PR DESCRIPTION
The `unsafe_timeout` wrapper runs markdown conversion in a separate
thread to protect production against slow renders. Coverage.py is
not thread-safe and flakes with "Set changed size during iteration"
when its internal data structures are concurrently modified across
threads. Since the timeout serves no purpose in tests (inputs are
controlled), bypass it to eliminate this flaky failure.

## Test plan
- [x] `./tools/test-backend zerver.tests.test_delete_unclaimed_attachments` — all 11 tests pass
- [x] `./tools/test-backend zerver.tests.test_markdown` — all 134 tests pass
- [x] `ruff check` and `mypy` pass on the changed file

## Self-review checklist
- [x] The PR addresses all points described in the issue
- [x] All relevant tests pass locally
- [x] Code follows existing patterns in the codebase (`settings.TEST_SUITE` is used throughout)
- [x] Each commit is a minimal coherent idea
- [x] No debugging code or unnecessary comments remain

---

The user asked to fix a flaky test: `test_delete_with_scheduled_messages` in `zerver.tests.test_delete_unclaimed_attachments.UnclaimedAttachmentTest`, which failed with `RuntimeError: Set changed size during iteration` inside coverage.py's collector when markdown rendering ran in a separate thread via `unsafe_timeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)