### PR TITLE
message_edit_history: Prevent edit history overlay when no edit history exists.

### DIFF
--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -352,27 +352,35 @@ export function handle_keyboard_events(event_key: string): void {
 }
 
 export function initialize(): void {
-    $("body").on("mouseenter", ".message_edit_notice, .edit-notifications", (e) => {
-        if (
-            realm.realm_message_edit_history_visibility_policy !==
-            message_edit_history_visibility_policy_values.never.code
-        ) {
-            $(e.currentTarget).addClass("message_edit_notice_hover");
-        }
-    });
+    $("body").on(
+        "mouseenter",
+        ".message_edit_notice, .edit-notifications.has-edit-history",
+        (e) => {
+            if (
+                realm.realm_message_edit_history_visibility_policy !==
+                message_edit_history_visibility_policy_values.never.code
+            ) {
+                $(e.currentTarget).addClass("message_edit_notice_hover");
+            }
+        },
+    );
 
-    $("body").on("mouseleave", ".message_edit_notice, .edit-notifications", (e) => {
-        if (
-            realm.realm_message_edit_history_visibility_policy !==
-            message_edit_history_visibility_policy_values.never.code
-        ) {
-            $(e.currentTarget).removeClass("message_edit_notice_hover");
-        }
-    });
+    $("body").on(
+        "mouseleave",
+        ".message_edit_notice, .edit-notifications.has-edit-history",
+        (e) => {
+            if (
+                realm.realm_message_edit_history_visibility_policy !==
+                message_edit_history_visibility_policy_values.never.code
+            ) {
+                $(e.currentTarget).removeClass("message_edit_notice_hover");
+            }
+        },
+    );
 
     $("body").on(
         "click",
-        ".message_edit_notice, .edit-notifications",
+        ".message_edit_notice, .edit-notifications.has-edit-history",
         function (this: HTMLElement, e) {
             e.stopPropagation();
             e.preventDefault();

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1095,6 +1095,10 @@
     cursor: pointer;
 }
 
+.edit-notifications.has-edit-history {
+    cursor: pointer;
+}
+
 .fade-in-message {
     animation-name: fadeInMessage;
     animation-duration: 1s;

--- a/web/templates/edited_notice.hbs
+++ b/web/templates/edited_notice.hbs
@@ -1,4 +1,4 @@
-<div class="edit-notifications"></div>
+<div class="edit-notifications{{#if modified}} has-edit-history{{/if}}"></div>
 {{#if modified}}
     {{#unless (eq msg/local_edit_timestamp undefined)}}
         <div class="message_edit_notice">


### PR DESCRIPTION
Clicking the editing indicator previously opened the edit history overlay even when the message had no edit or move history. 
- Now if there is no edit or move history then clicking editing indicator does not open the overlay.
- When we hover on the editing indicator it shows `ponter` cursor only if the edit history overlay can open

<!-- Describe your pull request here.-->

Fixes: [#issues > top bar missing content](https://chat.zulip.org/#narrow/channel/9-issues/topic/top.20bar.20missing.20content/with/2407826)<!-- Issue link, or clear description.-->

**How changes were tested:**
Manually verified the behaviour

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
`When there is no edit history`

https://github.com/user-attachments/assets/b6eb8eea-6f41-4237-83de-52b96765703c

`When there is edit history`

https://github.com/user-attachments/assets/8f449741-e338-4023-b604-11bde2bc3f4b



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
