### PR TITLE
scheduled-message: Run markdown once via check_message.

### DIFF
--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -22,7 +22,6 @@ from zerver.lib.exceptions import (
     RealmDeactivatedError,
     UserDeactivatedError,
 )
-from zerver.lib.markdown import render_message_markdown
 from zerver.lib.message import SendMessageRequest, access_message, truncate_topic
 from zerver.lib.recipient_parsing import extract_direct_message_recipient_ids, extract_stream_id
 from zerver.lib.reminders import get_reminder_formatted_content, notify_remove_reminder
@@ -114,11 +113,8 @@ def do_schedule_messages(
         scheduled_message.recipient = send_request.message.recipient
         topic_name = send_request.message.topic_name()
         scheduled_message.set_topic_name(topic_name=topic_name)
-        rendering_result = render_message_markdown(
-            send_request.message, send_request.message.content, send_request.realm
-        )
         scheduled_message.content = send_request.message.content
-        scheduled_message.rendered_content = rendering_result.rendered_content
+        scheduled_message.rendered_content = send_request.rendering_result.rendered_content
         scheduled_message.sending_client = send_request.message.sending_client
         scheduled_message.stream = send_request.stream
         scheduled_message.realm = send_request.realm
@@ -192,6 +188,7 @@ def edit_scheduled_message(
         scheduled_message_object.recipient, sender.id
     )
 
+    send_request: SendMessageRequest | None = None
     # If any recipient information or message content has been updated,
     # we check the message again.
     if recipient_type_name is not None or message_to is not None or message_content is not None:
@@ -238,6 +235,7 @@ def edit_scheduled_message(
         )
 
     if recipient_type_name is not None or message_to is not None:
+        assert send_request is not None
         # User has updated the scheduled message's recipient.
         scheduled_message_object.recipient = send_request.message.recipient
         scheduled_message_object.stream = send_request.stream
@@ -253,14 +251,12 @@ def edit_scheduled_message(
         scheduled_message_object.set_topic_name(topic_name=new_topic_name)
 
     if message_content is not None:
+        assert send_request is not None
         # User has updated the scheduled messages's content.
-        rendering_result = render_message_markdown(
-            send_request.message, send_request.message.content, send_request.realm
-        )
         scheduled_message_object.content = send_request.message.content
-        scheduled_message_object.rendered_content = rendering_result.rendered_content
+        scheduled_message_object.rendered_content = send_request.rendering_result.rendered_content
         attachment_reference_change = check_attachment_reference_change(
-            scheduled_message_object, rendering_result
+            scheduled_message_object, send_request.rendering_result
         )
         scheduled_message_object.has_attachment = attachment_reference_change.did_attachment_change
 


### PR DESCRIPTION
When scheduling a new `ScheduledMessage` or editing an existing one's content, we run `check_message` creating a `SendMessageRequest` that has already run the markdown processor on the content of the scheduled message.

So instead of running markdown again for scheduling or editing a `ScheduledMessage`, we use the `SendMessageRequest.rendering_result`.

Note that when we actually deliver/send the scheduled message, we rerun `check_message` so that markdown syntax referencing data that's mutable will be up-to-date for when it's sent vs when it was scheduled/edited.

```python
def send_scheduled_message(scheduled_message: ScheduledMessage) -> None:
...

    # Calling check_message again is important because permissions may
    # have changed since the message was originally scheduled. This
    # means that Markdown syntax referencing mutable organization data
    # (for example, mentioning a user by name) will work (or not) as
    # if the message was sent at the delivery time, not the sending
    # time.
    send_request = check_message(
        scheduled_message.sender,
        scheduled_message.sending_client,
        addressee,
        scheduled_message.content,
        scheduled_message.realm,
    )
```

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
