### PR TITLE
compose: Fix Jitsi URL generation to append pathname.

### DIFF
--- a/web/src/compose_call.ts
+++ b/web/src/compose_call.ts
@@ -30,7 +30,8 @@ export function get_jitsi_server_url(video_call_id?: string): URL | null {
     }
     const url = new URL(base_url);
     if (video_call_id !== undefined) {
-        url.pathname = `/${video_call_id}`;
+        const separator = url.pathname.endsWith("/") ? "" : "/";
+        url.pathname += `${separator}${video_call_id}`;
     }
     return url;
 }

--- a/web/tests/compose_video.test.cjs
+++ b/web/tests/compose_video.test.cjs
@@ -153,6 +153,15 @@ test("videos", ({override}) => {
             /\[translated: Join video call\.]\(https:\/\/realm.example.com\/\d{15}#config.startWithVideoMuted=false\)/;
         assert.ok(called);
         assert.match(syntax_to_insert, video_link_regex);
+
+        // Scenario where the URL has a path segment (like an auth token)
+        override(realm, "realm_jitsi_server_url", "https://jitsi.example.com/custom-token");
+        handler.call($textarea, ev);
+
+        video_link_regex =
+            /\[translated: Join video call\.\]\(https:\/\/jitsi\.example\.com\/custom-token\/\d{15}#config\.startWithVideoMuted=false\)/;
+
+        assert.match(syntax_to_insert, video_link_regex);
     })();
 
     (function test_zoom_video_and_audio_links_compose_clicked() {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
[Commit](https://github.com/zulip/zulip/commit/9b18fb4e9f07783470cd2410cfe5b1de0722f4a1) that caused the regression linked here

Fixes: <!-- Issue link, or clear description.-->
Issue discussion linked here: [#issues > Jitsi Meet URL path segment suddenly removed](https://chat.zulip.org/#narrow/channel/9-issues/topic/Jitsi.20Meet.20URL.20path.20segment.20suddenly.20removed/with/2408693)

**How changes were tested:**
- Tested via dev environment.
- Also ran the test introduced in this commit.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
#### Test in Dev environment:
(`custom-token` is the URL path already present. Notice that the `video_call_id` gets appended to it, instead of replacing it.)
<img width="731" height="93" alt="dev-env-test" src="https://github.com/user-attachments/assets/2da98717-da41-463f-ae79-2127047228fe" />

#### Proof of the modified test `compose_video.test.cjs` passing:
<img width="497" height="170" alt="test-success" src="https://github.com/user-attachments/assets/54a74bbf-1dc0-4fb6-9f1d-fbc61a58ece3" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
