### PR TITLE
video-calls: Create shared error templates for translated strings.

### DIFF
--- a/zerver/tests/test_create_video_call.py
+++ b/zerver/tests/test_create_video_call.py
@@ -496,7 +496,7 @@ class BigBlueButtonVideoCallTest(ZulipTestCase):
             "/calls/bigbluebutton/join",
             {"bigbluebutton": self.signed_bbb_a_object},
         )
-        self.assert_json_error(response, "Error authenticating to the BigBlueButton server.")
+        self.assert_json_error(response, "Error authenticating to the BigBlueButton server")
 
     @responses.activate
     def test_join_bigbluebutton_redirect_server_error(self) -> None:
@@ -552,7 +552,7 @@ class BigBlueButtonVideoCallTest(ZulipTestCase):
                 "/calls/bigbluebutton/join",
                 {"bigbluebutton": self.signed_bbb_a_object},
             )
-            self.assert_json_error(response, "BigBlueButton is not configured.")
+            self.assert_json_error(response, "BigBlueButton credentials have not been configured")
 
 
 class ConstructorGroupsVideoCallTest(ZulipTestCase):
@@ -762,7 +762,9 @@ class NextcloudVideoCallTest(ZulipTestCase):
                     "/json/calls/nextcloud_talk/create",
                     {"room_name": "#Test > team check-in"},
                 )
-                self.assert_json_error(response, "Nextcloud Talk is not configured")
+                self.assert_json_error(
+                    response, "Nextcloud Talk credentials have not been configured"
+                )
 
     @responses.activate
     def test_create_nextcloud_talk_server_error(self) -> None:

--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -67,6 +67,56 @@ class CreateVideoCallFailedError(JsonableError):
         )
 
 
+class VideoCallProviderNotConfiguredError(JsonableError):
+    def __init__(self, provider_name: str) -> None:
+        super().__init__(
+            _("{provider_name} credentials have not been configured").format(
+                provider_name=provider_name
+            )
+        )
+
+
+class VideoCallProviderCredentialsError(JsonableError):
+    def __init__(self, provider_name: str) -> None:
+        super().__init__(
+            _("Invalid {provider_name} credentials").format(provider_name=provider_name)
+        )
+
+
+class VideoCallServerConnectionError(JsonableError):
+    def __init__(self, provider_name: str, reason: str) -> None:
+        super().__init__(
+            _("Error connecting to the {provider_name} server: {reason}").format(
+                provider_name=provider_name, reason=reason
+            )
+        )
+
+
+class VideoCallServerAuthError(JsonableError):
+    def __init__(self, provider_name: str) -> None:
+        super().__init__(
+            _("Error authenticating to the {provider_name} server").format(
+                provider_name=provider_name
+            )
+        )
+
+
+class VideoCallServerStatusError(JsonableError):
+    def __init__(self, provider_name: str, status: str | None) -> None:
+        super().__init__(
+            _("{provider_name} server returned an unexpected error: {status}").format(
+                provider_name=provider_name, status=status
+            )
+        )
+
+
+class VideoCallProviderSessionIdError(JsonableError):
+    def __init__(self, provider_name: str) -> None:
+        super().__init__(
+            _("Invalid {provider_name} session identifier").format(provider_name=provider_name)
+        )
+
+
 class UnknownZoomUserError(JsonableError):
     code = ErrorCode.UNKNOWN_ZOOM_USER
 
@@ -156,11 +206,7 @@ class OAuthVideoCallProvider(ABC):
 
     def __get_session(self, user: UserProfile) -> OAuth2Session:
         if self.client_id is None or self.client_secret is None:
-            raise JsonableError(
-                _("{provider_name} credentials have not been configured").format(
-                    provider_name=self.provider_name
-                )
-            )
+            raise VideoCallProviderNotConfiguredError(self.provider_name)
 
         return OAuth2Session(
             self.client_id,
@@ -211,11 +257,7 @@ class OAuthVideoCallProvider(ABC):
         self, request: HttpRequest, sid: str, code: str, **kwargs: Any
     ) -> HttpResponse:
         if not constant_time_compare(sid, self.__get_sid(request)):
-            raise JsonableError(
-                _("Invalid {provider_name} session identifier").format(
-                    provider_name=self.provider_name
-                )
-            )
+            raise VideoCallProviderSessionIdError(self.provider_name)
         assert isinstance(request.user, UserProfile)
         oauth = self.__get_session(request.user)
         try:
@@ -223,9 +265,7 @@ class OAuthVideoCallProvider(ABC):
                 self.token_url, code=code, client_secret=self.client_secret, **kwargs
             )
         except OAuth2Error:
-            raise JsonableError(
-                _("Invalid {provider_name} credentials").format(provider_name=self.provider_name)
-            )
+            raise VideoCallProviderCredentialsError(self.provider_name)
 
         self.update_token(request.user, token)
         return render(request, "zerver/close_window.html")
@@ -324,7 +364,7 @@ def complete_zoom_user(
 @cache_with_key(zoom_server_access_token_cache_key, timeout=3600 - 240)
 def get_zoom_server_to_server_access_token(account_id: str) -> str:
     if settings.VIDEO_ZOOM_CLIENT_ID is None:
-        raise JsonableError(_("Zoom credentials have not been configured"))
+        raise VideoCallProviderNotConfiguredError("Zoom")
 
     client_id = settings.VIDEO_ZOOM_CLIENT_ID.encode("utf-8")
     client_secret = str(settings.VIDEO_ZOOM_CLIENT_SECRET).encode("utf-8")
@@ -340,7 +380,7 @@ def get_zoom_server_to_server_access_token(account_id: str) -> str:
     if not response.ok:
         # {reason: 'Bad request', error: 'invalid_request'} for invalid account ID
         # {'reason': 'Invalid client_id or client_secret', 'error': 'invalid_client'}
-        raise JsonableError(_("Invalid Zoom credentials"))
+        raise VideoCallProviderCredentialsError("Zoom")
     return response.json()["access_token"]
 
 
@@ -462,7 +502,7 @@ def join_bigbluebutton(request: HttpRequest, *, bigbluebutton: str) -> HttpRespo
     assert request.user.is_authenticated
 
     if settings.BIG_BLUE_BUTTON_URL is None or settings.BIG_BLUE_BUTTON_SECRET is None:
-        raise JsonableError(_("BigBlueButton is not configured."))
+        raise VideoCallProviderNotConfiguredError("BigBlueButton")
 
     try:
         bigbluebutton_data = Signer().unsign_object(bigbluebutton)
@@ -494,19 +534,15 @@ def join_bigbluebutton(request: HttpRequest, *, bigbluebutton: str) -> HttpRespo
             reason = f"HTTP {response.status_code}: {response.text:.200}"
         else:
             reason = str(e)
-        raise JsonableError(
-            _("Error connecting to the BigBlueButton server: {reason}").format(reason=reason)
-        )
+        raise VideoCallServerConnectionError("BigBlueButton", reason=reason)
 
     payload = ElementTree.fromstring(response.text)
     if assert_is_not_none(payload.find("messageKey")).text == "checksumError":
-        raise JsonableError(_("Error authenticating to the BigBlueButton server."))
+        raise VideoCallServerAuthError("BigBlueButton")
 
     status = assert_is_not_none(payload.find("returncode")).text
     if status != "SUCCESS":
-        raise JsonableError(
-            _("BigBlueButton server returned an unexpected error: {status}").format(status=status)
-        )
+        raise VideoCallServerStatusError("BigBlueButton", status=status)
 
     join_params = urlencode(
         {
@@ -573,7 +609,7 @@ def create_nextcloud_talk_url(
         or settings.NEXTCLOUD_TALK_USERNAME is None
         or settings.NEXTCLOUD_TALK_PASSWORD is None
     ):
-        raise JsonableError(_("Nextcloud Talk is not configured"))
+        raise VideoCallProviderNotConfiguredError("Nextcloud Talk")
 
     room_name = truncate_content(room_name, MAX_NEXTCLOUD_TALK_ROOM_NAME_LENGTH, "...")
     # https://nextcloud-talk.readthedocs.io/en/stable/conversation/#creating-a-new-conversation
@@ -604,9 +640,7 @@ def create_nextcloud_talk_url(
             reason = f"HTTP {response.status_code}: {response.text:.200}"
         else:
             reason = str(e)
-        raise JsonableError(
-            _("Error connecting to the Nextcloud Talk server: {reason}").format(reason=reason)
-        )
+        raise VideoCallServerConnectionError("Nextcloud Talk", reason=reason)
     try:
         data = response.json()
         token = data["ocs"]["data"]["token"]


### PR DESCRIPTION
To reduce the translation burden, as we add more call providers, use shared errors with translated strings instead of hard coding a provider name in a translated string.

For example, `"Error authenticating to the BigBlueButton server."` becomes `"Error authenticating to the {provider_name} server"` so that other video call integrations can use that error string without adding a string to be translated.

**Notes**:
- As there are some translated strings with hard coded video call provider names in them (e.g., the example above), there will be a need for translators to update any of those translations for the generic version.
- There's still a `UnknownZoomUserError` that's existed for a while, which is not made generic in these changes.
  - This has an error code set and is used by both Zoom integrations, so it seems fine to leave as is.
  - Currently, other integrations don't have a user email error.
- There's one remaining `JsonableError` case: `raise JsonableError(_("Invalid signature."))`.
  - This is used only for the BigBlueButton integration at the moment. And it doesn't have the provider name hard coded in the string, so it could be reused as is without creating an additional string to translate.

---

@apoorvapendse - Mentioning you so that you're aware of these changes since the Webex integration is still pending (#37540).

@Niloth-p - Mentioning you as you've been working in this area recently as well.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
