### PR TITLE
people: Add email domain matching in people search.

### DIFF
--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1388,6 +1388,11 @@ export function build_person_matcher(query: string): (user: User) => boolean {
             return true;
         }
 
+        const domain = visible_email.split("@")[1]!;
+        if (domain.startsWith(query.toLowerCase())) {
+            return true;
+        }
+
         return termlet_matchers.every((matcher) => matcher(user));
     };
 }

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -846,6 +846,20 @@ run_test("filtered_users", () => {
     assert.equal(filtered_people.size, 1);
     assert.ok(filtered_people.has(linus.user_id));
 
+    // Test filtering by email domain.
+    filtered_people = people.filter_people_by_search_terms(users, "example.com");
+    assert.equal(filtered_people.size, 7);
+
+    filtered_people = people.filter_people_by_search_terms(users, "example");
+    assert.equal(filtered_people.size, 7);
+
+    filtered_people = people.filter_people_by_search_terms(users, "zulip.com");
+    assert.equal(filtered_people.size, 0);
+
+    // Test case-insensitive domain matching.
+    filtered_people = people.filter_people_by_search_terms(users, "EXAMPLE.COM");
+    assert.equal(filtered_people.size, 7);
+
     filtered_people = people.filter_people_by_search_terms(users, "ch di, maria");
     assert.equal(filtered_people.size, 2);
     assert.ok(filtered_people.has(charles.user_id));


### PR DESCRIPTION

This PR implements email-domain matching for the people search, using the existing visible-email data path.

People search currently matches user ID prefixes, visible email prefixes, and name termlets. This change parses the domain part of the user's visible email and adds it as a searchable field. This allows queries like `example` or `example.com` to correctly match expected users while preserving existing behavior.

**Notes for maintainers:**
- A previous attempt at this feature (#17065) modified email visibility globally on the backend, creating a large footprint and stalled progress.
- This alternative approach is scoped strictly to the frontend search matcher (`build_person_matcher`).
- By matching against the domain portion of `visible_email` (which is already provided safely by the server based on permissions), this implementation automatically respects the current user's email visibility settings without modifying API payload contracts or backend privacy semantics.

Fixes: #12050

**How changes were tested:**

- [x] `./tools/lint web/src/people.ts web/tests/people.test.cjs`
- [x] `./tools/test-js-with-node web/tests/people.test.cjs`

**Screenshots and screen captures:**
![Recording 2026-03-19 215332](https://github.com/user-attachments/assets/959a5612-2ec0-4d79-9d86-438e50e2b64c)


<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the AI use policy.

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see commit discipline).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>