### PR TITLE
[ai] email_mirror: Include full subject in body when longer than topic limit.

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -41,6 +41,7 @@ from zerver.models import (
     UserProfile,
 )
 from zerver.models.clients import get_client
+from zerver.models.constants import MAX_TOPIC_NAME_LENGTH
 from zerver.models.streams import StreamTopicsPolicyEnum, get_stream_by_id_in_realm
 from zerver.models.users import get_system_bot, get_user_profile_by_id
 from zproject.backends import is_user_active
@@ -460,6 +461,8 @@ def process_stream_message(to: str, message: EmailMessage) -> None:
         topic = _("Email with no subject")
     else:
         topic = subject
+        if len(subject) > MAX_TOPIC_NAME_LENGTH:
+            options["subject_in_body"] = True
 
     body = construct_zulip_body(message, subject, realm, sender=sender, **options)
     send_zulip(sender, channel, topic, body)

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -414,6 +414,35 @@ class TestStreamEmailMessages(ZulipTestCase):
             message.content, "**Subject:** Test subject\n\nTestStreamEmailMessages body"
         )
 
+    def test_receive_stream_email_messages_long_subject(self) -> None:
+        user_profile = self.example_user("hamlet")
+        self.login_user(user_profile)
+        self.subscribe(user_profile, "Denmark")
+        stream = get_stream("Denmark", user_profile.realm)
+
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
+        stream_to_address = encode_email_address(stream.name, email_token)
+
+        incoming_valid_message = EmailMessage()
+        incoming_valid_message.set_content("TestStreamEmailMessages body")
+
+        long_subject = "A" * 61
+        incoming_valid_message["Subject"] = long_subject
+        incoming_valid_message["From"] = self.example_email("hamlet")
+        incoming_valid_message["To"] = stream_to_address
+
+        process_message(incoming_valid_message)
+
+        message = most_recent_message(user_profile)
+
+        # Topic should be truncated to MAX_TOPIC_NAME_LENGTH with "..." suffix.
+        self.assertEqual(message.topic_name(), "A" * 57 + "...")
+        # Full subject should appear in the message body via subject_in_body mechanism.
+        self.assertEqual(
+            message.content,
+            f"**Subject:** {long_subject}\n\nTestStreamEmailMessages body",
+        )
+
     def test_receive_private_stream_email_messages_success(self) -> None:
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)


### PR DESCRIPTION
Fixes: #10539.

## Summary

When an email is sent to Zulip via the email gateway and the subject line exceeds `MAX_TOPIC_NAME_LENGTH` (60 characters), the subject is silently truncated to fit the topic field. The full subject is lost with no indication to readers.

`construct_zulip_body()` already supports a `subject_in_body=True` option that prepends `**Subject:** {full subject}` to the message body — this is the mechanism used when a channel's topics policy is set to empty-topic-only. This PR applies the same mechanism when the subject is simply too long.

The fix is a two-line addition in `process_stream_message()`: after assigning `topic = subject`, check whether the subject exceeds the limit and set `options["subject_in_body"] = True` if so. No new machinery needed.

**Why every long-subject message rather than only the first?** Multiple distinct long subjects can truncate to the same 60-character prefix, making it impossible to distinguish them by topic alone. Including the full subject in every such message body avoids ambiguity.

## How changes were tested

- Added `test_receive_stream_email_messages_long_subject`: sends an email with a 61-character subject, then asserts the topic is truncated to 57 chars + `"..."` (via `truncate_topic`) and the message body contains `**Subject:** {full subject}` as its first line.
- The new test exercises the same code path as the existing `empty_topic_only` tests, which already exercise `subject_in_body=True` end-to-end.

**Test plan:**
- [x] `./tools/test-backend zerver.tests.test_email_mirror`

## Screenshots and screen captures

N/A (no UI changes)

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Followed the AI use policy.
- [x] Explains differences from previous plans (none — implementation matches issue spec exactly).
- [x] Highlights technical choices: reused `subject_in_body` rather than introducing new logic.
- [x] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message explains reasoning and motivation.
- [x] End-to-end functionality: the subject line now survives the 60-char truncation.
- [x] Corner cases: subject exactly 60 chars (no trigger), 61 chars (trigger), empty subject (unaffected — separate branch), `empty_topic_only` channel (unaffected — already sets `subject_in_body` before this code runs).

</details>