### PR TITLE
video_calls: Add JWT authentication support for Jitsi Meet.

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -191,6 +191,7 @@
 * [Remove an APNs device token](/api/remove-apns-token)
 * [Add an FCM registration token](/api/add-fcm-token)
 * [Remove an FCM registration token](/api/remove-fcm-token)
+* [Create Jitsi Meet video call](/api/create-jitsi-video-call)
 * [Create BigBlueButton video call](/api/create-big-blue-button-video-call)
 * [Create Constructor Groups video call](/api/create-constructor-groups-video-call)
 * [Create Nextcloud Talk video call](/api/create-nextcloud-talk-video-call)

--- a/api_docs/unmerged.d/ZF-c876d2.md
+++ b/api_docs/unmerged.d/ZF-c876d2.md
@@ -1,0 +1,15 @@
+**Feature level ZF-c876d2**
+
+* [`GET /calls/jitsi/create`](/api/create-jitsi-video-call): Added new
+  endpoint that generates a Jitsi Meet video call URL with JWT
+  authentication.
+
+* [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events):
+  Added `jitsi_jwt_enabled` boolean field, indicating whether
+  JWT-authenticated Jitsi Meet calls are usable for the current realm.
+
+* [`GET /events`](/api/get-events): The `realm/update` event for the
+  `jitsi_server_url` property has been replaced by a `realm/update_dict`
+  event with `property: "default"` whose `data` carries both
+  `jitsi_server_url` and the recomputed `jitsi_jwt_enabled`, so clients
+  can update both fields together.

--- a/docs/production/video-calls.md
+++ b/docs/production/video-calls.md
@@ -34,6 +34,34 @@ server [in organization
 settings](https://zulip.com/help/configure-call-provider#use-a-self-hosted-instance-of-jitsi-meet).
 No server configuration changes are required.
 
+### JWT authentication
+
+Self-hosted Jitsi Meet servers can be configured to require JWT tokens for
+authentication. When configured, Zulip generates a signed token for each user
+when they join a call. The token sets the user's `affiliation` to `owner` for
+the call creator (granting moderator privileges) and `member` for all other
+participants.
+
+:::{note}
+The `affiliation` claim is silently ignored by a standard Jitsi Meet
+installation. To honor it and grant moderator privileges to the call
+creator, install and enable the
+[token_affiliation](https://github.com/jitsi-contrib/prosody-plugins/tree/main/token_affiliation)
+Prosody plugin.
+:::
+
+To enable this, your Jitsi Meet server must first be [configured to require
+JWT tokens](https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker/#authentication-using-jwt-tokens). Then configure your Zulip server:
+
+1. In `/etc/zulip/zulip-secrets.conf`, set `jitsi_server_app_id` to the
+   app ID configured on your Jitsi server.
+
+1. In `/etc/zulip/zulip-secrets.conf`, set `jitsi_server_app_secret` to the
+   secret configured on your Jitsi server.
+
+1. Restart the Zulip server with
+   `/home/zulip/deployments/current/scripts/restart-server`.
+
 ## Zoom
 
 To use a [Zoom](https://zoom.us) integration on a self-hosted

--- a/starlight_help/src/content/docs/configure-call-provider.mdx
+++ b/starlight_help/src/content/docs/configure-call-provider.mdx
@@ -55,6 +55,11 @@ instance of Jitsi Meet.
   <SaveChanges />
 </FlattenedSteps>
 
+<ZulipTip>
+  Self-hosted instances of Jitsi Meet can use JWT authentication tokens. This
+  requires [configuration](https://zulip.readthedocs.io/en/stable/production/video-calls.html#jwt-authentication).
+</ZulipTip>
+
 ## Related articles
 
 * [Start a call](/help/start-a-call)

--- a/templates/zerver/integrations/jitsi.md
+++ b/templates/zerver/integrations/jitsi.md
@@ -27,6 +27,14 @@ instance of Jitsi Meet.
 
 {end_tabs}
 
+
+!!! tip ""
+
+      Self-hosted Jitsi Meet servers can be configured to require JWT tokens for
+      authentication. You will need to [configure your Jitsi
+      application](https://zulip.readthedocs.io/en/stable/production/video-calls.html#jwt-authentication)
+      in order to use this functionality.
+
 ## Related documentation
 
 - [How to start a call](/help/start-a-call)

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -33,6 +33,7 @@ IGNORED_PHRASES = [
     r"JSON",
     r"Jitsi",
     r"Jotform",
+    r"JWT",
     r"LinkedIn",
     r"LDAP",
     r"Markdown",

--- a/web/src/compose_call_ui.ts
+++ b/web/src/compose_call_ui.ts
@@ -244,32 +244,75 @@ export function generate_and_insert_audio_or_video_call_link(
                 break;
             }
             case available_providers.jitsi_meet?.id: {
-                const video_call_id = util.random_int(100000000000000, 999999999999999);
-                const video_call_url = compose_call.get_jitsi_server_url(video_call_id.toString());
-                if (video_call_url === null) {
-                    return;
-                }
-                /*  Because Jitsi remembers what last call type you joined
-                    in browser local storage, we need to specify that video
-                    should not be muted in the video call case, or your
-                    next call will also join without video after joining an
-                    audio-only call.
+                if (realm.jitsi_jwt_enabled) {
+                    const meeting_name = `${get_recipient_label()?.label_text ?? ""} meeting`;
+                    const request = {
+                        meeting_name,
+                        voice_only: is_audio_call,
+                    };
+                    const handle_success = (response: unknown): void => {
+                        const callback = (): void => {
+                            const data = call_response_schema.parse(response);
+                            if (is_audio_call) {
+                                insert_audio_call_url(data.url, $target_textarea);
+                            } else {
+                                insert_video_call_url(data.url, $target_textarea);
+                            }
+                        };
+                        compose_call_session.maybe_run_xhr_callback(xhr, callback);
+                    };
 
-                    This has the annoying downside that it requires users
-                    who have a personal preference to disable video every
-                    time, but Jitsi's UI makes that very easy to do, and
-                    that inconvenience is probably less important than letting
-                    the person organizing a call specify their intended
-                    call type (video vs audio).
-                */
-                const video_muted = is_audio_call ? "true" : "false";
-                video_call_url.hash = `config.startWithVideoMuted=${video_muted}`;
-                const video_call_link = video_call_url.toString();
+                    const handle_error = (
+                        _: JQuery.jqXHR<unknown>,
+                        status: JQuery.Ajax.ErrorTextStatus,
+                    ): void => {
+                        const callback = (): void => {
+                            if (status !== "abort") {
+                                ui_report.generic_embed_error(
+                                    $t_html({defaultMessage: "Failed to create video call."}),
+                                    2000,
+                                );
+                            }
+                        };
+                        compose_call_session.maybe_run_xhr_callback(xhr, callback);
+                    };
 
-                if (is_audio_call) {
-                    insert_audio_call_url(video_call_link, $target_textarea);
+                    xhr = channel.get({
+                        url: "/json/calls/jitsi/create",
+                        data: request,
+                        success: handle_success,
+                        error: handle_error,
+                    });
                 } else {
-                    insert_video_call_url(video_call_link, $target_textarea);
+                    const video_call_id = util.random_int(100000000000000, 999999999999999);
+                    const video_call_url = compose_call.get_jitsi_server_url(
+                        video_call_id.toString(),
+                    );
+                    if (video_call_url === null) {
+                        return;
+                    }
+                    /*  Because Jitsi remembers what last call type you joined
+                        in browser local storage, we need to specify that video
+                        should not be muted in the video call case, or your
+                        next call will also join without video after joining an
+                        audio-only call.
+
+                        This has the annoying downside that it requires users
+                        who have a personal preference to disable video every
+                        time, but Jitsi's UI makes that very easy to do, and
+                        that inconvenience is probably less important than letting
+                        the person organizing a call specify their intended
+                        call type (video vs audio).
+                    */
+                    const video_muted = is_audio_call ? "true" : "false";
+                    video_call_url.hash = `config.startWithVideoMuted=${video_muted}`;
+                    const video_call_link = video_call_url.toString();
+
+                    if (is_audio_call) {
+                        insert_audio_call_url(video_call_link, $target_textarea);
+                    } else {
+                        insert_video_call_url(video_call_link, $target_textarea);
+                    }
                 }
                 break;
             }

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -397,6 +397,12 @@ export function dispatch_normal_event(event) {
                             for (const [key, value] of Object.entries(event.data)) {
                                 if (key === "max_file_upload_size_mib") {
                                     realm[key] = value;
+                                } else if (key === "jitsi_jwt_enabled") {
+                                    // Stored unprefixed alongside
+                                    // server_jitsi_server_url — it's a
+                                    // server-computed flag, not a realm
+                                    // property.
+                                    realm.jitsi_jwt_enabled = value;
                                 } else {
                                     realm["realm_" + key] = value;
                                 }

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -620,6 +620,7 @@ export const realm_schema = z.object({
     server_max_deactivated_realm_deletion_days: z.nullable(z.number()),
     server_min_deactivated_realm_deletion_days: z.nullable(z.number()),
     server_jitsi_server_url: z.nullable(z.string()),
+    jitsi_jwt_enabled: z.boolean(),
     server_name_changes_disabled: z.boolean(),
     server_needs_upgrade: z.boolean(),
     server_presence_offline_threshold_seconds: z.number(),

--- a/web/tests/compose_call.test.cjs
+++ b/web/tests/compose_call.test.cjs
@@ -101,6 +101,89 @@ test("videos", ({override}) => {
         });
     })();
 
+    (function test_jitsi_jwt_video_and_audio_links_compose_clicked() {
+        let syntax_to_insert;
+        let called = false;
+
+        const $textarea = $.create("jitsi-jwt-target-stub");
+        $textarea.set_parents_result(".message_edit_form", []);
+
+        const ev = {
+            preventDefault() {},
+            stopPropagation() {},
+        };
+
+        override(compose_ui, "insert_syntax_and_focus", (syntax) => {
+            syntax_to_insert = syntax;
+            called = true;
+        });
+
+        override(
+            realm,
+            "realm_video_chat_provider",
+            realm_available_video_chat_providers.jitsi_meet.id,
+        );
+        override(realm, "realm_jitsi_server_url", "https://jitsi.example.com");
+        override(realm, "jitsi_jwt_enabled", true);
+
+        override(compose_closed_ui, "get_recipient_label", () => ({label_text: "general"}));
+
+        let success_callback;
+        const xhr_object = {abort() {}};
+        channel.get = (payload) => {
+            assert.equal(payload.url, "/json/calls/jitsi/create");
+            assert.equal(payload.data.meeting_name, "general meeting");
+            assert.equal(payload.data.voice_only, false);
+            success_callback = payload.success;
+            return xhr_object;
+        };
+
+        $("textarea#compose-textarea").val("");
+        const video_handler = $("body").get_on_handler("click", ".video_link");
+        video_handler.call($textarea, ev);
+        success_callback({
+            result: "success",
+            msg: "",
+            url: "/calls/jitsi/join?jitsi=SIGNED_DATA",
+        });
+        assert.ok(called);
+        assert.match(
+            syntax_to_insert,
+            /\[translated: Join video call\.]\(\/calls\/jitsi\/join\?jitsi=SIGNED_DATA\)/,
+        );
+
+        called = false;
+        channel.get = (payload) => {
+            assert.equal(payload.data.voice_only, true);
+            success_callback = payload.success;
+            return xhr_object;
+        };
+        const audio_handler = $("body").get_on_handler("click", ".audio_link");
+        audio_handler.call($textarea, ev);
+        success_callback({
+            result: "success",
+            msg: "",
+            url: "/calls/jitsi/join?jitsi=SIGNED_DATA_AUDIO",
+        });
+        assert.ok(called);
+        assert.match(
+            syntax_to_insert,
+            /\[translated: Join voice call\.]\(\/calls\/jitsi\/join\?jitsi=SIGNED_DATA_AUDIO\)/,
+        );
+
+        override(realm, "jitsi_jwt_enabled", false);
+        called = false;
+        with_overrides(({disallow}) => {
+            disallow(channel, "get");
+            video_handler.call($textarea, ev);
+        });
+        assert.ok(called);
+        assert.match(
+            syntax_to_insert,
+            /\[translated: Join video call\.]\(https:\/\/jitsi\.example\.com\/\d{15}#config\.startWithVideoMuted=false\)/,
+        );
+    })();
+
     (function test_jitsi_video_link_compose_clicked() {
         let syntax_to_insert;
         let called = false;
@@ -117,6 +200,8 @@ test("videos", ({override}) => {
             syntax_to_insert = syntax;
             called = true;
         });
+
+        override(realm, "jitsi_jwt_enabled", false);
 
         const handler = $("body").get_on_handler("click", ".video_link");
         $("textarea#compose-textarea").val("");

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -25,6 +25,7 @@ const alert_words_ui = mock_esm("../src/alert_words_ui");
 const attachments_ui = mock_esm("../src/attachments_ui");
 const audible_notifications = mock_esm("../src/audible_notifications");
 const bot_data = mock_esm("../src/bot_data");
+const compose_call_ui = mock_esm("../src/compose_call_ui");
 const compose_pm_pill = mock_esm("../src/compose_pm_pill");
 const {electron_bridge} = mock_esm("../src/electron_bridge", {
     electron_bridge: {},
@@ -683,6 +684,7 @@ run_test("realm settings", ({override}) => {
     override(navbar_alerts, "toggle_organization_profile_incomplete_banner", noop);
     override(compose_recipient, "update_topic_inputbox_on_topics_policy_change", noop);
     override(compose_recipient, "update_compose_area_placeholder_text", noop);
+    override(compose_call_ui, "update_audio_and_video_chat_button_display", noop);
 
     function test_electron_dispatch(event, fake_send_event) {
         with_overrides(({override}) => {
@@ -776,6 +778,8 @@ run_test("realm settings", ({override}) => {
     override(realm, "realm_plan_type", 2);
     override(realm, "realm_upload_quota_mib", 5000);
     override(realm, "max_file_upload_size_mib", 10);
+    override(realm, "realm_jitsi_server_url", "https://jitsi-old.example.com");
+    override(realm, "jitsi_jwt_enabled", false);
     override(realm, "server_supported_permission_settings", {
         realm: {
             create_multiuse_invite_group: {},
@@ -815,6 +819,8 @@ run_test("realm settings", ({override}) => {
     assert_same(realm.realm_plan_type, 3);
     assert_same(realm.realm_upload_quota_mib, 50000);
     assert_same(realm.max_file_upload_size_mib, 1024);
+    assert_same(realm.realm_jitsi_server_url, "https://jitsi.example.com");
+    assert_same(realm.jitsi_jwt_enabled, true);
     assert_same(add_subscribers_element_updated, true);
 
     event = event_fixtures.realm__update_dict__icon;

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -484,6 +484,8 @@ exports.fixtures = {
             upload_quota_mib: 50000,
             max_file_upload_size_mib: 1024,
             topics_policy: "disable_empty_topic",
+            jitsi_server_url: "https://jitsi.example.com",
+            jitsi_jwt_enabled: true,
         },
     },
 

--- a/web/tests/lib/example_realm.cjs
+++ b/web/tests/lib/example_realm.cjs
@@ -8,6 +8,7 @@ exports.make_realm = (opts = {}) => {
         custom_profile_field_types: [],
         giphy_api_key: "giphy-api-key",
         gif_rating_policy_options: {disabled: {id: 0, name: ""}},
+        jitsi_jwt_enabled: false,
         max_avatar_file_size_mib: 0,
         max_channel_folder_description_length: 0,
         max_channel_folder_name_length: 0,

--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -34,6 +34,7 @@ from zerver.lib.user_groups import (
     get_group_setting_value_for_audit_log_data,
 )
 from zerver.lib.utils import optional_bytes_to_mib
+from zerver.lib.video_calls import get_effective_jitsi_server_url, get_jitsi_jwt_config
 from zerver.models import (
     ArchivedAttachment,
     Attachment,
@@ -147,6 +148,21 @@ def do_set_realm_property(
             data={
                 "description": realm.description,
                 "rendered_description": realm.rendered_description,
+            },
+        )
+    if name == "jitsi_server_url":
+        # jitsi_jwt_enabled is a server-computed derived field that
+        # the client cannot recompute on its own (it depends on
+        # JITSI_SERVER_APP_ID/SECRET). Bundle it with the URL change
+        # so live clients pick the correct frontend code path.
+        effective_url = get_effective_jitsi_server_url(realm)
+        event = dict(
+            type="realm",
+            op="update_dict",
+            property="default",
+            data={
+                "jitsi_server_url": value,
+                "jitsi_jwt_enabled": get_jitsi_jwt_config(effective_url) is not None,
             },
         )
 

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -82,6 +82,7 @@ from zerver.lib.event_types import (
     RealmEmojiUpdateOneEvent,
     RealmExportConsentEvent,
     RealmExportEvent,
+    RealmJitsiServerUrlData,
     RealmLinkifiersEvent,
     RealmPlaygroundsEvent,
     RealmTopicsPolicyData,
@@ -554,6 +555,8 @@ def check_realm_update_dict(
             sub_type = RealmTopicsPolicyData
         elif "description" in event["data"]:
             sub_type = RealmDescriptionData
+        elif "jitsi_server_url" in event["data"]:
+            sub_type = RealmJitsiServerUrlData
         else:
             raise AssertionError("unhandled fields in data")
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -605,6 +605,11 @@ class RealmDescriptionData(BaseModel):
     rendered_description: str
 
 
+class RealmJitsiServerUrlData(BaseModel):
+    jitsi_server_url: str | None
+    jitsi_jwt_enabled: bool
+
+
 class NightLogoData(BaseModel):
     night_logo_url: str
     night_logo_source: str

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -94,6 +94,7 @@ from zerver.lib.users import (
     max_message_id_for_user,
 )
 from zerver.lib.utils import optional_bytes_to_mib
+from zerver.lib.video_calls import get_effective_jitsi_server_url, get_jitsi_jwt_config
 from zerver.models import (
     ChannelFolder,
     Client,
@@ -569,11 +570,8 @@ def fetch_initial_state_data(
             settings.JITSI_SERVER_URL.rstrip("/") if settings.JITSI_SERVER_URL is not None else None
         )
         state["server_jitsi_server_url"] = server_default_jitsi_server_url
-        state["jitsi_server_url"] = (
-            realm.jitsi_server_url
-            if realm.jitsi_server_url is not None
-            else server_default_jitsi_server_url
-        )
+        state["jitsi_server_url"] = get_effective_jitsi_server_url(realm)
+        state["jitsi_jwt_enabled"] = get_jitsi_jwt_config(state["jitsi_server_url"]) is not None
 
         state["server_can_summarize_topics"] = settings.TOPIC_SUMMARIZATION_MODEL is not None
 
@@ -1529,13 +1527,6 @@ def apply_event(
             field = "realm_" + event["property"]
             state[field] = event["value"]
 
-            if field == "realm_jitsi_server_url":
-                state["jitsi_server_url"] = (
-                    state["realm_jitsi_server_url"]
-                    if state["realm_jitsi_server_url"] is not None
-                    else state["server_jitsi_server_url"]
-                )
-
             if field == "realm_message_edit_history_visibility_policy":
                 state["realm_allow_edit_history"] = (
                     event["value"] != MessageEditHistoryVisibilityPolicyEnum.none.name
@@ -1555,7 +1546,16 @@ def apply_event(
                     # returned to clients in build_page_params_for_home_load.
                     continue
 
+                if key == "jitsi_jwt_enabled":
+                    state["jitsi_jwt_enabled"] = value
+                    continue
+
                 state["realm_" + key] = value
+
+                if key == "jitsi_server_url":
+                    state["jitsi_server_url"] = (
+                        value if value is not None else state["server_jitsi_server_url"]
+                    )
                 # It's a bit messy, but this is where we need to
                 # update the state for whether password authentication
                 # is enabled on this server.

--- a/zerver/lib/video_calls.py
+++ b/zerver/lib/video_calls.py
@@ -1,0 +1,26 @@
+from django.conf import settings
+
+from zerver.models import Realm
+
+
+def get_effective_jitsi_server_url(realm: Realm) -> str | None:
+    if realm.jitsi_server_url is not None:
+        return realm.jitsi_server_url.rstrip("/")
+    if settings.JITSI_SERVER_URL is None:
+        return None
+    return settings.JITSI_SERVER_URL.rstrip("/")
+
+
+def get_jitsi_jwt_config(jitsi_server_url: str | None) -> tuple[str, str, str] | None:
+    if (
+        jitsi_server_url is None
+        or jitsi_server_url == "https://meet.jit.si"
+        or settings.JITSI_SERVER_APP_ID is None
+        or settings.JITSI_SERVER_APP_SECRET is None
+    ):
+        return None
+    return (
+        jitsi_server_url,
+        settings.JITSI_SERVER_APP_ID,
+        settings.JITSI_SERVER_APP_SECRET,
+    )

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5654,9 +5654,24 @@ paths:
                                         `null`, the default, means that the organization is using the should use the
                                         server-level configuration, `server_jitsi_server_url`.
 
-                                        **Changes**: New in Zulip 8.0 (feature level 212). Previously, this was only
-                                        available as a server-level configuration, and required a server restart to
-                                        change.
+                                        Always accompanied by `jitsi_jwt_enabled` in the same event, since the
+                                        latter is derived from this value combined with server-level Jitsi JWT
+                                        credentials.
+
+                                        **Changes**: Moved from `realm/update` to `realm/update_dict` in
+                                        Zulip 13.0 (feature level ZF-c876d2) to bundle the recomputed
+                                        `jitsi_jwt_enabled` flag.
+
+                                        New in Zulip 8.0 (feature level 212). Previously, this was only available
+                                        as a server-level configuration, and required a server restart to change.
+                                    jitsi_jwt_enabled:
+                                      type: boolean
+                                      description: |
+                                        Whether JWT-authenticated Jitsi Meet calls are usable for this realm,
+                                        recomputed from the new `jitsi_server_url` value. Only sent when
+                                        `jitsi_server_url` is also present in this event.
+
+                                        **Changes**: New in Zulip 13.0 (feature level ZF-c876d2).
                                     logo_source:
                                       type: string
                                       description: |
@@ -21815,6 +21830,16 @@ paths:
 
                           **Changes**: New in Zulip 8.0 (feature level 212). Previously, this value
                           was available as the now-deprecated `jitsi_server_url`.
+                      jitsi_jwt_enabled:
+                        type: boolean
+                        description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
+                          Whether JWT-authenticated Jitsi Meet calls are usable for this
+                          realm. When `true`, clients should use the `/calls/jitsi/create` API to
+                          generate meeting links rather than constructing them client-side.
+
+                          **Changes**: New in Zulip 13.0 (feature level ZF-c876d2).
                       server_can_summarize_topics:
                         type: boolean
                         description: |
@@ -27164,6 +27189,67 @@ paths:
                     "bot_email": "outgoing-bot@localhost",
                     "bot_full_name": "Outgoing webhook test",
                   }
+
+  /calls/jitsi/create:
+    get:
+      tags: ["channels"]
+      operationId: create-jitsi-video-call
+      summary: Create Jitsi Meet video call
+      description: |
+        Create a Zulip join link for a Jitsi Meet video call using JWT
+        authentication. Requires a Jitsi Meet app ID and secret to be
+        configured on the Zulip server.
+
+        The returned URL points to a Zulip endpoint that generates a
+        per-user JWT and redirects to the Jitsi server.
+
+        **Changes**: New in Zulip 13.0 (feature level ZF-c876d2).
+      parameters:
+        - in: query
+          name: meeting_name
+          schema:
+            type: string
+          required: true
+          description: |
+            Meeting name for the Jitsi video call.
+          example: "general meeting"
+        - in: query
+          name: voice_only
+          schema:
+            type: boolean
+            default: false
+          required: false
+          description: |
+            Whether the call is voice-only. If true, cameras are
+            disabled for all participants. Only the call
+            creator/moderator can edit this configuration.
+          example: false
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      url:
+                        description: |
+                          The Zulip join URL for the Jitsi Meet video call.
+                          Visiting this URL while logged in will redirect to
+                          the Jitsi server with a signed JWT.
+                        type: string
+                        example: "/calls/jitsi/join?jitsi=SIGNED_DATA"
+                    example:
+                      {
+                        "msg": "",
+                        "result": "success",
+                        "url": "/calls/jitsi/join?jitsi=SIGNED_DATA",
+                      }
 
   /calls/bigbluebutton/create:
     get:

--- a/zerver/tests/test_create_video_call.py
+++ b/zerver/tests/test_create_video_call.py
@@ -1,15 +1,23 @@
+import datetime
 from unittest import mock
+from urllib.parse import urlencode, urljoin
 
+import jwt
 import orjson
 import requests
 import responses
+import time_machine
+from django.conf import settings
 from django.core.signing import Signer
 from django.http import HttpResponseRedirect
 from django.test import override_settings
+from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
+from zerver.lib.avatar import absolute_avatar_url
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.url_encoding import append_url_query_string
+from zerver.models import UserProfile
 
 
 @override_settings(VIDEO_ZOOM_SERVER_TO_SERVER_ACCOUNT_ID=None)
@@ -1004,3 +1012,211 @@ class NextcloudVideoCallTest(ZulipTestCase):
 
         json = self.assert_json_success(response)
         self.assertEqual(json["url"], "https://nextcloud.example.com/index.php/call/abc123token")
+
+
+class JitsiVideoCallTest(ZulipTestCase):
+    @override
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = self.example_user("hamlet")
+        self.user.realm.jitsi_server_url = "https://jitsi.example.com"
+        self.user.realm.save()
+        self.login_user(self.user)
+        self.signer = Signer()
+        self.signed_jitsi_video_call = self.signer.sign_object(
+            {
+                "room": "test-room",
+                "voice_only": False,
+                "moderator": self.user.id,
+            }
+        )
+        self.signed_jitsi_audio_call = self.signer.sign_object(
+            {
+                "room": "test-room",
+                "voice_only": True,
+                "moderator": self.user.id,
+            }
+        )
+
+    def test_create_jitsi_url_not_configured(self) -> None:
+        for setting_name in ["JITSI_SERVER_APP_ID", "JITSI_SERVER_APP_SECRET"]:
+            with self.settings(**{setting_name: None}):
+                response = self.client_get(
+                    "/json/calls/jitsi/create",
+                    {"meeting_name": "general meeting", "voice_only": "false"},
+                )
+                self.assert_json_error(response, "Jitsi JWT credentials have not been configured")
+
+    def test_create_jitsi_url_no_server_url(self) -> None:
+        self.user.realm.jitsi_server_url = None
+        self.user.realm.save()
+        with self.settings(JITSI_SERVER_URL=None):
+            response = self.client_get(
+                "/json/calls/jitsi/create",
+                {"meeting_name": "general meeting"},
+            )
+            self.assert_json_error(response, "Jitsi JWT credentials have not been configured")
+
+    def test_create_jitsi_url_public_jitsi(self) -> None:
+        self.user.realm.jitsi_server_url = None
+        self.user.realm.save()
+        with self.settings(JITSI_SERVER_URL="https://meet.jit.si"):
+            response = self.client_get(
+                "/json/calls/jitsi/create",
+                {"meeting_name": "general meeting"},
+            )
+            self.assert_json_error(response, "Jitsi JWT credentials have not been configured")
+
+    def test_create_jitsi_video_link(self) -> None:
+        with mock.patch("zerver.views.video_calls.random.randint", return_value=123456789012):
+            response = self.client_get(
+                "/json/calls/jitsi/create",
+                {"meeting_name": "General > Meeting!"},
+            )
+        response_dict = self.assert_json_success(response)
+        self.assertEqual(
+            response_dict["url"],
+            append_url_query_string(
+                "/calls/jitsi/join",
+                "jitsi="
+                + self.signer.sign_object(
+                    {
+                        "room": "general-meeting-123456789012",
+                        "voice_only": False,
+                        "moderator": self.user.id,
+                    }
+                ),
+            ),
+        )
+
+    def test_create_jitsi_audio_link(self) -> None:
+        with mock.patch("zerver.views.video_calls.random.randint", return_value=123456789012):
+            response = self.client_get(
+                "/json/calls/jitsi/create",
+                {"meeting_name": "General > Meeting!", "voice_only": "true"},
+            )
+        response_dict = self.assert_json_success(response)
+        self.assertEqual(
+            response_dict["url"],
+            append_url_query_string(
+                "/calls/jitsi/join",
+                "jitsi="
+                + self.signer.sign_object(
+                    {
+                        "room": "general-meeting-123456789012",
+                        "voice_only": True,
+                        "moderator": self.user.id,
+                    }
+                ),
+            ),
+        )
+
+    def test_join_jitsi_not_configured(self) -> None:
+        for setting_name in ["JITSI_SERVER_APP_ID", "JITSI_SERVER_APP_SECRET"]:
+            with self.settings(**{setting_name: None}):
+                response = self.client_get(
+                    "/calls/jitsi/join", {"jitsi": self.signed_jitsi_video_call}
+                )
+                self.assert_json_error(response, "Jitsi JWT credentials have not been configured")
+
+    def test_join_jitsi_no_server_url(self) -> None:
+        self.user.realm.jitsi_server_url = None
+        self.user.realm.save()
+        with self.settings(JITSI_SERVER_URL=None):
+            response = self.client_get("/calls/jitsi/join", {"jitsi": self.signed_jitsi_video_call})
+            self.assert_json_error(response, "Jitsi JWT credentials have not been configured")
+
+    def test_join_jitsi_public_jitsi(self) -> None:
+        self.user.realm.jitsi_server_url = None
+        self.user.realm.save()
+        with self.settings(JITSI_SERVER_URL="https://meet.jit.si"):
+            response = self.client_get("/calls/jitsi/join", {"jitsi": self.signed_jitsi_video_call})
+            self.assert_json_error(response, "Jitsi JWT credentials have not been configured")
+
+    def test_join_jitsi_invalid_signature(self) -> None:
+        response = self.client_get("/calls/jitsi/join", {"jitsi": "tampered-data"})
+        self.assert_json_error(response, "Invalid signature.")
+
+    def _build_jitsi_redirect_url(
+        self,
+        room: str,
+        voice_only: bool,
+        user: UserProfile | None = None,
+        affiliation: str = "owner",
+    ) -> str:
+        if user is None:
+            user = self.user
+        payload = {
+            "iss": settings.JITSI_SERVER_APP_ID,
+            "aud": "jitsi",
+            "sub": "jitsi.example.com",
+            "exp": timezone_now() + datetime.timedelta(minutes=5),
+            "room": room,
+            "context": {
+                "user": {
+                    "name": user.full_name,
+                    "email": user.email,
+                    "avatar": absolute_avatar_url(user) or "",
+                    "id": str(user.id),
+                    "affiliation": affiliation,
+                }
+            },
+        }
+        assert settings.JITSI_SERVER_APP_SECRET is not None
+        token = jwt.encode(payload, settings.JITSI_SERVER_APP_SECRET, algorithm="HS256")
+        video_muted = "true" if voice_only else "false"
+        return urljoin(
+            "https://jitsi.example.com",
+            f"/{room}?{urlencode({'jwt': token})}#config.startWithVideoMuted={video_muted}",
+        )
+
+    @time_machine.travel(
+        datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc), tick=False
+    )
+    def test_join_jitsi_redirects_to_jitsi_server(self) -> None:
+        response = self.client_get("/calls/jitsi/join", {"jitsi": self.signed_jitsi_video_call})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response["Location"],
+            self._build_jitsi_redirect_url("test-room", voice_only=False),
+        )
+
+    @time_machine.travel(
+        datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc), tick=False
+    )
+    def test_join_jitsi_audio_call_mutes_video(self) -> None:
+        response = self.client_get("/calls/jitsi/join", {"jitsi": self.signed_jitsi_audio_call})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response["Location"],
+            self._build_jitsi_redirect_url("test-room", voice_only=True),
+        )
+
+    @time_machine.travel(
+        datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc), tick=False
+    )
+    def test_join_jitsi_uses_requester_identity_not_creators(self) -> None:
+        bob = self.example_user("othello")
+        self.login_user(bob)
+        response = self.client_get("/calls/jitsi/join", {"jitsi": self.signed_jitsi_video_call})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response["Location"],
+            self._build_jitsi_redirect_url(
+                "test-room", voice_only=False, user=bob, affiliation="member"
+            ),
+        )
+
+    def test_join_jitsi_uses_realm_url_over_server_default(self) -> None:
+        self.user.realm.jitsi_server_url = "https://custom.jitsi.example.com"
+        self.user.realm.save()
+        response = self.client_get("/calls/jitsi/join", {"jitsi": self.signed_jitsi_video_call})
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("custom.jitsi.example.com", response["Location"])
+
+    def test_join_jitsi_requires_login(self) -> None:
+        self.logout()
+        response = self.client_get("/calls/jitsi/join", {"jitsi": self.signed_jitsi_video_call})
+        # Unauthenticated users are redirected to login, not given a JWT.
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response["Location"])

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -4605,6 +4605,7 @@ class RealmPropertyActionTest(BaseAction):
                 "message_content_edit_limit_seconds",
                 "topics_policy",
                 "description",
+                "jitsi_server_url",
             ]:
                 check_realm_update_dict("events[0]", events[0])
             else:

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -102,6 +102,7 @@ class HomeTest(ZulipTestCase):
         "is_guest",
         "is_moderator",
         "is_owner",
+        "jitsi_jwt_enabled",
         "jitsi_server_url",
         "klipy_api_key",
         "last_event_id",

--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -8,6 +8,7 @@ from base64 import b64encode
 from typing import Any, Literal
 from urllib.parse import quote, urlencode, urljoin, urlsplit
 
+import jwt
 import requests
 from defusedxml import ElementTree
 from django.conf import settings
@@ -16,6 +17,7 @@ from django.http import HttpRequest, HttpResponse
 from django.middleware import csrf
 from django.shortcuts import redirect, render
 from django.utils.crypto import constant_time_compare, salted_hmac
+from django.utils.text import slugify
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 from django.views.decorators.cache import never_cache
@@ -29,6 +31,7 @@ from typing_extensions import TypedDict, override
 
 from zerver.actions.video_calls import do_set_video_call_provider_token
 from zerver.decorator import zulip_login_required
+from zerver.lib.avatar import absolute_avatar_url
 from zerver.lib.cache import (
     cache_with_key,
     flush_zoom_server_access_token_cache,
@@ -44,6 +47,7 @@ from zerver.lib.subdomains import get_subdomain
 from zerver.lib.typed_endpoint import typed_endpoint, typed_endpoint_without_parameters
 from zerver.lib.url_encoding import append_url_query_string
 from zerver.lib.utils import assert_is_not_none
+from zerver.lib.video_calls import get_effective_jitsi_server_url, get_jitsi_jwt_config
 from zerver.models import UserProfile
 from zerver.models.realms import get_realm
 
@@ -686,6 +690,81 @@ def join_bigbluebutton(request: HttpRequest, *, bigbluebutton: str) -> HttpRespo
         settings.BIG_BLUE_BUTTON_URL + "api/join", join_params
     )
     return redirect(append_url_query_string(redirect_url_base, "checksum=" + checksum))
+
+
+@typed_endpoint
+def get_jitsi_url(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    *,
+    meeting_name: str,
+    voice_only: Json[bool] = False,
+) -> HttpResponse:
+    jitsi_server_url = get_effective_jitsi_server_url(user_profile.realm)
+    if get_jitsi_jwt_config(jitsi_server_url) is None:
+        raise VideoCallProviderNotConfiguredError("Jitsi JWT")
+
+    # Build a room name that is human-readable (derived from the meeting
+    # name) but unique per call (random suffix)
+    slug = slugify(meeting_name)
+    room = f"{slug}-{random.randint(100000000000, 999999999999)}"
+
+    signed = Signer().sign_object(
+        {
+            "room": room,
+            "voice_only": voice_only,
+            "moderator": user_profile.id,
+        }
+    )
+    url = append_url_query_string("/calls/jitsi/join", "jitsi=" + signed)
+    return json_success(request, data={"url": url})
+
+
+@zulip_login_required
+@never_cache
+@typed_endpoint
+def join_jitsi(request: HttpRequest, *, jitsi: str) -> HttpResponse:
+    assert isinstance(request.user, UserProfile)
+    user_profile = request.user
+    config = get_jitsi_jwt_config(get_effective_jitsi_server_url(user_profile.realm))
+    if config is None:
+        raise VideoCallProviderNotConfiguredError("Jitsi JWT")
+    jitsi_server_url, app_id, app_secret = config
+
+    try:
+        jitsi_data = Signer().unsign_object(jitsi)
+    except Exception:
+        raise JsonableError(_("Invalid signature."))
+
+    room = jitsi_data["room"]
+    voice_only = jitsi_data["voice_only"]
+
+    # https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker/#authentication-using-jwt-tokens
+    payload = {
+        "iss": app_id,
+        "aud": "jitsi",
+        "sub": urlsplit(jitsi_server_url).hostname,
+        "exp": timezone_now() + datetime.timedelta(minutes=5),
+        "room": room,
+        "context": {
+            "user": {
+                "name": user_profile.full_name,
+                "email": user_profile.email,
+                "avatar": absolute_avatar_url(user_profile) or "",
+                "id": str(user_profile.id),
+                "affiliation": "owner" if jitsi_data["moderator"] == user_profile.id else "member",
+            }
+        },
+    }
+    token = jwt.encode(payload, app_secret, algorithm="HS256")
+
+    video_muted = "true" if voice_only else "false"
+    jwt_query = urlencode({"jwt": token})
+    redirect_url = urljoin(
+        jitsi_server_url,
+        f"/{room}?{jwt_query}#config.startWithVideoMuted={video_muted}",
+    )
+    return redirect(redirect_url)
 
 
 @typed_endpoint_without_parameters

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -529,6 +529,9 @@ DROPBOX_APP_KEY = get_secret("dropbox_app_key")
 
 BIG_BLUE_BUTTON_SECRET = get_secret("big_blue_button_secret")
 
+JITSI_SERVER_APP_ID = get_secret("jitsi_server_app_id")
+JITSI_SERVER_APP_SECRET = get_secret("jitsi_server_app_secret")
+
 CONSTRUCTOR_GROUPS_ACCESS_KEY = get_secret("constructor_groups_access_key")
 CONSTRUCTOR_GROUPS_SECRET_KEY = get_secret("constructor_groups_secret_key")
 

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -797,7 +797,9 @@ SOCIAL_AUTH_SAML_SUPPORT_CONTACT = {
 ## Controls the Jitsi Meet video call integration.  By default, the
 ## integration uses the SaaS https://meet.jit.si server.  You can specify
 ## your own Jitsi Meet server, or if you'd like to disable the
-## integration, set JITSI_SERVER_URL = None.
+## integration, set JITSI_SERVER_URL = None. To enable JWT authentication
+## for a self-hosted Jitsi Meet server, set jitsi_server_app_id and
+## jitsi_server_app_secret in zulip-secrets.conf.
 # JITSI_SERVER_URL = "https://jitsi.example.com"
 
 ## Controls the BigBlueButton video call integration.  You must also

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -207,6 +207,10 @@ VIDEO_WEBEX_CLIENT_SECRET = "client_secret"
 BIG_BLUE_BUTTON_SECRET = "123"
 BIG_BLUE_BUTTON_URL = "https://bbb.example.com/bigbluebutton/"
 
+JITSI_SERVER_URL = "https://jitsi.example.com"
+JITSI_SERVER_APP_ID = "zulip_test"
+JITSI_SERVER_APP_SECRET = "test-jitsi-secret-padded-to-32-bytes!!"
+
 CONSTRUCTOR_GROUPS_URL = "https://example.constructor.app/api/groups/xapi"
 CONSTRUCTOR_GROUPS_ACCESS_KEY = "test-access-key"
 CONSTRUCTOR_GROUPS_SECRET_KEY = "test-secret-key"

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -268,7 +268,9 @@ from zerver.views.video_calls import (
     create_nextcloud_talk_url,
     deauthorize_zoom_user,
     get_bigbluebutton_url,
+    get_jitsi_url,
     join_bigbluebutton,
+    join_jitsi,
     make_constructor_groups_video_call,
     make_webex_video_call,
     make_zoom_video_call,
@@ -599,6 +601,8 @@ v1_api_and_json_patterns = [
     rest_path("calls/webex/create", POST=make_webex_video_call),
     # Used to generate a BigBlueButton video call URL
     rest_path("calls/bigbluebutton/create", GET=get_bigbluebutton_url),
+    # Used to generate a Jitsi Meet video call URL (JWT auth only)
+    rest_path("calls/jitsi/create", GET=get_jitsi_url),
     # Used to generate a Constructor Groups video call URL
     rest_path("calls/constructorgroups/create", POST=make_constructor_groups_video_call),
     # Used to generate a Nextcloud Talk video call URL
@@ -739,6 +743,8 @@ i18n_urls = [
     path("calls/webex/complete", complete_webex_user),
     # Used to join a BigBlueButton video call
     path("calls/bigbluebutton/join", join_bigbluebutton),
+    # Used to join a Jitsi Meet video call (JWT auth only)
+    path("calls/jitsi/join", join_jitsi),
     # Integrations documentation
     path(
         "integrations/",


### PR DESCRIPTION
Jitsi Meet supports [JWT-based authentication](https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker/#authentication-using-jwt-tokens) for self-hosted servers, which lets the server pass the joining user's identity to Jitsi.

This PR adds JWT support by introducing two new views:

  - `get_jitsi_url` (`GET /calls/jitsi/create`): slugifies the meeting name, appends a random suffix, signs the room name and call type with Django's `Signer`, and returns a local redirect URL. This keeps the room name server-side so the client cannot tamper with it.
  - `join_jitsi` (`GET /calls/jitsi/join`) : verifies the signed data, builds a JWT with the user's identity (`jwt.encode`), and redirects the user to the Jitsi server with the token.

JWT is only used for self-hosted zulip using self-hosted Jitsi server configured at the server level via `JITSI_SERVER_URL`; the public `meet.jit.si` and realm-level custom Jitsi URLs continue to use the existing non-JWT flow, unchanged.

This change adds a `server_jitsi_jwt_configured` boolean to the POST /register (/api/register-queue) response, indicating whether the Zulip server has JWT credentials configured for its `server_jitsi_server_url`.
 
Previously, clients supporting the modern API always constructed Jitsi call URLs client-side by appending a random room name to `realm_jitsi_server_url ?? server_jitsi_server_url`. Now, when `server_jitsi_jwt_configured` is true and `realm_jitsi_server_url` is null, clients must instead call the new GET /calls/jitsi/create (/api/create-jitsi-video-call) endpoint to obtain a call URL, rather than constructing one directly.

Overriding `realm_jitsi_server_url` to a custom Jitsi Meet server disables the JWT-signed flow for that organization, since the Zulip server's JWT credentials only belong to `server_jitsi_server_url`.

Setup instructions are in `docs/production/video-calls.md`. The integrations page and help center article also mention the new functionality and link to that section.

 The JWT token Zulip generates sets the affiliation field to owner for the call creator and member for other participants, but this only takes effect on the Jitsi server if the https://github.com/jitsi-contrib/prosody-plugins/blob/main/token_affiliation/README.md Prosody plugin is installed and enabled. Without it, the affiliation claim in the token is silently ignored. Is it worth adding a note to the "JWT authentication" section of docs/production/video-calls.md pointing operators to that plugin? 

Fixes: #28657

Conversations:
[#api design > Jitsi with JWT auth, PR #38590, issue #28657](https://chat.zulip.org/#narrow/channel/378-api-design/topic/Jitsi.20with.20JWT.20auth.2C.20PR.20.2338590.2C.20issue.20.2328657/with/2523802)

[#design > Jitsi JWT](https://chat.zulip.org/#narrow/channel/101-design/topic/Jitsi.20JWT/with/2512560)

**How changes were tested:**

The changes were manually tested using dev environment.

**Screenshots and screen captures:**

Functionality:

[Screencast_20260915_112502.webm](https://github.com/user-attachments/assets/ca38efbc-4758-46e4-9bc7-9742c4016357)

<img width="380" height="132" alt="Screenshot_20260915_112148-1" src="https://github.com/user-attachments/assets/7292091a-cdf9-4170-8e4a-42562b6ccf6d" />


Documentation:

Production:

<img width="838" height="824" alt="image" src="https://github.com/user-attachments/assets/e3c1a87c-ef5c-47f5-824b-3e318b560471" />

help-center:
<img width="838" height="824" alt="image" src="https://github.com/user-attachments/assets/a6bdaeac-07c9-481b-8de5-511a045757c0" />


api-doc:
<img width="825" height="1440" alt="image" src="https://github.com/user-attachments/assets/91d854c7-8118-47e6-92a1-499ca835aa03" />


integration:

<img width="975" height="838" alt="image" src="https://github.com/user-attachments/assets/a7d03a61-c8cc-4df9-aea6-05ca531805cc" />

-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
