### PR TITLE
Improve wording in asking great questions guide

### DIFF
--- a/docs/contributing/asking-great-questions.md
+++ b/docs/contributing/asking-great-questions.md
@@ -2,8 +2,8 @@
 
 A well-formed question helps you learn, respects the person answering, and makes
 efficient use of time for everyone involved. Asking the right question, to the
-right person, in the right way, at the right time, is a skill which requires a
-lifetime of fine-tuning. This page offers some guidelines and resources that the
+right person, in the right way, at the right time, is a skill that requires a
+lifetime of fine-tuning. This page offers some guidelines and resources the
 [Zulip community](https://zulip.com/development-community/) has found helpful in this pursuit.
 
 ## Where to ask your question
@@ -16,7 +16,7 @@ the discussion.
 The [Zulip community
 guide](https://zulip.com/development-community/#where-do-i-send-my-message)
 offers guidelines on how the major public channels in the community are used.
-Don’t stress too much about picking the right place if you’re not sure, as
+Don’t stress too much about picking the right place if you're not sure, as
 moderators can [move your question thread to a different
 channel](https://zulip.com/help/move-content-to-another-channel) if needed.
 
@@ -36,7 +36,7 @@ In brief, to formulate a great question, you should:
 - Try to solve your own problem first, including reading through relevant
   documentation and code.
 - Identify the precise point on which you feel stuck.
-- Formulate a clear question, which includes an appropriate amount of context
+- Formulate a clear question that includes an appropriate amount of context
   and a specific request for help.
 
 When your question is answered, follow through on the advice you receive, and (when

--- a/docs/contributing/asking-great-questions.md
+++ b/docs/contributing/asking-great-questions.md
@@ -2,8 +2,8 @@
 
 A well-formed question helps you learn, respects the person answering, and makes
 efficient use of time for everyone involved. Asking the right question, to the
-right person, in the right way, at the right time, is a skill which requires a
-lifetime of fine-tuning. This page offers some guidelines and resources that the
+right person, in the right way, at the right time, is a skill that requires a
+lifetime of fine-tuning. This page offers some guidelines and resources the
 [Zulip community](https://zulip.com/development-community/) has found helpful in this pursuit.
 
 ## Where to ask your question
@@ -36,7 +36,7 @@ In brief, to formulate a great question, you should:
 - Try to solve your own problem first, including reading through relevant
   documentation and code.
 - Identify the precise point on which you feel stuck.
-- Formulate a clear question, which includes an appropriate amount of context
+- Formulate a clear question that includes an appropriate amount of context
   and a specific request for help.
 
 When your question is answered, follow through on the advice you receive, and (when


### PR DESCRIPTION
This PR improves grammar and clarity in the asking great questions documentation.

Changes made:
- Changed "which requires" to "that requires" for better grammar
- Removed redundant "that" before "the [Zulip community]" for clearer phrasing

These are minor wording improvements to make the documentation more professional and easier to read.