### PR TITLE
[ai] filter: Add mentions: search operator for filtering by user mentions.

### DIFF
--- a/starlight_help/src/content/docs/search-for-messages.mdx
+++ b/starlight_help/src/content/docs/search-for-messages.mdx
@@ -142,6 +142,8 @@ additional messages.
   received the message.
 * `is:mentioned`: Search messages where you were
   [mentioned](/help/mention-a-user-or-group).
+* `mentions:Elena García`: Search messages where Elena is
+  [mentioned](/help/mention-a-user-or-group).
 * `is:starred`: Search your [starred messages](/help/star-a-message).
 
 ### Search by message status

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -468,8 +468,14 @@ export class Filter {
                     }
                 }
 
-                if (for_pills && operator === "sender" && operand.toLowerCase() === "me") {
-                    operand = String(people.my_current_user_id());
+                if (for_pills && operand.toLowerCase() === "me") {
+                    if (operator === "sender") {
+                        operand = String(people.my_current_user_id());
+                    } else if (operator === "mentions") {
+                        // mentions:me is equivalent to is:mentioned.
+                        operator = "is";
+                        operand = "mentioned";
+                    }
                 }
 
                 // Check if the operator is known, if not then we treat
@@ -558,6 +564,15 @@ export class Filter {
                     break;
                 }
                 case "mentions": {
+                    // mentions:me is equivalent to is:mentioned.
+                    if (suggestion.operand.toLowerCase() === "me") {
+                        potential_narrow_term = {
+                            operator: "is",
+                            operand: "mentioned",
+                            negated: suggestion.negated,
+                        };
+                        break;
+                    }
                     const result = convert_single_user_id_suggestion_to_term(
                         suggestion,
                         canonical_operator,

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -223,6 +223,8 @@ function build_term_predicate(term: NarrowCanonicalTerm): ((message: Message) =>
         // can_apply_locally() when a search term is present.
         // istanbul ignore next
         case "search":
+        // istanbul ignore next -- falls through
+        case "mentions":
             throw new Error("build_term_predicate called for search term");
     }
 
@@ -234,6 +236,7 @@ function build_term_predicate(term: NarrowCanonicalTerm): ((message: Message) =>
 const USER_OPERATORS = new Set([
     "dm-including",
     "dm",
+    "mentions",
     "sender",
     "from",
     "pm-with",
@@ -291,6 +294,7 @@ export class Filter {
             case "topic":
                 break;
             case "sender":
+            case "mentions":
             case "dm":
             case "dm-including":
                 break;
@@ -538,6 +542,20 @@ export class Filter {
                     };
                     break;
                 }
+                case "mentions": {
+                    const operand = Number(suggestion.operand);
+
+                    if (Number.isNaN(operand)) {
+                        return undefined;
+                    }
+
+                    potential_narrow_term = {
+                        operator: canonical_operator,
+                        operand,
+                        negated: suggestion.negated,
+                    };
+                    break;
+                }
                 default:
                     potential_narrow_term = {
                         operator: canonical_operator,
@@ -587,6 +605,7 @@ export class Filter {
             case "topic":
                 return true;
             case "sender":
+            case "mentions":
                 return people.is_valid_user_id(term.operand);
             case "dm":
             case "dm-including":
@@ -663,6 +682,7 @@ export class Filter {
             "dm-including",
             "with",
             "sender",
+            "mentions",
             "near",
             "id",
             "is-alerted",
@@ -734,6 +754,9 @@ export class Filter {
 
             case "dm-including":
                 return verb + "direct messages including";
+
+            case "mentions":
+                return verb + "messages mentioning";
 
             case "in":
                 return verb + "messages in";
@@ -1645,6 +1668,10 @@ export class Filter {
             // rendered by the backend; links, attachments, and images
             // are not handled properly by the local echo Markdown
             // processor.
+            return false;
+        }
+
+        if (this.has_operator("mentions")) {
             return false;
         }
 

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -243,6 +243,21 @@ const USER_OPERATORS = new Set([
     "group-pm-with",
 ]);
 
+function convert_single_user_id_suggestion_to_term(
+    suggestion: NarrowTermSuggestion,
+    canonical_operator: "sender" | "mentions",
+): NarrowCanonicalTerm | undefined {
+    const operand = Number(suggestion.operand);
+    if (Number.isNaN(operand)) {
+        return undefined;
+    }
+    return {
+        operator: canonical_operator,
+        operand,
+        negated: suggestion.negated,
+    };
+}
+
 export class Filter {
     _terms: NarrowCanonicalTerm[];
     _sorted_term_types?: string[] = undefined;
@@ -524,36 +539,33 @@ export class Filter {
                     break;
                 }
                 case "sender": {
-                    let operand: number;
                     if (suggestion.operand.toLowerCase() === "me") {
-                        operand = people.my_current_user_id();
-                    } else {
-                        operand = Number(suggestion.operand);
+                        potential_narrow_term = {
+                            operator: canonical_operator,
+                            operand: people.my_current_user_id(),
+                            negated: suggestion.negated,
+                        };
+                        break;
                     }
-
-                    if (Number.isNaN(operand)) {
+                    const result = convert_single_user_id_suggestion_to_term(
+                        suggestion,
+                        canonical_operator,
+                    );
+                    if (result === undefined) {
                         return undefined;
                     }
-
-                    potential_narrow_term = {
-                        operator: canonical_operator,
-                        operand,
-                        negated: suggestion.negated,
-                    };
+                    potential_narrow_term = result;
                     break;
                 }
                 case "mentions": {
-                    const operand = Number(suggestion.operand);
-
-                    if (Number.isNaN(operand)) {
+                    const result = convert_single_user_id_suggestion_to_term(
+                        suggestion,
+                        canonical_operator,
+                    );
+                    if (result === undefined) {
                         return undefined;
                     }
-
-                    potential_narrow_term = {
-                        operator: canonical_operator,
-                        operand,
-                        negated: suggestion.negated,
-                    };
+                    potential_narrow_term = result;
                     break;
                 }
                 default:

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -42,6 +42,7 @@ export function encode_operand(term: NarrowCanonicalTerm): string {
             slug = people.user_ids_to_slug(term.operand);
             break;
         case "sender":
+        case "mentions":
             slug = people.user_ids_to_slug([term.operand]);
             break;
         case "channel":
@@ -79,13 +80,13 @@ export function decode_operand(
         }
     }
 
-    if (operator === "sender") {
+    if (operator === "sender" || operator === "mentions") {
         const user_ids = people.slug_to_user_ids(operand);
         if (user_ids?.length !== 1) {
             // User mistyped the URL since we don't support
-            // group operand for `sender` narrow. Returning
-            // -1 will lead to us showing a proper user
-            // doesn't exist message in the UI.
+            // group operand for `sender` or `mentions` narrow.
+            // Returning -1 will lead to us showing a proper
+            // user doesn't exist message in the UI.
             // Other options is to throw an error which will
             // lead to us showing a "Invalid URL" banner which
             // is not very nice looking.

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -233,10 +233,17 @@ export function parse_narrow(hash: string[]): NarrowCanonicalTerm[] | undefined 
             return undefined;
         }
 
-        const canonical_operator = filter_util.canonicalize_operator(
+        let canonical_operator = filter_util.canonicalize_operator(
             narrow_operator_schema.parse(operator),
         );
-        const operand = decode_operand(canonical_operator, raw_operand);
+        let operand = decode_operand(canonical_operator, raw_operand);
+
+        // mentions:me is equivalent to is:mentioned.
+        if (canonical_operator === "mentions" && raw_operand === "me") {
+            canonical_operator = "is";
+            operand = "mentioned";
+        }
+
         terms.push({
             negated,
             operator: canonical_operator,

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -523,6 +523,38 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                 ),
             };
         }
+
+        case "mentions": {
+            const mentioned_user = people.maybe_get_user_by_id(first_term.operand, true);
+
+            if (!mentioned_user) {
+                return {
+                    title: $t({defaultMessage: "This user does not exist!"}),
+                };
+            }
+
+            // mentions:me is redirected to is:mentioned in Filter.parse(),
+            // so mentioned_user will never be the current user here.
+            return {
+                title: $t(
+                    {
+                        defaultMessage: "No messages in your message history mention {person} yet.",
+                    },
+                    {person: mentioned_user.full_name},
+                ),
+                title_html: $t_html(
+                    {
+                        defaultMessage:
+                            "No messages in <z-link>your message history</z-link> mention {person} yet.",
+                    },
+                    {
+                        "z-link": (content_html) =>
+                            `<a href="/help/search-for-messages#search-shared-history" target="_blank" rel="noopener noreferrer">${content_html.join("")}</a>`,
+                        person: mentioned_user.full_name,
+                    },
+                ),
+            };
+        }
     }
     return default_banner;
 }

--- a/web/src/narrow_error.ts
+++ b/web/src/narrow_error.ts
@@ -12,15 +12,22 @@ export type SearchData = {
 
 export type NarrowBannerData = {
     title: string;
+    title_html?: string;
     html?: string;
     search_data?: SearchData;
 };
 
 export function narrow_error(narrow_banner_data: NarrowBannerData): string {
     const title = narrow_banner_data.title;
+    const title_html = narrow_banner_data.title_html;
     const notice_html = narrow_banner_data.html;
     const search_data = narrow_banner_data.search_data;
 
-    const empty_feed_notice = render_empty_feed_notice({title, notice_html, search_data});
+    const empty_feed_notice = render_empty_feed_notice({
+        title,
+        title_html,
+        notice_html,
+        search_data,
+    });
     return empty_feed_notice;
 }

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -23,7 +23,7 @@ export type SearchUserPill = {
 } & SearchUserPillContext;
 
 export type SearchUserPillContext = {
-    operator: "dm" | "dm-including" | "sender";
+    operator: "dm" | "dm-including" | "mentions" | "sender";
     negated: boolean;
     users: {
         full_name: string;
@@ -71,6 +71,7 @@ export function get_search_string_from_item(item: SearchPill): string {
     switch (item.operator) {
         case "dm":
         case "dm-including":
+        case "mentions":
         case "sender":
             assert(item.type === "search_user");
             operand = item.users.map((user) => user.email).join(",");
@@ -207,6 +208,7 @@ export function generate_pills_html(suggestion: Suggestion, text_query: string):
         switch (search_pill.operator) {
             case "dm":
             case "dm-including":
+            case "mentions":
             case "sender":
                 return search_user_pill_data_from_term(narrow_term);
             case "topic": {
@@ -362,6 +364,7 @@ export function create_pills($pill_container: JQuery): SearchPillWidget {
             switch (item.operator) {
                 case "dm":
                 case "dm-including":
+                case "mentions":
                 case "sender":
                     assert(item.type === "search_user");
                     return render_search_user_pill(item);
@@ -392,7 +395,7 @@ export function create_pills($pill_container: JQuery): SearchPillWidget {
 }
 
 function get_user_ids_from_term_with_user_pill_operator(term: NarrowCanonicalTerm): number[] {
-    if (term.operator === "sender") {
+    if (term.operator === "sender" || term.operator === "mentions") {
         return [term.operand];
     }
 
@@ -402,7 +405,10 @@ function get_user_ids_from_term_with_user_pill_operator(term: NarrowCanonicalTer
 
 function search_user_pill_data_from_term(term: NarrowCanonicalTerm): SearchUserPill {
     assert(
-        term.operator === "dm" || term.operator === "dm-including" || term.operator === "sender",
+        term.operator === "dm" ||
+            term.operator === "dm-including" ||
+            term.operator === "mentions" ||
+            term.operator === "sender",
     );
     const user_ids = get_user_ids_from_term_with_user_pill_operator(term);
     const users = user_ids.map((user_id) => people.get_by_user_id(user_id));
@@ -419,7 +425,7 @@ function is_sent_by_me_pill(pill: SearchUserPill): boolean {
 
 function search_user_pill_data(
     users: User[],
-    operator: "dm" | "dm-including" | "sender",
+    operator: "dm" | "dm-including" | "mentions" | "sender",
     negated: boolean,
 ): SearchUserPill {
     return {
@@ -441,7 +447,7 @@ function search_user_pill_data(
 function append_user_pill(
     users: User[],
     pill_widget: SearchPillWidget,
-    operator: "dm" | "dm-including" | "sender",
+    operator: "dm" | "dm-including" | "mentions" | "sender",
     negated: boolean,
 ): void {
     const pill_data = search_user_pill_data(users, operator, negated);
@@ -496,6 +502,7 @@ export function set_search_bar_contents(
         switch (term.operator) {
             case "dm":
             case "dm-including":
+            case "mentions":
             case "sender": {
                 const user_ids = get_user_ids_from_term_with_user_pill_operator(narrow_term);
                 const users = user_ids.map((user_id) => people.get_by_user_id(user_id));
@@ -539,6 +546,7 @@ export function get_current_search_pill_terms(
                     negated: item.negated,
                 };
             case "sender":
+            case "mentions":
                 assert(item.type === "search_user");
                 return {
                     operator: item.operator,

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -117,6 +117,7 @@ const incompatible_patterns: Record<SearchFilter, TermPattern[]> = {
         {operator: "in"},
         {operator: "topic"},
     ],
+    mentions: [{operator: "mentions"}],
     sender: [{operator: "sender"}, {operator: "from"}],
     "is:starred": [{operator: "is", operand: "starred"}],
     "is:mentioned": [{operator: "is", operand: "mentioned"}],
@@ -387,7 +388,7 @@ function get_person_suggestions(
     people_getter: () => User[],
     last: NarrowCanonicalTermSuggestion,
     terms: NarrowCanonicalTerm[],
-    autocomplete_operator: "dm" | "sender" | "dm-including",
+    autocomplete_operator: "dm" | "sender" | "dm-including" | "mentions",
 ): Suggestion[] {
     if (last.operator === "is" && last.operand === "dm") {
         last = {operator: "dm", operand: "", negated: false};
@@ -415,8 +416,9 @@ function get_person_suggestions(
                 });
                 break;
             case "sender":
+            case "mentions":
                 terms.push({
-                    operator: "sender",
+                    operator: autocomplete_operator,
                     operand: person.user_id,
                     negated: last.negated,
                 });
@@ -855,6 +857,7 @@ function get_operator_suggestions(
             "dm-including",
             "sender",
             "near",
+            "mentions",
         ];
         legacy_operator_choices = ["from", "pm-with", "streams", "stream"];
     }
@@ -913,6 +916,7 @@ function get_operator_suggestions(
                     true,
                 );
             case "sender":
+            case "mentions":
                 return format_as_suggestion(
                     [
                         {
@@ -1091,7 +1095,7 @@ export let get_suggestions = function (
         last = text_search_terms.at(-1)!;
     }
 
-    const person_suggestion_ops = ["sender", "dm", "dm-including"];
+    const person_suggestion_ops = ["sender", "dm", "dm-including", "mentions"];
 
     // Handle spaces in person name in new suggestions only. Checks if the last operator is 'search'
     // and the second last operator in search_terms is one out of person_suggestion_ops.
@@ -1143,7 +1147,7 @@ export let get_suggestions = function (
     const people_getter = make_people_getter(last);
 
     function get_people(
-        flavor: "dm" | "sender" | "dm-including",
+        flavor: "dm" | "sender" | "dm-including" | "mentions",
     ): (last: NarrowCanonicalTermSuggestion, base_terms: NarrowCanonicalTerm[]) => Suggestion[] {
         return function (
             last: NarrowCanonicalTermSuggestion,
@@ -1169,6 +1173,7 @@ export let get_suggestions = function (
         get_people("dm"),
         get_people("sender"),
         get_people("dm-including"),
+        get_people("mentions"),
         get_topic_suggestions,
         get_has_filter_suggestions,
     ];

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -44,6 +44,7 @@ export const narrow_canonical_operator_schema = z.enum([
     "id",
     "in",
     "is",
+    "mentions",
     "near",
     "search",
     "sender",
@@ -121,6 +122,11 @@ export const narrow_canonical_term_schema = z.discriminatedUnion("operator", [
     z.object({
         operator: z.literal("with"),
         operand: z.string(),
+        negated: z.optional(z.boolean()),
+    }),
+    z.object({
+        operator: z.literal("mentions"),
+        operand: z.number(),
         negated: z.optional(z.boolean()),
     }),
     z.object({

--- a/web/templates/empty_feed_notice.hbs
+++ b/web/templates/empty_feed_notice.hbs
@@ -1,5 +1,5 @@
 <div class="empty_feed_notice">
-    <h4 class="empty-feed-notice-title"> {{ title }} </h4>
+    <h4 class="empty-feed-notice-title"> {{#if title_html}}{{{ title_html }}}{{else}}{{ title }}{{/if}} </h4>
     {{#if search_data}}
         {{#if search_data.has_stop_word}}
         <div class="empty-feed-notice-description">

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -128,6 +128,15 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">mentions:<span class="operator_value">user</span></td>
+                        <td class="definition">
+                            {{#tr}}
+                                Narrow to messages that mention <z-value></z-value>.
+                                {{#*inline "z-value"}}<span class="operator_value">user</span>{{/inline}}
+                            {{/tr}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">is:starred</td>
                         <td class="definition">
                             {{t 'Narrow to starred messages.'}}

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -647,6 +647,17 @@ test("basics", () => {
     filter = new Filter(terms);
     assert.ok(filter.is_channel_view());
 
+    terms = [{operator: "mentions", operand: joe.user_id}];
+    filter = new Filter(terms);
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(!filter.contains_no_partial_conversations());
+    assert.ok(!filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.is_channel_view());
+
     // Throw error on invalid operator.
     assert.throws(() => get_predicate([["bogus", "33"]]), {
         name: "$ZodError",
@@ -1053,6 +1064,10 @@ test("canonicalization", () => {
     term = Filter.canonicalize_term({operator: "has", operand: "reactions"});
     assert.equal(term.operator, "has");
     assert.equal(term.operand, "reaction");
+
+    term = Filter.canonicalize_term({operator: "mentions", operand: joe.user_id});
+    assert.equal(term.operator, "mentions");
+    assert.equal(term.operand, joe.user_id);
 });
 
 test("ensure_channel_topic_terms", () => {
@@ -1392,6 +1407,9 @@ test("predicate_basics", ({override}) => {
         content:
             '<p><audio controls preload="metadata" src="/user_uploads/randompath/test.mp3" title="zulip.mp3"></audio></p>',
     };
+
+    predicate = get_predicate([["mentions", joe.user_id]]);
+    assert.ok(predicate({}));
 
     const inline_img_msg = {
         content:
@@ -1955,6 +1973,10 @@ test("describe", ({mock_template, override}) => {
     terms = [{operator: "dm-including", operand: ""}];
     string = "direct messages including";
     assert.equal(Filter.search_description_as_html(terms, true), string);
+
+    terms = [{operator: "mentions", operand: ""}];
+    string = "messages mentioning";
+    assert.equal(Filter.search_description_as_html(terms, true), string);
 });
 
 test("can_bucket_by", () => {
@@ -2184,6 +2206,9 @@ test("convert_suggestion_to_term", () => {
         ["sender:me", true],
         [`dm:${[alice.user_id, -1]}`, false],
         [`dm:${[alice.user_id, joe.user_id]}`, true],
+        [`mentions:${alice.user_id}`, true],
+        ["mentions:-1", false],
+        ["mentions:invalid", false],
     ];
     for (const [search_term_string, expected_is_valid] of test_data) {
         assert.equal(
@@ -2981,6 +3006,9 @@ run_test("is_spectator_compatible", () => {
     // "group-pm-with:" was replaced with "dm-including:"
     assert.ok(
         !Filter.is_spectator_compatible([{operator: "group-pm-with", operand: "hamlet@zulip.com"}]),
+    );
+    assert.ok(
+        !Filter.is_spectator_compatible([{operator: "mentions", operand: "hamlet@zulip.com"}]),
     );
 });
 

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1023,6 +1023,11 @@ test("canonicalization", () => {
     assert.equal(term.operator, "sender");
     assert.equal(term.operand, me.user_id);
 
+    // mentions:me redirects to is:mentioned
+    term = Filter.convert_suggestion_to_term({operator: "mentions", operand: "me"});
+    assert.equal(term.operator, "is");
+    assert.equal(term.operand, "mentioned");
+
     // "pm-with" was renamed to "dm"
     term = Filter.convert_suggestion_to_term({operator: "pm-with", operand: "me"});
     assert.equal(term.operator, "dm");
@@ -1621,6 +1626,14 @@ test("parse", () => {
     terms = [{operator: "sender", operand: `${me.user_id}`, negated: true}];
     _test(true);
 
+    string = "mentions:me";
+    terms = [{operator: "is", operand: "mentioned"}];
+    _test(true);
+
+    string = "-mentions:me";
+    terms = [{operator: "is", operand: "mentioned", negated: true}];
+    _test(true);
+
     string = "https://www.google.com";
     terms = [{operator: "search", operand: "https://www.google.com"}];
     _test();
@@ -2207,6 +2220,7 @@ test("convert_suggestion_to_term", () => {
         [`dm:${[alice.user_id, -1]}`, false],
         [`dm:${[alice.user_id, joe.user_id]}`, true],
         [`mentions:${alice.user_id}`, true],
+        ["mentions:me", true],
         ["mentions:-1", false],
         ["mentions:invalid", false],
     ];

--- a/web/tests/hash_util.test.cjs
+++ b/web/tests/hash_util.test.cjs
@@ -203,6 +203,15 @@ run_test("test_parse_narrow", () => {
         hash_util.parse_narrow(["narrow", "stream", "99-frontend", "topic", "", "near", ""]),
         undefined,
     );
+
+    // mentions:me in URL is converted to is:mentioned.
+    assert.deepEqual(hash_util.parse_narrow(["narrow", "mentions", "me"]), [
+        {negated: false, operator: "is", operand: "mentioned"},
+    ]);
+
+    assert.deepEqual(hash_util.parse_narrow(["narrow", "-mentions", "me"]), [
+        {negated: true, operator: "is", operand: "mentioned"},
+    ]);
 });
 
 run_test("test_channels_settings_edit_url", () => {

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -60,9 +60,10 @@ mock_esm("../src/spectators", {
     login_to_access() {},
 });
 
-function empty_narrow_html(title, notice_html, search_data) {
+function empty_narrow_html(title, notice_html, search_data, title_html) {
     const opts = {
         title,
+        title_html,
         notice_html,
         search_data,
     };
@@ -572,6 +573,25 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: No search results."),
+    );
+
+    current_filter = set_filter([["mentions", alice.user_id]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html(
+            "translated: No messages in your message history mention Alice Smith yet.",
+            undefined,
+            undefined,
+            'translated: No messages in <a href="/help/search-for-messages#search-shared-history" target="_blank" rel="noopener noreferrer">your message history</a> mention Alice Smith yet.',
+        ),
+    );
+
+    current_filter = set_filter([["mentions", -1]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html("translated: This user does not exist!"),
     );
 
     current_filter = set_filter([["is", "invalid"]]);

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -132,6 +132,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
                 `sender:${zoe.user_id}`,
                 `dm:${zoe.user_id}`,
                 `dm-including:${zoe.user_id}`,
+                `mentions:${zoe.user_id}`,
             ];
 
             /* Test highlighter */
@@ -148,6 +149,9 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
 
             expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">dm-including:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n</span>\n    \n</div>\n`;
             assert.equal(opts.item_html(search_suggestions[3], "zo"), expected_value);
+
+            expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">mentions:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n</span>\n    \n</div>\n`;
+            assert.equal(opts.item_html(search_suggestions[4], "zo"), expected_value);
 
             /* Test sorter */
             assert.equal(opts.sorter(search_suggestions.strings), search_suggestions.strings);

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -183,6 +183,7 @@ test("dm_suggestions", ({override}) => {
         `is:dm dm:${alice.user_id}`,
         `is:dm sender:${alice.user_id}`,
         `is:dm dm-including:${alice.user_id}`,
+        `is:dm mentions:${alice.user_id}`,
     ];
     assert.deepEqual(suggestions, expected);
 
@@ -273,6 +274,7 @@ test("dm_suggestions", ({override}) => {
         `is:starred has:link is:dm dm:${alice.user_id}`,
         `is:starred has:link is:dm sender:${alice.user_id}`,
         `is:starred has:link is:dm dm-including:${alice.user_id}`,
+        `is:starred has:link is:dm mentions:${alice.user_id}`,
     ];
     assert.deepEqual(suggestions, expected);
 
@@ -307,6 +309,7 @@ test("group_suggestions", () => {
         `dm:${bob.user_id},${alice.user_id}`,
         `dm:${bob.user_id} sender:${alice.user_id}`,
         `dm:${bob.user_id} dm-including:${alice.user_id}`,
+        `dm:${bob.user_id} mentions:${alice.user_id}`,
     ];
     assert.deepEqual(suggestions, expected);
 
@@ -318,6 +321,7 @@ test("group_suggestions", () => {
         `dm:${ted.user_id} my`,
         `dm:${ted.user_id} sender:${me.user_id}`,
         `dm:${ted.user_id} dm-including:${me.user_id}`,
+        `dm:${ted.user_id} mentions:${me.user_id}`,
     ];
     assert.deepEqual(suggestions, expected);
 
@@ -339,6 +343,7 @@ test("group_suggestions", () => {
         `dm:${bob.user_id},${alice.user_id}`,
         `dm:${bob.user_id} sender:${alice.user_id}`,
         `dm:${bob.user_id} dm-including:${alice.user_id}`,
+        `dm:${bob.user_id} mentions:${alice.user_id}`,
     ];
     assert.deepEqual(suggestions, expected);
 
@@ -351,6 +356,7 @@ test("group_suggestions", () => {
         `is:starred has:link dm:${bob.user_id},${ted.user_id}`,
         `is:starred has:link dm:${bob.user_id} sender:${ted.user_id}`,
         `is:starred has:link dm:${bob.user_id} dm-including:${ted.user_id}`,
+        `is:starred has:link dm:${bob.user_id} mentions:${ted.user_id}`,
     ];
     assert.deepEqual(suggestions, expected);
 
@@ -504,6 +510,7 @@ test("check_is_suggestions", ({override}) => {
         `dm:${alice.user_id}`,
         `sender:${alice.user_id}`,
         `dm-including:${alice.user_id}`,
+        `mentions:${alice.user_id}`,
         "has:image",
     ];
     assert.deepEqual(suggestions, expected);
@@ -668,7 +675,13 @@ test("topic_suggestions", ({override, override_rewire}) => {
     );
 
     suggestions = get_suggestions("te");
-    expected = ["te", `dm:${ted.user_id}`, `sender:${ted.user_id}`, `dm-including:${ted.user_id}`];
+    expected = [
+        "te",
+        `dm:${ted.user_id}`,
+        `sender:${ted.user_id}`,
+        `dm-including:${ted.user_id}`,
+        `mentions:${ted.user_id}`,
+    ];
     assert.deepEqual(suggestions, expected);
 
     stream_topic_history.add_message({
@@ -689,6 +702,7 @@ test("topic_suggestions", ({override, override_rewire}) => {
         `dm:${ted.user_id}`,
         `sender:${ted.user_id}`,
         `dm-including:${ted.user_id}`,
+        `mentions:${ted.user_id}`,
         `channel:${office_id} topic:team`,
         `channel:${office_id} topic:✔+team+work`,
         `channel:${office_id} topic:test`,
@@ -995,6 +1009,8 @@ test("people_suggestions", ({override}) => {
         `sender:${ted.user_id}`,
         `dm-including:${bob.user_id}`,
         `dm-including:${ted.user_id}`,
+        `mentions:${bob.user_id}`,
+        `mentions:${ted.user_id}`,
     ];
 
     assert.deepEqual(suggestions, expected);
@@ -1018,12 +1034,21 @@ test("people_suggestions", ({override}) => {
         `dm-including:${bob.user_id}`,
         `dm-including:${ted.user_id}`,
         `dm-including:${inaccessible_user.user_id}`,
+        `mentions:${bob.user_id}`,
+        `mentions:${ted.user_id}`,
+        `mentions:${inaccessible_user.user_id}`,
     ];
     assert.deepEqual(suggestions, expected);
 
     suggestions = get_suggestions("Ted "); // note space
 
-    expected = ["Ted", `dm:${ted.user_id}`, `sender:${ted.user_id}`, `dm-including:${ted.user_id}`];
+    expected = [
+        "Ted",
+        `dm:${ted.user_id}`,
+        `sender:${ted.user_id}`,
+        `dm-including:${ted.user_id}`,
+        `mentions:${ted.user_id}`,
+    ];
 
     assert.deepEqual(suggestions, expected);
 

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -714,8 +714,22 @@ class NarrowBuilder:
         # topic_wildcard_mentioned) or silent mentions, since this
         # operator is defined to only match explicit @-mentions
         # directed at notifying this user individually.
-        cond = (column("user_profile_id", Integer) == target_user.id) & (
-            column("flags", Integer).op("&")(literal(UserMessage.flags.mentioned.mask)) != 0
+        #
+        # Use a subquery on the target user's UserMessage rows,
+        # since the base query's UserMessage join is constrained to
+        # the current user, who may differ from the mentioned user.
+        # We correlate via zerver_message.id (present in both base
+        # query variants) to avoid ambiguity with the outer query's
+        # zerver_usermessage table.
+        cond = (
+            select(1)
+            .select_from(table("zerver_usermessage"))
+            .where(
+                column("message_id", Integer) == literal_column("zerver_message.id", Integer),
+                column("user_profile_id", Integer) == literal(target_user.id),
+                column("flags", Integer).op("&")(literal(UserMessage.flags.mentioned.mask)) != 0,
+            )
+            .exists()
         )
 
         return query.where(maybe_negate(cond))

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -88,7 +88,7 @@ def decode_hash_component(string: str) -> str:
 def decode_narrow_operand(operator: str, operand: str) -> str | int | list[int]:
     # These have the similar slug formatting for their operands which
     # contain object ID(s).
-    if operator in ["dm-including", "dm", "sender", "channel"]:
+    if operator in ["dm-including", "dm", "mentions", "sender", "channel"]:
         result = parse_recipient_slug(operand)
         return result[0] if isinstance(result, tuple) else ""
 

--- a/zerver/tests/fixtures/narrow_url_to_narrow_terms.json
+++ b/zerver/tests/fixtures/narrow_url_to_narrow_terms.json
@@ -135,6 +135,17 @@
         ]
     },
     {
+        "name": "mentions_link",
+        "near_link": "http://testserver/#narrow/mentions/35-Iago",
+        "expected_output": [
+            {
+                "operator": "mentions",
+                "operand": 35,
+                "negated": false
+            }
+        ]
+    },
+    {
         "name": "legacy_channel_synonym",
         "near_link": "http://testserver/#narrow/stream/13-Denmark",
         "expected_output": [

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -4897,6 +4897,49 @@ class GetOldMessagesTest(ZulipTestCase):
 
         self.assertEqual([m["id"] for m in result["messages"]], [mention_message_id])
 
+    def test_get_visible_messages_with_mentions_narrow_cross_user(self) -> None:
+        hamlet = self.example_user("hamlet")
+        self.login_user(hamlet)
+
+        iago = self.example_user("iago")
+        stream = self.make_stream("design")
+        self.subscribe(hamlet, stream.name)
+        self.subscribe(iago, stream.name)
+
+        # Send a message mentioning Iago; Hamlet will search for it.
+        content = f"Hello @**{iago.full_name}**!"
+        mention_message_id = self.send_stream_message(
+            hamlet,
+            stream.name,
+            content=content,
+        )
+
+        # Use a silent mention of Iago to test that it is excluded.
+        silent_mention_content = f"Hello @_**{iago.full_name}**!"
+        self.send_stream_message(
+            hamlet,
+            stream.name,
+            content=silent_mention_content,
+        )
+
+        narrow = [dict(operator="mentions", operand=iago.id)]
+
+        post_params = dict(
+            narrow=orjson.dumps(narrow).decode(),
+            num_before=10,
+            num_after=0,
+            anchor=LARGER_THAN_MAX_MESSAGE_ID,
+        )
+        payload = self.client_get("/json/messages", dict(post_params))
+        self.assert_json_success(payload)
+        result = orjson.loads(payload.content)
+
+        # BUG: The by_mention query adds user_profile_id = target_user.id
+        # directly, which conflicts with the base query's
+        # user_profile_id = current_user.id when they differ.
+        # This should return [mention_message_id] once fixed.
+        self.assertEqual([m["id"] for m in result["messages"]], [])
+
     def test_exclude_muting_conditions(self) -> None:
         realm = get_realm("zulip")
         self.make_stream("web stuff")

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -830,7 +830,7 @@ class NarrowBuilderTest(ZulipTestCase):
         term = NarrowParameter(operator="mentions", operand=self.user_profile.id)
         self._do_add_term_test(
             term,
-            "WHERE user_profile_id = %(user_profile_id_1)s AND (flags & %(param_1)s) != %(param_2)s",
+            "WHERE EXISTS (SELECT 1 \nFROM zerver_usermessage \nWHERE message_id = zerver_message.id AND user_profile_id = %(param_1)s AND (flags & %(param_2)s) != %(param_3)s)",
         )
 
     def test_add_term_using_mentions_operator_with_different_user_email(self) -> None:
@@ -839,7 +839,7 @@ class NarrowBuilderTest(ZulipTestCase):
 
         self._do_add_term_test(
             term,
-            "WHERE user_profile_id = %(user_profile_id_1)s AND (flags & %(param_1)s) != %(param_2)s",
+            "WHERE EXISTS (SELECT 1 \nFROM zerver_usermessage \nWHERE message_id = zerver_message.id AND user_profile_id = %(param_1)s AND (flags & %(param_2)s) != %(param_3)s)",
         )
 
         self.send_stream_message(
@@ -850,7 +850,7 @@ class NarrowBuilderTest(ZulipTestCase):
 
         self._do_add_term_test(
             term,
-            "WHERE user_profile_id = %(user_profile_id_1)s AND (flags & %(param_1)s) != %(param_2)s",
+            "WHERE EXISTS (SELECT 1 \nFROM zerver_usermessage \nWHERE message_id = zerver_message.id AND user_profile_id = %(param_1)s AND (flags & %(param_2)s) != %(param_3)s)",
         )
 
 
@@ -4934,11 +4934,7 @@ class GetOldMessagesTest(ZulipTestCase):
         self.assert_json_success(payload)
         result = orjson.loads(payload.content)
 
-        # BUG: The by_mention query adds user_profile_id = target_user.id
-        # directly, which conflicts with the base query's
-        # user_profile_id = current_user.id when they differ.
-        # This should return [mention_message_id] once fixed.
-        self.assertEqual([m["id"] for m in result["messages"]], [])
+        self.assertEqual([m["id"] for m in result["messages"]], [mention_message_id])
 
     def test_exclude_muting_conditions(self) -> None:
         realm = get_realm("zulip")


### PR DESCRIPTION
Fixes: #34751

This pull request adds support for a new mentions: search filter, allowing users to search for messages that explicitly mention a specific user using the mentions:user syntax. Previously, users could only find messages where they themselves were mentioned via is:mentioned. To search for messages mentioning other users, one had to manually type the @**username**. This update simplifies that process by introducing a dedicated, user-friendly filter. The filter behaves similarly to dm-including: in the UI, including typeahead suggestions. It supports only one user per pill search. The filter excludes silent mentions (@_**username**), group mentions (@**all**, @**everyone**), and wildcard mentions.

Previous work and bug Fix: [#38459](https://github.com/zulip/zulip/pull/38459) 

### ✨ Key Features

- Adds support for the `mentions:` search operator.
- Works similarly to `dm-including:`:
  - Shows typeahead suggestions.
  - Supports one user per pill.
- Excludes:
  - Silent mentions (`@_**username**`)
  - Group mentions (`@**all**`, `@**everyone**`)
  - Wildcard mentions
- Supports server side filtering, configure as client not able to filter treat as keyword search.
- Support `mentions:me` by redirecting it to `is:mentioned`, extracting shared logic with `sender:me` into a helper function, in a separate commit.

**How changes were tested:**

- [x] Added js test.
- [x] Ui testing.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

|  |  |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/145127d6-420e-4cf3-b4f7-0bd453d99c55" width="400"/> | <img src="https://github.com/user-attachments/assets/d572e687-51ae-46f3-94ba-d3cb5ef71e98" width="400"/> |
| <img src="https://github.com/user-attachments/assets/941f0460-974e-40fa-8e3d-9380853b0315" width="400"/> | <img src="https://github.com/user-attachments/assets/7bfe728f-ae22-4145-ad97-2b75da238ef0" width="400"/> |
| <img src="https://github.com/user-attachments/assets/9f044544-9201-441f-af2b-dde3d2a42712" width="400"/> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
