### PR TITLE
group_settings: Fix member list container scrolling.

### DIFF
--- a/web/src/add_group_members_pill.ts
+++ b/web/src/add_group_members_pill.ts
@@ -92,6 +92,7 @@ export function create({
     onPillCreateAction,
     onPillRemoveAction,
     add_button_pill_update_callback,
+    onTextInputCallback,
 }: {
     $pill_container: JQuery;
     get_potential_members: () => User[];
@@ -100,6 +101,7 @@ export function create({
     onPillCreateAction?: (pill_user_ids: number[], pill_subgroup_ids: number[]) => void;
     onPillRemoveAction?: (pill_user_ids: number[], pill_subgroup_ids: number[]) => void;
     add_button_pill_update_callback?: () => void;
+    onTextInputCallback?: () => void;
 }): CombinedPillContainer {
     const pill_widget = input_pill.create<CombinedPill>({
         $container: $pill_container,
@@ -129,6 +131,12 @@ export function create({
                 const user_ids = await get_pill_user_ids(pill_widget);
                 onPillRemoveAction(user_ids, get_pill_group_ids(pill_widget));
             })();
+        });
+    }
+
+    if (onTextInputCallback) {
+        pill_widget.onTextInputHook(() => {
+            onTextInputCallback();
         });
     }
 

--- a/web/src/add_group_members_pill.ts
+++ b/web/src/add_group_members_pill.ts
@@ -91,6 +91,7 @@ export function create({
     with_add_button,
     onPillCreateAction,
     onPillRemoveAction,
+    add_button_pill_update_callback,
 }: {
     $pill_container: JQuery;
     get_potential_members: () => User[];
@@ -98,6 +99,7 @@ export function create({
     with_add_button: boolean;
     onPillCreateAction?: (pill_user_ids: number[], pill_subgroup_ids: number[]) => void;
     onPillRemoveAction?: (pill_user_ids: number[], pill_subgroup_ids: number[]) => void;
+    add_button_pill_update_callback?: () => void;
 }): CombinedPillContainer {
     const pill_widget = input_pill.create<CombinedPill>({
         $container: $pill_container,
@@ -154,7 +156,11 @@ export function create({
     });
 
     if (with_add_button) {
-        add_subscribers_pill.set_up_handlers_for_add_button_state(pill_widget, $pill_container);
+        add_subscribers_pill.set_up_handlers_for_add_button_state(
+            pill_widget,
+            $pill_container,
+            add_button_pill_update_callback,
+        );
     }
 
     return pill_widget;

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -344,6 +344,62 @@ export function resize_group_members_list(): void {
     $(":root").css("--group-member-list-max-height", `${members_list_height}px`);
 }
 
+export function resize_group_creation_members_list(): void {
+    if ($("#groups_overlay_container").find(".two-pane-settings-overlay.show").length === 0) {
+        return;
+    }
+
+    if ($("#user_group_creation_form .user_group_members_container").css("display") === "none") {
+        return;
+    }
+
+    const $group_creation_container = $(
+        "#user_group_creation_form .two-pane-settings-creation-simplebar-container",
+    );
+    const $choose_subscribers_title = $group_creation_container.find(".new-group-members-title");
+    const $user_group_creation_status = $group_creation_container.find(
+        ".user_group_creation_error",
+    );
+    const $member_list_add = $group_creation_container.find(".member_list_add");
+    const $create_members_list_header = $group_creation_container.find(
+        ".create_member_list_header",
+    );
+
+    const elements_above_members_list = [
+        $choose_subscribers_title,
+        $user_group_creation_status,
+        $member_list_add,
+        $create_members_list_header,
+    ];
+
+    let total_height_of_elements_above_members_list = 0;
+    for (const $elem of elements_above_members_list) {
+        const outer_height = $elem.outerHeight(true) ?? 0;
+        total_height_of_elements_above_members_list += outer_height;
+    }
+
+    const $group_creation_error = $group_creation_container.find(".user_group_create_info");
+    const group_creation_error_height =
+        $group_creation_error.css("display") !== "none"
+            ? $group_creation_error.outerHeight(true)!
+            : 0;
+    const groups_creation_container_height = $group_creation_container.height();
+    assert(groups_creation_container_height !== undefined);
+
+    const members_list_container_bottom_border_width = 1;
+    const group_creation_body_padding = 15;
+    const group_creation_bottom_margin = 20;
+
+    const members_list_height =
+        groups_creation_container_height -
+        total_height_of_elements_above_members_list -
+        group_creation_body_padding -
+        group_creation_bottom_margin -
+        group_creation_error_height -
+        members_list_container_bottom_border_width;
+    $(":root").css("--new-group-member-list-max-height", `${members_list_height}px`);
+}
+
 export function resize_stream_filters_container(): void {
     resize_bottom_whitespace();
     $("#left_sidebar_scroll_container").css("max-height", get_stream_filters_max_height());
@@ -487,4 +543,5 @@ export function resize_page_components(): void {
     resize_stream_subscribers_list();
     resize_stream_creation_subscribers_list();
     resize_group_members_list();
+    resize_group_creation_members_list();
 }

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -284,6 +284,66 @@ export function resize_stream_creation_subscribers_list(): void {
     $(":root").css("--new-stream-subscriber-list-max-height", `${subscribers_list_height}px`);
 }
 
+export function resize_group_members_list(): void {
+    if ($("#groups_overlay_container").find(".two-pane-settings-overlay.show").length === 0) {
+        return;
+    }
+
+    if (
+        $("#user_group_settings .group_setting_section[data-group-section='members']").length ===
+            0 ||
+        $("#user_group_settings .group_setting_section[data-group-section='members']").css(
+            "display",
+        ) === "none"
+    ) {
+        return;
+    }
+
+    const $groups_info = $("#groups_overlay .two-pane-settings-container .right");
+
+    const $tab_container = $("#user_group_settings .group_settings_header");
+
+    const $membership_status = $(".member_list_settings_container .membership-status");
+
+    // These below three elements are conditionally hidden: they
+    // are not shown for role based groups.
+    const $add_members_title = $(".member_list_settings_container .add-members-heading");
+    const $members_list_settings = $(".member_list_settings_container .member_list_settings");
+    const $subscription_request_result = $(".user_group_subscription_request_result");
+
+    const $members_list_header = $(".member_list_settings_container .members-list-header");
+
+    const elements_above_members_list = [
+        $tab_container,
+        $membership_status,
+        $add_members_title,
+        $members_list_settings,
+        $subscription_request_result,
+        $members_list_header,
+    ];
+
+    let total_height_of_elements_above_members_list = 0;
+    for (const $elem of elements_above_members_list) {
+        const outer_height = $elem.outerHeight(true) ?? 0;
+        total_height_of_elements_above_members_list += outer_height;
+    }
+
+    const right_subheader_height = height_of($(".right .two-pane-settings-subheader"));
+    const group_settings_inner_box_margin = 18;
+    const groups_info_height = $groups_info.height();
+    assert(groups_info_height !== undefined);
+
+    const members_list_container_bottom_border_width = 1;
+
+    const members_list_height =
+        groups_info_height -
+        total_height_of_elements_above_members_list -
+        right_subheader_height -
+        2 * group_settings_inner_box_margin -
+        members_list_container_bottom_border_width;
+    $(":root").css("--group-member-list-max-height", `${members_list_height}px`);
+}
+
 export function resize_stream_filters_container(): void {
     resize_bottom_whitespace();
     $("#left_sidebar_scroll_container").css("max-height", get_stream_filters_max_height());
@@ -426,4 +486,5 @@ export function resize_page_components(): void {
     resize_settings_creation_overlay($("#channels_overlay_container"));
     resize_stream_subscribers_list();
     resize_stream_creation_subscribers_list();
+    resize_group_members_list();
 }

--- a/web/src/user_group_components.ts
+++ b/web/src/user_group_components.ts
@@ -78,6 +78,7 @@ export const show_user_group_settings_pane = {
         $("#groups_overlay .deactivated-user-group-icon").hide();
         resize.resize_settings_overlay($("#groups_overlay_container"));
         resize.resize_settings_creation_overlay($("#groups_overlay_container"));
+        resize.resize_group_creation_members_list();
     },
 };
 

--- a/web/src/user_group_create.ts
+++ b/web/src/user_group_create.ts
@@ -9,6 +9,7 @@ import * as group_permission_settings from "./group_permission_settings.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
 import * as loading from "./loading.ts";
+import * as resize from "./resize.ts";
 import * as settings_components from "./settings_components.ts";
 import * as settings_data from "./settings_data.ts";
 import {realm} from "./state_data.ts";
@@ -178,6 +179,7 @@ function clear_error_display(): void {
     user_group_name_error.clear_errors();
     $(".user_group_create_info").hide();
     user_group_membership_error.clear_errors();
+    resize.resize_group_creation_members_list();
 }
 
 export function show_new_user_group_modal(): void {
@@ -202,6 +204,7 @@ function create_user_group(): void {
             $t_html({defaultMessage: "The group description cannot contain newline characters."}),
             $(".user_group_create_info"),
         );
+        resize.resize_group_creation_members_list();
         return;
     }
     const user_ids = user_group_create_members.get_principals();
@@ -244,6 +247,7 @@ function create_user_group(): void {
             );
             reset_name();
             loading.destroy_indicator($("#user_group_creating_indicator"));
+            resize.resize_group_creation_members_list();
         },
     });
 }

--- a/web/src/user_group_create_members.ts
+++ b/web/src/user_group_create_members.ts
@@ -9,6 +9,7 @@ import * as ListWidget from "./list_widget.ts";
 import type {ListWidget as ListWidgetType} from "./list_widget.ts";
 import * as people from "./people.ts";
 import type {User} from "./people.ts";
+import * as resize from "./resize.ts";
 import {current_user} from "./state_data.ts";
 import type {CombinedPillContainer} from "./typeahead_helper.ts";
 import * as user_group_components from "./user_group_components.ts";
@@ -36,6 +37,7 @@ function add_members(user_ids: number[], subgroup_ids: number[]): void {
     user_group_create_members_data.add_user_ids(user_ids);
     user_group_create_members_data.add_subgroup_ids(subgroup_ids);
     redraw_member_list();
+    resize.resize_group_creation_members_list();
 }
 
 function soft_remove_user_id(user_id: number): void {
@@ -68,6 +70,7 @@ function sync_members(user_ids: number[], subgroup_ids: number[]): void {
     user_group_create_members_data.sync_user_ids(user_ids);
     user_group_create_members_data.sync_subgroup_ids(subgroup_ids);
     redraw_member_list();
+    resize.resize_group_creation_members_list();
 }
 
 function build_pill_widget({$parent_container}: {$parent_container: JQuery}): void {
@@ -85,6 +88,7 @@ function build_pill_widget({$parent_container}: {$parent_container: JQuery}): vo
         // logic of when to remove a user and when not to depending upon
         // their channel and individual pills.
         onPillRemoveAction: sync_members,
+        onTextInputCallback: resize.resize_group_creation_members_list,
     });
 }
 

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1220,6 +1220,11 @@ export function setup_group_settings(group: UserGroup): void {
             select_tab = key;
             const hash = hash_util.group_edit_url(group, select_tab);
             browser_history.update(hash);
+            if (key === "members") {
+                requestAnimationFrame(() => {
+                    resize.resize_group_members_list();
+                });
+            }
         },
     });
 

--- a/web/src/user_group_edit_members.ts
+++ b/web/src/user_group_edit_members.ts
@@ -18,6 +18,7 @@ import * as ListWidget from "./list_widget.ts";
 import type {ListWidget as ListWidgetType} from "./list_widget.ts";
 import * as people from "./people.ts";
 import type {User} from "./people.ts";
+import * as resize from "./resize.ts";
 import * as scroll_util from "./scroll_util.ts";
 import * as settings_data from "./settings_data.ts";
 import {current_user} from "./state_data.ts";
@@ -144,6 +145,10 @@ export function enable_member_management({
     // current_group_id and pill_widget are module-level variables
     current_group_id = group_id;
 
+    const pill_update_callback = function (): void {
+        resize.resize_group_members_list();
+    };
+
     if (!group.is_system_group) {
         const $pill_container = $parent_container.find(".pill-container");
         pill_widget = add_group_members_pill.create({
@@ -151,9 +156,13 @@ export function enable_member_management({
             get_potential_members,
             get_potential_groups: get_potential_subgroups,
             with_add_button: true,
+            onPillCreateAction: pill_update_callback,
+            onPillRemoveAction: pill_update_callback,
+            add_button_pill_update_callback: pill_update_callback,
         });
         $pill_container.find(".input").on("input", () => {
             $parent_container.find(".user_group_subscription_request_result").empty();
+            resize.resize_group_members_list();
         });
     }
 
@@ -238,6 +247,7 @@ function show_user_group_membership_request_error_result(error_message: string):
     scroll_util
         .get_content_element($user_group_subscription_req_result_elem)
         .html(rendered_error_message);
+    resize.resize_group_members_list();
 }
 
 function show_user_group_membership_request_success_result({
@@ -307,6 +317,7 @@ function show_user_group_membership_request_success_result({
     scroll_util
         .get_content_element($user_group_subscription_req_result_elem)
         .html(rendered_success_banner);
+    resize.resize_group_members_list();
 }
 
 export function edit_user_group_membership({

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -694,6 +694,8 @@
     */
     --stream-subscriber-list-max-height: 100%;
     --new-stream-subscriber-list-max-height: 100%;
+    --group-member-list-max-height: 100%;
+
     /*
       Reusable dimensions and offsets.
     */

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -695,6 +695,7 @@
     --stream-subscriber-list-max-height: 100%;
     --new-stream-subscriber-list-max-height: 100%;
     --group-member-list-max-height: 100%;
+    --new-group-member-list-max-height: 100%;
 
     /*
       Reusable dimensions and offsets.

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -194,13 +194,20 @@ h4.user_group_setting_subsection_title {
     border-right: 1px solid var(--color-border-table-subscriber-list);
     border-radius: 4px;
 
+    .member_list_container {
+        max-height: var(--group-member-list-max-height);
+    }
+
+    .subscriber_list_container {
+        max-height: var(--stream-subscriber-list-max-height);
+    }
+
     .member_list_container,
     .subscriber_list_container {
         position: relative;
         border-bottom: 1px solid var(--color-border-table-subscriber-list);
         border-bottom-left-radius: 4px;
         border-bottom-right-radius: 4px;
-        max-height: var(--stream-subscriber-list-max-height);
         overflow: auto;
         text-align: left;
         -webkit-overflow-scrolling: touch;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1086,6 +1086,10 @@ h4.user_group_setting_subsection_title {
     container: settings-overlay / inline-size;
 }
 
+#user_group_creation_form .member_list_container {
+    max-height: var(--new-group-member-list-max-height);
+}
+
 .two-pane-settings-overlay {
     .tab-switcher {
         display: flex;

--- a/web/templates/user_group_settings/new_user_group_users.hbs
+++ b/web/templates/user_group_settings/new_user_group_users.hbs
@@ -1,7 +1,6 @@
 <div class="member_list_add float-left">
     {{> add_members_form hide_add_button=true}}
 </div>
-<br />
 
 <div class="create_member_list_header">
     <h4 class="user_group_setting_subsection_title">{{t 'Members preview' }}</h4>

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -35,7 +35,7 @@
                 </div>
                 <div class="user_group_members_container user_group_creation">
                     <section id="choose_member_section">
-                        <h4 class="user_group_setting_subsection_title">
+                        <h4 class="user_group_setting_subsection_title new-group-members-title">
                             <label for="people_to_add_in_group">{{t "Choose members" }}</label>
                         </h4>
                         <div id="user_group_membership_error" class="user_group_creation_error"></div>

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -3,7 +3,7 @@
         {{> user_group_membership_status .}}
     </div>
     {{#unless group.is_system_group}}
-        <h4 class="user_group_setting_subsection_title">
+        <h4 class="user_group_setting_subsection_title add-members-heading">
             {{t "Add members" }}
         </h4>
         <div class="user_group_subscription_request_result banner-wrapper"></div>
@@ -14,7 +14,7 @@
             <div class="clear-float"></div>
         </div>
     {{/unless}}
-    <div>
+    <div class="members-list-header">
         <h4 class="inline-block user_group_setting_subsection_title">{{t "Members"}}</h4>
         <span class="member-search float-right">
             <input type="text" class="search filter_text_input" placeholder="{{t 'Filter' }}" />


### PR DESCRIPTION
Added resize function to correctly calculate the maximum height of the member list container, similar to how it is done for the subscriber list. This prevents the outer scrollbar from being incorrectly triggered in the user group settings overlay.

- Called the resize function only after the elements are visible, ensuring their heights are computed correctly instead of returning 0.

- Some elements above the member list are not always visible, so their height is handled as 0 when they are not present.

<!-- Describe your pull request here.-->

Fixes: [#issues > 📂 Scrolling Not Working in Members List inside Roles tab](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20Scrolling.20Not.20Working.20in.20Members.20List.20inside.20Roles.20tab/with/2413367)

**How changes were tested:**

- [x] UI testing, responsiveness.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
|--|--|
|<img width="1920" height="965" alt="before_user_group_settings" src="https://github.com/user-attachments/assets/36645565-d0bf-420d-ae48-8138209039b5" />|<img width="1917" height="963" alt="user_group_settings" src="https://github.com/user-attachments/assets/33c8d013-e57c-4479-8cca-b62083ae572b" />|
|<img width="1920" height="967" alt="before_user_group_settings_role_tab" src="https://github.com/user-attachments/assets/49655011-967a-4b6c-b11d-d14d15e9c255" />|<img width="1920" height="968" alt="user_group_settings_role_tab" src="https://github.com/user-attachments/assets/4ba1f52e-4461-45e5-8c0d-966cee72c704" />|

| Second commit (user creation form) |
|--|
|<img width="1920" height="967" alt="image" src="https://github.com/user-attachments/assets/cbeef4a4-f1a5-4b0a-abb5-e32846b49e20" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
