### PR TITLE
sidebars: Fixed inconsistent margins on sidebar action buttons.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -459,11 +459,11 @@
     .channel-folders-inbox-menu-icon {
         display: grid;
         /* width excluding left & right margin */
-        width: calc(var(--left-sidebar-vdots-width) - 3px);
+        width: calc(var(--left-sidebar-vdots-width) - 4px);
         cursor: pointer;
         place-items: center center;
         border-radius: 3px;
-        margin: 2px 2px 2px 1px;
+        margin: 2px;
         color: var(--color-vdots-visible);
 
         i.zulip-icon {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -57,8 +57,7 @@
 .add-stream-icon-container {
     grid-area: add-channel;
     display: grid;
-    /* 2px right margin here to match the new topic margin-right */
-    margin: 2px 1px 2px 0;
+    margin: 2px;
     border-radius: 3px;
     color: var(--color-sidebar-action);
 

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -521,9 +521,7 @@
         /* Push back against default right-sidebar
            spacing for better vdots alignment. */
         padding: 0;
-        /* No left/right margin to maintain vdots
-           alignment with user rows below. */
-        margin: 2px 0;
+        margin: 2px;
 
         &:hover {
             color: var(--color-vdots-hover);


### PR DESCRIPTION
The Browse Channels button in the left sidebar, the three-dot menu button in the right sidebar, and the three-dot menu button
in the inbox view had inconsistent margins causing them to appear too close to adjacent elements. This fixes the margins to 2px on all sides for consistency.

Note :
The 3dots from inbox had an inconsistent left margin of 1px instead of 2px, causing slight misalignment.

Fixes: https://chat.zulip.org/#narrow/channel/101-design/topic/right-sidebar.3A.20Inconsistent.20margins.20on.20three-dot.20menu.20button/with/2403176

**How changes were tested:**
Tested visually in the browser.

**Screenshots and screen captures:**
### Left sidebar

| Before | After |
| --- | --- |
|<img width="1536" height="2048" alt="before left" src="https://github.com/user-attachments/assets/ea6b77e1-80ce-4b93-9cef-70d60e408d0e" />|<img width="1536" height="2048" alt="after left" src="https://github.com/user-attachments/assets/3f7e6b9b-6e63-4ad9-8bbe-c28cb4d41ffe" />|
 

### Right sidebar

| Before | After |
| --- | --- |
| <img width="1536" height="2048" alt="localhost_9991_(iPad Mini) (1)" src="https://github.com/user-attachments/assets/57826ac3-7fed-4fe6-9b0f-538881534bc2" /> | <img width="1536" height="2048" alt="after right" src="https://github.com/user-attachments/assets/7ec3d983-2d42-4238-b7d8-eec8d773b174" /> |

### Inbox

| Before | After |
| --- | --- |
|<img width="1536" height="2048" alt="localhost_9991_(iPad Mini)" src="https://github.com/user-attachments/assets/123e9726-3c58-4fc3-bd03-2cb73b0ffa35" />| <img width="1536" height="2048" alt="after inbox" src="https://github.com/user-attachments/assets/9db8c13d-62de-4e6c-aa6f-8faa095887b9" />|
 
<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
Communicate decisions, questions, and potential concerns.
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.
Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
Completed manual review and testing of the following:
- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>