### PR TITLE
screenshots: Replace jQuery globals in screenshot scripts.

### DIFF
--- a/tools/screenshots/message-screenshot.ts
+++ b/tools/screenshots/message-screenshot.ts
@@ -1,4 +1,4 @@
-/* global $, CSS */
+/* global CSS */
 
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -73,10 +73,14 @@ async function run(): Promise<void> {
         await page.waitForSelector(messageSelector);
         // remove unread marker and don't select message
         const marker = `#message-row-${message_list_id}-${CSS.escape(messageId)} .unread_marker`;
-        await page.evaluate((sel) => $(sel).remove(), marker);
+        await page.evaluate((sel) => {
+            globalThis.document.querySelector(sel)?.remove();
+        }, marker);
         const messageBox = await page.$(messageSelector);
         assert.ok(messageBox !== null);
-        await page.evaluate((msg) => $(msg).removeClass("selected_message"), messageSelector);
+        await page.evaluate((msg) => {
+            globalThis.document.querySelector(msg)?.classList.remove("selected_message");
+        }, messageSelector);
         const messageGroup = await messageBox.$("xpath/..");
         assert.ok(messageGroup !== null);
         // Compute screenshot area, with some padding around the message group

--- a/tools/screenshots/thread-screenshot.ts
+++ b/tools/screenshots/thread-screenshot.ts
@@ -1,4 +1,4 @@
-/* global $, CSS */
+/* global CSS */
 
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -85,7 +85,7 @@ async function run(): Promise<void> {
             `${message_list_id}`,
         )}"] .unread_marker`;
         await page.evaluate((sel) => {
-            $(sel).remove();
+            globalThis.document.querySelector(sel)?.remove();
         }, marker);
 
         const messageSelector = `#message-row-${message_list_id}-${CSS.escape(messageId)}`;
@@ -93,13 +93,17 @@ async function run(): Promise<void> {
 
         const messageListBox = await page.$(messageListSelector);
         assert.ok(messageListBox !== null);
-        await page.evaluate((msg) => $(msg).removeClass("selected_message"), messageSelector);
+        await page.evaluate((msg) => {
+            globalThis.document.querySelector(msg)?.classList.remove("selected_message");
+        }, messageSelector);
 
         // This is done so as to get white background while capturing screenshots.
         const background_selectors = [".app-main", ".message-feed", ".message_header"];
         await page.evaluate((selectors) => {
             for (const selector of selectors) {
-                $(selector).css("background-color", "white");
+                for (const element of globalThis.document.querySelectorAll<HTMLElement>(selector)) {
+                    element.style.backgroundColor = "white";
+                }
             }
         }, background_selectors);
 


### PR DESCRIPTION
The screenshot generation scripts were failing with ReferenceError: $ is not defined after #37788 removed the expose-loader configuration that exposed jQuery globally in the webpack build.

The scripts were still using $ inside page.evaluate() callbacks, which run in the browser page context where $ is no longer available.

Changes:

- Removed $ from /* global $, CSS */ in both screenshot scripts
- Replaced $(sel).remove() with querySelectorAll + element.remove()
- Replaced $(msg).removeClass("selected_message") with querySelector + classList.remove()
- Replaced $(selector).css("background-color", "white") with element.style.backgroundColor = "white"

**How changes were tested:**
-  `./tools/screenshots/generate-integration-docs-screenshot --integration github`
- `./tools/screenshots/generate-user-messages-screenshot --thread tools/screenshots/companies.json`

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
