### PR TITLE
fix(recent conversations): preserve scroll anchor when loading older messages

### DIFF
--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1175,8 +1175,20 @@ export class MessageListView {
         }
 
         const save_scroll_position = (): void => {
-            if (orig_scrolltop_offset === undefined && this.selected_row().length > 0) {
-                orig_scrolltop_offset = this.selected_row().get_offset_to_window().top;
+            if (orig_scrolltop_offset !== undefined) {
+                return;
+            }
+
+            let $selected_row = this.selected_row();
+            if ($selected_row.length === 0) {
+                const selected_id = message_lists.current?.selected_id();
+                if (selected_id !== undefined && selected_id > -1) {
+                    $selected_row = this.get_row(selected_id);
+                }
+            }
+
+            if ($selected_row.length > 0 && $selected_row[0]) {
+                orig_scrolltop_offset = $selected_row.get_offset_to_window().top;
             }
         };
 
@@ -1316,12 +1328,16 @@ export class MessageListView {
         if (list === message_lists.current) {
             // Update the fade.
 
-            const get_element = (message_group: MessageGroup): JQuery => {
+            const get_element = (message_group: MessageGroup): JQuery | undefined => {
                 // We don't have a MessageGroup class, but we can at least hide the messy details
                 // of rows.ts from compose_fade.  We provide a callback function to be lazy--
                 // compose_fade may not actually need the elements depending on its internal
                 // state.
-                const $message_row = this.get_row(message_group.message_containers[0]!.msg.id);
+                const first_container = message_group.message_containers[0];
+                if (first_container === undefined || first_container.msg === undefined) {
+                    return undefined;
+                }
+                const $message_row = this.get_row(first_container.msg.id);
                 return rows.get_message_recipient_row($message_row);
             };
 

--- a/web/tests/message_list_view.test.cjs
+++ b/web/tests/message_list_view.test.cjs
@@ -28,6 +28,20 @@ mock_esm("../src/people", {
     small_avatar_url: () => "fake/small/avatar/url",
     get_muted_user_avatar_url: () => "fake/muted_user/avatar/url",
     maybe_get_user_by_id: noop,
+    pm_perma_link: () => "",
+});
+
+mock_esm("../src/narrow_state", {
+    is_message_feed_visible: () => true,
+});
+mock_esm("../src/message_viewport", {
+    is_scrolled_up: () => false,
+});
+mock_esm("../src/condense", {
+    condense_and_collapse: noop,
+});
+mock_esm("../src/message_lists", {
+    current: undefined,
 });
 
 const {Filter} = zrequire("../src/filter");
@@ -862,4 +876,78 @@ test("render_windows", ({mock_template}) => {
         move_end: 250,
         no_move_start: 0,
     });
+});
+
+test("save_scroll_position_fallback", ({override, mock_template}) => {
+    // This test verifies that save_scroll_position falls back to
+    // message_lists.current.selected_id() if this.selected_row() is empty.
+    mock_template("recipient_row.hbs", false, () => "<recipient-row-stub>");
+    mock_template("single_message.hbs", false, () => "<single-message-stub>");
+    mock_template("bookend.hbs", false, () => "<bookend-stub>");
+
+    const list = new message_list.MessageList({
+        data: new MessageListData({
+            filter: new Filter([]),
+            excludes_muted_topics: false,
+        }),
+        is_node_test: true,
+    });
+    const view = list.view;
+
+    let row_offset_called = false;
+    const selected_id = 100;
+
+    // Mock message_lists.current
+    override(zrequire("message_lists"), "current", list);
+
+    // Mock selected_id
+    list.data.set_selected_id(selected_id);
+
+    // Mock get_row to return a fake row for the selected_id
+    const $row = $.create("row-stub");
+    $row.length = 1;
+    $row.get_offset_to_window = () => {
+        row_offset_called = true;
+        return {top: 50};
+    };
+
+    override(view, "get_row", (id) => {
+        if (id === selected_id) {
+            return $row;
+        }
+        return $.create("empty-id-list", {elements: []});
+    });
+
+    // Mock selected_row to be empty (simulating the bug condition where selection row isn't in DOM or established)
+    override(view, "selected_row", () => $.create("empty-selected-row", {elements: []}));
+
+    // We need to trigger a render that calls save_scroll_position.
+    // We mock build_message_groups and merge_message_groups to simulate a prepend operation.
+    const messages = [{id: 1, timestamp: 100}];
+    const message_containers = [{msg: messages[0]}];
+    override(view, "build_message_groups", () => [{message_containers}]);
+    override(view, "merge_message_groups", (groups) => ({
+        prepend_groups: groups,
+        rerender_groups: [],
+        append_groups: [],
+        append_messages: [],
+    }));
+    const $rendered_group = $.create("fake-group");
+    override(view, "_render_group", () => {
+        $rendered_group.find = () => $.create("empty-find-results", {elements: []});
+        return $rendered_group;
+    });
+
+    // We also need to mock those things that are called after _render_group
+    $rendered_group.first = () => ({
+        prev: () => ({
+            remove: noop,
+        }),
+    });
+    override(view, "_post_process", noop);
+
+    // Trigger render with "top" to invoke prepending logic which calls save_scroll_position
+    view.render(messages, "top");
+
+    assert.ok(row_offset_called, "Should have called get_offset_to_window on the fallback row");
 });


### PR DESCRIPTION
This PR fixes a bug where the viewport would jump unexpectedly when loading older messages in a narrow, specifically when the selected message is no longer in the DOM or hasn't been established yet.

Fixes: #38506 (Viewport jumps when loading older messages)

How changes were tested:

1. Added a new unit test web/tests/message_list_view.test.cjs > save_scroll_position_fallback which verifies that we use the selected_id to find a fallback row if selected_row() is empty.

2. Verified that save_scroll_position successfully identifies the correct fallback row and records its offset.

3. Verified locally that the fix prevents the TypeError and subsequent viewport anchor loss.
