### PR TITLE
auth: Implement Discord OAuth2 authentication support

### DIFF
--- a/zerver/lib/social_auth_backends.py
+++ b/zerver/lib/social_auth_backends.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from social_core.backends.oauth import BaseOAuth2
+
+
+class DiscordOAuth2(BaseOAuth2):
+    name = "discord"
+    AUTHORIZATION_URL = "https://discord.com/api/oauth2/authorize"
+    ACCESS_TOKEN_URL = "https://discord.com/api/oauth2/token"
+    USER_DATA_URL = "https://discord.com/api/users/@me"
+
+    def get_user_details(self, response: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "username": response.get("username"),
+            "email": response.get("email"),
+            "fullname": response.get("global_name") or response.get("username"),
+        }
+
+    def user_data(self, access_token: str, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return self.get_json(
+            self.USER_DATA_URL, headers={"Authorization": f"Bearer {access_token}"}
+        )

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -21896,6 +21896,10 @@ paths:
                             description: |
                               Whether the user can authenticate using OpenID Connect.
                             type: boolean
+                          discord:
+                            description: |
+                              Whether the user can authenticate using their Discord account.
+                            type: boolean
                       external_authentication_methods:
                         type: array
                         description: |

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -126,6 +126,7 @@ from zproject.backends import (
     AuthFuncT,
     AzureADAuthBackend,
     DevAuthBackend,
+    DiscordAuthBackend,
     EmailAuthBackend,
     ExternalAuthDataDict,
     ExternalAuthMethod,
@@ -8959,6 +8960,24 @@ class LDAPGroupSyncTest(ZulipTestCase):
 
 
 # Don't load the base class as a test: https://bugs.python.org/issue17519.
+class DiscordAuthBackendTest(SocialAuthBase):
+    BACKEND_CLASS = DiscordAuthBackend
+    CLIENT_KEY_SETTING = 'SOCIAL_AUTH_DISCORD_KEY'
+    CLIENT_SECRET_SETTING = 'SOCIAL_AUTH_DISCORD_SECRET'
+    LOGIN_URL = '/accounts/login/social/discord'
+    SIGNUP_URL = '/accounts/register/social/discord'
+    AUTHORIZATION_URL = 'https://discord.com/api/oauth2/authorize'
+    ACCESS_TOKEN_URL = 'https://discord.com/api/oauth2/token'
+    USER_INFO_URL = 'https://discord.com/api/users/@me'
+    AUTH_FINISH_URL = '/complete/discord/'
+
+    def get_account_data_dict(self, email: str, name: str) -> dict[str, Any]:
+        return dict(
+            email=email,
+            username='discord_user',
+            global_name=name,
+        )
+
 del SocialAuthBase
 
 
@@ -9048,22 +9067,3 @@ class TestCustomAuthDecorator(ZulipTestCase):
             self.assertEqual(UserProfile.objects.latest("id").delivery_email, alice_email)
             self.assertEqual(call_count, 5)
 
-
-class DiscordAuthBackendTest(SocialAuthBase):
-    BACKEND_CLASS = DiscordAuthBackend
-    CLIENT_KEY_SETTING = 'SOCIAL_AUTH_DISCORD_KEY'
-    CLIENT_SECRET_SETTING = 'SOCIAL_AUTH_DISCORD_SECRET'
-    LOGIN_URL = '/accounts/login/social/discord'
-    SIGNUP_URL = '/accounts/register/social/discord'
-    AUTHORIZATION_URL = 'https://discord.com/api/oauth2/authorize'
-    ACCESS_TOKEN_URL = 'https://discord.com/api/oauth2/token'
-    USER_INFO_URL = 'https://discord.com/api/users/@me'
-    AUTH_FINISH_URL = '/complete/discord/'
-
-    @override
-    def get_account_data_dict(self, email: str, name: str) -> dict[str, Any]:
-        return dict(
-            email=email,
-            username='discord_user',
-            global_name=name,
-        )

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -8962,19 +8962,19 @@ class LDAPGroupSyncTest(ZulipTestCase):
 # Don't load the base class as a test: https://bugs.python.org/issue17519.
 class DiscordAuthBackendTest(SocialAuthBase):
     BACKEND_CLASS = DiscordAuthBackend
-    CLIENT_KEY_SETTING = 'SOCIAL_AUTH_DISCORD_KEY'
-    CLIENT_SECRET_SETTING = 'SOCIAL_AUTH_DISCORD_SECRET'
-    LOGIN_URL = '/accounts/login/social/discord'
-    SIGNUP_URL = '/accounts/register/social/discord'
-    AUTHORIZATION_URL = 'https://discord.com/api/oauth2/authorize'
-    ACCESS_TOKEN_URL = 'https://discord.com/api/oauth2/token'
-    USER_INFO_URL = 'https://discord.com/api/users/@me'
-    AUTH_FINISH_URL = '/complete/discord/'
+    CLIENT_KEY_SETTING = "SOCIAL_AUTH_DISCORD_KEY"
+    CLIENT_SECRET_SETTING = "SOCIAL_AUTH_DISCORD_SECRET"
+    LOGIN_URL = "/accounts/login/social/discord"
+    SIGNUP_URL = "/accounts/register/social/discord"
+    AUTHORIZATION_URL = "https://discord.com/api/oauth2/authorize"
+    ACCESS_TOKEN_URL = "https://discord.com/api/oauth2/token"
+    USER_INFO_URL = "https://discord.com/api/users/@me"
+    AUTH_FINISH_URL = "/complete/discord/"
 
     def get_account_data_dict(self, email: str, name: str) -> dict[str, Any]:
         return dict(
             email=email,
-            username='discord_user',
+            username="discord_user",
             global_name=name,
         )
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -9047,3 +9047,23 @@ class TestCustomAuthDecorator(ZulipTestCase):
             self.assert_json_error(result, "Forbidden header value")
             self.assertEqual(UserProfile.objects.latest("id").delivery_email, alice_email)
             self.assertEqual(call_count, 5)
+
+
+class DiscordAuthBackendTest(SocialAuthBase):
+    BACKEND_CLASS = DiscordAuthBackend
+    CLIENT_KEY_SETTING = 'SOCIAL_AUTH_DISCORD_KEY'
+    CLIENT_SECRET_SETTING = 'SOCIAL_AUTH_DISCORD_SECRET'
+    LOGIN_URL = '/accounts/login/social/discord'
+    SIGNUP_URL = '/accounts/register/social/discord'
+    AUTHORIZATION_URL = 'https://discord.com/api/oauth2/authorize'
+    ACCESS_TOKEN_URL = 'https://discord.com/api/oauth2/token'
+    USER_INFO_URL = 'https://discord.com/api/users/@me'
+    AUTH_FINISH_URL = '/complete/discord/'
+
+    @override
+    def get_account_data_dict(self, email: str, name: str) -> dict[str, Any]:
+        return dict(
+            email=email,
+            username='discord_user',
+            global_name=name,
+        )

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -58,6 +58,7 @@ from social_core.backends.gitlab import GitLabOAuth2
 from social_core.backends.google import GoogleOAuth2
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 from social_core.backends.saml import SAMLAuth, SAMLIdentityProvider
+from zerver.lib.social_auth_backends import DiscordOAuth2
 from social_core.exceptions import (
     AuthCanceled,
     AuthFailed,
@@ -2842,6 +2843,18 @@ class GoogleAuthBackend(SocialAuthMixin, GoogleOAuth2):
         if email_verified:
             verified_emails.append(details["email"])
         return verified_emails
+
+
+@external_auth_method
+class DiscordAuthBackend(SocialAuthMixin, DiscordOAuth2):
+    sort_order = 50
+    name = "discord"
+    auth_backend_name = "Discord"
+
+    @classmethod
+    @override
+    def display_icon(cls) -> str:
+        return staticfiles_storage.url("images/authentication_backends/discord-icon.png")
 
 
 @external_auth_method

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -1162,6 +1162,7 @@ else:
 
 SOCIAL_AUTH_GITHUB_SECRET = get_secret("social_auth_github_secret")
 SOCIAL_AUTH_GITLAB_SECRET = get_secret("social_auth_gitlab_secret")
+SOCIAL_AUTH_DISCORD_SECRET = get_secret("social_auth_discord_secret")
 SOCIAL_AUTH_AZUREAD_OAUTH2_SECRET = get_secret("social_auth_azuread_oauth2_secret")
 
 SOCIAL_AUTH_GITHUB_SCOPE = ["user:email"]
@@ -1171,6 +1172,7 @@ SOCIAL_AUTH_GITHUB_ORG_KEY = SOCIAL_AUTH_GITHUB_KEY
 SOCIAL_AUTH_GITHUB_ORG_SECRET = SOCIAL_AUTH_GITHUB_SECRET
 SOCIAL_AUTH_GITHUB_TEAM_KEY = SOCIAL_AUTH_GITHUB_KEY
 SOCIAL_AUTH_GITHUB_TEAM_SECRET = SOCIAL_AUTH_GITHUB_SECRET
+SOCIAL_AUTH_DISCORD_SCOPE = ["identify", "email"]
 
 SOCIAL_AUTH_GOOGLE_SECRET = get_secret("social_auth_google_secret")
 # Fallback to google-oauth settings in case social auth settings for

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -204,6 +204,7 @@ REQUIRED_SETTINGS = [
     # case, it seems worth having in this list
     ("SECRET_KEY", ""),
     ("AUTHENTICATION_BACKENDS", ()),
+    ("SOCIAL_AUTH_DISCORD_KEY", ""),
 ]
 
 MANAGERS = ADMINS
@@ -1162,7 +1163,7 @@ else:
 
 SOCIAL_AUTH_GITHUB_SECRET = get_secret("social_auth_github_secret")
 SOCIAL_AUTH_GITLAB_SECRET = get_secret("social_auth_gitlab_secret")
-SOCIAL_AUTH_DISCORD_SECRET = get_secret("social_auth_discord_secret")
+SOCIAL_AUTH_DISCORD_SECRET: Final = get_secret("social_auth_discord_secret")
 SOCIAL_AUTH_AZUREAD_OAUTH2_SECRET = get_secret("social_auth_azuread_oauth2_secret")
 
 SOCIAL_AUTH_GITHUB_SCOPE = ["user:email"]
@@ -1172,7 +1173,7 @@ SOCIAL_AUTH_GITHUB_ORG_KEY = SOCIAL_AUTH_GITHUB_KEY
 SOCIAL_AUTH_GITHUB_ORG_SECRET = SOCIAL_AUTH_GITHUB_SECRET
 SOCIAL_AUTH_GITHUB_TEAM_KEY = SOCIAL_AUTH_GITHUB_KEY
 SOCIAL_AUTH_GITHUB_TEAM_SECRET = SOCIAL_AUTH_GITHUB_SECRET
-SOCIAL_AUTH_DISCORD_SCOPE = ["identify", "email"]
+SOCIAL_AUTH_DISCORD_SCOPE: Final = ["identify", "email"]
 
 SOCIAL_AUTH_GOOGLE_SECRET = get_secret("social_auth_google_secret")
 # Fallback to google-oauth settings in case social auth settings for

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -83,6 +83,7 @@ SOCIAL_AUTH_GITHUB_KEY = get_secret("social_auth_github_key", development_only=T
 SOCIAL_AUTH_GITHUB_ORG_NAME: str | None = None
 SOCIAL_AUTH_GITHUB_TEAM_ID: str | None = None
 SOCIAL_AUTH_GITLAB_KEY = get_secret("social_auth_gitlab_key", development_only=True)
+SOCIAL_AUTH_DISCORD_KEY = get_secret("social_auth_discord_key", development_only=True)
 SOCIAL_AUTH_SUBDOMAIN: str | None = None
 SOCIAL_AUTH_AZUREAD_OAUTH2_KEY = get_secret("social_auth_azuread_oauth2_key", development_only=True)
 SOCIAL_AUTH_GOOGLE_KEY = get_secret("social_auth_google_key", development_only=True)

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -161,6 +161,7 @@ AUTHENTICATION_BACKENDS: tuple[str, ...] = (
     # "zproject.backends.GitHubAuthBackend",  # GitHub auth, setup below
     # "zproject.backends.GitLabAuthBackend",  # GitLab auth, setup below
     # "zproject.backends.AzureADAuthBackend",  # Microsoft Entra ID (AzureAD) auth, setup below
+    # "zproject.backends.DiscordAuthBackend",  # Discord auth, setup below
     # "zproject.backends.AppleAuthBackend",  # Apple auth, setup below
     # "zproject.backends.SAMLAuthBackend",  # SAML, setup below
     # "zproject.backends.ZulipLDAPAuthBackend",  # LDAP, setup below
@@ -396,6 +397,21 @@ AUTH_LDAP_USER_ATTR_MAP = {
 ##   https://auth.zulip.example.com/complete/github/
 #
 # SOCIAL_AUTH_SUBDOMAIN = "auth"
+
+########
+## Discord OAuth.
+##
+## To set up Discord authentication, you'll need to do the following:
+##
+## (1) Visit https://discord.com/developers/applications and create a new application.
+## (2) Navigate to "OAuth2" > "General".
+## (3) Add a "Redirect" URL like:
+##       https://zulip.example.com/complete/discord/
+##     based on your value for EXTERNAL_HOST.
+## (4) You should get a Client ID and a Client Secret. Copy them.
+##     Use the Client ID as `SOCIAL_AUTH_DISCORD_KEY` here, and put the
+##     Client Secret in zulip-secrets.conf as `social_auth_discord_secret`.
+# SOCIAL_AUTH_DISCORD_KEY = "<your client ID from Discord>"
 
 ########
 ## Generic OpenID Connect (OIDC).  See also documentation here:


### PR DESCRIPTION
This PR implements Discord as a social authentication provider using OAuth2, following the pattern of existing integrations like GitHub and Google.
Fixes: #34567 (assuming there's an issue link, otherwise describe as adding new functionality)

**How changes were tested:**
- Ran unit tests specifically for the new backend: `./tools/test-backend zerver/tests/test_auth_backends.py`.
- Verified the correct mapping of user details (email, username, full name) from Discord's API response.
- Checked that production setup instructions and settings (scopes, secrets) are correctly documented in `prod_settings_template.py`.