### PR TITLE
sidebars: Add drop shadow to sticky section headers when scrolled.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -1185,6 +1185,23 @@ export class BuddyList extends BuddyListConf {
 
         $scroll_container.on("scroll", () => {
             this.fill_screen_with_content();
+
+            // Toggle drop shadow on sticky headers when content scrolls beneath them.
+            const scroll_container_rect = $scroll_container[0]!.getBoundingClientRect();
+            const has_scrolled_down = $scroll_container.scrollTop()! > 0;
+
+            // Separate reads and writes to avoid layout thrashing.
+            const headers_to_update = [...$(".buddy-list-subsection-header")].map((el) => {
+                const rect = el.getBoundingClientRect();
+                return {
+                    $el: $(el),
+                    is_stuck: has_scrolled_down && rect.top <= scroll_container_rect.top,
+                };
+            });
+
+            for (const {$el, is_stuck} of headers_to_update) {
+                $el.toggleClass("sidebar-header-drop-shadow", is_stuck);
+            }
         });
     }
 

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1598,7 +1598,8 @@ export function set_event_handlers({
 
     let mark_scroll_inactive_timeout: ReturnType<typeof setTimeout> | undefined;
     // check for user scrolls on streams list for first time
-    scroll_util.get_scroll_element($("#left_sidebar_scroll_container")).on("scroll", () => {
+    const $scroll_container = scroll_util.get_scroll_element($("#left_sidebar_scroll_container"));
+    $scroll_container.on("scroll", () => {
         is_actively_scrolling = true;
         clearTimeout(mark_scroll_inactive_timeout);
         mark_scroll_inactive_timeout = setTimeout(() => {
@@ -1606,6 +1607,28 @@ export function set_event_handlers({
         }, 200);
 
         toggle_pm_header_icon();
+
+        // Toggle drop shadow on sticky headers when content scrolls beneath them.
+        // Read all positions before writing classes to avoid layout thrashing.
+        const scroll_container_rect = $scroll_container[0]!.getBoundingClientRect();
+        const has_scrolled_down = $scroll_container.scrollTop()! > 0;
+
+        const $sticky_headers = $scroll_container.find(
+            "#direct-messages-section-header, .stream-list-subsection-header",
+        );
+        const headers_to_update = [...$sticky_headers].map((header) => {
+            // Each sticky header pins at scroll_container_rect.top + its CSS `top` offset.
+            const sticky_top = Number.parseFloat(getComputedStyle(header).top) || 0;
+            const stuck_position = scroll_container_rect.top + sticky_top;
+            const at_stuck_position =
+                Math.abs(header.getBoundingClientRect().top - stuck_position) < 1;
+            const is_stuck = has_scrolled_down && at_stuck_position;
+            return {header, is_stuck};
+        });
+
+        for (const {header, is_stuck} of headers_to_update) {
+            $(header).toggleClass("sidebar-header-drop-shadow", is_stuck);
+        }
     });
 
     $("#streams_list").on(

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -288,6 +288,17 @@
         background-color: var(--color-background);
     }
 
+    &.sidebar-header-drop-shadow {
+        box-shadow: 0 4px 4px -2px var(--color-shadow-sidebar-row-hover);
+    }
+
+    /* Combine hover border with drop shadow since CSS box-shadow doesn't stack. */
+    &:not(.zoom-in):hover.sidebar-header-drop-shadow {
+        box-shadow:
+            inset 0 0 0 1px var(--color-shadow-sidebar-row-hover),
+            0 4px 4px -2px var(--color-shadow-sidebar-row-hover);
+    }
+
     #toggle-direct-messages-section-icon {
         grid-area: starting-anchor-element;
         /* Horizontally center the icon in its allotted grid area. */
@@ -460,6 +471,10 @@
        below. This extra margin prevents that overlap. */
     margin-bottom: 1px;
 
+    &.sidebar-header-drop-shadow {
+        box-shadow: 0 4px 4px -2px var(--color-shadow-sidebar-row-hover);
+    }
+
     .markers-and-unreads {
         display: flex;
         align-items: center;
@@ -502,6 +517,13 @@
 
         .add_stream_icon {
             visibility: visible;
+        }
+
+        /* Combine hover border with drop shadow since CSS box-shadow doesn't stack. */
+        &.sidebar-header-drop-shadow {
+            box-shadow:
+                inset 0 0 0 1px var(--color-shadow-sidebar-row-hover),
+                0 4px 4px -2px var(--color-shadow-sidebar-row-hover);
         }
     }
 

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -276,6 +276,17 @@
         .buddy-list-heading {
             opacity: var(--opacity-sidebar-heading-hover);
         }
+
+        /* Combine hover border with drop shadow since CSS box-shadow doesn't stack. */
+        &.sidebar-header-drop-shadow {
+            box-shadow:
+                inset 0 0 0 1px var(--color-shadow-sidebar-row-hover),
+                0 4px 4px -2px var(--color-shadow-sidebar-row-hover);
+        }
+    }
+
+    &.sidebar-header-drop-shadow {
+        box-shadow: 0 4px 4px -2px var(--color-shadow-sidebar-row-hover);
     }
 }
 

--- a/web/tests/buddy_list.test.cjs
+++ b/web/tests/buddy_list.test.cjs
@@ -35,6 +35,7 @@ function init_simulated_scrolling() {
     const $wrapper = $.create("#buddy_list_wrapper");
     $wrapper[0].scrollHeight = 0;
     $wrapper[0].scrollTop = 0;
+    $wrapper[0].getBoundingClientRect = () => ({top: 0});
 
     $("#buddy_list_wrapper_padding").set_height(0);
 
@@ -351,6 +352,45 @@ run_test("find_li w/bad key", ({override}) => {
     });
 
     assert.deepEqual($undefined_li, undefined);
+});
+
+run_test("drop_shadow_on_scroll", ({override}) => {
+    const buddy_list = new BuddyList();
+    override(buddy_list, "fill_screen_with_content", noop);
+    stub_buddy_list_elements();
+    const elem = init_simulated_scrolling();
+    stub_buddy_list_elements();
+
+    override(background_task, "run_async_function_without_await", noop);
+    clear_buddy_list(buddy_list);
+    buddy_list.start_scroll_handler();
+
+    const $header = $(".buddy-list-subsection-header");
+
+    // Simulate scrolling with the header stuck at the container's top edge.
+    elem.scrollTop = 5;
+    $header[0].getBoundingClientRect = () => ({
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: 0,
+    });
+    $(buddy_list.scroll_container_selector).trigger("scroll");
+    assert.ok($header.hasClass("sidebar-header-drop-shadow"));
+
+    // Simulate the header returning to its natural (non-stuck) position.
+    $header[0].getBoundingClientRect = () => ({
+        top: 100,
+        bottom: 100,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: 0,
+    });
+    $(buddy_list.scroll_container_selector).trigger("scroll");
+    assert.ok(!$header.hasClass("sidebar-header-drop-shadow"));
 });
 
 run_test("scrolling", ({override}) => {

--- a/web/tests/lib/zjquery_element.cjs
+++ b/web/tests/lib/zjquery_element.cjs
@@ -175,6 +175,9 @@ class FakeElement extends RejectMissing {
         fake_element_state.set(this, new FakeElementState());
     }
     append() {}
+    getBoundingClientRect() {
+        return {top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0};
+    }
     closest(selector) {
         const state = fake_element_state.get(this);
         if (!state.closest_results.has(selector)) {
@@ -706,6 +709,16 @@ exports.FakeJQuery = class extends RejectMissing {
     replaceWith(...args) {
         assert.equal(this.length, 1);
         this[0].replaceWith(...dom_args(args));
+        return this;
+    }
+    scrollTop(...args) {
+        if (args.length === 0) {
+            return 0 in this ? this[0].scrollTop : undefined;
+        }
+        const [value] = args;
+        for (const element of this) {
+            element.scrollTop = value;
+        }
         return this;
     }
     set_children(elements) {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #34467


Adds a drop shadow to sticky section headers in the left and right sidebars when content has scrolled beneath them.

On scroll, JS detects when each sticky header is pinned and toggles a sidebar-header-drop-shadow class, which the CSS uses to apply a drop shadow.

**How changes were tested:**
Used dev server to test scrolling and drop shadow behavior.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

Left sidebar
|before (light mode) |after (light mode)|
| --- | --- |
|<img width="473" height="641" alt="image" src="https://github.com/user-attachments/assets/04e53fbd-e3c2-4483-8506-efad8a83cf8f" />|<img width="473" height="641" alt="image" src="https://github.com/user-attachments/assets/295092bf-c596-4a8b-8fa1-47775b7e56b3" />|

|before (dark mode)|after (dark mode)|
| --- | --- |
|<img width="473" height="641" alt="image" src="https://github.com/user-attachments/assets/6251e2c4-c18c-4662-ad78-76cab0a290a4" />|<img width="473" height="641" alt="image" src="https://github.com/user-attachments/assets/cba42f31-98ea-4417-8aae-d181bfc253f6" />|

Right sidebar
|before (light mode) |after (light mode)|
| --- | --- |
|<img width="393" height="445" alt="image" src="https://github.com/user-attachments/assets/bf4d7c4e-5a70-4fc6-bcba-7c51b426fa11" />|<img width="393" height="445" alt="image" src="https://github.com/user-attachments/assets/b017fce8-425d-40c7-9f85-0651e2fbf014" />|

|before (dark mode)|after (dark mode)|
| --- | --- |
|<img width="393" height="445" alt="image" src="https://github.com/user-attachments/assets/11b948a5-c8ac-46ff-bff2-b3110487e4c0" />|<img width="393" height="445" alt="image" src="https://github.com/user-attachments/assets/1f072555-379f-4643-9462-fd947ae0576f" />|


Screen recording

<img width="2079" height="882" alt="LGDisplayExtension_KlmznXpDDf" src="https://github.com/user-attachments/assets/6335f71c-72af-4c5e-87d3-478941d2ba7b" />
<img width="2081" height="880" alt="chrome_R06qaeSZt0" src="https://github.com/user-attachments/assets/441a0322-2787-49a5-bc13-fda4ced3f755" />

<details>


<summary>Self-review checklist</summary>




<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
