### PR TITLE
topic_filter_pill: Extract shared typeahead helpers.

### DIFF
--- a/web/src/topic_filter_pill.ts
+++ b/web/src/topic_filter_pill.ts
@@ -3,6 +3,7 @@ import render_input_pill from "../templates/input_pill.hbs";
 import {$t} from "./i18n.ts";
 import type {InputPillConfig, InputPillContainer} from "./input_pill.ts";
 import * as input_pill from "./input_pill.ts";
+import * as typeahead_helper from "./typeahead_helper.ts";
 
 export type TopicFilterPill = {
     type: "topic_filter";
@@ -12,6 +13,14 @@ export type TopicFilterPill = {
 };
 
 export type TopicFilterPillWidget = InputPillContainer<TopicFilterPill>;
+
+type TopicFilterTypeaheadOptions = {
+    item_html: (item: TopicFilterPill, query: string) => string | undefined;
+    matcher: (item: TopicFilterPill, query: string) => boolean;
+    sorter: (items: TopicFilterPill[], query: string) => TopicFilterPill[];
+    stopAdvance: boolean;
+    dropup: boolean;
+};
 
 export const filter_options: TopicFilterPill[] = [
     {
@@ -36,6 +45,59 @@ export const filter_options: TopicFilterPill[] = [
         match_prefix_required: "-is",
     },
 ];
+
+export function get_typeahead_base_options(): TopicFilterTypeaheadOptions {
+    return {
+        item_html(item: TopicFilterPill, _query: string) {
+            return typeahead_helper.render_topic_state(item.label);
+        },
+        matcher(item: TopicFilterPill, query: string) {
+            // This basically only matches if `is:` is in the query.
+            return (
+                query.includes(":") &&
+                (item.syntax.toLowerCase().startsWith(query.toLowerCase()) ||
+                    (item.syntax.startsWith("-") &&
+                        item.syntax.slice(1).toLowerCase().startsWith(query.toLowerCase())))
+            );
+        },
+        sorter(items: TopicFilterPill[], _query: string) {
+            // This sort order places "Unresolved topics" first
+            // always, which is good because that's almost always
+            // what users will want.
+            return items;
+        },
+        // Prevents key events from propagating to other handlers or
+        // triggering default browser actions.
+        stopAdvance: true,
+        // Use dropup, to match compose typeahead.
+        dropup: true,
+    };
+}
+
+export function get_matching_filter_options({
+    current_items,
+    query,
+    allow_resolved_topic_filters,
+}: {
+    current_items: TopicFilterPill[];
+    query: string;
+    allow_resolved_topic_filters: boolean;
+}): TopicFilterPill[] {
+    const current_syntaxes = new Set(current_items.map((item) => item.syntax));
+
+    return filter_options.filter((option) => {
+        if (!allow_resolved_topic_filters && option.syntax.endsWith("resolved")) {
+            return false;
+        }
+        if (current_syntaxes.has(option.syntax)) {
+            return false;
+        }
+        if (option.match_prefix_required && !query.startsWith(option.match_prefix_required)) {
+            return false;
+        }
+        return true;
+    });
+}
 
 export function create_item_from_syntax(
     syntax: string,

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -23,7 +23,6 @@ import * as topic_filter_pill from "./topic_filter_pill.ts";
 import type {TopicFilterPill, TopicFilterPillWidget} from "./topic_filter_pill.ts";
 import * as topic_list_data from "./topic_list_data.ts";
 import type {TopicInfo} from "./topic_list_data.ts";
-import * as typeahead_helper from "./typeahead_helper.ts";
 import * as ui_util from "./ui_util.ts";
 import * as vdom from "./vdom.ts";
 
@@ -626,55 +625,27 @@ export function setup_topic_search_typeahead(): void {
     };
 
     const options = {
+        ...topic_filter_pill.get_typeahead_base_options(),
         source() {
             const stream_id = active_stream_id();
             assert(stream_id !== undefined);
 
             const pills = topic_filter_pill_widget!.items();
-            const current_syntaxes = new Set(pills.map((pill) => pill.syntax));
             const query = $("#topic_filter_query").text().trim();
             const has_locally_available_resolved_topics =
                 stream_topic_history.stream_has_locally_available_resolved_topics(stream_id);
-            return topic_filter_pill.filter_options.filter((option) => {
-                if (!has_locally_available_resolved_topics && option.syntax.endsWith("resolved")) {
-                    // Technically, it could still be useful to show
-                    // the is:resolved option, as local data is not
-                    // complete. But because zooming the topic list
-                    // does the topic history fetch, it's reasonable to
-                    // ignore that possibility and just only show the
-                    // resolved topic options if we can confirm
-                    // they're relevant.
-                    return false;
-                }
-                if (current_syntaxes.has(option.syntax)) {
-                    return false;
-                }
-                if (
-                    option.match_prefix_required &&
-                    !query.startsWith(option.match_prefix_required)
-                ) {
-                    return false;
-                }
-                return true;
+            return topic_filter_pill.get_matching_filter_options({
+                current_items: pills,
+                query,
+                // Technically, it could still be useful to show
+                // the is:resolved option, as local data is not
+                // complete. But because zooming the topic list
+                // does the topic history fetch, it's reasonable to
+                // ignore that possibility and just only show the
+                // resolved topic options if we can confirm
+                // they're relevant.
+                allow_resolved_topic_filters: has_locally_available_resolved_topics,
             });
-        },
-        item_html(item: TopicFilterPill) {
-            return typeahead_helper.render_topic_state(item.label);
-        },
-        matcher(item: TopicFilterPill, query: string) {
-            // This basically only matches if `is:` is in the query.
-            return (
-                query.includes(":") &&
-                (item.syntax.toLowerCase().startsWith(query.toLowerCase()) ||
-                    (item.syntax.startsWith("-") &&
-                        item.syntax.slice(1).toLowerCase().startsWith(query.toLowerCase())))
-            );
-        },
-        sorter(items: TopicFilterPill[]) {
-            // This sort order places "Unresolved topics" first
-            // always, which is good because that's almost always what
-            // users will want.
-            return items;
         },
         updater(item: TopicFilterPill) {
             assert(topic_filter_pill_widget !== null);
@@ -684,11 +655,6 @@ export function setup_topic_search_typeahead(): void {
             $input.trigger("focus");
             return get_left_sidebar_topic_search_term();
         },
-        // Prevents key events from propagating to other handlers or
-        // triggering default browser actions.
-        stopAdvance: true,
-        // Use dropup, to match compose typeahead.
-        dropup: true,
     };
 
     topic_state_typeahead = new Typeahead(typeahead_input, options);


### PR DESCRIPTION
This is a prep PR to share topic-state typeahead helpers with the left sidebar filter.

Prep refactors extracted from https://github.com/zulip/zulip/pull/37534 to simplify review.

**How changes were tested:**

This does not change any behaviour.



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
