### PR TITLE
navbar_alerts: Show warning banner when API rate limit is exceeded.

### DIFF
--- a/web/src/channel.ts
+++ b/web/src/channel.ts
@@ -9,6 +9,11 @@ import * as reload_state from "./reload_state.ts";
 import {normalize_path, shouldCreateSpanForRequest} from "./sentry.ts";
 import * as spectators from "./spectators.ts";
 
+let rate_limit_banner_callback: ((retry_after: number) => void) | undefined;
+
+export function set_rate_limit_banner_callback(callback: (retry_after: number) => void): void {
+    rate_limit_banner_callback = callback;
+}
 // We omit `success` handler from original `AjaxSettings` type because it types
 // the `data` parameter as `any` type and we want to avoid that.
 type AjaxRequestHandlerOptions = Omit<JQuery.AjaxSettings, "success"> & {
@@ -98,48 +103,68 @@ function call_in_span(
             return;
         }
 
-        if (xhr.status === 401) {
-            if (password_change_in_progress || orig_password_changes !== password_changes) {
-                // The backend for handling password change API requests
-                // will replace the user's session; this results in a
-                // brief race where any API request will fail with a 401
-                // error after the old session is deactivated but before
-                // the new one has been propagated to the browser.  So we
-                // skip our normal HTTP 401 error handling if we're in the
-                // process of executing a password change.
-                return;
-            }
+        switch (xhr.status) {
+            case 401: {
+                if (password_change_in_progress || orig_password_changes !== password_changes) {
+                    // The backend for handling password change API requests
+                    // will replace the user's session; this results in a
+                    // brief race where any API request will fail with a 401
+                    // error after the old session is deactivated but before
+                    // the new one has been propagated to the browser.  So we
+                    // skip our normal HTTP 401 error handling if we're in the
+                    // process of executing a password change.
+                    return;
+                }
 
-            if (page_params.page_type === "home" && page_params.is_spectator) {
-                // In theory, the spectator implementation should be
-                // designed to prevent accessing widgets that would
-                // make network requests not available to spectators.
-                //
-                // In the case that we have a bug in that logic, we
-                // prefer the user experience of offering the
-                // login_to_access widget over reloading the page.
-                spectators.login_to_access();
-            } else if (page_params.page_type === "home") {
-                // We got logged out somehow, perhaps from another window
-                // changing the user's password, or a session timeout.  We
-                // could display an error message, but jumping right to
-                // the login page conveys the same information with a
-                // smoother relogin experience.
-                window.location.replace(page_params.login_page);
-                return;
+                if (page_params.page_type === "home" && page_params.is_spectator) {
+                    // In theory, the spectator implementation should be
+                    // designed to prevent accessing widgets that would
+                    // make network requests not available to spectators.
+                    //
+                    // In the case that we have a bug in that logic, we
+                    // prefer the user experience of offering the
+                    // login_to_access widget over reloading the page.
+                    spectators.login_to_access();
+                } else if (page_params.page_type === "home") {
+                    // We got logged out somehow, perhaps from another window
+                    // changing the user's password, or a session timeout.  We
+                    // could display an error message, but jumping right to
+                    // the login page conveys the same information with a
+                    // smoother relogin experience.
+                    window.location.replace(page_params.login_page);
+                    return;
+                }
+
+                break;
             }
-        } else if (xhr.status === 403) {
-            if (xhr.responseJSON === undefined) {
-                blueslip.error("Unexpected 403 response from server", {
-                    xhr: xhr.responseText,
-                    args,
+            case 403: {
+                if (xhr.responseJSON === undefined) {
+                    blueslip.error("Unexpected 403 response from server", {
+                        xhr: xhr.responseText,
+                        args,
+                    });
+                } else if (
+                    z.object({code: z.literal("CSRF_FAILED")}).safeParse(xhr.responseJSON)
+                        .success &&
+                    reload_state.csrf_failed_handler !== undefined
+                ) {
+                    reload_state.csrf_failed_handler();
+                }
+
+                break;
+            }
+            case 429: {
+                const rate_limit_schema = z.object({
+                    code: z.literal("RATE_LIMIT_HIT"),
+                    "retry-after": z.number(),
                 });
-            } else if (
-                z.object({code: z.literal("CSRF_FAILED")}).safeParse(xhr.responseJSON).success &&
-                reload_state.csrf_failed_handler !== undefined
-            ) {
-                reload_state.csrf_failed_handler();
+                const parsed = rate_limit_schema.safeParse(xhr.responseJSON);
+                if (parsed.success && rate_limit_banner_callback !== undefined) {
+                    rate_limit_banner_callback(parsed.data["retry-after"]);
+                }
+                break;
             }
+            // No default
         }
         orig_error(xhr, error_type, xhn);
     };

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -320,6 +320,45 @@ const SERVER_NEEDS_UPGRADE_BANNER: AlertBanner = {
     custom_classes: "navbar-alert-banner",
 };
 
+const rate_limit_banner = (retry_after: number): AlertBanner => {
+    const minutes = Math.floor(retry_after / 60);
+    const seconds = retry_after % 60;
+    let label = "";
+    if (minutes > 0 && seconds > 0) {
+        label = $t(
+            {
+                defaultMessage:
+                    "You are sending too many requests. Please wait {minutes, plural, one {# minute} other {# minutes}} and {seconds, plural, one {# second} other {# seconds}} before trying again.",
+            },
+            {minutes, seconds},
+        );
+    } else if (minutes > 0) {
+        label = $t(
+            {
+                defaultMessage:
+                    "You are sending too many requests. Please wait {minutes, plural, one {# minute} other {# minutes}} before trying again.",
+            },
+            {minutes},
+        );
+    } else {
+        label = $t(
+            {
+                defaultMessage:
+                    "You are sending too many requests. Please wait {seconds, plural, one {# second} other {# seconds}} before trying again.",
+            },
+            {seconds},
+        );
+    }
+    return {
+        process: "rate-limit",
+        intent: "danger",
+        label,
+        buttons: [],
+        close_button: true,
+        custom_classes: "navbar-alert-banner",
+    };
+};
+
 const bankruptcy_banner = (): AlertBanner => {
     const old_unreads_missing = unread.old_unreads_missing;
     const unread_msgs_count = unread.get_unread_message_count();
@@ -515,7 +554,17 @@ export function check_and_show_muted_messages_banner(): void {
     }
 }
 
+export function open_rate_limit_banner(retry_after: number): void {
+    // Don't show a second banner if one is already visible.
+    const $existing = $("#navbar_alerts_wrapper").find(".banner[data-process='rate-limit']");
+    if ($existing.length > 0) {
+        return;
+    }
+    open_navbar_banner_and_resize(rate_limit_banner(retry_after));
+}
+
 export function initialize(): void {
+    channel.set_rate_limit_banner_callback(open_rate_limit_banner);
     const ls = localstorage();
     const browser_time_zone = timerender.browser_time_zone();
     if (realm.demo_organization_scheduled_deletion_date) {
@@ -807,6 +856,10 @@ export function initialize(): void {
                     realm.demo_organization_scheduled_deletion_date =
                         new Date("2025-01-30T10:00:00.000Z").getTime() / 1000;
                     open_navbar_banner_and_resize(demo_organization_deadline_banner());
+                    popover_menus.hide_current_popover_if_visible(instance);
+                });
+                $popper.on("click", ".rate-limit", () => {
+                    open_navbar_banner_and_resize(rate_limit_banner(90));
                     popover_menus.hide_current_popover_if_visible(instance);
                 });
                 $popper.on("click", ".time_zone_update_offer", () => {

--- a/web/templates/popovers/navbar_banners_testing_popover.hbs
+++ b/web/templates/popovers/navbar_banners_testing_popover.hbs
@@ -60,5 +60,11 @@
                 <span class="popover-menu-label">{{t "Time zone update offer"}}</span>
             </a>
         </li>
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="rate-limit popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-edit" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Rate limit exceeded"}}</span>
+            </a>
+        </li>
     </ul>
 </div>

--- a/web/tests/channel.test.cjs
+++ b/web/tests/channel.test.cjs
@@ -397,3 +397,31 @@ test("error in callback", () => {
         },
     });
 });
+
+let banner_shown = false;
+let banner_retry_secs;
+
+channel.set_rate_limit_banner_callback((retry_after_secs) => {
+    banner_shown = true;
+    banner_retry_secs = retry_after_secs;
+});
+
+run_test("rate_limit_banner_on_429", () => {
+    banner_shown = false;
+    banner_retry_secs = undefined;
+
+    test_with_mock_ajax({
+        xhr: {
+            status: 429,
+            responseJSON: {code: "RATE_LIMIT_HIT", "retry-after": 90},
+        },
+        run_code() {
+            channel.post({url: "/json/endpoint"});
+        },
+        check_ajax_options(options) {
+            options.simulate_error();
+            assert.ok(banner_shown);
+            assert.equal(banner_retry_secs, 90);
+        },
+    });
+});


### PR DESCRIPTION
Fixes #37618
When a user exceeds the API rate limit, show a dismissible red danger navbar banner with the retry time formatted as minutes and seconds, following the pattern of existing navbar alert banners.

**Changes made:**

Added 429 status handling in wrapped_error in `channel.ts` inside the existing switch statement (similar to 401 and 403 handling), using a registered callback to avoid a circular import between `channel.ts `and `navbar_alerts.ts`
Added `set_rate_limit_banner_callback` in `channel.ts` to allow `navbar_alerts.ts` to register the banner function at initialization time.

Added `rate_limit_banner` constant and `open_rate_limit_banner` export in `navbar_alerts.ts` following the pattern of existing navbar banners like `SERVER_NEEDS_UPGRADE_BANNER`.

Removed the previously incorrect `open_rate_limit_banner` implementation from `popup_banners.ts`
Added "Rate limit exceeded" entry to `navbar_banners_testing_popover.hbs` for manual testing
The banner shows only once even if triggered multiple times (deduplication via data-process="rate-limit")
Retry time is formatted into minutes and/or seconds using ICU plural format

**How changes were tested:**
Tested using the navbar banners testing popover (bottom-left debug icon → "Rate limit exceeded") with different values:

90 seconds → "Please wait 1 minute and 30 seconds before trying again."
45 seconds → "Please wait 45 seconds before trying again."
120 seconds → "Please wait 2 minutes before trying again."
Triggering multiple times shows the banner only once
**Screenshots:**

| Test case | Result |
|-----------|--------|
| `open_rate_limit_banner(90)` | <img width="750" height="1334" alt="90" src="https://github.com/user-attachments/assets/839f8e15-f7f7-4be2-8fd0-1a8a57e37531" />|
| `open_rate_limit_banner(45)` |<img width="750" height="1334" alt="45" src="https://github.com/user-attachments/assets/b8d49108-a29b-4fd7-acf8-89c0f1aeeb49" />|


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
