### PR TITLE
[ai] streams: Send channel events notices for subscribe/unsubscribe actions.

### DIFF
--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -916,6 +916,32 @@ def bulk_add_subscriptions(
         subscriber_peer_info=subscriber_peer_info,
     )
 
+    if not from_user_creation:
+        notification_bot = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
+        for sub_info in subs_to_add + subs_to_activate:
+            stream = sub_info.stream
+            if not stream.invite_only or stream.deactivated:
+                continue
+            user = sub_info.user
+            with override_language(realm.default_language):
+                if acting_user is not None and acting_user.id != user.id:
+                    content = _(
+                        "{acting_user_mention} subscribed {user_mention} to this channel."
+                    ).format(
+                        acting_user_mention=silent_mention_syntax_for_user(acting_user),
+                        user_mention=silent_mention_syntax_for_user(user),
+                    )
+                else:
+                    content = _("{user_mention} subscribed to this channel.").format(
+                        user_mention=silent_mention_syntax_for_user(user)
+                    )
+            maybe_send_channel_events_notice(
+                notification_bot,
+                stream,
+                content,
+                acting_user=acting_user,
+            )
+
     return (
         subs_to_add + subs_to_activate,
         already_subscribed,
@@ -1167,6 +1193,31 @@ def bulk_remove_subscriptions(
         for user, stream in removed_sub_tuples:
             altered_user_dict[user].add(stream.id)
         send_user_remove_events_on_removing_subscriptions(realm, altered_user_dict)
+
+    notification_bot = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
+    for sub_info in subs_to_deactivate:
+        stream = sub_info.stream
+        if not stream.invite_only or stream.deactivated:
+            continue
+        user = sub_info.user
+        with override_language(realm.default_language):
+            if acting_user is not None and acting_user.id != user.id:
+                content = _(
+                    "{acting_user_mention} unsubscribed {user_mention} from this channel."
+                ).format(
+                    acting_user_mention=silent_mention_syntax_for_user(acting_user),
+                    user_mention=silent_mention_syntax_for_user(user),
+                )
+            else:
+                content = _("{user_mention} unsubscribed from this channel.").format(
+                    user_mention=silent_mention_syntax_for_user(user)
+                )
+        maybe_send_channel_events_notice(
+            notification_bot,
+            stream,
+            content,
+            acting_user=acting_user,
+        )
 
     return (
         removed_sub_tuples,

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -5627,6 +5627,146 @@ class InviteOnlyStreamTest(ZulipTestCase):
         self.assertTrue(prospero.id in json["subscribers"])
 
 
+class PrivateChannelJoinLeaveNotificationTest(ZulipTestCase):
+    def test_subscribe_to_private_channel_sends_notification(self) -> None:
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+
+        stream = self.make_stream("private_channel", invite_only=True)
+        self.subscribe(iago, "private_channel")
+
+        bulk_add_subscriptions(iago.realm, [stream], [hamlet], acting_user=iago)
+
+        messages = get_topic_messages(iago, stream, "channel events")
+        self.assert_length(messages, 1)
+        self.assertEqual(
+            messages[0].content,
+            f"@_**{iago.full_name}|{iago.id}** subscribed @_**{hamlet.full_name}|{hamlet.id}** to this channel.",
+        )
+
+    def test_self_subscribe_to_private_channel_sends_notification(self) -> None:
+        hamlet = self.example_user("hamlet")
+
+        stream = self.make_stream("private_channel_self", invite_only=True)
+        self.subscribe(hamlet, "private_channel_self")
+
+        messages = get_topic_messages(hamlet, stream, "channel events")
+        self.assert_length(messages, 1)
+        self.assertEqual(
+            messages[0].content,
+            f"@_**{hamlet.full_name}|{hamlet.id}** subscribed to this channel.",
+        )
+
+    def test_subscribe_to_public_channel_does_not_send_notification(self) -> None:
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+
+        stream = self.make_stream("public_channel", invite_only=False)
+        self.subscribe(iago, "public_channel")
+
+        bulk_add_subscriptions(iago.realm, [stream], [hamlet], acting_user=iago)
+
+        messages = get_topic_messages(iago, stream, "channel events")
+        self.assert_length(messages, 0)
+
+    def test_unsubscribe_from_private_channel_sends_notification(self) -> None:
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+
+        stream = self.make_stream("private_unsub", invite_only=True)
+        self.subscribe(iago, "private_unsub")
+        self.subscribe(hamlet, "private_unsub")
+
+        bulk_remove_subscriptions(iago.realm, [hamlet], [stream], acting_user=iago)
+
+        messages = get_topic_messages(iago, stream, "channel events")
+        self.assert_length(messages, 1)
+        self.assertEqual(
+            messages[0].content,
+            f"@_**{iago.full_name}|{iago.id}** unsubscribed @_**{hamlet.full_name}|{hamlet.id}** from this channel.",
+        )
+
+    def test_self_unsubscribe_from_private_channel_sends_notification(self) -> None:
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+
+        stream = self.make_stream("private_self_unsub", invite_only=True)
+        self.subscribe(iago, "private_self_unsub")
+        self.subscribe(hamlet, "private_self_unsub")
+
+        bulk_remove_subscriptions(hamlet.realm, [hamlet], [stream], acting_user=hamlet)
+
+        messages = get_topic_messages(iago, stream, "channel events")
+        self.assert_length(messages, 1)
+        self.assertEqual(
+            messages[0].content,
+            f"@_**{hamlet.full_name}|{hamlet.id}** unsubscribed from this channel.",
+        )
+
+    def test_unsubscribe_from_public_channel_does_not_send_notification(self) -> None:
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+
+        stream = self.make_stream("public_unsub", invite_only=False)
+        self.subscribe(iago, "public_unsub")
+        self.subscribe(hamlet, "public_unsub")
+
+        bulk_remove_subscriptions(iago.realm, [hamlet], [stream], acting_user=iago)
+
+        messages = get_topic_messages(iago, stream, "channel events")
+        self.assert_length(messages, 0)
+
+    def test_no_notification_when_send_channel_events_messages_disabled(self) -> None:
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+
+        stream = self.make_stream("private_no_notif", invite_only=True)
+        self.subscribe(iago, "private_no_notif")
+        self.subscribe(hamlet, "private_no_notif")
+
+        do_set_realm_property(hamlet.realm, "send_channel_events_messages", False, acting_user=None)
+
+        bulk_remove_subscriptions(hamlet.realm, [hamlet], [stream], acting_user=hamlet)
+
+        messages = get_topic_messages(iago, stream, "channel events")
+        self.assert_length(messages, 0)
+
+    def test_no_notification_on_subscribe_during_user_creation(self) -> None:
+        hamlet = self.example_user("hamlet")
+
+        stream = self.make_stream("private_creation", invite_only=True)
+        self.subscribe(hamlet, "private_creation")
+
+        cordelia = self.example_user("cordelia")
+        bulk_add_subscriptions(
+            cordelia.realm, [stream], [cordelia], from_user_creation=True, acting_user=None
+        )
+
+        messages = get_topic_messages(hamlet, stream, "channel events")
+        self.assert_length(messages, 0)
+
+    def test_no_notification_for_deactivated_channel(self) -> None:
+        """Subscribing to or unsubscribing from a deactivated (archived) private
+        channel must not trigger a channel-events notice, because the
+        notification bot cannot send to deactivated streams."""
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+
+        stream = self.make_stream("private_deactivated", invite_only=True)
+        self.subscribe(iago, "private_deactivated")
+        self.subscribe(hamlet, "private_deactivated")
+        do_deactivate_stream(stream, acting_user=None)
+
+        # Subscribing to a deactivated private channel must not raise an error
+        # or send a notification.
+        cordelia = self.example_user("cordelia")
+        bulk_add_subscriptions(iago.realm, [stream], [cordelia], acting_user=iago)
+
+        # Unsubscribing from a deactivated private channel must not raise an
+        # error or send a notification.
+        bulk_remove_subscriptions(iago.realm, [hamlet], [stream], acting_user=iago)
+
+
 class StreamTrafficTest(ZulipTestCase):
     def test_average_weekly_stream_traffic_calculation(self) -> None:
         # No traffic data for the stream


### PR DESCRIPTION
Fixes: #2746.

## Summary

Private channels currently receive no notification when a user joins or leaves. Other channel lifecycle events — archiving, unarchiving, permission changes — already send messages to the "channel events" topic via `maybe_send_channel_events_notice()`. Subscription changes were the missing piece.

This PR adds notification calls at the end of `bulk_add_subscriptions()` and `bulk_remove_subscriptions()` for private channels (`invite_only=True`). Public channels are excluded: join/leave events there would be high-volume and low-value. The notification messages follow the format specified in the issue:

- `@_**actor** subscribed @_**user** to this channel.` (admin/owner subscribing another user)
- `@_**user** subscribed to this channel.` (self-subscribe)
- `@_**actor** unsubscribed @_**user** from this channel.`
- `@_**user** unsubscribed from this channel.`

User mentions use `silent_mention_syntax_for_user()` (producing `@_**name|id**`) consistent with every other notification message in `streams.py`. The `from_user_creation=True` guard in `bulk_add_subscriptions` prevents spurious notifications during account creation. The feature is gated on the existing `send_channel_events_messages` realm setting, handled transparently inside `maybe_send_channel_events_notice()`.

## How changes were tested

Added `PrivateChannelJoinLeaveNotificationTest` with 8 test cases covering:

1. Admin subscribing another user to a private channel → message with both names
2. User self-subscribing to a private channel → message with one name
3. Subscribing to a **public** channel → no message
4. Admin unsubscribing another user from a private channel → message with both names
5. User self-unsubscribing from a private channel → message with one name
6. Unsubscribing from a **public** channel → no message
7. `send_channel_events_messages = False` → no message
8. `from_user_creation=True` → no message

**Test plan:**
- [x] `./tools/test-backend zerver.tests.test_subs.PrivateChannelJoinLeaveNotificationTest`

## Screenshots and screen captures

N/A (no UI changes)

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Followed the AI use policy.
- [x] Explains differences from previous plans (none — spec from issue followed directly).
- [x] Highlights technical choices: `silent_mention_syntax_for_user()` used instead of bare `full_name` to produce clickable, unambiguous mentions; notifications placed *after* all DB writes and event dispatches to avoid sending messages for transactions that later roll back.
- [x] Calls out remaining concern: bulk operations (e.g. an admin subscribing 50 users at once) will produce one message per user per channel. The issue spec does not call for batching; this can be optimized later if needed.
- [x] Automated tests verify all paths including the negative cases.
- [x] Each commit is a coherent idea.
- [x] User-facing strings use `_()` for translation.
- [x] Corner cases: reactivating a previously deactivated subscription (`subs_to_activate`) also triggers a notification, consistent with the user re-joining the channel.

</details>