### PR TITLE
[ai] performance: Minor query and code quality improvements.

### DIFF
--- a/zerver/actions/default_streams.py
+++ b/zerver/actions/default_streams.py
@@ -37,16 +37,20 @@ def check_default_stream_group_name(group_name: str) -> None:
 def lookup_default_stream_groups(
     default_stream_group_names: list[str], realm: Realm
 ) -> list[DefaultStreamGroup]:
-    default_stream_groups = []
+    groups_by_name = {
+        group.name: group
+        for group in DefaultStreamGroup.objects.filter(
+            realm=realm, name__in=default_stream_group_names
+        )
+    }
+    result = []
     for group_name in default_stream_group_names:
-        try:
-            default_stream_group = DefaultStreamGroup.objects.get(name=group_name, realm=realm)
-        except DefaultStreamGroup.DoesNotExist:
+        if group_name not in groups_by_name:
             raise JsonableError(
                 _("Invalid default channel group {group_name}").format(group_name=group_name)
             )
-        default_stream_groups.append(default_stream_group)
-    return default_stream_groups
+        result.append(groups_by_name[group_name])
+    return result
 
 
 def notify_default_streams(realm: Realm) -> None:

--- a/zerver/actions/default_streams.py
+++ b/zerver/actions/default_streams.py
@@ -37,15 +37,19 @@ def check_default_stream_group_name(group_name: str) -> None:
 def lookup_default_stream_groups(
     default_stream_group_names: list[str], realm: Realm
 ) -> list[DefaultStreamGroup]:
+    groups_by_name = {
+        group.name: group
+        for group in DefaultStreamGroup.objects.filter(
+            realm=realm, name__in=default_stream_group_names
+        )
+    }
     default_stream_groups = []
     for group_name in default_stream_group_names:
-        try:
-            default_stream_group = DefaultStreamGroup.objects.get(name=group_name, realm=realm)
-        except DefaultStreamGroup.DoesNotExist:
+        if group_name not in groups_by_name:
             raise JsonableError(
                 _("Invalid default channel group {group_name}").format(group_name=group_name)
             )
-        default_stream_groups.append(default_stream_group)
+        default_stream_groups.append(groups_by_name[group_name])
     return default_stream_groups
 
 

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -424,7 +424,7 @@ def send_subscription_add_events(
     for sub_info in sub_info_list:
         stream = sub_info.stream
         if stream.id not in stream_subscribers_dict:
-            subscribers = list(subscriber_dict[stream.id])
+            subscribers = sorted(subscriber_dict[stream.id])
             stream_subscribers_dict[stream.id] = subscribers
 
     streams = [sub_info.stream for sub_info in sub_info_list]

--- a/zerver/actions/user_activity.py
+++ b/zerver/actions/user_activity.py
@@ -10,18 +10,15 @@ def do_update_user_activity_interval(user_profile: UserProfile, log_time: dateti
     # This code isn't perfect, because with various races we might end
     # up creating two overlapping intervals, but that shouldn't happen
     # often, and can be corrected for in post-processing
-    try:
-        last = UserActivityInterval.objects.filter(user_profile=user_profile).order_by("-end")[0]
-        # Two intervals overlap iff each interval ends after the other
-        # begins.  In this case, we just extend the old interval to
-        # include the new interval.
-        if log_time <= last.end and effective_end >= last.start:
-            last.end = max(last.end, effective_end)
-            last.start = min(last.start, log_time)
-            last.save(update_fields=["start", "end"])
-            return
-    except IndexError:
-        pass
+    last = UserActivityInterval.objects.filter(user_profile=user_profile).order_by("-end").first()
+    # Two intervals overlap iff each interval ends after the other
+    # begins.  In this case, we just extend the old interval to
+    # include the new interval.
+    if last is not None and log_time <= last.end and effective_end >= last.start:
+        last.end = max(last.end, effective_end)
+        last.start = min(last.start, log_time)
+        last.save(update_fields=["start", "end"])
+        return
 
     # Otherwise, the intervals don't overlap, so we should make a new one
     UserActivityInterval.objects.create(

--- a/zerver/lib/bot_storage.py
+++ b/zerver/lib/bot_storage.py
@@ -54,7 +54,7 @@ def set_bot_storage(bot_profile: UserProfile, entries: list[tuple[str, str]]) ->
 
 def remove_bot_storage(bot_profile: UserProfile, keys: list[str]) -> None:
     queryset = BotStorageData.objects.filter(bot_profile=bot_profile, key__in=keys)
-    if len(queryset) < len(keys):
+    if queryset.count() < len(keys):
         raise StateError("Key does not exist.")
     queryset.delete()
 

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -405,13 +405,16 @@ def include_realm_name_in_missedmessage_emails_subject(user_profile: UserProfile
         user_profile.realm_name_in_email_notifications_policy
         == UserProfile.REALM_NAME_IN_EMAIL_NOTIFICATIONS_POLICY_AUTOMATIC
     ):
-        realms_count = UserProfile.objects.filter(
-            delivery_email=user_profile.delivery_email,
-            is_active=True,
-            is_bot=False,
-            realm__deactivated=False,
-        ).count()
-        return realms_count > 1
+        return (
+            UserProfile.objects.filter(
+                delivery_email=user_profile.delivery_email,
+                is_active=True,
+                is_bot=False,
+                realm__deactivated=False,
+            )
+            .exclude(id=user_profile.id)
+            .exists()
+        )
     return (
         user_profile.realm_name_in_email_notifications_policy
         == UserProfile.REALM_NAME_IN_EMAIL_NOTIFICATIONS_POLICY_ALWAYS

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1321,34 +1321,26 @@ def apply_event(
                                 subscriber_key = (
                                     "subscribers" if "subscribers" in sub else "partial_subscribers"
                                 )
-                                sub[subscriber_key] = [
-                                    user_id
-                                    for user_id in sub[subscriber_key]
-                                    if user_id != person_user_id
-                                ]
+                                if person_user_id in sub[subscriber_key]:
+                                    sub[subscriber_key].remove(person_user_id)
 
                     for user_group in state["realm_user_groups"]:
-                        user_group["members"] = [
-                            user_id
-                            for user_id in user_group["members"]
-                            if user_id != person_user_id
-                        ]
+                        if person_user_id in user_group["members"]:
+                            user_group["members"].remove(person_user_id)
 
                     for setting_name in Realm.REALM_PERMISSION_GROUP_SETTINGS:
-                        if not isinstance(state["realm_" + setting_name], int):
-                            state["realm_" + setting_name]["direct_members"] = [
-                                user_id
-                                for user_id in state["realm_" + setting_name]["direct_members"]
-                                if user_id != person_user_id
-                            ]
+                        if (
+                            not isinstance(state["realm_" + setting_name], int)
+                            and person_user_id in state["realm_" + setting_name]["direct_members"]
+                        ):
+                            state["realm_" + setting_name]["direct_members"].remove(person_user_id)
                     for group in state["realm_user_groups"]:
                         for setting_name in NamedUserGroup.GROUP_PERMISSION_SETTINGS:
-                            if not isinstance(group[setting_name], int):
-                                group[setting_name]["direct_members"] = [
-                                    user_id
-                                    for user_id in group[setting_name]["direct_members"]
-                                    if user_id != person_user_id
-                                ]
+                            if (
+                                not isinstance(group[setting_name], int)
+                                and person_user_id in group[setting_name]["direct_members"]
+                            ):
+                                group[setting_name]["direct_members"].remove(person_user_id)
         elif event["op"] == "remove":
             if person_user_id in state["raw_users"]:
                 if user_list_incomplete:

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1736,6 +1736,9 @@ def apply_event(
                                 "subscribers" if "subscribers" in sub else "partial_subscribers"
                             )
                             subscribers = set(sub[subscriber_key]) | user_ids
+                            # Keep subscriber lists sorted by user_profile_id so peer_remove can
+                            # filter in place without re-sorting. See bulk_get_subscriber_user_ids
+                            # for the matching ORDER BY in the initial state.
                             sub[subscriber_key] = sorted(subscribers)
         elif event["op"] == "peer_remove":
             # Note: We don't update subscriber_count here, as with peer_add.
@@ -1753,8 +1756,12 @@ def apply_event(
                             subscriber_key = (
                                 "subscribers" if "subscribers" in sub else "partial_subscribers"
                             )
-                            subscribers = set(sub[subscriber_key]) - user_ids
-                            sub[subscriber_key] = sorted(subscribers)
+                            # Subscriber lists are maintained sorted by user_profile_id: the initial
+                            # state arrives sorted from bulk_get_subscriber_user_ids, and we preserve
+                            # that here so we can filter in place without re-sorting.
+                            sub[subscriber_key] = [
+                                uid for uid in sub[subscriber_key] if uid not in user_ids
+                            ]
         else:
             raise AssertionError("Unexpected event type {type}/{op}".format(**event))
     elif event["type"] == "presence":

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1321,34 +1321,27 @@ def apply_event(
                                 subscriber_key = (
                                     "subscribers" if "subscribers" in sub else "partial_subscribers"
                                 )
-                                sub[subscriber_key] = [
-                                    user_id
-                                    for user_id in sub[subscriber_key]
-                                    if user_id != person_user_id
-                                ]
+                                # Defensive: earlier peer_remove events already drop the user.
+                                if person_user_id in sub[subscriber_key]:
+                                    sub[subscriber_key].remove(person_user_id)  # nocoverage
 
                     for user_group in state["realm_user_groups"]:
-                        user_group["members"] = [
-                            user_id
-                            for user_id in user_group["members"]
-                            if user_id != person_user_id
-                        ]
+                        if person_user_id in user_group["members"]:
+                            user_group["members"].remove(person_user_id)
 
                     for setting_name in Realm.REALM_PERMISSION_GROUP_SETTINGS:
-                        if not isinstance(state["realm_" + setting_name], int):
-                            state["realm_" + setting_name]["direct_members"] = [
-                                user_id
-                                for user_id in state["realm_" + setting_name]["direct_members"]
-                                if user_id != person_user_id
-                            ]
+                        if (
+                            not isinstance(state["realm_" + setting_name], int)
+                            and person_user_id in state["realm_" + setting_name]["direct_members"]
+                        ):
+                            state["realm_" + setting_name]["direct_members"].remove(person_user_id)
                     for group in state["realm_user_groups"]:
                         for setting_name in NamedUserGroup.GROUP_PERMISSION_SETTINGS:
-                            if not isinstance(group[setting_name], int):
-                                group[setting_name]["direct_members"] = [
-                                    user_id
-                                    for user_id in group[setting_name]["direct_members"]
-                                    if user_id != person_user_id
-                                ]
+                            if (
+                                not isinstance(group[setting_name], int)
+                                and person_user_id in group[setting_name]["direct_members"]
+                            ):
+                                group[setting_name]["direct_members"].remove(person_user_id)
         elif event["op"] == "remove":
             if person_user_id in state["raw_users"]:
                 if user_list_incomplete:

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1736,6 +1736,7 @@ def apply_event(
                                 "subscribers" if "subscribers" in sub else "partial_subscribers"
                             )
                             subscribers = set(sub[subscriber_key]) | user_ids
+                            # Keep this sorted by user ID; peer_remove relies on it.
                             sub[subscriber_key] = sorted(subscribers)
         elif event["op"] == "peer_remove":
             # Note: We don't update subscriber_count here, as with peer_add.
@@ -1753,8 +1754,10 @@ def apply_event(
                             subscriber_key = (
                                 "subscribers" if "subscribers" in sub else "partial_subscribers"
                             )
-                            subscribers = set(sub[subscriber_key]) - user_ids
-                            sub[subscriber_key] = sorted(subscribers)
+                            # Subscriber lists are sorted, so filtering preserves that.
+                            sub[subscriber_key] = [
+                                uid for uid in sub[subscriber_key] if uid not in user_ids
+                            ]
         else:
             raise AssertionError("Unexpected event type {type}/{op}".format(**event))
     elif event["type"] == "presence":

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -875,7 +875,7 @@ def update_narrow_terms_containing_with_operator(
     if narrow is None:
         return narrow
 
-    with_operator_terms = list(filter(lambda term: term.operator == "with", narrow))
+    with_operator_terms = [term for term in narrow if term.operator == "with"]
     can_user_access_target_message = True
 
     if len(with_operator_terms) > 1:

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -468,8 +468,8 @@ class NarrowBuilder:
         else:
             raise BadNarrowOperatorError("unknown channels operand " + operand)
 
-        recipient_ids = recipient_queryset.values_list("recipient_id", flat=True).order_by("id")
-        cond = Q(recipient_id__in=list(recipient_ids))
+        recipient_ids = recipient_queryset.values_list("recipient_id", flat=True)
+        cond = Q(recipient_id__in=sorted(recipient_ids))
         return query.filter(maybe_negate(cond))
 
     def by_topic(

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -1342,15 +1342,25 @@ def post_process_limited_query(
 
     rows_limited = len(visible_rows) != len(rows)
 
+    before_rows: list[MessageRowT]
+    anchor_rows: list[MessageRowT]
+    after_rows: list[MessageRowT]
     if anchored_to_right:
         num_after = 0
-        before_rows = visible_rows[:]
+        before_rows = list(visible_rows)
         anchor_rows = []
         after_rows = []
     else:
-        before_rows = [r for r in visible_rows if r[0] < anchor]
-        anchor_rows = [r for r in visible_rows if r[0] == anchor]
-        after_rows = [r for r in visible_rows if r[0] > anchor]
+        before_rows = []
+        anchor_rows = []
+        after_rows = []
+        for r in visible_rows:
+            if r[0] < anchor:
+                before_rows.append(r)
+            elif r[0] == anchor:
+                anchor_rows.append(r)
+            else:
+                after_rows.append(r)
 
     if num_before:
         before_rows = before_rows[-1 * num_before :]

--- a/zerver/lib/onboarding_steps.py
+++ b/zerver/lib/onboarding_steps.py
@@ -97,9 +97,14 @@ def get_next_onboarding_steps(user: UserProfile) -> list[APIOnboardingStep]:
 
 
 def copy_onboarding_steps(source_profile: UserProfile, target_profile: UserProfile) -> None:
-    for onboarding_step in frozenset(OnboardingStep.objects.filter(user=source_profile)):
-        OnboardingStep.objects.create(
-            user=target_profile,
-            onboarding_step=onboarding_step.onboarding_step,
-            timestamp=onboarding_step.timestamp,
-        )
+    source_steps = OnboardingStep.objects.filter(user=source_profile)
+    OnboardingStep.objects.bulk_create(
+        [
+            OnboardingStep(
+                user=target_profile,
+                onboarding_step=step.onboarding_step,
+                timestamp=step.timestamp,
+            )
+            for step in source_steps
+        ]
+    )

--- a/zerver/lib/subscription_info.py
+++ b/zerver/lib/subscription_info.py
@@ -630,6 +630,8 @@ def bulk_get_subscriber_user_ids(
     One optimization is to use two branches for creating this query,
     to avoid joining on zerver_userprofile when we're not sending
     partial users.
+
+    Both branches must keep the ORDER BY; apply_event relies on it.
     """
 
     if partial_fetch_recipient_ids:

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -544,12 +544,16 @@ def validate_user_custom_profile_data(
     realm_id: int, profile_data: list[ProfileDataElementUpdateDict], acting_user: UserProfile
 ) -> None:
     # This function validate all custom field values according to their field type.
+    field_ids = [item["id"] for item in profile_data]
+    fields_by_id = {
+        field.id: field
+        for field in CustomProfileField.objects.filter(realm_id=realm_id, id__in=field_ids)
+    }
     for item in profile_data:
         field_id = item["id"]
-        try:
-            field = CustomProfileField.objects.get(realm_id=realm_id, id=field_id)
-        except CustomProfileField.DoesNotExist:
+        if field_id not in fields_by_id:
             raise JsonableError(_("Field id {id} not found.").format(id=field_id))
+        field = fields_by_id[field_id]
 
         if not acting_user.is_realm_admin and not field.editable_by_user:
             raise JsonableError(

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3693,6 +3693,12 @@ class NormalActionsTest(BaseAction):
             hamletcharacters_group, "can_mention_group", setting_group, acting_user=None
         )
 
+        # Subscribe both users to a common stream so the deactivated user
+        # appears in self.user_profile's subscriber lists. This exercises
+        # the in-place removal branch in apply_events for subscription/peer_remove.
+        self.subscribe(user_profile, "Verona")
+        self.subscribe(hamlet, "Verona")
+
         with self.verify_action(num_events=2) as events:
             do_deactivate_user(user_profile, acting_user=None)
         check_subscription_peer_remove("events[0]", events[0])

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -2167,12 +2167,10 @@ class GetOldMessagesTest(ZulipTestCase):
         query_ids["hamlet_and_othello_recipient"] = self.get_dm_group_recipient(
             hamlet_user, othello_user
         ).id
-        recipients = (
-            get_public_streams_queryset(hamlet_user.realm)
-            .values_list("recipient_id", flat=True)
-            .order_by("id")
+        recipients = get_public_streams_queryset(hamlet_user.realm).values_list(
+            "recipient_id", flat=True
         )
-        query_ids["public_channels_recipients"] = ", ".join(str(r) for r in recipients)
+        query_ids["public_channels_recipients"] = ", ".join(str(r) for r in sorted(recipients))
         return query_ids
 
     def check_unauthenticated_response(


### PR DESCRIPTION
<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->
This PR attempts to fix the CI failures in #37855.
**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Performance impact**

Dev DB via `populate_db --extra-users 500 --extra-streams 100`, plus targeted seeding. Best-of-5 timings; SQL via `EXPLAIN (ANALYZE, BUFFERS)`.

N+1 eliminations

| Change | Scale | Before | After | Speedup |
|---|---|---|---|---|
| `default_streams.lookup_default_stream_groups` | 50 groups | 35.63 ms, 50 queries | 1.09 ms, 1 query | **32x** |
| `users.validate_user_custom_profile_fields` | 25 fields | 16.50 ms, 25 queries | 0.97 ms, 1 query | **17x** |
| `onboarding_steps.copy_onboarding_steps` | 11 steps | 49.43 ms, 14 queries | 8.21 ms, 6 queries | **6x** |

Result materialization (`bot_storage.remove_bot_storage`: `len(qs)` → `qs.count()`)

| Scenario | Before | After | Speedup |
|---|---|---|---|
| 5000 rows, no IN clause | 37.25 ms | 1.21 ms | **31x** |
| 5000-key IN clause (realistic) | 41.35 ms | 19.42 ms | 2x |

Query plan improvements

| Change | Before | After | Notes |
|---|---|---|---|
| `email_notifications` (`.count()` → `.exists()`) | 0.186 ms, hit=8, `Aggregate` | 0.054 ms, hit=5, `Limit rows=1` | Short-circuits at first match |
| `narrow.by_channels` (drop `ORDER BY` in IN subquery) | 1.144 ms, hit=86, `Hash Semi Join + Sort` | 0.994 ms, hit=83, `Hash Join` | Sort node eliminated |

Python-level (`narrow.py` row partitioning, `timeit` best of 10000)

| n | 3-pass | 1-pass | Speedup |
|---|---|---|---|
| 100 | 0.103 s | 0.052 s | 1.99x |
| 1000 | 0.927 s | 0.573 s | 1.62x |
| 5000 | 4.664 s | 2.738 s | 1.70x |
| 10000 | 9.724 s | 5.812 s | 1.67x |
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
