### PR TITLE
[ai] settings: Sort current user's custom emoji first by author.

### DIFF
--- a/web/src/settings_emoji.ts
+++ b/web/src/settings_emoji.ts
@@ -62,6 +62,14 @@ export function reset(): void {
 }
 
 function sort_author_full_name(a: ServerEmoji, b: ServerEmoji): number {
+    const current_user_id = people.my_current_user_id();
+    const current_user_is_author_a = a.author_id === current_user_id;
+    const current_user_is_author_b = b.author_id === current_user_id;
+
+    if (current_user_is_author_a !== current_user_is_author_b) {
+        return current_user_is_author_a ? -1 : 1;
+    }
+
     const author_a = a.author?.full_name;
     const author_b = b.author?.full_name;
 

--- a/web/tests/settings_emoji.test.cjs
+++ b/web/tests/settings_emoji.test.cjs
@@ -7,6 +7,14 @@ const {run_test} = require("./lib/test.cjs");
 const $ = require("./lib/zjquery.cjs");
 
 const upload_widget = mock_esm("../src/upload_widget");
+const emoji = mock_esm("../src/emoji");
+const list_widget = mock_esm("../src/list_widget", {
+    default_get_item: () => undefined,
+    generic_sort_functions: () => ({}),
+});
+const people = mock_esm("../src/people", {
+    is_person_active: () => true,
+});
 const settings_emoji = zrequire("settings_emoji");
 
 run_test("add_custom_emoji_post_render", () => {
@@ -27,4 +35,70 @@ run_test("add_custom_emoji_post_render", () => {
     };
     settings_emoji.add_custom_emoji_post_render();
     assert.ok(build_widget_stub);
+});
+
+run_test("author sort puts current user first", ({override}) => {
+    const $emoji_table = $("#admin_emoji_table");
+    const $settings_section = $("#emoji-settings-section");
+    const $search_input = $("input.search");
+    $emoji_table.set_closest_results(".settings-section", $settings_section);
+    $settings_section.set_find_results("input.search", $search_input);
+
+    const emoji_data = {
+        1: {
+            author_id: 2,
+            deactivated: false,
+            id: "1",
+            name: "other_emoji_a",
+            source_url: "/other-a.png",
+        },
+        2: {
+            author_id: 1,
+            deactivated: false,
+            id: "2",
+            name: "my_emoji",
+            source_url: "/mine.png",
+        },
+        3: {
+            author_id: 3,
+            deactivated: false,
+            id: "3",
+            name: "other_emoji_b",
+            source_url: "/other-b.png",
+        },
+        4: {
+            author_id: null,
+            deactivated: false,
+            id: "4",
+            name: "unknown_author_emoji",
+            source_url: "/unknown.png",
+        },
+    };
+
+    override(emoji, "get_server_realm_emoji_data", () => emoji_data);
+    override(people, "my_current_user_id", () => 1);
+    override(people, "get_user_by_id_assert_valid", (user_id) => {
+        const users = {
+            1: {full_name: "Current User", avatar_url: "/me.png"},
+            2: {full_name: "Alice", avatar_url: "/alice.png"},
+            3: {full_name: "Bob", avatar_url: "/bob.png"},
+        };
+        return users[user_id];
+    });
+
+    let sort_author_full_name;
+    override(list_widget, "create", (_$container, list, opts) => {
+        assert.equal(list.length, 4);
+        sort_author_full_name = opts.sort_fields.author_full_name;
+    });
+
+    settings_emoji.set_up();
+
+    const list = Object.values(emoji_data);
+    list.sort(sort_author_full_name);
+
+    assert.deepEqual(
+        list.map((item) => item.name),
+        ["my_emoji", "other_emoji_a", "other_emoji_b", "unknown_author_emoji"],
+    );
 });


### PR DESCRIPTION
Fixes: #8170.

## Why this change
This issue asks for improving custom emoji table sorting by **Author** so that emojis uploaded by the current user appear first.

## What changed
- Updated `author_full_name` sorting in `settings_emoji` to prioritize rows where `author_id` matches the current user ID.
- Preserved existing behavior for all other rows:
  - remaining authors are sorted alphabetically by full name
  - rows with unknown author stay at the end
- Added a focused unit test in `web/tests/settings_emoji.test.cjs` that verifies:
  - current user's emoji is sorted first
  - other authors remain alphabetically sorted
  - unknown-author rows are placed last

## Testing
- [x] `source .venv/bin/activate && ./tools/test-js-with-node --skip-provision-check web/tests/settings_emoji.test.cjs`

## Notes
- I was not able to run full Zulip provisioning in this local macOS environment (`./tools/provision` fails due to `/etc/os-release` expectation), so I ran targeted tests relevant to this change.
- This PR intentionally does **not** add a separate “show only my emojis” filter, since that approach was previously discussed and closed as not matching the issue design.
