### PR TITLE
email_pill: Add logic to convert email addresses with names attached into invite users email input to pills.

### DIFF
--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -61,6 +61,7 @@ from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import activate_push_notification_service
 from zerver.lib.timestamp import TimeZoneNotUTCError, ceiling_to_day, floor_to_day
 from zerver.lib.topic import DB_TOPIC_NAME
+from zerver.lib.types import Invitee
 from zerver.lib.user_counts import realm_user_count_by_role
 from zerver.lib.utils import assert_is_not_none
 from zerver.models import (
@@ -1696,7 +1697,7 @@ class TestLoggingCountStats(AnalyticsTestCase):
         with invite_context():
             do_invite_users(
                 user,
-                ["user1@domain.tld", "user2@domain.tld"],
+                [Invitee(email="user1@domain.tld"), Invitee(email="user2@domain.tld")],
                 [stream],
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -1708,7 +1709,7 @@ class TestLoggingCountStats(AnalyticsTestCase):
         with invite_context():
             do_invite_users(
                 user,
-                ["user1@domain.tld", "user2@domain.tld"],
+                [Invitee(email="user1@domain.tld"), Invitee(email="user2@domain.tld")],
                 [stream],
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -1719,7 +1720,10 @@ class TestLoggingCountStats(AnalyticsTestCase):
         with invite_context(failure=True):
             do_invite_users(
                 user,
-                ["user3@domain.tld", "malformed"],
+                [
+                    Invitee(email="user3@domain.tld"),
+                    Invitee(email="malformed"),
+                ],
                 [stream],
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -1730,7 +1734,7 @@ class TestLoggingCountStats(AnalyticsTestCase):
         with invite_context():
             skipped = do_invite_users(
                 user,
-                ["first@domain.tld", "user4@domain.tld"],
+                [Invitee(email="first@domain.tld"), Invitee(email="user4@domain.tld")],
                 [stream],
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,

--- a/web/src/email_pill.ts
+++ b/web/src/email_pill.ts
@@ -1,5 +1,7 @@
 import {parseAddressList, parseOneAddress} from "email-addresses";
 
+import render_input_pill from "../templates/input_pill.hbs";
+
 import type {InputPillConfig, InputPillContainer} from "./input_pill.ts";
 import * as input_pill from "./input_pill.ts";
 
@@ -66,6 +68,19 @@ export function split_text_to_form_email_pills(raw_emails: string): string[] {
         .map((email) => (email.name ? `"${email.name}" <${email.address}>` : email.address));
 }
 
+export function generate_pill_html(item: EmailPill): string {
+    const parsed_address = parseOneAddress(item.email);
+    const name = parsed_address?.name;
+    // Remove quotes from the name if they exist
+    const invited_user_name = name?.replaceAll(/"([^"]*)"/g, "$1");
+
+    return render_input_pill({
+        is_email_pill: true,
+        invited_user_name,
+        display_value: invited_user_name ? `<${item.parsed_email}>` : item.parsed_email,
+    });
+}
+
 export function create_pills(
     $pill_container: JQuery,
     pill_config?: InputPillConfig,
@@ -78,6 +93,7 @@ export function create_pills(
         get_display_value_from_item: get_email_from_item,
         split_text_on_comma: false,
         split_text_to_form_pills: split_text_to_form_email_pills,
+        generate_pill_html,
     });
     return pill_container;
 }

--- a/web/src/email_pill.ts
+++ b/web/src/email_pill.ts
@@ -1,4 +1,4 @@
-import {parseOneAddress} from "email-addresses";
+import {parseAddressList, parseOneAddress} from "email-addresses";
 
 import type {InputPillConfig, InputPillContainer} from "./input_pill.ts";
 import * as input_pill from "./input_pill.ts";
@@ -52,6 +52,20 @@ export function get_current_email(
     return null;
 }
 
+export function split_text_to_form_email_pills(raw_emails: string): string[] {
+    const parsed_emails = parseAddressList(raw_emails);
+
+    // If the input string cannot be parsed into valid email addresses,
+    // return the string so that the pill code can handle the invalid case.
+    if (!parsed_emails) {
+        return [raw_emails];
+    }
+
+    return parsed_emails
+        .filter((email) => email.type === "mailbox")
+        .map((email) => (email.name ? `"${email.name}" <${email.address}>` : email.address));
+}
+
 export function create_pills(
     $pill_container: JQuery,
     pill_config?: InputPillConfig,
@@ -62,6 +76,8 @@ export function create_pills(
         create_item_from_text: create_item_from_email,
         get_text_from_item: get_email_from_item,
         get_display_value_from_item: get_email_from_item,
+        split_text_on_comma: false,
+        split_text_to_form_pills: split_text_to_form_email_pills,
     });
     return pill_container;
 }

--- a/web/src/email_pill.ts
+++ b/web/src/email_pill.ts
@@ -1,31 +1,37 @@
+import {parseOneAddress} from "email-addresses";
+
 import type {InputPillConfig, InputPillContainer} from "./input_pill.ts";
 import * as input_pill from "./input_pill.ts";
 
 type EmailPill = {
     type: "email";
     email: string;
+    parsed_email: string;
 };
 
 export type EmailPillWidget = InputPillContainer<EmailPill>;
-
-const email_regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export function create_item_from_email(
     email: string,
     current_items: EmailPill[],
 ): EmailPill | undefined {
-    if (!email_regex.test(email)) {
+    const original_email = email;
+    const parsed_address = parseOneAddress(email);
+    if (parsed_address?.type !== "mailbox") {
         return undefined;
     }
 
-    const existing_emails = current_items.map((item) => item.email);
-    if (existing_emails.includes(email)) {
+    const parsed_email = parsed_address.address;
+
+    const existing_emails = current_items.map((item) => item.parsed_email);
+    if (existing_emails.includes(parsed_email)) {
         return undefined;
     }
 
     return {
         type: "email",
-        email,
+        email: original_email,
+        parsed_email,
     };
 }
 
@@ -37,8 +43,11 @@ export function get_current_email(
     pill_container: input_pill.InputPillContainer<EmailPill>,
 ): string | null {
     const current_text = pill_container.getCurrentText();
-    if (current_text !== null && email_regex.test(current_text)) {
-        return current_text;
+    if (current_text !== null) {
+        const parsed_address = parseOneAddress(current_text);
+        if (parsed_address?.type === "mailbox") {
+            return current_text;
+        }
     }
     return null;
 }

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -37,6 +37,7 @@ type InputPillCreateOptions<ItemType> = {
         remove_pill: (pill: HTMLElement) => void,
     ) => void;
     show_outline_on_invalid_input?: boolean;
+    split_text_to_form_pills?: (pills: string) => string[];
 };
 
 export type InputPill<ItemType> = {
@@ -63,6 +64,7 @@ type InputPillStore<ItemType> = {
     split_text_on_comma: boolean;
     convert_to_pill_on_enter: boolean;
     show_outline_on_invalid_input: boolean;
+    split_text_to_form_pills: InputPillCreateOptions<ItemType>["split_text_to_form_pills"];
 };
 
 // These are the functions that are exposed to other modules.
@@ -111,6 +113,7 @@ export function create<ItemType extends {type: string}>(
         generate_pill_html: opts.generate_pill_html,
         on_pill_exit: opts.on_pill_exit,
         show_outline_on_invalid_input: opts.show_outline_on_invalid_input ?? false,
+        split_text_to_form_pills: opts.split_text_to_form_pills,
     };
 
     // a dictionary of internal functions. Some of these are exposed as well,
@@ -270,7 +273,11 @@ export function create<ItemType extends {type: string}>(
 
         insertManyPills(pills: string | string[]) {
             if (typeof pills === "string") {
-                pills = pills.split(/,/g).map((pill) => pill.trim());
+                if (!store.split_text_on_comma && store.split_text_to_form_pills) {
+                    pills = store.split_text_to_form_pills(pills);
+                } else {
+                    pills = pills.split(/,/g).map((pill) => pill.trim());
+                }
             }
 
             // this is an array to push all the errored values to, so it's drafts
@@ -358,6 +365,12 @@ export function create<ItemType extends {type: string}>(
                 // and append the pill, then clear the input.
                 const value = funcs.value(this).trim();
                 if (value.length > 0) {
+                    // If there are multiple values separated by commas, we should use insertManyPills
+                    // to handle them properly when pressing the Enter key.
+                    if (!store.split_text_on_comma && value.includes(",")) {
+                        funcs.insertManyPills(value);
+                        return;
+                    }
                     // append the pill and by proxy create the pill object.
                     const ret = funcs.appendPill(value);
 
@@ -403,7 +416,7 @@ export function create<ItemType extends {type: string}>(
 
             // Typing of the comma is prevented if the last field doesn't validate,
             // as well as when the new pill is created.
-            if (e.key === ",") {
+            if (e.key === "," && store.split_text_on_comma) {
                 // if the pill is successful, it will create the pill and clear
                 // the input.
                 if (funcs.appendPill(store.$input.text().trim())) {

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -57,6 +57,15 @@
             background-color: var(--color-background-input-pill-hover);
         }
 
+        .invited-user-name {
+            flex: 1;
+            min-width: 0;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            margin-right: 3px;
+        }
+
         .pill-image {
             height: var(--height-input-pill);
             width: var(--height-input-pill);

--- a/web/templates/input_pill.hbs
+++ b/web/templates/input_pill.hbs
@@ -11,6 +11,11 @@
     {{/if}}
     {{/if}}
     <span class="pill-label">
+        {{#if is_email_pill}}
+            {{~#if invited_user_name}}
+                <span class="invited-user-name">{{invited_user_name}}</span>
+            {{~/if~}}
+        {{/if}}
         <span class="pill-value">
             {{#if has_stream}}
                 {{> decorated_channel_name stream=stream }}

--- a/zerver/actions/invites.py
+++ b/zerver/actions/invites.py
@@ -33,6 +33,7 @@ from zerver.lib.invites import notify_invites_changed
 from zerver.lib.queue import queue_event_on_commit
 from zerver.lib.send_email import FromAddress, clear_scheduled_invitation_emails, send_future_email
 from zerver.lib.timestamp import datetime_to_timestamp
+from zerver.lib.types import Invitee
 from zerver.lib.utils import assert_is_not_none
 from zerver.models import (
     Message,
@@ -188,7 +189,7 @@ def check_invite_limit(realm: Realm, num_invitees: int) -> None:
 @transaction.atomic(durable=True)
 def do_invite_users(
     user_profile: UserProfile,
-    invitee_emails: Collection[str],
+    invitees: Collection[Invitee],
     streams: Collection[Stream],
     notify_referrer_on_join: bool = True,
     user_groups: Collection[NamedUserGroup] = [],
@@ -198,7 +199,7 @@ def do_invite_users(
     invite_as: int = PreregistrationUser.INVITE_AS["MEMBER"],
     welcome_message_custom_text: str | None = None,
 ) -> list[tuple[str, str, bool]]:
-    num_invites = len(invitee_emails)
+    num_invites = len(invitees)
 
     # Lock the realm, since we need to not race with other invitations
     realm = Realm.objects.select_for_update(no_key=True).get(id=user_profile.realm_id)
@@ -229,34 +230,36 @@ def do_invite_users(
                 sent_invitations=False,
             )
 
-    good_emails: set[str] = set()
+    good_invitees: set[Invitee] = set()
     errors: list[tuple[str, str, bool]] = []
     validate_email_allowed_in_realm = get_realm_email_validator(realm)
-    for email in invitee_emails:
+    for invitee in invitees:
         email_error = validate_email_is_valid(
-            email,
+            invitee.email,
             validate_email_allowed_in_realm,
         )
 
         if email_error:
-            errors.append((email, email_error, False))
+            errors.append((invitee.email, email_error, False))
         else:
-            good_emails.add(email)
+            good_invitees.add(invitee)
 
     """
-    good_emails are emails that look ok so far,
+    good_invitees are invitee names and emails that look ok so far,
     but we still need to make sure they're not
     gonna conflict with existing users
     """
-    error_dict = get_existing_user_errors(realm, good_emails, allow_inactive_mirror_dummies=True)
+    error_dict = get_existing_user_errors(
+        realm, {invitee.email for invitee in good_invitees}, allow_inactive_mirror_dummies=True
+    )
 
     skipped: list[tuple[str, str, bool]] = []
     for email in error_dict:
         msg, deactivated = error_dict[email]
         skipped.append((email, msg, deactivated))
-        good_emails.remove(email)
+        good_invitees = {item for item in good_invitees if item.email != email}
 
-    validated_emails = list(good_emails)
+    validated_invitees = list(good_invitees)
 
     if errors:
         raise InvitationError(
@@ -265,7 +268,7 @@ def do_invite_users(
             sent_invitations=False,
         )
 
-    if skipped and len(skipped) == len(invitee_emails):
+    if skipped and len(skipped) == len(invitees):
         # All e-mails were skipped, so we didn't actually invite anyone.
         raise InvitationError(
             _("We weren't able to invite anyone."), skipped, sent_invitations=False
@@ -273,10 +276,13 @@ def do_invite_users(
 
     # Now that we are past all the possible errors, we actually create
     # the PreregistrationUser objects and trigger the email invitations.
-    for email in validated_emails:
+    for validated_invitee in validated_invitees:
         # The logged in user is the referrer.
         prereg_user = PreregistrationUser(
-            email=email,
+            email=validated_invitee.email,
+            # We include a name if specified in the invitation request, but leave full_name_validated=False,
+            # so the receiving user can spell their name as they like after accepting the invitation.
+            full_name=validated_invitee.full_name,
             referred_by=user_profile,
             invited_as=invite_as,
             realm=realm,

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -447,3 +447,9 @@ class DirectMessageEditRequest:
     content: str
     orig_content: str
     is_content_edited: bool
+
+
+@dataclass(frozen=True)
+class Invitee:
+    email: str
+    full_name: str = ""

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -86,7 +86,7 @@ from zerver.lib.test_helpers import (
     use_s3_backend,
 )
 from zerver.lib.thumbnail import DEFAULT_AVATAR_SIZE, MEDIUM_AVATAR_SIZE, resize_avatar
-from zerver.lib.types import Validator
+from zerver.lib.types import Invitee, Validator
 from zerver.lib.url_encoding import append_url_query_string
 from zerver.lib.user_groups import (
     get_system_user_group_by_name,
@@ -1580,7 +1580,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
         with self.captureOnCommitCallbacks(execute=True):
             do_invite_users(
                 iago,
-                [email],
+                [Invitee(full_name=name, email=email)],
                 [],
                 include_realm_default_subscriptions=True,
                 invite_expires_in_minutes=2 * 24 * 60,
@@ -1981,7 +1981,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
         with self.captureOnCommitCallbacks(execute=True):
             do_invite_users(
                 iago,
-                [email],
+                [Invitee(full_name=name, email=email)],
                 [],
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -266,6 +266,7 @@ from zerver.lib.test_helpers import (
 from zerver.lib.timestamp import convert_to_UTC, datetime_to_timestamp
 from zerver.lib.topic import TOPIC_NAME
 from zerver.lib.types import (
+    Invitee,
     ProfileDataElementUpdateDict,
     UserGroupMembersData,
     UserGroupMembersDict,
@@ -1501,7 +1502,7 @@ class NormalActionsTest(BaseAction):
         with self.verify_action(state_change_expected=False) as events:
             do_invite_users(
                 self.user_profile,
-                ["foo@zulip.com"],
+                [Invitee(email="foo@zulip.com")],
                 streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -1533,7 +1534,7 @@ class NormalActionsTest(BaseAction):
         with self.captureOnCommitCallbacks(execute=True):
             do_invite_users(
                 user_profile,
-                ["foo@zulip.com"],
+                [Invitee(email="foo@zulip.com")],
                 [],
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -1556,7 +1557,7 @@ class NormalActionsTest(BaseAction):
         with self.captureOnCommitCallbacks(execute=True):
             do_invite_users(
                 self.user_profile,
-                ["foo@zulip.com"],
+                [Invitee(email="foo@zulip.com")],
                 streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -1608,7 +1609,7 @@ class NormalActionsTest(BaseAction):
         with self.captureOnCommitCallbacks(execute=True):
             do_invite_users(
                 self.user_profile,
-                ["foo@zulip.com"],
+                [Invitee(email="foo@zulip.com")],
                 streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -55,6 +55,7 @@ from zerver.lib.send_email import queue_scheduled_emails
 from zerver.lib.streams import ensure_stream
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import find_key_by_email
+from zerver.lib.types import Invitee
 from zerver.lib.user_groups import get_direct_user_groups, is_user_in_group
 from zerver.models import (
     DefaultStream,
@@ -74,7 +75,7 @@ from zerver.models.realm_audit_logs import AuditLogEventType
 from zerver.models.realms import get_realm
 from zerver.models.streams import get_stream
 from zerver.models.users import get_user_by_delivery_email
-from zerver.views.invite import INVITATION_LINK_VALIDITY_MINUTES, get_invitee_emails_set
+from zerver.views.invite import INVITATION_LINK_VALIDITY_MINUTES, get_invitees_set
 from zerver.views.registration import accounts_home
 
 if TYPE_CHECKING:
@@ -139,7 +140,7 @@ class StreamSetupTest(ZulipTestCase):
 
         do_invite_users(
             admin,
-            [new_user_email],
+            [Invitee(email=new_user_email)],
             streams,
             include_realm_default_subscriptions=False,
             invite_expires_in_minutes=1000,
@@ -172,7 +173,7 @@ class StreamSetupTest(ZulipTestCase):
 
         do_invite_users(
             admin,
-            [new_user_email],
+            [Invitee(email=new_user_email)],
             streams=[],
             user_groups=user_groups,
             include_realm_default_subscriptions=False,
@@ -1953,7 +1954,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         with self.captureOnCommitCallbacks(execute=True):
             do_invite_users(
                 self.user_profile,
-                ["foo@zulip.com"],
+                [Invitee(email="foo@zulip.com")],
                 streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -1962,14 +1963,14 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         with self.captureOnCommitCallbacks(execute=True):
             do_invite_users(
                 self.user_profile,
-                ["foo@zulip.com"],
+                [Invitee(email="foo@zulip.com")],
                 streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
             )
             do_invite_users(
                 self.user_profile,
-                ["foo@zulip.com"],
+                [Invitee(email="foo@zulip.com")],
                 streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -1981,7 +1982,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         with self.captureOnCommitCallbacks(execute=True):
             do_invite_users(
                 lear_user,
-                ["foo@zulip.com"],
+                [Invitee(email="foo@zulip.com")],
                 [],
                 include_realm_default_subscriptions=True,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -2352,35 +2353,35 @@ class InvitationsTestCase(InviteUserBase):
         with self.captureOnCommitCallbacks(execute=True):
             do_invite_users(
                 user_profile,
-                ["TestOne@zulip.com"],
+                [Invitee(email="TestOne@zulip.com")],
                 streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
             )
             do_invite_users(
                 user_profile,
-                ["TestTwo@zulip.com"],
+                [Invitee(email="TestTwo@zulip.com")],
                 streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
             )
             do_invite_users(
                 hamlet,
-                ["TestThree@zulip.com"],
+                [Invitee(email="TestThree@zulip.com")],
                 streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
             )
             do_invite_users(
                 othello,
-                ["TestFour@zulip.com"],
+                [Invitee(email="TestFour@zulip.com")],
                 streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
             )
             do_invite_users(
                 self.mit_user("sipbtest"),
-                ["TestOne@mit.edu"],
+                [Invitee(email="TestOne@mit.edu")],
                 [],
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -2424,7 +2425,7 @@ class InvitationsTestCase(InviteUserBase):
         with self.captureOnCommitCallbacks(execute=True):
             do_invite_users(
                 user_profile,
-                ["TestOne@zulip.com"],
+                [Invitee(email="TestOne@zulip.com")],
                 streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -2436,7 +2437,7 @@ class InvitationsTestCase(InviteUserBase):
         ):
             do_invite_users(
                 user_profile,
-                ["TestTwo@zulip.com"],
+                [Invitee(email="TestTwo@zulip.com")],
                 streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -2491,14 +2492,14 @@ class InvitationsTestCase(InviteUserBase):
             # after a large amount of days.
             do_invite_users(
                 user_profile,
-                ["TestOne@zulip.com"],
+                [Invitee(email="TestOne@zulip.com")],
                 streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=None,
             )
             do_invite_users(
                 user_profile,
-                ["TestTwo@zulip.com"],
+                [Invitee(email="TestTwo@zulip.com")],
                 streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=100 * 24 * 60,
@@ -2967,6 +2968,25 @@ class InvitationsTestCase(InviteUserBase):
         self.assertIsNotNone(user)
         self.assertEqual(user.delivery_email, email)
 
+    def test_prereg_user_object_has_full_name_set(self) -> None:
+        emails = 'TestOne <test1@zulip.com>, test2@zulip.com, "Test, Three" <test3@zulip.com>, Test Four <test4@zulip.com>'
+        self.login("iago")
+        result = self.client_post(
+            "/json/invites", {"invitee_emails": emails, "stream_ids": orjson.dumps([]).decode()}
+        )
+        self.assert_json_success(result)
+
+        expected_users = {
+            "test1@zulip.com": "TestOne",
+            "test2@zulip.com": "",
+            "test3@zulip.com": "Test, Three",
+            "test4@zulip.com": "Test Four",
+        }
+
+        for email, expected_name in expected_users.items():
+            prereg_user = PreregistrationUser.objects.get(email=email)
+            self.assertEqual(prereg_user.full_name, expected_name)
+
 
 class InviteeEmailsParserTests(ZulipTestCase):
     @override
@@ -2978,25 +2998,41 @@ class InviteeEmailsParserTests(ZulipTestCase):
 
     def test_if_emails_separated_by_commas_are_parsed_and_striped_correctly(self) -> None:
         emails_raw = f"{self.email1} ,{self.email2}, {self.email3}"
-        expected_set = {self.email1, self.email2, self.email3}
-        self.assertEqual(get_invitee_emails_set(emails_raw), expected_set)
+        expected_set = {
+            Invitee(full_name="", email=self.email1),
+            Invitee(full_name="", email=self.email2),
+            Invitee(full_name="", email=self.email3),
+        }
+        self.assertEqual(get_invitees_set(emails_raw), expected_set)
 
     def test_if_emails_separated_by_newlines_are_parsed_and_striped_correctly(self) -> None:
         emails_raw = f"{self.email1}\n {self.email2}\n {self.email3} "
-        expected_set = {self.email1, self.email2, self.email3}
-        self.assertEqual(get_invitee_emails_set(emails_raw), expected_set)
+        expected_set = {
+            Invitee(full_name="", email=self.email1),
+            Invitee(full_name="", email=self.email2),
+            Invitee(full_name="", email=self.email3),
+        }
+        self.assertEqual(get_invitees_set(emails_raw), expected_set)
 
     def test_if_emails_from_email_client_separated_by_newlines_are_parsed_correctly(self) -> None:
         emails_raw = (
             f"Email One <{self.email1}>\nEmailTwo<{self.email2}>\nEmail Three<{self.email3}>"
         )
-        expected_set = {self.email1, self.email2, self.email3}
-        self.assertEqual(get_invitee_emails_set(emails_raw), expected_set)
+        expected_set = {
+            Invitee(full_name="Email One", email=self.email1),
+            Invitee(full_name="EmailTwo", email=self.email2),
+            Invitee(full_name="Email Three", email=self.email3),
+        }
+        self.assertEqual(get_invitees_set(emails_raw), expected_set)
 
     def test_if_emails_in_mixed_style_are_parsed_correctly(self) -> None:
         emails_raw = f"Email One <{self.email1}>,EmailTwo<{self.email2}>\n{self.email3}"
-        expected_set = {self.email1, self.email2, self.email3}
-        self.assertEqual(get_invitee_emails_set(emails_raw), expected_set)
+        expected_set = {
+            Invitee(full_name="Email One", email=self.email1),
+            Invitee(full_name="EmailTwo", email=self.email2),
+            Invitee(full_name="", email=self.email3),
+        }
+        self.assertEqual(get_invitees_set(emails_raw), expected_set)
 
 
 class MultiuseInviteTest(ZulipTestCase):

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -63,6 +63,7 @@ from zerver.lib.test_helpers import (
     ratelimit_rule,
     reset_email_visibility_to_everyone_in_zulip_realm,
 )
+from zerver.lib.types import Invitee
 from zerver.models import (
     CustomProfileField,
     CustomProfileFieldValue,
@@ -3421,7 +3422,7 @@ class UserSignUpTest(ZulipTestCase):
         with self.captureOnCommitCallbacks(execute=True):
             do_invite_users(
                 admin,
-                [mirror_dummy.delivery_email],
+                [Invitee(email=mirror_dummy.delivery_email)],
                 [],
                 invite_expires_in_minutes=None,
                 include_realm_default_subscriptions=True,

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -56,6 +56,7 @@ from zerver.lib.test_helpers import (
     reset_email_visibility_to_everyone_in_zulip_realm,
     simulated_empty_cache,
 )
+from zerver.lib.types import Invitee
 from zerver.lib.upload import upload_avatar_image
 from zerver.lib.user_groups import get_system_user_group_for_user
 from zerver.lib.users import (
@@ -1129,7 +1130,7 @@ class QueryCountTest(ZulipTestCase):
         with self.captureOnCommitCallbacks(execute=True):
             do_invite_users(
                 user_profile=self.example_user("hamlet"),
-                invitee_emails=["fred@zulip.com"],
+                invitees=[Invitee(email="fred@zulip.com")],
                 streams=streams,
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -2245,7 +2246,7 @@ class ActivateTest(ZulipTestCase):
         with self.captureOnCommitCallbacks(execute=True):
             do_invite_users(
                 iago,
-                ["new1@zulip.com", "new2@zulip.com"],
+                [Invitee(email="new1@zulip.com"), Invitee(email="new2@zulip.com")],
                 [],
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -2253,7 +2254,7 @@ class ActivateTest(ZulipTestCase):
             )
             do_invite_users(
                 desdemona,
-                ["new3@zulip.com", "new4@zulip.com"],
+                [Invitee(email="new3@zulip.com"), Invitee(email="new4@zulip.com")],
                 [],
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=invite_expires_in_minutes,
@@ -2262,7 +2263,7 @@ class ActivateTest(ZulipTestCase):
 
             do_invite_users(
                 iago,
-                ["new5@zulip.com"],
+                [Invitee(email="new5@zulip.com")],
                 [],
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=None,
@@ -2270,7 +2271,7 @@ class ActivateTest(ZulipTestCase):
             )
             do_invite_users(
                 desdemona,
-                ["new6@zulip.com"],
+                [Invitee(email="new6@zulip.com")],
                 [],
                 include_realm_default_subscriptions=False,
                 invite_expires_in_minutes=None,

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -23,6 +23,7 @@ from zerver.lib.response import json_success
 from zerver.lib.streams import access_stream_by_id, get_streams_to_which_user_cannot_add_subscribers
 from zerver.lib.typed_endpoint import ApiParamConfig, PathOnly, typed_endpoint
 from zerver.lib.typed_endpoint_validators import check_int_in_validator
+from zerver.lib.types import Invitee
 from zerver.lib.user_groups import UserGroupMembershipDetails, access_user_group_for_update
 from zerver.models import (
     MultiuseInvite,
@@ -171,7 +172,7 @@ def invite_users_backend(
     if not invitee_emails_raw:
         raise JsonableError(_("You must specify at least one email address."))
 
-    invitee_emails = get_invitee_emails_set(invitee_emails_raw)
+    invitee_emails = get_invitees_set(invitee_emails_raw)
 
     streams = access_streams_for_invite(stream_ids, user_profile)
     user_groups = access_user_groups_for_invite(group_ids, user_profile)
@@ -212,6 +213,16 @@ def get_invitee_emails_set(invitee_emails_raw: str) -> set[str]:
             invitee_emails_raw.split("\n"), strict=False
         )
     } - {""}
+
+
+def get_invitees_set(invitee_emails_raw: str) -> set[Invitee]:
+    return {
+        Invitee(email=email, full_name=full_name)
+        for full_name, email in email.utils.getaddresses(
+            invitee_emails_raw.split("\n"), strict=False
+        )
+        if email
+    }
 
 
 @require_human_non_guest_user


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR includes the changes:

The email-addresses library is now used to parse email addresses in RFC5322 format, ensuring accurate extraction of names and emails.
- Modified create_item_from_email to pass the full name with email into the pill.
- Additionally, the invite emails are now sent as a stringified JSON containing full_name and email properties.
- Changed the data structure of invitee emails from Collection[str] to Collection[Invitee] where Invitee is a new dataclass to store the corresponding name to email.
- Renamed good_emails togood_invitees andvalidated_emails to validated_invitees.

Fixes: https://github.com/zulip/zulip/issues/32874.

This is a replacement PR for #32881. Difference from the previous PR
- Previously the parsing logic in  `get_invitees_set` used regular expressions (re) to extract emails and names. As in commit 97a7b9f183e31c51d10c422aa87c7db7e1743dbc we removed `re` and used `email address parser` I have modified to use the same.

**How changes were tested:**
Manually verified working of the invites 

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
`Before Pressing Enter`
<img width="762" height="696" alt="Screenshot 2026-03-15 000535" src="https://github.com/user-attachments/assets/eaafa094-5715-4d16-b21b-12b7c8620457" />

`After Pressing Enter`
<img width="748" height="681" alt="image" src="https://github.com/user-attachments/assets/13e3c010-d64e-424e-b8c5-df3d8602edd3" />

`Full name populated when invitation is opend with editing allowed`
<img width="463" height="752" alt="image" src="https://github.com/user-attachments/assets/3b8ee5b0-7f24-404a-a5af-93ad90eaa565" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
