### PR TITLE
[ai] recent_view: Fix focus restoration for unrendered rows.

### DIFF
--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -501,7 +501,18 @@ export function revive_current_focus(): boolean {
                 const last_visited_topic_index = current_list.findIndex(
                     (topic) => topic.last_msg_id === topic_last_msg_id,
                 );
-                if (last_visited_topic_index !== -1) {
+                // Only restore focus to the topic if it hasn't moved
+                // too far from where the user left off. A topic can
+                // shift significantly due to new messages arriving
+                // (sorted by time), topic renames (sorted by topic),
+                // or marking as read (sorted by unread count), which
+                // would disorient the user by jumping them far from
+                // their previous scroll position.
+                const max_focus_shift = 10;
+                if (
+                    last_visited_topic_index !== -1 &&
+                    Math.abs(last_visited_topic_index - row_focus) <= max_focus_shift
+                ) {
                     row_focus = last_visited_topic_index;
                 }
             }


### PR DESCRIPTION
discussion: [#issues > Scroll Position Behavior in Sorted by Unread message count](https://chat.zulip.org/#narrow/channel/9-issues/topic/Scroll.20Position.20Behavior.20in.20Sorted.20by.20Unread.20message.20count/with/2407174)

## Summary
- Fix `set_table_focus` to render more rows when the target row is beyond
  what's currently rendered but exists in the full filtered list, using the
  existing `get_min_load_count` mechanism.
- Skip `last_visited_topic` restoration in `revive_current_focus` when the
  topic's position has shifted by more than 10 rows, to avoid disorienting
  jumps.

---

User prompted to make two changes to `set_table_focus` and `revive_current_focus`
in `recent_view_ui`:

1. In `set_table_focus`, check if the topic widget has unrendered rows and
   render enough (with a buffer) before trying to find the topic and restore
   focus. This fixes `last_visited_topic` restoration which would fail when
   the topic's index exceeded the initially rendered row count.

2. Ignore `last_visited_topic` restoration on first `revive_current_focus` if
   the topic's position changed significantly, since new messages (time sort),
   topic renames (topic sort), or marking as read (unread sort) can push the
   user far from their last position.


For testing:
Populate db by ./manage.py populate_db -n 5000 --max-topics=1000

1st commit:
* Sort by time and scroll down a few page fulls and then click on topic and navigate back to recent view to see the same topic being focused.

2nd commit:
* Sort by unread count descending. Click on first unread row and read topic, and go back to recent view to see that you are still where you left off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)