### PR TITLE
left-sidebar: Fix zoomed-in topics modal styling for spectators.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -2420,6 +2420,22 @@ li.topic-list-item {
     }
 }
 
+/* For spectators, the topic menu has no DM section to leave space
+   for, so the padding-top and content height set above are adjusted. */
+.spectator-view #left-sidebar.zoom-in-topics #left-sidebar-modal {
+    .left-sidebar-modal-close-area {
+        padding-top: var(--left-sidebar-modal-close-area-padding-top);
+    }
+
+    #left-sidebar-modal-content {
+        height: calc(
+            100dvh - var(--navbar-fixed-height) -
+                var(--left-sidebar-modal-close-area-padding-top) -
+                var(--left-sidebar-modal-close-area-height)
+        );
+    }
+}
+
 @container app (width <= $cq_ml_min) {
     .left-sidebar-modal-close-area .zulip-icon-close {
         margin-right: 5px;


### PR DESCRIPTION
We were incorrectly leaving space for the DM section when in the zoomed-in topics view for spectators. This commit reduces the padding of close section so that we do not leave space for the DM section and adjusts the content area height accordingly.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->[#design > modal styling for zoomed in sidebar #34471 @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/modal.20styling.20for.20zoomed.20in.20sidebar.20.2334471/near/2403640)

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
| Before | After |
| ------ | ------ |
|<img width="816" height="1560" alt="image" src="https://github.com/user-attachments/assets/11b19246-b0e1-49a8-9dad-1c525a15872f" /> | <img width="816" height="1560" alt="image" src="https://github.com/user-attachments/assets/603e3a0a-8dd9-492b-b09e-6a974d288846" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
