### PR TITLE
modal: Add modal_select_wide class for full-width inputs

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -653,6 +653,7 @@
     /* Informational overlay */
     --informational-overlay-max-width: 43.75em;
     --modal-input-width: 23.2142em;
+    --modal-wide-input-width: 100%;
     /* Dropdown menu width. This is a legacy value that comes from bootstrap.
        See 1c6bed55e4e800b5bad7150f6bdd274cd7f6504e for more context. */
     --width-dropdown-widget-button: 206px;

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -832,6 +832,10 @@
     }
 }
 
+.modal_select_wide {
+    width: var(--modal-wide-input-width);
+}
+
 .modal-field-label {
     margin-bottom: var(--margin-bottom-field-description);
     /* Avoid having the clickable area extend to the full width of the containing element */

--- a/web/templates/start_export_modal.hbs
+++ b/web/templates/start_export_modal.hbs
@@ -3,9 +3,9 @@
     <div class="input-group">
         <label for="export_type" class="modal-field-label">{{t "Data to export" }} {{> help_link_widget
             link="/help/export-your-organization" }}</label>
-        <select id="export_type" class="modal_select modal_select_wide bootstrap-focus-style"> {{#each
-            export_type_values}}
-            <option {{#if this.default }}selected{{/if}} value="{{this.slug}}">{{this.description}}</option>
+        <select id="export_type" class="modal_select modal_select_wide bootstrap-focus-style">
+            {{#each export_type_values}}
+                <option {{#if this.default }}selected{{/if}} value="{{this.slug}}">{{this.description}}</option>
             {{/each}}
         </select>
     </div>

--- a/web/templates/start_export_modal.hbs
+++ b/web/templates/start_export_modal.hbs
@@ -1,10 +1,11 @@
 <p id="allow_private_data_export_banner_container"></p>
 <form class="modal-form" id="start-export-form">
     <div class="input-group">
-        <label for="export_type" class="modal-field-label">{{t "Data to export" }} {{> help_link_widget link="/help/export-your-organization" }}</label>
-        <select id="export_type" class="modal_select bootstrap-focus-style">
-            {{#each export_type_values}}
-                <option {{#if this.default }}selected{{/if}} value="{{this.slug}}">{{this.description}}</option>
+        <label for="export_type" class="modal-field-label">{{t "Data to export" }} {{> help_link_widget
+            link="/help/export-your-organization" }}</label>
+        <select id="export_type" class="modal_select modal_select_wide bootstrap-focus-style"> {{#each
+            export_type_values}}
+            <option {{#if this.default }}selected{{/if}} value="{{this.slug}}">{{this.description}}</option>
             {{/each}}
         </select>
     </div>


### PR DESCRIPTION
Adds CSS infrastructure to standardize modal inputs to two sizes as described in #34375.

The existing `.modal_select` defaults to half-width (`--modal-input-width`). This PR adds `.modal_select_wide` using `--modal-wide-input-width: 100%` for full-width inputs, and applies it to the export type dropdown as an example.

**Before** (half-width):
<img width="1470" height="956" alt="Before changes" src="https://github.com/user-attachments/assets/40deebee-9688-490c-875e-5460f63789bb" />


**After** (full-width):
<img width="1470" height="956" alt="After changes" src="https://github.com/user-attachments/assets/30ec1f21-32cf-4a01-9f3e-1abe60d74035" />
