### PR TITLE
message_list_view: Hide resolve topic option in archived channels

### DIFF
--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -275,7 +275,7 @@ export function get_topic_popover_content_context({
     const can_rename_topic =
         stream_data.user_can_move_messages_within_channel(sub) &&
         !stream_data.is_empty_topic_only_channel(sub.stream_id);
-    const can_resolve_topic = !sub.is_archived && stream_data.can_resolve_topics(sub);
+    const can_resolve_topic = stream_data.can_resolve_topics(sub);
 
     const visibility_policy = user_topics.get_topic_visibility_policy(sub.stream_id, topic_name);
     const all_visibility_policies = user_topics.all_visibility_policies;

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -812,6 +812,10 @@ export function can_subscribe_others(sub: StreamSubscription): boolean {
 }
 
 export function can_resolve_topics(sub: StreamSubscription | undefined): boolean {
+    if (sub?.is_archived) {
+        return false;
+    }
+
     if (settings_data.user_can_resolve_topic()) {
         return true;
     }

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -1643,6 +1643,13 @@ test("can_resolve_topics", ({override}) => {
         can_resolve_topics_group: admins_group.id,
     };
     stream_data.add_sub_for_tests(sub);
+    const archived_sub = {
+        name: "Archived",
+        stream_id: 99,
+        is_archived: true,
+        can_resolve_topics_group: admins_group.id,
+    };
+    stream_data.add_sub_for_tests(archived_sub);
 
     assert.equal(stream_data.can_resolve_topics(undefined), false);
     initialize_and_override_current_user(admin_user_id, override);
@@ -1666,6 +1673,8 @@ test("can_resolve_topics", ({override}) => {
     assert.equal(stream_data.can_resolve_topics(sub), true);
     initialize_and_override_current_user(test_user.user_id, override);
     assert.equal(stream_data.can_resolve_topics(sub), true);
+    initialize_and_override_current_user(admin_user_id, override);
+    assert.equal(stream_data.can_resolve_topics(archived_sub), false);
 });
 
 test("can_unsubscribe_others", ({override}) => {


### PR DESCRIPTION
The resolve topic option was incorrectly shown in the message view header for archived channels, where it serves no purpose since users cannot send messages there.

This was inconsistent with the popover menu, which already had the correct `is_archived` guard in place (`popover_menus_data.ts`). Fixed by adding the same guard to `message_list_view.ts`:


Fixes: [#issues > resolve topic button in archived channel conversation](https://chat.zulip.org/#narrow/channel/9-issues/topic/resolve.20topic.20button.20in.20archived.20channel.20conversation/with/2414519)


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|-------|
|<img width="1039" height="228" alt="Screenshot 2026-03-21 032058" src="https://github.com/user-attachments/assets/f3382f2f-bc21-412c-bb50-43ddbc90ebd6" />|<img width="1035" height="219" alt="Screenshot 2026-03-21 032210" src="https://github.com/user-attachments/assets/de6e1a56-81df-4ab8-8dfb-05ba70aa8003" />|

| Before | After |
|--------|-------|
|<img width="1030" height="469" alt="Screenshot 2026-03-21 032757" src="https://github.com/user-attachments/assets/be9e4bc9-99b8-4580-af37-e23089ac62f4" />|<img width="1031" height="470" alt="Screenshot 2026-03-21 032818" src="https://github.com/user-attachments/assets/7a8c86fd-d807-4fe4-a365-81537ff9eeea" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
