### PR TITLE
reactions: Live-update vote text in pills on user rename.

### DIFF
--- a/web/src/reactions.ts
+++ b/web/src/reactions.ts
@@ -741,3 +741,16 @@ export function rewire_update_vote_text_on_message(
 ): void {
     update_vote_text_on_message = value;
 }
+
+export function update_user_full_name(user_id: number): void {
+    // When a user's full name changes, we need to re-render the
+    // vote text on any reaction pill that includes that user, since
+    // vote text may contain display names.
+    for (const msg_list of message_lists.all_rendered_message_lists()) {
+        for (const message of msg_list.all_messages()) {
+            if ([...message.clean_reactions.values()].some((r) => r.user_ids.includes(user_id))) {
+                update_vote_text_on_message(message);
+            }
+        }
+    }
+}

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -15,6 +15,7 @@ import * as message_live_update from "./message_live_update.ts";
 import * as navbar_alerts from "./navbar_alerts.ts";
 import * as people from "./people.ts";
 import * as pm_list from "./pm_list.ts";
+import * as reactions from "./reactions.ts";
 import * as settings from "./settings.ts";
 import * as settings_account from "./settings_account.ts";
 import * as settings_bots from "./settings_bots.ts";
@@ -97,6 +98,7 @@ export const update_person = function update(event: UserUpdate): void {
         settings_users.update_user_data(event.user_id, event);
         activity_ui.redraw();
         message_live_update.update_user_full_name(event.user_id, event.full_name);
+        reactions.update_user_full_name(event.user_id);
         pm_list.update_private_messages();
         user_profile.update_profile_modal_ui(user, event);
         if (people.is_my_user_id(event.user_id)) {

--- a/web/tests/reactions.test.cjs
+++ b/web/tests/reactions.test.cjs
@@ -555,6 +555,25 @@ test("update_vote_text_on_message", ({override, override_rewire}) => {
     assert.deepEqual(message, updated_message);
 });
 
+test("update_user_full_name", ({override, override_rewire}) => {
+    const message = sample_message_with_clean_reactions();
+    override(message_lists, "all_rendered_message_lists", () => [{all_messages: () => [message]}]);
+
+    let updated_messages = [];
+    override_rewire(reactions, "update_vote_text_on_message", (msg) => {
+        updated_messages.push(msg.id);
+    });
+
+    // alice_user_id (5) is in reactions — should trigger update.
+    reactions.update_user_full_name(alice_user_id);
+    assert.deepEqual(updated_messages, [1001]);
+
+    // User 999 has no reactions — should not trigger update.
+    updated_messages = [];
+    reactions.update_user_full_name(999);
+    assert.deepEqual(updated_messages, []);
+});
+
 test("find_reaction", () => {
     const message_id = 99;
     const local_id = "unicode_emoji,1f44b";


### PR DESCRIPTION
When a user's full name changes, reaction pill vote text was not updated until refresh. Tooltips were correct since they read from the people store, but the pill text had no handler for realm_user/update.

Fix this by updating vote text for rendered messages when the people store is updated.

Fixes #38595.

<!-- Describe your pull request here.-->


**How changes were tested:**
Open two tabs with User A and User B, have User A react to a message, then change User A’s name and check User B’s view, before the fix the pill shows the old name, after the fix it updates live to the new name.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="657" height="287" alt="Screenshot 2026-03-21 at 22 33 04" src="https://github.com/user-attachments/assets/c32393cc-7bc2-496b-bf11-1ddd6f285282" />

https://github.com/user-attachments/assets/415fb53c-5e9e-4f80-b5ed-3470b785c905




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>


