### PR TITLE
[ai] tools: Add Git worktree workflow with parallel dev servers.

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -652,6 +652,8 @@ message content.
 ./tools/test-backend        # Run Python tests
 ./tools/test-js-with-node   # Run JavaScript tests
 ./tools/run-mypy            # Run type checker
+./tools/create-worktree     # Add a Git worktree that shares the main checkout's provisioned state
+./tools/remove-worktree     # Remove a worktree created by tools/create-worktree
 git grep "pattern"          # Search codebase (use extensively!)
 ```
 
@@ -659,3 +661,34 @@ If a tool complains that provision is outdated, run `./tools/provision`
 to fix it. Do not use `--skip-provision-check` to work around the
 error; the check exists because tests and linters depend on provisioned
 dependencies being current.
+
+## Working in Git worktrees
+
+Use `tools/create-worktree NAME [BRANCH]` to add a worktree at
+`$HOME/zulip-NAME` whenever you need to look at another branch
+(e.g., reviewing a PR, picking up a side task) without disturbing
+the current checkout. The script symlinks the main checkout's
+`.venv`, `node_modules`, generated assets, dev secrets, and
+`.claude/settings.local.json`, so the new worktree is usable in
+seconds without re-running provision. Each worktree has its own
+`var/`, so logs, the dev server's PID file, and the cache key
+prefix stay separate.
+
+`tools/run-dev` automatically picks the next free port range
+(`9971..9976`, `9961..9966`, `9951..9956`) when the main
+checkout's dev server is already on `9991..9996`, so two worktrees
+can run dev servers at the same time. Use `tools/remove-worktree
+NAME` (with `--force` if there are uncommitted changes) when
+you're done; the branch is preserved.
+
+Caveats — see `docs/git/zulip-tools.md` for the full workflow:
+
+- **Run `tools/provision` only in the main checkout, never in a
+  worktree.** The script refuses inside a worktree because shared
+  `.venv`/`node_modules` would be mutated on behalf of a branch
+  that may not be ready for it.
+- **All worktrees share one PostgreSQL database and one RabbitMQ
+  vhost.** Branches with diverging migrations or queue worker
+  schemas can interfere; run queue workers in only one worktree
+  at a time and pass `--streamlined` to `run-dev` in the others.
+- **`--base-port 9981` is reserved** for `tools/test-js-with-puppeteer`.

--- a/docs/git/zulip-tools.md
+++ b/docs/git/zulip-tools.md
@@ -29,6 +29,103 @@ $ ls -l .git/hooks
 pre-commit -> ../../tools/pre-commit
 ```
 
+## Work on multiple branches with `git worktree`
+
+`tools/provision` takes several minutes the first time, and re-runs
+on every branch that changes Python or npm dependencies.
+`tools/create-worktree` makes that cost a one-time thing: each new
+worktree symlinks the expensive provisioned artifacts (`.venv`,
+`node_modules`, generated assets) back to the main checkout, so
+creating a worktree takes seconds instead of minutes.
+
+### Create a worktree
+
+```console
+$ ./tools/create-worktree my-feature
+Worktree ready at /home/you/zulip-my-feature
+```
+
+The worktree lives at `$HOME/zulip-NAME` and checks out a branch of
+the same name, creating it from `HEAD` if it does not already exist.
+Pass a second argument to use a different branch — local, remote
+(`origin/foo`), or a fork remote (`upstream/main`):
+
+```console
+$ ./tools/create-worktree review-1234 upstream/main
+```
+
+### Run a dev server in a worktree
+
+```console
+$ cd ~/zulip-my-feature
+$ ./tools/run-dev
+```
+
+`run-dev` automatically falls back to the next free port range
+(`9971..9976`, then `9961..9966`, then `9951..9956`) when the default
+`9991..9996` is already in use, so two dev servers in two worktrees
+just work. Pass `--base-port PORT` to pin a specific range.
+
+### Remove a worktree
+
+```console
+$ ./tools/remove-worktree my-feature
+Removed worktree /home/you/zulip-my-feature
+```
+
+`remove-worktree` refuses if the worktree has uncommitted changes;
+pass `--force` to discard them. The branch itself is preserved; use
+`git branch -D my-feature` to drop it.
+
+### What's shared, what's per-worktree
+
+`create-worktree` symlinks these heavy provisioned artifacts back to
+the main checkout:
+
+- `.venv/` and `node_modules/` (the bulk of provisioning time)
+- `static/generated/`, `web/generated/`,
+  `static/webpack-bundles/`, `starlight_help/dist/`
+- compiled gettext catalogs (`*.mo`), `locale/en/`,
+  `language_*.json`, per-locale `mobile.json`
+- `zproject/dev-secrets.conf` — so PostgreSQL and RabbitMQ
+  credentials stay aligned with the system services that
+  `tools/provision` configured
+
+Each worktree has its **own `var/`**, so logs, the dev server's PID
+file, and the cache key prefix don't collide when running dev
+servers in parallel.
+
+### Caveats
+
+- **`tools/provision` must run in the main checkout, not in a
+  worktree.** Running provision against a symlinked `.venv` from a
+  worktree would mutate the main checkout's virtualenv from a
+  branch that may not be ready for it. The script refuses with a
+  clear error directing you to the main checkout.
+- **All worktrees share one PostgreSQL database and one RabbitMQ
+  vhost.** Branches with diverging migrations or queue worker
+  changes can interfere with each other. If you need to test a
+  migration without affecting other branches, do it in the main
+  checkout. Run queue workers in only one worktree at a time;
+  others should pass `--streamlined` to `run-dev`.
+- **`--base-port 9981` is reserved.** `tools/test-js-with-puppeteer`
+  hardcodes 9981..9986. Don't pin a dev server to that range or the
+  next Puppeteer run will collide.
+- **`tools/clean-branches` does not know about worktrees.** Remove
+  the worktree first, then prune the branch — otherwise the worktree
+  directory is left behind orphaned, holding the branch checked out.
+- **Worktrees are not portable.** Symlinks use absolute paths into
+  the main checkout, and `dev-secrets.conf` is shared. Don't copy
+  a worktree to another machine or user account.
+
+### Disk usage
+
+A worktree's symlinks reuse multi-gigabyte directories from the main
+checkout (`.venv` is typically 1.5–2 GB, `node_modules` 500 MB–1 GB,
+generated assets a few hundred MB). A fresh worktree adds about
+50 MB on disk for source plus its own `var/`. Most of the cost is
+absorbed by the main checkout no matter how many worktrees you run.
+
 ## Configure continuous integration for your Zulip fork
 
 You might also wish to [configure continuous integration for your fork][zulip-git-guide-ci].

--- a/starlight_help/.gitignore
+++ b/starlight_help/.gitignore
@@ -1,5 +1,5 @@
 # build output
-dist/
+/dist
 dist_no_relative_links/
 # generated types
 .astro/

--- a/static/.gitignore
+++ b/static/.gitignore
@@ -4,8 +4,8 @@
 # Generated static files
 
 # Copied zulip_bots package
-/generated/bots/
+/generated/bots
 # Copied integrations package
-/generated/integrations/
+/generated/integrations
 # From emoji
 /generated/emoji

--- a/tools/create-worktree
+++ b/tools/create-worktree
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# Create a Git worktree that shares provisioned resources with the
+# main Zulip checkout, so working on multiple branches in parallel
+# does not require re-running `tools/provision`.
+#
+# See docs/git/zulip-tools.md for the full worktree workflow.
+
+set -euo pipefail
+shopt -s nullglob
+
+usage() {
+    cat <<'USAGE' >&2
+Usage: tools/create-worktree NAME [BRANCH]
+
+Create a Git worktree at $HOME/zulip-NAME that symlinks the main
+checkout's .venv, node_modules, and other expensive provisioned
+artifacts.  Each worktree has its own var/ directory, so logs, the
+dev server's PID file, and the cache key prefix stay separate.
+
+Arguments:
+  NAME    Worktree directory suffix; the worktree is at $HOME/zulip-NAME.
+  BRANCH  Branch to check out (default: NAME).  Created off HEAD when
+          the branch does not yet exist locally or as a remote-tracking
+          ref.
+USAGE
+    exit "${1:-1}"
+}
+
+for arg in "$@"; do
+    case $arg in
+        -h | --help) usage 0 ;;
+    esac
+done
+case ${1:-} in
+    "") usage 1 ;;
+esac
+[[ $# -le 2 ]] || usage 1
+
+# Whitelist NAME to letters, digits, dot, underscore, dash, with a
+# leading letter or digit.  This is stricter than the ad-hoc rejects
+# below need to be, but produces a much clearer error than letting
+# the pattern fail later through `git check-ref-format`.
+worktree_name=$1
+if ! [[ $worktree_name =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    echo "Error: NAME must start with a letter or digit and contain only" >&2
+    echo "       letters, digits, '.', '_', or '-' (got '$worktree_name')." >&2
+    exit 1
+fi
+
+branch=${2:-$worktree_name}
+
+# Refuse if HOME is unset *or* empty; otherwise the cleanup-on-error
+# path below would try to remove "/zulip-NAME".  `set -u` already
+# catches the unset case but not the empty one.
+: "${HOME:?HOME must be set and non-empty}"
+
+main_repo=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)
+worktree_path="$HOME/zulip-$worktree_name"
+
+# Refuse to run from inside an existing worktree: we'd otherwise
+# create symlinks pointing at another worktree, which is brittle when
+# that worktree later gets removed.  A regular checkout has `.git` as
+# a directory; a Git worktree has `.git` as a small text file
+# pointing back into the main checkout's gitdir.
+if [[ -f $main_repo/.git ]]; then
+    echo "Error: $main_repo is itself a worktree." >&2
+    echo "       Run create-worktree from the main checkout, the one with" >&2
+    echo "       provisioned .venv and node_modules." >&2
+    exit 1
+fi
+
+if ! git -C "$main_repo" check-ref-format --branch "$branch" >/dev/null 2>&1; then
+    echo "Error: '$branch' is not a valid Git branch name." >&2
+    exit 1
+fi
+
+if [[ -e $worktree_path || -L $worktree_path ]]; then
+    echo "Error: $worktree_path already exists." >&2
+    exit 1
+fi
+
+# A worktree under the main checkout creates a self-referential mess
+# (recursion through symlinks, confusing git status).  Force users to
+# pick somewhere outside the main checkout.
+case "$worktree_path/" in
+    "$main_repo/"*)
+        echo "Error: \$HOME/zulip-$worktree_name is inside the main checkout at $main_repo." >&2
+        exit 1
+        ;;
+esac
+
+# `git worktree add` keeps administrative state under
+# .git/worktrees/<name>/ even after the worktree directory is removed
+# manually (e.g. `rm -rf $HOME/zulip-foo`).  The next `worktree add`
+# fails with "already exists" for that name.  Auto-prune the orphan
+# entry so the user doesn't have to know about `git worktree prune`.
+git -C "$main_repo" worktree prune
+
+if [[ ! -d $main_repo/.venv || ! -d $main_repo/node_modules ]]; then
+    echo "Error: $main_repo is missing .venv or node_modules." >&2
+    echo "       Run tools/provision in the main checkout first." >&2
+    exit 1
+fi
+
+# Resolve the branch we're about to check out and verify it doesn't
+# track files inside any of the directories we plan to symlink.  If
+# it did, writes in the worktree would mutate the main repo's
+# working tree through the symlink — refuse instead.
+if git -C "$main_repo" rev-parse --verify --quiet "refs/heads/$branch" >/dev/null; then
+    branch_committish=refs/heads/$branch
+elif git -C "$main_repo" rev-parse --verify --quiet "refs/remotes/$branch" >/dev/null; then
+    branch_committish=refs/remotes/$branch
+else
+    branch_committish=HEAD
+fi
+
+# Top-level shared paths.  Each entry is checked against the branch's
+# ls-tree before we symlink it; if the branch tracks any file at or
+# under the path, we abort with a clear message.
+SHARED_TOP_LEVEL=(
+    .venv
+    node_modules
+    zproject/dev-secrets.conf
+    static/webpack-bundles
+    static/images/landing-page/hello/generated
+    starlight_help/dist
+    locale/en
+)
+
+branch_tracks_path() {
+    # Avoid `head | grep` here: with `set -euo pipefail` the early
+    # SIGPIPE from `head -n1` makes the pipeline exit 141, which the
+    # `if branch_tracks_path` caller misreads as "not tracked".
+    local path=$1
+    [[ -n $(git -C "$main_repo" ls-tree -r --name-only "$branch_committish" -- "$path") ]]
+}
+
+for path in "${SHARED_TOP_LEVEL[@]}"; do
+    if branch_tracks_path "$path"; then
+        echo "Error: branch '$branch' tracks files at '$path'," >&2
+        echo "       which create-worktree would symlink to the main checkout." >&2
+        echo "       This combination would let writes in the worktree mutate" >&2
+        echo "       the main checkout's working tree.  Refusing." >&2
+        exit 1
+    fi
+done
+
+# Create the worktree.  Pass -b only when the branch does not already
+# exist locally or as a remote-tracking ref, so reusing an existing
+# branch works without "branch already exists" errors.
+if [[ $branch_committish == HEAD ]]; then
+    git -C "$main_repo" worktree add -b "$branch" -- "$worktree_path"
+else
+    git -C "$main_repo" worktree add -- "$worktree_path" "$branch"
+fi
+
+# From here on, tear down the partial worktree on any setup failure
+# so the user can re-run create-worktree without manual cleanup.
+cleanup_on_error() {
+    echo "Setup failed; removing partial worktree at $worktree_path." >&2
+    git -C "$main_repo" worktree remove --force -- "$worktree_path" 2>/dev/null \
+        || rm -rf -- "$worktree_path"
+}
+trap cleanup_on_error ERR
+
+# Symlink a single provisioned file or directory from the main repo
+# into the worktree.  Skips silently when the source is missing;
+# refuses when the target already exists, since that means the
+# worktree's branch tracks content at that path (which we already
+# rejected for the SHARED_TOP_LEVEL entries, but generated/* paths
+# below are checked here).
+link() {
+    local rel=$1
+    local source="$main_repo/$rel"
+    local target="$worktree_path/$rel"
+    [[ -e $source || -L $source ]] || return 0
+    if [[ -e $target || -L $target ]]; then
+        echo "Error: $rel already exists in the worktree (the branch tracks it)." >&2
+        echo "       Refusing to overwrite; this would mutate main via the symlink." >&2
+        return 1
+    fi
+    mkdir -p -- "$(dirname -- "$target")"
+    # -T (--no-target-directory) prevents the silent "create a symlink
+    # *inside* an existing directory" mode of ln, which would
+    # otherwise corrupt the worktree if we ever raced with another
+    # process that created the target directory between checks.
+    ln -sT -- "$source" "$target"
+}
+
+# Heavy provisioned dependencies and shared dev configuration.  We
+# symlink dev-secrets.conf rather than copying it: passwords stay
+# aligned with the main checkout's services, and a worktree never
+# diverges to use a stale copy.
+link .venv
+link node_modules
+link zproject/dev-secrets.conf
+
+# Claude Code's per-project allowlist sits in
+# `.claude/settings.local.json`, which is gitignored.  Sharing it
+# means a fresh worktree skips re-prompting for the same permissions
+# the main checkout already granted.
+link .claude/settings.local.json
+
+# Generated-but-gitignored content inside tracked directories.  The
+# subdirectories themselves are tracked (each has a README.md), but
+# their contents are produced by provision.
+link_generated_in() {
+    local gen_dir=$1
+    local item name
+    for item in "$main_repo/$gen_dir"/*; do
+        name=${item##*/}
+        [[ $name == README.md ]] && continue
+        link "$gen_dir/$name"
+    done
+}
+link_generated_in static/generated
+link_generated_in web/generated
+
+# Entirely-gitignored output directories.
+link static/webpack-bundles
+link static/images/landing-page/hello/generated
+link starlight_help/dist
+link locale/en
+
+# Compiled gettext catalogs (*.mo) and other gitignored i18n outputs.
+for mo in "$main_repo"/locale/*/LC_MESSAGES/*.mo; do
+    link "${mo#"$main_repo"/}"
+done
+for json in "$main_repo"/locale/*.json; do
+    link "${json#"$main_repo"/}"
+done
+for mobile_json in "$main_repo"/locale/*/mobile.json; do
+    link "${mobile_json#"$main_repo"/}"
+done
+
+# Each worktree owns its var/, so logs, the run-dev PID file, and
+# the cache key prefix don't collide when running dev servers in
+# parallel.  Pre-create the directories run-dev expects, mirroring
+# what tools/provision normally produces.
+mkdir -p -- \
+    "$worktree_path/var/log" \
+    "$worktree_path/var/run" \
+    "$worktree_path/var/puppeteer"
+
+# Avatars and message-attachment uploads live under var/uploads and
+# are referenced by absolute path / UUID from rows in the shared dev
+# database.  A per-worktree var/uploads would 404 every avatar
+# uploaded from the main checkout, so we symlink the directory back
+# to the main checkout's storage.
+ln -sT -- "$main_repo/var/uploads" "$worktree_path/var/uploads"
+
+trap - ERR
+
+cat <<MESSAGE
+Worktree ready at $worktree_path
+
+To start a dev server in the worktree:
+
+    cd $worktree_path
+    ./tools/run-dev
+
+See docs/git/zulip-tools.md for the worktree workflow.
+MESSAGE

--- a/tools/lib/run_dev_helpers.py
+++ b/tools/lib/run_dev_helpers.py
@@ -1,0 +1,51 @@
+"""Helpers for tools/run-dev that benefit from being unit-testable."""
+
+import socket
+
+# Each run-dev instance reserves 6 consecutive ports starting from
+# its base port (proxy, Django, Tornado, webpack, help center, tusd).
+# The fallback range below leaves a 20-port gap between successive
+# bases so we can run up to four dev servers in parallel without
+# overlap.  TEST_BASE_PORT (9981) sits inside the gap between 9991
+# and 9971, claiming 9981..9986; that range never collides with the
+# fallback proxy bases or their derived ports.
+PORTS_PER_INSTANCE = 6
+DEFAULT_BASE_PORT = 9991
+TEST_BASE_PORT = 9981
+FALLBACK_BASE_PORTS = [DEFAULT_BASE_PORT, 9971, 9961, 9951]
+
+
+def is_port_available(port: int, interface: str | None) -> bool:
+    # Best-effort: probe the same interface run-dev will eventually
+    # bind to, so a port held by another process on a different
+    # interface isn't reported as available.  When --interface is None
+    # (Vagrant/zulipdev mode listens on all interfaces), bind to "" to
+    # match aiohttp's behaviour.
+    bind_host = "" if interface is None else interface
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind((bind_host, port))
+        except OSError:
+            return False
+        return True
+
+
+def is_port_range_available(base: int, interface: str | None) -> bool:
+    return all(is_port_available(base + offset, interface) for offset in range(PORTS_PER_INSTANCE))
+
+
+def pick_base_port(requested: int | None, interface: str | None) -> int | None:
+    """Return the base port to use, or None if every fallback range is busy.
+
+    Probes the entire 6-port range for each candidate, not just the
+    proxy port; otherwise a stray Tornado on +2 would let run-dev
+    start on a base that's doomed to fail later.  The probe is
+    best-effort (TOCTOU-prone) — a mismatch surfaces as a clear bind
+    failure when the listener actually starts.
+    """
+    if requested is not None:
+        return requested
+    for candidate in FALLBACK_BASE_PORTS:
+        if is_port_range_available(candidate, interface):
+            return candidate
+    return None

--- a/tools/provision
+++ b/tools/provision
@@ -48,6 +48,26 @@ PARENT_PATH=$(
     pwd -P
 )
 cd "$PARENT_PATH"
+
+# Worktrees created by tools/create-worktree share the main checkout's
+# .venv, node_modules, and other provisioned artifacts via symlinks.
+# Running provision in such a worktree would mutate the main checkout
+# on behalf of a branch that may not be ready for it.  Refuse on any
+# of three signals: the worktree marker file, a symlinked .venv, or
+# a symlinked node_modules.  A real .git directory plus a fully real
+# .venv means we're in the main checkout and provision can proceed.
+if [ -f .git ] || [ -L .venv ] || [ -L node_modules ]; then
+    echo "Error: this checkout looks like a Git worktree (or has shared" >&2
+    echo "       provisioned dependencies symlinked from another checkout)." >&2
+    echo >&2
+    echo "       Run tools/provision in the main checkout instead.  The" >&2
+    echo "       worktree will pick up the updated .venv and node_modules" >&2
+    echo "       automatically once provisioning finishes." >&2
+    echo >&2
+    echo "       See docs/git/zulip-tools.md for the worktree workflow." >&2
+    exit 1
+fi
+
 mkdir -p var/log
 LOG_PATH="var/log/provision.log"
 

--- a/tools/remove-worktree
+++ b/tools/remove-worktree
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Remove a Git worktree previously created by tools/create-worktree.
+#
+# By default we delegate to `git worktree remove`, which refuses if
+# the worktree has uncommitted changes.  Pass --force to discard
+# them; that's the only way data is destroyed.
+
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE' >&2
+Usage: tools/remove-worktree NAME [--force]
+
+Remove the worktree at $HOME/zulip-NAME.  Refuses if the worktree
+has uncommitted changes; pass --force to discard them.
+USAGE
+    exit "${1:-1}"
+}
+
+force=0
+positional=()
+for arg in "$@"; do
+    case $arg in
+        -h | --help) usage 0 ;;
+        --force) force=1 ;;
+        --) ;; # no-op; tolerate but don't act on a stray separator
+        -*) usage 1 ;;
+        *) positional+=("$arg") ;;
+    esac
+done
+
+[[ ${#positional[@]} -eq 1 ]] || usage 1
+worktree_name=${positional[0]}
+
+if ! [[ $worktree_name =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    echo "Error: NAME must start with a letter or digit and contain only" >&2
+    echo "       letters, digits, '.', '_', or '-' (got '$worktree_name')." >&2
+    exit 1
+fi
+
+# Refuse if HOME is unset *or* empty so we don't construct
+# "/zulip-NAME" and pass it to git worktree remove.
+: "${HOME:?HOME must be set and non-empty}"
+
+main_repo=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)
+worktree_path="$HOME/zulip-$worktree_name"
+
+# Cross-check that the path Git knows about matches what we're about
+# to remove.  This guards against accidentally removing a directory
+# that happens to share the name but isn't tracked as a worktree.
+# We collect the porcelain output into a variable rather than piping
+# it; otherwise an early SIGPIPE from grep can mask a real error
+# under `set -euo pipefail`.
+if ! grep -Fxq -- "$worktree_path" \
+    <(git -C "$main_repo" worktree list --porcelain | awk '/^worktree /{print substr($0,10)}'); then
+    echo "Error: $worktree_path is not registered as a Git worktree of $main_repo." >&2
+    echo "       If the directory was removed manually, run \`git -C $main_repo worktree prune\`." >&2
+    exit 1
+fi
+
+if ((force)); then
+    git -C "$main_repo" worktree remove --force -- "$worktree_path"
+else
+    git -C "$main_repo" worktree remove -- "$worktree_path"
+fi
+
+echo "Removed worktree $worktree_path"

--- a/tools/run-dev
+++ b/tools/run-dev
@@ -274,13 +274,21 @@ def do_one_time_webpack_compile() -> None:
 
 
 def start_webpack_watcher() -> "subprocess.Popen[bytes]":
-    webpack_cmd = ["./tools/webpack", "--watch", f"--port={webpack_port}"]
+    # Always disable the webpack-dev-server host check.  The check
+    # exists to protect dev servers bound to all interfaces from DNS
+    # rebinding attacks, but our run-dev proxy *also* rewrites the
+    # Host header to the upstream's `127.0.0.1:<webpack_port>` while
+    # the browser's Origin stays as the proxy hostname (e.g.
+    # `http://localhost:9971/`); webpack-dev-server's `isSameOrigin`
+    # then rejects the websocket as "Invalid Host/Origin header"
+    # whenever the proxy hostname isn't a literal IP.  In practice
+    # webpack-dev-server is reachable only via the run-dev proxy and
+    # is bound to 127.0.0.1 (or all interfaces when --interface is
+    # explicitly empty), so disabling the check loses no real
+    # security and avoids the false positive.
+    webpack_cmd = ["./tools/webpack", "--watch", f"--port={webpack_port}", "--disable-host-check"]
     if options.minify:
         webpack_cmd.append("--minify")
-    if options.interface is None:
-        # If interface is None and we're listening on all ports, we also need
-        # to disable the webpack host check so that webpack will serve assets.
-        webpack_cmd.append("--disable-host-check")
     if options.interface:
         webpack_cmd.append(f"--host={options.interface}")
     else:

--- a/tools/run-dev
+++ b/tools/run-dev
@@ -5,6 +5,7 @@ import errno
 import logging
 import os
 import pwd
+import re
 import signal
 import subprocess
 import sys
@@ -26,6 +27,13 @@ import aiohttp.web_fileresponse
 from aiohttp import hdrs, web
 
 from scripts.lib.zulip_tools import CYAN, ENDC
+from tools.lib.run_dev_helpers import (
+    DEFAULT_BASE_PORT,
+    FALLBACK_BASE_PORTS,
+    PORTS_PER_INSTANCE,
+    TEST_BASE_PORT,
+    pick_base_port,
+)
 from tools.lib.test_script import add_provision_check_override_param, assert_provisioning_status_ok
 from zerver.lib.mime_types import EXTRA_MIME_TYPES
 from zerver.lib.partial import partial
@@ -37,9 +45,8 @@ DESCRIPTION = """
 Starts the app listening on localhost, for local development.
 
 This script launches the Django and Tornado servers, then runs a reverse proxy
-which serves to both of them.  After it's all up and running, browse to
-
-    http://localhost:9991/
+which serves to both of them.  After it's all up and running, browse to the
+URL printed at the end of startup (http://localhost:9991/ by default).
 
 Note that, while runserver and runtornado have the usual auto-restarting
 behavior, the reverse proxy itself does *not* automatically restart on changes
@@ -51,6 +58,17 @@ parser = argparse.ArgumentParser(
 )
 
 parser.add_argument("--test", action="store_true", help="Use the testing database and ports")
+parser.add_argument(
+    "--base-port",
+    type=int,
+    metavar="PORT",
+    help=(
+        "Lowest port to use; defaults to 9991, with auto-fallback to the next "
+        "free range when running multiple dev servers (see "
+        "docs/git/zulip-tools.md for the worktree workflow). "
+        "Avoid 9981, which is reserved for tools/test-js-with-puppeteer."
+    ),
+)
 parser.add_argument("--minify", action="store_true", help="Minifies assets for testing in dev")
 parser.add_argument("--interface", help="Set the IP or hostname for the proxy to listen on")
 parser.add_argument(
@@ -79,7 +97,7 @@ parser.add_argument(
 parser.add_argument(
     "--only-help-center",
     action="store_true",
-    help="Run help center dev server on port 9991 without running the Zulip web app and related services",
+    help="Run help center dev server on the proxy port without running the Zulip web app and related services",
 )
 add_provision_check_override_param(parser)
 options = parser.parse_args()
@@ -106,14 +124,29 @@ elif options.interface == "":
     options.interface = None
 
 runserver_args: list[str] = []
-base_port = 9991
 if options.test:
-    base_port = 9981
+    base_port = TEST_BASE_PORT
     settings_module = "zproject.test_settings"
     # Don't auto-reload when running Puppeteer tests
     runserver_args = ["--noreload"]
     runtornado_command = ["./manage.py", "runtornado"]
 else:
+    chosen = pick_base_port(options.base_port, options.interface)
+    if chosen is None:
+        print(
+            "ERROR: All fallback port ranges are in use; tried bases "
+            + ", ".join(str(p) for p in FALLBACK_BASE_PORTS),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    base_port = chosen
+    if options.base_port is None and base_port != DEFAULT_BASE_PORT:
+        print(
+            f"Port range starting at {DEFAULT_BASE_PORT} is in use; "
+            f"using {base_port}..{base_port + PORTS_PER_INSTANCE - 1} instead. "
+            f"See docs/git/zulip-tools.md for the worktree workflow.",
+            file=sys.stderr,
+        )
     settings_module = "zproject.settings"
     runtornado_command = [
         "-m",
@@ -125,6 +158,21 @@ else:
         "--immediate-reloads",
         "--automated",
     ]
+
+# Tell Django settings which port range we're using, so derived
+# settings (EXTERNAL_HOST, TORNADO_PORTS, STATIC_URL, the SAML entity
+# ID) stay in sync with the proxy port.
+os.environ["BASE_PORT"] = str(base_port)
+
+# When EXTERNAL_HOST is preset (e.g. on dev droplets), rewrite its
+# port so it matches the proxy port we ended up choosing.  Only
+# rewrite when the trailing component after the last `:` is all
+# digits, so values like "host" (no port) or "[::1]" are left alone.
+EXTERNAL_HOST_PORT_RE = re.compile(r":(\d+)$")
+if not options.test:
+    external_host = os.getenv("EXTERNAL_HOST")
+    if external_host is not None and EXTERNAL_HOST_PORT_RE.search(external_host):
+        os.environ["EXTERNAL_HOST"] = EXTERNAL_HOST_PORT_RE.sub(f":{base_port}", external_host)
 
 manage_args = [f"--settings={settings_module}"]
 os.environ["DJANGO_SETTINGS_MODULE"] = settings_module

--- a/tools/tests/test_run_dev_helpers.py
+++ b/tools/tests/test_run_dev_helpers.py
@@ -1,0 +1,114 @@
+import sys
+import unittest
+from unittest.mock import patch
+
+try:
+    from tools.lib.run_dev_helpers import (
+        DEFAULT_BASE_PORT,
+        FALLBACK_BASE_PORTS,
+        PORTS_PER_INSTANCE,
+        is_port_range_available,
+        pick_base_port,
+    )
+except ImportError:
+    print("ERROR!!! You need to run this via tools/test-tools.")
+    sys.exit(1)
+
+
+class PickBasePortTest(unittest.TestCase):
+    def test_explicit_request_returned_unchanged(self) -> None:
+        # An explicit --base-port wins, even if the requested port is
+        # outside the fallback list and even if it's busy: the user
+        # gets a clear bind error at listener startup, not silent
+        # rerouting to a different port.
+        with patch(
+            "tools.lib.run_dev_helpers.is_port_range_available", return_value=False
+        ) as mocked:
+            self.assertEqual(pick_base_port(8080, None), 8080)
+            mocked.assert_not_called()
+
+    def test_picks_default_when_free(self) -> None:
+        with patch("tools.lib.run_dev_helpers.is_port_range_available", return_value=True):
+            self.assertEqual(pick_base_port(None, None), DEFAULT_BASE_PORT)
+
+    def test_falls_back_to_next_free_range(self) -> None:
+        # 9991 busy, 9971 free; pick 9971.
+        with patch(
+            "tools.lib.run_dev_helpers.is_port_range_available",
+            side_effect=[False, True, True, True],
+        ):
+            self.assertEqual(pick_base_port(None, None), 9971)
+
+    def test_falls_back_through_to_last_candidate(self) -> None:
+        # First three busy, fourth free.
+        with patch(
+            "tools.lib.run_dev_helpers.is_port_range_available",
+            side_effect=[False, False, False, True],
+        ):
+            self.assertEqual(pick_base_port(None, None), FALLBACK_BASE_PORTS[-1])
+
+    def test_returns_none_when_every_range_busy(self) -> None:
+        # All four candidates busy: caller must surface an error and exit.
+        with patch("tools.lib.run_dev_helpers.is_port_range_available", return_value=False):
+            self.assertIsNone(pick_base_port(None, None))
+
+
+class IsPortRangeAvailableTest(unittest.TestCase):
+    def test_probes_full_six_port_range(self) -> None:
+        # The probe must check all six ports starting at base, not
+        # just the proxy port.  Otherwise a stray Tornado on +2 would
+        # let run-dev start with a doomed base.
+        with patch("tools.lib.run_dev_helpers.is_port_available", return_value=True) as mocked:
+            self.assertTrue(is_port_range_available(9991, None))
+            calls = [call.args for call in mocked.call_args_list]
+            self.assertEqual(
+                calls,
+                [(9991 + offset, None) for offset in range(PORTS_PER_INSTANCE)],
+            )
+
+    def test_short_circuits_on_first_busy_port(self) -> None:
+        # If +0 is busy, we don't bother probing +1..+5.
+        with patch(
+            "tools.lib.run_dev_helpers.is_port_available",
+            side_effect=[False, True, True, True, True, True],
+        ) as mocked:
+            self.assertFalse(is_port_range_available(9991, None))
+            self.assertEqual(mocked.call_count, 1)
+
+    def test_detects_collision_in_middle_of_range(self) -> None:
+        # +0..+1 free, +2 busy: range is unusable.
+        with patch(
+            "tools.lib.run_dev_helpers.is_port_available",
+            side_effect=[True, True, False, True, True, True],
+        ):
+            self.assertFalse(is_port_range_available(9991, None))
+
+
+class FallbackPortsTest(unittest.TestCase):
+    def test_fallback_ranges_do_not_overlap_test_base(self) -> None:
+        # The test base port (9981) and its derived ports (9981..9986)
+        # must not collide with any fallback proxy base or its derived
+        # +1..+5 ports.  The 20-port stride makes this work, but a
+        # future change to the constants could regress it silently.
+        from tools.lib.run_dev_helpers import TEST_BASE_PORT
+
+        test_range = set(range(TEST_BASE_PORT, TEST_BASE_PORT + PORTS_PER_INSTANCE))
+        for base in FALLBACK_BASE_PORTS:
+            fallback_range = set(range(base, base + PORTS_PER_INSTANCE))
+            self.assertEqual(
+                fallback_range & test_range,
+                set(),
+                f"Fallback {base}..{base + PORTS_PER_INSTANCE - 1} overlaps test range "
+                f"{TEST_BASE_PORT}..{TEST_BASE_PORT + PORTS_PER_INSTANCE - 1}",
+            )
+
+    def test_fallback_ranges_do_not_overlap_each_other(self) -> None:
+        # Each fallback claims 6 ports; with a 20-port stride between
+        # bases, no two ranges should overlap.
+        seen: set[int] = set()
+        for base in FALLBACK_BASE_PORTS:
+            range_ports = set(range(base, base + PORTS_PER_INSTANCE))
+            self.assertEqual(
+                seen & range_ports, set(), f"Fallback {base} overlaps an earlier fallback"
+            )
+            seen |= range_ports

--- a/tools/webpack
+++ b/tools/webpack
@@ -73,7 +73,12 @@ def build_for_dev_server(host: str, port: str, minify: bool, disable_host_check:
     if disable_host_check:
         webpack_args.append("--allowed-hosts=all")
     else:
-        webpack_args.append(f"--allowed-hosts={host},.zulipdev.com,.zulipdev.org")
+        # `localhost` covers both the default 127.0.0.1 bind and the
+        # zulipdev.com → 127.0.0.1 mapping, and is needed when run-dev
+        # is reached on an alternate port (e.g. in a Git worktree)
+        # via http://localhost:9971/, which doesn't match either of
+        # the dot-prefixed zulipdev.* entries.
+        webpack_args.append(f"--allowed-hosts={host},localhost,.zulipdev.com,.zulipdev.org")
 
     # Tell webpack-dev-server to fall back to periodic polling on
     # filesystems where inotify is known to be broken.

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -607,7 +607,11 @@ if STATIC_URL is None:
     if PRODUCTION or IS_DEV_DROPLET or os.getenv("EXTERNAL_HOST") is not None:
         STATIC_URL = urljoin(ROOT_DOMAIN_URI, "/static/")
     else:
-        STATIC_URL = "http://localhost:9991/static/"
+        try:
+            _static_base_port = int(os.environ.get("BASE_PORT") or "9991")
+        except ValueError:
+            _static_base_port = 9991
+        STATIC_URL = f"http://localhost:{_static_base_port}/static/"
 
 LOCAL_AVATARS_DIR = os.path.join(LOCAL_UPLOADS_DIR, "avatars") if LOCAL_UPLOADS_DIR else None
 LOCAL_FILES_DIR = os.path.join(LOCAL_UPLOADS_DIR, "files") if LOCAL_UPLOADS_DIR else None

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -21,21 +21,31 @@ LOCAL_UPLOADS_DIR = os.path.join(DEPLOY_ROOT, "var/uploads")
 IS_DEV_DROPLET = pwd.getpwuid(os.getuid()).pw_name == "zulipdev"
 
 FORWARD_ADDRESS_CONFIG_FILE = "var/forward_address.ini"
+
+# run-dev sets BASE_PORT to the proxy port it ended up using; default
+# to 9991 when settings are imported outside of run-dev (e.g. by
+# management commands), or when an unrelated stale value is in the
+# environment.
+try:
+    DEV_BASE_PORT = int(os.environ.get("BASE_PORT") or "9991")
+except ValueError:
+    DEV_BASE_PORT = 9991
+
 # Check if test_settings.py set EXTERNAL_HOST.
 external_host_env = os.getenv("EXTERNAL_HOST")
 if external_host_env is None:
     if IS_DEV_DROPLET:
         # For our droplets, we use the hostname (eg github_username.zulipdev.org) by default.
         # Note that this code is duplicated in run-dev.
-        EXTERNAL_HOST = os.uname()[1].lower() + ":9991"
+        EXTERNAL_HOST = os.uname()[1].lower() + f":{DEV_BASE_PORT}"
     else:
         # For local development environments, we use localhost by
         # default, via the "zulipdev.com" hostname.
-        EXTERNAL_HOST = "zulipdev.com:9991"
+        EXTERNAL_HOST = f"zulipdev.com:{DEV_BASE_PORT}"
         # Serve the main dev realm at the literal name "localhost",
         # so it works out of the box even when not on the Internet.
         REALM_HOSTS = {
-            "zulip": "localhost:9991",
+            "zulip": f"localhost:{DEV_BASE_PORT}",
         }
 else:
     EXTERNAL_HOST = external_host_env
@@ -82,7 +92,7 @@ EXTRA_INSTALLED_APPS = ["zilencer", "analytics", "corporate"]
 CAMO_URI = ""
 KATEX_SERVER = False
 
-TORNADO_PORTS = [9993]
+TORNADO_PORTS = [DEV_BASE_PORT + 2]
 
 OPEN_REALM_CREATION = True
 WEB_PUBLIC_STREAMS_ENABLED = True
@@ -192,7 +202,7 @@ LANDING_PAGE_NAVBAR_MESSAGE: str | None = None
 USE_X_FORWARDED_PORT = True
 
 # Override the default SAML entity ID
-SOCIAL_AUTH_SAML_SP_ENTITY_ID = "http://localhost:9991"
+SOCIAL_AUTH_SAML_SP_ENTITY_ID = f"http://localhost:{DEV_BASE_PORT}"
 if IS_DEV_DROPLET:
     SOCIAL_AUTH_SAML_SP_ENTITY_ID = EXTERNAL_URI_SCHEME + "zulip." + EXTERNAL_HOST
 

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -41,7 +41,11 @@ DATABASES["default"] = {
 
 
 if FULL_STACK_ZULIP_TEST:
-    TORNADO_PORTS = [9983]
+    try:
+        _test_base_port = int(os.environ.get("BASE_PORT") or "9981")
+    except ValueError:
+        _test_base_port = 9981
+    TORNADO_PORTS = [_test_base_port + 2]
 else:
     # Backend tests don't use tornado
     USING_TORNADO = False


### PR DESCRIPTION
## Summary

Lets a developer keep multiple Zulip branches checked out at the same time,
with a dev server running in each, without re-running `tools/provision` for
every branch.

- **`tools/create-worktree NAME [BRANCH]`** creates a checkout at
  `$HOME/zulip-NAME` and symlinks the heavy provisioned artifacts
  (`.venv`, `node_modules`, generated assets, locale catalogs,
  `zproject/dev-secrets.conf`, `.claude/settings.local.json`, and
  `var/uploads`) back to the main checkout. Each worktree owns its own
  `var/log`, `var/run`, and cache key prefix.
  **`tools/remove-worktree NAME [--force]`** cleanly tears one down.

- **`tools/run-dev` gains `--base-port PORT`** and auto-falls-back through
  9971, 9961, 9951 when the default 9991 range is busy. The chosen base
  flows through to Django via a `BASE_PORT` env var so `EXTERNAL_HOST`,
  `TORNADO_PORTS`, `STATIC_URL`, and the SAML entity ID stay consistent.
  `--disable-host-check` is now unconditional, fixing a long-standing
  "Invalid Host/Origin header" false positive that broke hot reload when
  the dev server was reached via `localhost`.

- **`tools/provision`** refuses to run inside a worktree whose `.venv`,
  `node_modules`, or `.git` is shared from another checkout, with a clear
  message pointing the user at the main checkout.

- **Docs**: `docs/git/zulip-tools.md` gains a full worktree section
  (workflow, what's shared vs. per-worktree, caveats around shared
  services and the reserved 9981..9986 test range, disk savings).
  `.claude/CLAUDE.md` references the new scripts so AI contributors land
  on the same workflow.

## Test plan

- [x] `./tools/test-tools` passes, including the new
  `tools/tests/test_run_dev_helpers.py` covering `pick_base_port`'s
  fallback chain, the full six-port probe, and the invariant that the
  test base port range doesn't overlap any fallback.
- [x] `./tools/lint --modified` is clean.
- [x] Settings import with `BASE_PORT` unset / set to a number / set to
  garbage / set to `""` — the defensive `try/except ValueError` falls
  back to 9991 in all cases.
- [x] Round-trip: `tools/create-worktree wt-foo` then
  `tools/remove-worktree wt-foo` — clean before, during, and after.
- [x] Input rejection — `foo/bar`, `-rf`, an invalid branch name, a
  destination that already exists, a destination inside the main
  checkout, and being run from another worktree all refuse with clear
  errors.
- [x] Orphan recovery — `rm -rf ~/zulip-foo` followed by
  `tools/create-worktree foo` succeeds (auto-prunes the orphaned
  `.git/worktrees/foo` entry before `worktree add`).
- [x] `tools/provision` inside a worktree refuses with a pointer to the
  main checkout.
- [x] Two parallel `tools/run-dev` instances in different worktrees —
  first binds 9991..9996, the second auto-picks 9971..9976; hot reload
  via websocket works for both, reached at `localhost:<port>`.
- [x] User avatars and uploaded files render in the worktree dev
  server since `var/uploads` is symlinked back to main.

## Self-review

- [x] Each commit is a minimal coherent idea, passes lint/tests
  individually.
- [x] Commit messages explain *why*, not just *what*.
- [x] No secrets are hardcoded; the `dev-secrets.conf` symlink is
  documented as machine-local.
- [x] Security: positive whitelist on NAME; `git check-ref-format
  --branch` on BRANCH; refusal to create worktrees inside the main
  checkout, on top of another worktree, or for branches that track
  files at any of the symlinked top-level paths; `ln -sT --` to refuse
  implicit-into-directory symlink semantics; `--` separators on every
  git/rm/ln; empty `\$HOME` asserted before destructive paths are
  built; `set -euo pipefail` plus an `ERR` trap that rolls back partial
  worktrees.

---

### How this was created

@amanagr had a `~/create-zulip-worktree.sh` script for creating git
worktrees with symlinked provisioned resources. The original prompt
was to make it widely available in the Zulip repo, add a companion
remove script, fix the known starlight-help-center bug where symlinked
`dist` showed as unstaged in `git status`, and make `run-dev` support
running on different ports so multiple worktrees could have concurrent
dev servers.

The branch was rebuilt from scratch and refined with input from a
security review (three passes), five expert critiques (CLI ergonomics,
Zulip-maintainer standards, Claude Code workflow, SRE risk, and an
alternative-design contrarian), and two commit-split verifiers. The
resulting ten commits were sized for independent review and are
individually green on lint + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)