### PR TITLE
settings_profile_fields: Uncheck `use_for_user_matching` checkbox.

### DIFF
--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -234,6 +234,15 @@ function initialize_form_to_defaults(): void {
     external_accounts_dropdown_widget.render();
 }
 
+function should_check_user_matching_for_external_account(
+    account_type: string | number | undefined,
+): boolean {
+    const unchecked_account_types = new Set(["atlassian", "mastodon"]);
+    const should_uncheck_checkbox =
+        typeof account_type === "string" && unchecked_account_types.has(account_type);
+    return !should_uncheck_checkbox;
+}
+
 function external_account_item_click_callback(
     event: JQuery.ClickEvent,
     dropdown: tippy.Instance,
@@ -260,6 +269,10 @@ function external_account_item_click_callback(
     assert(external_account !== undefined);
     $("#profile_field_name").val(external_account.name).prop("disabled", true);
     $("#profile_field_hint").val(external_account.hint).prop("disabled", true);
+    $("#profile_field_use_for_user_matching").prop(
+        "checked",
+        should_check_user_matching_for_external_account(external_account.text.toLowerCase()),
+    );
     widget.render();
 }
 
@@ -318,7 +331,11 @@ function update_form_for_field_type_selection(): void {
 
     if (is_valid_to_use_for_user_matching(profile_field_type)) {
         $("#profile_field_use_for_user_matching").closest(".input-group").show();
-        const check_use_for_user_mentions = profile_field_type === field_types.EXTERNAL_ACCOUNT.id;
+        const check_use_for_user_mentions =
+            profile_field_type === field_types.EXTERNAL_ACCOUNT.id &&
+            should_check_user_matching_for_external_account(
+                external_accounts_dropdown_widget.value(),
+            );
         $("#profile_field_use_for_user_matching").prop("checked", check_use_for_user_mentions);
     } else {
         $("#profile_field_use_for_user_matching").closest(".input-group").hide();


### PR DESCRIPTION
For particular default external accounts that use opaque values: Atlassian account IDs, Mastodon URLs.

Split out from #38008.
Note that the Atlassian account gets added only in #38008.

**Question:** Is it worth adding a `use_for_user_matching_by_default` field to `ExternalAccount` dataclass in `external_accounts.py`, or is that overkill at this point of time?

<details>
<summary><h3>Screenshots</h3></summary>

<img width="637" height="653" alt="image" src="https://github.com/user-attachments/assets/72c8b27c-9c86-4eab-bd33-865c2eb5022b" />
<img width="637" height="653" alt="image" src="https://github.com/user-attachments/assets/41207654-67a6-4517-bed2-2b886de3ac49" />
<img width="637" height="574" alt="image" src="https://github.com/user-attachments/assets/cc510aef-0cec-4ced-a4d6-993d24981df2" />

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
