### PR TITLE
video_calls: Tag Constructor Groups' room name for translation.

### DIFF
--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -545,11 +545,12 @@ def make_constructor_groups_video_call(
     user_profile: UserProfile,
 ) -> HttpResponse:
     service = ConstructorGroupsService()
+    room_name = _("{full_name}'s Zulip room").format(full_name=user_profile.full_name)
 
     room_data = service.get_or_create_default_room(
         creator_email=user_profile.delivery_email,
-        name=f"{user_profile.full_name}'s Zulip room",
-        fallback_name=f"{user_profile.full_name}'s Zulip room ({user_profile.realm_id}-{user_profile.id})",
+        name=room_name,
+        fallback_name=f"{room_name} ({user_profile.realm_id}-{user_profile.id})",
     )
 
     room_url = room_data.get("url", "")


### PR DESCRIPTION
[#integrations > Constructor Groups video call room name](https://chat.zulip.org/#narrow/channel/127-integrations/topic/Constructor.20Groups.20video.20call.20room.20name/with/2404241)
Previous PR: https://github.com/zulip/zulip/pull/38059#discussion_r2906044173


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
