### PR TITLE
widgets: Replace FontAwesome icons in poll and todo widgets

### DIFF
--- a/web/templates/widgets/poll_widget.hbs
+++ b/web/templates/widgets/poll_widget.hbs
@@ -1,11 +1,11 @@
 <div class="poll-widget">
     <div class="poll-widget-header-area">
         <h4 class="poll-question-header"></h4>
-        <i class="fa fa-pencil poll-edit-question"></i>
+        <i class="zulip-icon zulip-icon-pencil poll-edit-question"></i>
         <div class="poll-question-bar">
             <input type="text" class="poll-question" placeholder="{{t 'Add question'}}" />
-            <button class="poll-question-remove"><i class="fa fa-remove"></i></button>
-            <button class="poll-question-check"><i class="fa fa-check"></i></button>
+            <button class="poll-question-remove"><i class="zulip-icon zulip-icon-close"></i></button>
+            <button class="poll-question-check"><i class="zulip-icon zulip-icon-check"></i></button>
         </div>
     </div>
     <div class="poll-please-wait">

--- a/web/templates/widgets/poll_widget_example.hbs
+++ b/web/templates/widgets/poll_widget_example.hbs
@@ -1,6 +1,6 @@
 <div class="poll-widget">
     <h4 class="poll-question-header">{{t "What did you drink this morning?"}}</h4>
-    <i class="fa fa-pencil poll-edit-question"></i>
+    <i class="zulip-icon zulip-icon-pencil poll-edit-question"></i>
     <ul class="poll-widget">
         <li>
             <button class="poll-vote">

--- a/web/templates/widgets/todo_widget.hbs
+++ b/web/templates/widgets/todo_widget.hbs
@@ -1,11 +1,11 @@
 <div class="todo-widget">
     <div class="todo-widget-header-area">
         <h4 class="todo-task-list-title-header">{{t "Task list" }}</h4>
-        <i class="fa fa-pencil todo-edit-task-list-title"></i>
+        <i class="zulip-icon zulip-icon-pencil todo-edit-task-list-title"></i>
         <div class="todo-task-list-title-bar">
             <input type="text" class="todo-task-list-title" placeholder="{{t 'Add todo task list title'}}" />
-            <button class="todo-task-list-title-remove"><i class="fa fa-remove"></i></button>
-            <button class="todo-task-list-title-check"><i class="fa fa-check"></i></button>
+            <button class="todo-task-list-title-remove"><i class="zulip-icon zulip-icon-close"></i></button>
+            <button class="todo-task-list-title-check"><i class="zulip-icon zulip-icon-check"></i></button>
         </div>
     </div>
     <ul class="todo-widget">


### PR DESCRIPTION
Replaces `fa-pencil`, `fa-check`, and `fa-remove` in the poll and todo widget templates with their `zulip-icon` equivalents.

<!-- Describe your pull request here.-->

Fixes: part of #36224.

**How changes were tested:** 
- Created poll and todo from composer to compare icons.
- Used Chrome dev tool to check CSS style



<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

|before - pencil |after - pencil | 
| --- | --- |
|<img width="1367" height="509" alt="screensht_pencile_before" src="https://github.com/user-attachments/assets/20812a27-9cc9-4dcc-b4fe-628b621eb054" />|<img width="1363" height="506" alt="screenshot_pencile_after2" src="https://github.com/user-attachments/assets/abf71594-95be-4162-ae20-27def5a8c8a1" />|



|before - close and check |after - close and check|
| --- | --- |
|<img width="1368" height="528" alt="screenshot_editbutton_before" src="https://github.com/user-attachments/assets/8a6b9969-7361-4f9a-8b58-770671c03260" />|<img width="1360" height="527" alt="screenshot_editbutton_after" src="https://github.com/user-attachments/assets/6b8a2361-7945-4197-89d7-820e8fbe3f7c" />




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
