### PR TITLE
forms: clarify disposable email validation message

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -126,7 +126,7 @@ def email_is_not_disposable(email: str) -> None:
     try:
         validate_is_not_disposable(email)
     except DisposableEmailError:
-        raise ValidationError(_("Please use your real email address."))
+        raise ValidationError(_("Please use a non-disposable email address."))
 
 
 class RealmDetailsForm(forms.Form):

--- a/zerver/tests/test_realm_creation.py
+++ b/zerver/tests/test_realm_creation.py
@@ -954,7 +954,7 @@ class RealmCreationTest(ZulipTestCase):
     @override_settings(OPEN_REALM_CREATION=True)
     def test_mailinator_signup(self) -> None:
         result = self.client_post("/new/", {"email": "hi@mailinator.com"})
-        self.assert_in_response("Please use your real email address.", result)
+        self.assert_in_response("Please use a non-disposable email address.", result)
 
     @override_settings(OPEN_REALM_CREATION=True)
     def test_subdomain_restrictions(self) -> None:


### PR DESCRIPTION
This PR improves the clarity of the validation error message shown when a user enters a disposable email address.

Previously:
"Please use your real email address."

Updated to:
"Please use a non-disposable email address."

This makes the message more precise and clearly communicates that disposable email addresses are not allowed.

**How changes were tested:**
- Verified that the updated message appears when a disposable email is entered.
- No functional changes were made beyond improving wording.