### PR TITLE
[ai] buddy_list: Use ::before for idle status circle in avatar mode.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -207,6 +207,20 @@
             &.user-circle-offline {
                 display: none;
             }
+
+            /* Move the idle gradient onto ::before so that the
+               background-color halo from this element is preserved,
+               matching the approach used in typeahead.css. */
+            &.user-circle-idle {
+                background: var(--color-background);
+
+                &::before {
+                    background: var(--gradient-user-circle-idle-avatar);
+                    background-clip: text;
+                    -webkit-text-fill-color: transparent;
+                    border-radius: 50%;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes: #37031.

## Summary

In the right sidebar's avatar display mode, the over-avatar status circle is a font icon `<span>` styled with `background-color: var(--color-background)` and a matching `border`, forming a halo that separates the circle from the avatar. For the idle state, `user_circles.css` applies `background: var(--gradient-user-circle-idle-avatar)` to `.with_avatar .user-circle-idle`, which overwrites `background-color` and destroys the halo — the circle renders without its background separation.

PR #36490 solved the identical problem in the typeahead by keeping `background-color` on the `<span>` and moving the idle gradient onto a `::before` pseudo-element (`background-clip: text` on the pseudo-element renders the gradient through the font glyph). This PR applies the same fix to `right_sidebar.css`.

The change is confined to a single new CSS block inside `.user_sidebar_entry.with_avatar .user-circle.user-circle-idle`. No template changes are needed; the existing `<span>` structure is preserved.

## How changes were tested

This is a pure CSS fix with no logic to unit-test. Manual verification against a running dev server is needed to confirm the idle avatar circle renders with its background halo in both light and dark themes. The non-avatar idle circle is unaffected (no `background-color` halo exists there to break).

**Test plan:**
- [ ] Start `./tools/run-dev` and verify the right sidebar idle user avatar circle renders correctly (gradient visible, white border halo present) in light and dark themes.
- [ ] Confirm active, offline, and deactivated avatar circles are unaffected.

## Screenshots and screen captures

N/A — no dev environment available to produce screenshots.

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Followed the AI use policy.
- [x] Explains differences from previous plans: an earlier draft incorrectly removed the `<span>` elements entirely and moved state classes onto `<li>`, which would have caused `user_circles.css` idle rules (`-webkit-text-fill-color: transparent`) to cascade to row text. This PR takes the minimal correct approach instead.
- [x] Highlights technical choices: only the avatar idle case needs `::before`; the non-avatar idle circle has no `background-color` halo to protect, so `user_circles.css` already works correctly there.
- [x] Calls out open question: the issue title says "Use `::before` for status circle" broadly, but the actual breakage only affects the avatar idle case. If maintainers intended a broader restructuring (removing all `<span>` DOM nodes), that would be a larger separate change requiring visual testing across all states and display modes.
- [x] Each commit is a coherent idea.
- [x] No template or JS changes — pure CSS, no regression risk beyond rendering.

</details>