### PR TITLE
group-settings: Fix handling state of workplace users setting.

### DIFF
--- a/web/src/group_permission_settings.ts
+++ b/web/src/group_permission_settings.ts
@@ -4,6 +4,7 @@ import * as z from "zod/mini";
 import * as blueslip from "./blueslip.ts";
 import type * as dropdown_widget from "./dropdown_widget.ts";
 import {$t} from "./i18n.ts";
+import {page_params} from "./page_params.ts";
 import * as settings_config from "./settings_config.ts";
 import {realm} from "./state_data.ts";
 import type {GroupPermissionSetting, GroupSettingValue} from "./state_data.ts";
@@ -226,6 +227,17 @@ export function get_assigned_permission_object(
                         "This permission cannot be removed, as it would mean that nobody is allowed to take this action.",
                 });
             }
+
+            if (
+                setting_name === "workplace_users_group" &&
+                page_params.is_cloud_realm_with_discounted_plan
+            ) {
+                assigned_permission_object.can_edit = false;
+                assigned_permission_object.tooltip_message = $t(
+                    {defaultMessage: "Contact {sales_email} to change this setting."},
+                    {sales_email: "sales@zulip.com"},
+                );
+            }
             return assigned_permission_object;
         }
 
@@ -265,6 +277,17 @@ export function get_assigned_permission_object(
                         "This permission cannot be removed, as it would mean that nobody is allowed to take this action.",
                 });
             }
+        }
+
+        if (
+            setting_name === "workplace_users_group" &&
+            page_params.is_cloud_realm_with_discounted_plan
+        ) {
+            assigned_permission_object.can_edit = false;
+            assigned_permission_object.tooltip_message = $t(
+                {defaultMessage: "Contact {sales_email} to change this setting."},
+                {sales_email: "sales@zulip.com"},
+            );
         }
         return assigned_permission_object;
     }

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -18,6 +18,7 @@ import type {
 } from "./group_permission_settings.ts";
 import * as group_setting_pill from "./group_setting_pill.ts";
 import {$t, get_language_list_columns} from "./i18n.ts";
+import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import {
     realm_default_settings_schema,
@@ -1942,6 +1943,13 @@ export function get_group_assigned_realm_permissions(group: UserGroup): {
     } of settings_config.realm_group_permission_settings) {
         const assigned_permission_objects = [];
         for (const setting_name of settings) {
+            if (
+                setting_name === "workplace_users_group" &&
+                (!page_params.development_environment ||
+                    !page_params.non_workplace_pricing_eligible)
+            ) {
+                continue;
+            }
             const setting_value = realm[z.keyof(realm_schema).parse("realm_" + setting_name)];
             const can_edit = settings_config.owner_editable_realm_group_permission_settings.has(
                 setting_name,


### PR DESCRIPTION
This PR updates the code to not show workplace users setting in the group permissions panel
in production and also in general for realms that are not eligible for non-workplace pricing like
we do for this setting's UI in "Organization settings".

Also, for realms on discounted plans, we disable the checkbox and show appropriate tooltip when
the checkbox is disabled, again similar to how we do for this setting's UI in "Organization settings".

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

[Screencast from 2026-03-19 20-22-33.webm](https://github.com/user-attachments/assets/7d288876-0353-46d8-a443-5a6ffb692ba4)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
