### PR TITLE
api-docs: Tweak display_recipient rendered descriptions.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -27972,9 +27972,16 @@ components:
 
             See the help center article on [message formatting](/help/format-your-message-using-markdown) for details on Zulip-flavored Markdown.
         display_recipient:
+          description: |
+            Data on the recipient of the message. Will be one of the following:
           oneOf:
             - type: string
+              description: |
+                The name of the channel the message was received in.
             - type: array
+              description: |
+                An array of dictionaries containing basic data on the users who
+                received the message.
               items:
                 type: object
                 additionalProperties: false
@@ -27995,10 +28002,6 @@ components:
                     type: boolean
                     description: |
                       Whether the user is a mirror dummy.
-          description: |
-            Data on the recipient of the message;
-            either the name of a channel or a dictionary containing basic data on
-            the users who received the message.
         edit_history:
           type: array
           items:


### PR DESCRIPTION
Makes a small improvement to the `display_recipient` rendered descriptions.

**Notes**:
- #35223 added the missing fields for the array of user information objects.
- This adds separate descriptions for each of the options for this field.

<details>
<summary>diff of changes to current main API docs</summary>

```diff
diff -r -u current_api_docs_html/get-events.html new_api_docs_html/get-events.html
--- current_api_docs_html/get-events.html	2026-03-19 17:18:12.481110283 +0100
+++ new_api_docs_html/get-events.html	2026-03-19 17:18:48.914249483 +0100
@@ -2134,9 +2134,14 @@
 </li>
 <li>
 <p><code>display_recipient</code>: <span class="api-field-type">string | (object)[]</span></p>
-<p>Data on the recipient of the message;
-either the name of a channel or a dictionary containing basic data on
-the users who received the message.</p>
+<p>Data on the recipient of the message. Will be one of the following:</p>
+<ul>
+<li>
+<p>The name of the channel the message was received in.</p>
+</li>
+<li>
+<p>An array of dictionaries containing basic data on the users who
+    received the message.</p>
 <ul>
 <li>
 <p><code>id</code>: <span class="api-field-type">integer</span></p>
@@ -2156,6 +2161,8 @@
 </li>
 </ul>
 </li>
+</ul>
+</li>
 <li>
 <p><code>edit_history</code>: <span class="api-field-type">(object)[]</span></p>
 <p>An array of objects, with each object documenting the
diff -r -u current_api_docs_html/get-message.html new_api_docs_html/get-message.html
--- current_api_docs_html/get-message.html	2026-03-19 17:18:04.626395283 +0100
+++ new_api_docs_html/get-message.html	2026-03-19 17:18:39.012161898 +0100
@@ -469,9 +469,14 @@
 </li>
 <li>
 <p><code>display_recipient</code>: <span class="api-field-type">string | (object)[]</span></p>
-<p>Data on the recipient of the message;
-either the name of a channel or a dictionary containing basic data on
-the users who received the message.</p>
+<p>Data on the recipient of the message. Will be one of the following:</p>
+<ul>
+<li>
+<p>The name of the channel the message was received in.</p>
+</li>
+<li>
+<p>An array of dictionaries containing basic data on the users who
+    received the message.</p>
 <ul>
 <li>
 <p><code>id</code>: <span class="api-field-type">integer</span></p>
@@ -491,6 +496,8 @@
 </li>
 </ul>
 </li>
+</ul>
+</li>
 <li>
 <p><code>edit_history</code>: <span class="api-field-type">(object)[]</span></p>
 <p>An array of objects, with each object documenting the
diff -r -u current_api_docs_html/get-messages.html new_api_docs_html/get-messages.html
--- current_api_docs_html/get-messages.html	2026-03-19 17:18:04.333467674 +0100
+++ new_api_docs_html/get-messages.html	2026-03-19 17:18:38.635701163 +0100
@@ -689,9 +689,14 @@
 </li>
 <li>
 <p><code>display_recipient</code>: <span class="api-field-type">string | (object)[]</span></p>
-<p>Data on the recipient of the message;
-either the name of a channel or a dictionary containing basic data on
-the users who received the message.</p>
+<p>Data on the recipient of the message. Will be one of the following:</p>
+<ul>
+<li>
+<p>The name of the channel the message was received in.</p>
+</li>
+<li>
+<p>An array of dictionaries containing basic data on the users who
+    received the message.</p>
 <ul>
 <li>
 <p><code>id</code>: <span class="api-field-type">integer</span></p>
@@ -711,6 +716,8 @@
 </li>
 </ul>
 </li>
+</ul>
+</li>
 <li>
 <p><code>edit_history</code>: <span class="api-field-type">(object)[]</span></p>
 <p>An array of objects, with each object documenting the
diff -r -u current_api_docs_html/outgoing-webhook-payload.html new_api_docs_html/outgoing-webhook-payload.html
--- current_api_docs_html/outgoing-webhook-payload.html	2026-03-19 17:18:13.428076351 +0100
+++ new_api_docs_html/outgoing-webhook-payload.html	2026-03-19 17:18:50.422305519 +0100
@@ -442,9 +442,14 @@
 </li>
 <li>
 <p><code>display_recipient</code>: <span class="api-field-type">string | (object)[]</span></p>
-<p>Data on the recipient of the message;
-either the name of a channel or a dictionary containing basic data on
-the users who received the message.</p>
+<p>Data on the recipient of the message. Will be one of the following:</p>
+<ul>
+<li>
+<p>The name of the channel the message was received in.</p>
+</li>
+<li>
+<p>An array of dictionaries containing basic data on the users who
+    received the message.</p>
 <ul>
 <li>
 <p><code>id</code>: <span class="api-field-type">integer</span></p>
@@ -464,6 +469,8 @@
 </li>
 </ul>
 </li>
+</ul>
+</li>
 <li>
 <p><code>edit_history</code>: <span class="api-field-type">(object)[]</span></p>
 <p>An array of objects, with each object documenting the
```
</details

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="1456" height="628" alt="Screenshot From 2026-03-19 17-16-13" src="https://github.com/user-attachments/assets/363a0378-bb74-49af-aafa-c24627c74585" /> | <img width="1456" height="704" alt="Screenshot From 2026-03-19 17-16-38" src="https://github.com/user-attachments/assets/1993913c-90a3-4bf3-a14c-fd283955f1b5" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
