### PR TITLE
search: Fix narrow banner for quoted stop words.

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -92,11 +92,18 @@ function empty_search_query_banner(current_filter: Filter): NarrowBannerData {
 
     // Gather information about each query word
     for (const query_word of query_words) {
-        if (realm.stop_words.includes(query_word)) {
+        // Capture leading quotes, the core word, and trailing quotes
+        const match = /^(['"]*)(.*?)(['"]*)$/.exec(query_word);
+        const prefix = match?.[1] ?? "";
+        const cleaned_query_word = match?.[2] ?? query_word;
+        const suffix = match?.[3] ?? "";
+        if (realm.stop_words.includes(cleaned_query_word)) {
             search_string_result.has_stop_word = true;
             search_string_result.query_words.push({
-                query_word,
+                query_word: cleaned_query_word,
                 is_stop_word: true,
+                prefix,
+                suffix,
             });
         } else {
             search_string_result.query_words.push({

--- a/web/src/narrow_error.ts
+++ b/web/src/narrow_error.ts
@@ -3,6 +3,8 @@ import render_empty_feed_notice from "../templates/empty_feed_notice.hbs";
 type QueryWord = {
     query_word: string;
     is_stop_word: boolean;
+    prefix?: string;
+    suffix?: string;
 };
 
 export type SearchData = {

--- a/web/templates/empty_feed_notice.hbs
+++ b/web/templates/empty_feed_notice.hbs
@@ -6,7 +6,7 @@
             {{t "Common words were excluded from your search:" }} <br/>
             {{#each search_data.query_words}}
                 {{#if is_stop_word}}
-                <del>{{query_word}}</del>
+                {{prefix}}<del>{{query_word}}</del>{{suffix}}
                 {{else}}
                 <span class="search-query-word">{{query_word}}</span>
                 {{/if}}

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -148,7 +148,9 @@ run_test("empty_narrow_html", ({mock_template}) => {
     const search_data_with_stop_word = {
         has_stop_word: true,
         query_words: [
-            {query_word: "a", is_stop_word: true},
+            {query_word: "this", is_stop_word: true, prefix: '"', suffix: '"'},
+            {query_word: "is", is_stop_word: true, prefix: "'", suffix: "'"},
+            {query_word: "a", is_stop_word: true, prefix: "", suffix: ""},
             {query_word: "search", is_stop_word: false},
         ],
     };
@@ -159,6 +161,8 @@ run_test("empty_narrow_html", ({mock_template}) => {
     <h4 class="empty-feed-notice-title"> This is a title </h4>
         <div class="empty-feed-notice-description">
             translated: Common words were excluded from your search: <br/>
+                &quot;<del>this</del>&quot;
+                &#x27;<del>is</del>&#x27;
                 <del>a</del>
                 <span class="search-query-word">search</span>
         </div>
@@ -169,9 +173,9 @@ run_test("empty_narrow_html", ({mock_template}) => {
     const search_data_with_stop_words = {
         has_stop_word: true,
         query_words: [
-            {query_word: "a", is_stop_word: true},
+            {query_word: "a", is_stop_word: true, prefix: "", suffix: ""},
             {query_word: "search", is_stop_word: false},
-            {query_word: "and", is_stop_word: true},
+            {query_word: "and", is_stop_word: true, prefix: "", suffix: ""},
             {query_word: "return", is_stop_word: false},
         ],
     };
@@ -691,8 +695,8 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
     const expected_search_data = {
         has_stop_word: true,
         query_words: [
-            {query_word: "what", is_stop_word: true},
-            {query_word: "about", is_stop_word: true},
+            {query_word: "what", is_stop_word: true, prefix: "", suffix: ""},
+            {query_word: "about", is_stop_word: true, prefix: "", suffix: ""},
             {query_word: "grail", is_stop_word: false},
         ],
     };
@@ -701,6 +705,20 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: No search results.", undefined, expected_search_data),
+    );
+
+    current_filter = set_filter([["search", "\"what\" 'about' grail"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html("translated: No search results.", undefined, {
+            has_stop_word: true,
+            query_words: [
+                {query_word: "what", is_stop_word: true, prefix: '"', suffix: '"'},
+                {query_word: "about", is_stop_word: true, prefix: "'", suffix: "'"},
+                {query_word: "grail", is_stop_word: false},
+            ],
+        }),
     );
 
     const streamA_id = 88;


### PR DESCRIPTION
Previously, searching a stop word within quotes did not trigger the expected warning: "Common words are excluded from your search." This commit corrects the behavior so that the warning is shown consistently.

Fixes #30470.
This PR resolves conflicts in #36054.
A few differences from the prev attempt, It instead of removing all double quotes, it removes double quotes in the front and back of the query word. 
Also adds logic tests to verify quoted strings are correctly identified as stop words.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Search | Before | After |
| --- | --- | --- |
| **Without quoted search** | ![Before without quotes](https://github.com/user-attachments/assets/f4463fe8-a5be-455d-9a29-7e8add97fd4a) | ![After without quotes](https://github.com/user-attachments/assets/f4463fe8-a5be-455d-9a29-7e8add97fd4a) |
| **With quoted search** | ![Before with quotes](https://github.com/user-attachments/assets/3fb50ff9-4c45-4e65-94c0-7c4aaf4f49a3) | ![After with quotes](https://github.com/user-attachments/assets/45e1a616-36e2-485d-848d-a991227ff5ec) |

| `from` as the first word | `from` as the last word |
| :---: | :---: |
| <img width="1019" height="483" alt="'from' as first word" src="https://github.com/user-attachments/assets/7dcfb17e-0e4e-4a20-b374-c73e6eaf4ecf" /> | <img width="1035" height="532" alt="'from' as last word" src="https://github.com/user-attachments/assets/d9ffab19-de5f-4cb3-9dcb-110d99fc3d2a" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
