### PR TITLE
[ai] stream_list: Fix zoomed-in topic list sidebar errors.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1222,12 +1222,8 @@ export function update_stream_sidebar_for_narrow(filter: Filter): JQuery | undef
     const $stream_li = get_stream_li(stream_id);
 
     if (!$stream_li) {
-        // This is a sanity check.  When we narrow to a subscribed
-        // stream, there will always be a stream list item
-        // corresponding to that stream in our sidebar.  This error
-        // stopped appearing from March 2018 until at least
-        // April 2020, so if it appears again, something regressed.
-        blueslip.error("No stream_li for subscribed stream", {stream_id});
+        // When zoomed into a channel's topic list, only the
+        // zoomed-in channel has a row in the sidebar.
         clear_topics();
         return undefined;
     }


### PR DESCRIPTION
## Summary

- Simplify `set_stream_unread_count` from two code paths to one — the previous
  `override_zoomed_in = false` path that updated all regular sidebar rows while
  zoomed in was unnecessary since `build_stream_list` already calls
  `update_dom_with_unread_counts` at the end of each rebuild.
- Remove incorrect `blueslip.error` in `set_in_home_view` that logged
  "passed in bad stream id" for valid channels not visible while zoomed in.
- Remove incorrect `blueslip.error` in `update_stream_sidebar_for_narrow` that
  logged "No stream_li for subscribed stream" when called for non-zoomed channels.

---

This PR was prompted by the observation that `update_stream_sidebar_for_narrow`
has the same class of bug as the one fixed in fd4b469f6c — where `get_stream_li`
returns `undefined` for non-zoomed channels when the user is zoomed into a
channel's topic list, but the callers incorrectly treated this as an error. A
full audit of all `get_stream_li` call sites in `stream_list.ts` was performed
to find and fix all instances of this pattern.

Tested manually that the changes don't cause any bugs when updating unread count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)