### PR TITLE
[ai] dialog: Mark single-line modals as compact.

### DIFF
--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -122,6 +122,7 @@ function delete_attachments(attachment: string, file_name: string): void {
         modal_title_html: $t_html({defaultMessage: "Delete file?"}),
         modal_content_html,
         modal_submit_button_text: $t({defaultMessage: "Delete"}),
+        is_compact: true,
         focus_submit_on_open: true,
         on_click() {
             dialog_widget.submit_api_request(channel.del, "/json/attachments/" + attachment, {});

--- a/web/src/deprecated_feature_notice.ts
+++ b/web/src/deprecated_feature_notice.ts
@@ -54,6 +54,7 @@ export function maybe_show_deprecation_notice(key: string): void {
             modal_title_html: $t_html({defaultMessage: "Deprecation notice"}),
             modal_content_html: message,
             modal_submit_button_text: $t({defaultMessage: "Got it"}),
+            is_compact: true,
             on_click() {
                 return;
             },

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1504,6 +1504,7 @@ function warn_user_about_unread_msgs(last_sent_msg_id: number, num_unread: numbe
         modal_content_html: render_confirm_edit_messages({
             num_unread,
         }),
+        is_compact: true,
         on_click() {
             // Select the message we want to edit to mark messages between it and the
             // current selected id as read.

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -2291,6 +2291,7 @@ export function initialize(): void {
                     modal_content_html: render_confirm_join_group_direct_member({
                         associated_subgroup_names,
                     }),
+                    is_compact: true,
                     id: "confirm_join_group_direct_member",
                     on_click() {
                         const $group_row = row_for_group_id(user_group_id);


### PR DESCRIPTION
The "Delete file?" and "Deprecation notice" modals are simple single-line confirmations that should use the compact modal style.

I haven't tested manually; let me know if I need to.
