### PR TITLE
search: Add vertical padding to search box when pills wrap.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -293,6 +293,12 @@
             }
         }
 
+        &.focused {
+            .search-input-and-pills {
+                padding-block: 0.3571em; /* 5px at 14px em */
+            }
+        }
+
         &.focused .user-pill-container {
             flex-flow: row wrap;
         }


### PR DESCRIPTION
When multiple search filters are applied and pills wrap onto a second line, the pills were stuck to the top and bottom edges with no spacing. This adds vertical padding to the focused search container so wrapped pills have adequate spacing.
The value 0.3571em (5px at 14px em) matches the existing gap value used in .search-input-and-pills, so the vertical padding feels consistent with the spacing between pills.

Fixes #35426.

**How changes were tested:**
Tested locally by adding multiple search filters until pills wrap to a second line, and verified the spacing looks correct in both focused and unfocused states.

**Screenshots and screen captures:**

| State | Before | After |
|-------|--------|-------|
| Multiple rows (focused) |<img width="768" height="298" alt="Screenshot 2026-03-14 003042" src="https://github.com/user-attachments/assets/458e4c10-8fee-4353-a700-35c31c9b1682" /> | <img width="767" height="296" alt="Screenshot (538)" src="https://github.com/user-attachments/assets/3a058db2-02d6-4df9-90c7-f70a2d45e92a" />|




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
