### PR TITLE
[ai] message_header: Fix stale inline display style on unresolve indicator.

### DIFF
--- a/web/src/message_list.ts
+++ b/web/src/message_list.ts
@@ -554,14 +554,14 @@ export class MessageList {
         $recipient_row.find(".topic_edit").append($form);
         $recipient_row.find(".stream_topic").hide();
         $recipient_row.find(".topic_edit").show();
-        $recipient_row.find(".recipient-bar-control").hide();
+        $recipient_row.find(".recipient_bar_controls").addClass("topic-edit-mode");
     }
 
     hide_edit_topic_on_recipient_row($recipient_row: JQuery): void {
         $recipient_row.find(".stream_topic").show();
         $recipient_row.find(".topic_edit").empty();
         $recipient_row.find(".topic_edit").hide();
-        $recipient_row.find(".recipient-bar-control").show();
+        $recipient_row.find(".recipient_bar_controls").removeClass("topic-edit-mode");
     }
 
     reselect_selected_id(): void {

--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -281,6 +281,10 @@
     display: flex;
     flex-grow: 1;
     align-items: center;
+
+    &.topic-edit-mode .recipient-bar-control {
+        display: none;
+    }
 }
 
 .on_hover_topic_read {


### PR DESCRIPTION
Fixes: stale inline `display` style on unresolve loading indicator after exiting inline topic edit.

When editing a topic in the recipient bar of a resolved topic and then
canceling, `hide_edit_topic_on_recipient_row` called jQuery `.show()` on all
`.recipient-bar-control` elements. jQuery `.show()` sets an inline `display:
inline-block` style, which overrides the CSS `.hide` class on the
`on-hover-unresolve-loading-indicator` button, leaving it with `display:
inline-block` instead of `none`.

**How to reproduce:**

1. Resolve a topic.
2. Click the pencil icon in the recipient bar to start editing the topic.
3. Press <kbd>Escape</kbd> or click away to cancel the edit.
4. Inspect the unresolve loading indicator button — it has `display:
   inline-block` (from the jQuery inline style) instead of `display: none`
   (from the `.hide` CSS class).

**Fix:** Replace the jQuery `.hide()`/`.show()` calls on individual
`.recipient-bar-control` children with a `topic-edit-mode` CSS class toggled
on the parent `.recipient_bar_controls` container. Removing the class on edit
exit lets CSS take back control — elements with `.hide` stay hidden, and
normal elements become visible — without any inline style conflicts.

before:

 https://github.com/user-attachments/assets/fd07cd5c-e1cb-40a1-8fb0-ea0b39d1734c 


after:

 https://github.com/user-attachments/assets/5a4f6c20-a739-457a-b4c9-c50e16ede671





**How changes were tested:**

- [x] Reproduced the bug, verified the fix resolves it.
- [x] `./tools/test-js-with-node web/tests/message_list web/tests/message_list_view` — pass.

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

---

> **User prompt that created this PR:**
> In message view recipient bar, for a resolved topic, when you edit topic and exit, `recipient-bar-control on-hover-unresolve-loading-indicator hidden-for-spectators hide icon-button icon-button-neutral` has `display: inline-block` instead `none` and the button is not visible.