### PR TITLE
[ai] recent_view_ui: Skip rerender when recent view is not visible.

### DIFF
--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1055,7 +1055,7 @@ export function filters_should_hide_row(topic_data: ConversationData): boolean {
 }
 
 export function bulk_inplace_rerender(row_keys: string[]): void {
-    if (!topics_widget) {
+    if (!topics_widget || !recent_view_util.is_visible()) {
         return;
     }
 


### PR DESCRIPTION
Recent view was calling `scrollTo(0)` on bulk inplace rerenders when new messages were backfilled. 

Identified by checking which function where calling `scrollTo` after messages are fetched.

discussion: [#issues > conversation view scrolling up in Firefox](https://chat.zulip.org/#narrow/channel/9-issues/topic/conversation.20view.20scrolling.20up.20in.20Firefox/with/2408776)

