### PR TITLE
compose: Focus message box automatically for channels

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -110,6 +110,7 @@ function show_compose_box(opts: ComposeActionsOpts): void {
     } else {
         opts_by_message_type = {
             trigger: opts.trigger,
+            focus_message_box: true,
             message_type: "stream",
             stream_id: opts.stream_id,
             topic: opts.topic,


### PR DESCRIPTION
his PR addresses the user experience issue where the message compose box did not automatically receive focus when opening a channel/stream. Currently, users have to manually click the box before they can start typing.

I have modified web/src/compose_actions.ts to ensure that focus_message_box: true is passed when triggering the compose box for streams, making the interaction seamless and consistent with private messages.

Related Issue
Fixes: #38500

Changes
Updated show_compose_box function logic in web/src/compose_actions.ts.

Added focus_message_box: true to the opts_by_message_type object for stream messages.

Testing Plan
[ ] Manually verified on local dev server (./tools/run-dev).

[ ] Verified that clicking a stream/channel now automatically focuses the textarea.

[ ] Ran frontend tests using ./tools/test-js-with-node.