### PR TITLE
[ai] help: Document filters in recent conversations view.

### DIFF
--- a/starlight_help/src/content/docs/recent-conversations.mdx
+++ b/starlight_help/src/content/docs/recent-conversations.mdx
@@ -20,6 +20,79 @@ import RecentConversations from "../include/_RecentConversations.mdx";
   <kbd>L</kbd>, <kbd>H</kbd>) can be used to move between elements.
 </KeyboardTip>
 
+## Filter conversations
+
+### Filter by topic status
+
+In the web app, you can control whether **recent conversations** includes all
+topics, just [unmuted](/help/mute-a-topic) topics, or only topics you
+[follow](/help/follow-a-topic).
+
+<Tabs>
+  <TabItem label="Desktop/Web">
+    <FlattenedSteps>
+      <GoToRecentConversations />
+
+      1. Select **All topics**, **Standard view**, or **Followed topics** from
+         the dropdown in the upper left of the **recent conversations** view.
+    </FlattenedSteps>
+  </TabItem>
+</Tabs>
+
+### Filter by keyword
+
+<Tabs>
+  <TabItem label="Desktop/Web">
+    <FlattenedSteps>
+      <GoToRecentConversations />
+
+      1. Use the **Filter topics** box at the top to find a conversation.
+         You can filter by channel, topic, or direct message participants.
+    </FlattenedSteps>
+  </TabItem>
+</Tabs>
+
+<KeyboardTip>
+  In the **recent conversations** view, you can use <kbd>T</kbd> to start
+  filtering.
+</KeyboardTip>
+
+### Filter by folder
+
+If your organization sorts channels into [folders](/help/channel-folders), you
+can filter **recent conversations** to show only conversations in channels in a
+specific folder.
+
+<Tabs>
+  <TabItem label="Desktop/Web">
+    <FlattenedSteps>
+      <GoToRecentConversations />
+
+      1. Select a folder from the folder dropdown at the top of the
+         **recent conversations** view.
+    </FlattenedSteps>
+  </TabItem>
+</Tabs>
+
+### Other filters
+
+You can filter which conversations are shown to focus your attention:
+
+* **Include DMs**: Enable to include direct messages conversations.
+* **Unread**: Enable to only show conversations where you have unread messages.
+* **Participated**: Enable to only show conversations where you participated recently.
+
+<Tabs>
+  <TabItem label="Desktop/Web">
+    <FlattenedSteps>
+      <GoToRecentConversations />
+
+      1. Click **Include DMs**, **Unread**, or **Participated** at the top to
+         toggle the corresponding filter.
+    </FlattenedSteps>
+  </TabItem>
+</Tabs>
+
 ## Load more conversations
 
 The **recent conversations** view displays a limited number of conversations
@@ -51,3 +124,6 @@ containing the most recent messages.
 * [List of topics in a channel](/help/list-of-topics)
 * [Combined feed](/help/combined-feed)
 * [Configure home view](/help/configure-home-view)
+* [Channel folders](/help/channel-folders)
+* [Mute or unmute a topic](/help/mute-a-topic)
+* [Follow a topic](/help/follow-a-topic)


### PR DESCRIPTION
I reviewed and manually adjusted these changes.

<img width="703" height="1057" alt="Screenshot 2026-03-11 at 16 08 05" src="https://github.com/user-attachments/assets/7e6365b8-b05b-449f-895a-64cb945e88f8" />


# Claude's description
[ai] help: Document filters in recent conversations view.

  The recent conversations view has several filter controls that were not
  documented in the help center. This adds a "Filter conversations"
  section to the recent conversations help page, parallel to the existing
  one on the inbox page, covering:

  - **Filter by topic status**: All topics / Standard view / Followed
    topics dropdown.
  - **Filter by keyword**: The "Filter topics" search box.
  - **Filter by folder**: Folder dropdown for users with channel folders.
  - **Other filters**: Include DMs, Unread, and Participated toggle
    buttons.

  Also adds Channel folders, Mute or unmute a topic, and Follow a topic
  to the related articles list.

  ## Test plan
  - [x] `./tools/lint starlight_help/src/content/docs/recent-conversations.mdx`

  ## Self-review checklist
  - [x] All relevant tests pass locally
  - [x] Code follows existing patterns in the codebase
  - [x] Commit messages, comments, and PR description are well done
  - [x] Each commit is a minimal coherent idea
  - [x] No debugging code or unnecessary comments remain
  - [x] Documentation is updated if behavior changes
