### PR TITLE
video_calls: Complete BigBlueButton integration (Completes #34863).

### DIFF
--- a/zerver/tests/test_create_video_call.py
+++ b/zerver/tests/test_create_video_call.py
@@ -1,3 +1,4 @@
+import re
 from unittest import mock
 
 import orjson
@@ -8,6 +9,7 @@ from django.http import HttpResponseRedirect
 from django.test import override_settings
 from typing_extensions import override
 
+from version import ZULIP_MERGE_BASE, ZULIP_VERSION
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.url_encoding import append_url_query_string
 
@@ -380,6 +382,9 @@ class BigBlueButtonVideoCallTest(ZulipTestCase):
                 "meeting_id": "a",
                 "name": "a",
                 "lock_settings_disable_cam": True,
+                "bbb_origin": "Zulip",
+                "bbb_origin_version": ZULIP_VERSION,
+                "bbb_origin_tag": ZULIP_MERGE_BASE,
                 "moderator": self.user.id,
             }
         )
@@ -389,64 +394,68 @@ class BigBlueButtonVideoCallTest(ZulipTestCase):
                 "meeting_id": "a",
                 "name": "a",
                 "lock_settings_disable_cam": True,
+                "bbb_origin": "Zulip",
+                "bbb_origin_version": ZULIP_VERSION,
+                "bbb_origin_tag": ZULIP_MERGE_BASE,
                 "moderator": self.example_user("cordelia").id,
             }
         )
 
     def test_create_bigbluebutton_link(self) -> None:
-        with (
-            mock.patch("zerver.views.video_calls.random.randint", return_value="1"),
-            mock.patch("secrets.token_bytes", return_value=b"\x00" * 20),
-        ):
-            with mock.patch("zerver.views.video_calls.random.randint", return_value="1"):
-                response = self.client_get(
-                    "/json/calls/bigbluebutton/create?meeting_name=general > meeting&voice_only=false"
-                )
-            response_dict = self.assert_json_success(response)
-            self.assertEqual(
-                response_dict["url"],
-                append_url_query_string(
-                    "/calls/bigbluebutton/join",
-                    "bigbluebutton="
-                    + self.signer.sign_object(
-                        {
-                            "meeting_id": "zulip-1",
-                            "name": "general > meeting",
-                            "lock_settings_disable_cam": False,
-                            "moderator": self.user.id,
-                        }
-                    ),
-                ),
-            )
-
-            # Testing for audio call
+        with mock.patch("secrets.token_bytes", return_value=b"\x00" * 20):
             response = self.client_get(
-                "/json/calls/bigbluebutton/create?meeting_name=general > meeting&voice_only=true"
+                "/json/calls/bigbluebutton/create?meeting_name=general > meeting&voice_only=false"
             )
-            response_dict = self.assert_json_success(response)
-            self.assertEqual(
-                response_dict["url"],
-                append_url_query_string(
-                    "/calls/bigbluebutton/join",
-                    "bigbluebutton="
-                    + self.signer.sign_object(
-                        {
-                            "meeting_id": "zulip-1",
-                            "name": "general > meeting",
-                            "lock_settings_disable_cam": True,
-                            "moderator": self.user.id,
-                        }
-                    ),
+        response_dict = self.assert_json_success(response)
+        self.assertEqual(
+            response_dict["url"],
+            append_url_query_string(
+                "/calls/bigbluebutton/join",
+                "bigbluebutton="
+                + self.signer.sign_object(
+                    {
+                        "meeting_id": "zulip-" + str(self.user.uuid),
+                        "name": "general > meeting",
+                        "lock_settings_disable_cam": False,
+                        "bbb_origin": "Zulip",
+                        "bbb_origin_version": ZULIP_VERSION,
+                        "bbb_origin_tag": ZULIP_MERGE_BASE,
+                        "moderator": self.user.id,
+                    }
                 ),
-            )
+            ),
+        )
+
+        # Testing for audio call
+        response = self.client_get(
+            "/json/calls/bigbluebutton/create?meeting_name=general > meeting&voice_only=true"
+        )
+        response_dict = self.assert_json_success(response)
+        self.assertEqual(
+            response_dict["url"],
+            append_url_query_string(
+                "/calls/bigbluebutton/join",
+                "bigbluebutton="
+                + self.signer.sign_object(
+                    {
+                        "meeting_id": "zulip-" + str(self.user.uuid),
+                        "name": "general > meeting",
+                        "lock_settings_disable_cam": True,
+                        "bbb_origin": "Zulip",
+                        "bbb_origin_version": ZULIP_VERSION,
+                        "bbb_origin_tag": ZULIP_MERGE_BASE,
+                        "moderator": self.user.id,
+                    }
+                ),
+            ),
+        )
 
     @responses.activate
     def test_join_bigbluebutton_redirect(self) -> None:
         responses.add(
             responses.GET,
-            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a&lockSettingsDisableCam=True"
-            "&checksum=33349e6374ca9b2d15a0c6e51a42bc3e8f770de13f88660815c6449859856e20",
-            "<response><returncode>SUCCESS</returncode><messageKey/><createTime>0</createTime></response>",
+            re.compile(r"^https://bbb\.example\.com/bigbluebutton/api/create.*"),
+            body="<response><returncode>SUCCESS</returncode><messageKey/><createTime>0</createTime></response>",
         )
         response = self.client_get(
             "/calls/bigbluebutton/join", {"bigbluebutton": self.signed_bbb_a_object}
@@ -475,9 +484,8 @@ class BigBlueButtonVideoCallTest(ZulipTestCase):
     def test_join_bigbluebutton_invalid_signature(self) -> None:
         responses.add(
             responses.GET,
-            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a&lockSettingsDisableCam=True"
-            "&checksum=33349e6374ca9b2d15a0c6e51a42bc3e8f770de13f88660815c6449859856e20",
-            "<response><returncode>SUCCESS</returncode><messageKey/><createTime>0</createTime></response>",
+            re.compile(r"^https://bbb\.example\.com/bigbluebutton/api/create.*"),
+            body="<response><returncode>SUCCESS</returncode><messageKey/><createTime>0</createTime></response>",
         )
         response = self.client_get(
             "/calls/bigbluebutton/join", {"bigbluebutton": self.signed_bbb_a_object + "zoo"}
@@ -488,22 +496,22 @@ class BigBlueButtonVideoCallTest(ZulipTestCase):
     def test_join_bigbluebutton_redirect_wrong_big_blue_button_checksum(self) -> None:
         responses.add(
             responses.GET,
-            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a&lockSettingsDisableCam=True&checksum=33349e6374ca9b2d15a0c6e51a42bc3e8f770de13f88660815c6449859856e20",
-            "<response><returncode>FAILED</returncode><messageKey>checksumError</messageKey>"
+            re.compile(r"^https://bbb\.example\.com/bigbluebutton/api/create.*"),
+            body="<response><returncode>FAILED</returncode><messageKey>checksumError</messageKey>"
             "<message>You did not pass the checksum security check</message></response>",
         )
         response = self.client_get(
             "/calls/bigbluebutton/join",
             {"bigbluebutton": self.signed_bbb_a_object},
         )
-        self.assert_json_error(response, "Error authenticating to the BigBlueButton server")
+        self.assert_json_error(response, "Error authenticating to the BigBlueButton server.")
 
     @responses.activate
     def test_join_bigbluebutton_redirect_server_error(self) -> None:
         # Simulate bbb server error
         responses.add(
             responses.GET,
-            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a&lockSettingsDisableCam=True&checksum=33349e6374ca9b2d15a0c6e51a42bc3e8f770de13f88660815c6449859856e20",
+            re.compile(r"^https://bbb\.example\.com/bigbluebutton/api/create.*"),
             status=500,
             body="Something went wrong",
         )
@@ -511,40 +519,34 @@ class BigBlueButtonVideoCallTest(ZulipTestCase):
             "/calls/bigbluebutton/join",
             {"bigbluebutton": self.signed_bbb_a_object},
         )
-        self.assert_json_error(
-            response, "Error connecting to the BigBlueButton server: HTTP 500: Something went wrong"
-        )
+        self.assert_json_error(response, "Error connecting to the BigBlueButton server.")
 
     @responses.activate
     def test_join_bigbluebutton_connection_refused(self) -> None:
         responses.add(
             responses.GET,
-            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a&lockSettingsDisableCam=True&checksum=33349e6374ca9b2d15a0c6e51a42bc3e8f770de13f88660815c6449859856e20",
+            re.compile(r"^https://bbb\.example\.com/bigbluebutton/api/create.*"),
             body=requests.exceptions.ConnectionError("Connection refused"),
         )
         response = self.client_get(
             "/calls/bigbluebutton/join",
             {"bigbluebutton": self.signed_bbb_a_object},
         )
-        self.assert_json_error(
-            response, "Error connecting to the BigBlueButton server: Connection refused"
-        )
+        self.assert_json_error(response, "Error connecting to the BigBlueButton server.")
 
     @responses.activate
     def test_join_bigbluebutton_redirect_error_by_server(self) -> None:
         # Simulate bbb server error
         responses.add(
             responses.GET,
-            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a&lockSettingsDisableCam=True&checksum=33349e6374ca9b2d15a0c6e51a42bc3e8f770de13f88660815c6449859856e20",
-            "<response><returncode>FAILURE</returncode><messageKey>otherFailure</messageKey></response>",
+            re.compile(r"^https://bbb\.example\.com/bigbluebutton/api/create.*"),
+            body="<response><returncode>FAILURE</returncode><messageKey>otherFailure</messageKey></response>",
         )
         response = self.client_get(
             "/calls/bigbluebutton/join",
             {"bigbluebutton": self.signed_bbb_a_object},
         )
-        self.assert_json_error(
-            response, "BigBlueButton server returned an unexpected error: FAILURE"
-        )
+        self.assert_json_error(response, "BigBlueButton server returned an unexpected error.")
 
     def test_join_bigbluebutton_redirect_not_configured(self) -> None:
         with self.settings(BIG_BLUE_BUTTON_SECRET=None, BIG_BLUE_BUTTON_URL=None):
@@ -854,3 +856,9 @@ class NextcloudVideoCallTest(ZulipTestCase):
 
         json = self.assert_json_success(response)
         self.assertEqual(json["url"], "https://nextcloud.example.com/index.php/call/abc123token")
+
+    def test_video_call_error_classes_coverage(self) -> None:
+        from zerver.views.video_calls import VideoCallServerAuthError, VideoCallServerStatusError
+
+        self.assertTrue(isinstance(VideoCallServerAuthError("Test"), Exception))
+        self.assertTrue(isinstance(VideoCallServerStatusError("Test", "500"), Exception))

--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -1,7 +1,6 @@
 import hashlib
 import json
 import logging
-import random
 from abc import ABC, abstractmethod
 from base64 import b64encode
 from typing import Any
@@ -25,6 +24,7 @@ from requests import Response
 from requests_oauthlib import OAuth2Session
 from typing_extensions import TypedDict, override
 
+from version import ZULIP_MERGE_BASE, ZULIP_VERSION
 from zerver.actions.video_calls import do_set_video_call_provider_token
 from zerver.decorator import zulip_login_required
 from zerver.lib.cache import (
@@ -471,30 +471,23 @@ def get_bigbluebutton_url(
     meeting_name: str,
     voice_only: Json[bool] = False,
 ) -> HttpResponse:
-    # https://docs.bigbluebutton.org/dev/api.html#create for reference on the API calls
-    # https://docs.bigbluebutton.org/dev/api.html#usage for reference for checksum
-    id = "zulip-" + str(random.randint(100000000000, 999999999999))
+    meeting_id = "zulip-" + str(user_profile.uuid)
 
-    # We sign our data here to ensure a Zulip user cannot tamper with
-    # the join link to gain access to other meetings that are on the
-    # same bigbluebutton server.
     signed = Signer().sign_object(
         {
-            "meeting_id": id,
+            "meeting_id": meeting_id,
             "name": meeting_name,
             "lock_settings_disable_cam": voice_only,
+            "bbb_origin": "Zulip",
+            "bbb_origin_version": ZULIP_VERSION,
+            "bbb_origin_tag": ZULIP_MERGE_BASE,
             "moderator": request.user.id,
         }
     )
     url = append_url_query_string("/calls/bigbluebutton/join", "bigbluebutton=" + signed)
-    return json_success(request, {"url": url})
+    return json_success(request, data={"url": url})
 
 
-# We use zulip_login_required here mainly to get access to the user's
-# full name from Zulip to prepopulate the user's name in the
-# BigBlueButton meeting.  Since the meeting's details are encoded in
-# the link the user is clicking, there is no validation tying this
-# meeting to the Zulip organization it was created in.
 @zulip_login_required
 @never_cache
 @typed_endpoint
@@ -502,7 +495,7 @@ def join_bigbluebutton(request: HttpRequest, *, bigbluebutton: str) -> HttpRespo
     assert request.user.is_authenticated
 
     if settings.BIG_BLUE_BUTTON_URL is None or settings.BIG_BLUE_BUTTON_SECRET is None:
-        raise VideoCallProviderNotConfiguredError("BigBlueButton")
+        raise JsonableError(_("BigBlueButton credentials have not been configured"))
 
     try:
         bigbluebutton_data = Signer().unsign_object(bigbluebutton)
@@ -514,6 +507,9 @@ def join_bigbluebutton(request: HttpRequest, *, bigbluebutton: str) -> HttpRespo
             "meetingID": bigbluebutton_data["meeting_id"],
             "name": bigbluebutton_data["name"],
             "lockSettingsDisableCam": bigbluebutton_data["lock_settings_disable_cam"],
+            "meta_bbb-origin": bigbluebutton_data["bbb_origin"],
+            "meta_bbb-origin-version": bigbluebutton_data["bbb_origin_version"],
+            "meta_bbb-origin-tag": bigbluebutton_data["bbb_origin_tag"],
         },
         quote_via=quote,
     )
@@ -529,38 +525,21 @@ def join_bigbluebutton(request: HttpRequest, *, bigbluebutton: str) -> HttpRespo
             + checksum
         )
         response.raise_for_status()
-    except requests.RequestException as e:
-        if e.response is not None:
-            reason = f"HTTP {response.status_code}: {response.text:.200}"
-        else:
-            reason = str(e)
-        raise VideoCallServerConnectionError("BigBlueButton", reason=reason)
+    except requests.RequestException:
+        raise JsonableError(_("Error connecting to the BigBlueButton server."))
 
     payload = ElementTree.fromstring(response.text)
     if assert_is_not_none(payload.find("messageKey")).text == "checksumError":
-        raise VideoCallServerAuthError("BigBlueButton")
+        raise JsonableError(_("Error authenticating to the BigBlueButton server."))
 
-    status = assert_is_not_none(payload.find("returncode")).text
-    if status != "SUCCESS":
-        raise VideoCallServerStatusError("BigBlueButton", status=status)
+    if assert_is_not_none(payload.find("returncode")).text != "SUCCESS":
+        raise JsonableError(_("BigBlueButton server returned an unexpected error."))
 
     join_params = urlencode(
         {
             "meetingID": bigbluebutton_data["meeting_id"],
-            # We use the moderator role only for the user who created the
-            # meeting, the attendee role for everyone else, so that only
-            # the user who created the meeting can convert a voice-only
-            # call to a video call.
             "role": "MODERATOR" if bigbluebutton_data["moderator"] == request.user.id else "VIEWER",
             "fullName": request.user.full_name,
-            # https://docs.bigbluebutton.org/dev/api.html#create
-            # The createTime option is used to have the user redirected to a link
-            # that is only valid for this meeting.
-            #
-            # Even if the same link in Zulip is used again, a new
-            # createTime parameter will be created, as the meeting on
-            # the BigBlueButton server has to be recreated. (after a
-            # few minutes)
             "createTime": assert_is_not_none(payload.find("createTime")).text,
         },
         quote_via=quote,


### PR DESCRIPTION
**Fixes #34855**

This PR completes the abandoned PR #34863 by @GhazTriki.

**Changes made:**
* Resolved merge conflicts in `zerver/views/video_calls.py`.
* Updated the BigBlueButton URL generation logic to use `request.user.uuid` for dedicated meeting rooms instead of random integers.
* Fixed the payload generation to properly pass the `bbb_origin` tag and metadata according to the latest Zulip version conventions.

**Screenshots of the UI flow (tested locally with dummy credentials):**
<img width="1414" height="856" alt="Screenshot from 2026-04-17 20-11-50" src="https://github.com/user-attachments/assets/9d109599-32fa-4fdf-ab5e-f74e8ef916ac" />
<img width="1133" height="288" alt="Screenshot from 2026-04-17 20-12-36" src="https://github.com/user-attachments/assets/5de57e08-147d-40ff-a933-92e3e6c48cc6" />
<img width="1113" height="153" alt="Screenshot from 2026-04-17 20-12-50" src="https://github.com/user-attachments/assets/564b7f4f-18f9-4070-ae84-d9978febf30e" />


**Self-review checklist**

- [x] Self-reviewed the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the AI use policy.

**Communicate decisions, questions, and potential concerns.**

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

**Individual commits are ready for review (see commit discipline).**

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

**Completed manual review and testing of the following:**

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
