### PR TITLE
push: Add Pydantic validation for remote server payload.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -432,9 +432,7 @@ def parse_fcm_options(options: dict[str, Any], data: dict[str, Any]) -> str:
 
     Returns `priority`.
     """
-    priority = (
-        options.pop("priority", None) if isinstance(options, dict) else options.get("priority")
-    )
+    priority = options.pop("priority", None)
     if priority is None:
         # An older server.  Identify if this seems to be an actual notification.
         if data.get("event") == "message":
@@ -448,7 +446,7 @@ def parse_fcm_options(options: dict[str, Any], data: dict[str, Any]) -> str:
             ).format(priority=priority)
         )
 
-    if options and isinstance(options, dict) and len(options) > 0:
+    if options:
         # We're strict about the API; there is no use case for a newer Zulip
         # server talking to an older bouncer, so we only need to provide
         # one-way compatibility.


### PR DESCRIPTION
Replaces the generic Dict[str, Any] typing for the gcm_payload, pns_payload, and gcm_options fields in the
RemoteServerNotificationPayload payload structure.

By adding explicit GcmPayload, ApnsPayload, and GcmOptions Wait models, we allow the @typed_endpoint decorator on

emote_server_notify_push to validate incoming pushes strictly. The models are dumped back to dictionaries before being passed into downstream push notification helper functions, ensuring backward compatibility with existing Android and Apple payload processing.

Fixes #29469.

<!-- Describe your pull request here.-->



**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
