### PR TITLE
Fix realm creation race condition 21160

### DIFF
--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1894,11 +1894,11 @@ class UserSignUpTest(ZulipTestCase):
 
         # Step 3: Simulate the race — do_create_realm raises IntegrityError
         # because another request already created the same subdomain
-    with patch(
+        with patch(
         "zerver.views.registration.do_create_realm",
         side_effect=IntegrityError,
     ):
-        result = self.submit_reg_form_for_user(
+            result = self.submit_reg_form_for_user(
             email,
             "password",
             realm_subdomain="custom-test",

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1908,7 +1908,7 @@ class UserSignUpTest(ZulipTestCase):
 
         # Should get a 400, not a 500
         self.assertEqual(result.status_code, 400)
-        self.assert_in_response("Organisation already exists.",result)
+        self.assert_in_response("Organisation already exists.", result)
 
     def test_signup_with_weak_password(self) -> None:
         """

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1875,6 +1875,7 @@ class UserSignUpTest(ZulipTestCase):
                 f"/accounts/login/?email={quote(email)}&already_registered=1"
             )
         )
+
     def test_realm_creation_race_condition(self) -> None:
         """
         If two realm creation requests race and do_create_realm raises
@@ -1885,8 +1886,8 @@ class UserSignUpTest(ZulipTestCase):
 
         # Step 1: Submit the realm creation form to get a confirmation email
         self.submit_realm_creation_form(
-        email, realm_subdomain="custom-test", realm_name="Zulip test"
-    )
+            email, realm_subdomain="custom-test", realm_name="Zulip test"
+        )
 
         # Step 2: Follow the confirmation link
         confirmation_url = self.get_confirmation_url_from_outbox(email)
@@ -1895,15 +1896,15 @@ class UserSignUpTest(ZulipTestCase):
         # Step 3: Simulate the race — do_create_realm raises IntegrityError
         # because another request already created the same subdomain
         with patch(
-        "zerver.views.registration.do_create_realm",
-        side_effect=IntegrityError,
-    ):
+            "zerver.views.registration.do_create_realm",
+            side_effect=IntegrityError,
+        ):
             result = self.submit_reg_form_for_user(
-            email,
-            "password",
-            realm_subdomain="custom-test",
-            realm_name="Zulip test",
-        )
+                email,
+                "password",
+                realm_subdomain="custom-test",
+                realm_name="Zulip test",
+            )
 
         # Should get a 400, not a 500
         self.assertEqual(result.status_code, 400)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1875,6 +1875,38 @@ class UserSignUpTest(ZulipTestCase):
                 f"/accounts/login/?email={quote(email)}&already_registered=1"
             )
         )
+    def test_realm_creation_race_condition(self) -> None:
+        """
+        If two realm creation requests race and do_create_realm raises
+        an IntegrityError (duplicate subdomain), accounts_register should
+        return a 400, not a 500.
+        """
+        email = self.nonreg_email("newguy")
+
+        # Step 1: Submit the realm creation form to get a confirmation email
+        self.submit_realm_creation_form(
+        email, realm_subdomain="custom-test", realm_name="Zulip test"
+    )
+
+        # Step 2: Follow the confirmation link
+        confirmation_url = self.get_confirmation_url_from_outbox(email)
+        self.client_get(confirmation_url)
+
+        # Step 3: Simulate the race — do_create_realm raises IntegrityError
+        # because another request already created the same subdomain
+    with patch(
+        "zerver.views.registration.do_create_realm",
+        side_effect=IntegrityError,
+    ):
+        result = self.submit_reg_form_for_user(
+            email,
+            "password",
+            realm_subdomain="custom-test",
+            realm_name="Zulip test",
+        )
+
+        # Should get a 400, not a 500
+        self.assertEqual(result.status_code, 400)
 
     def test_signup_with_weak_password(self) -> None:
         """

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1908,6 +1908,7 @@ class UserSignUpTest(ZulipTestCase):
 
         # Should get a 400, not a 500
         self.assertEqual(result.status_code, 400)
+        self.assert_in_response("Organisation already exists.",result)
 
     def test_signup_with_weak_password(self) -> None:
         """

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -688,8 +688,7 @@ def registration_helper(
                     how_realm_creator_found_zulip_extra_context=how_found_zulip_extra_context,
                 )
             except IntegrityError:
-                   raise JsonableError(_("Organization already exists."))
-            
+                raise JsonableError(_("Organization already exists."))
         assert realm is not None
 
         full_name = form.cleaned_data["full_name"]

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -688,11 +688,8 @@ def registration_helper(
                     how_realm_creator_found_zulip_extra_context=how_found_zulip_extra_context,
                 )
             except IntegrityError:
-                return render(
-                    request,
-                    "zerver/portico/register.html",  # check the actual template name used elsewhere in this file
-                    context={"form": form, "error_msg": "Organization URL is already in use."},
-                )
+                   raise JsonableError(_("Organization already exists."))
+            
         assert realm is not None
 
         full_name = form.cleaned_data["full_name"]

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -676,17 +676,17 @@ def registration_helper(
                 extra_context_field = HOW_FOUND_ZULIP_EXTRA_CONTEXT[how_found_zulip]
                 how_found_zulip_extra_context = form.cleaned_data[extra_context_field]
             try:
-              realm = do_create_realm(
-                string_id,
-                realm_name,
-                org_type=realm_type,
-                default_language=realm_default_language,
-                prereg_realm=prereg_realm,
-                how_realm_creator_found_zulip=RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS[
-                    how_found_zulip
-                ],
-                how_realm_creator_found_zulip_extra_context=how_found_zulip_extra_context,
-            )
+                realm = do_create_realm(
+                    string_id,
+                    realm_name,
+                    org_type=realm_type,
+                    default_language=realm_default_language,
+                    prereg_realm=prereg_realm,
+                    how_realm_creator_found_zulip=RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS[
+                        how_found_zulip
+                    ],
+                    how_realm_creator_found_zulip_extra_context=how_found_zulip_extra_context,
+                )
             except IntegrityError:
                 return render(
                     request,

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -26,6 +26,7 @@ from django.utils.translation import override as override_language
 from django.views.decorators.cache import never_cache
 from django_auth_ldap.backend import LDAPBackend, _LDAPUser
 from pydantic import Json, NonNegativeInt, StringConstraints
+from django.db import IntegrityError
 
 from confirmation import settings as confirmation_settings
 from confirmation.models import (
@@ -675,8 +676,8 @@ def registration_helper(
             if how_found_zulip in HOW_FOUND_ZULIP_EXTRA_CONTEXT:
                 extra_context_field = HOW_FOUND_ZULIP_EXTRA_CONTEXT[how_found_zulip]
                 how_found_zulip_extra_context = form.cleaned_data[extra_context_field]
-
-            realm = do_create_realm(
+            try:
+              realm = do_create_realm(
                 string_id,
                 realm_name,
                 org_type=realm_type,
@@ -687,6 +688,12 @@ def registration_helper(
                 ],
                 how_realm_creator_found_zulip_extra_context=how_found_zulip_extra_context,
             )
+            except IntegrityError:
+                return render(
+                    request,
+                    "zerver/portico/register.html",  # check the actual template name used elsewhere in this file
+                    context={"form": form, "error_msg": "Organization URL is already in use."},
+                )
         assert realm is not None
 
         full_name = form.cleaned_data["full_name"]

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -26,7 +26,6 @@ from django.utils.translation import override as override_language
 from django.views.decorators.cache import never_cache
 from django_auth_ldap.backend import LDAPBackend, _LDAPUser
 from pydantic import Json, NonNegativeInt, StringConstraints
-from django.db import IntegrityError
 
 from confirmation import settings as confirmation_settings
 from confirmation.models import (


### PR DESCRIPTION
Description:
When two realm creation requests race on the same subdomain, do_create_realm raises an IntegrityError (duplicate key on string_id). Previously this bubbled up as a 500. This PR catches that error in accounts_register and returns a 400 with a clear error message instead.
Fixes: #21160
How changes were tested:
Added test_realm_creation_race_condition in zerver/tests/test_signup.py inside UserSignUpTest. The test mocks do_create_realm to raise IntegrityError and asserts the response is 400.

Checklist:

-  [x] Self-reviewed the changes
 - [x] Explains differences from previous plans
 - [x] Automated tests verify logic
 - [x] Each commit is a coherent idea
 - [x] Commit messages explain motivation
 - [x] AI use policy (used Claude for PR writing and review)