### PR TITLE
[ai] message_edit: Compute topic_participant_user_ids for embeds.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -456,7 +456,13 @@ def do_update_embedded_data(
         for group_id in rendered_content.mentions_user_group_ids:
             members = mention_data.get_group_members(group_id)
             rendered_content.mentions_user_ids.update(members)
-        update_user_message_flags(rendered_content, ums)
+
+        topic_participant_user_ids: set[int] = set()
+        if rendered_content.mentions_topic_wildcard and message.is_channel_message:
+            topic_participant_user_ids = participants_for_topic(
+                message.realm_id, message.recipient_id, message.topic_name()
+            )
+        update_user_message_flags(rendered_content, ums, topic_participant_user_ids)
         message.rendered_content = rendered_content.rendered_content
         message.rendered_content_version = markdown_version
         update_fields.append("rendered_content_version")

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -556,6 +556,102 @@ class PreviewTestCase(ZulipTestCase):
             int(UserMessage.flags.mentioned | UserMessage.flags.is_private),
         )
 
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_topic_wildcard_mention_preserved(self) -> None:
+        url = "http://test.org/"
+        cache_delete(preview_url_cache_key(url))
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        self.subscribe(hamlet, "Denmark")
+        self.subscribe(cordelia, "Denmark")
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            msg_id = self.send_stream_message(
+                hamlet,
+                "Denmark",
+                topic_name="test",
+                content=url + " @**topic**",
+            )
+            patched.assert_called_once()
+            queue = patched.call_args[0][0]
+            self.assertEqual(queue, "embed_links")
+            event = patched.call_args[0][1]
+
+        # Hamlet sent the message, so he is a topic participant.
+        self.assertEqual(
+            int(UserMessage.objects.get(message_id=msg_id, user_profile=hamlet).flags),
+            int(UserMessage.flags.topic_wildcard_mentioned | UserMessage.flags.read),
+        )
+        # Cordelia is not a participant in the topic
+        self.assertEqual(
+            int(UserMessage.objects.get(message_id=msg_id, user_profile=cordelia).flags),
+            0,
+        )
+
+        self.create_mock_response(url)
+        with self.settings(TEST_SUITE=False), self.assertLogs(level="INFO") as info_logs:
+            FetchLinksEmbedData().consume(event)
+        self.assertTrue(
+            "INFO:root:Time spent on get_link_embed_data for http://test.org/: "
+            in info_logs.output[0]
+        )
+
+        # The topic wildcard mention flag must be preserved.
+        self.assertEqual(
+            int(UserMessage.objects.get(message_id=msg_id, user_profile=hamlet).flags),
+            int(UserMessage.flags.topic_wildcard_mentioned | UserMessage.flags.read),
+        )
+        self.assertEqual(
+            int(UserMessage.objects.get(message_id=msg_id, user_profile=cordelia).flags),
+            0,
+        )
+
+        # Test the topic wildcard mention flag is preserved when editing a message as well.
+        msg_id = self.send_stream_message(
+            cordelia, "Denmark", topic_name="test", content=" @**topic**"
+        )
+        # Both Hamlet and Cordelia are topic participants.
+        self.assertEqual(
+            int(UserMessage.objects.get(message_id=msg_id, user_profile=hamlet).flags),
+            int(UserMessage.flags.topic_wildcard_mentioned),
+        )
+        self.assertEqual(
+            int(UserMessage.objects.get(message_id=msg_id, user_profile=cordelia).flags),
+            int(UserMessage.flags.topic_wildcard_mentioned | UserMessage.flags.read),
+        )
+
+        self.login("cordelia")
+        with mock_queue_publish("zerver.actions.message_edit.queue_event_on_commit") as patched:
+            result = self.client_patch(
+                "/json/messages/" + str(msg_id),
+                {
+                    "content": url + " @**topic**",
+                },
+            )
+            self.assert_json_success(result)
+            patched.assert_called_once()
+            queue = patched.call_args[0][0]
+            self.assertEqual(queue, "embed_links")
+            event = patched.call_args[0][1]
+
+        self.create_mock_response(url)
+        with self.settings(TEST_SUITE=False), self.assertLogs(level="INFO") as info_logs:
+            FetchLinksEmbedData().consume(event)
+        self.assertTrue(
+            "INFO:root:Time spent on get_link_embed_data for http://test.org/: "
+            in info_logs.output[0]
+        )
+
+        # The topic wildcard mention flag must be preserved.
+        self.assertEqual(
+            int(UserMessage.objects.get(message_id=msg_id, user_profile=hamlet).flags),
+            int(UserMessage.flags.topic_wildcard_mentioned),
+        )
+        self.assertEqual(
+            int(UserMessage.objects.get(message_id=msg_id, user_profile=cordelia).flags),
+            int(UserMessage.flags.topic_wildcard_mentioned | UserMessage.flags.read),
+        )
+
     def test_get_link_embed_data(self) -> None:
         url = "http://test.org/"
         embedded_link = f'<a href="{url}" title="The Rock">The Rock</a>'


### PR DESCRIPTION
When do_update_embedded_data re-renders a message that contains @topic mentions, update_user_message_flags was called without topic_participant_user_ids (defaulting to an empty set).  This caused the topic_wildcard_mentioned flag to be cleared for all user messages, even when users were genuine topic participants.

Compute topic_participant_user_ids when the rendering result contains topic wildcard mentions, matching the pattern used in do_update_message.

Original commit - https://github.com/zulip/zulip/commit/fe99fbb05bafe81ff46ec5ca602abf64cb3934fc

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

[Screencast from 2026-03-12 20-32-51.webm](https://github.com/user-attachments/assets/2d12f32e-71b7-45d5-9c29-8cd10890a7a1)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
