### PR TITLE
typeahead: Open topic typeahead immediately when user lacks create-topic permission.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1564,7 +1564,9 @@ export function initialize_topic_edit_typeahead(
         getCustomItemClassname() {
             return "topic-edit-typeahead";
         },
-        showOnClick: false,
+        showOnClick: !stream_data.can_create_new_topics_in_stream(
+            stream_data.get_stream_id(stream_name) ?? 0,
+        ),
     });
 }
 
@@ -1715,6 +1717,7 @@ export function initialize({
             return [...people_candidates, ...topics];
         },
         items: max_num_items,
+        showOnClick: false,
         item_html(item: string | UserPillData): string {
             if (typeof item === "string") {
                 const is_empty_string_topic = item === "";


### PR DESCRIPTION
When a user lacks the `can_create_topic` permission in a channel, 
the topic typeahead should open immediately on click, since they 
cannot enter a free-form topic and must select from existing ones.

Changes:
- In `stream_message_topic_typeahead`: set `showOnClick: true` so 
  the typeahead opens immediately on click.
- In `initialize_topic_edit_typeahead`: set `showOnClick` based on 
  whether the user can create new topics in the stream.

Fixes #36970.