### PR TITLE
api-docs: Add notes about mobile client logout with new API key.

### DIFF
--- a/api_docs/api-keys.md
+++ b/api_docs/api-keys.md
@@ -45,7 +45,8 @@ Zulip API with a specific account on a Zulip server.
 
 ## Invalidate an API key
 
-To invalidate an existing API key, you have to generate a new key.
+To invalidate an existing API key, you have to generate a new key. Generating a
+new API key will immediately log you out of this account on all mobile devices.
 
 {start_tabs}
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1406,6 +1406,7 @@ label.preferences-radio-choice-label {
 
 #show_api_key {
     .api-key-container {
+        padding-bottom: 10px;
         display: flex;
         align-items: center;
         gap: 8px;

--- a/web/templates/settings/api_key_modal.hbs
+++ b/web/templates/settings/api_key_modal.hbs
@@ -36,6 +36,9 @@
                         </span>
                     </div>
                     <div id="user_api_key_error" class="text-error"></div>
+                    <p class="small">
+                        {{t "Generating a new API key will immediately log you out of this account on all mobile devices." }}
+                    </p>
                 </div>
             </main>
             <footer class="modal__footer">


### PR DESCRIPTION
Updates the API documentation article for API keys to note that generating a new API key will logout the account from any mobile clients, and updates the API key modal in the web app with a similar note.

**Notes**:
- We already note this in the help center article on protecting your account, which has a section about generating a new API key: https://zulip.com/help/protect-your-account. Used a variation on this text for the API doc and modal, "Changing your API key will..." -> "Generating a new API key will...", as this better matches the text/buttons on these pages.

Relevant CZO discussion: [#mobile > Suddenly no longer logged in on any zulip](https://chat.zulip.org/#narrow/channel/48-mobile/topic/Suddenly.20no.20longer.20logged.20in.20on.20any.20zulip/with/2409869).

---

**Screenshots and screen captures:**

*After getting the API key. Note that text does not change if either button is clicked.*
|Before | After |
| --- | --- |
| <img width="1230" height="362" alt="Screenshot From 2026-03-16 13-06-27" src="https://github.com/user-attachments/assets/7aa495a9-d7e7-4dd2-b000-bb0cccef3841" /> | <img width="1224" height="400" alt="Screenshot From 2026-03-18 12-08-03" src="https://github.com/user-attachments/assets/b934917e-543e-428f-af14-314ff913f00e" />




*Before getting the API key - no change*
|Before | After |
| --- | --- |
| <img width="1230" height="560" alt="Screenshot From 2026-03-16 13-08-42" src="https://github.com/user-attachments/assets/24a50e7c-d7f1-42f5-b516-2f155b7b3222" /> | <img width="1230" height="560" alt="Screenshot From 2026-03-16 13-09-15" src="https://github.com/user-attachments/assets/2567ed28-fbf9-407e-8db6-4fed689ec494" />


[CURRENT DOC](https://zulip.com/api/api-keys)
<img width="1514" height="560" alt="Screenshot From 2026-03-17 19-24-26" src="https://github.com/user-attachments/assets/8cbd5f4f-9e2b-4bcd-b9b1-7e915b7a1138" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
