### PR TITLE
drafts: Replace local render with server's for backend_only_syntax.

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -24,6 +24,7 @@ import {$t, $t_html} from "./i18n.ts";
 import * as linkifiers from "./linkifiers.ts";
 import * as loading from "./loading.ts";
 import * as markdown from "./markdown.ts";
+import {message_render_response_schema} from "./message_store.ts";
 import * as people from "./people.ts";
 import {postprocess_content} from "./postprocess_content.ts";
 import * as rendered_markdown from "./rendered_markdown.ts";
@@ -66,12 +67,6 @@ type SelectedLinesSections = {
     separating_new_line_after: boolean;
     after_lines: string;
 };
-
-const message_render_response_schema = z.object({
-    msg: z.string(),
-    result: z.string(),
-    rendered: z.string(),
-});
 
 export let compose_spinner_visible = false;
 

--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -8,16 +8,20 @@ import render_draft_table_body from "../templates/draft_table_body.hbs";
 import render_drafts_list from "../templates/drafts_list.hbs";
 
 import * as browser_history from "./browser_history.ts";
+import * as channel from "./channel.ts";
 import * as compose_actions from "./compose_actions.ts";
 import {show_copied_confirmation} from "./copied_tooltip.ts";
 import type {FormattedDraft, LocalStorageDraft} from "./drafts.ts";
 import * as drafts from "./drafts.ts";
 import {$t} from "./i18n.ts";
+import * as markdown from "./markdown.ts";
+import {message_render_response_schema} from "./message_store.ts";
 import * as message_view from "./message_view.ts";
 import * as messages_overlay_ui from "./messages_overlay_ui.ts";
 import * as mouse_drag from "./mouse_drag.ts";
 import * as overlays from "./overlays.ts";
 import * as people from "./people.ts";
+import {postprocess_content} from "./postprocess_content.ts";
 import * as rendered_markdown from "./rendered_markdown.ts";
 import * as stream_data from "./stream_data.ts";
 import * as user_card_popover from "./user_card_popover.ts";
@@ -262,6 +266,37 @@ function get_formatted_drafts_data(): {
     return {narrow_drafts, other_drafts, narrow_drafts_header};
 }
 
+function fetch_server_rendered_drafts(formatted_drafts: FormattedDraft[]): void {
+    // compose_ui.ts does thumbnail polling to check for thumbnails for recently
+    // uploaded images. We don't want to do that here since there will always
+    // be some time delta between writing a message and seeing the draft overlay
+    // for it.
+    for (const draft of formatted_drafts) {
+        if (markdown.contains_backend_only_syntax(draft.raw_content)) {
+            void channel.post({
+                url: "/json/messages/render",
+                data: {content: draft.raw_content},
+                success(response_data) {
+                    if (!overlays.drafts_open()) {
+                        return;
+                    }
+                    const data = message_render_response_schema.parse(response_data);
+                    const $content_element = $(
+                        `[data-draft-id="${CSS.escape(draft.draft_id)}"] .message_content`,
+                    );
+                    if ($content_element.length === 0) {
+                        return;
+                    }
+                    $content_element.html(postprocess_content(data.rendered));
+                    rendered_markdown.update_elements($content_element);
+                },
+                // We don't do anything on error and keep displaying the
+                // locally rendered message.
+            });
+        }
+    }
+}
+
 function render_widgets(
     narrow_drafts: FormattedDraft[],
     other_drafts: FormattedDraft[],
@@ -297,6 +332,7 @@ function render_widgets(
     }
     update_rendered_drafts(narrow_drafts.length > 0, other_drafts.length > 0);
     update_bulk_delete_ui();
+    fetch_server_rendered_drafts([...narrow_drafts, ...other_drafts]);
 }
 
 function setup_event_handlers(): void {

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -65,6 +65,12 @@ export const single_message_content_schema = z.object({
     }),
 });
 
+export const message_render_response_schema = z.object({
+    msg: z.string(),
+    result: z.string(),
+    rendered: z.string(),
+});
+
 export const submessage_schema = z.object({
     id: z.number(),
     sender_id: z.number(),

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -13,6 +13,7 @@ const $ = require("./lib/zjquery.cjs");
 const user_pill = mock_esm("../src/user_pill", {get_user_ids: () => []});
 const settings_data = mock_esm("../src/settings_data");
 const messages_overlay_ui = mock_esm("../src/messages_overlay_ui");
+const channel = mock_esm("../src/channel");
 
 const people = zrequire("people");
 const compose_state = zrequire("compose_state");
@@ -88,11 +89,15 @@ set_global("setTimeout", (f, delay) => {
     assert.equal(delay, setTimeout_delay);
     f();
 });
-mock_esm("../src/markdown", {
+const markdown = mock_esm("../src/markdown", {
     render: noop,
+    contains_backend_only_syntax: () => false,
 });
-mock_esm("../src/overlays", {
+const overlays = mock_esm("../src/overlays", {
     open_overlay: noop,
+});
+mock_esm("../src/rendered_markdown", {
+    update_elements: noop,
 });
 
 const tippy_sel = ".top_left_drafts .unread_count";
@@ -778,4 +783,78 @@ test("filter_drafts", ({override, mock_template}) => {
     $.set_results("#drafts_table .overlay-message-row", []);
     $.set_results(".draft-selection-checkbox", []);
     drafts_overlay_ui.launch();
+});
+
+test("server_rendering_for_backend_only_syntax", ({override, mock_template}) => {
+    override(settings_data, "using_dark_theme", () => false);
+
+    const now = Date.now();
+    const draft_with_image = {
+        topic: "topic",
+        type: "stream",
+        content: "Look at this screenshot: https://user-uploads.zulipdev.org/upload/image.png",
+        stream_id: 30,
+        updatedAt: now,
+        is_sending_saving: false,
+        drafts_version: 1,
+    };
+    const draft_without_image = {
+        topic: "topic",
+        type: "stream",
+        content: "This is a plain text draft",
+        stream_id: 30,
+        updatedAt: now - 1000,
+        is_sending_saving: false,
+        drafts_version: 1,
+    };
+
+    const draft_model = drafts.draft_model;
+    const ls = localstorage();
+    ls.set("drafts", {id1: draft_with_image, id2: draft_without_image});
+    assert.deepEqual(draft_model.get(), {id1: draft_with_image, id2: draft_without_image});
+
+    override(
+        markdown,
+        "contains_backend_only_syntax",
+        (content) => content === draft_with_image.content,
+    );
+
+    const locally_rendered_content =
+        '<p>Look at this screenshot: <a href="https://user-uploads.zulipdev.org/upload/image.png">https://user-uploads.zulipdev.org/upload/image.png</a></p>';
+    const server_rendered_content =
+        '<p>Look at this screenshot: <a href="https://user-uploads.zulipdev.org/upload/image.png" target="_blank" rel="noopener noreferrer" title="https://user-uploads.zulipdev.org/upload/image.png"><img src="/thumbnail?url=user_uploads%2Fimage.png&amp;size=thumbnail"></a></p>';
+
+    let post_calls = 0;
+    const $content_element = $.create('[data-draft-id="id1"] .message_content');
+    $content_element.html(locally_rendered_content);
+    override(overlays, "drafts_open", () => true);
+
+    mock_template("draft_table_body.hbs", false, () => "<draft table stub>");
+    override(messages_overlay_ui, "set_initial_element", noop);
+    override(messages_overlay_ui, "get_and_clear_pending_restore_element_id", () => undefined);
+
+    // These selectors are accessed during render_widgets() and
+    // update_bulk_delete_ui() inside launch().
+    $.set_results(".drafts-list", []);
+    $.set_results("#drafts_table .overlay-message-row", []);
+    $.set_results(".draft-selection-checkbox", []);
+
+    override(channel, "post", (payload) => {
+        post_calls += 1;
+        assert.equal(payload.url, "/json/messages/render");
+        assert.equal(payload.data.content, draft_with_image.content);
+
+        const resp = {
+            msg: "",
+            result: "success",
+            rendered: server_rendered_content,
+        };
+        payload.success(resp);
+        assert.equal($content_element.html(), server_rendered_content);
+    });
+    drafts_overlay_ui.launch();
+
+    // Only the draft with the image triggered a server render request;
+    // the plain text draft did not.
+    assert.equal(post_calls, 1);
 });


### PR DESCRIPTION
Fixes
https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20inline.20images.20are.20oversize.20in.20the.20Drafts.20overlay/with/2410434.

We render all the messages locally first, then we make server requests for messages containing backend only syntax, and replace relevant message content. If there is any error in the request, we do not do anything and keep displaying the locally rendered content.

Tests written with the help of claude.

<!-- Describe your pull request here.-->


**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Before:
<img width="1116" height="830" alt="Screenshot 2026-03-16 at 4 42 14 PM" src="https://github.com/user-attachments/assets/7a00d88d-be7f-44e5-bbf5-53f7684b91c4" />

After:
<img width="1116" height="830" alt="Screenshot 2026-03-16 at 4 41 54 PM" src="https://github.com/user-attachments/assets/406ea20d-53a4-418e-8ee7-ab938091f2ef" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
