### PR TITLE
i18n: Intelligently merge regional translation data.

### DIFF
--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -45,14 +45,30 @@ def get_available_language_codes() -> list[str]:
 def get_language_translation_data(language: str) -> dict[str, str]:
     if language == "en":
         return {}
+
     locale = translation.to_locale(language)
-    path = os.path.join(settings.DEPLOY_ROOT, "locale", locale, "translations.json")
-    try:
-        with open(path, "rb") as reader:
-            return orjson.loads(reader.read())
-    except FileNotFoundError:
-        print(f"Translation for {language} not found at {path}")
-        return {}
+    base_locale = locale.split("_")[0]
+
+    def _load_translations(loc: str) -> dict[str, str]:
+        path = os.path.join(settings.DEPLOY_ROOT, "locale", loc, "translations.json")
+        try:
+            with open(path, "rb") as reader:
+                return orjson.loads(reader.read())
+        except FileNotFoundError:
+            print(f"Translation for {loc} not found at {path}")
+            return {}
+
+    # 1. Start with the base language data (e.g., "de")
+    data = _load_translations(base_locale)
+
+    # 2. If it's a regional variant (e.g., "de_AT"), merge its non-empty strings
+    if locale != base_locale:
+        regional_data = _load_translations(locale)
+        for key, value in regional_data.items():
+            if value:
+                data[key] = value
+
+    return data
 
 
 def get_and_set_request_language(

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -175,6 +175,39 @@ class TranslationTestCase(ZulipTestCase):
         with mock.patch("zerver.lib.i18n.get_language_list", return_value=mocked_language_list):
             self.assertEqual(get_browser_language_code(req), "de")
 
+    def test_get_language_translation_data(self) -> None:
+        from unittest import mock
+
+        from zerver.lib.i18n import get_language_translation_data
+
+        # 1. English immediately returns an empty dict
+        self.assertEqual(get_language_translation_data("en"), {})
+
+        with (
+            mock.patch("builtins.open", new_callable=mock.mock_open) as mock_file,
+            mock.patch("zerver.lib.i18n.orjson.loads") as mock_loads,
+            mock.patch("builtins.print"),
+        ):
+            # 2. Test successful merge of base and regional locales
+            # The first dict simulates the base file, the second simulates the regional file
+            mock_loads.side_effect = [
+                {"hello": "hallo", "world": "welt", "apple": "apfel"},
+                {"world": "regional_welt", "apple": ""},
+            ]
+
+            data = get_language_translation_data("de-at")
+
+            # 'hello' only exists in base
+            self.assertEqual(data["hello"], "hallo")
+            # 'world' exists in both, regional should win
+            self.assertEqual(data["world"], "regional_welt")
+            # 'apple' is empty in regional, base should NOT be overwritten
+            self.assertEqual(data["apple"], "apfel")
+
+            # 3. Test that missing files are handled safely
+            mock_file.side_effect = FileNotFoundError
+            self.assertEqual(get_language_translation_data("invalid-lang"), {})
+
 
 class JsonTranslationTestCase(ZulipTestCase):
     @override


### PR DESCRIPTION
This PR updates `get_language_translation_data` to use the correct translation discovery algorithm for country-specific variants.

Previously, if a user selected a regional locale like `de-at`, the backend would only load the `translations.json` file for `de_AT`. If that file only contained a small subset of overridden strings, the frontend would lose the base `de` fallback strings.

**Changes:**
* Extracted the JSON file-reading logic into a `_load_translations` helper function.
* Updated `get_language_translation_data` to first load the base language data (e.g., `de`) and then merge the regional variant data (e.g., `de_AT`) over it.
* Implemented a check (`if value:`) to ensure regional strings only overwrite base strings if the regional string is not empty.
* Added a new test `test_get_language_translation_data` in `zerver/tests/test_i18n.py` to verify the dictionary merging logic and the handling of missing translation files.

Fixes: #17956

**How changes were tested:**
Ran `./tools/test-backend zerver/tests/test_i18n.py`
Ran `./tools/lint`

**Screenshots and screen captures:**
N/A (Backend logic only)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>