### PR TITLE
user_group_edit: Hide filter dropdown on roles tab.

### DIFF
--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1693,6 +1693,7 @@ export function switch_group_tab(tab_name: string): void {
         use `group_list_toggler.goto`.
     */
 
+    update_filter_widget_visibility(tab_name);
     redraw_left_panel(tab_name);
     setup_group_list_tab_hash(tab_name);
 }
@@ -1885,15 +1886,22 @@ function setup_dropdown_filters_widget(): void {
     filters_dropdown_widget.setup();
 }
 
-function update_filter_widget_visibility(): void {
-    if (user_groups.realm_has_deactivated_user_groups()) {
-        $("#user-group-edit-filter-options").show();
-    } else {
+function update_filter_widget_visibility(tab_name?: string): void {
+    const active_tab = tab_name ?? get_active_data().$tabs.first().attr("data-tab-key");
+    if (active_tab === "roles") {
+        // Roles cannot be deactivated, so the active/deactivated filter
+        // dropdown is not applicable on the roles tab. We hide the dropdown
+        // and ignore the filter value completely for this tab.
+        $("#user-group-edit-filter-options").hide();
+        update_displayed_groups(FILTERS.ACTIVE_GROUPS);
+    } else if (!user_groups.realm_has_deactivated_user_groups()) {
         $("#user-group-edit-filter-options").hide();
         update_displayed_groups(FILTERS.ACTIVE_GROUPS);
         if (filters_dropdown_widget) {
             filters_dropdown_widget.render(FILTERS.ACTIVE_GROUPS);
         }
+    } else {
+        $("#user-group-edit-filter-options").show();
     }
 }
 


### PR DESCRIPTION
Fixes the issue where the active/deactivated filter dropdown was visible on the `Roles` tab, even though the `Roles` cannot be deactivated.

<!-- Describe your pull request here.-->

Fixes: [#issues > active/deactivated dropdown on roles tab](https://chat.zulip.org/#narrow/channel/9-issues/topic/active.2Fdeactivated.20dropdown.20on.20roles.20tab/with/2406238)


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

## **Screenshots and screen captures:**

| Before | After |
|--------|-------|
|<img width="718" height="145" alt="Screenshot 2026-03-12 124316" src="https://github.com/user-attachments/assets/07db9b20-c5e1-4fe3-afb6-4f91e5e6eb4d" />|<img width="721" height="145" alt="Screenshot 2026-03-12 124530" src="https://github.com/user-attachments/assets/90d9e76c-b2c7-49cb-ae94-ac7a0ce93d7c" />|

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/6e34f2a1-9603-4667-855d-ee08c4923d61" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/aa027d98-345a-4a71-845f-a999b9eb93a7" width="400" controls></video> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
