### PR TITLE
remote-billing: Update error for user without has_billing_access.

### DIFF
--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -187,7 +187,9 @@ class SelfHostedBillingEndpointBasicTest(RemoteRealmBillingTestCase):
             "/self-hosted-billing/not-configured/",
         ]:
             result = self.client_get(url)
-            self.assert_json_error(result, "Must be an organization owner")
+            self.assert_json_error(
+                result, "You do not have permission to manage plans and billing."
+            )
 
         # Login as an organization owner to gain access.
         self.login("desdemona")

--- a/zerver/views/push_notifications.py
+++ b/zerver/views/push_notifications.py
@@ -21,7 +21,6 @@ from zerver.lib.exceptions import (
     ErrorCode,
     JsonableError,
     MissingRemoteRealmError,
-    OrganizationOwnerRequiredError,
     PushServiceNotConfiguredError,
     RemoteRealmServerMismatchError,
     ResourceNotFoundError,
@@ -147,6 +146,11 @@ def send_e2ee_test_push_notification_api(
     return json_success(request)
 
 
+class CannotManageRemoteBillingError(JsonableError):
+    def __init__(self) -> None:
+        super().__init__(_("You do not have permission to manage plans and billing."))
+
+
 def self_hosting_auth_view_common(
     request: HttpRequest, user_profile: UserProfile, next_page: str | None = None
 ) -> str:
@@ -155,7 +159,7 @@ def self_hosting_auth_view_common(
         # but this endpoint shouldn't be accessible via the UI to an unauthorized
         # user_profile - and they need to directly enter the URL in their browser. So a json
         # error may be sufficient.
-        raise OrganizationOwnerRequiredError
+        raise CannotManageRemoteBillingError
 
     if not uses_notification_bouncer():
         if settings.CORPORATE_ENABLED:
@@ -257,7 +261,7 @@ def self_hosting_auth_not_configured(request: HttpRequest) -> HttpResponse:
     assert user.is_authenticated
     assert isinstance(user, UserProfile)
     if not user.has_billing_access:
-        raise OrganizationOwnerRequiredError
+        raise CannotManageRemoteBillingError
 
     if settings.CORPORATE_ENABLED or uses_notification_bouncer():
         # This error page should only be available if the config error


### PR DESCRIPTION
Since these remote billing authentication views are checking a user-group based setting and not for an owner account, we should return a different error here.

Adds `CannotManageRemoteBillingError` as a JsonableError with a clearer error string: "You do not have permission to manage plans and billing."

**Notes**:
- This also changes the error code from `UNAUTHORIZED_PRINCIPAL` to `BAD_REQUEST`.
- Users without billing management permissions would have to manually enter the URL in a browser to get to these pages. The examples below are from hamlet in a dev environment.

---

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
|<img width="1262" height="418" alt="Screenshot From 2026-03-17 20-02-07" src="https://github.com/user-attachments/assets/c6015593-f447-4857-bad3-bf9906c4adb6" /> | <img width="1262" height="418" alt="Screenshot From 2026-03-17 19-56-19" src="https://github.com/user-attachments/assets/ebe07b7d-6063-4b97-a1b9-785dfc2c09d5" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
