### PR TITLE
Clarify 'to' parameter in send-message documentation

### DIFF
--- a/api_docs/send-message.md
+++ b/api_docs/send-message.md
@@ -65,6 +65,7 @@ file.
 ## Parameters
 The `to` parameter specifies who will receive the message.
 For direct messages, it should be a list of user IDs or email addresses. Including your own user ID or email is allowed, but it will be ignored by the server.
+Fixes #19619.
 
 {generate_api_arguments_table|zulip.yaml|/messages:post}
 


### PR DESCRIPTION
Fixes #19619
While going through the send-message API documentation, I noticed that the explanation of the `to` parameter for private messages could be a bit clearer.
The current text mentions that it can be a list of user IDs or email addresses, but it doesn't explicitly say that these represent the recipients of the private message. I’ve added a short clarification to make that intent clearer and also noted that including the sender’s own user ID/email in the list is allowed but ignored by the server.
Hopefully this small clarification makes the behavior easier to understand for developers using the API.