### PR TITLE
unread_ops: Show banner for small batch mark-as-read operations.

### DIFF
--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -31,7 +31,6 @@ import * as unread from "./unread.ts";
 import * as unread_ui from "./unread_ui.ts";
 import * as watchdog from "./watchdog.ts";
 
-let update_read_flag_banner_displayed = false;
 let unsubscribed_ignored_channels: number[] = [];
 
 // We might want to use a slightly smaller batch for the first
@@ -162,21 +161,16 @@ function show_read_flag_update_progress_banner(
     // we don't bother distracting the user with the banner
     // since the success is obvious through the updating UI.
     popup_banners.open_update_read_flags_for_narrow_banner(operation, messages_updated);
-    update_read_flag_banner_displayed = true;
 }
 
 function show_read_flag_update_success_banner(
     operation: "read" | "unread",
     messages_updated: number,
 ): void {
-    if (!update_read_flag_banner_displayed) {
-        // If the operation completed in a single batch,
-        // and we never showed the progress banner,
-        // we skip showing the success banner as well.
+    if (messages_updated === 0) {
         return;
     }
     popup_banners.open_update_read_flags_for_narrow_banner(operation, messages_updated, true);
-    update_read_flag_banner_displayed = false;
 }
 
 function bulk_update_read_flags_for_narrow(
@@ -197,6 +191,11 @@ function bulk_update_read_flags_for_narrow(
     } = {},
     caller_modal_id?: string,
 ): void {
+    const is_initial_call = anchor === "oldest" && messages_read_till_now === 0;
+    if (is_initial_call) {
+        const operation = op === "add" ? "read" : "unread";
+        popup_banners.open_update_read_flags_for_narrow_banner(operation, 0);
+    }
     const terms_with_integer_channel_id = narrow.map((term) => {
         if (term.operator === "channel") {
             return {


### PR DESCRIPTION
Fixes: https://github.com/zulip/zulip/issues/14503


When marking messages as read, the success banner **Done! X messages marked as read** was only shown for large operations that required multiple batches (1000+ messages). For smaller counts, the operation completed silently with no feedback to the user

The fix restores the `is_initial_call` block in `bulk_update_read_flags_for_narrow` to always open the banner in loading state at the start of the operation. The success banner is also updated to skip only when `messages_updated === 0`  rather than when no progress banner was previously shown.

**How changes were tested:**

Tested locally on the web Zulip app with small message counts < 1000 and large counts 1000+. The green done! banner now appears in both cases.

**Screenshots and screen captures:**

Before, no banner shown for small batch operations
<img width="1800" height="1169" alt="Screenshot 2026-03-19 at 10 48 11" src="https://github.com/user-attachments/assets/7a2cc17c-f7db-4112-9bc8-e6dcf386ee55" />


After, green success banner shows for any count > 0
<img width="1800" height="1169" alt="Screenshot 2026-03-19 at 10 38 35" src="https://github.com/user-attachments/assets/b070d43c-50a4-4776-ab51-5d85f7dfba97" />

<img width="1800" height="1169" alt="Screenshot 2026-03-19 at 10 45 52" src="https://github.com/user-attachments/assets/79177869-1c7d-4c63-8895-40600867aa2d" />



<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
