### PR TITLE
 avatar: Fix missing variable interpolation in jdenticon log message

### DIFF
--- a/zerver/lib/avatar.py
+++ b/zerver/lib/avatar.py
@@ -207,7 +207,7 @@ def generate_avatar_jdenticon(input: str, medium: bool) -> bytes:
         stdout = subprocess.check_output(command)
         return stdout
     except subprocess.CalledProcessError as error:  # nocoverage
-        logger.exception("Jdenticon generation failed for user_id:{input}")
+        logger.exception("Jdenticon generation failed for user_id: %s", input)
         raise error
 
 


### PR DESCRIPTION
Fixes  #38570 

## Changes

In `generate_avatar_jdenticon()`, the exception log message used a plain
string instead of a %-style format string, so `{input}` was printed
literally instead of the actual jdenticon key value.

Before:
```python
logger.exception("Jdenticon generation failed for user_id:{input}")
```

After:
```python
logger.exception("Jdenticon generation failed for user_id: %s", input)
```

## Testing

No functional change — this only affects the log output when jdenticon
generation fails via `subprocess.CalledProcessError`.