### PR TITLE
emoji_picker: fix auto-closing on mobile when keyboard opens

### DIFF
--- a/web/src/emoji_picker.ts
+++ b/web/src/emoji_picker.ts
@@ -834,10 +834,12 @@ function get_default_emoji_popover_options(
             refill_section_head_offsets($popover);
             show_emoji_catalog();
             register_popover_events($popover);
-            // Don't focus filter box on mobile since it leads to window resize due
-            // to keyboard being open and scrolls the emoji popover out of view while
-            // still open in Chrome Android and can hide it based on device height in Firefox Android.
-            if (!util.is_mobile()) {
+            // Don't auto-focus the filter on touch devices, since the soft
+            // keyboard opening can resize the viewport and cause the popover
+            // to be hidden or destroyed.
+            // We use a media query rather than util.is_mobile() because some
+            // touch devices (iPadOS 13+) report a desktop User-Agent string.
+            if (window.matchMedia("(hover: hover) and (pointer: fine)").matches) {
                 change_focus_to_filter();
             }
         },


### PR DESCRIPTION
When a user opens the emoji picker on a touch device and the search
box appears near the bottom of the screen, the soft keyboard opening
causes the picker to immediately close itself.

This happens because focusing the search box triggers the keyboard,
which shrinks the viewport and pushes the emoji button out of view.
Zulip then detects the reference as hidden and closes the popover.

The root cause is that util.is_mobile() uses the User-Agent string,
which iPadOS 13+ and some Android tablets spoof as desktop browsers.
So the auto-focus runs on these devices when it shouldn't.

Fixed by replacing the is_mobile() check with a CSS media query
`(hover: hover) and (pointer: fine)` which correctly identifies
touch-primary devices regardless of their UA string.

Fixes: #28703

**How changes were tested:**
Tested manually on Chrome DevTools mobile emulator by switching to
iPhone/iPad device mode, opening the emoji picker, and verifying the
picker no longer closes when the search box is focused.

**Screenshots and screen captures:**
No screenshot needed — the fix prevents a bug (picker closing) rather
than changing visual appearance.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:
- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>