### PR TITLE
tests: Expand coverage for compare_by_pms in typeahead_helper.

### DIFF
--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -1122,10 +1122,37 @@ test("compare_language", () => {
     assert.equal(th.compare_language("custom_a", "custom_b"), util.strcmp("custom_a", "custom_b"));
 });
 
-// TODO: This is incomplete for testing this function, and
-// should be filled out more. This case was added for codecov.
 test("compare_by_pms", () => {
+    // Same user should return 0
     assert.equal(th.compare_by_pms(a_user, a_user), 0);
+
+    // Alphabetical fallback when PM counts and partner status are equal
+    assert.equal(
+        th.compare_by_pms(a_user, b_user_1),
+        util.strcmp(a_user.full_name, b_user_1.full_name),
+    );
+
+    // Reverse order should match strcmp behavior
+    assert.equal(
+        th.compare_by_pms(b_user_1, a_user),
+        util.strcmp(b_user_1.full_name, a_user.full_name),
+    );
+
+    pm_conversations.set_partner(b_user_1.user_id);
+
+    // PM count takes priority over partner status
+    people.set_recipient_count_for_testing(a_user.user_id, 10);
+    people.set_recipient_count_for_testing(b_user_1.user_id, 5);
+
+    assert.equal(th.compare_by_pms(a_user, b_user_1), -1);
+    assert.equal(th.compare_by_pms(b_user_1, a_user), 1);
+
+    // Partner priority when counts are equal
+    people.set_recipient_count_for_testing(a_user.user_id, 0);
+    people.set_recipient_count_for_testing(b_user_1.user_id, 0);
+
+    assert.equal(th.compare_by_pms(a_user, b_user_1), 1);
+    assert.equal(th.compare_by_pms(b_user_1, a_user), -1);
 });
 
 test("sort_group_setting_options", ({override_rewire}) => {


### PR DESCRIPTION
The existing test for `compare_by_pms` only verified the trivial case
where both arguments were the same user.

This change expands the test coverage by adding cases that verify the
alphabetical fallback behavior when `PM counts` and partner status are
equal, including both comparison directions.

**How changes were tested:**

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->Resolves the TODO indicating that the test was incomplete.

**How changes were tested:**

- Ran `tools/test-js-with-node web/tests/typeahead_helper.test.cjs`
- Ran `tools/lint --fix` to ensure formatting and lint checks pass.
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
