### PR TITLE
composebox_typeahead: Suggest topics when typing '#' without selecting stream.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -17,6 +17,7 @@ import type {EmojiDict} from "./emoji.ts";
 import * as flatpickr from "./flatpickr.ts";
 import {$t} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
+import * as linkifiers from "./linkifiers.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_store from "./message_store.ts";
 import * as message_util from "./message_util.ts";
@@ -101,6 +102,14 @@ export type TopicSuggestion = {
     is_new_topic: boolean;
 };
 
+export type StreamTopicSuggestion = {
+    topic: string;
+    topic_display_name: string;
+    is_empty_string_topic: boolean;
+    type: "stream_topic";
+    stream_data: StreamPillData;
+};
+
 type TimeJumpSuggestion = {
     message: string;
     type: "time_jump";
@@ -119,6 +128,7 @@ export type TypeaheadSuggestion =
     | TimeJumpSuggestion
     | LanguageSuggestion
     | TopicSuggestion
+    | StreamTopicSuggestion
     | EmojiSuggestion
     | SlashCommandSuggestion;
 
@@ -258,6 +268,62 @@ function get_topic_matcher(query: string): (topic: string) => boolean {
             should_remove_diacritics,
         );
     };
+}
+
+function query_matches_linkifier_pattern(query: string): boolean {
+    for (const pattern of linkifiers.get_linkifier_map().keys()) {
+        if (pattern.test(query)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Finds topics matching `token` in every channel, so `#keyword` can
+// suggest topics without picking a channel first.  Only topic history
+// the client already has is used; fetching every channel on each
+// keystroke would be too slow.
+function get_stream_topic_matches(
+    token: string,
+    candidate_list: StreamPillData[],
+): StreamTopicSuggestion[] {
+    const topic_matcher = get_topic_matcher(token);
+    const current_stream_id = compose_state.stream_id();
+    // Topics in the channel we are composing to are the most likely
+    // match, so we collect them separately to sort them first.
+    const current_stream_topic_matches: StreamTopicSuggestion[] = [];
+    const other_stream_topic_matches: StreamTopicSuggestion[] = [];
+    for (const sub of candidate_list) {
+        const is_current_stream = sub.stream_id === current_stream_id;
+        // Unsorted: we filter to a few matches and re-sort those below,
+        // so sorting each channel's full history first would be wasted.
+        for (const topic of stream_topic_history.get_recent_topic_names_unsorted(sub.stream_id)) {
+            if (!topic_matcher(topic)) {
+                continue;
+            }
+            // Skip the empty topic elsewhere; it exists in nearly every
+            // channel and would bury real topics.
+            if (topic === "" && !is_current_stream) {
+                continue;
+            }
+            (is_current_stream ? current_stream_topic_matches : other_stream_topic_matches).push({
+                topic,
+                topic_display_name: util.get_final_topic_display_name(topic),
+                is_empty_string_topic: topic === "",
+                type: "stream_topic",
+                stream_data: sub,
+            });
+        }
+    }
+
+    return [
+        ...typeahead_helper.sorter(
+            token,
+            current_stream_topic_matches,
+            (x) => x.topic_display_name,
+        ),
+        ...typeahead_helper.sorter(token, other_stream_topic_matches, (x) => x.topic_display_name),
+    ];
 }
 
 export function should_enter_send(e: JQuery.KeyDownEvent): boolean {
@@ -1240,7 +1306,8 @@ export function get_candidates(
         }
 
         current_token = current_token.slice(1);
-        if (current_token.startsWith("**")) {
+        const uses_channel_mention_syntax = current_token.startsWith("**");
+        if (uses_channel_mention_syntax) {
             current_token = current_token.slice(2);
         }
 
@@ -1259,7 +1326,25 @@ export function get_candidates(
             }));
         const matcher = get_stream_matcher(token);
         const matches = candidate_list.filter((item) => matcher(item));
-        return typeahead_helper.sort_streams(matches, token);
+        const sorted_stream_matches = typeahead_helper.sort_streams(matches, token);
+
+        // Typing an issue number is a common use of `#`, so we never
+        // open the typeahead only to show topics.  If a channel matches
+        // we show its topics too.  Linkifier patterns usually include
+        // the `#`, so we test what the user typed; `#**` clearly means
+        // a channel, so it is exempt.
+        if (
+            sorted_stream_matches.length === 0 &&
+            !uses_channel_mention_syntax &&
+            query_matches_linkifier_pattern("#" + token)
+        ) {
+            return [];
+        }
+
+        if (sorted_stream_matches.length >= max_num_items) {
+            return sorted_stream_matches;
+        }
+        return [...sorted_stream_matches, ...get_stream_topic_matches(token, candidate_list)];
     }
 
     if (ALLOWED_MARKDOWN_FEATURES.timestamp) {
@@ -1314,6 +1399,8 @@ export function content_item_html(
                 }
                 return typeahead_helper.render_stream_topic(item);
             }
+            case "stream_topic":
+                return typeahead_helper.render_stream_and_topic(item);
             case "time_jump":
                 return typeahead_helper.render_typeahead_item({primary: item.message});
             default:
@@ -1509,6 +1596,20 @@ export function content_typeahead_selected(
                 );
             }
             beginning = beginning.slice(0, syntax_start_index) + replacement_text + " ";
+            break;
+        }
+        case "stream_topic": {
+            // Like the "stream" case: the token excludes the `#` and
+            // the `**`, so remove the `#*` left behind.
+            beginning = beginning.slice(0, -token.length - 1);
+            if (beginning.endsWith("#*")) {
+                beginning = beginning.slice(0, -2);
+            }
+
+            void compose_validate.warn_if_private_stream_is_linked(item.stream_data, $textbox);
+            beginning +=
+                topic_link_util.get_stream_topic_link_syntax(item.stream_data.name, item.topic) +
+                " ";
             break;
         }
         case "time_jump": {

--- a/web/src/stream_topic_history.ts
+++ b/web/src/stream_topic_history.ts
@@ -221,7 +221,10 @@ export class PerStreamHistory {
         }
     }
 
-    get_recent_topic_names(): string[] {
+    get_recent_topics(): {
+        local_echo_topics: {pretty_name: string; message_id: number}[];
+        server_topics: {pretty_name: string; message_id: number}[];
+    } {
         // Combines several data sources to produce a complete picture
         // of topics the client knows about.
         //
@@ -244,12 +247,25 @@ export class PerStreamHistory {
             local_echo_topics.map((message_topic) => message_topic.pretty_name.toLowerCase()),
         );
 
-        // We first sort the topics without locally echoed messages,
-        // and then prepend topics with locally echoed messages.
         const server_topics = [...my_recents, ...missing_topics].filter(
             (message_topic) => !local_echo_set.has(message_topic.pretty_name.toLowerCase()),
         );
+        return {local_echo_topics, server_topics};
+    }
+
+    get_recent_topic_names(): string[] {
+        const {local_echo_topics, server_topics} = this.get_recent_topics();
+        // We first sort the topics without locally echoed messages,
+        // and then prepend topics with locally echoed messages.
         server_topics.sort((a, b) => b.message_id - a.message_id);
+        return [...local_echo_topics, ...server_topics].map((obj) => obj.pretty_name);
+    }
+
+    // Same topic names as `get_recent_topic_names`, but without the
+    // recency sort.  Callers that filter to a few matches and re-sort
+    // those use this to avoid sorting a channel's full topic history.
+    get_recent_topic_names_unsorted(): string[] {
+        const {local_echo_topics, server_topics} = this.get_recent_topics();
         return [...local_echo_topics, ...server_topics].map((obj) => obj.pretty_name);
     }
 
@@ -373,6 +389,16 @@ export function get_recent_topic_names(stream_id: number): string[] {
     const history = find_or_create(stream_id);
 
     return history.get_recent_topic_names();
+}
+
+export function get_recent_topic_names_unsorted(stream_id: number): string[] {
+    // Not `find_or_create`: a missing history acts like an empty one,
+    // and caching one per channel would grow `stream_dict` without bound.
+    // This is called for every channel on each keystroke of a `#`
+    // typeahead, so that growth would be real.
+    const history = stream_dict.get(stream_id) ?? new PerStreamHistory(stream_id);
+
+    return history.get_recent_topic_names_unsorted();
 }
 
 export function get_max_message_id(stream_id: number): number {

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -9,6 +9,7 @@ import * as compose_state from "./compose_state.ts";
 import type {
     LanguageSuggestion,
     SlashCommandSuggestion,
+    StreamTopicSuggestion,
     TopicSuggestion,
 } from "./composebox_typeahead.ts";
 import type {InputPillContainer} from "./input_pill.ts";
@@ -69,6 +70,8 @@ export let render_typeahead_item = (args: {
     stream?: StreamData;
     emoji_code?: string | undefined;
     topic_object?: TopicSuggestion;
+    topic?: string | undefined;
+    topic_is_empty_string?: boolean;
     is_stream_topic?: boolean;
     is_empty_string_topic?: boolean;
     is_default_language?: boolean;
@@ -226,6 +229,16 @@ export const render_stream_topic = (topic_object: TopicSuggestion): string =>
     render_typeahead_item({
         topic_object,
         is_stream_topic: true,
+    });
+
+// `render_stream_topic` shows a topic under an already-chosen channel.
+// This shows the channel and topic together, for topic suggestions
+// that can come from any channel.
+export const render_stream_and_topic = (item: StreamTopicSuggestion): string =>
+    render_typeahead_item({
+        stream: item.stream_data,
+        topic: item.topic_display_name,
+        topic_is_empty_string: item.is_empty_string_topic,
     });
 
 export function rewire_render_stream(value: typeof render_stream): void {

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -96,6 +96,10 @@
             color: var(--color-compose-chevron-arrow);
             text-decoration: none;
         }
+
+        .stream-to-topic-separator {
+            margin: 0 0.25em; /* 4px at 16px em */
+        }
     }
 
     .active > a {

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -32,6 +32,9 @@
         <strong class="typeahead-strong-section{{#if is_empty_string_topic}} empty-topic-display{{/if}}{{#if is_default_language}} default-language-display{{/if}}">
             {{~#if stream~}}
                 {{~> decorated_channel_name stream=stream ~}}
+                {{~#if topic~}}
+                    <span class="stream-to-topic-separator">&gt;</span><strong class="typeahead-strong-section{{#if topic_is_empty_string}} empty-topic-display{{/if}}">{{~ topic ~}}</strong>
+                {{~/if~}}
                 {{~else~}}
                 {{~ primary ~}}
             {{~/if~}}

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -129,6 +129,7 @@ set_global("setTimeout", (f, time) => {
 set_global("document", "document-stub");
 
 const typeahead = zrequire("typeahead");
+const linkifiers = zrequire("linkifiers");
 const stream_topic_history = zrequire("stream_topic_history");
 const compose_state = zrequire("compose_state");
 const emoji = zrequire("emoji");
@@ -1173,6 +1174,30 @@ test("content_typeahead_selected", ({override}) => {
     expected_value = "[#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)>";
     assert.equal(actual_value, expected_value);
 
+    // stream_topic
+    ct.get_or_set_completing_for_tests("stream_topic");
+    const sweden_ice_topic = {
+        topic: "more ice",
+        topic_display_name: "more ice",
+        is_empty_string_topic: false,
+        type: "stream_topic",
+        stream_data: sweden_stream,
+    };
+
+    query = "Hello #more ic";
+    ct.get_or_set_token_for_testing("more ic");
+    actual_value = ct.content_typeahead_selected(sweden_ice_topic, query, input_element);
+    expected_value = "Hello #**Sweden>more ice** ";
+    assert.equal(actual_value, expected_value);
+
+    // The token excludes the `**`, so selecting a topic must also
+    // clean up the leftover `#*`.
+    query = "Hello #**more ic";
+    ct.get_or_set_token_for_testing("more ic");
+    actual_value = ct.content_typeahead_selected(sweden_ice_topic, query, input_element);
+    expected_value = "Hello #**Sweden>more ice** ";
+    assert.equal(actual_value, expected_value);
+
     // topic_list
     ct.get_or_set_completing_for_tests("topic_list");
 
@@ -1759,7 +1784,8 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                     return 7;
                 };
                 let actual_value = options.source("test #s", input_element);
-                assert.deepEqual(sorted_names_from(actual_value), ["Sweden", "The Netherlands"]);
+                const stream_matches = actual_value.filter((item) => item.type === "stream");
+                assert.deepEqual(sorted_names_from(stream_matches), ["Sweden", "The Netherlands"]);
                 assert.ok(caret_called);
 
                 othello.delivery_email = "othello@zulip.com";
@@ -2833,6 +2859,19 @@ test("content_item_html", ({override_rewire}) => {
     });
     ct.content_item_html("")(emoji);
 
+    ct.get_or_set_completing_for_tests("stream_topic");
+    assert.ok(
+        ct
+            .content_item_html("")({
+                topic: "more ice",
+                topic_display_name: "more ice",
+                is_empty_string_topic: false,
+                type: "stream_topic",
+                stream_data: sweden_stream,
+            })
+            .includes("more ice"),
+    );
+
     ct.get_or_set_completing_for_tests("mention");
     let th_render_person_called = false;
     override_rewire(typeahead_helper, "render_person", (person, opts) => {
@@ -2892,6 +2931,36 @@ test("content_item_html", ({override_rewire}) => {
     assert.ok(th_render_stream_called);
     assert.ok(th_render_typeahead_item_called);
     assert.ok(th_render_slash_command_called);
+});
+
+test("render_stream_and_topic", () => {
+    // The topic renders next to the channel, styled like it, so that
+    // it reads as a `channel > topic` link.
+    const html = typeahead_helper.render_stream_and_topic({
+        topic: "more ice",
+        topic_display_name: "more ice",
+        is_empty_string_topic: false,
+        type: "stream_topic",
+        stream_data: sweden_stream,
+    });
+    assert.ok(html.includes("Sweden"));
+    assert.ok(html.includes('<strong class="typeahead-strong-section">more ice</strong>'));
+    assert.ok(!html.includes("empty-topic-display"));
+
+    // The empty topic gets its usual styling, and only on the topic,
+    // not on the channel name.
+    const empty_topic_html = typeahead_helper.render_stream_and_topic({
+        topic: "",
+        topic_display_name: get_final_topic_display_name(""),
+        is_empty_string_topic: true,
+        type: "stream_topic",
+        stream_data: sweden_stream,
+    });
+    assert.ok(
+        empty_topic_html.includes(
+            `<strong class="typeahead-strong-section empty-topic-display">${get_final_topic_display_name("")}</strong>`,
+        ),
+    );
 });
 
 function possibly_silent_list(list, is_silent) {
@@ -3367,4 +3436,116 @@ test("get_pm_people respects DM permissions", ({override}) => {
     // permission group should not appear.
     results = ct.get_pm_people("othello");
     assert.deepEqual(results, []);
+});
+
+test("stream_topic suggestions for '#'", ({override_rewire}) => {
+    // We compose to Denmark below, so seed it to check that its topics
+    // sort before other channels'.
+    for (const [message_id, topic_name] of [
+        [201, "ice hockey"],
+        [202, "design"],
+    ]) {
+        stream_topic_history.add_message({
+            stream_id: denmark_stream.stream_id,
+            message_id,
+            topic_name,
+        });
+    }
+
+    const input_element = {
+        $element: {},
+        type: "input",
+    };
+
+    function candidates_for(input) {
+        // Stub out split_at_cursor that uses $(':focus')
+        override_rewire(ct, "split_at_cursor", () => [input, ""]);
+        return ct.get_candidates(input, input_element);
+    }
+
+    function suggestions_for(input) {
+        return candidates_for(input).map((item) =>
+            item.type === "stream_topic"
+                ? `${item.stream_data.name} > ${item.topic_display_name}`
+                : item.name,
+        );
+    }
+
+    // A query that names no channel still suggests matching topics
+    // from every channel.
+    compose_state.set_stream_id(undefined);
+    assert.deepEqual(suggestions_for("#ice").toSorted(), [
+        "Denmark > ice hockey",
+        "Sweden > even more ice",
+        "Sweden > ice",
+        "Sweden > more ice",
+    ]);
+
+    // Topics in the channel being composed to sort first.
+    compose_state.set_stream_id(denmark_stream.stream_id);
+    assert.deepEqual(suggestions_for("#ice")[0], "Denmark > ice hockey");
+    compose_state.set_stream_id(sweden_stream.stream_id);
+    assert.deepEqual(suggestions_for("#ice")[0], "Sweden > ice");
+
+    // Channels come before topics, so topics never get in the way of a
+    // plain channel mention.  "stream" sorts before "stream_topic", so
+    // an already-sorted list of types proves the order.
+    const types = candidates_for("#de").map((item) => item.type);
+    assert.ok(types.includes("stream") && types.includes("stream_topic"));
+    assert.deepEqual(types.toSorted(), types);
+
+    // The empty topic matches by its display name, but only for the
+    // channel being composed to, so it does not bury real topics by
+    // appearing for every channel.  Denmark also has an empty topic here.
+    stream_topic_history.add_message({
+        stream_id: denmark_stream.stream_id,
+        message_id: 204,
+        topic_name: "",
+    });
+    compose_state.set_stream_id(sweden_stream.stream_id);
+    assert.deepEqual(suggestions_for("#general ch"), [
+        `Sweden > ${get_final_topic_display_name("")}`,
+    ]);
+    compose_state.set_stream_id(denmark_stream.stream_id);
+    assert.deepEqual(suggestions_for("#general ch"), [
+        `Denmark > ${get_final_topic_display_name("")}`,
+    ]);
+
+    // Topics are offered for the explicit `#**` syntax too.
+    assert.deepEqual(suggestions_for("#**ice hock"), ["Denmark > ice hockey"]);
+
+    const issues_stream = stream_item(
+        make_stream({
+            name: "12 issues",
+            stream_id: 7,
+            subscribed: true,
+        }),
+    );
+    stream_data.add_sub_for_tests(issues_stream);
+    stream_topic_history.add_message({
+        stream_id: issues_stream.stream_id,
+        message_id: 203,
+        topic_name: "1234 bug",
+    });
+    linkifiers.update_linkifier_rules([
+        {
+            pattern: "#(?P<id>[0-9]{2,8})",
+            url_template: "https://trac.example.com/ticket/{id}",
+        },
+    ]);
+
+    // An issue number handled by a linkifier should not open the
+    // typeahead just to show topics...
+    assert.deepEqual(suggestions_for("#1234"), []);
+    // ...but the explicit channel-mention syntax is never suppressed...
+    assert.deepEqual(suggestions_for("#**1234"), ["12 issues > 1234 bug"]);
+    // ...and neither is a query naming a channel, since the typeahead
+    // would have opened for the channel anyway.
+    assert.deepEqual(suggestions_for("#12"), ["12 issues", "12 issues > 1234 bug"]);
+
+    linkifiers.update_linkifier_rules([]);
+
+    // Channels filling the typeahead skip topic gathering.
+    override_rewire(ct, "max_num_items", 1);
+    assert.deepEqual(suggestions_for("#12"), ["12 issues"]);
 });

--- a/web/tests/stream_topic_history.test.cjs
+++ b/web/tests/stream_topic_history.test.cjs
@@ -130,6 +130,35 @@ test("basics", () => {
     });
 });
 
+test("get_recent_topic_names_unsorted", () => {
+    const stream_id = 56;
+
+    for (const [message_id, topic_name] of [
+        [101, "topic1"],
+        [103, "topic2"],
+        [102, "topic3"],
+    ]) {
+        stream_topic_history.add_message({stream_id, message_id, topic_name});
+    }
+
+    // Same set of topics as the sorted getter, but not in recency order.
+    assert.deepEqual(stream_topic_history.get_recent_topic_names_unsorted(stream_id).toSorted(), [
+        "topic1",
+        "topic2",
+        "topic3",
+    ]);
+    assert.deepEqual(stream_topic_history.get_recent_topic_names(stream_id), [
+        "topic2",
+        "topic3",
+        "topic1",
+    ]);
+
+    // A channel we have no history for returns nothing, and asking does
+    // not create a cached history for it.
+    assert.deepEqual(stream_topic_history.get_recent_topic_names_unsorted(9999), []);
+    assert.ok(!stream_topic_history.stream_has_topics(9999));
+});
+
 test("server_history", () => {
     const sub = make_stream({
         name: "devel",


### PR DESCRIPTION
## Changes

Previously, typing `#` in the compose box only suggested streams (channels); users had to first select a stream before topics would appear in the typeahead.

This PR adds topic suggestions directly when typing `#` without requiring the user to select a stream first.

## Behavior

When a user types `#keyword`, the typeahead now shows:
1. **Streams** matching the keyword (sorted, shown first)
2. **Topics** matching the keyword across all streams (shown after streams)
   - Topics from the **current stream** are prioritized
   - Topics from other streams follow after

Fixes: #14468

<hr>
**_Note_** - Empty topic ("general chat") handling: Since nearly every channel has an empty topic, matching it across all channels would fill the typeahead with `channel > general chat` rows and bury real topics (any prefix of "general" matches "general chat"). So the empty topic is offered only for the channel being composed to, not for other channels.
<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

## **Screenshots and screen captures:**

**Now also suggest the topics.**

| Before | After |
|--------|-------|
|<img width="1057" height="542" alt="Screenshot 2026-03-11 013723" src="https://github.com/user-attachments/assets/a8d6be2f-ffec-4e36-969e-9ac9646ac4c7" />|<img width="1035" height="345" alt="Screenshot 2026-03-11 125603" src="https://github.com/user-attachments/assets/9faa85ef-b0a6-470d-b6ff-323c80e027d2" />|

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/f047522a-16e9-4dff-b3fd-05356c3d05a4" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/e18e2cea-0c7f-4adf-bfc8-082b0f1cc561" width="400" controls></video> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
