### PR TITLE
zabbix: Add severity-based emoji indicators

### DIFF
--- a/zerver/webhooks/zabbix/tests.py
+++ b/zerver/webhooks/zabbix/tests.py
@@ -10,7 +10,7 @@ class ZabbixHookTests(WebhookTestCase):
         Tests if zabbix alert is handled correctly
         """
         expected_topic_name = "www.example.com"
-        expected_message = "PROBLEM (Average) alert on [www.example.com](https://zabbix.example.com/tr_events.php?triggerid=14032&eventid=10528):\n* Zabbix agent on www.example.com is unreachable for 5 minutes\n* Agent ping is Up (1)"
+        expected_message = "🟡 PROBLEM (Average) alert on [www.example.com](https://zabbix.example.com/tr_events.php?triggerid=14032&eventid=10528):\n* Zabbix agent on www.example.com is unreachable for 5 minutes\n* Agent ping is Up (1)"
         self.check_webhook("zabbix_alert", expected_topic_name, expected_message)
 
     def test_zabbix_invalid_payload_with_missing_data(self) -> None:

--- a/zerver/webhooks/zabbix/view.py
+++ b/zerver/webhooks/zabbix/view.py
@@ -60,6 +60,16 @@ def get_topic_for_http_request(payload: WildValue) -> str:
 def get_body_for_http_request(payload: WildValue) -> str:
     hostname = payload["hostname"].tame(check_string)
     severity = payload["severity"].tame(check_string)
+    severity_map = {
+        "critical": "🔴",
+        "disaster": "🔴",
+        "high": "🔴",
+        "warning": "🟡",
+        "average": "🟡",
+        "ok": "🟢",
+        "information": "🟢",
+    }
+    emoji = severity_map.get(severity.lower(), "")
     status = payload["status"].tame(check_string)
     item = payload["item"].tame(check_string)
     trigger = payload["trigger"].tame(check_string)
@@ -73,4 +83,5 @@ def get_body_for_http_request(payload: WildValue) -> str:
         "trigger": trigger,
         "link": link,
     }
-    return ZABBIX_MESSAGE_TEMPLATE.format(**data)
+    message = ZABBIX_MESSAGE_TEMPLATE.format(**data)
+    return f"{emoji} {message}".strip()


### PR DESCRIPTION
Fixes #31240.

Adds emoji indicators to Zabbix webhook alerts to make alert severity easier to identify.

Critical / high alerts → 🔴  
Warning / average alerts → 🟡  
OK / information alerts → 🟢  

### How changes were tested
Verified the message formatting and updated webhook tests to
match the new emoji indicators. All CI checks are passing.

### Screenshots
Before:-
<img width="951" height="419" alt="what if you just want to kook at something and go back to where you were" src="https://github.com/user-attachments/assets/08a4b507-def3-43dd-9215-311b00e19c54" />

After:-
<img width="988" height="616" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/7fead26e-cd99-4266-a3fd-928c09e76050" />


### Self-review checklist

- [x] I have read the Zulip contribution guidelines.
- [x] I have added or updated tests where needed.
- [x] CI checks are passing.