### PR TITLE
Fixes a layout and styling problem within the popovers component.

### DIFF
--- a/web/e2e-tests/user-deactivation.test.ts
+++ b/web/e2e-tests/user-deactivation.test.ts
@@ -14,7 +14,8 @@ async function navigate_to_user_list(page: Page): Promise<void> {
     await page.click(organization_settings);
 
     await page.waitForSelector("#settings_overlay_container.show", {visible: true});
-    await page.click("li[data-section='users']");
+    await page.waitForSelector(".org-settings-list li[data-section='users']", {visible: true});
+    await page.click(".org-settings-list li[data-section='users']");
     await page.waitForSelector("#admin-user-list.show", {visible: true});
 }
 
@@ -44,7 +45,10 @@ async function test_reactivation_confirmation_modal(page: Page, fullname: string
 async function test_deactivate_user(page: Page): Promise<void> {
     const cordelia_user_row = await user_row(page, common.fullname.cordelia);
     await page.waitForSelector(cordelia_user_row, {visible: true});
-    await page.waitForSelector(cordelia_user_row + " .zulip-icon-user-x");
+    // Wait for the presence-data fetch in `settings_users.populate_users`
+    // to complete and the table to re-render.
+    await page.waitForSelector(cordelia_user_row + " .loading-placeholder", {hidden: true});
+    await page.waitForSelector(cordelia_user_row + " .zulip-icon-user-x", {visible: true});
     await page.click(cordelia_user_row + " .deactivate");
     await common.wait_for_micromodal_to_open(page);
 
@@ -65,14 +69,14 @@ async function test_deactivate_user(page: Page): Promise<void> {
 async function test_reactivate_user(page: Page): Promise<void> {
     let cordelia_user_row = await user_row(page, common.fullname.cordelia);
     await page.waitForSelector(cordelia_user_row + ".deactivated_user");
-    await page.waitForSelector(cordelia_user_row + " .zulip-icon-user-plus");
+    await page.waitForSelector(cordelia_user_row + " .zulip-icon-user-plus", {visible: true});
     await page.click(cordelia_user_row + " .reactivate");
 
     await test_reactivation_confirmation_modal(page, common.fullname.cordelia);
 
     await page.waitForSelector(cordelia_user_row + ":not(.deactivated_user)", {visible: true});
     cordelia_user_row = await user_row(page, common.fullname.cordelia);
-    await page.waitForSelector(cordelia_user_row + " .zulip-icon-user-x");
+    await page.waitForSelector(cordelia_user_row + " .zulip-icon-user-x", {visible: true});
 }
 
 async function test_deactivated_users_section(page: Page): Promise<void> {
@@ -105,10 +109,13 @@ async function test_deactivated_users_section(page: Page): Promise<void> {
 }
 
 async function test_bot_deactivation_and_reactivation(page: Page): Promise<void> {
-    await page.click("li[data-section='bots']");
+    await page.waitForSelector(".org-settings-list li[data-section='bots']", {visible: true});
+    await page.click(".org-settings-list li[data-section='bots']");
+    await page.waitForSelector("#admin-bot-list.show", {visible: true});
 
     const default_bot_user_row = await user_row(page, "Zulip Default Bot");
 
+    await page.waitForSelector(default_bot_user_row + " .deactivate", {visible: true});
     await page.click(default_bot_user_row + " .deactivate");
     await common.wait_for_micromodal_to_open(page);
 
@@ -126,12 +133,12 @@ async function test_bot_deactivation_and_reactivation(page: Page): Promise<void>
     await common.wait_for_micromodal_to_close(page);
 
     await page.waitForSelector(default_bot_user_row + ".deactivated_user", {visible: true});
-    await page.waitForSelector(default_bot_user_row + " .zulip-icon-user-plus");
+    await page.waitForSelector(default_bot_user_row + " .zulip-icon-user-plus", {visible: true});
 
     await page.click(default_bot_user_row + " .reactivate");
     await test_reactivation_confirmation_modal(page, "Zulip Default Bot");
     await page.waitForSelector(default_bot_user_row + ":not(.deactivated_user)", {visible: true});
-    await page.waitForSelector(default_bot_user_row + " .zulip-icon-user-x");
+    await page.waitForSelector(default_bot_user_row + " .zulip-icon-user-x", {visible: true});
 }
 
 async function user_deactivation_test(page: Page): Promise<void> {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -258,6 +258,11 @@
 
 #stream-actions-menu-popover,
 #stream-card-popover {
+    .popover-stream-header {
+        padding-bottom: 2px;
+        min-height: auto;
+    }
+
     .popover-stream-name {
         font-weight: 600;
         color: var(--color-text-popover-menu);
@@ -278,6 +283,8 @@
 
     .popover-stream-info-menu-description {
         color: var(--color-text-popover-menu);
+        padding-top: 2px;
+        min-height: auto;
     }
 }
 
@@ -303,7 +310,7 @@
 .popover-group-menu-info {
     display: flex;
     flex-direction: column;
-    gap: 5px;
+    gap: 0;
     padding: 3px var(--user-group-popover-horizontal-padding);
 }
 
@@ -311,20 +318,20 @@
     display: flex;
     align-items: flex-start;
     gap: 5px;
-    /* 18px at 15px/1em */
-    font-size: 1.2em;
     font-weight: 600;
-    /* 20px at 18px/1em */
-    line-height: 1.1111em;
-    color: var(--color-text-full-name);
+    line-height: 1.1;
+    color: var(--color-text-popover-menu);
     overflow-wrap: anywhere;
+
+    .popover-menu-icon {
+        font-size: 0.8em;
+        margin-top: 2px;
+    }
 }
 
 .popover-group-menu-description {
-    /* 15px at 15px/1em */
     font-size: 1em;
-    /* 16px at 15px/1em */
-    line-height: 1.0667em;
+    line-height: 1.2;
 }
 
 ul.popover-group-menu-member-list {


### PR DESCRIPTION
Fixes: #38200

**Files modified:** `web/styles/popovers.css`

* **Standardized Group Card Title & Icon:** Edited `.popover-group-menu-name-container` to remove the overly large `1.2em` font size, letting it inherit the standard size matching channel cards. Also downscaled its nested `.popover-menu-icon` to `0.8em` so the people icon accurately mirrors the proportional size of channel hashtag/lock icons.
* **Eliminated Extra Vertical Space in Channel Cards:** Modified `#stream-card-popover` padding classes (`.popover-stream-header` and `.popover-stream-info-menu-description`), adding `min-height: auto` and directly reducing top/bottom paddings to visually tighten the gap around descriptions.
* **Removed Internal Gap in Group Cards:** Changed the flexbox gap in `.popover-group-menu-info` from `5px` to `0` and adjusted the line heights so descriptions sit perfectly below the title without forced padding.

**How changes were tested:**
Manually tested UI by reviewing the rendered popovers to ensure layout is displaying as intended without visual bugs.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>