### PR TITLE
activity: Use IdleDetector API when available.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -65,6 +65,7 @@ EXEMPT_FILES = make_set(
         "web/src/bootstrap_typeahead.ts",
         "web/src/bot_helper.ts",
         "web/src/browser_history.ts",
+        "web/src/browser_idle_detection.ts",
         "web/src/buddy_list.ts",
         "web/src/buddy_list_presence.ts",
         "web/src/buttons.ts",

--- a/web/src/activity.ts
+++ b/web/src/activity.ts
@@ -3,6 +3,8 @@ import _ from "lodash";
 import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
+import * as blueslip from "./blueslip.ts";
+import * as browser_idle_detection from "./browser_idle_detection.ts";
 import * as channel from "./channel.ts";
 import {electron_bridge} from "./electron_bridge.ts";
 import {page_params} from "./page_params.ts";
@@ -56,6 +58,14 @@ export let client_is_active = document.hasFocus();
 export let new_user_input = true;
 
 export let received_new_messages = false;
+
+let idle_handler_setup_done = false;
+
+// Whether the browser's IdleDetector API currently owns idle tracking.
+// While true, we rely on its OS-level idle signal and suppress the
+// DOM-event heuristic (the `mark_client_idle_later` debounce). If the
+// detector ever fails to (re)start, we fall back to that heuristic.
+let idle_detector_active = false;
 
 type UserInputHook = () => void;
 const on_new_user_input_hooks: UserInputHook[] = [];
@@ -178,13 +188,95 @@ export function rewire_send_presence_to_server(value: typeof send_presence_to_se
     send_presence_to_server = value;
 }
 
-export function mark_client_active(): void {
-    // exported for testing
+function report_client_active(): void {
+    // Records that the user is active and notifies the server, without
+    // arming the `mark_client_idle_later` debounce. The IdleDetector
+    // path uses this once it has taken over idle tracking, so that its
+    // "active" transitions can't resurrect the cancelled debounce.
     if (!client_is_active) {
         client_is_active = true;
         send_presence_to_server();
     }
+}
+
+export function mark_client_active(): void {
+    // exported for testing
+    if (idle_detector_active) {
+        // The IdleDetector owns idle tracking, so we defer to its
+        // OS-level signal and ignore DOM-event activity rather than
+        // re-arming the idle timer it replaced.
+        return;
+    }
+    report_client_active();
     mark_client_idle_later();
+}
+
+export function setup_idle_handler(): void {
+    // This code is separated out of `initialize` to facilitate testing
+    if (!browser_idle_detection.supported()) {
+        blueslip.log("Browser idle detector not supported");
+        return;
+    }
+
+    if (idle_handler_setup_done) {
+        return;
+    }
+    idle_handler_setup_done = true;
+
+    $(document).one(
+        "keypress click",
+        /* istanbul ignore next */ () => {
+            void browser_idle_detection.request_permission();
+        },
+    );
+
+    void browser_idle_detection.on_permission_change(() => {
+        void browser_idle_detection
+            .init({
+                idle_timeout: DEFAULT_IDLE_TIMEOUT_MS,
+                on_idle: mark_client_idle,
+                on_active: report_client_active,
+            })
+            // eslint-disable-next-line promise/prefer-await-to-then
+            .then((result) => {
+                if (result === "started") {
+                    // The IdleDetector now owns idle tracking. We leave
+                    // the shared `window` input listeners bound (other
+                    // modules listen for these same events) but suppress
+                    // their debounce via `idle_detector_active`, and
+                    // cancel any idle timer they had already armed.
+                    idle_detector_active = true;
+                    mark_client_idle_later.cancel();
+                    blueslip.info("Browser IdleDetector started");
+                    return;
+                }
+                if (result.name === "AbortError") {
+                    // A newer init() superseded this detector (e.g. the
+                    // permission was revoked and granted again), so it is
+                    // not in charge; leave idle tracking untouched.
+                    return;
+                }
+                if (result.name === "NotAllowedError") {
+                    // Permission hasn't been granted yet; we requested it
+                    // above, and this callback runs again once it is.
+                    return;
+                }
+                // The detector genuinely failed to start. If we had
+                // already handed off to an earlier detector, fall back to
+                // the DOM-event heuristic so idle tracking keeps working.
+                if (idle_detector_active) {
+                    idle_detector_active = false;
+                    mark_client_idle_later();
+                }
+                blueslip.error("Browser IdleDetector failed to start: " + result.message);
+                return;
+            });
+    });
+}
+
+export function reset_idle_handler_for_testing(): void {
+    idle_handler_setup_done = false;
+    idle_detector_active = false;
 }
 
 export function initialize(): void {
@@ -199,4 +291,6 @@ export function initialize(): void {
     if (client_is_active) {
         mark_client_idle_later();
     }
+
+    setup_idle_handler();
 }

--- a/web/src/activity.ts
+++ b/web/src/activity.ts
@@ -3,6 +3,8 @@ import _ from "lodash";
 import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
+import * as blueslip from "./blueslip.ts";
+import * as browser_idle_detection from "./browser_idle_detection.ts";
 import * as channel from "./channel.ts";
 import {electron_bridge} from "./electron_bridge.ts";
 import {page_params} from "./page_params.ts";
@@ -42,6 +44,10 @@ export type ActivityState = "active" | "idle";
 /* Broadcast "idle" to server after 5 minutes of local inactivity */
 const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 
+// Whether this window has been interacted with recently, which is a
+// weaker claim than the user being at their computer; code that cares
+// whether this window itself is in use wants this variable.
+//
 // When you open Zulip in a new browser window, client_is_active
 // should be true.  When a server-initiated reload happens, however,
 // it should be initialized to false.  We handle this with a check for
@@ -56,6 +62,13 @@ export let client_is_active = document.hasFocus();
 export let new_user_input = true;
 
 export let received_new_messages = false;
+
+let idle_handler_setup_done = false;
+
+// Whether the user is at their computer, per the browser's IdleDetector
+// API, or undefined when we have no such signal. Only the presence
+// status uses this; `client_is_active` answers a different question.
+let user_is_active_on_system: boolean | undefined;
 
 type UserInputHook = () => void;
 const on_new_user_input_hooks: UserInputHook[] = [];
@@ -105,6 +118,13 @@ export function compute_active_status(): ActivityState {
             return "idle";
         }
         return "active";
+    }
+
+    if (user_is_active_on_system !== undefined) {
+        if (user_is_active_on_system) {
+            return "active";
+        }
+        return "idle";
     }
 
     if (client_is_active) {
@@ -182,9 +202,81 @@ export function mark_client_active(): void {
     // exported for testing
     if (!client_is_active) {
         client_is_active = true;
-        send_presence_to_server();
+        if (user_is_active_on_system === undefined) {
+            send_presence_to_server();
+        }
     }
     mark_client_idle_later();
+}
+
+function set_user_active_on_system(is_active: boolean | undefined): void {
+    const previous_status = compute_active_status();
+    user_is_active_on_system = is_active;
+    if (previous_status !== "active" && compute_active_status() === "active") {
+        send_presence_to_server();
+    }
+}
+
+function handle_idle_detection_permission(granted: boolean): void {
+    if (!granted) {
+        browser_idle_detection.stop();
+        set_user_active_on_system(undefined);
+        return;
+    }
+
+    void browser_idle_detection
+        .init({
+            idle_timeout: DEFAULT_IDLE_TIMEOUT_MS,
+            on_idle() {
+                set_user_active_on_system(false);
+            },
+            on_active() {
+                set_user_active_on_system(true);
+            },
+        })
+        // eslint-disable-next-line promise/prefer-await-to-then
+        .then((result) => {
+            if (result === "started") {
+                blueslip.info("Browser IdleDetector started");
+                return;
+            }
+            if (result.name === "AbortError") {
+                return;
+            }
+            set_user_active_on_system(undefined);
+            blueslip.error("Browser IdleDetector failed to start: " + result.message);
+            return;
+        });
+}
+
+export function setup_idle_handler(): void {
+    if (electron_bridge?.get_idle_on_system !== undefined) {
+        return;
+    }
+
+    if (!browser_idle_detection.supported()) {
+        blueslip.log("Browser idle detector not supported");
+        return;
+    }
+
+    if (idle_handler_setup_done) {
+        return;
+    }
+    idle_handler_setup_done = true;
+
+    $(document).one(
+        "keypress click",
+        /* istanbul ignore next */ () => {
+            void browser_idle_detection.request_permission();
+        },
+    );
+
+    void browser_idle_detection.on_permission_change(handle_idle_detection_permission);
+}
+
+export function reset_idle_handler_for_testing(): void {
+    idle_handler_setup_done = false;
+    user_is_active_on_system = undefined;
 }
 
 export function initialize(): void {
@@ -199,4 +291,6 @@ export function initialize(): void {
     if (client_is_active) {
         mark_client_idle_later();
     }
+
+    setup_idle_handler();
 }

--- a/web/src/browser_idle_detection.ts
+++ b/web/src/browser_idle_detection.ts
@@ -1,0 +1,97 @@
+declare global {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface IdleDetectorConstructor {
+        requestPermission: () => Promise<"granted" | "denied">;
+        new (): IdleDetector;
+    }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface IdleDetector extends EventTarget {
+        readonly userState: "active" | "idle" | null;
+        readonly screenState: "locked" | "unlocked" | null;
+        start: (options?: {threshold: number; signal?: AbortSignal}) => Promise<void>;
+        addEventListener: (
+            type: "change",
+            listener: () => void,
+            options?: {signal?: AbortSignal},
+        ) => void;
+    }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface Window {
+        IdleDetector?: IdleDetectorConstructor;
+    }
+}
+
+export function supported(): boolean {
+    // This API doesn't have widespread support yet, and probably
+    // never will. It is not available in Firefox and Safari.
+    return "IdleDetector" in window;
+}
+
+// Must be called from a handler in a user gesture (ie, click, keypress etc)
+export async function request_permission(): Promise<"granted" | "denied"> {
+    if (window.IdleDetector === undefined) {
+        return "denied";
+    }
+    return window.IdleDetector.requestPermission();
+}
+
+let active_abort_controller: AbortController | undefined;
+
+export async function init({
+    idle_timeout,
+    on_idle,
+    on_active,
+}: {
+    idle_timeout: number;
+    on_idle: () => void;
+    on_active: () => void;
+}): Promise<"started" | Error> {
+    if (window.IdleDetector === undefined) {
+        return new Error("IdleDetector not supported");
+    }
+    // Permission can be granted more than once (e.g., revoked and
+    // re-granted), and each grant calls this function. Abort any
+    // previously-started detector so we don't stack live detectors that
+    // each fire `change` events.
+    active_abort_controller?.abort();
+    const abort_controller = new AbortController();
+    active_abort_controller = abort_controller;
+    try {
+        const idle_detector = new window.IdleDetector();
+        idle_detector.addEventListener(
+            "change",
+            () => {
+                if (idle_detector.userState === "idle" || idle_detector.screenState === "locked") {
+                    on_idle();
+                } else {
+                    on_active();
+                }
+            },
+            {signal: abort_controller.signal},
+        );
+        // The spec enforces a minimum threshold of 60_000ms; anything
+        // lower rejects with a TypeError.
+        await idle_detector.start({threshold: idle_timeout, signal: abort_controller.signal});
+        return "started";
+    } catch (error) {
+        if (error instanceof Error) {
+            return error;
+        }
+        return new Error(JSON.stringify(error));
+    }
+}
+
+export async function on_permission_change(on_granted: () => void): Promise<void> {
+    const permission_status = await navigator.permissions.query({
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        name: "idle-detection" as PermissionName,
+    });
+    if (permission_status.state === "granted") {
+        on_granted();
+    }
+    permission_status.addEventListener("change", () => {
+        if (permission_status.state === "granted") {
+            on_granted();
+        }
+    });
+}

--- a/web/src/browser_idle_detection.ts
+++ b/web/src/browser_idle_detection.ts
@@ -1,0 +1,90 @@
+declare global {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface IdleDetectorConstructor {
+        requestPermission: () => Promise<"granted" | "denied">;
+        new (): IdleDetector;
+    }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface IdleDetector extends EventTarget {
+        readonly userState: "active" | "idle" | null;
+        readonly screenState: "locked" | "unlocked" | null;
+        start: (options?: {threshold: number; signal?: AbortSignal}) => Promise<void>;
+        addEventListener: (
+            type: "change",
+            listener: () => void,
+            options?: {signal?: AbortSignal},
+        ) => void;
+    }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface Window {
+        IdleDetector?: IdleDetectorConstructor;
+    }
+}
+
+export function supported(): boolean {
+    return "IdleDetector" in window;
+}
+
+export async function request_permission(): Promise<"granted" | "denied"> {
+    if (window.IdleDetector === undefined) {
+        return "denied";
+    }
+    return window.IdleDetector.requestPermission();
+}
+
+let active_abort_controller: AbortController | undefined;
+
+export function stop(): void {
+    active_abort_controller?.abort();
+    active_abort_controller = undefined;
+}
+
+export async function init({
+    idle_timeout,
+    on_idle,
+    on_active,
+}: {
+    idle_timeout: number;
+    on_idle: () => void;
+    on_active: () => void;
+}): Promise<"started" | Error> {
+    if (window.IdleDetector === undefined) {
+        return new Error("IdleDetector not supported");
+    }
+    stop();
+    const abort_controller = new AbortController();
+    active_abort_controller = abort_controller;
+    try {
+        const idle_detector = new window.IdleDetector();
+        const report_state = (): void => {
+            if (idle_detector.userState === "idle" || idle_detector.screenState === "locked") {
+                on_idle();
+            } else {
+                on_active();
+            }
+        };
+        idle_detector.addEventListener("change", report_state, {signal: abort_controller.signal});
+        // The spec rejects a threshold below 60_000ms with a TypeError.
+        await idle_detector.start({threshold: idle_timeout, signal: abort_controller.signal});
+        // `change` fires only on transitions, so report the state we
+        // start in; a page loaded in a background tab has none coming.
+        report_state();
+        return "started";
+    } catch (error) {
+        if (error instanceof Error) {
+            return error;
+        }
+        return new Error(JSON.stringify(error));
+    }
+}
+
+export async function on_permission_change(on_change: (granted: boolean) => void): Promise<void> {
+    const permission_status = await navigator.permissions.query({
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        name: "idle-detection" as PermissionName,
+    });
+    on_change(permission_status.state === "granted");
+    permission_status.addEventListener("change", () => {
+        on_change(permission_status.state === "granted");
+    });
+}

--- a/web/tests/activity.test.cjs
+++ b/web/tests/activity.test.cjs
@@ -22,8 +22,12 @@ const _document = {
     hasFocus() {
         return true;
     },
+    to_$() {
+        return $("document-stub");
+    },
 };
 
+const browser_idle_detection = mock_esm("../src/browser_idle_detection");
 const buddy_list_presence = mock_esm("../src/buddy_list_presence");
 const keydown_util = mock_esm("../src/keydown_util", {handle() {}});
 const padded_widget = mock_esm("../src/padded_widget");
@@ -656,4 +660,80 @@ test("check_should_redraw_new_user", ({override}) => {
     override(realm, "realm_presence_disabled", false);
     // A new user that didn't have presence info should not be redrawn.
     assert.equal(activity_ui.check_should_redraw_new_user(99999), false);
+});
+
+test("browser_idle_detection", ({override, override_rewire}) => {
+    override(browser_idle_detection, "supported", () => false);
+    activity.setup_idle_handler();
+    blueslip.expect("log", "Browser idle detector not supported");
+
+    override(browser_idle_detection, "supported", () => true);
+
+    // Avoid real presence requests when exercising mark_client_active.
+    let presence_update_count = 0;
+    override_rewire(activity, "send_presence_to_server", () => {
+        presence_update_count += 1;
+    });
+
+    // Spy on the debounce cancel (calling through, so we can still tidy
+    // up the timer afterwards). Once the IdleDetector starts, it owns
+    // idle tracking, so we cancel the debounce exactly once.
+    let cancel_count = 0;
+    const real_cancel = activity.mark_client_idle_later.cancel.bind(
+        activity.mark_client_idle_later,
+    );
+    override(activity.mark_client_idle_later, "cancel", () => {
+        cancel_count += 1;
+        real_cancel();
+    });
+
+    let on_granted;
+    override(browser_idle_detection, "init", () => ({
+        // eslint-disable-next-line unicorn/no-thenable
+        then(cb) {
+            on_granted = cb;
+        },
+    }));
+    override(browser_idle_detection, "on_permission_change", (cb) => cb());
+
+    activity.reset_idle_handler_for_testing();
+    activity.setup_idle_handler();
+    // Cover the idempotency guard.
+    activity.setup_idle_handler();
+
+    blueslip.expect("info", "Browser IdleDetector started");
+    on_granted("started");
+    assert.equal(cancel_count, 1);
+
+    // After handoff, DOM-event activity defers to the IdleDetector: it
+    // neither re-marks the client active nor re-arms the idle timer.
+    activity.clear_for_testing();
+    presence_update_count = 0;
+    activity.mark_client_active();
+    assert.equal(activity.client_is_active, false);
+    assert.equal(presence_update_count, 0);
+
+    // An AbortError means a newer detector superseded this one; it is
+    // silent and leaves idle tracking with the IdleDetector.
+    on_granted({name: "AbortError"});
+    assert.equal(cancel_count, 1);
+    activity.mark_client_active();
+    assert.equal(activity.client_is_active, false);
+
+    // A NotAllowedError (permission not yet granted) is also silent.
+    on_granted({name: "NotAllowedError"});
+    assert.equal(cancel_count, 1);
+
+    // A genuine failure is logged and falls back to the DOM-event
+    // heuristic, so mark_client_active resumes tracking activity.
+    blueslip.expect("error", "Browser IdleDetector failed to start: error message");
+    on_granted({name: "SomeOtherError", message: "error message"});
+    activity.clear_for_testing();
+    presence_update_count = 0;
+    activity.mark_client_active();
+    assert.equal(activity.client_is_active, true);
+    assert.equal(presence_update_count, 1);
+
+    // Cancel the idle timer armed above so it doesn't outlive the test.
+    real_cancel();
 });

--- a/web/tests/activity.test.cjs
+++ b/web/tests/activity.test.cjs
@@ -22,9 +22,14 @@ const _document = {
     hasFocus() {
         return true;
     },
+    to_$() {
+        return $("document-stub");
+    },
 };
 
+const browser_idle_detection = mock_esm("../src/browser_idle_detection");
 const buddy_list_presence = mock_esm("../src/buddy_list_presence");
+const {electron_bridge} = mock_esm("../src/electron_bridge", {electron_bridge: {}});
 const keydown_util = mock_esm("../src/keydown_util", {handle() {}});
 const padded_widget = mock_esm("../src/padded_widget");
 const pm_list = mock_esm("../src/pm_list");
@@ -119,7 +124,7 @@ function add_sub_and_set_as_current_narrow(sub) {
 }
 
 function test(label, f) {
-    run_test(label, (helpers) => {
+    run_test(label, async (helpers) => {
         helpers.override(user_settings, "presence_enabled", true);
         // Simulate a small window by having the
         // fill_screen_with_content render the entire
@@ -148,7 +153,7 @@ function test(label, f) {
         activity.clear_for_testing();
         activity_ui.set_cursor_and_filter();
 
-        f(helpers);
+        await f(helpers);
 
         presence.clear_internal_data();
     });
@@ -656,4 +661,112 @@ test("check_should_redraw_new_user", ({override}) => {
     override(realm, "realm_presence_disabled", false);
     // A new user that didn't have presence info should not be redrawn.
     assert.equal(activity_ui.check_should_redraw_new_user(99999), false);
+});
+
+test("browser_idle_detection_skipped_in_desktop_app", ({override, disallow}) => {
+    disallow(browser_idle_detection, "supported");
+    disallow(browser_idle_detection, "on_permission_change");
+    override(electron_bridge, "get_idle_on_system", () => false);
+
+    activity.reset_idle_handler_for_testing();
+    activity.setup_idle_handler();
+
+    assert.equal(activity.compute_active_status(), "active");
+});
+
+test("browser_idle_detection", async ({override, override_rewire}) => {
+    override(browser_idle_detection, "supported", () => false);
+    activity.setup_idle_handler();
+    blueslip.expect("log", "Browser idle detector not supported");
+
+    override(browser_idle_detection, "supported", () => true);
+
+    let presence_update_count = 0;
+    override_rewire(activity, "send_presence_to_server", () => {
+        presence_update_count += 1;
+    });
+
+    let init_count = 0;
+    let init_result;
+    let init_promise;
+    let detector_on_idle;
+    let detector_on_active;
+    override(browser_idle_detection, "init", ({on_idle, on_active}) => {
+        init_count += 1;
+        detector_on_idle = on_idle;
+        detector_on_active = on_active;
+        init_promise = Promise.resolve(init_result);
+        return init_promise;
+    });
+    let stop_count = 0;
+    override(browser_idle_detection, "stop", () => {
+        stop_count += 1;
+    });
+    let handle_permission;
+    override(browser_idle_detection, "on_permission_change", (on_change) => {
+        handle_permission = on_change;
+    });
+
+    activity.reset_idle_handler_for_testing();
+    activity.setup_idle_handler();
+    activity.setup_idle_handler();
+
+    const grant_permission = async (result) => {
+        init_result = result;
+        handle_permission(true);
+        await init_promise;
+    };
+
+    activity.clear_for_testing();
+    handle_permission(false);
+    assert.equal(init_count, 0);
+    presence_update_count = 0;
+    activity.mark_client_active();
+    assert.equal(activity.client_is_active, true);
+    assert.equal(activity.compute_active_status(), "active");
+    assert.equal(presence_update_count, 1);
+    activity.mark_client_idle();
+    assert.equal(activity.compute_active_status(), "idle");
+
+    blueslip.expect("info", "Browser IdleDetector started", 2);
+    await grant_permission("started");
+    assert.equal(init_count, 1);
+
+    presence_update_count = 0;
+    detector_on_active();
+    assert.equal(activity.compute_active_status(), "active");
+    assert.equal(presence_update_count, 1);
+
+    detector_on_idle();
+    assert.equal(activity.compute_active_status(), "idle");
+    assert.equal(presence_update_count, 1);
+
+    activity.clear_for_testing();
+    presence_update_count = 0;
+    activity.mark_client_active();
+    assert.equal(activity.client_is_active, true);
+    assert.equal(activity.compute_active_status(), "idle");
+    assert.equal(presence_update_count, 0);
+
+    stop_count = 0;
+    handle_permission(false);
+    assert.equal(stop_count, 1);
+    assert.equal(activity.compute_active_status(), "active");
+    assert.equal(presence_update_count, 1);
+
+    activity.mark_client_idle();
+    await grant_permission({name: "AbortError"});
+    assert.equal(activity.compute_active_status(), "idle");
+
+    await grant_permission("started");
+    detector_on_idle();
+    activity.mark_client_active();
+    assert.equal(activity.compute_active_status(), "idle");
+    presence_update_count = 0;
+    blueslip.expect("error", "Browser IdleDetector failed to start: error message");
+    await grant_permission({name: "SomeOtherError", message: "error message"});
+    assert.equal(activity.compute_active_status(), "active");
+    assert.equal(presence_update_count, 1);
+
+    activity.mark_client_idle_later.cancel();
 });

--- a/web/tests/browser_idle_detection.test.cjs
+++ b/web/tests/browser_idle_detection.test.cjs
@@ -1,0 +1,218 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {set_global, zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+class FakeIdleDetector {
+    static requested_permission = false;
+    static permission = "granted";
+    static last_started;
+
+    static start_behavior = "resolve";
+
+    static initial_user_state = "active";
+
+    userState = FakeIdleDetector.initial_user_state;
+    screenState = "unlocked";
+    threshold;
+    listener;
+
+    static async requestPermission() {
+        this.requested_permission = true;
+        return this.permission;
+    }
+
+    addEventListener(type, listener, {signal}) {
+        assert.equal(type, "change");
+        this.listener = listener;
+        signal.addEventListener("abort", () => {
+            this.listener = undefined;
+        });
+    }
+
+    async start({threshold, signal}) {
+        this.threshold = threshold;
+        FakeIdleDetector.last_started = this;
+        switch (FakeIdleDetector.start_behavior) {
+            case "resolve":
+                break;
+            case "reject_error":
+                throw new DOMException("nope", "NotSupportedError");
+            case "reject_non_error":
+                // eslint-disable-next-line no-throw-literal
+                throw "not an Error";
+            default:
+                await new Promise((_resolve, reject) => {
+                    signal.addEventListener("abort", () => {
+                        reject(new DOMException("aborted", "AbortError"));
+                    });
+                });
+        }
+    }
+
+    change({userState, screenState}) {
+        this.userState = userState;
+        this.screenState = screenState;
+        this.listener?.();
+    }
+}
+
+const permission_status = {
+    state: "granted",
+    listener: undefined,
+    addEventListener(type, listener) {
+        assert.equal(type, "change");
+        permission_status.listener = listener;
+    },
+    set_state(state) {
+        permission_status.state = state;
+        permission_status.listener?.();
+    },
+};
+
+set_global("window", {});
+set_global("navigator", {
+    permissions: {
+        async query({name}) {
+            assert.equal(name, "idle-detection");
+            return permission_status;
+        },
+    },
+});
+
+const browser_idle_detection = zrequire("browser_idle_detection");
+
+function make_init_options() {
+    const transitions = [];
+    return {
+        transitions,
+        options: {
+            idle_timeout: 5 * 60 * 1000,
+            on_idle() {
+                transitions.push("idle");
+            },
+            on_active() {
+                transitions.push("active");
+            },
+        },
+    };
+}
+
+run_test("unsupported browser", async () => {
+    delete window.IdleDetector;
+    assert.equal(browser_idle_detection.supported(), false);
+    assert.equal(await browser_idle_detection.request_permission(), "denied");
+
+    const {options} = make_init_options();
+    const result = await browser_idle_detection.init(options);
+    assert.ok(result instanceof Error);
+    assert.equal(result.message, "IdleDetector not supported");
+});
+
+run_test("request_permission", async () => {
+    window.IdleDetector = FakeIdleDetector;
+    assert.equal(browser_idle_detection.supported(), true);
+
+    FakeIdleDetector.requested_permission = false;
+    FakeIdleDetector.permission = "denied";
+    assert.equal(await browser_idle_detection.request_permission(), "denied");
+    assert.ok(FakeIdleDetector.requested_permission);
+});
+
+run_test("init reports state transitions", async () => {
+    window.IdleDetector = FakeIdleDetector;
+    FakeIdleDetector.start_behavior = "resolve";
+
+    const {transitions, options} = make_init_options();
+    assert.equal(await browser_idle_detection.init(options), "started");
+
+    const detector = FakeIdleDetector.last_started;
+    assert.equal(detector.threshold, 5 * 60 * 1000);
+
+    assert.deepEqual(transitions, ["active"]);
+
+    detector.change({userState: "idle", screenState: "unlocked"});
+    detector.change({userState: "active", screenState: "locked"});
+    detector.change({userState: "active", screenState: "unlocked"});
+    assert.deepEqual(transitions, ["active", "idle", "idle", "active"]);
+
+    browser_idle_detection.stop();
+    detector.change({userState: "idle", screenState: "unlocked"});
+    assert.deepEqual(transitions, ["active", "idle", "idle", "active"]);
+});
+
+run_test("init supersedes a previous detector", async () => {
+    window.IdleDetector = FakeIdleDetector;
+    FakeIdleDetector.start_behavior = "resolve";
+
+    const first = make_init_options();
+    assert.equal(await browser_idle_detection.init(first.options), "started");
+    const first_detector = FakeIdleDetector.last_started;
+
+    const second = make_init_options();
+    assert.equal(await browser_idle_detection.init(second.options), "started");
+
+    first_detector.change({userState: "idle", screenState: "unlocked"});
+    FakeIdleDetector.last_started.change({userState: "idle", screenState: "unlocked"});
+    assert.deepEqual(first.transitions, ["active"]);
+    assert.deepEqual(second.transitions, ["active", "idle"]);
+
+    browser_idle_detection.stop();
+});
+
+run_test("init reports an idle starting state", async () => {
+    window.IdleDetector = FakeIdleDetector;
+    FakeIdleDetector.start_behavior = "resolve";
+    FakeIdleDetector.initial_user_state = "idle";
+
+    const {transitions, options} = make_init_options();
+    assert.equal(await browser_idle_detection.init(options), "started");
+    assert.deepEqual(transitions, ["idle"]);
+
+    FakeIdleDetector.initial_user_state = "active";
+    browser_idle_detection.stop();
+});
+
+run_test("init interrupted before it starts", async () => {
+    window.IdleDetector = FakeIdleDetector;
+    FakeIdleDetector.start_behavior = "hang";
+
+    const {options} = make_init_options();
+    const init_promise = browser_idle_detection.init(options);
+    browser_idle_detection.stop();
+
+    const result = await init_promise;
+    assert.ok(result instanceof Error);
+    assert.equal(result.name, "AbortError");
+});
+
+run_test("init failures", async () => {
+    window.IdleDetector = FakeIdleDetector;
+
+    FakeIdleDetector.start_behavior = "reject_error";
+    const error_result = await browser_idle_detection.init(make_init_options().options);
+    assert.ok(error_result instanceof Error);
+    assert.equal(error_result.name, "NotSupportedError");
+
+    FakeIdleDetector.start_behavior = "reject_non_error";
+    const non_error_result = await browser_idle_detection.init(make_init_options().options);
+    assert.ok(non_error_result instanceof Error);
+    assert.equal(non_error_result.message, '"not an Error"');
+});
+
+run_test("on_permission_change", async () => {
+    const states = [];
+    permission_status.state = "prompt";
+    permission_status.listener = undefined;
+    await browser_idle_detection.on_permission_change((granted) => {
+        states.push(granted);
+    });
+
+    assert.deepEqual(states, [false]);
+    permission_status.set_state("granted");
+    permission_status.set_state("prompt");
+    permission_status.set_state("denied");
+    assert.deepEqual(states, [false, true, false, false]);
+});


### PR DESCRIPTION
The IdleDetector API does not have much support
across browsers due to privacy concerns.
See https://developer.mozilla.org/en-US/docs/Web/API/IdleDetector#browser_compatibility

Practically, it is a chromium-only feature, yet it is still useful to implement this feature since the
majority of our web users are in Chromium-based
browsers that do support it.

Link found useful: https://developer.mozilla.org/en-US/docs/Web/API/Idle_Detection_API

This PR resolves the conflicts on https://github.com/zulip/zulip/pull/34219

Fixes #25056

[CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/chrome.20idle.20detection/near/1537514)

<!-- Describe your pull request here.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
