### PR TITLE
mentions: Have same styling for @ and silent self mentions.

### DIFF
--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -146,13 +146,7 @@ export const update_elements = ($content: JQuery): void => {
         if (user_id === "*" && message && message.stream_wildcard_mentioned) {
             $(this).addClass("user-mention-me");
         }
-        if (
-            user_id !== undefined &&
-            user_id !== "*" &&
-            people.is_my_user_id(user_id) &&
-            message &&
-            message.mentioned_me_directly
-        ) {
+        if (user_id !== undefined && user_id !== "*" && people.is_my_user_id(user_id) && message) {
             $(this).addClass("user-mention-me");
         }
 

--- a/web/tests/rendered_markdown.test.cjs
+++ b/web/tests/rendered_markdown.test.cjs
@@ -220,9 +220,14 @@ run_test("user-mention", ({override}) => {
     assert.equal($cordelia.text(), `@${cordelia.full_name}`);
     assert.equal($polonius.text(), `translated: @${polonius.full_name} (guest)`);
 
-    // message row found
     const message = {mentioned_me_directly: true};
     set_message_for_message_content($content, message);
+    rm.update_elements($content);
+    assert.ok($iago.hasClass("user-mention-me"));
+
+    // Silent mentions should also have the `user-mention-me` class.
+    $iago.removeClass("user-mention-me");
+    message.mentioned_me_directly = false;
     rm.update_elements($content);
     assert.ok($iago.hasClass("user-mention-me"));
 });


### PR DESCRIPTION
Fixes
https://chat.zulip.org/#narrow/channel/101-design/topic/User.20group.20mentions.20inconsistency.

message.mentioned_me_directly was a check to see if this was an `@` mention, which we don't need anymore.


**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Before:
<img width="910" height="208" alt="Screenshot 2026-03-17 at 2 36 16 PM" src="https://github.com/user-attachments/assets/d7904560-1b5e-4c89-a112-42a59c4a6036" />

After:
<img width="910" height="208" alt="Screenshot 2026-03-17 at 2 35 55 PM" src="https://github.com/user-attachments/assets/fa11cd56-57e3-412b-a404-71dd27f91e01" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
