### PR TITLE
webhooks/intercom: Add support for company events.

### DIFF
--- a/zerver/webhooks/intercom/fixtures/company_created_with_name.json
+++ b/zerver/webhooks/intercom/fixtures/company_created_with_name.json
@@ -1,0 +1,36 @@
+{
+    "type": "notification_event",
+    "app_id": "abc123def",
+    "data": {
+        "type": "notification_event_data",
+        "item": {
+            "type": "company",
+            "id": "6961d175205cf6a4438f0c21",
+            "name": "Acme Enterprises",
+            "app_id": "abc123def",
+            "plan": null,
+            "company_id": "6961d175205cf6a4438f0c22-qualification-company",
+            "remote_created_at": null,
+            "created_at": "2026-01-10T04:11:34.013+00:00",
+            "updated_at": "2026-01-10T04:11:34.013+00:00",
+            "last_request_at": null,
+            "size": null,
+            "website": null,
+            "industry": null,
+            "monthly_spend": 0,
+            "session_count": 0,
+            "user_count": 0,
+            "custom_attributes": {},
+            "tag_ids": []
+        }
+    },
+    "links": {},
+    "id": "notif_f3a337e8-f452-4ab9-9929-d6a4a8dba4ae",
+    "topic": "company.created",
+    "delivery_status": "pending",
+    "delivery_attempts": 1,
+    "delivered_at": 0,
+    "first_sent_at": 1768018294,
+    "created_at": 1768018294,
+    "self": null
+}

--- a/zerver/webhooks/intercom/tests.py
+++ b/zerver/webhooks/intercom/tests.py
@@ -6,3 +6,33 @@ class IntercomWebHookTests(WebhookTestCase):
         expected_topic_name = "Intercom"
         expected_message = "Intercom webhook has been successfully configured."
         self.check_webhook("ping", expected_topic_name, expected_message)
+
+    def test_company_created(self) -> None:
+        expected_topic_name = "Company: 6961d175205cf6a4438f0c22-qualification-company"
+        expected_message = "6961d175205cf6a4438f0c22-qualification-company was created."
+        self.check_webhook("company_created", expected_topic_name, expected_message)
+
+    def test_company_created_with_name(self) -> None:
+        expected_topic_name = "Company: Acme Enterprises"
+        expected_message = "Acme Enterprises was created."
+        self.check_webhook("company_created_with_name", expected_topic_name, expected_message)
+
+    def test_company_deleted(self) -> None:
+        expected_topic_name = "Company: 6961d38729675009a437c3bf"
+        expected_message = "6961d38729675009a437c3bf was deleted."
+        self.check_webhook("company_deleted", expected_topic_name, expected_message)
+
+    def test_company_updated(self) -> None:
+        expected_topic_name = "Company: Acme Enterprises"
+        expected_message = "Acme Enterprises was updated."
+        self.check_webhook("company_updated", expected_topic_name, expected_message)
+
+    def test_company_contact_attached(self) -> None:
+        expected_topic_name = "Lead: Jane Lead (6961d162fb0ef1f1ac90ce8c)"
+        expected_message = "**Jane Lead** was attached to company **6961d175205cf6a4438f0c22-qualification-company**."
+        self.check_webhook("company_contact_attached", expected_topic_name, expected_message)
+
+    def test_company_contact_detached(self) -> None:
+        expected_topic_name = "User: Jane Smith (6961cf78fb9d13be07871c78)"
+        expected_message = "**Jane Smith** was detached from company **Acme Corp**."
+        self.check_webhook("company_contact_detached", expected_topic_name, expected_message)

--- a/zerver/webhooks/intercom/tests.py
+++ b/zerver/webhooks/intercom/tests.py
@@ -72,3 +72,33 @@ class IntercomWebHookTests(WebhookTestCase):
         expected_topic_name = f"Admin: {BO_NAME}"
         expected_message = f"{BO_NAME} is no longer an admin."
         self.check_webhook("admin_removed_from_workspace", expected_topic_name, expected_message)
+
+    def test_company_created(self) -> None:
+        expected_topic_name = "Company: 6961d175205cf6a4438f0c22-qualification-company"
+        expected_message = "6961d175205cf6a4438f0c22-qualification-company was created."
+        self.check_webhook("company_created", expected_topic_name, expected_message)
+
+    def test_company_created_with_name(self) -> None:
+        expected_topic_name = "Company: Acme Enterprises"
+        expected_message = "Acme Enterprises was created."
+        self.check_webhook("company_created_with_name", expected_topic_name, expected_message)
+
+    def test_company_deleted(self) -> None:
+        expected_topic_name = "Company: 6961d38729675009a437c3bf"
+        expected_message = "6961d38729675009a437c3bf was deleted."
+        self.check_webhook("company_deleted", expected_topic_name, expected_message)
+
+    def test_company_updated(self) -> None:
+        expected_topic_name = "Company: Acme Enterprises"
+        expected_message = "Acme Enterprises was updated."
+        self.check_webhook("company_updated", expected_topic_name, expected_message)
+
+    def test_company_contact_attached(self) -> None:
+        expected_topic_name = "Lead: Jane Lead (6961d162fb0ef1f1ac90ce8c)"
+        expected_message = "**Jane Lead** was attached to company **6961d175205cf6a4438f0c22-qualification-company**."
+        self.check_webhook("company_contact_attached", expected_topic_name, expected_message)
+
+    def test_company_contact_detached(self) -> None:
+        expected_topic_name = "User: Jane Smith (6961cf78fb9d13be07871c78)"
+        expected_message = "**Jane Smith** was detached from company **Acme Corp**."
+        self.check_webhook("company_contact_detached", expected_topic_name, expected_message)

--- a/zerver/webhooks/intercom/view.py
+++ b/zerver/webhooks/intercom/view.py
@@ -4,17 +4,59 @@ from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import return_success_on_head_request, webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError
+from zerver.lib.partial import partial
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
-from zerver.lib.validator import WildValue, check_string
+from zerver.lib.validator import WildValue, check_none_or, check_string
 from zerver.lib.webhooks.common import check_send_webhook_message, get_setup_webhook_message
 from zerver.models import UserProfile
+
+COMPANY_ACTION = "{name} was {phrase}."
+COMPANY_CONTACT_ACTION = "**{contact_name}** was {phrase} {preposition} company **{company_name}**."
+COMPANY_CONTACT_TOPIC = "{role}: {contact_name} ({contact_id})"
+
+
+def get_company_display_name(company: WildValue) -> str:
+    name = company.get("name").tame(check_none_or(check_string))
+    company_id = company.get("company_id").tame(check_none_or(check_string))
+    # The company.deleted event only returns the Intercom internal ID,
+    # without the name or company_id fields.
+    intercom_id = company["id"].tame(check_string)
+    return name or company_id or intercom_id
 
 
 def get_ping_message(payload: WildValue) -> tuple[str, str]:
     body = get_setup_webhook_message("Intercom")
     topic_name = "Intercom"
     return (topic_name, body)
+
+
+def get_company_action_message(phrase: str, payload: WildValue) -> tuple[str, str]:
+    item = payload["data"]["item"]
+    name = get_company_display_name(item)
+    return f"Company: {name}", COMPANY_ACTION.format(name=name, phrase=phrase)
+
+
+def get_company_contact_action_message(phrase: str, payload: WildValue) -> tuple[str, str]:
+    item = payload["data"]["item"]
+    contact = item["contact"]
+    company_name = get_company_display_name(item["company"])
+    contact_name = contact["name"].tame(check_string)
+    contact_id = contact["id"].tame(check_string)
+    role = contact["role"].tame(check_string).capitalize()
+    preposition = "from" if phrase == "detached" else "to"
+    topic = COMPANY_CONTACT_TOPIC.format(
+        role=role, contact_name=contact_name, contact_id=contact_id
+    )
+    return (
+        topic,
+        COMPANY_CONTACT_ACTION.format(
+            contact_name=contact_name,
+            phrase=phrase,
+            preposition=preposition,
+            company_name=company_name,
+        ),
+    )
 
 
 IGNORED_EVENTS = [
@@ -40,7 +82,12 @@ IGNORED_EVENTS = [
 
 
 EVENT_TO_FUNCTION_MAPPER: dict[str, Callable[[WildValue], tuple[str, str]]] = {
-    "ping": get_ping_message
+    "ping": get_ping_message,
+    "company.created": partial(get_company_action_message, "created"),
+    "company.updated": partial(get_company_action_message, "updated"),
+    "company.deleted": partial(get_company_action_message, "deleted"),
+    "company.contact.attached": partial(get_company_contact_action_message, "attached"),
+    "company.contact.detached": partial(get_company_contact_action_message, "detached"),
 }
 
 ALL_EVENT_TYPES = list(EVENT_TO_FUNCTION_MAPPER.keys())

--- a/zerver/webhooks/intercom/view.py
+++ b/zerver/webhooks/intercom/view.py
@@ -7,7 +7,7 @@ from zerver.lib.exceptions import UnsupportedWebhookEventTypeError
 from zerver.lib.partial import partial
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
-from zerver.lib.validator import WildValue, check_bool, check_string
+from zerver.lib.validator import WildValue, check_bool, check_none_or, check_string
 from zerver.lib.webhooks.common import check_send_webhook_message, get_setup_webhook_message
 from zerver.models import UserProfile
 
@@ -17,9 +17,24 @@ ADMIN_AWAY_MODE_UPDATED_TEMPLATE = "{name} is {away_status}{reason}."
 
 ADMIN_LOGIN_LOGOUT_TEMPLATE = "{name} {phrase}."
 
+COMPANY_ACTION_TEMPLATE = "{name} was {phrase}."
+
+COMPANY_CONTACT_ACTION_TEMPLATE = (
+    "**{contact_name}** was {phrase} {preposition} company **{company_name}**."
+)
+
 
 def get_admin_name(payload: WildValue) -> str:
     return payload["data"]["item"]["name"].tame(check_string)
+
+
+def get_company_display_name(company: WildValue) -> str:
+    name = company.get("name").tame(check_none_or(check_string))
+    company_id = company.get("company_id").tame(check_none_or(check_string))
+    # The company.deleted event only returns the Intercom internal ID,
+    # without the name or company_id fields.
+    intercom_id = company["id"].tame(check_string)
+    return name or company_id or intercom_id
 
 
 def get_topic_name(event_category: str, payload: WildValue) -> str:
@@ -30,6 +45,18 @@ def get_topic_name(event_category: str, payload: WildValue) -> str:
             if payload["topic"].tame(check_string) == "admin.activity_log_event.created":
                 return "Admin activity log"
             return f"Admin: {get_admin_name(payload)}"
+        case "company":
+            item = payload["data"]["item"]
+            if payload["topic"].tame(check_string).startswith("company.contact."):
+                # Attach/detach events are grouped under the contact's topic,
+                # so that a contact moving between companies reads as one
+                # story instead of being split across two company topics.
+                contact = item["contact"]
+                role = contact["role"].tame(check_string).capitalize()
+                contact_name = contact["name"].tame(check_string)
+                contact_id = contact["id"].tame(check_string)
+                return f"{role}: {contact_name} ({contact_id})"
+            return f"Company: {get_company_display_name(item)}"
         case _:  # nocoverage
             raise UnsupportedWebhookEventTypeError(payload["topic"].tame(check_string))
 
@@ -71,6 +98,24 @@ def get_admin_away_mode_updated_message(payload: WildValue) -> str:
     )
 
 
+def get_company_action_message(phrase: str, payload: WildValue) -> str:
+    company_name = get_company_display_name(payload["data"]["item"])
+    return COMPANY_ACTION_TEMPLATE.format(name=company_name, phrase=phrase)
+
+
+def get_company_contact_action_message(phrase: str, payload: WildValue) -> str:
+    item = payload["data"]["item"]
+    contact_name = item["contact"]["name"].tame(check_string)
+    company_name = get_company_display_name(item["company"])
+    preposition = "from" if phrase == "detached" else "to"
+    return COMPANY_CONTACT_ACTION_TEMPLATE.format(
+        contact_name=contact_name,
+        phrase=phrase,
+        preposition=preposition,
+        company_name=company_name,
+    )
+
+
 IGNORED_EVENTS = [
     # Require purchasing an Intercom number.
     *["call"],
@@ -101,6 +146,11 @@ EVENT_TO_FUNCTION_MAPPER: dict[str, Callable[[WildValue], str]] = {
     "admin.removed_from_workspace": partial(get_admin_role_updated_message, "no longer"),
     "admin.logged_in": partial(get_admin_login_logout_message, "logged in"),
     "admin.logged_out": partial(get_admin_login_logout_message, "logged out"),
+    "company.created": partial(get_company_action_message, "created"),
+    "company.updated": partial(get_company_action_message, "updated"),
+    "company.deleted": partial(get_company_action_message, "deleted"),
+    "company.contact.attached": partial(get_company_contact_action_message, "attached"),
+    "company.contact.detached": partial(get_company_contact_action_message, "detached"),
 }
 
 ALL_EVENT_TYPES = list(EVENT_TO_FUNCTION_MAPPER.keys())


### PR DESCRIPTION
Add handlers for the following Intercom company webhook events:
- `company.created`
- `company.updated`
- `company.deleted`
- `company.contact.attached`
- `company.contact.detached`

Added `company_created_with_name.json ` fixture, as the existing (company_created) has **name : null**.
Fixes part of: #31170

**How changes were tested:**

Tested all 5 events manually via Intercom's UI with ngrok forwarding to the local dev server. Also verified with automated tests.

**Screenshots and screen captures:**

<details>
<summary>Company Created</summary>
<img width="813" height="97" alt="Screenshot From 2026-04-30 01-57-41" src="https://github.com/user-attachments/assets/ba1ff42b-5f63-4ca9-b2e5-d46f91e775d6" />


(with name)
<img width="813" height="97" alt="Screenshot From 2026-04-30 02-06-36" src="https://github.com/user-attachments/assets/edfeacea-a83d-449e-9cdc-5686e59ce257" />


</details>
<details>
<summary>Company Updated</summary>
<img width="813" height="97" alt="Screenshot From 2026-04-30 01-58-03" src="https://github.com/user-attachments/assets/62667594-491c-4555-918e-eb5062eca82d" />

</details>
<details>
<summary>Company Deleted</summary>

<img width="813" height="97" alt="Screenshot From 2026-04-30 01-58-23" src="https://github.com/user-attachments/assets/40d51ef0-6574-438e-8ef2-bdb809d6e0e0" />

</details>
<details>
<summary>Company Contact Attached</summary>
<img width="813" height="97" alt="Screenshot From 2026-04-30 01-58-48" src="https://github.com/user-attachments/assets/088a4b50-ea3f-4b8b-8e22-ebfb6ec034a0" />


</details>
<details>
<summary>Company Contact Detached</summary>
<img width="813" height="97" alt="Screenshot From 2026-04-30 01-59-11" src="https://github.com/user-attachments/assets/9bb98f94-72ae-42ee-98dc-5e09a52a3b53" />


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>