### PR TITLE
[ai] stream_events: Guard message list access for inbox channel view.

### DIFF
--- a/web/src/stream_events.ts
+++ b/web/src/stream_events.ts
@@ -226,8 +226,7 @@ export function update_property<P extends keyof UpdatableStreamProperties>(
             }
             stream_settings_ui.update_settings_for_archived_and_unarchived(sub);
             message_view_header.maybe_rerender_title_area_for_stream(stream_id);
-            if (is_narrowed_to_stream) {
-                assert(message_lists.current !== undefined);
+            if (is_narrowed_to_stream && message_lists.current !== undefined) {
                 message_lists.current.update_trailing_bookend(true);
             }
             message_live_update.rerender_messages_view();
@@ -324,8 +323,7 @@ export function mark_subscribed(
     stream_list.update_subscribe_to_more_streams_link();
     user_profile.update_user_profile_streams_list_for_users([people.my_current_user_id()]);
 
-    if (narrow_state.narrowed_to_stream_id(sub.stream_id)) {
-        assert(message_lists.current !== undefined);
+    if (narrow_state.narrowed_to_stream_id(sub.stream_id) && message_lists.current !== undefined) {
         message_lists.current.update_trailing_bookend(true);
         const then_select_id =
             typeof message_lists.current.selected_id === "function"
@@ -362,10 +360,9 @@ export function mark_unsubscribed(sub: StreamSubscription): void {
         return;
     }
 
-    if (narrow_state.narrowed_to_stream_id(sub.stream_id)) {
+    if (narrow_state.narrowed_to_stream_id(sub.stream_id) && message_lists.current !== undefined) {
         // Update UI components if we just unsubscribed from the
         // currently viewed stream.
-        assert(message_lists.current !== undefined);
         message_lists.current.update_trailing_bookend(true);
 
         // This update would likely be better implemented by having it


### PR DESCRIPTION
Fixes assertion failures when `narrowed_to_stream_id()` returns `true`
while viewing the inbox channel topic list, where `message_lists.current`
is `undefined`.

## Summary

- When the inbox channel view is active, `narrow_state.filter()` returns
  `inbox_util.filter` (which has a "channel" term), so
  `narrowed_to_stream_id()` returns `true`.
- But `message_lists.current` is `undefined` in the inbox view since
  it's not a traditional message list.
- Three locations in `stream_events.ts` assumed a truthy
  `narrowed_to_stream_id()` implied a defined `message_lists.current`,
  hitting `assert(message_lists.current !== undefined)` and crashing.
- Fix: replace the assert with `&& message_lists.current !== undefined`
  in the condition, so message-list operations are safely skipped in the
  inbox channel view.

## Audit findings

A full codebase audit was done to check whether any other callers of
`narrow_state` functions have the same pattern (truthy narrow check →
assume `message_lists.current` defined). The audit traced all 18
exported functions in `narrow_state.ts` that call `filter()` and
examined every caller across `web/src/`.

**Locations fixed (all in `web/src/stream_events.ts`):**

| Location | Function | Line |
|---|---|---|
| `is_archived` property updater | `update_property` | ~229 |
| `mark_subscribed` | `mark_subscribed` | ~327 |
| `mark_unsubscribed` | `mark_unsubscribed` | ~366 |

**No other bugs found.** Other callers are safe because:

1. **`narrowed_by_topic_reply()`** returns `false` for inbox view
   (requires both channel + topic terms; inbox filter only has channel).
   This protects: `search_suggestion.ts`, `typing_events.ts`,
   `compose_actions.ts`, `hotkey.ts`, `stream_popover.ts`,
   `compose_setup.ts`, `compose_reply.ts`.
2. **`narrowed_by_pm_reply()`** returns `false` for inbox view (requires
   a "dm" term). This protects: `compose_reply.ts`,
   `compose_actions.ts`, `hotkey.ts`, `search_suggestion.ts`.
3. **Non-null assertions on `stream_id()`** (e.g., `compose_tooltips.ts`
   line 233, `search_suggestion.ts` line 960) are only reachable through
   code paths gated by conditions that return `false` for inbox view.
4. **Event handlers** in other modules either check
   `message_lists.current` explicitly (e.g., `hotkey.ts` line 1357,
   `narrow_history.ts` line 29), or are gated behind view-state checks
   (`inbox_util.is_visible()`, `narrow_state.is_message_feed_visible()`).

## Test plan

- [x] `./tools/lint web/src/stream_events.ts` passes
- [x] `./tools/test-js-with-node web/tests/stream_events.test.cjs` passes

---

**User prompt:** When user is narrow to channel list of topics view (powered by inbox_ui) instead of message list, `narrowed_to_stream_id` is true since `narrow_state.filter()` is defined. This fails asserts like `message_lists.current !== undefined` across the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)