### PR TITLE
outgoing_http: Don't try to use non-existent Smokescreen in dev.

### DIFF
--- a/zerver/lib/outgoing_http.py
+++ b/zerver/lib/outgoing_http.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import requests
+from django.conf import settings
 from typing_extensions import override
 from urllib3.util import Retry
 
@@ -40,7 +41,7 @@ class OutgoingSession(requests.Session):
         if headers:
             self.headers.update(headers)
 
-        if proxies is None:
+        if proxies is None and not settings.DEVELOPMENT:
             proxy_host = get_config("http_proxy", "host", "localhost")
             proxy_port = get_config("http_proxy", "port", "4750")
             proxy = ""
@@ -52,7 +53,7 @@ class OutgoingSession(requests.Session):
                         "https": proxy,
                     }
                 )
-        else:
+        elif proxies is not None:
             self.proxies.update(proxies)
 
 

--- a/zerver/tests/test_outgoing_http.py
+++ b/zerver/tests/test_outgoing_http.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import requests
 import responses
+from django.test import override_settings
 from requests.adapters import HTTPAdapter
 from typing_extensions import override
 from urllib3.util import Retry
@@ -44,6 +45,9 @@ class RequestMockWithTimeoutAsHeader(responses.RequestsMock):
         return super()._on_request(adapter, request, **kwargs)
 
 
+# The general forcing of requests through Smokescreen only happens
+# when DEVELOPMENT=False
+@override_settings(DEVELOPMENT=False)
 class TestOutgoingHttp(ZulipTestCase):
     def test_headers(self) -> None:
         with RequestMockWithProxySupport() as mock_requests:


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
