### PR TITLE
left_sidebar: Closing curve should not clash with focus box.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -2183,7 +2183,7 @@ ul.topic-list.topic-list-has-topics::after {
     /* 12px at 16px/1em */
     bottom: 0.75em;
     left: 16px;
-    width: 12px;
+    width: 4px;
     border-bottom: 1px solid var(--color-topic-indent-border);
     pointer-events: none;
 }


### PR DESCRIPTION
Addresses
https://github.com/zulip/zulip/pull/37960#issuecomment-3954886785

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
| Scenario                          | Old                                                                 | Main                                                                 | New                                                                 |
|----------------------------------|----------------------------------------------------------------------|----------------------------------------------------------------------|----------------------------------------------------------------------|
| Multiline Last Topic             | <img src="https://github.com/user-attachments/assets/e8a9111e-8885-4de4-bc46-0d9cbeb50919" width="250"/> | <img src="https://github.com/user-attachments/assets/99d898f7-cb7c-4b1f-be70-766c9345fc14" width="250"/> | <img src="https://github.com/user-attachments/assets/32cc5dd0-c952-4345-901f-aac90273022f" width="250"/> |
| Without Focus (Resolved)         | <img src="https://github.com/user-attachments/assets/54bbbfa6-060c-41f8-9aff-64a149ac223d" width="250"/> | <img src="https://github.com/user-attachments/assets/6f233551-ac77-4f00-971b-c124f4dcab5a" width="250"/> | <img src="https://github.com/user-attachments/assets/555ba052-88ae-4459-8818-f4c2b1812d4c" width="250"/> |
| With Focus (Resolved)            | <img src="https://github.com/user-attachments/assets/aa88f39c-ad6b-4ee0-9e83-94d7a74db160" width="250"/> | <img src="https://github.com/user-attachments/assets/216f702f-82d2-4876-92d8-391b858edeb6" width="250"/> | <img src="https://github.com/user-attachments/assets/2233477c-0351-405f-a2f4-4e607ddc5ae8" width="250"/> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
