### PR TITLE
portico/navbar: Allow submenu overflow so long menus are scrollable

### DIFF
--- a/web/styles/portico/navbar.css
+++ b/web/styles/portico/navbar.css
@@ -28,7 +28,7 @@ details summary::-webkit-details-marker {
     backdrop-filter: blur(10px);
     color: hsl(0deg 0% 100%);
     z-index: 10;
-    overflow: hidden;
+    overflow: visible;
     transition: background-color 0.3s ease-out;
 
     &:hover {


### PR DESCRIPTION
Fixes #37091.\n\nThe top navigation container used , which clipped tall submenus (e.g., Case studies) and prevented scrolling to reach the bottom entries. Switching to  lets the submenu extend beyond the navbar and remain page-scrollable. No behavioral impact outside the portico navbar; backdrop and hover styles remain intact.