### PR TITLE
reaction: Remove user object from reaction events.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 484**
+
+* [`GET /events`](/api/get-events): Removed the deprecated `user` object
+  from `reaction` events, as all core clients have migrated to use the
+  `user_id` field, superseding the temporary re-addition in feature level 339
+  and completing the transition started in feature level 328.
+
 **Feature level 483**
 
 * [`POST /mobile_push/register`](/api/register-push-device): On a

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 483
+API_FEATURE_LEVEL = 484
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -345,11 +345,6 @@ exports.fixtures = {
         emoji_name: "airplane",
         emoji_code: "2708",
         user_id: test_user.user_id,
-        user: {
-            email: test_user.email,
-            full_name: test_user.full_name,
-            user_id: test_user.user_id,
-        },
     },
 
     reaction__remove: {
@@ -360,11 +355,6 @@ exports.fixtures = {
         emoji_name: "8ball",
         emoji_code: "1f3b1",
         user_id: test_user.user_id,
-        user: {
-            email: test_user.email,
-            full_name: test_user.full_name,
-            user_id: test_user.user_id,
-        },
     },
 
     realm__deactivated: {

--- a/zerver/actions/reactions.py
+++ b/zerver/actions/reactions.py
@@ -19,18 +19,10 @@ from zerver.models import Message, Reaction, UserProfile
 from zerver.tornado.django_api import send_event_on_commit
 
 
-class ReactionEventUserDict(TypedDict):
-    user_id: int
-    email: str
-    full_name: str
-    is_mirror_dummy: bool
-
-
 class ReactionEvent(TypedDict):
     type: Literal["reaction"]
     op: Literal["add", "remove"]
     user_id: int
-    user: ReactionEventUserDict
     message_id: int
     emoji_name: str
     emoji_code: str
@@ -43,21 +35,10 @@ def notify_reaction_update(
     reaction: Reaction,
     op: Literal["add", "remove"],
 ) -> None:
-    user_dict: ReactionEventUserDict = {
-        "user_id": user_profile.id,
-        "email": user_profile.email,
-        "full_name": user_profile.full_name,
-        "is_mirror_dummy": user_profile.is_mirror_dummy,
-    }
-
     event: ReactionEvent = {
         "type": "reaction",
         "op": op,
         "user_id": user_profile.id,
-        # TODO: We plan to remove this redundant user_dict object once
-        # clients are updated to support accessing use user_id.  See
-        # https://github.com/zulip/zulip/pull/14711 for details.
-        "user": user_dict,
         "message_id": message.id,
         "emoji_name": reaction.emoji_name,
         "emoji_code": reaction.emoji_code,

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -367,15 +367,6 @@ class EventModernPresence(BaseEvent):
     presences: dict[str, ModernPresence]
 
 
-# Type for the legacy user field; the `user_id` field is intended to
-# replace this and we expect to remove this once clients have migrated
-# to support the modern API.
-class ReactionLegacyUserType(BaseModel):
-    email: str
-    full_name: str
-    user_id: int
-
-
 class EventReactionAdd(BaseEvent):
     type: Literal["reaction"]
     op: Literal["add"]
@@ -384,7 +375,6 @@ class EventReactionAdd(BaseEvent):
     emoji_code: str
     reaction_type: Literal["realm_emoji", "unicode_emoji", "zulip_extra_emoji"]
     user_id: int
-    user: ReactionLegacyUserType
 
 
 class EventReactionRemove(BaseEvent):
@@ -395,7 +385,6 @@ class EventReactionRemove(BaseEvent):
     emoji_code: str
     reaction_type: Literal["realm_emoji", "unicode_emoji", "zulip_extra_emoji"]
     user_id: int
-    user: ReactionLegacyUserType
 
 
 class BotServicesOutgoing(BaseModel):

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1811,18 +1811,11 @@ paths:
                                     emoji_name: {}
                                     reaction_type: {}
                                     user_id: {}
-                                    user: {}
                                   example:
                                     {
                                       "type": "reaction",
                                       "op": "add",
                                       "user_id": 10,
-                                      "user":
-                                        {
-                                          "user_id": 10,
-                                          "email": "user10@zulip.testserver",
-                                          "full_name": "King Hamlet",
-                                        },
                                       "message_id": 32,
                                       "emoji_name": "tada",
                                       "emoji_code": "1f389",
@@ -1857,18 +1850,11 @@ paths:
                                     emoji_name: {}
                                     reaction_type: {}
                                     user_id: {}
-                                    user: {}
                                   example:
                                     {
                                       "type": "reaction",
                                       "op": "remove",
                                       "user_id": 10,
-                                      "user":
-                                        {
-                                          "user_id": 10,
-                                          "email": "user10@zulip.testserver",
-                                          "full_name": "King Hamlet",
-                                        },
                                       "message_id": 52,
                                       "emoji_name": "tada",
                                       "emoji_code": "1f389",
@@ -28220,45 +28206,17 @@ components:
               description: |
                 The ID of the user who added the reaction.
 
-                **Changes**: New in Zulip 3.0 (feature level 2). The `user`
-                object is deprecated and will be removed in the future.
-            user:
-              type: object
-              additionalProperties: false
-              deprecated: true
-              description: |
-                Dictionary with data on the user who added the
-                reaction, including the user ID as the `user_id`
-                field.
+                **Changes**: In Zulip 12.0 (feature level 484),
+                the deprecated `user` object field was removed. It contained
+                the following properties: `user_id`, `email`,
+                `full_name`, and `is_mirror_dummy`.
 
-                **Changes**: This field was re-added in Zulip 10.0 (feature
-                level 339) after having been removed in Zulip 10.0 (feature
-                level 328). It remains deprecated; it was re-added because the
-                React Native mobile app was still using it.
+                Previously, in Zulip 10.0 (feature level 339), this
+                object was temporarily re-added to support older mobile
+                clients, after having been removed in Zulip 10.0
+                (feature level 328).
 
-                **Deprecated** and to be removed in a future release once core
-                clients have migrated to use the adjacent `user_id` field, which
-                was introduced in Zulip 3.0 (feature level 2). Clients
-                supporting older Zulip server versions should use the user ID
-                mentioned in the description above as they would the `user_id`
-                field.
-              properties:
-                user_id:
-                  type: integer
-                  description: |
-                    ID of the user.
-                email:
-                  type: string
-                  description: |
-                    Zulip API email of the user.
-                full_name:
-                  type: string
-                  description: |
-                    Full name of the user.
-                is_mirror_dummy:
-                  type: boolean
-                  description: |
-                    Whether the user is a mirror dummy.
+                New in Zulip 3.0 (feature level 2).
     MessagesEvent:
       allOf:
         - $ref: "#/components/schemas/MessagesBase"

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -499,7 +499,6 @@ class ReactionEventTest(ZulipTestCase):
         event_user_ids = set(events[0]["users"])
 
         self.assertEqual(expected_recipient_ids, event_user_ids)
-        self.assertEqual(event["user"]["email"], reaction_sender.email)
         self.assertEqual(event["type"], "reaction")
         self.assertEqual(event["op"], "add")
         self.assertEqual(event["emoji_name"], "smile")
@@ -1176,9 +1175,6 @@ class ReactionAPIEventTest(EmojiReactionBase):
         event_user_ids = set(events[0]["users"])
 
         self.assertEqual(expected_recipient_ids, event_user_ids)
-        self.assertEqual(event["user"]["user_id"], reaction_sender.id)
-        self.assertEqual(event["user"]["email"], reaction_sender.email)
-        self.assertEqual(event["user"]["full_name"], reaction_sender.full_name)
         self.assertEqual(event["type"], "reaction")
         self.assertEqual(event["op"], "add")
         self.assertEqual(event["message_id"], pm_id)
@@ -1221,9 +1217,6 @@ class ReactionAPIEventTest(EmojiReactionBase):
         event_user_ids = set(events[0]["users"])
 
         self.assertEqual(expected_recipient_ids, event_user_ids)
-        self.assertEqual(event["user"]["user_id"], reaction_sender.id)
-        self.assertEqual(event["user"]["email"], reaction_sender.email)
-        self.assertEqual(event["user"]["full_name"], reaction_sender.full_name)
         self.assertEqual(event["type"], "reaction")
         self.assertEqual(event["op"], "remove")
         self.assertEqual(event["message_id"], pm_id)


### PR DESCRIPTION
The `user` object was temporarily restored to reaction events in #33009 to maintain compatibility with mobile clients.
As the Zulip mobile app has fully migrated to using the `user_id` field, this PR permanently removes the `user` object from reaction events.


**Screenshots and screen captures:**
- N/A 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
