### PR TITLE
streams: Send notification when users are unsubscribed from channels.

### DIFF
--- a/api_docs/unmerged.d/ZF-515bab.md
+++ b/api_docs/unmerged.d/ZF-515bab.md
@@ -1,2 +1,20 @@
+* [`DELETE /users/me/subscriptions`](/api/unsubscribe): The server now
+  sends a Notification Bot direct message to users who have been
+  unsubscribed from one or more channels by another user. Self-
+  unsubscribes and unsubscribed bots do not receive these notifications.
+
+* [`DELETE /users/me/subscriptions`](/api/unsubscribe): Added the
+  `send_messages_to_removed_subscribers` parameter, which determines
+  whether the server sends the Notification Bot direct messages
+  introduced above to users who were unsubscribed by this request.
+
+* [`DELETE /users/me/subscriptions`](/api/unsubscribe): Added
+  `messages_sent_to_removed_subscribers` to the response, which is only
+  present if `send_messages_to_removed_subscribers` was `true` in the
+  request.
+
 * [`POST /register`](/api/register-queue): Renamed
-  `max_bulk_new_subscription_messages` to `max_bulk_subscription_messages`.
+  `max_bulk_new_subscription_messages` to `max_bulk_subscription_messages`,
+  reflecting that the cap now also applies to the
+  `send_messages_to_removed_subscribers` parameter on
+  [`DELETE /users/me/subscriptions`](/api/unsubscribe).

--- a/api_docs/unmerged.d/ZF-515bab.md
+++ b/api_docs/unmerged.d/ZF-515bab.md
@@ -1,0 +1,2 @@
+* [`POST /register`](/api/register-queue): Renamed
+  `max_bulk_new_subscription_messages` to `max_bulk_subscription_messages`.

--- a/api_docs/unmerged.d/ZF-515bab.md
+++ b/api_docs/unmerged.d/ZF-515bab.md
@@ -1,2 +1,22 @@
+* [`DELETE /users/me/subscriptions`](/api/unsubscribe): The server now
+  sends a [Notification Bot](/help/configure-automated-notices) direct
+  message to users who have been unsubscribed from one or more channels
+  by another user. Self-unsubscribes and unsubscribed bots do not
+  receive these notifications.
+
+* [`DELETE /users/me/subscriptions`](/api/unsubscribe): Added
+  `send_messages_to_removed_subscribers` boolean parameter, which
+  determines whether the server sends the Notification Bot direct
+  messages introduced above to users who were unsubscribed by this
+  request.
+
+* [`DELETE /users/me/subscriptions`](/api/unsubscribe): Added
+  `messages_sent_to_removed_subscribers` boolean field to the response,
+  which is only present if `send_messages_to_removed_subscribers` was
+  `true` in the request.
+
 * [`POST /register`](/api/register-queue): Renamed
-  `max_bulk_new_subscription_messages` to `max_bulk_subscription_messages`.
+  `max_bulk_new_subscription_messages` to `max_bulk_subscription_messages`,
+  reflecting that the cap now also applies to the
+  `send_messages_to_removed_subscribers` parameter on
+  [`DELETE /users/me/subscriptions`](/api/unsubscribe).

--- a/starlight_help/src/content/docs/configure-automated-notices.mdx
+++ b/starlight_help/src/content/docs/configure-automated-notices.mdx
@@ -75,7 +75,8 @@ automated notices to help others understand how content was moved.
 ## Notices about users
 
 You will be notified if someone [subscribes you to a
-channel](/help/subscribe-users-to-a-channel), or changes your
+channel](/help/subscribe-users-to-a-channel), [unsubscribes you from a
+channel](/help/unsubscribe-users-from-a-channel), or changes your
 [group](/help/user-groups) membership.
 
 ### New user announcements

--- a/starlight_help/src/content/include/_AutomatedDmChannelUnsubscription.mdx
+++ b/starlight_help/src/content/include/_AutomatedDmChannelUnsubscription.mdx
@@ -1,0 +1,6 @@
+import ZulipNote from "../../components/ZulipNote.astro";
+
+<ZulipNote>
+  **Note**: Unsubscribing someone else from a channel sends them an
+  automated direct message from Notification Bot.
+</ZulipNote>

--- a/starlight_help/src/content/include/_UnsubscribeUserFromChannel.mdx
+++ b/starlight_help/src/content/include/_UnsubscribeUserFromChannel.mdx
@@ -2,6 +2,7 @@ import {TabItem, Tabs} from "@astrojs/starlight/components";
 
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import NavigationSteps from "../../components/NavigationSteps.astro";
+import AutomatedDmChannelUnsubscription from "../include/_AutomatedDmChannelUnsubscription.mdx";
 import ChannelSettingsNavbarTip from "../include/_ChannelSettingsNavbarTip.mdx";
 import DependsOnPermissions from "../include/_DependsOnPermissions.mdx";
 import RightSidebarViewProfile from "../include/_RightSidebarViewProfile.mdx";
@@ -39,3 +40,5 @@ import CloseIcon from "~icons/zulip-icon/close";
     </FlattenedSteps>
   </TabItem>
 </Tabs>
+
+<AutomatedDmChannelUnsubscription />

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -454,7 +454,7 @@ export const realm_schema = z.object({
     max_stream_description_length: z.number(),
     max_stream_name_length: z.number(),
     max_topic_length: z.number(),
-    max_bulk_new_subscription_messages: z.number(),
+    max_bulk_subscription_messages: z.number(),
     password_min_guesses: z.number(),
     password_min_length: z.number(),
     password_max_length: z.number(),

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -460,7 +460,7 @@ export const realm_schema = z.object({
     max_stream_description_length: z.number(),
     max_stream_name_length: z.number(),
     max_topic_length: z.number(),
-    max_bulk_new_subscription_messages: z.number(),
+    max_bulk_subscription_messages: z.number(),
     password_min_guesses: z.number(),
     password_min_length: z.number(),
     password_max_length: z.number(),

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -119,7 +119,7 @@ function show_stream_subscription_request_success_result({
 function update_notification_choice_checkbox(added_user_count: number): void {
     const $send_notification_checkbox = $(".send_notification_to_new_subscribers");
     const $send_notification_container = $(".send_notification_to_new_subscribers_container");
-    if (added_user_count > realm.max_bulk_new_subscription_messages) {
+    if (added_user_count > realm.max_bulk_subscription_messages) {
         $send_notification_checkbox.prop("checked", false);
         $send_notification_checkbox.prop("disabled", true);
         $send_notification_container.addClass("control-label-disabled");

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -983,7 +983,7 @@ export function initialize(): void {
                         "Notification message cannot be sent when subscribing more than {max_users} users.",
                 },
                 {
-                    max_users: realm.max_bulk_new_subscription_messages,
+                    max_users: realm.max_bulk_subscription_messages,
                 },
             );
             instance.setContent(content);

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -986,7 +986,7 @@ export function initialize(): void {
                         "Notification message cannot be sent when subscribing more than {max_users} users.",
                 },
                 {
-                    max_users: realm.max_bulk_new_subscription_messages,
+                    max_users: realm.max_bulk_subscription_messages,
                 },
             );
             instance.setContent(content);

--- a/web/tests/lib/example_realm.cjs
+++ b/web/tests/lib/example_realm.cjs
@@ -19,7 +19,7 @@ exports.make_realm = (opts = {}) => {
         max_stream_description_length: 0,
         max_stream_name_length: 0,
         max_topic_length: 0,
-        max_bulk_new_subscription_messages: 0,
+        max_bulk_subscription_messages: 0,
         password_min_guesses: 0,
         password_min_length: 0,
         password_max_length: 0,

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -590,7 +590,7 @@ def fetch_initial_state_data(
 
         state["max_stream_name_length"] = Stream.MAX_NAME_LENGTH
         state["max_stream_description_length"] = Stream.MAX_DESCRIPTION_LENGTH
-        state["max_bulk_new_subscription_messages"] = settings.MAX_BULK_NEW_SUBSCRIPTION_MESSAGES
+        state["max_bulk_subscription_messages"] = settings.MAX_BULK_SUBSCRIPTION_MESSAGES
         state["max_topic_length"] = MAX_TOPIC_NAME_LENGTH
         state["max_message_length"] = settings.MAX_MESSAGE_LENGTH
         state["max_channel_folder_name_length"] = ChannelFolder.MAX_NAME_LENGTH

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -22735,13 +22735,16 @@ paths:
                               Configuration for group level group permission settings.
                             additionalProperties:
                               $ref: "#/components/schemas/GroupPermissionSetting"
-                      max_bulk_new_subscription_messages:
+                      max_bulk_subscription_messages:
                         description: |
                           Maximum number of new subscribers for which the server will
                           respect the `send_new_subscription_messages` parameter when
                           [adding subscribers to a channel](/api/subscribe#parameter-send_new_subscription_messages).
 
-                          **Changes**: New in Zulip 11.0 (feature level 397).
+                          **Changes**: In Zulip 13.0 (feature level ZF-515bab), renamed from
+                          `max_bulk_new_subscription_messages`.
+
+                          New in Zulip 11.0 (feature level 397).
                         type: number
                         example: 100
                     example:
@@ -30843,7 +30846,7 @@ components:
 
         The server will never send direct messages when the total number of users
         who were subscribed to channels in this request was more than the value
-        of `max_bulk_new_subscription_messages`, which is available in the [`POST
+        of `max_bulk_subscription_messages`, which is available in the [`POST
         /register`](/api/register-queue) response.
 
         **Changes**: Before Zulip 11.0 (feature level 397), new subscribers

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13488,6 +13488,19 @@ paths:
                           with users about the effect of this request.
 
                           **Changes**: New in Zulip 11.0 (feature level 397).
+                      messages_sent_to_removed_subscribers:
+                        type: boolean
+                        description: |
+                          Only present if the parameter `send_messages_to_removed_subscribers`
+                          in the request was `true`.
+
+                          Whether Notification Bot DMs were in fact sent to the removed
+                          subscribers as requested by the
+                          `send_messages_to_removed_subscribers` parameter. Clients may
+                          find this value useful to communicate with users about the
+                          effect of this request.
+
+                          **Changes**: New in Zulip 13.0 (feature level ZF-515bab).
                     example:
                       {
                         "msg": "",
@@ -13518,7 +13531,14 @@ paths:
           by the [`can_remove_subscribers_group`][can-remove-parameter]
           for the channel.
 
-        **Changes**: Before Zulip 10.0 (feature level 362),
+        **Changes**: In Zulip 13.0 (feature level ZF-515bab), the server began sending a
+        Notification Bot direct message to users who have been
+        unsubscribed from one or more channels by another user, with
+        accompanying `send_messages_to_removed_subscribers` request
+        parameter and `messages_sent_to_removed_subscribers` response
+        field documented below.
+
+        Before Zulip 10.0 (feature level 362),
         subscriptions in archived channels could not be modified.
 
         Before Zulip 8.0 (feature level 208), if a user specified by
@@ -13574,12 +13594,29 @@ paths:
                   example: ["Verona", "Denmark"]
                 principals:
                   $ref: "#/components/schemas/Principals"
+                send_messages_to_removed_subscribers:
+                  description: |
+                    Whether other users unsubscribed via this request should be sent a
+                    direct message, from Notification Bot, notifying them that they
+                    were unsubscribed and by whom.
+
+                    The server will never send direct messages when the total number of
+                    users who were unsubscribed from channels in this request was more
+                    than the value of `max_bulk_subscription_messages`, which is
+                    available in the [`POST /register`](/api/register-queue) response.
+
+                    **Changes**: New in Zulip 13.0 (feature level ZF-515bab).
+                  type: boolean
+                  default: true
+                  example: true
               required:
                 - subscriptions
             encoding:
               subscriptions:
                 contentType: application/json
               principals:
+                contentType: application/json
+              send_messages_to_removed_subscribers:
                 contentType: application/json
       responses:
         "200":
@@ -13608,6 +13645,19 @@ paths:
                         description: |
                           A list of the names of channels which were unsubscribed from as a result
                           of the query.
+                      messages_sent_to_removed_subscribers:
+                        type: boolean
+                        description: |
+                          Only present if the parameter `send_messages_to_removed_subscribers`
+                          in the request was `true`.
+
+                          Whether Notification Bot DMs were in fact sent to the removed
+                          subscribers as requested by the
+                          `send_messages_to_removed_subscribers` parameter. Clients may
+                          find this value useful to communicate with users about the
+                          effect of this request.
+
+                          **Changes**: New in Zulip 13.0 (feature level ZF-515bab).
                     example:
                       {
                         "msg": "",
@@ -22737,12 +22787,15 @@ paths:
                               $ref: "#/components/schemas/GroupPermissionSetting"
                       max_bulk_subscription_messages:
                         description: |
-                          Maximum number of new subscribers for which the server will
+                          Maximum number of affected users for which the server will
                           respect the `send_new_subscription_messages` parameter when
-                          [adding subscribers to a channel](/api/subscribe#parameter-send_new_subscription_messages).
+                          [adding subscribers to a channel](/api/subscribe#parameter-send_new_subscription_messages),
+                          or the `send_messages_to_removed_subscribers` parameter when
+                          [unsubscribing users from a channel](/api/unsubscribe#parameter-send_messages_to_removed_subscribers).
 
                           **Changes**: In Zulip 13.0 (feature level ZF-515bab), renamed from
-                          `max_bulk_new_subscription_messages`.
+                          `max_bulk_new_subscription_messages`; the cap now applies to
+                          both subscription and unsubscription notifications.
 
                           New in Zulip 11.0 (feature level 397).
                         type: number
@@ -25327,7 +25380,7 @@ paths:
             The target message's ID.
           schema:
             type: integer
-          example: 47
+          example: 48
           required: true
       requestBody:
         required: true

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -22877,13 +22877,16 @@ paths:
                               Configuration for group level group permission settings.
                             additionalProperties:
                               $ref: "#/components/schemas/GroupPermissionSetting"
-                      max_bulk_new_subscription_messages:
+                      max_bulk_subscription_messages:
                         description: |
                           Maximum number of new subscribers for which the server will
                           respect the `send_new_subscription_messages` parameter when
                           [adding subscribers to a channel](/api/subscribe#parameter-send_new_subscription_messages).
 
-                          **Changes**: New in Zulip 11.0 (feature level 397).
+                          **Changes**: In Zulip 13.0 (feature level ZF-515bab), renamed from
+                          `max_bulk_new_subscription_messages`.
+
+                          New in Zulip 11.0 (feature level 397).
                         type: number
                         example: 100
                     example:
@@ -31019,7 +31022,7 @@ components:
 
         The server will never send direct messages when the total number of users
         who were subscribed to channels in this request was more than the value
-        of `max_bulk_new_subscription_messages`, which is available in the [`POST
+        of `max_bulk_subscription_messages`, which is available in the [`POST
         /register`](/api/register-queue) response.
 
         **Changes**: Before Zulip 11.0 (feature level 397), new subscribers

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13511,6 +13511,19 @@ paths:
                           with users about the effect of this request.
 
                           **Changes**: New in Zulip 11.0 (feature level 397).
+                      messages_sent_to_removed_subscribers:
+                        type: boolean
+                        description: |
+                          Only present if the parameter `send_messages_to_removed_subscribers`
+                          in the request was `true`.
+
+                          Whether Notification Bot DMs were in fact sent to the removed
+                          subscribers as requested by the
+                          `send_messages_to_removed_subscribers` parameter. Clients may
+                          find this value useful to communicate with users about the
+                          effect of this request.
+
+                          **Changes**: New in Zulip 13.0 (feature level ZF-515bab).
                     example:
                       {
                         "msg": "",
@@ -13541,8 +13554,15 @@ paths:
           by the [`can_remove_subscribers_group`][can-remove-parameter]
           for the channel.
 
-        **Changes**: Before Zulip 10.0 (feature level 362),
-        subscriptions in archived channels could not be modified.
+        **Changes**: In Zulip 13.0 (feature level ZF-515bab), the server began
+        sending a [Notification Bot](/help/configure-automated-notices) direct
+        message to users who have been unsubscribed from one or more channels by
+        another user, with accompanying `send_messages_to_removed_subscribers`
+        request parameter and `messages_sent_to_removed_subscribers` response
+        field documented below.
+
+        Before Zulip 10.0 (feature level 362), subscriptions in archived
+        channels could not be modified.
 
         Before Zulip 8.0 (feature level 208), if a user specified by
         the [`principals`][principals-param] parameter was a
@@ -13597,12 +13617,30 @@ paths:
                   example: ["Verona", "Denmark"]
                 principals:
                   $ref: "#/components/schemas/Principals"
+                send_messages_to_removed_subscribers:
+                  description: |
+                    Whether other users unsubscribed via this request should be sent a
+                    direct message, from [Notification
+                    Bot](/help/configure-automated-notices), notifying them that they
+                    were unsubscribed and by whom.
+
+                    The server will never send direct messages when the total number of
+                    users who were unsubscribed from channels in this request was more
+                    than the value of `max_bulk_subscription_messages`, which is
+                    available in the [`POST /register`](/api/register-queue) response.
+
+                    **Changes**: New in Zulip 13.0 (feature level ZF-515bab).
+                  type: boolean
+                  default: true
+                  example: true
               required:
                 - subscriptions
             encoding:
               subscriptions:
                 contentType: application/json
               principals:
+                contentType: application/json
+              send_messages_to_removed_subscribers:
                 contentType: application/json
       responses:
         "200":
@@ -13631,6 +13669,19 @@ paths:
                         description: |
                           A list of the names of channels which were unsubscribed from as a result
                           of the query.
+                      messages_sent_to_removed_subscribers:
+                        type: boolean
+                        description: |
+                          Only present if the parameter `send_messages_to_removed_subscribers`
+                          in the request was `true`.
+
+                          Whether Notification Bot DMs were in fact sent to the removed
+                          subscribers as requested by the
+                          `send_messages_to_removed_subscribers` parameter. Clients may
+                          find this value useful to communicate with users about the
+                          effect of this request.
+
+                          **Changes**: New in Zulip 13.0 (feature level ZF-515bab).
                     example:
                       {
                         "msg": "",
@@ -22879,12 +22930,15 @@ paths:
                               $ref: "#/components/schemas/GroupPermissionSetting"
                       max_bulk_subscription_messages:
                         description: |
-                          Maximum number of new subscribers for which the server will
+                          Maximum number of affected users for which the server will
                           respect the `send_new_subscription_messages` parameter when
-                          [adding subscribers to a channel](/api/subscribe#parameter-send_new_subscription_messages).
+                          [adding subscribers to a channel](/api/subscribe#parameter-send_new_subscription_messages),
+                          or the `send_messages_to_removed_subscribers` parameter when
+                          [unsubscribing users from a channel](/api/unsubscribe#parameter-send_messages_to_removed_subscribers).
 
                           **Changes**: In Zulip 13.0 (feature level ZF-515bab), renamed from
-                          `max_bulk_new_subscription_messages`.
+                          `max_bulk_new_subscription_messages`; the cap now applies to
+                          both subscription and unsubscription notifications.
 
                           New in Zulip 11.0 (feature level 397).
                         type: number
@@ -25476,7 +25530,7 @@ paths:
             The target message's ID.
           schema:
             type: integer
-          example: 47
+          example: 48
           required: true
       requestBody:
         required: true

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -106,7 +106,7 @@ class HomeTest(ZulipTestCase):
         "klipy_api_key",
         "last_event_id",
         "max_avatar_file_size_mib",
-        "max_bulk_new_subscription_messages",
+        "max_bulk_subscription_messages",
         "max_channel_folder_description_length",
         "max_channel_folder_name_length",
         "max_file_upload_size_mib",

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -69,7 +69,7 @@ from zerver.lib.subscription_info import (
     validate_user_access_to_subscribers_helper,
 )
 from zerver.lib.test_classes import ZulipTestCase, get_topic_messages
-from zerver.lib.test_helpers import HostRequestMock, cache_tries_captured
+from zerver.lib.test_helpers import HostRequestMock, cache_tries_captured, most_recent_message
 from zerver.lib.types import UserGroupMembersData
 from zerver.lib.user_groups import UserGroupMembershipDetails, get_group_setting_value_for_api
 from zerver.models import (
@@ -3164,9 +3164,11 @@ class StreamAdminTest(ZulipTestCase):
         If you're a realm admin, you can remove people from public streams, even
         those you aren't on.
         """
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
         result = self.attempt_unsubscribe_of_principal(
-            query_count=15,
-            target_users=[self.example_user("cordelia")],
+            query_count=40,
+            target_users=[cordelia],
             is_realm_admin=True,
             is_subbed=True,
             invite_only=False,
@@ -3175,6 +3177,14 @@ class StreamAdminTest(ZulipTestCase):
         json = self.assert_json_success(result)
         self.assert_length(json["removed"], 1)
         self.assert_length(json["not_removed"], 0)
+
+        msg = most_recent_message(cordelia)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+        self.assertEqual(msg.sender_id, self.notification_bot(cordelia.realm).id)
+        self.assertEqual(
+            msg.content,
+            f"@_**Iago|{iago.id}** unsubscribed you from #**hümbüǵ**.",
+        )
 
     def test_realm_admin_remove_multiple_users_from_stream(self) -> None:
         """
@@ -3192,8 +3202,8 @@ class StreamAdminTest(ZulipTestCase):
             for name in ["cordelia", "prospero", "iago", "hamlet", "outgoing_webhook_bot"]
         ]
         result = self.attempt_unsubscribe_of_principal(
-            query_count=22,
-            cache_count=13,
+            query_count=75,
+            cache_count=32,
             target_users=target_users,
             is_realm_admin=True,
             is_subbed=True,
@@ -3209,9 +3219,11 @@ class StreamAdminTest(ZulipTestCase):
         If you're a realm admin, you can remove other people from private streams you
         are on.
         """
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
         result = self.attempt_unsubscribe_of_principal(
-            query_count=18,
-            target_users=[self.example_user("cordelia")],
+            query_count=43,
+            target_users=[cordelia],
             is_realm_admin=True,
             is_subbed=True,
             invite_only=True,
@@ -3221,14 +3233,24 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_length(json["removed"], 1)
         self.assert_length(json["not_removed"], 0)
 
+        msg = most_recent_message(cordelia)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+        self.assertEqual(msg.sender_id, self.notification_bot(cordelia.realm).id)
+        self.assertEqual(
+            msg.content,
+            f"@_**Iago|{iago.id}** unsubscribed you from #**hümbüǵ**.",
+        )
+
     def test_realm_admin_remove_others_from_unsubbed_private_stream(self) -> None:
         """
         If you're a realm admin, you can remove people from private
         streams you aren't on.
         """
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
         result = self.attempt_unsubscribe_of_principal(
-            query_count=18,
-            target_users=[self.example_user("cordelia")],
+            query_count=44,
+            target_users=[cordelia],
             is_realm_admin=True,
             is_subbed=False,
             invite_only=True,
@@ -3238,6 +3260,14 @@ class StreamAdminTest(ZulipTestCase):
         json = self.assert_json_success(result)
         self.assert_length(json["removed"], 1)
         self.assert_length(json["not_removed"], 0)
+
+        msg = most_recent_message(cordelia)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+        self.assertEqual(msg.sender_id, self.notification_bot(cordelia.realm).id)
+        self.assertEqual(
+            msg.content,
+            f"@_**Iago|{iago.id}** unsubscribed you from #**hümbüǵ**.",
+        )
 
     def test_cant_remove_others_from_stream_legacy_emails(self) -> None:
         result = self.attempt_unsubscribe_of_principal(
@@ -3252,9 +3282,11 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_json_error(result, "Insufficient permission")
 
     def test_admin_remove_others_from_stream_legacy_emails(self) -> None:
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
         result = self.attempt_unsubscribe_of_principal(
-            query_count=15,
-            target_users=[self.example_user("cordelia")],
+            query_count=40,
+            target_users=[cordelia],
             is_realm_admin=True,
             is_subbed=True,
             invite_only=False,
@@ -3265,9 +3297,17 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_length(json["removed"], 1)
         self.assert_length(json["not_removed"], 0)
 
+        msg = most_recent_message(cordelia)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+        self.assertEqual(msg.sender_id, self.notification_bot(cordelia.realm).id)
+        self.assertEqual(
+            msg.content,
+            f"@_**Iago|{iago.id}** unsubscribed you from #**hümbüǵ**.",
+        )
+
     def test_admin_remove_multiple_users_from_stream_legacy_emails(self) -> None:
         result = self.attempt_unsubscribe_of_principal(
-            query_count=17,
+            query_count=56,
             target_users=[self.example_user("cordelia"), self.example_user("prospero")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3419,6 +3459,346 @@ class StreamAdminTest(ZulipTestCase):
                 recipient__type_id=stream.id, recipient__type=Recipient.STREAM, active=True
             ).exists()
         )
+
+    def test_no_notification_on_self_unsubscribe(self) -> None:
+        """
+        When an admin unsubscribes themselves alongside other users in the
+        same call, the admin should not receive a notification DM for
+        their own unsubscription.
+        """
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        self.login_user(iago)
+        stream_name = "test_self_unsub_filter"
+        self.make_stream(stream_name)
+        self.subscribe(iago, stream_name)
+        self.subscribe(cordelia, stream_name)
+
+        notification_bot = self.notification_bot(iago.realm)
+        iago_dms_before = UserMessage.objects.filter(
+            user_profile=iago,
+            message__sender_id=notification_bot.id,
+        ).count()
+        cordelia_dms_before = UserMessage.objects.filter(
+            user_profile=cordelia,
+            message__sender_id=notification_bot.id,
+        ).count()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([stream_name]).decode(),
+                    "principals": orjson.dumps([iago.id, cordelia.id]).decode(),
+                },
+            )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 2)
+
+        self.assertEqual(
+            UserMessage.objects.filter(
+                user_profile=cordelia,
+                message__sender_id=notification_bot.id,
+            ).count(),
+            cordelia_dms_before + 1,
+        )
+        self.assertEqual(
+            UserMessage.objects.filter(
+                user_profile=iago,
+                message__sender_id=notification_bot.id,
+            ).count(),
+            iago_dms_before,
+        )
+
+    def test_no_notification_for_bot_unsubscription(self) -> None:
+        """
+        When an admin unsubscribes a bot alongside a regular user in the
+        same call, the bot should not receive a notification DM.
+        """
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        webhook_bot = self.example_user("webhook_bot")
+        do_change_bot_owner(webhook_bot, bot_owner=hamlet, acting_user=hamlet)
+        self.login_user(iago)
+        stream_name = "test_bot_unsub_filter"
+        self.make_stream(stream_name)
+        self.subscribe(iago, stream_name)
+        self.subscribe(cordelia, stream_name)
+        self.subscribe(webhook_bot, stream_name)
+
+        notification_bot = self.notification_bot(iago.realm)
+        bot_dms_before = UserMessage.objects.filter(
+            user_profile=webhook_bot,
+            message__sender_id=notification_bot.id,
+        ).count()
+        cordelia_dms_before = UserMessage.objects.filter(
+            user_profile=cordelia,
+            message__sender_id=notification_bot.id,
+        ).count()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([stream_name]).decode(),
+                    "principals": orjson.dumps([cordelia.id, webhook_bot.id]).decode(),
+                },
+            )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 2)
+
+        self.assertEqual(
+            UserMessage.objects.filter(
+                user_profile=cordelia,
+                message__sender_id=notification_bot.id,
+            ).count(),
+            cordelia_dms_before + 1,
+        )
+        self.assertEqual(
+            UserMessage.objects.filter(
+                user_profile=webhook_bot,
+                message__sender_id=notification_bot.id,
+            ).count(),
+            bot_dms_before,
+        )
+
+    def test_notification_multiple_channels_unsubscription(self) -> None:
+        """
+        When a user is unsubscribed from multiple channels at once, they
+        receive a single DM listing all channels as a bullet list.
+        """
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
+        self.login_user(iago)
+
+        stream_names = ["alpha_stream", "beta_stream"]
+        for stream_name in stream_names:
+            self.make_stream(stream_name)
+            self.subscribe(iago, stream_name)
+            self.subscribe(cordelia, stream_name)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps(stream_names).decode(),
+                    "principals": orjson.dumps([cordelia.id]).decode(),
+                },
+            )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 2)
+
+        msg = most_recent_message(cordelia)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+        self.assertEqual(msg.sender_id, self.notification_bot(cordelia.realm).id)
+        self.assertEqual(
+            msg.content,
+            f"@_**Iago|{iago.id}** unsubscribed you from the following channels:\n\n"
+            "* #**alpha_stream**\n"
+            "* #**beta_stream**",
+        )
+
+    def test_no_notification_when_bulk_unsubscription_exceeds_limit(self) -> None:
+        """
+        When more than MAX_BULK_SUBSCRIPTION_MESSAGES users are
+        unsubscribed at once, no notification DMs should be sent.
+        """
+        cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+        self.login_user(iago)
+        stream_name = "test_bulk_unsub"
+        self.make_stream(stream_name)
+        self.subscribe(iago, stream_name)
+        self.subscribe(cordelia, stream_name)
+        self.subscribe(hamlet, stream_name)
+
+        notification_bot = self.notification_bot(iago.realm)
+        msg_count_before = UserMessage.objects.filter(
+            user_profile__in=[cordelia, hamlet],
+            message__sender_id=notification_bot.id,
+        ).count()
+
+        with (
+            self.settings(MAX_BULK_SUBSCRIPTION_MESSAGES=1),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            result = self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([stream_name]).decode(),
+                    "principals": orjson.dumps([cordelia.id, hamlet.id]).decode(),
+                },
+            )
+
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 2)
+        self.assertFalse(json["messages_sent_to_removed_subscribers"])
+
+        msg_count_after = UserMessage.objects.filter(
+            user_profile__in=[cordelia, hamlet],
+            message__sender_id=notification_bot.id,
+        ).count()
+        self.assertEqual(msg_count_before, msg_count_after)
+
+    def test_no_notification_when_send_messages_disabled(self) -> None:
+        """
+        When `send_messages_to_removed_subscribers=False` is passed,
+        no notification DMs should be sent and the response should not
+        include a `messages_sent_to_removed_subscribers` field.
+        """
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        self.login_user(iago)
+        stream_name = "test_send_messages_false"
+        self.make_stream(stream_name)
+        self.subscribe(iago, stream_name)
+        self.subscribe(cordelia, stream_name)
+
+        notification_bot = self.notification_bot(iago.realm)
+        cordelia_dms_before = UserMessage.objects.filter(
+            user_profile=cordelia,
+            message__sender_id=notification_bot.id,
+        ).count()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([stream_name]).decode(),
+                    "principals": orjson.dumps([cordelia.id]).decode(),
+                    "send_messages_to_removed_subscribers": orjson.dumps(False).decode(),
+                },
+            )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 1)
+        self.assertNotIn("messages_sent_to_removed_subscribers", json)
+
+        self.assertEqual(
+            UserMessage.objects.filter(
+                user_profile=cordelia,
+                message__sender_id=notification_bot.id,
+            ).count(),
+            cordelia_dms_before,
+        )
+
+    def test_self_unsubscribe_reports_no_messages_sent(self) -> None:
+        """
+        A plain self-unsubscribe sends no DM, so the response reports
+        messages_sent_to_removed_subscribers as False rather than True.
+        """
+        hamlet = self.example_user("hamlet")
+        self.login_user(hamlet)
+        stream_name = "test_self_unsub_field"
+        self.make_stream(stream_name)
+        self.subscribe(hamlet, stream_name)
+
+        notification_bot = self.notification_bot(hamlet.realm)
+        hamlet_dms_before = UserMessage.objects.filter(
+            user_profile=hamlet,
+            message__sender_id=notification_bot.id,
+        ).count()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = self.client_delete(
+                "/json/users/me/subscriptions",
+                {"subscriptions": orjson.dumps([stream_name]).decode()},
+            )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 1)
+        self.assertFalse(json["messages_sent_to_removed_subscribers"])
+
+        self.assertEqual(
+            UserMessage.objects.filter(
+                user_profile=hamlet,
+                message__sender_id=notification_bot.id,
+            ).count(),
+            hamlet_dms_before,
+        )
+
+    def test_notification_cap_counts_only_eligible_recipients(self) -> None:
+        """
+        The bulk cap applies to the users who will actually be notified, so
+        a self-unsubscribe and a bot removed in the same call do not count
+        against it and do not block an eligible user's notification.
+        """
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        webhook_bot = self.example_user("webhook_bot")
+        do_change_bot_owner(webhook_bot, bot_owner=iago, acting_user=iago)
+        self.login_user(iago)
+        stream_name = "test_cap_eligible"
+        self.make_stream(stream_name)
+        for user in [iago, cordelia, webhook_bot]:
+            self.subscribe(user, stream_name)
+
+        notification_bot = self.notification_bot(iago.realm)
+        cordelia_dms_before = UserMessage.objects.filter(
+            user_profile=cordelia,
+            message__sender_id=notification_bot.id,
+        ).count()
+
+        # Three users are removed, but only cordelia is an eligible
+        # recipient, so a cap of 1 must not block her notification.
+        with (
+            self.settings(MAX_BULK_SUBSCRIPTION_MESSAGES=1),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            result = self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([stream_name]).decode(),
+                    "principals": orjson.dumps([iago.id, cordelia.id, webhook_bot.id]).decode(),
+                },
+            )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 3)
+        self.assertTrue(json["messages_sent_to_removed_subscribers"])
+
+        self.assertEqual(
+            UserMessage.objects.filter(
+                user_profile=cordelia,
+                message__sender_id=notification_bot.id,
+            ).count(),
+            cordelia_dms_before + 1,
+        )
+
+    def test_unsubscriptions_query_count(self) -> None:
+        """
+        Test database query count when unsubscribing users via
+        api/v1/users/me/subscriptions, including the DM notification.
+        """
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
+        self.login_user(iago)
+
+        public_stream = "public_unsub_qc"
+        self.make_stream(public_stream)
+        for user in [iago, cordelia, hamlet]:
+            self.subscribe(user, public_stream)
+        with self.assert_database_query_count(52):
+            self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([public_stream]).decode(),
+                    "principals": orjson.dumps([cordelia.id, hamlet.id]).decode(),
+                },
+            )
+
+        private_stream = "private_unsub_qc"
+        self.make_stream(private_stream, invite_only=True)
+        for user in [iago, cordelia, hamlet]:
+            self.subscribe(user, private_stream)
+        with self.assert_database_query_count(46):
+            self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([private_stream]).decode(),
+                    "principals": orjson.dumps([cordelia.id, hamlet.id]).decode(),
+                },
+            )
 
 
 class SubscriptionRestApiTest(ZulipTestCase):

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -5462,7 +5462,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # be sent.
         now = timezone_now()
         test_channel = self.make_stream("test C")
-        with self.settings(MAX_BULK_NEW_SUBSCRIPTION_MESSAGES=5):
+        with self.settings(MAX_BULK_SUBSCRIPTION_MESSAGES=5):
             response = self.subscribe_via_post(
                 desdemona,
                 [test_channel.name],
@@ -5493,7 +5493,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # still expect an announcement message and new channel
         # message (and no DM notifications).
         now = timezone_now()
-        with self.settings(MAX_BULK_NEW_SUBSCRIPTION_MESSAGES=5):
+        with self.settings(MAX_BULK_SUBSCRIPTION_MESSAGES=5):
             response = self.subscribe_via_post(
                 desdemona,
                 ["test D"],

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -70,7 +70,7 @@ from zerver.lib.subscription_info import (
     validate_user_access_to_subscribers_helper,
 )
 from zerver.lib.test_classes import ZulipTestCase, get_topic_messages
-from zerver.lib.test_helpers import HostRequestMock, cache_tries_captured
+from zerver.lib.test_helpers import HostRequestMock, cache_tries_captured, most_recent_message
 from zerver.lib.types import UserGroupMembersData
 from zerver.lib.user_groups import UserGroupMembershipDetails, get_group_setting_value_for_api
 from zerver.models import (
@@ -3253,9 +3253,11 @@ class StreamAdminTest(ZulipTestCase):
         If you're a realm admin, you can remove people from public streams, even
         those you aren't on.
         """
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
         result = self.attempt_unsubscribe_of_principal(
-            query_count=15,
-            target_users=[self.example_user("cordelia")],
+            query_count=40,
+            target_users=[cordelia],
             is_realm_admin=True,
             is_subbed=True,
             invite_only=False,
@@ -3264,6 +3266,14 @@ class StreamAdminTest(ZulipTestCase):
         json = self.assert_json_success(result)
         self.assert_length(json["removed"], 1)
         self.assert_length(json["not_removed"], 0)
+
+        msg = most_recent_message(cordelia)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+        self.assertEqual(msg.sender_id, self.notification_bot(cordelia.realm).id)
+        self.assertEqual(
+            msg.content,
+            f"@_**Iago|{iago.id}** unsubscribed you from #**hümbüǵ**.",
+        )
 
     def test_realm_admin_remove_multiple_users_from_stream(self) -> None:
         """
@@ -3281,8 +3291,8 @@ class StreamAdminTest(ZulipTestCase):
             for name in ["cordelia", "prospero", "iago", "hamlet", "outgoing_webhook_bot"]
         ]
         result = self.attempt_unsubscribe_of_principal(
-            query_count=22,
-            cache_count=12,
+            query_count=75,
+            cache_count=31,
             target_users=target_users,
             is_realm_admin=True,
             is_subbed=True,
@@ -3298,9 +3308,11 @@ class StreamAdminTest(ZulipTestCase):
         If you're a realm admin, you can remove other people from private streams you
         are on.
         """
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
         result = self.attempt_unsubscribe_of_principal(
-            query_count=18,
-            target_users=[self.example_user("cordelia")],
+            query_count=43,
+            target_users=[cordelia],
             is_realm_admin=True,
             is_subbed=True,
             invite_only=True,
@@ -3310,14 +3322,24 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_length(json["removed"], 1)
         self.assert_length(json["not_removed"], 0)
 
+        msg = most_recent_message(cordelia)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+        self.assertEqual(msg.sender_id, self.notification_bot(cordelia.realm).id)
+        self.assertEqual(
+            msg.content,
+            f"@_**Iago|{iago.id}** unsubscribed you from #**hümbüǵ**.",
+        )
+
     def test_realm_admin_remove_others_from_unsubbed_private_stream(self) -> None:
         """
         If you're a realm admin, you can remove people from private
         streams you aren't on.
         """
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
         result = self.attempt_unsubscribe_of_principal(
-            query_count=18,
-            target_users=[self.example_user("cordelia")],
+            query_count=44,
+            target_users=[cordelia],
             is_realm_admin=True,
             is_subbed=False,
             invite_only=True,
@@ -3327,6 +3349,14 @@ class StreamAdminTest(ZulipTestCase):
         json = self.assert_json_success(result)
         self.assert_length(json["removed"], 1)
         self.assert_length(json["not_removed"], 0)
+
+        msg = most_recent_message(cordelia)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+        self.assertEqual(msg.sender_id, self.notification_bot(cordelia.realm).id)
+        self.assertEqual(
+            msg.content,
+            f"@_**Iago|{iago.id}** unsubscribed you from #**hümbüǵ**.",
+        )
 
     def test_cant_remove_others_from_stream_legacy_emails(self) -> None:
         result = self.attempt_unsubscribe_of_principal(
@@ -3341,9 +3371,11 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_json_error(result, "Insufficient permission")
 
     def test_admin_remove_others_from_stream_legacy_emails(self) -> None:
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
         result = self.attempt_unsubscribe_of_principal(
-            query_count=15,
-            target_users=[self.example_user("cordelia")],
+            query_count=40,
+            target_users=[cordelia],
             is_realm_admin=True,
             is_subbed=True,
             invite_only=False,
@@ -3354,9 +3386,17 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_length(json["removed"], 1)
         self.assert_length(json["not_removed"], 0)
 
+        msg = most_recent_message(cordelia)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+        self.assertEqual(msg.sender_id, self.notification_bot(cordelia.realm).id)
+        self.assertEqual(
+            msg.content,
+            f"@_**Iago|{iago.id}** unsubscribed you from #**hümbüǵ**.",
+        )
+
     def test_admin_remove_multiple_users_from_stream_legacy_emails(self) -> None:
         result = self.attempt_unsubscribe_of_principal(
-            query_count=17,
+            query_count=56,
             target_users=[self.example_user("cordelia"), self.example_user("prospero")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3508,6 +3548,346 @@ class StreamAdminTest(ZulipTestCase):
                 recipient__type_id=stream.id, recipient__type=Recipient.STREAM, active=True
             ).exists()
         )
+
+    def test_no_notification_on_self_unsubscribe(self) -> None:
+        """
+        When an admin unsubscribes themselves alongside other users in the
+        same call, the admin should not receive a notification DM for
+        their own unsubscription.
+        """
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        self.login_user(iago)
+        stream_name = "test_self_unsub_filter"
+        self.make_stream(stream_name)
+        self.subscribe(iago, stream_name)
+        self.subscribe(cordelia, stream_name)
+
+        notification_bot = self.notification_bot(iago.realm)
+        iago_dms_before = UserMessage.objects.filter(
+            user_profile=iago,
+            message__sender_id=notification_bot.id,
+        ).count()
+        cordelia_dms_before = UserMessage.objects.filter(
+            user_profile=cordelia,
+            message__sender_id=notification_bot.id,
+        ).count()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([stream_name]).decode(),
+                    "principals": orjson.dumps([iago.id, cordelia.id]).decode(),
+                },
+            )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 2)
+
+        self.assertEqual(
+            UserMessage.objects.filter(
+                user_profile=cordelia,
+                message__sender_id=notification_bot.id,
+            ).count(),
+            cordelia_dms_before + 1,
+        )
+        self.assertEqual(
+            UserMessage.objects.filter(
+                user_profile=iago,
+                message__sender_id=notification_bot.id,
+            ).count(),
+            iago_dms_before,
+        )
+
+    def test_no_notification_for_bot_unsubscription(self) -> None:
+        """
+        When an admin unsubscribes a bot alongside a regular user in the
+        same call, the bot should not receive a notification DM.
+        """
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        webhook_bot = self.example_user("webhook_bot")
+        do_change_bot_owner(webhook_bot, bot_owner=hamlet, acting_user=hamlet)
+        self.login_user(iago)
+        stream_name = "test_bot_unsub_filter"
+        self.make_stream(stream_name)
+        self.subscribe(iago, stream_name)
+        self.subscribe(cordelia, stream_name)
+        self.subscribe(webhook_bot, stream_name)
+
+        notification_bot = self.notification_bot(iago.realm)
+        bot_dms_before = UserMessage.objects.filter(
+            user_profile=webhook_bot,
+            message__sender_id=notification_bot.id,
+        ).count()
+        cordelia_dms_before = UserMessage.objects.filter(
+            user_profile=cordelia,
+            message__sender_id=notification_bot.id,
+        ).count()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([stream_name]).decode(),
+                    "principals": orjson.dumps([cordelia.id, webhook_bot.id]).decode(),
+                },
+            )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 2)
+
+        self.assertEqual(
+            UserMessage.objects.filter(
+                user_profile=cordelia,
+                message__sender_id=notification_bot.id,
+            ).count(),
+            cordelia_dms_before + 1,
+        )
+        self.assertEqual(
+            UserMessage.objects.filter(
+                user_profile=webhook_bot,
+                message__sender_id=notification_bot.id,
+            ).count(),
+            bot_dms_before,
+        )
+
+    def test_notification_multiple_channels_unsubscription(self) -> None:
+        """
+        When a user is unsubscribed from multiple channels at once, they
+        receive a single DM listing all channels as a bullet list.
+        """
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
+        self.login_user(iago)
+
+        stream_names = ["alpha_stream", "beta_stream"]
+        for stream_name in stream_names:
+            self.make_stream(stream_name)
+            self.subscribe(iago, stream_name)
+            self.subscribe(cordelia, stream_name)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps(stream_names).decode(),
+                    "principals": orjson.dumps([cordelia.id]).decode(),
+                },
+            )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 2)
+
+        msg = most_recent_message(cordelia)
+        self.assertEqual(msg.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+        self.assertEqual(msg.sender_id, self.notification_bot(cordelia.realm).id)
+        self.assertEqual(
+            msg.content,
+            f"@_**Iago|{iago.id}** unsubscribed you from the following channels:\n\n"
+            "* #**alpha_stream**\n"
+            "* #**beta_stream**",
+        )
+
+    def test_no_notification_when_bulk_unsubscription_exceeds_limit(self) -> None:
+        """
+        When more than MAX_BULK_SUBSCRIPTION_MESSAGES users are
+        unsubscribed at once, no notification DMs should be sent.
+        """
+        cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+        self.login_user(iago)
+        stream_name = "test_bulk_unsub"
+        self.make_stream(stream_name)
+        self.subscribe(iago, stream_name)
+        self.subscribe(cordelia, stream_name)
+        self.subscribe(hamlet, stream_name)
+
+        notification_bot = self.notification_bot(iago.realm)
+        msg_count_before = UserMessage.objects.filter(
+            user_profile__in=[cordelia, hamlet],
+            message__sender_id=notification_bot.id,
+        ).count()
+
+        with (
+            self.settings(MAX_BULK_SUBSCRIPTION_MESSAGES=1),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            result = self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([stream_name]).decode(),
+                    "principals": orjson.dumps([cordelia.id, hamlet.id]).decode(),
+                },
+            )
+
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 2)
+        self.assertFalse(json["messages_sent_to_removed_subscribers"])
+
+        msg_count_after = UserMessage.objects.filter(
+            user_profile__in=[cordelia, hamlet],
+            message__sender_id=notification_bot.id,
+        ).count()
+        self.assertEqual(msg_count_before, msg_count_after)
+
+    def test_no_notification_when_send_messages_disabled(self) -> None:
+        """
+        When `send_messages_to_removed_subscribers=False` is passed,
+        no notification DMs should be sent and the response should not
+        include a `messages_sent_to_removed_subscribers` field.
+        """
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        self.login_user(iago)
+        stream_name = "test_send_messages_false"
+        self.make_stream(stream_name)
+        self.subscribe(iago, stream_name)
+        self.subscribe(cordelia, stream_name)
+
+        notification_bot = self.notification_bot(iago.realm)
+        cordelia_dms_before = UserMessage.objects.filter(
+            user_profile=cordelia,
+            message__sender_id=notification_bot.id,
+        ).count()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([stream_name]).decode(),
+                    "principals": orjson.dumps([cordelia.id]).decode(),
+                    "send_messages_to_removed_subscribers": orjson.dumps(False).decode(),
+                },
+            )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 1)
+        self.assertNotIn("messages_sent_to_removed_subscribers", json)
+
+        self.assertEqual(
+            UserMessage.objects.filter(
+                user_profile=cordelia,
+                message__sender_id=notification_bot.id,
+            ).count(),
+            cordelia_dms_before,
+        )
+
+    def test_self_unsubscribe_reports_no_messages_sent(self) -> None:
+        """
+        A plain self-unsubscribe sends no DM, so the response reports
+        messages_sent_to_removed_subscribers as False rather than True.
+        """
+        hamlet = self.example_user("hamlet")
+        self.login_user(hamlet)
+        stream_name = "test_self_unsub_field"
+        self.make_stream(stream_name)
+        self.subscribe(hamlet, stream_name)
+
+        notification_bot = self.notification_bot(hamlet.realm)
+        hamlet_dms_before = UserMessage.objects.filter(
+            user_profile=hamlet,
+            message__sender_id=notification_bot.id,
+        ).count()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = self.client_delete(
+                "/json/users/me/subscriptions",
+                {"subscriptions": orjson.dumps([stream_name]).decode()},
+            )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 1)
+        self.assertFalse(json["messages_sent_to_removed_subscribers"])
+
+        self.assertEqual(
+            UserMessage.objects.filter(
+                user_profile=hamlet,
+                message__sender_id=notification_bot.id,
+            ).count(),
+            hamlet_dms_before,
+        )
+
+    def test_notification_cap_counts_only_eligible_recipients(self) -> None:
+        """
+        The bulk cap applies to the users who will actually be notified, so
+        a self-unsubscribe and a bot removed in the same call do not count
+        against it and do not block an eligible user's notification.
+        """
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        webhook_bot = self.example_user("webhook_bot")
+        do_change_bot_owner(webhook_bot, bot_owner=iago, acting_user=iago)
+        self.login_user(iago)
+        stream_name = "test_cap_eligible"
+        self.make_stream(stream_name)
+        for user in [iago, cordelia, webhook_bot]:
+            self.subscribe(user, stream_name)
+
+        notification_bot = self.notification_bot(iago.realm)
+        cordelia_dms_before = UserMessage.objects.filter(
+            user_profile=cordelia,
+            message__sender_id=notification_bot.id,
+        ).count()
+
+        # Three users are removed, but only cordelia is an eligible
+        # recipient, so a cap of 1 must not block her notification.
+        with (
+            self.settings(MAX_BULK_SUBSCRIPTION_MESSAGES=1),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            result = self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([stream_name]).decode(),
+                    "principals": orjson.dumps([iago.id, cordelia.id, webhook_bot.id]).decode(),
+                },
+            )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 3)
+        self.assertTrue(json["messages_sent_to_removed_subscribers"])
+
+        self.assertEqual(
+            UserMessage.objects.filter(
+                user_profile=cordelia,
+                message__sender_id=notification_bot.id,
+            ).count(),
+            cordelia_dms_before + 1,
+        )
+
+    def test_unsubscriptions_query_count(self) -> None:
+        """
+        Test database query count when unsubscribing users via
+        api/v1/users/me/subscriptions, including the DM notification.
+        """
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
+        self.login_user(iago)
+
+        public_stream = "public_unsub_qc"
+        self.make_stream(public_stream)
+        for user in [iago, cordelia, hamlet]:
+            self.subscribe(user, public_stream)
+        with self.assert_database_query_count(52):
+            self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([public_stream]).decode(),
+                    "principals": orjson.dumps([cordelia.id, hamlet.id]).decode(),
+                },
+            )
+
+        private_stream = "private_unsub_qc"
+        self.make_stream(private_stream, invite_only=True)
+        for user in [iago, cordelia, hamlet]:
+            self.subscribe(user, private_stream)
+        with self.assert_database_query_count(46):
+            self.client_delete(
+                "/json/users/me/subscriptions",
+                {
+                    "subscriptions": orjson.dumps([private_stream]).decode(),
+                    "principals": orjson.dumps([cordelia.id, hamlet.id]).decode(),
+                },
+            )
 
 
 class SubscriptionRestApiTest(ZulipTestCase):

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -5551,7 +5551,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # be sent.
         now = timezone_now()
         test_channel = self.make_stream("test C")
-        with self.settings(MAX_BULK_NEW_SUBSCRIPTION_MESSAGES=5):
+        with self.settings(MAX_BULK_SUBSCRIPTION_MESSAGES=5):
             response = self.subscribe_via_post(
                 desdemona,
                 [test_channel.name],
@@ -5582,7 +5582,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # still expect an announcement message and new channel
         # message (and no DM notifications).
         now = timezone_now()
-        with self.settings(MAX_BULK_NEW_SUBSCRIPTION_MESSAGES=5):
+        with self.settings(MAX_BULK_SUBSCRIPTION_MESSAGES=5):
             response = self.subscribe_via_post(
                 desdemona,
                 ["test D"],

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -611,6 +611,7 @@ def remove_subscriptions_backend(
     user_profile: UserProfile,
     *,
     principals: Json[list[str] | list[int]] | None = None,
+    send_messages_to_removed_subscribers: Json[bool] = True,
     streams_raw: Annotated[Json[list[str]], ApiParamConfig("subscriptions")],
 ) -> HttpResponse:
     realm = user_profile.realm
@@ -635,10 +636,16 @@ def remove_subscriptions_backend(
         unsubscribing_others=unsubscribing_others,
     )
 
-    result: dict[str, list[str]] = dict(removed=[], not_removed=[])
+    result: dict[str, Any] = dict(removed=[], not_removed=[])
     (removed, not_subscribed) = bulk_remove_subscriptions(
         realm, people_to_unsub, streams, acting_user=user_profile
     )
+
+    if send_messages_to_removed_subscribers:
+        result["messages_sent_to_removed_subscribers"] = send_user_unsubscribed_notifications(
+            acting_user=user_profile,
+            removed=removed,
+        )
 
     for subscriber, removed_stream in removed:
         result["removed"].append(removed_stream.name)
@@ -648,25 +655,51 @@ def remove_subscriptions_backend(
     return json_success(request, data=result)
 
 
+def format_channel_notification_message(
+    acting_user: UserProfile,
+    channel_names: set[str],
+    single_channel_message: str,
+    multiple_channels_message: str,
+) -> str:
+    # The message templates are passed in already translated so that their
+    # literals stay individually extractable for translation.
+    channels = sorted(channel_names)
+    user_full_name = silent_mention_syntax_for_user(acting_user)
+    if len(channels) == 1:
+        return single_channel_message.format(
+            user_full_name=user_full_name,
+            channel_name=f"#**{channels[0]}**",
+        )
+
+    message = multiple_channels_message.format(user_full_name=user_full_name)
+    message += "\n\n"
+    for channel_name in channels:
+        message += f"* #**{channel_name}**\n"
+    return message
+
+
 def you_were_just_subscribed_message(
     acting_user: UserProfile, recipient_user: UserProfile, stream_names: set[str]
 ) -> str:
-    subscriptions = sorted(stream_names)
-    if len(subscriptions) == 1:
-        with override_language(recipient_user.default_language):
-            return _("{user_full_name} subscribed you to {channel_name}.").format(
-                user_full_name=silent_mention_syntax_for_user(acting_user),
-                channel_name=f"#**{subscriptions[0]}**",
-            )
-
     with override_language(recipient_user.default_language):
-        message = _("{user_full_name} subscribed you to the following channels:").format(
-            user_full_name=silent_mention_syntax_for_user(acting_user),
+        single_channel_message = _("{user_full_name} subscribed you to {channel_name}.")
+        multiple_channels_message = _("{user_full_name} subscribed you to the following channels:")
+    return format_channel_notification_message(
+        acting_user, stream_names, single_channel_message, multiple_channels_message
+    )
+
+
+def you_were_just_unsubscribed_message(
+    acting_user: UserProfile, recipient_user: UserProfile, channel_names: set[str]
+) -> str:
+    with override_language(recipient_user.default_language):
+        single_channel_message = _("{user_full_name} unsubscribed you from {channel_name}.")
+        multiple_channels_message = _(
+            "{user_full_name} unsubscribed you from the following channels:"
         )
-    message += "\n\n"
-    for channel_name in subscriptions:
-        message += f"* #**{channel_name}**\n"
-    return message
+    return format_channel_notification_message(
+        acting_user, channel_names, single_channel_message, multiple_channels_message
+    )
 
 
 RETENTION_DEFAULT: str | int = "realm_default"
@@ -964,6 +997,57 @@ def add_subscriptions_backend(
     if not authorization_errors_fatal:
         result["unauthorized"] = [s.name for s in unauthorized_streams]
     return json_success(request, data=result)
+
+
+def send_user_unsubscribed_notifications(
+    acting_user: UserProfile,
+    removed: list[tuple[UserProfile, Stream]],
+) -> bool:
+    """Notifies each user unsubscribed by someone else with a Notification
+    Bot direct message, and returns whether any such messages were sent.
+    Self-unsubscribes and bots do not receive these notifications."""
+    channels_by_user: dict[int, set[str]] = defaultdict(set)
+    user_by_id: dict[int, UserProfile] = {}
+    for user, channel in removed:
+        if user.id == acting_user.id:
+            # Don't notify users who unsubscribed themselves.
+            continue
+        if user.is_bot:
+            # Don't send notification DMs to bots.
+            continue
+        channels_by_user[user.id].add(channel.name)
+        user_by_id[user.id] = user
+
+    if not channels_by_user:
+        return False
+
+    if len(channels_by_user) > settings.MAX_BULK_SUBSCRIPTION_MESSAGES:
+        # Skip these DMs when a very large number of users are unsubscribed
+        # at once, as sending them can be expensive and spammy.
+        return False
+
+    sender = get_system_bot(settings.NOTIFICATION_BOT, acting_user.realm_id)
+    mention_backend = MentionBackend(acting_user.realm_id)
+    notifications = []
+    for user_id, channel_names in channels_by_user.items():
+        recipient_user = user_by_id[user_id]
+        msg = you_were_just_unsubscribed_message(
+            acting_user=acting_user,
+            recipient_user=recipient_user,
+            channel_names=channel_names,
+        )
+        notifications.append(
+            internal_prep_private_message(
+                sender=sender,
+                recipient_user=recipient_user,
+                content=msg,
+                mention_backend=mention_backend,
+                acting_user=acting_user,
+            )
+        )
+
+    do_send_messages(notifications)
+    return True
 
 
 def send_user_subscribed_and_new_channel_notifications(

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -944,7 +944,7 @@ def add_subscriptions_backend(
 
     if send_new_subscription_messages:
         send_user_subscribed_direct_messages = (
-            len(result["subscribed"]) <= settings.MAX_BULK_NEW_SUBSCRIPTION_MESSAGES
+            len(result["subscribed"]) <= settings.MAX_BULK_SUBSCRIPTION_MESSAGES
         )
         result["new_subscription_messages_sent"] = send_user_subscribed_direct_messages
     else:

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -962,7 +962,7 @@ def add_subscriptions_backend(
 
     if send_new_subscription_messages:
         send_user_subscribed_direct_messages = (
-            len(result["subscribed"]) <= settings.MAX_BULK_NEW_SUBSCRIPTION_MESSAGES
+            len(result["subscribed"]) <= settings.MAX_BULK_SUBSCRIPTION_MESSAGES
         )
         result["new_subscription_messages_sent"] = send_user_subscribed_direct_messages
     else:

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -619,6 +619,7 @@ def remove_subscriptions_backend(
     user_profile: UserProfile,
     *,
     principals: Json[list[str] | list[int]] | None = None,
+    send_messages_to_removed_subscribers: Json[bool] = True,
     streams_raw: Annotated[Json[list[str]], ApiParamConfig("subscriptions")],
 ) -> HttpResponse:
     realm = user_profile.realm
@@ -643,38 +644,69 @@ def remove_subscriptions_backend(
         unsubscribing_others=unsubscribing_others,
     )
 
-    result: dict[str, list[str]] = dict(removed=[], not_removed=[])
     (removed, not_subscribed) = bulk_remove_subscriptions(
         realm, people_to_unsub, streams, acting_user=user_profile
     )
 
-    for subscriber, removed_stream in removed:
-        result["removed"].append(removed_stream.name)
-    for subscriber, not_subscribed_stream in not_subscribed:
-        result["not_removed"].append(not_subscribed_stream.name)
+    result: dict[str, list[str] | bool] = dict(
+        removed=[stream.name for __, stream in removed],
+        not_removed=[stream.name for __, stream in not_subscribed],
+    )
+
+    if send_messages_to_removed_subscribers:
+        result["messages_sent_to_removed_subscribers"] = send_user_unsubscribed_notifications(
+            acting_user=user_profile,
+            removed=removed,
+        )
 
     return json_success(request, data=result)
+
+
+def format_channel_notification_message(
+    acting_user: UserProfile,
+    channel_names: set[str],
+    single_channel_message: str,
+    multiple_channels_message: str,
+) -> str:
+    # The message templates are passed in already translated so that their
+    # literals stay individually extractable for translation.
+    channels = sorted(channel_names)
+    user_full_name = silent_mention_syntax_for_user(acting_user)
+    if len(channels) == 1:
+        return single_channel_message.format(
+            user_full_name=user_full_name,
+            channel_name=f"#**{channels[0]}**",
+        )
+
+    message = multiple_channels_message.format(user_full_name=user_full_name)
+    message += "\n\n"
+    for channel_name in channels:
+        message += f"* #**{channel_name}**\n"
+    return message
 
 
 def you_were_just_subscribed_message(
     acting_user: UserProfile, recipient_user: UserProfile, stream_names: set[str]
 ) -> str:
-    subscriptions = sorted(stream_names)
-    if len(subscriptions) == 1:
-        with override_language(recipient_user.default_language):
-            return _("{user_full_name} subscribed you to {channel_name}.").format(
-                user_full_name=silent_mention_syntax_for_user(acting_user),
-                channel_name=f"#**{subscriptions[0]}**",
-            )
-
     with override_language(recipient_user.default_language):
-        message = _("{user_full_name} subscribed you to the following channels:").format(
-            user_full_name=silent_mention_syntax_for_user(acting_user),
+        single_channel_message = _("{user_full_name} subscribed you to {channel_name}.")
+        multiple_channels_message = _("{user_full_name} subscribed you to the following channels:")
+    return format_channel_notification_message(
+        acting_user, stream_names, single_channel_message, multiple_channels_message
+    )
+
+
+def you_were_just_unsubscribed_message(
+    acting_user: UserProfile, recipient_user: UserProfile, channel_names: set[str]
+) -> str:
+    with override_language(recipient_user.default_language):
+        single_channel_message = _("{user_full_name} unsubscribed you from {channel_name}.")
+        multiple_channels_message = _(
+            "{user_full_name} unsubscribed you from the following channels:"
         )
-    message += "\n\n"
-    for channel_name in subscriptions:
-        message += f"* #**{channel_name}**\n"
-    return message
+    return format_channel_notification_message(
+        acting_user, channel_names, single_channel_message, multiple_channels_message
+    )
 
 
 RETENTION_DEFAULT: str | int = "realm_default"
@@ -982,6 +1014,57 @@ def add_subscriptions_backend(
     if not authorization_errors_fatal:
         result["unauthorized"] = [s.name for s in unauthorized_streams]
     return json_success(request, data=result)
+
+
+def send_user_unsubscribed_notifications(
+    acting_user: UserProfile,
+    removed: list[tuple[UserProfile, Stream]],
+) -> bool:
+    """Notifies each user unsubscribed by someone else with a Notification
+    Bot direct message, and returns whether any such messages were sent.
+    Self-unsubscribes and bots do not receive these notifications."""
+    channels_by_user: dict[int, set[str]] = defaultdict(set)
+    user_by_id: dict[int, UserProfile] = {}
+    for user, channel in removed:
+        if user.id == acting_user.id:
+            # Don't notify users who unsubscribed themselves.
+            continue
+        if user.is_bot:
+            # Don't send notification DMs to bots.
+            continue
+        channels_by_user[user.id].add(channel.name)
+        user_by_id[user.id] = user
+
+    if not channels_by_user:
+        return False
+
+    if len(channels_by_user) > settings.MAX_BULK_SUBSCRIPTION_MESSAGES:
+        # Skip these DMs when a very large number of users are unsubscribed
+        # at once, as sending them can be expensive and spammy.
+        return False
+
+    sender = get_system_bot(settings.NOTIFICATION_BOT, acting_user.realm_id)
+    mention_backend = MentionBackend(acting_user.realm_id)
+    notifications = []
+    for user_id, channel_names in channels_by_user.items():
+        recipient_user = user_by_id[user_id]
+        msg = you_were_just_unsubscribed_message(
+            acting_user=acting_user,
+            recipient_user=recipient_user,
+            channel_names=channel_names,
+        )
+        notifications.append(
+            internal_prep_private_message(
+                sender=sender,
+                recipient_user=recipient_user,
+                content=msg,
+                mention_backend=mention_backend,
+                acting_user=acting_user,
+            )
+        )
+
+    do_send_messages(notifications)
+    return True
 
 
 def send_user_subscribed_and_new_channel_notifications(

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -728,9 +728,10 @@ MAX_STREAM_SIZE_FOR_TYPING_NOTIFICATIONS = 100
 # be soft-reactivated in the case of user group mention.
 MAX_GROUP_SIZE_FOR_MENTION_REACTIVATION = 11
 
-# The maximum number of newly subscribed users for which the server
-# will consider sending DMs to each new subscriber.
-MAX_BULK_NEW_SUBSCRIPTION_MESSAGES = 100
+# The maximum number of affected users for which the server will consider
+# sending DMs to each subscribed or removed subscriber when users are
+# added to or removed from channels in bulk.
+MAX_BULK_SUBSCRIPTION_MESSAGES = 100
 
 # Limiting guest access to other users via the
 # can_access_all_users_group setting makes presence queries much more


### PR DESCRIPTION
This mirrors the existing behavior where users are notified when they are subscribed by another user, extending it to send a Notification Bot DM when a user is unsubscribed from a channel by another user.

This hooks into the view layer, matching the subscription flow.

Tests are updated within existing unsubscribe flows, with additional coverage for edge cases, and existing query counts are updated to reflect the new behavior. Documentation is updated accordingly.


Fixes #29272

---
## Screenshots 

### *Channel removal notification:*
<img width="1128" height="77" alt="Screen Shot 2026-03-22 at 00 42 28" src="https://github.com/user-attachments/assets/d8d4f8a7-b727-478e-9bab-09b151e7a15b" />

---

### *Help Center: "Unsubscribe a user from a channel"*
<img width="840" height="618" alt="image" src="https://github.com/user-attachments/assets/afaef811-7d98-4822-9e32-e610cc6e023a" />

---

### *Help Center: "Configure automated notices"*
<img width="726" height="123" alt="image" src="https://github.com/user-attachments/assets/01bf60ba-16c0-4b20-bc3a-75197a2771bd" />

---

## Relationship to previous PRs

This addresses the same feature as #29307, but takes a more focused approach based on prior review feedback.

Unlike earlier attempts that modified the message sending pipeline, this implementation keeps the logic within the existing unsubscribe flow and uses the standard message send path, reducing scope while maintaining correct behavior and query characteristics.

---
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
