### PR TITLE
api_documentation: Make Draft id read-only.

### DIFF
--- a/zerver/lib/markdown/api_arguments_table_generator.py
+++ b/zerver/lib/markdown/api_arguments_table_generator.py
@@ -221,6 +221,11 @@ class APIArgumentsTablePreprocessor(Preprocessor):
 
         object_values = schema.get("properties", {})
         for value in object_values:
+            if object_values[value].get("readOnly", False):
+                # readOnly object properties are included in responses
+                # but not in requests.
+                continue
+
             description = ""
             if "description" in object_values[value]:
                 description = object_values[value]["description"]
@@ -268,6 +273,8 @@ class APIArgumentsTablePreprocessor(Preprocessor):
             details = ""
             if "object" in data_type and "properties" in object_values[value]:
                 details += self.render_object_details(object_values[value], str(value))
+            elif "items" in object_values[value] and "properties" in object_values[value]["items"]:
+                details += self.render_object_details(object_values[value]["items"], str(value))
             elif "oneOf" in object_values[value]:
                 details += self.render_oneof_block(object_values[value], str(value))
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -28584,10 +28584,9 @@ components:
       properties:
         id:
           type: integer
+          readOnly: true
           description: |
-            The unique ID of the draft. It will only used whenever the drafts are
-            fetched. This field should not be specified when the draft is being
-            created or edited.
+            The unique ID of the draft.
         type:
           type: string
           description: |


### PR DESCRIPTION
This PR updates the `Draft` schema in the OpenAPI documentation to mark the `id` field as `readOnly: true`.

As discussed in the issue, the `id` property is generated by the server and is present in the returned object when drafts are fetched. However, clients should not be expected or required to provide this field when sending data to create or edit a draft. Adding the `readOnly` property correctly models this behavior in OpenAPI 3.0, preventing validation issues without requiring duplicate schemas for requests and responses.

Fixes: #20826

**How changes were tested:**
* Ran the backend OpenAPI tests locally (`./tools/test-backend zerver/tests/test_openapi.py`) to ensure the schema update doesn't break existing validations. All 21 tests passed successfully.
* Ran the linter (`./tools/lint --fix`) to ensure YAML formatting and indentation are correct.

**Screenshots and screen captures:**
N/A - This is a backend API documentation (schema) change.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>