### PR TITLE
message_edit_history: Add option to delete prior versions.

### DIFF
--- a/api_docs/delete-message-history.md
+++ b/api_docs/delete-message-history.md
@@ -1,0 +1,31 @@
+{generate_api_header(/messages/{message_id}/history:delete)}
+
+## Usage examples
+
+{start_tabs}
+
+{generate_code_example(python)|/messages/{message_id}/history:delete|example}
+
+{tab|curl}
+
+{!curl-auth-credentials.md!}
+```curl
+curl -sSX DELETE {{ api_url }}/v1/messages/MESSAGE_ID/history \
+    -u EMAIL_ADDRESS:API_KEY
+```
+
+{end_tabs}
+
+## Parameters
+
+{generate_api_parameter_description(/messages/{message_id}/history:delete)}
+
+## Response
+
+#### Return values
+
+{generate_return_values(/messages/{message_id}/history:delete)}
+
+#### Example response(s)
+
+{generate_code_example(python)|/messages/{message_id}/history:delete|fixture}

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -12,6 +12,7 @@
 * [Fetch a single message](/api/get-message)
 * [Check if messages match a narrow](/api/check-messages-match-narrow)
 * [Get a message's edit history](/api/get-message-history)
+* [Delete a message's edit history](/api/delete-message-history)
 * [Update personal message flags](/api/update-message-flags)
 * [Update personal message flags for narrow](/api/update-message-flags-for-narrow)
 * [Mark all messages as read](/api/mark-all-as-read)

--- a/starlight_help/src/content/docs/view-a-messages-edit-history.mdx
+++ b/starlight_help/src/content/docs/view-a-messages-edit-history.mdx
@@ -27,6 +27,22 @@ import MessageEditHistoryIntro from "../include/_MessageEditHistoryIntro.mdx";
   </TabItem>
 </Tabs>
 
+## Delete a message's edit history
+
+Users who have permission to [delete a message](/help/delete-a-message) can
+also delete its edit history. This removes the previous versions of the
+message content, while keeping a record that the edit history was deleted.
+
+<Tabs>
+  <TabItem label="Desktop/Web">
+    <Steps>
+      1. Open the message's edit history.
+      1. Click **Delete prior versions of this message**.
+      1. Click **Confirm**.
+    </Steps>
+  </TabItem>
+</Tabs>
+
 ## Related articles
 
 * [Edit a message](/help/edit-a-message)

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -2,13 +2,16 @@ import $ from "jquery";
 import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
+import render_confirm_delete_edit_history from "../templates/confirm_dialog/confirm_delete_edit_history.hbs";
 import render_message_edit_history from "../templates/message_edit_history.hbs";
 import render_message_history_overlay from "../templates/message_history_overlay.hbs";
 
 import {exit_overlay} from "./browser_history.ts";
 import * as channel from "./channel.ts";
+import * as confirm_dialog from "./confirm_dialog.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as loading from "./loading.ts";
+import * as message_delete from "./message_delete.ts";
 import * as message_lists from "./message_lists.ts";
 import type {Message} from "./message_store.ts";
 import * as messages_overlay_ui from "./messages_overlay_ui.ts";
@@ -45,6 +48,7 @@ type EditHistoryEntry = {
     prev_stream: string | undefined;
     prev_stream_id: number | undefined;
     new_stream: string | undefined;
+    history_deleted_by_mention_html: string | undefined;
 };
 
 const server_message_history_schema = z.object({
@@ -61,6 +65,7 @@ const server_message_history_schema = z.object({
             prev_content: z.optional(z.string()),
             prev_rendered_content: z.optional(z.string()),
             content_html_diff: z.optional(z.string()),
+            history_deleted_by: z.optional(z.number()),
         }),
     ),
 });
@@ -126,6 +131,8 @@ export function fetch_and_render_message_history(message: Message): void {
             moved: message_container.moved,
             edited: message_container.edited,
             move_history_only,
+            can_delete_history:
+                message_container.edited && message_delete.get_deletability(message),
         }),
     );
     $("#message-edit-history-overlay-container").attr("data-message-id", message.id);
@@ -174,14 +181,15 @@ export function fetch_and_render_message_history(message: Message): void {
                 let initial_entry_for_move_history = false;
 
                 if (index === 0) {
+                    const history_deleted = data.message_history.some(
+                        (entry) => entry.history_deleted_by !== undefined,
+                    );
                     edited_by_notice = $t({defaultMessage: "Posted by {full_name}"}, {full_name});
                     if (move_history_only) {
-                        // If message history is limited to moves only, then we
-                        // display the original topic and channel for the message.
                         initial_entry_for_move_history = true;
                         new_topic_display_name = util.get_final_topic_display_name(msg.topic);
-                    } else {
-                        // Otherwise, we display the original message content.
+                    } else if (!history_deleted) {
+                        // Only show content if history has not been deleted.
                         body_to_render = msg.rendered_content;
                     }
                 } else if (msg.prev_topic !== undefined && msg.prev_content) {
@@ -220,10 +228,17 @@ export function fetch_and_render_message_history(message: Message): void {
                     if (prev_stream_item !== null) {
                         prev_stream_item.new_stream = get_display_stream_name(msg.prev_stream);
                     }
-                } else {
-                    // just a content edit
+                } else if (msg.history_deleted_by !== undefined) {
+                    edited_by_notice = $t({defaultMessage: "Edited by {full_name}"}, {full_name});
+                    // Last edited entry: show current message content after history deletion.
+                    if (index === data.message_history.length - 1) {
+                        body_to_render = msg.rendered_content;
+                    }
+                } else if (msg.content_html_diff !== undefined) {
                     edited_by_notice = $t({defaultMessage: "Edited by {full_name}"}, {full_name});
                     body_to_render = msg.content_html_diff;
+                } else {
+                    continue;
                 }
                 const item: EditHistoryEntry = {
                     initial_entry_for_move_history,
@@ -242,6 +257,14 @@ export function fetch_and_render_message_history(message: Message): void {
                     prev_stream,
                     prev_stream_id,
                     new_stream: undefined,
+                    history_deleted_by_mention_html:
+                        msg.history_deleted_by !== undefined &&
+                        index !== data.message_history.length - 1
+                            ? `<span class="user-mention silent" data-user-id="${msg.history_deleted_by}">${people.get_user_by_id_assert_valid(msg.history_deleted_by).full_name}</span>`
+                            : index === 0 &&
+                                data.message_history.some((e) => e.history_deleted_by !== undefined)
+                              ? `<span class="user-mention silent" data-user-id="${data.message_history.find((e) => e.history_deleted_by !== undefined)!.history_deleted_by}">${people.get_user_by_id_assert_valid(data.message_history.find((e) => e.history_deleted_by !== undefined)!.history_deleted_by!).full_name}</span>`
+                              : undefined,
                 };
 
                 if (msg.prev_stream) {
@@ -289,6 +312,18 @@ export function fetch_and_render_message_history(message: Message): void {
             });
             $("#message-history-overlay").attr("data-message-id", message.id);
             hide_loading_indicator();
+            // Hide delete button if history was already deleted
+            // and no new content edits have happened since.
+            // Skip index 0 (Posted by entry) as it always has body_to_render.
+            const already_deleted = data.message_history.some(
+                (entry) => entry.history_deleted_by !== undefined,
+            );
+            const has_new_content_edit_after_deletion = data.message_history.some(
+                (entry) => entry.prev_content !== undefined,
+            );
+            if (already_deleted && !has_new_content_edit_after_deletion) {
+                $(".delete-edit-history-button").hide();
+            }
             $("#message-history-overlay .overlay-messages-list").append($(rendered_list_html));
 
             // Pass the history through rendered_markdown.ts
@@ -432,5 +467,30 @@ export function initialize(): void {
 
     $("body").on("click", "#message-history-overlay .message_edit_history_content", (e) => {
         messages_overlay_ui.handle_overlay_media_click(e, "message_edit_history");
+    });
+
+    $("body").on("click", ".delete-edit-history-button", () => {
+        const message_id = $("#message-edit-history-overlay-container").attr("data-message-id");
+        assert(message_id !== undefined);
+
+        confirm_dialog.launch({
+            modal_title_html: $t_html({defaultMessage: "Delete prior versions of this message?"}),
+            modal_content_html: render_confirm_delete_edit_history({}),
+            on_click() {
+                void channel.del({
+                    url: "/json/messages/" + message_id + "/history",
+                    success() {
+                        overlays.close_overlay("message_edit_history");
+                    },
+                    error(xhr) {
+                        ui_report.error(
+                            $t_html({defaultMessage: "Error deleting message edit history."}),
+                            xhr,
+                            $("#message-history-overlay #message-history-error"),
+                        );
+                    },
+                });
+            },
+        });
     });
 }

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -896,8 +896,13 @@ export function update_messages(events: UpdateMessageEvent[]): void {
             // flag is used to indicated update_message events that are
             // triggered by server latency optimizations, not user
             // interactions; these should not generate edit history updates.
-            if (!event.rendering_only && any_message_content_edited) {
-                anchor_message.last_edit_timestamp = event.edit_timestamp;
+            if (
+                !event.rendering_only &&
+                (any_message_content_edited || event.edit_history_deleted)
+            ) {
+                anchor_message.last_edit_timestamp = event.edit_history_deleted
+                    ? anchor_message.last_edit_timestamp
+                    : event.edit_timestamp;
             }
 
             message_notifications.received_messages([anchor_message]);

--- a/web/src/server_event_types.ts
+++ b/web/src/server_event_types.ts
@@ -26,6 +26,7 @@ export const update_message_event_schema = z.object({
     type: z.literal("update_message"),
     user_id: z.nullable(z.number()),
     rendering_only: z.boolean(),
+    edit_history_deleted: z.optional(z.boolean()),
     message_id: z.number(),
     message_ids: z.array(z.number()),
     flags: z.array(z.string()),

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -830,6 +830,10 @@ input.settings_text_input {
     }
 
     .overlay-messages-header {
+        .delete-edit-history-button {
+            display: block;
+            margin: 6px auto 0;
+        }
         padding-top: 4px;
         padding-bottom: 8px;
         text-align: center;

--- a/web/templates/confirm_dialog/confirm_delete_edit_history.hbs
+++ b/web/templates/confirm_dialog/confirm_delete_edit_history.hbs
@@ -1,0 +1,3 @@
+<p>
+    {{t "Information about message edits will still be shown, but old message content will be removed." }}
+</p>

--- a/web/templates/message_edit_history.hbs
+++ b/web/templates/message_edit_history.hbs
@@ -55,6 +55,11 @@
                             {{ rendered_markdown body_to_render}}
                         </div>
                         {{/if}}
+                        {{#if history_deleted_by_mention_html}}
+                        <div class="message_content rendered_markdown message_edit_history_content">
+                            <p>{{t "Content deleted from this message's history by" }} {{{history_deleted_by_mention_html}}}.</p>
+                        </div>
+                        {{/if}}
                         {{/if}}
                     </div>
                 </div>

--- a/web/templates/message_history_overlay.hbs
+++ b/web/templates/message_history_overlay.hbs
@@ -15,6 +15,14 @@
                     <h1>{{t "Message move history" }}</h1>
                 {{/if}}
                 {{/if}}
+                {{#if can_delete_history}}
+                {{> components/action_button
+                  label=(t "Delete prior versions of this message")
+                  variant="subtle"
+                  intent="danger"
+                  custom_classes="delete-edit-history-button"
+                  }}
+                {{/if}}
                 <div class="exit">
                     <span class="exit-sign">&times;</span>
                 </div>
@@ -27,4 +35,3 @@
         </div>
     </div>
 </div>
-

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
+import orjson
 from django.conf import settings
 from django.db import transaction
 from django.db.models import Q, QuerySet
@@ -1822,3 +1823,39 @@ def re_thumbnail(
         assert isinstance(message, ArchivedMessage)
         message.rendered_content = new_content
         message.save(update_fields=["rendered_content"])
+
+
+def do_delete_message_edit_history(
+    message: Message,
+    acting_user: UserProfile,
+) -> None:
+    """
+    Strips prev_content from all edit history entries and inserts
+    an audit record noting who deleted the history.
+    """
+    if message.edit_history is None:  # nocoverage
+        return
+
+    edit_history: list[EditHistoryEvent] = orjson.loads(message.edit_history)
+
+    # Remove content fields from every entry and mark all as edit history deleted
+    for entry in edit_history:
+        entry.pop("prev_content", None)
+        entry.pop("prev_rendered_content", None)
+        entry.pop("prev_rendered_content_version", None)
+        entry["history_deleted_by"] = acting_user.id
+
+    message.edit_history = orjson.dumps(edit_history).decode()
+    message.save(update_fields=["edit_history"])
+
+    # Send event so frontend keeps (edited) indicator and updates message state
+    event = {
+        "type": "update_message",
+        "user_id": acting_user.id,
+        "message_id": message.id,
+        "rendering_only": False,
+        "edit_history_deleted": True,
+    }
+    ums = UserMessage.objects.filter(message=message.id)
+    users = [{"id": um.user_profile_id, "flags": um.flags_list()} for um in ums]
+    send_event_on_commit(acting_user.realm, event, users)

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -336,7 +336,7 @@ def messages_for_ids(
                     item["topic"], item["prev_topic"]
                 ):
                     last_moved_timestamp = max(last_moved_timestamp, item["timestamp"])
-                if "prev_content" in item:
+                if "prev_content" in item or "history_deleted_by" in item:
                     last_edit_timestamp = max(last_edit_timestamp, item["timestamp"])
             if last_moved_timestamp != 0:
                 msg_dict["last_moved_timestamp"] = last_moved_timestamp

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -118,6 +118,7 @@ class EditHistoryEvent(TypedDict, total=False):
     prev_content: str
     prev_rendered_content: str | None
     prev_rendered_content_version: int | None
+    history_deleted_by: int
 
 
 class FormattedEditHistoryEvent(TypedDict, total=False):
@@ -137,6 +138,7 @@ class FormattedEditHistoryEvent(TypedDict, total=False):
     prev_rendered_content: str | None
     rendered_content: str | None
     content_html_diff: str
+    history_deleted_by: int
 
 
 class UserTopicDict(TypedDict, total=False):

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9233,6 +9233,11 @@ paths:
                               type: integer
                               description: |
                                 The UNIX timestamp for this edit.
+                            history_deleted_by:
+                              type: integer
+                              description: |
+                                Only present if the message edit history was deleted.
+                                The ID of the admin user who deleted the edit history.
                         description: |
                           A chronologically sorted, oldest to newest, array
                           of `snapshot` objects, each one with the values of
@@ -9272,6 +9277,38 @@ paths:
                   - $ref: "#/components/schemas/InvalidMessageError"
                   - description: |
                       An example JSON response for when the specified message does not exist:
+    delete:
+      operationId: delete-message-history
+      summary: Delete a message's edit history
+      tags: ["messages"]
+      description: |
+        Delete the edit history of a message, removing the previous versions
+        of the message content. A record that the edit history was deleted
+        will be kept, including who deleted it.
+        Users who have permission to [delete a message](/help/delete-a-message)
+        also have permission to delete its edit history.
+      parameters:
+        - $ref: "#/components/parameters/MessageId"
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JsonSuccess"
+              examples:
+                response:
+                  value: {"msg": "", "result": "success"}
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/InvalidMessageError"
+                  - description: |
+                      An example error response if the message has no
+                      content edits to delete.
   /messages/flags:
     post:
       operationId: update-message-flags

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -2808,3 +2808,62 @@ class EditMessageTest(ZulipTestCase):
             ),
             {hamlet.id},
         )
+
+    def test_delete_message_edit_history(self) -> None:
+        hamlet = self.example_user("hamlet")
+
+        # Send and edit a message
+        msg_id = self.send_stream_message(
+            hamlet,
+            "Denmark",
+            topic_name="test topic",
+            content="original content",
+        )
+        self.login("hamlet")
+        result = self.client_patch(
+            f"/json/messages/{msg_id}",
+            {"content": "edited content"},
+        )
+        self.assert_json_success(result)
+
+        # Admin can delete edit history
+        self.login("iago")
+        result = self.client_delete(f"/json/messages/{msg_id}/history")
+        self.assert_json_success(result)
+
+        # Verify content is removed from history
+        history = self.client_get(f"/json/messages/{msg_id}/history")
+        history_data = orjson.loads(history.content)
+        self.assertFalse(any("prev_content" in entry for entry in history_data["message_history"]))
+
+        # Verify audit entry exists
+        self.assertTrue(
+            any("history_deleted_by" in entry for entry in history_data["message_history"])
+        )
+
+        # Non-admin cannot delete edit history
+        self.login("cordelia")
+        result = self.client_delete(f"/json/messages/{msg_id}/history")
+        self.assert_json_error(result, "You don't have permission to delete this message")
+
+        # Cannot delete history with no content edits
+        msg_id_no_edit = self.send_stream_message(
+            hamlet, "Denmark", topic_name="test topic", content="no edits"
+        )
+        self.login("iago")
+        result = self.client_delete(f"/json/messages/{msg_id_no_edit}/history")
+        self.assert_json_error(result, "This message has no edit history to delete.")
+
+        # Cannot delete history if only topic was edited (no content edits)
+        msg_id_topic_only = self.send_stream_message(
+            hamlet, "Denmark", topic_name="original topic", content="some content"
+        )
+        self.login("hamlet")
+        result = self.client_patch(
+            f"/json/messages/{msg_id_topic_only}",
+            {"topic": "new topic"},
+        )
+        self.assert_json_success(result)
+        self.login("iago")
+        result = self.client_delete(f"/json/messages/{msg_id_topic_only}/history")
+        self.assert_json_error(result, "This message has no content edits to delete.")

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext as _
 from pydantic import Json, NonNegativeInt
 
 from zerver.actions.message_delete import do_delete_messages
-from zerver.actions.message_edit import check_update_message
+from zerver.actions.message_edit import check_update_message, do_delete_message_edit_history
 from zerver.context_processors import get_valid_realm_from_request
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.html_diff import highlight_html_differences
@@ -93,6 +93,8 @@ def fill_edit_history_entries(
             formatted_entry["prev_stream"] = edit_history_event["prev_stream"]
             formatted_entry["stream"] = edit_history_event["stream"]
 
+        if "history_deleted_by" in edit_history_event:
+            formatted_entry["history_deleted_by"] = edit_history_event["history_deleted_by"]
         formatted_edit_history.append(formatted_entry)
 
     initial_message_history: FormattedEditHistoryEvent = {
@@ -144,6 +146,31 @@ def get_message_edit_history(
     return json_success(
         request, data={"message_history": list(reversed(visible_message_edit_history))}
     )
+
+
+@typed_endpoint
+def delete_message_edit_history(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    *,
+    message_id: PathOnly[NonNegativeInt],
+) -> HttpResponse:
+    message = access_message(user_profile, message_id, is_modifying_message=True)
+
+    # Only users who can delete the message can delete its history
+    validate_can_delete_message(user_profile, message)
+
+    # Only makes sense if message was actually content-edited
+    if message.edit_history is None:
+        raise JsonableError(_("This message has no edit history to delete."))
+
+    raw_history: list[EditHistoryEvent] = orjson.loads(message.edit_history)
+    has_content_edit = any("prev_content" in entry for entry in raw_history)
+    if not has_content_edit:
+        raise JsonableError(_("This message has no content edits to delete."))
+
+    do_delete_message_edit_history(message, user_profile)
+    return json_success(request)
 
 
 @typed_endpoint

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -72,6 +72,7 @@ from zerver.views.invite import (
 from zerver.views.llms_txt import llms_txt
 from zerver.views.message_edit import (
     delete_message_backend,
+    delete_message_edit_history,
     get_message_edit_history,
     json_fetch_raw_message,
     update_message_backend,
@@ -437,7 +438,11 @@ v1_api_and_json_patterns = [
     rest_path("messages/render", POST=render_message_backend),
     rest_path("messages/flags", POST=update_message_flags),
     rest_path("messages/flags/narrow", POST=update_message_flags_for_narrow),
-    rest_path("messages/<int:message_id>/history", GET=get_message_edit_history),
+    rest_path(
+        "messages/<int:message_id>/history",
+        GET=get_message_edit_history,
+        DELETE=delete_message_edit_history,
+    ),
     rest_path("messages/matches_narrow", GET=messages_in_narrow_backend),
     rest_path("users/me/subscriptions/properties", POST=update_subscription_properties_backend),
     rest_path("users/me/subscriptions/<int:stream_id>", PATCH=update_subscriptions_property),


### PR DESCRIPTION
Adds a "Delete prior versions of this message" button to the message edit history modal allowing users with message deletion permission to remove sensitive content from a message's edit history.

Fixes: #19632

## Changes

### Backend (key points only)
- Added `do_delete_message_edit_history()` action that strips `prev_content` from all edit history entries and inserts an audit record noting who deleted the history.
- Added `DELETE /json/messages/{id}/history` API endpoint with permission check (only users who can delete the message can delete its history).

### Frontend
- Added "Delete prior versions of this message" button in the message edit history modal header (only shown to users with delete permission and only when the message has content edits).
- Added confirmation dialog before deletion.
- After deletion shows "Edit history deleted by __user_" entry with "Content deleted from this message's history by @_user. (Silent mention)"
- The button is hidden if the edit history was already deleted and no new edits have been made since.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Show 'Delete prior versions of this message' Button | Confirmation dialog before deletion |
|--------|-------|
|<img width="1118" height="785" alt="Screenshot 2026-03-15 155526" src="https://github.com/user-attachments/assets/a57d2cab-b79b-43bd-b784-709a2b44921e" />|<img width="1119" height="789" alt="Screenshot 2026-03-15 155545" src="https://github.com/user-attachments/assets/7366dcc9-0127-4f47-bf5a-1f7cb47740ad" />|

| Show 'Edit history deleted by __user_ and message box' | Re-edited after deletion |
|--------|-------|
|<img width="1121" height="791" alt="Screenshot 2026-03-15 155607" src="https://github.com/user-attachments/assets/b46a67bc-5b81-4b3d-b3a9-c01861ec95ea" />|<img width="1116" height="789" alt="Screenshot 2026-03-15 155647" src="https://github.com/user-attachments/assets/97848078-1fe2-41ba-aed7-cc9e91adbe2c" />|

| Multiple deletions in Message edit history | Delete a message’s edit history in help centre |
|--------|-------|
|<img width="1113" height="784" alt="Screenshot 2026-03-15 155706" src="https://github.com/user-attachments/assets/5bf10198-9a31-418a-a1d2-665c354d8368" />|<img width="1919" height="830" alt="Screenshot 2026-03-15 170523" src="https://github.com/user-attachments/assets/5cd06af9-187b-4457-86ff-d6a09e051223" />|

<video src="https://github.com/user-attachments/assets/aad4bf90-c423-4133-b108-78abbeaf3914" width="400" controls></video> 





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
