### PR TITLE
[ai] stream_list: Don't warn for expected zoomed-in unread count misses.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -925,9 +925,9 @@ function set_stream_unread_count(
     if (zoomed_in) {
         const $stream_li = get_stream_li(stream_id);
         if (!$stream_li) {
-            // This can happen for legitimate reasons, but we warn
-            // just in case.
-            blueslip.warn("stream id no longer in sidebar: " + stream_id);
+            // When zoomed in, only the zoomed-in stream has a
+            // row in the zoomed view, so this is expected for
+            // all other streams.
             return;
         }
         update_count_in_dom(


### PR DESCRIPTION
When zoomed into a stream's topic list, `get_stream_li` only
returns a result for the zoomed-in stream. The previous code
logged a blueslip warning for every other subscribed stream
with unreads on each unread count update, producing a flood
of "stream id no longer in sidebar" console warnings during
normal operation.

---

Prompted by https://chat.zulip.org/#narrow/channel/9-issues/topic/.22stream.20id.20no.20longer.20in.20sidebar.22

Asked Claude to check for cases where channels are not present in left sidebar but user is still subscribed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)