### PR TITLE
Synchronize Realm plan_type with Stripe upgrade

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1906,7 +1906,18 @@ class BillingSession(ABC):
                 "billing_schedule": billing_schedule,
                 "tier": plan_tier,
             }
-
+# Ensure the realm plan type is updated at the end of a successful upgrade.
+        # This triggers the WebSocket event that hides the "Upgrade" button in the UI.
+        if isinstance(self, RealmBillingSession) and self.realm is not None:
+            from zerver.lib.actions import do_change_realm_plan_type
+            from zerver.models import Realm
+            
+            new_plan_type = Realm.PLAN_TYPE_STANDARD
+            if plan_tier == CustomerPlan.TIER_CLOUD_PLUS:
+                new_plan_type = Realm.PLAN_TYPE_PLUS
+            
+            if self.realm.plan_type != new_plan_type:
+                do_change_realm_plan_type(self.realm, new_plan_type, acting_user=None)
             if free_trial:
                 plan_params["status"] = CustomerPlan.FREE_TRIAL
                 if charge_automatically:


### PR DESCRIPTION
This PR addresses an issue where the Realm plan_type was not immediately synchronized after a successful Stripe upgrade. By adding this update at the end of the upgrade process, we ensure that the internal state matches the Stripe status immediately.

Technical Changes
File: corporate/lib/stripe.py

Action: Added a synchronization step for the realm plan type at the end of the upgrade logic.
Impact: This triggers the necessary WebSocket events to update the UI (such as hiding the "Upgrade" button) without requiring a page refresh or waiting for a background sync.
