### PR TITLE
[ai] message_edit: Fix mentioned_me_directly using wrong source field.

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1372,7 +1372,7 @@ export async function save_message_row_edit($row: JQuery): Promise<void> {
             collapsed: message.collapsed,
             alerted: message.alerted,
             mentioned: message.mentioned,
-            mentioned_me_directly: message.mentioned,
+            mentioned_me_directly: message.mentioned_me_directly,
         });
         edit_locally_echoed = true;
 


### PR DESCRIPTION
When saving message state before a local echo edit, the code stored message.mentioned into the mentioned_me_directly field instead of message.mentioned_me_directly. If the edit failed and the original state was restored, a wildcard mention (mentioned=true, mentioned_me_directly=false) would incorrectly become a direct mention.

Found via asking Claude Code to audit the codebase for bugs. 

@amanagr can you do manual testing to verify this one? Feel free to merge if it is is indeed correct, I feel like there's like a 1% chance that there's something deeper wrong here.