### PR TITLE
[ai] users: Fix check_full_name using admin profile during creation.

### DIFF
--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -234,6 +234,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.get_bot_user(email)
 
     def test_add_bot_with_username_in_use(self) -> None:
+        hamlet = self.example_user("hamlet")
         self.login("hamlet")
         self.assert_num_bots_equal(0)
         self.create_bot()
@@ -256,6 +257,17 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         )
         result = self.client_post("/json/bots", bot_info)
         self.assert_json_error(result, "Name is already in use.")
+
+        # Duplicate names are not allowed for bots even when require_unique_names
+        # is false, but this test is added just for completion.
+        dup_full_name = hamlet.full_name
+        do_set_realm_property(hamlet.realm, "require_unique_names", True, acting_user=None)
+        bot_info = dict(
+            full_name=dup_full_name,
+            short_name="whatever",
+        )
+        result = self.client_post("/json/bots", bot_info)
+        self.assert_json_error(result, "Unique names required in this organization.")
 
     def test_add_bot_with_user_avatar(self) -> None:
         email = "hambot-bot@zulip.testserver"

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1499,6 +1499,24 @@ class AdminCreateUserTest(ZulipTestCase):
         result = self.client_post("/json/users", valid_params)
         self.assert_json_success(result)
 
+        # Test require_unique_names.
+        do_set_realm_property(realm, "require_unique_names", True, acting_user=None)
+        params = dict(
+            email="same-name@zulip.net",
+            password="xxxx",
+            full_name=admin.full_name,
+        )
+        result = self.client_post("/json/users", params)
+        self.assert_json_error(result, "Unique names required in this organization.")
+
+        params["full_name"] = self.example_user("iago").full_name
+        result = self.client_post("/json/users", params)
+        self.assert_json_error(result, "Unique names required in this organization.")
+
+        params["full_name"] = "Iago new"
+        result = self.client_post("/json/users", params)
+        self.assert_json_success(result)
+
 
 class UserProfileTest(ZulipTestCase):
     def test_valid_user_id(self) -> None:

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -662,7 +662,7 @@ def add_bot_backend(
     if bot_type != UserProfile.INCOMING_WEBHOOK_BOT:
         service_name = service_name or short_name
     full_name = check_full_name(
-        full_name_raw=full_name_raw, user_profile=user_profile, realm=user_profile.realm
+        full_name_raw=full_name_raw, user_profile=None, realm=user_profile.realm
     )
     form = CreateUserForm({"full_name": full_name, "email": email})
 
@@ -899,7 +899,7 @@ def create_user_backend(
         raise JsonableError(_("User not authorized to create users"))
 
     full_name = check_full_name(
-        full_name_raw=full_name_raw, user_profile=user_profile, realm=user_profile.realm
+        full_name_raw=full_name_raw, user_profile=None, realm=user_profile.realm
     )
     form = CreateUserForm({"full_name": full_name, "email": email})
     if not form.is_valid():


### PR DESCRIPTION
Both add_bot_backend and create_user_backend passed the acting admin's user_profile to check_full_name.  With
require_unique_names enabled, this excludes the admin's own name from the uniqueness check, allowing a new user to be created with the same name as the admin.

For bots, it was not a problem since we do not allow two bots with same name even with require_unique_names disabled, but this commit still fixes the call to check_full_name in add_bot_backend.

Pass user_profile=None since we're creating a new user, not editing an existing one.

Original commit - https://github.com/zulip/zulip/commit/179d3276e4efe1e5fcae800588aa4fb9d1f3ac6b
<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
