### PR TITLE
Event queue bugs identified by Claude Code auditing the codebase

### DIFF
--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -146,6 +146,7 @@ class ClientDescriptor:
         # loading event queues that lack that key.
         return dict(
             user_profile_id=self.user_profile_id,
+            user_recipient_id=self.user_recipient_id,
             realm_id=self.realm_id,
             event_queue=self.event_queue.to_dict(),
             queue_timeout=self.queue_timeout,


### PR DESCRIPTION
I think the first commit has basically no impact; it would throw an exception in that case, but likely just has never actually occurred and never will as it is transition code for an old transition.

The second commit claims to fix a bug in e2d56db2a349e957184631aaa0f18c303d2a5748. I'm not entirely sure I understand how that `recipient_id` field is used, but figured it might be good for @alexmv to dig into it, because those `recipient_id` values will have an abrupt transition when we cut over to the new DirectMessageGroup system.