### PR TITLE
[ai] typing: Deduplicate user IDs for self-DM typing notifications.

### DIFF
--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -893,3 +893,24 @@ class TestSendTypingNotificationsSettings(ZulipTestCase):
         self.assert_length(events, 1)
         event_user_ids = set(events[0]["users"])
         self.assertEqual(expected_recipient_ids, event_user_ids)
+
+    def test_message_edit_notifications_for_direct_messages_to_self(self) -> None:
+        hamlet = self.example_user("hamlet")
+        msg_id = self.send_personal_message(hamlet, hamlet)
+
+        params = dict(
+            op="start",
+        )
+        with self.capture_send_event_calls(expected_num_events=1) as events:
+            result = self.api_post(hamlet, f"/api/v1/messages/{msg_id}/typing", params)
+
+        self.assert_json_success(result)
+        self.assert_length(events, 1)
+
+        # Make sure that hamlet being both the sender and recipient is not included twice.
+        self.assert_length(events[0]["users"], 1)
+        self.assertEqual([hamlet.id], events[0]["users"])
+
+        event = events[0]["event"]
+        self.assert_length(event["recipient"]["user_ids"], 1)
+        self.assertEqual([hamlet.id], event["recipient"]["user_ids"])

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -106,7 +106,8 @@ def send_message_edit_notification_backend(
             raise JsonableError(_("User has disabled typing notifications for direct messages"))
 
         if recipient.type == Recipient.PERSONAL:
-            recipient_ids = [user_profile.id, recipient.type_id]
+            # For self-DMs, both IDs are the same; deduplicate.
+            recipient_ids = list({user_profile.id, recipient.type_id})
         else:
             recipient_ids = list(get_direct_message_group_user_ids(recipient))
 


### PR DESCRIPTION
For self-DMs, user_profile.id and recipient.type_id are identical, producing a duplicate list like [5, 5].  Use a set to deduplicate.

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
