### PR TITLE
email_mirror: Add alias for iso-8859-8-i hebrew encoding

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -1,6 +1,8 @@
+import encodings.aliases
 import logging
 import re
 import secrets
+import sys
 from email.headerregistry import Address, AddressHeader
 from email.message import EmailMessage
 from re import Match
@@ -44,6 +46,15 @@ from zerver.models.clients import get_client
 from zerver.models.streams import StreamTopicsPolicyEnum, get_stream_by_id_in_realm
 from zerver.models.users import get_system_bot, get_user_profile_by_id
 from zproject.backends import is_user_active
+
+if sys.version_info < (3, 14):
+    # https://github.com/python/cpython/issues/62824
+    encodings.aliases.aliases.update(
+        {
+            "iso_8859_8_i": "iso8859_8",
+            "iso_8859_8_e": "iso8859_8",
+        }
+    )
 
 logger = logging.getLogger(__name__)
 

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -28,6 +28,7 @@ from zerver.lib.email_mirror import (
     create_missed_message_address,
     filter_footer,
     generate_missed_message_token,
+    get_message_part_by_type,
     get_missed_message_token_from_address,
     is_forwarded,
     is_missed_message_address,
@@ -1872,6 +1873,21 @@ class TestContentTypeInvalidCharset(ZulipTestCase):
         message = most_recent_message(user_profile)
 
         self.assertEqual(message.content, "Email fixture 1.txt body")
+
+    def test_israel_encoding_alias(self) -> None:
+        # in hebrew: shalom (שלום)
+        hebrew_text_bytes = b"\xf9\xec\xe5\xed"
+
+        message = EmailMessage()
+        message.set_payload(hebrew_text_bytes)
+
+        # testing exact string
+        message["Content-Type"] = 'text/plain; charset="iso-8859-8-i"'
+
+        # return the decoded string
+        decoded_body = get_message_part_by_type(message, "text/plain")
+
+        self.assertEqual(decoded_body, "שלום")
 
 
 class TestEmailMirrorProcessMessageNoValidRecipient(ZulipTestCase):


### PR DESCRIPTION
<!-- Describe your pull request here.-->
My Pull Request (PR) adds a character set alias for `iso-8859-8-i` (Language: Hebrew) in the Zulip email gateway.

 <!-- Issue link, or clear description.-->
**Fixes:**

- I refactored `get_message_part_by_type` in `zever/lib/email_mirror.py` to use `part.get_content_charset()` for clarity, which removes the reliance on manual indexing via `message.get_charsets()`.

- I also added a version conditional fix for Python versions younger than 3.14. This updates `encodings.aliases` to map to `iso_8859_8_i` and `iso_8859_8_e` to a recognized `iso8859_8` codec.

- I have updated comments in these code files to describe the changes.

**How changes were tested:**

- _Backend Testing:_ I added a new test case, `test_israel_encoding_alias` to this file: `zerver/tests/test_email_mirror.py`. The test feeds raw ISO-8859-8 bytes for "שלום" (Shalom) into the decoder and gives the correct string output.

- _Regression Testing:_ After backend testing, I ran all the tests in `zerver/tests/test_email_mirror.py`. This results in 71 tests being run in `~18.137` seconds with a status of: `OK`.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<!-- **Screenshots and screen captures:** -->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

#### Refer to Issue #23188 for further information.
#### Status: Merged