### PR TITLE
linkifiers: Handle optional groups in expand_reverse_template.

### DIFF
--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -446,6 +446,24 @@ run_test("reverse_linkify_text", () => {
         },
     ]);
     assert.equal(compose_ui.reverse_linkify_text("https://github.com/zulip/zulip/pull/123"), null);
+
+    // Pattern with an optional group.
+    linkifiers.update_linkifier_rules([
+        {
+            id: 10,
+            pattern: "(?P<prefix>[a-z]+-)?ZUL-(?P<id>\\d+)",
+            url_template: "https://realm.com/my_realm_filter/{prefix}ZUL-{id}",
+            reverse_template: "{prefix}ZUL-{id}",
+        },
+    ]);
+    assert.equal(
+        compose_ui.reverse_linkify_text("https://realm.com/my_realm_filter/ZUL-15"),
+        "ZUL-15",
+    );
+    assert.equal(
+        compose_ui.reverse_linkify_text("https://realm.com/my_realm_filter/abc-ZUL-15"),
+        "abc-ZUL-15",
+    );
 });
 
 run_test("quote_message", ({override, override_rewire}) => {

--- a/zerver/models/linkifiers.py
+++ b/zerver/models/linkifiers.py
@@ -50,7 +50,10 @@ def expand_reverse_template(
                     ),
                     params={"name": name},
                 )
-            output.append(match.group(name))
+            # For optional groups, match.group might return None, which we cannot
+            # append in the output to be .join(ed) later, so we add an empty string
+            # in that case.
+            output.append(match.group(name) or "")
             index = end_index + 1
         else:
             output.append(reverse_template[index])

--- a/zerver/tests/test_realm_linkifiers.py
+++ b/zerver/tests/test_realm_linkifiers.py
@@ -86,6 +86,28 @@ class RealmFilterTest(ZulipTestCase):
         result = self.client_post("/json/realm/filters", info=data)
         self.assert_json_error(result, "Example text does not match auto-conversion field.")
 
+        # Example input does not contain the optional group.
+        data = {
+            "pattern": r"(?P<prefix>[a-z]+-)?ZUL-(?P<id>\d+)",
+            "url_template": "https://realm.com/my_realm_filter/{prefix}ZUL-{id}",
+            "example_input": "ZUL-15",
+            "reverse_template": "{prefix}ZUL-{id}",
+        }
+        result = self.client_post("/json/realm/filters", info=data)
+        self.assert_json_success(result)
+        self.assertIsNotNone(re.match(data["pattern"], "ZUL-15"))
+
+        # Similar pattern, but with the optional group present in the example.
+        data = {
+            "pattern": r"(?P<prefix>[a-z]+-)?ZUL-NEW-(?P<id>\d+)",
+            "url_template": "https://realm.com/my_realm_filter/{prefix}ZUL-NEW-{id}",
+            "example_input": "abc-ZUL-NEW-15",
+            "reverse_template": "{prefix}ZUL-NEW-{id}",
+        }
+        result = self.client_post("/json/realm/filters", info=data)
+        self.assert_json_success(result)
+        self.assertIsNotNone(re.match(data["pattern"], "abc-ZUL-NEW-15"))
+
         data = {
             "pattern": r"ZUL-(?P<id>\d+)",
             "url_template": "https://realm.com/my_realm_filter/{id}",


### PR DESCRIPTION
We were getting a TypeError in "".join(output) in
expand_reverse_template since output was containing None from match.group(name) returning None for optional group which did not match. This commit fixes that.

We don't need changes to the JS expand_reverse_template since template.match(segment) returns "" instead of undefined if the optional group is not present. We still add similar test cases as we did on the Python side.

<!-- Describe your pull request here.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
