### PR TITLE
webhooks: Separate command and text in outgoing payloads (Fixes #19589)

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -72,7 +72,14 @@ class GenericOutgoingWebhookService(OutgoingWebhookServiceInterface):
             is_incoming_1_to_1=event["message"]["recipient_id"] == self.user_profile.recipient_id,
         )
 
+        # Split command into trigger and content for Slack compatibility
+        parts = event["command"].strip().split(" ", 1)
+        command = parts[0]
+        text = parts[1] if len(parts) > 1 else ""
+
         request_data = {
+            "command": command,
+            "text": text,
             "data": event["command"],
             "message": message_dict,
             "bot_email": self.user_profile.email,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -26032,6 +26032,14 @@ paths:
                     type: string
                     description: |
                       The message content, in raw [Zulip-flavored Markdown](/help/format-your-message-using-markdown) format (not rendered to HTML).
+                  command:
+                    type: string
+                    description: |
+                      The first word of the content string, used as the trigger command.
+                  text:
+                    type: string
+                    description: |
+                      The rest of the content string after the command.
                   trigger:
                     type: string
                     description: |


### PR DESCRIPTION
### Description
This issue has been open for some time with several attempted implementations. This PR provides a clean separation of `command` and `text` fields in the `GenericOutgoingWebhookService` to ensure Slack compatibility. 

Crucially, this PR includes the necessary updates to the OpenAPI schema (`zerver/openapi/zulip.yaml`) which have been a blocker in previous attempts.

### Changes
- Updated `make_request` in `zerver/lib/outgoing_webhook.py` to decouple the trigger command from the message body.
- Updated `zerver/openapi/zulip.yaml` to reflect the new API contract.
- Verified logic with `test_outgoing_webhook_interfaces.py`.

**Note to Maintainers:** I noticed several other PRs are open for this (#38098). This implementation specifically focuses on the schema validation and backend logic to ensure it passes the full CI suite.