### PR TITLE
linear: Add support for Project webhook events.

### DIFF
--- a/zerver/webhooks/linear/fixtures/issue_label_create.json
+++ b/zerver/webhooks/linear/fixtures/issue_label_create.json
@@ -1,0 +1,12 @@
+{
+    "action": "create",
+    "createdAt": "2023-04-11T19:26:16.461Z",
+    "data": {
+        "id": "521660ac-782f-4dd9-8928-95dbc9cb4c9b",
+        "name": "Bug",
+        "color": "#e01e5a"
+    },
+    "type": "IssueLabel",
+    "organizationId": "7a661544-df08-4cd1-a1e3-5ec611898806",
+    "webhookTimestamp": 1681241176588
+}

--- a/zerver/webhooks/linear/fixtures/project_remove.json
+++ b/zerver/webhooks/linear/fixtures/project_remove.json
@@ -1,0 +1,19 @@
+{
+    "action": "remove",
+    "createdAt": "2023-04-11T19:26:16.461Z",
+    "data": {
+        "id": "521660ac-782f-4dd9-8928-95dbc9cb4c9b",
+        "createdAt": "2023-04-11T19:26:16.461Z",
+        "updatedAt": "2023-04-11T19:26:16.461Z",
+        "name": "This is just a sample project to test the working.",
+        "state": "backlog",
+        "teamIds": [
+            "9e383f51-2629-4f19-97ff-451cc2f0a0ad"
+        ]
+    },
+    "url": "https://linear.app/webhooks/project/this-is-just-a-sample-project-to-test-the-working-3d89ec1c20d3",
+    "type": "Project",
+    "organizationId": "7a661544-df08-4cd1-a1e3-5ec611898806",
+    "webhookTimestamp": 1681241176588
+}
+

--- a/zerver/webhooks/linear/tests.py
+++ b/zerver/webhooks/linear/tests.py
@@ -72,10 +72,21 @@ class LinearHookTests(WebhookTestCase):
         self.check_webhook("issue_update", expected_topic_name, expected_message)
 
     def test_project_create(self) -> None:
-        payload = self.get_body("project_create")
+        expected_topic_name = "Project: This is just a sample project to test the working."
+        expected_message = "[Project](https://linear.app/webhooks/project/this-is-just-a-sample-project-to-test-the-working-3d89ec1c20d3) **This is just a sample project to test the working.** was created."
+        self.check_webhook("project_create", expected_topic_name, expected_message)
+
+    def test_project_remove(self) -> None:
+        expected_topic_name = "Project: This is just a sample project to test the working."
+        expected_message = (
+            "Project **This is just a sample project to test the working.** has been removed."
+        )
+        self.check_webhook("project_remove", expected_topic_name, expected_message)
+
+    def test_issue_label_create(self) -> None:
         result = self.client_post(
             self.url,
-            payload,
+            self.get_body("issue_label_create"),
             content_type="application/json",
         )
         self.assert_json_success(result)

--- a/zerver/webhooks/linear/view.py
+++ b/zerver/webhooks/linear/view.py
@@ -17,6 +17,8 @@ ISSUE_CREATE_OR_UPDATE_TEMPLATE = "[{type}]({url}) was {action} in team {team_na
 ISSUE_REMOVE_TEMPLATE = "This issue has been removed from team {team_name}."
 COMMENT_CREATE_OR_UPDATE_TEMPLATE = "{user} [{action}]({url}) on issue **{issue_title}**:"
 COMMENT_REMOVE_TEMPLATE = "{user} has removed a comment."
+PROJECT_CREATE_OR_UPDATE_TEMPLATE = "[Project]({url}) **{name}** was {action}."
+PROJECT_REMOVE_TEMPLATE = "Project **{name}** has been removed."
 
 
 def get_issue_created_or_updated_message(event: str, payload: WildValue, action: str) -> str:
@@ -97,13 +99,26 @@ def get_comment_message(payload: WildValue, event: str) -> str:
     )
 
 
+def get_project_message(payload: WildValue, event: str) -> str:
+    action = payload["action"].tame(check_string)
+    name = payload["data"]["name"].tame(check_string)
+    if action == "remove":
+        return PROJECT_REMOVE_TEMPLATE.format(name=name)
+    return PROJECT_CREATE_OR_UPDATE_TEMPLATE.format(
+        url=payload["url"].tame(check_string),
+        name=name,
+        action="created" if action == "create" else "updated",
+    )
+
+
 EVENT_FUNCTION_MAPPER: dict[str, Callable[[WildValue, str], str]] = {
     "issue": get_issue_or_sub_issue_message,
     "sub_issue": get_issue_or_sub_issue_message,
     "comment": get_comment_message,
+    "project": get_project_message,
 }
 
-IGNORED_EVENTS = ["IssueLabel", "Project", "ProjectUpdate", "Cycle", "Reaction"]
+IGNORED_EVENTS = ["IssueLabel", "ProjectUpdate", "Cycle", "Reaction"]
 
 ALL_EVENT_TYPES = list(EVENT_FUNCTION_MAPPER.keys())
 
@@ -143,6 +158,9 @@ def get_topic(user_specified_topic: str | None, event: str, payload: WildValue) 
     elif event == "issue":
         title = payload["data"]["title"].tame(check_string)
         return f"Issue: {title}"
+    elif event == "project":
+        name = payload["data"]["name"].tame(check_string)
+        return f"Project: {name}"
 
     raise UnsupportedWebhookEventTypeError(event)
 
@@ -155,6 +173,8 @@ def get_event_type(payload: WildValue) -> str | None:
         return "issue" if not has_parent_id else "sub_issue"
     elif event_type == "Comment":
         return "comment"
+    elif event_type == "Project":
+        return "project"
     elif event_type in IGNORED_EVENTS:
         return None
 


### PR DESCRIPTION
Previously, the Linear webhook integration silently ignored Project
events (create, update, and remove), returning a success response
without sending any Zulip notification.

This commit adds handlers for these three Project event types. When
a project is created, updated, or removed in Linear, a formatted
notification is sent to the configured Zulip stream with the project
name and a link.

Fixes part of #23118.