### PR TITLE
oauth: Make Zulip an OAuth provider.

### DIFF
--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -220,6 +220,42 @@ exactly what data is being used in the test without looking at other
 resources. It also gives us more freedom to edit the development
 environment directory without worrying about tests.
 
+## Zulip as an OAuth2 provider
+
+Zulip can act as an OAuth2 authorization server so third-party apps
+can obtain an access token and call the Zulip API on behalf of a user.
+This uses [django-oauth-toolkit][1] and is experimental: it is not
+supported in production or covered by security support.
+
+To enable it, set `ENABLE_ZULIP_OAUTH` to `True`. That is the default
+in the development environment; production settings default to
+`False`. When enabled, Zulip installs the `oauth2_provider` Django app
+(models and migrations), serves OAuth endpoints under `/o/`, and accepts
+`Authorization: Bearer` tokens on the REST API. When disabled, the app
+is not installed and those code paths are not loaded.
+
+To try the flow in development:
+
+- Open `/o/applications/` while logged in and register an application
+  (authorization code grant only).
+- Complete the authorization code flow at `/o/authorize/` and exchange
+  the code at `/o/token/`.
+- Call Zulip REST API endpoints with
+  `Authorization: Bearer <access_token>`. Unauthenticated `/api`
+  responses advertise both `Bearer` and `Basic` in
+  `WWW-Authenticate` when this feature is enabled.
+
+No additional secrets are required in `dev-secrets.conf` (or
+`/etc/zulip/zulip-secrets.conf` in production). Access tokens are
+stored in the database and looked up when validating a request.
+
+Tokens currently grant the same API access as the authorizing user's
+API key. Incoming webhook bots cannot use bearer authentication.
+
+As of writing, this only authorizes access to Zulip itself (the API
+and related endpoints such as uploads). It is not a general identity
+provider for other applications.
+
 ## Two factor authentication
 
 Zulip uses [django-two-factor-auth][0] as a beta 2FA integration.
@@ -247,3 +283,4 @@ password.
 Visit <https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete> for more details.
 
 [0]: https://github.com/Bouke/django-two-factor-auth
+[1]: https://github.com/jazzband/django-oauth-toolkit

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -220,6 +220,47 @@ exactly what data is being used in the test without looking at other
 resources. It also gives us more freedom to edit the development
 environment directory without worrying about tests.
 
+## Zulip as an OAuth2 provider
+
+Zulip can act as an OAuth2 authorization server so third-party apps
+can obtain an access token and call the Zulip API on behalf of a user.
+This uses [django-oauth-toolkit][1] and is experimental: it is not
+supported in production or covered by security support.
+
+To enable it, set `ENABLE_ZULIP_OAUTH` to `True`. That is the default
+in the development environment; production settings default to
+`False`. When enabled, Zulip installs the `oauth2_provider` Django app
+(models and migrations), serves OAuth endpoints under `/o/`, and accepts
+`Authorization: Bearer` tokens on the REST API. When disabled, the app
+is not installed and those code paths are not loaded.
+
+To try the flow in development:
+
+- As an organization administrator, open `/o/applications/` and
+  register an application (authorization code grant only). Each
+  application is owned by the administrator who created it.
+- As the Zulip user who will grant access (any logged-in user, not
+  only an administrator), complete the authorization code flow. PKCE
+  with `S256` is required. Send `code_challenge` and
+  `code_challenge_method=S256` on `GET /o/authorize/`. Then send the
+  matching `code_verifier` with the code, `redirect_uri`, and client
+  credentials on `POST /o/token/`.
+- Call Zulip REST API endpoints with
+  `Authorization: Bearer <access_token>`. Unauthenticated `/api`
+  responses advertise both `Bearer` and `Basic` in
+  `WWW-Authenticate` when this feature is enabled.
+
+No additional secrets are required in `dev-secrets.conf` (or
+`/etc/zulip/zulip-secrets.conf` in production). Access tokens are
+stored in the database and looked up when validating a request.
+
+Tokens currently grant the same API access as the authorizing user's
+API key. Incoming webhook bots cannot use bearer authentication.
+
+As of writing, this only authorizes access to Zulip itself (the API
+and related endpoints such as uploads). It is not a general identity
+provider for other applications.
+
 ## Two factor authentication
 
 Zulip uses [django-two-factor-auth][0] as a beta 2FA integration.
@@ -247,3 +288,4 @@ password.
 Visit <https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete> for more details.
 
 [0]: https://github.com/Bouke/django-two-factor-auth
+[1]: https://github.com/jazzband/django-oauth-toolkit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,9 @@ prod = [
 
   # Used to parse User-Agent string for OS & browser names
   "ua-parser[regex]>=1.0.2",
+
+  # Needed to make Zulip server act as OAuth2 Provider
+  "django-oauth-toolkit",
 ]
 docs = [
   # Needed to build RTD docs
@@ -444,6 +447,7 @@ module = [
     "talon_core.*",
     "tlds.*",
     "two_factor.*",
+    "oauth2_provider.*"
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,9 @@ prod = [
 
   # Used to parse User-Agent string for OS & browser names
   "ua-parser[regex]>=1.0.2",
+
+  # Needed to make Zulip server act as OAuth2 Provider
+  "django-oauth-toolkit",
 ]
 docs = [
   # Needed to build RTD docs
@@ -441,6 +444,7 @@ module = [
     "talon_core.*",
     "tlds.*",
     "two_factor.*",
+    "oauth2_provider.*"
 ]
 ignore_missing_imports = true
 

--- a/tools/test-migrations
+++ b/tools/test-migrations
@@ -3,7 +3,8 @@ set -e
 echo 'Testing whether migrations are consistent with models'
 
 # Check if any migration looks to have a meaningless 'auto' name,
-# other than the existing handful from 2016 and 2017.
+# other than the existing handful from 2016 and 2017, and the ones
+# introduced by oauth2_provider.
 new_auto_named_migrations=$(./manage.py showmigrations \
     | grep -E ' [0-9]{4}_auto_' \
     | grep -Eve ' [0-9]{4}_auto_201[67]' \
@@ -13,6 +14,10 @@ new_auto_named_migrations=$(./manage.py showmigrations \
         -e ' 0002_auto_20190420_0723' \
         -e ' 0009_auto_20191118_0520' \
         -e ' 0007_auto_20201201_1019' \
+        -e ' 0002_auto_20190406_1805' \
+        -e ' 0003_auto_20201211_1314' \
+        -e ' 0004_auto_20200902_2022' \
+        -e ' 0005_auto_20211222_2352' \
     | sed 's/\[[x ]\] /  /' \
     || true)
 if [ "$new_auto_named_migrations" != "" ]; then

--- a/uv.lock
+++ b/uv.lock
@@ -1206,6 +1206,21 @@ wheels = [
 ]
 
 [[package]]
+name = "django-oauth-toolkit"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "jwcrypto" },
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/95/efd83b35c34b86eb2249d2b54c5eaf383c48f3f19034aa6f3807e37471b6/django_oauth_toolkit-3.2.0.tar.gz", hash = "sha256:c36761ae6810083d95a652e9c820046cde0d45a2e2a5574bbe7202656ec20bb6", size = 114211, upload-time = "2026-01-08T22:03:13.311Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/cc/f27a784c0ecd13335abd9ef85ebb80dbc04945f919da5f496f56e3562751/django_oauth_toolkit-3.2.0-py3-none-any.whl", hash = "sha256:bd2cd2719b010231a2f370f927dbcc740454fb1d0dd7e7f4138f36227363dc26", size = 87077, upload-time = "2026-01-08T22:03:12.123Z" },
+]
+
+[[package]]
 name = "django-otp"
 version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2238,6 +2253,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/37/88/8678fcb9f7db1aa7efb338d58f320203b74e865a12583c108291ed9d3df7/jsx-lexer-2.0.1.tar.gz", hash = "sha256:0d9aa653e74d7973d74021dde8349896c0df094d8e40349b92b35e0930ed7f71", size = 4007, upload-time = "2023-05-16T15:16:04.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/2d/6369d2f3ce55cee200202e37435601e5e50d575c2f8ffb367129e584f3f5/jsx_lexer-2.0.1-py2.py3-none-any.whl", hash = "sha256:508a08757764356aa36fd703596fdd59f789104f44b6568c7a14e27e62e57ad4", size = 4071, upload-time = "2023-05-16T15:16:02.786Z" },
+]
+
+[[package]]
+name = "jwcrypto"
+version = "1.5.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/db/870e5d5fb311b0bcf049630b5ba3abca2d339fd5e13ba175b4c13b456d08/jwcrypto-1.5.6.tar.gz", hash = "sha256:771a87762a0c081ae6166958a954f80848820b2ab066937dc8b8379d65b1b039", size = 87168, upload-time = "2024-03-06T19:58:31.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/58/4a1880ea64032185e9ae9f63940c9327c6952d5584ea544a8f66972f2fda/jwcrypto-1.5.6-py3-none-any.whl", hash = "sha256:150d2b0ebbdb8f40b77f543fb44ffd2baeff48788be71f67f03566692fd55789", size = 92520, upload-time = "2024-03-06T19:58:29.765Z" },
 ]
 
 [[package]]
@@ -6369,6 +6397,7 @@ dev = [
     { name = "django-bitfield" },
     { name = "django-bmemcached" },
     { name = "django-cte" },
+    { name = "django-oauth-toolkit" },
     { name = "django-scim2" },
     { name = "django-stubs" },
     { name = "django-stubs-ext" },
@@ -6510,6 +6539,7 @@ prod = [
     { name = "django-bitfield" },
     { name = "django-bmemcached" },
     { name = "django-cte" },
+    { name = "django-oauth-toolkit" },
     { name = "django-scim2" },
     { name = "django-stubs-ext" },
     { name = "django-two-factor-auth", extra = ["call", "phonenumberslite", "sms"] },
@@ -6608,6 +6638,7 @@ dev = [
     { name = "django-bitfield", git = "https://github.com/disqus/django-bitfield.git" },
     { name = "django-bmemcached" },
     { name = "django-cte" },
+    { name = "django-oauth-toolkit" },
     { name = "django-scim2" },
     { name = "django-stubs" },
     { name = "django-stubs-ext" },
@@ -6750,6 +6781,7 @@ prod = [
     { name = "django-bitfield", git = "https://github.com/disqus/django-bitfield.git" },
     { name = "django-bmemcached" },
     { name = "django-cte" },
+    { name = "django-oauth-toolkit" },
     { name = "django-scim2" },
     { name = "django-stubs-ext" },
     { name = "django-two-factor-auth", extras = ["call", "phonenumberslite", "sms"] },

--- a/uv.lock
+++ b/uv.lock
@@ -1356,6 +1356,21 @@ wheels = [
 ]
 
 [[package]]
+name = "django-oauth-toolkit"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "jwcrypto" },
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/95/efd83b35c34b86eb2249d2b54c5eaf383c48f3f19034aa6f3807e37471b6/django_oauth_toolkit-3.2.0.tar.gz", hash = "sha256:c36761ae6810083d95a652e9c820046cde0d45a2e2a5574bbe7202656ec20bb6", size = 114211, upload-time = "2026-01-08T22:03:13.311Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/cc/f27a784c0ecd13335abd9ef85ebb80dbc04945f919da5f496f56e3562751/django_oauth_toolkit-3.2.0-py3-none-any.whl", hash = "sha256:bd2cd2719b010231a2f370f927dbcc740454fb1d0dd7e7f4138f36227363dc26", size = 87077, upload-time = "2026-01-08T22:03:12.123Z" },
+]
+
+[[package]]
 name = "django-otp"
 version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2428,6 +2443,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/37/88/8678fcb9f7db1aa7efb338d58f320203b74e865a12583c108291ed9d3df7/jsx-lexer-2.0.1.tar.gz", hash = "sha256:0d9aa653e74d7973d74021dde8349896c0df094d8e40349b92b35e0930ed7f71", size = 4007, upload-time = "2023-05-16T15:16:04.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/2d/6369d2f3ce55cee200202e37435601e5e50d575c2f8ffb367129e584f3f5/jsx_lexer-2.0.1-py2.py3-none-any.whl", hash = "sha256:508a08757764356aa36fd703596fdd59f789104f44b6568c7a14e27e62e57ad4", size = 4071, upload-time = "2023-05-16T15:16:02.786Z" },
+]
+
+[[package]]
+name = "jwcrypto"
+version = "1.5.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/db/870e5d5fb311b0bcf049630b5ba3abca2d339fd5e13ba175b4c13b456d08/jwcrypto-1.5.6.tar.gz", hash = "sha256:771a87762a0c081ae6166958a954f80848820b2ab066937dc8b8379d65b1b039", size = 87168, upload-time = "2024-03-06T19:58:31.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/58/4a1880ea64032185e9ae9f63940c9327c6952d5584ea544a8f66972f2fda/jwcrypto-1.5.6-py3-none-any.whl", hash = "sha256:150d2b0ebbdb8f40b77f543fb44ffd2baeff48788be71f67f03566692fd55789", size = 92520, upload-time = "2024-03-06T19:58:29.765Z" },
 ]
 
 [[package]]
@@ -6539,6 +6567,7 @@ dev = [
     { name = "django-bitfield" },
     { name = "django-bmemcached" },
     { name = "django-cte" },
+    { name = "django-oauth-toolkit" },
     { name = "django-scim2" },
     { name = "django-stubs" },
     { name = "django-stubs-ext" },
@@ -6680,6 +6709,7 @@ prod = [
     { name = "django-bitfield" },
     { name = "django-bmemcached" },
     { name = "django-cte" },
+    { name = "django-oauth-toolkit" },
     { name = "django-scim2" },
     { name = "django-stubs-ext" },
     { name = "django-two-factor-auth", extra = ["call", "phonenumberslite", "sms"] },
@@ -6778,6 +6808,7 @@ dev = [
     { name = "django-bitfield" },
     { name = "django-bmemcached" },
     { name = "django-cte" },
+    { name = "django-oauth-toolkit" },
     { name = "django-scim2" },
     { name = "django-stubs", specifier = "<6.1.0" },
     { name = "django-stubs-ext", specifier = "<6.1.0" },
@@ -6920,6 +6951,7 @@ prod = [
     { name = "django-bitfield" },
     { name = "django-bmemcached" },
     { name = "django-cte" },
+    { name = "django-oauth-toolkit" },
     { name = "django-scim2" },
     { name = "django-stubs-ext", specifier = "<6.1.0" },
     { name = "django-two-factor-auth", extras = ["call", "phonenumberslite", "sms"] },

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 506
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (384, 0)  # bumped 2026-07-04 to update build_timezone_values
+PROVISION_VERSION = (384, 1)  # bumped 2026-07-12 to add django-oauth-toolkit

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 509
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (389, 0)  # bumped 2026-08-19 to upgrade Python requirements
+PROVISION_VERSION = (389, 1)  # bumped 2026-08-25 to add django-oauth-toolkit

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import re
 from collections.abc import Callable, Sequence
 from datetime import datetime
 from functools import wraps
@@ -58,7 +59,7 @@ from zerver.lib.webhooks.common import (
 )
 from zerver.models import UserProfile
 from zerver.models.clients import get_client
-from zerver.models.users import get_user_profile_by_api_key
+from zerver.models.users import get_user_profile_by_api_key, get_user_profile_by_id
 
 if TYPE_CHECKING:
     from django.http.request import _ImmutableQueryDict
@@ -66,6 +67,9 @@ if TYPE_CHECKING:
 webhook_logger = logging.getLogger("zulip.zerver.webhooks")
 webhook_unsupported_events_logger = logging.getLogger("zulip.zerver.webhooks.unsupported")
 webhook_anomalous_payloads_logger = logging.getLogger("zulip.zerver.webhooks.anomalous")
+
+BASIC_AUTH_SCHEME_RE = re.compile(r"(basic) +(\S+)", re.IGNORECASE)
+BASIC_OR_BEARER_AUTH_SCHEME_RE = re.compile(r"(bearer|basic) +(\S+)", re.IGNORECASE)
 
 ParamT = ParamSpec("ParamT")
 ReturnT = TypeVar("ReturnT")
@@ -274,6 +278,29 @@ def validate_api_key(
     request.user = user_profile
     process_client(request, user_profile, client_name=client_name)
 
+    return user_profile
+
+
+def validate_oauth_key(request: HttpRequest) -> UserProfile:
+    # oauth2_provider is only in INSTALLED_APPS when
+    # ENABLE_ZULIP_OAUTH is set.
+    from oauth2_provider.oauth2_backends import get_oauthlib_core
+
+    # No required scopes for now (same access model as API keys).
+    (ok, req) = get_oauthlib_core().verify_request(request, [])
+    if not ok:
+        raise JsonableError(_("OAuth token verification failed"))
+
+    user_profile = get_user_profile_by_id(user_profile_id=req.user.id)
+    request.user = user_profile
+
+    validate_account_and_subdomain(request, user_profile)
+
+    # Using oauth for webhooks might make sense some day, but we punt for now.
+    if user_profile.is_incoming_webhook:
+        raise JsonableError(_("This authentication scheme is not available to incoming webhooks"))
+
+    process_client(request, user_profile)
     return user_profile
 
 
@@ -776,8 +803,36 @@ def get_basic_credentials(
     return role, api_key
 
 
+def check_and_get_authentication_scheme(request: HttpRequest) -> str:
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header == "":
+        if settings.ENABLE_ZULIP_OAUTH:
+            raise UnauthorizedError(
+                _("Missing authorization header"),
+                www_authenticate="basic_or_bearer",
+            )
+        raise UnauthorizedError(_("Missing authorization header"))
+
+    if settings.ENABLE_ZULIP_OAUTH:
+        supported_schemes_match = BASIC_OR_BEARER_AUTH_SCHEME_RE.match(auth_header.strip())
+    else:
+        supported_schemes_match = BASIC_AUTH_SCHEME_RE.match(auth_header.strip())
+
+    if supported_schemes_match is None:
+        if settings.ENABLE_ZULIP_OAUTH:
+            raise JsonableError(
+                _(
+                    "This endpoint requires HTTP basic authentication or bearer token authentication."
+                )
+            )
+        else:
+            raise JsonableError(_("This endpoint requires HTTP basic authentication."))
+
+    return supported_schemes_match.group(1).lower()
+
+
 # A more REST-y authentication decorator, using, in particular, HTTP basic
-# authentication.
+# and bearer authentication.
 #
 # If webhook_client_name is specific, the request is a webhook view
 # with that string as the basis for the client string.
@@ -802,26 +857,34 @@ def authenticated_rest_api_view(
         def _wrapped_func_arguments(
             request: HttpRequest, /, *args: ParamT.args, **kwargs: ParamT.kwargs
         ) -> HttpResponse:
-            role, api_key = get_basic_credentials(
-                request, beanstalk_email_decode=beanstalk_email_decode
-            )
-
-            # Now we try to do authentication or die
-            try:
-                user_profile = validate_api_key(
-                    request,
-                    role,
-                    api_key,
-                    allow_webhook_access=allow_webhook_access,
-                    client_name=full_webhook_client_name(webhook_client_name),
+            auth_scheme = check_and_get_authentication_scheme(request)
+            if auth_scheme == "bearer":
+                try:
+                    user_profile = validate_oauth_key(request)
+                except JsonableError as e:
+                    raise UnauthorizedError(e.msg, www_authenticate="bearer")
+            else:
+                role, api_key = get_basic_credentials(
+                    request, beanstalk_email_decode=beanstalk_email_decode
                 )
 
-                if webhook_client_name is not None:
-                    request_notes = RequestNotes.get_notes(request)
-                    request_notes.is_webhook_view = True
+                # Now we try to do authentication or die
+                try:
+                    user_profile = validate_api_key(
+                        request,
+                        role,
+                        api_key,
+                        allow_webhook_access=allow_webhook_access,
+                        client_name=full_webhook_client_name(webhook_client_name),
+                    )
+                except JsonableError as e:
+                    raise UnauthorizedError(e.msg)
 
-            except JsonableError as e:
-                raise UnauthorizedError(e.msg)
+            # Apply for both basic and bearer so a future OAuth-authenticated
+            # webhook path gets the same request metadata as basic auth.
+            if webhook_client_name is not None:
+                RequestNotes.get_notes(request).is_webhook_view = True
+
             try:
                 if not skip_rate_limiting:
                     rate_limit_user(request, user_profile, domain="api_by_user")

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -165,8 +165,13 @@ class UnauthorizedError(JsonableError):
         if msg is None:
             msg = _("Not logged in: API authentication or user session required")
         super().__init__(msg)
-        if www_authenticate is None:
+        if www_authenticate is None or www_authenticate == "basic":
             self.www_authenticate = 'Basic realm="zulip"'
+        elif www_authenticate == "bearer":
+            self.www_authenticate = 'Bearer realm="zulip"'
+        elif www_authenticate == "basic_or_bearer":
+            # RFC 7235 allows multiple challenges in one header field.
+            self.www_authenticate = 'Bearer realm="zulip", Basic realm="zulip"'
         elif www_authenticate == "session":
             self.www_authenticate = 'Session realm="zulip"'
         else:

--- a/zerver/lib/oauth2.py
+++ b/zerver/lib/oauth2.py
@@ -1,0 +1,100 @@
+from typing import Any
+
+from django import forms
+from django.db import models
+from django.forms.models import modelform_factory
+from django.urls import path
+from django.utils.translation import gettext_lazy as _
+from oauth2_provider.models import get_application_model
+from oauth2_provider.views import (
+    ApplicationDelete,
+    ApplicationDetail,
+    ApplicationList,
+    ApplicationRegistration,
+    ApplicationUpdate,
+    AuthorizationView,
+    RevokeTokenView,
+    TokenView,
+)
+from typing_extensions import override
+
+# Fields shown on the stock django-oauth-toolkit application create/edit forms.
+APPLICATION_FORM_FIELDS = (
+    "name",
+    "client_id",
+    "client_secret",
+    "hash_client_secret",
+    "client_type",
+    "authorization_grant_type",
+    "redirect_uris",
+    "post_logout_redirect_uris",
+    "allowed_origins",
+    "algorithm",
+)
+
+
+class ZulipOAuthApplicationForm(forms.ModelForm[models.Model]):
+    """Application form with grant type fixed to authorization code.
+
+    The field is shown disabled so users cannot pick another OAuth grant
+    type. Django ignores client-submitted values for disabled fields and
+    uses the form initial value instead.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        Application = get_application_model()
+        grant_field = self.fields["authorization_grant_type"]
+        assert isinstance(grant_field, forms.ChoiceField)
+        grant_field.choices = [
+            (Application.GRANT_AUTHORIZATION_CODE, _("Authorization code")),
+        ]
+        grant_field.disabled = True
+        grant_field.initial = Application.GRANT_AUTHORIZATION_CODE
+        self.initial.setdefault("authorization_grant_type", Application.GRANT_AUTHORIZATION_CODE)
+
+
+def get_zulip_application_form_class() -> type[forms.ModelForm[models.Model]]:
+    return modelform_factory(
+        get_application_model(),
+        form=ZulipOAuthApplicationForm,
+        fields=APPLICATION_FORM_FIELDS,
+    )
+
+
+class ZulipApplicationRegistration(ApplicationRegistration):
+    @override
+    def get_form_class(self) -> type[forms.ModelForm[models.Model]]:
+        return get_zulip_application_form_class()
+
+
+class ZulipApplicationUpdate(ApplicationUpdate):
+    @override
+    def get_form_class(self) -> type[forms.ModelForm[models.Model]]:
+        return get_zulip_application_form_class()
+
+
+# The access token validation happens in zerver.decorator.authenticated_rest_api_view
+# and in zerver.views.tusd.authenticate_user.
+# The oauth2_provider package from django-oauth-toolkit supplies the database models,
+# migrations, and OAuth2 views out of the box.
+oauth2_endpoint_views = [
+    # OAuth2 Application Management endpoints
+    path("applications/", ApplicationList.as_view(), name="list"),
+    path(
+        "applications/register/",
+        ZulipApplicationRegistration.as_view(),
+        name="register",
+    ),
+    path("applications/<pk>/", ApplicationDetail.as_view(), name="detail"),
+    path("applications/<pk>/delete/", ApplicationDelete.as_view(), name="delete"),
+    path(
+        "applications/<pk>/update/",
+        ZulipApplicationUpdate.as_view(),
+        name="update",
+    ),
+    # tokens
+    path("authorize/", AuthorizationView.as_view(), name="authorize"),
+    path("token/", TokenView.as_view(), name="token"),
+    path("revoke-token/", RevokeTokenView.as_view(), name="revoke-token"),
+]

--- a/zerver/lib/oauth2.py
+++ b/zerver/lib/oauth2.py
@@ -1,0 +1,143 @@
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, Concatenate
+
+from django import forms
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db import models
+from django.forms.models import modelform_factory
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+from django.urls import path
+from django.utils.translation import gettext as _
+from oauth2_provider.models import get_application_model
+from oauth2_provider.views import (
+    ApplicationDelete,
+    ApplicationDetail,
+    ApplicationList,
+    ApplicationRegistration,
+    ApplicationUpdate,
+    AuthorizationView,
+    RevokeTokenView,
+    TokenView,
+)
+from typing_extensions import ParamSpec, override
+
+from zerver.decorator import zulip_login_required
+from zerver.models import UserProfile
+
+ParamT = ParamSpec("ParamT")
+
+# Fields shown on the stock django-oauth-toolkit application create/edit forms.
+APPLICATION_FORM_FIELDS = (
+    "name",
+    "client_id",
+    "client_secret",
+    "client_type",
+    "authorization_grant_type",
+    "redirect_uris",
+)
+
+
+class ZulipOAuthApplicationForm(forms.ModelForm[models.Model]):
+    """Application form with grant type fixed to authorization code.
+
+    The field is shown disabled so users cannot pick another OAuth grant
+    type. Django ignores client-submitted values for disabled fields and
+    uses the form initial value instead.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        Application = get_application_model()
+        grant_field = self.fields["authorization_grant_type"]
+        assert isinstance(grant_field, forms.ChoiceField)
+        grant_field.choices = [
+            (Application.GRANT_AUTHORIZATION_CODE, _("Authorization code")),
+        ]
+        grant_field.disabled = True
+        grant_field.initial = Application.GRANT_AUTHORIZATION_CODE
+        self.initial.setdefault("authorization_grant_type", Application.GRANT_AUTHORIZATION_CODE)
+
+
+def get_zulip_application_form_class() -> type[forms.ModelForm[models.Model]]:
+    return modelform_factory(
+        get_application_model(),
+        form=ZulipOAuthApplicationForm,
+        fields=APPLICATION_FORM_FIELDS,
+    )
+
+
+def require_oauth_application_admin(
+    view_func: Callable[Concatenate[HttpRequest, ParamT], HttpResponse],
+) -> Callable[Concatenate[HttpRequest, ParamT], HttpResponse]:
+    @zulip_login_required
+    @wraps(view_func)
+    def _wrapped_view_func(
+        request: HttpRequest, /, *args: ParamT.args, **kwargs: ParamT.kwargs
+    ) -> HttpResponse:
+        user_profile = request.user
+        assert isinstance(user_profile, UserProfile)
+        if not user_profile.is_realm_admin:
+            return render(request, "404.html", status=404)
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped_view_func
+
+
+class ZulipApplicationRegistration(ApplicationRegistration):
+    @override
+    def get_form_class(self) -> type[forms.ModelForm[models.Model]]:
+        return get_zulip_application_form_class()
+
+
+class ZulipApplicationUpdate(ApplicationUpdate):
+    @override
+    def get_form_class(self) -> type[forms.ModelForm[models.Model]]:
+        return get_zulip_application_form_class()
+
+
+class ZulipAuthorizationView(AuthorizationView):
+    @override
+    def handle_no_permission(self) -> HttpResponse:
+        # DOT redirects prompt=none to the raw redirect_uri without
+        # checking a registered client. We are not an OIDC provider.
+        return LoginRequiredMixin.handle_no_permission(self)
+
+
+# The access token validation happens in zerver.decorator.authenticated_rest_api_view
+# and in zerver.views.tusd.authenticate_user.
+# The oauth2_provider package from django-oauth-toolkit supplies the database models,
+# migrations, and OAuth2 views out of the box.
+oauth2_endpoint_views = [
+    # OAuth2 Application Management endpoints
+    path("applications/", require_oauth_application_admin(ApplicationList.as_view()), name="list"),
+    path(
+        "applications/register/",
+        require_oauth_application_admin(ZulipApplicationRegistration.as_view()),
+        name="register",
+    ),
+    path(
+        "applications/<pk>/",
+        require_oauth_application_admin(ApplicationDetail.as_view()),
+        name="detail",
+    ),
+    path(
+        "applications/<pk>/delete/",
+        require_oauth_application_admin(ApplicationDelete.as_view()),
+        name="delete",
+    ),
+    path(
+        "applications/<pk>/update/",
+        require_oauth_application_admin(ZulipApplicationUpdate.as_view()),
+        name="update",
+    ),
+    # tokens
+    path(
+        "authorize/",
+        zulip_login_required(ZulipAuthorizationView.as_view()),
+        name="authorize",
+    ),
+    path("token/", TokenView.as_view(), name="token"),
+    path("revoke-token/", RevokeTokenView.as_view(), name="revoke-token"),
+]

--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -120,7 +120,8 @@ def rest_dispatch(request: HttpRequest, /, **kwargs: object) -> HttpResponse:
     """Dispatch to a REST API endpoint.
 
     Authentication is verified in the following ways:
-        * for paths beginning with /api, HTTP basic auth
+        * for paths beginning with /api, HTTP basic auth (email:apiKey), and
+          when ENABLE_ZULIP_OAUTH is on, OAuth2 bearer tokens as well
         * for paths beginning with /json (used by the web client), the session token
 
     Unauthenticated requests may use this endpoint only with the
@@ -131,7 +132,7 @@ def rest_dispatch(request: HttpRequest, /, **kwargs: object) -> HttpResponse:
 
         * protect against CSRF (if the user is already authenticated through
           a Django session)
-        * authenticate via an API key (otherwise)
+        * authenticate via an API key or OAuth bearer token (otherwise)
         * coerce PUT/PATCH/DELETE into having POST-like semantics for
           retrieving variables
 
@@ -189,7 +190,7 @@ def rest_dispatch(request: HttpRequest, /, **kwargs: object) -> HttpResponse:
         target_function = csrf_protect(authenticated_json_view(target_function, **auth_kwargs))
 
     # most clients (mobile, bots, etc) use HTTP basic auth and REST calls, where instead of
-    # username:password, we use email:apiKey
+    # username:password, we use email:apiKey. With ENABLE_ZULIP_OAUTH, bearer tokens work too.
     elif request.path.startswith("/api") and "Authorization" in request.headers:
         # Wrap function with decorator to authenticate the user before
         # proceeding

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -391,7 +391,10 @@ class JsonErrorHandler(MiddlewareMixin):
                     f"{settings.HOME_NOT_LOGGED_IN}?{urlencode({'next': request.path})}"
                 )
             if request.path.startswith("/api"):
-                # For API routes, ask for HTTP basic auth (email:apiKey).
+                # For API routes, advertise HTTP basic auth (email:apiKey),
+                # and bearer tokens when the experimental OAuth provider is on.
+                if settings.ENABLE_ZULIP_OAUTH:
+                    return json_unauthorized(www_authenticate="basic_or_bearer")
                 return json_unauthorized()
             else:
                 # For /json routes, ask for session authentication.

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -4,6 +4,7 @@ import re
 import uuid
 from collections import defaultdict
 from collections.abc import Callable
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 from unittest import mock, skipUnless
 
@@ -12,6 +13,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest, HttpResponse
 from django.utils.timezone import now as timezone_now
+from oauth2_provider.models import AccessToken, Application
 from typing_extensions import override
 
 from zerver.actions.create_realm import do_create_realm
@@ -29,6 +31,7 @@ from zerver.decorator import (
     public_json_view,
     return_success_on_head_request,
     validate_api_key,
+    validate_oauth_key,
     web_public_view,
     webhook_view,
     zulip_login_required,
@@ -41,6 +44,7 @@ from zerver.lib.exceptions import (
     InvalidAPIKeyError,
     InvalidAPIKeyFormatError,
     JsonableError,
+    UnauthorizedError,
     UnsupportedWebhookEventTypeError,
 )
 from zerver.lib.initial_password import initial_password
@@ -465,7 +469,17 @@ class DecoratorLoggingTestCase(ZulipTestCase):
         credentials = f"{user_profile.email}:{api_key}"
         api_auth = "Digest " + base64.b64encode(credentials.encode()).decode()
         result = self.client_post("/api/v1/external/zendesk", {}, HTTP_AUTHORIZATION=api_auth)
-        self.assert_json_error(result, "This endpoint requires HTTP basic authentication.")
+        self.assert_json_error(
+            result,
+            "This endpoint requires HTTP basic authentication or bearer token authentication.",
+        )
+
+        with self.settings(ENABLE_ZULIP_OAUTH=False):
+            result = self.client_post("/api/v1/external/zendesk", {}, HTTP_AUTHORIZATION=api_auth)
+            self.assert_json_error(
+                result,
+                "This endpoint requires HTTP basic authentication.",
+            )
 
         api_auth = "Basic " + base64.b64encode(b"foo").decode()
         result = self.client_post("/api/v1/external/zendesk", {}, HTTP_AUTHORIZATION=api_auth)
@@ -473,10 +487,145 @@ class DecoratorLoggingTestCase(ZulipTestCase):
             result, "Invalid authorization header for basic auth", status_code=401
         )
 
-        result = self.client_post("/api/v1/external/zendesk", {})
+        # For coverage
+        result = self.client_post("/api/v1/remotes/push/register", {})
         self.assert_json_error(
             result, "Missing authorization header for basic auth", status_code=401
         )
+
+        result = self.client_post(
+            "/api/v1/remotes/push/register", {}, HTTP_AUTHORIZATION="bearer token"
+        )
+        self.assert_json_error(result, "This endpoint requires HTTP basic authentication.")
+
+        result = self.client_post("/api/v1/external/zendesk", {})
+        self.assert_json_error(result, "Missing authorization header", status_code=401)
+        self.assertEqual(
+            result["WWW-Authenticate"],
+            'Bearer realm="zulip", Basic realm="zulip"',
+        )
+
+        with self.settings(ENABLE_ZULIP_OAUTH=False):
+            result = self.client_post("/api/v1/external/zendesk", {})
+            self.assert_json_error(result, "Missing authorization header", status_code=401)
+            self.assertEqual(result["WWW-Authenticate"], 'Basic realm="zulip"')
+
+        result = self.client_post(
+            "/api/v1/external/zendesk",
+            {},
+            HTTP_AUTHORIZATION="Bearer invalid-token",
+        )
+        self.assert_json_error(result, "OAuth token verification failed", status_code=401)
+        self.assertEqual(result["WWW-Authenticate"], 'Bearer realm="zulip"')
+
+    def test_authenticated_rest_api_view_oauth_bearer_token(self) -> None:
+        @authenticated_rest_api_view()
+        def my_view(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
+            return json_success(request)
+
+        user_profile = self.example_user("hamlet")
+        application = Application.objects.create(
+            name="test_app",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        access_token = AccessToken.objects.create(
+            user=user_profile,
+            token="test-bearer-token",
+            application=application,
+            expires=timezone_now() + timedelta(days=1),
+        )
+
+        request = HostRequestMock(host="zulip.testserver")
+        request.method = "POST"
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {access_token.token}"
+
+        response = my_view(request)
+        self.assert_json_success(response)
+
+    def test_authenticated_rest_api_view_oauth_bearer_sets_is_webhook_view(
+        self,
+    ) -> None:
+        @authenticated_rest_api_view(webhook_client_name="GitHub")
+        def my_view(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
+            return json_success(request)
+
+        user_profile = self.example_user("hamlet")
+        application = Application.objects.create(
+            name="test_app",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        access_token = AccessToken.objects.create(
+            user=user_profile,
+            token="test-bearer-webhook-token",
+            application=application,
+            expires=timezone_now() + timedelta(days=1),
+        )
+
+        request = HostRequestMock(host="zulip.testserver")
+        request.method = "POST"
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {access_token.token}"
+
+        self.assertFalse(RequestNotes.get_notes(request).is_webhook_view)
+        response = my_view(request)
+        self.assert_json_success(response)
+        self.assertTrue(RequestNotes.get_notes(request).is_webhook_view)
+
+    def test_authenticated_rest_api_view_oauth_failure_unauthorized(self) -> None:
+        @authenticated_rest_api_view()
+        def my_view(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
+            return json_success(request)  # nocoverage
+
+        request = HostRequestMock(host="zulip.testserver")
+        request.method = "POST"
+        request.META["HTTP_AUTHORIZATION"] = "Bearer invalid-token"
+
+        with self.assertRaisesRegex(JsonableError, "OAuth token verification failed"):
+            validate_oauth_key(request)
+
+        with self.assertRaises(UnauthorizedError) as m:
+            my_view(request)
+        self.assertEqual(m.exception.msg, "OAuth token verification failed")
+        self.assertEqual(m.exception.www_authenticate, 'Bearer realm="zulip"')
+
+    def test_authenticated_rest_api_view_oauth_failure_for_incoming_webhook_bot(self) -> None:
+        @authenticated_rest_api_view()
+        def my_view(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
+            return json_success(request)  # nocoverage
+
+        user_profile = self.example_user("webhook_bot")
+
+        application = Application.objects.create(
+            name="test_app",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+
+        access_token = AccessToken.objects.create(
+            user=user_profile,
+            token="test-bearer-token",
+            application=application,
+            expires=timezone_now() + timedelta(days=1),
+        )
+
+        request = HostRequestMock(host="zulip.testserver")
+        request.method = "POST"
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {access_token.token}"
+
+        with self.assertRaisesRegex(
+            JsonableError,
+            "This authentication scheme is not available to incoming webhooks",
+        ):
+            validate_oauth_key(request)
+
+        with self.assertRaises(UnauthorizedError) as m:
+            my_view(request)
+        self.assertEqual(
+            m.exception.msg,
+            "This authentication scheme is not available to incoming webhooks",
+        )
+        self.assertEqual(m.exception.www_authenticate, 'Bearer realm="zulip"')
 
 
 class RateLimitTestCase(ZulipTestCase):
@@ -910,6 +1059,34 @@ class TestValidateApiKey(ZulipTestCase):
         zulip_realm = get_realm("zulip")
         self.webhook_bot = get_user("webhook-bot@zulip.com", zulip_realm)
         self.default_bot = get_user("default-bot@zulip.com", zulip_realm)
+
+    def test_validate_oauth_key_success(self) -> None:
+        user_profile = self.example_user("hamlet")
+        application = Application.objects.create(
+            name="test_app",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        access_token = AccessToken.objects.create(
+            user=user_profile,
+            token="test-token",
+            application=application,
+            expires=timezone_now() + timedelta(days=1),
+        )
+
+        request = HostRequestMock(host="zulip.testserver")
+        request.method = "GET"
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {access_token.token}"
+
+        user_from_token = validate_oauth_key(request)
+        self.assertEqual(user_from_token.id, user_profile.id)
+        self.assertEqual(request.user.id, user_profile.id)
+
+    def test_validate_oauth_key_failure(self) -> None:
+        request = HostRequestMock(host="zulip.testserver")
+        request.method = "GET"
+        with self.assertRaises(JsonableError):
+            validate_oauth_key(request)
 
     def test_has_api_key_format(self) -> None:
         self.assertFalse(has_api_key_format("TooShort"))

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -4,6 +4,7 @@ import re
 import uuid
 from collections import defaultdict
 from collections.abc import Callable
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 from unittest import mock, skipUnless
 
@@ -13,6 +14,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory
 from django.utils.timezone import now as timezone_now
+from oauth2_provider.models import AccessToken, Application
 from typing_extensions import override
 
 from zerver.actions.create_realm import do_create_realm
@@ -30,6 +32,7 @@ from zerver.decorator import (
     public_json_view,
     return_success_on_head_request,
     validate_api_key,
+    validate_oauth_key,
     web_public_view,
     webhook_view,
     zulip_login_required,
@@ -42,6 +45,7 @@ from zerver.lib.exceptions import (
     InvalidAPIKeyError,
     InvalidAPIKeyFormatError,
     JsonableError,
+    UnauthorizedError,
     UnsupportedWebhookEventTypeError,
 )
 from zerver.lib.initial_password import initial_password
@@ -463,7 +467,17 @@ class DecoratorLoggingTestCase(ZulipTestCase):
         credentials = f"{user_profile.email}:{api_key}"
         api_auth = "Digest " + base64.b64encode(credentials.encode()).decode()
         result = self.client_post("/api/v1/external/zendesk", {}, HTTP_AUTHORIZATION=api_auth)
-        self.assert_json_error(result, "This endpoint requires HTTP basic authentication.")
+        self.assert_json_error(
+            result,
+            "This endpoint requires HTTP basic authentication or bearer token authentication.",
+        )
+
+        with self.settings(ENABLE_ZULIP_OAUTH=False):
+            result = self.client_post("/api/v1/external/zendesk", {}, HTTP_AUTHORIZATION=api_auth)
+            self.assert_json_error(
+                result,
+                "This endpoint requires HTTP basic authentication.",
+            )
 
         api_auth = "Basic " + base64.b64encode(b"foo").decode()
         result = self.client_post("/api/v1/external/zendesk", {}, HTTP_AUTHORIZATION=api_auth)
@@ -471,10 +485,145 @@ class DecoratorLoggingTestCase(ZulipTestCase):
             result, "Invalid authorization header for basic auth", status_code=401
         )
 
-        result = self.client_post("/api/v1/external/zendesk", {})
+        # For coverage
+        result = self.client_post("/api/v1/remotes/push/register", {})
         self.assert_json_error(
             result, "Missing authorization header for basic auth", status_code=401
         )
+
+        result = self.client_post(
+            "/api/v1/remotes/push/register", {}, HTTP_AUTHORIZATION="bearer token"
+        )
+        self.assert_json_error(result, "This endpoint requires HTTP basic authentication.")
+
+        result = self.client_post("/api/v1/external/zendesk", {})
+        self.assert_json_error(result, "Missing authorization header", status_code=401)
+        self.assertEqual(
+            result["WWW-Authenticate"],
+            'Bearer realm="zulip", Basic realm="zulip"',
+        )
+
+        with self.settings(ENABLE_ZULIP_OAUTH=False):
+            result = self.client_post("/api/v1/external/zendesk", {})
+            self.assert_json_error(result, "Missing authorization header", status_code=401)
+            self.assertEqual(result["WWW-Authenticate"], 'Basic realm="zulip"')
+
+        result = self.client_post(
+            "/api/v1/external/zendesk",
+            {},
+            HTTP_AUTHORIZATION="Bearer invalid-token",
+        )
+        self.assert_json_error(result, "OAuth token verification failed", status_code=401)
+        self.assertEqual(result["WWW-Authenticate"], 'Bearer realm="zulip"')
+
+    def test_authenticated_rest_api_view_oauth_bearer_token(self) -> None:
+        @authenticated_rest_api_view()
+        def my_view(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
+            return json_success(request)
+
+        user_profile = self.example_user("hamlet")
+        application = Application.objects.create(
+            name="test_app",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        access_token = AccessToken.objects.create(
+            user=user_profile,
+            token="test-bearer-token",
+            application=application,
+            expires=timezone_now() + timedelta(days=1),
+        )
+
+        request = HostRequestMock(host="zulip.testserver")
+        request.method = "POST"
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {access_token.token}"
+
+        response = my_view(request)
+        self.assert_json_success(response)
+
+    def test_authenticated_rest_api_view_oauth_bearer_sets_is_webhook_view(
+        self,
+    ) -> None:
+        @authenticated_rest_api_view(webhook_client_name="GitHub")
+        def my_view(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
+            return json_success(request)
+
+        user_profile = self.example_user("hamlet")
+        application = Application.objects.create(
+            name="test_app",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        access_token = AccessToken.objects.create(
+            user=user_profile,
+            token="test-bearer-webhook-token",
+            application=application,
+            expires=timezone_now() + timedelta(days=1),
+        )
+
+        request = HostRequestMock(host="zulip.testserver")
+        request.method = "POST"
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {access_token.token}"
+
+        self.assertFalse(RequestNotes.get_notes(request).is_webhook_view)
+        response = my_view(request)
+        self.assert_json_success(response)
+        self.assertTrue(RequestNotes.get_notes(request).is_webhook_view)
+
+    def test_authenticated_rest_api_view_oauth_failure_unauthorized(self) -> None:
+        @authenticated_rest_api_view()
+        def my_view(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
+            return json_success(request)  # nocoverage
+
+        request = HostRequestMock(host="zulip.testserver")
+        request.method = "POST"
+        request.META["HTTP_AUTHORIZATION"] = "Bearer invalid-token"
+
+        with self.assertRaisesRegex(JsonableError, "OAuth token verification failed"):
+            validate_oauth_key(request)
+
+        with self.assertRaises(UnauthorizedError) as m:
+            my_view(request)
+        self.assertEqual(m.exception.msg, "OAuth token verification failed")
+        self.assertEqual(m.exception.www_authenticate, 'Bearer realm="zulip"')
+
+    def test_authenticated_rest_api_view_oauth_failure_for_incoming_webhook_bot(self) -> None:
+        @authenticated_rest_api_view()
+        def my_view(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
+            return json_success(request)  # nocoverage
+
+        user_profile = self.example_user("webhook_bot")
+
+        application = Application.objects.create(
+            name="test_app",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+
+        access_token = AccessToken.objects.create(
+            user=user_profile,
+            token="test-bearer-token",
+            application=application,
+            expires=timezone_now() + timedelta(days=1),
+        )
+
+        request = HostRequestMock(host="zulip.testserver")
+        request.method = "POST"
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {access_token.token}"
+
+        with self.assertRaisesRegex(
+            JsonableError,
+            "This authentication scheme is not available to incoming webhooks",
+        ):
+            validate_oauth_key(request)
+
+        with self.assertRaises(UnauthorizedError) as m:
+            my_view(request)
+        self.assertEqual(
+            m.exception.msg,
+            "This authentication scheme is not available to incoming webhooks",
+        )
+        self.assertEqual(m.exception.www_authenticate, 'Bearer realm="zulip"')
 
 
 class RateLimitTestCase(ZulipTestCase):
@@ -908,6 +1057,34 @@ class TestValidateApiKey(ZulipTestCase):
         zulip_realm = get_realm("zulip")
         self.webhook_bot = get_user("webhook-bot@zulip.com", zulip_realm)
         self.default_bot = get_user("default-bot@zulip.com", zulip_realm)
+
+    def test_validate_oauth_key_success(self) -> None:
+        user_profile = self.example_user("hamlet")
+        application = Application.objects.create(
+            name="test_app",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        access_token = AccessToken.objects.create(
+            user=user_profile,
+            token="test-token",
+            application=application,
+            expires=timezone_now() + timedelta(days=1),
+        )
+
+        request = HostRequestMock(host="zulip.testserver")
+        request.method = "GET"
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {access_token.token}"
+
+        user_from_token = validate_oauth_key(request)
+        self.assertEqual(user_from_token.id, user_profile.id)
+        self.assertEqual(request.user.id, user_profile.id)
+
+    def test_validate_oauth_key_failure(self) -> None:
+        request = HostRequestMock(host="zulip.testserver")
+        request.method = "GET"
+        with self.assertRaises(JsonableError):
+            validate_oauth_key(request)
 
     def test_has_api_key_format(self) -> None:
         self.assertFalse(has_api_key_format("TooShort"))

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -2183,7 +2183,8 @@ class GetOldMessagesTest(ZulipTestCase):
         set depending on which endpoint encounters the error.
 
         This verifies the status code as well as the value of the set header.
-        `www_authenticate` should be `Basic realm="zulip"` for paths starting with "/api", and
+        `www_authenticate` should be `Basic realm="zulip"` for paths starting with "/api"
+        (or include Bearer as well when ENABLE_ZULIP_OAUTH is on), and
         `Session realm="zulip"` otherwise.
         """
         self.assert_json_error(
@@ -2285,9 +2286,12 @@ class GetOldMessagesTest(ZulipTestCase):
         self.check_unauthenticated_response(result)
 
         # Paths starting with /api/v1 should receive a response that asks
-        # for basic auth.
+        # for API authentication (basic, and bearer when OAuth is enabled).
         result = self.client_get("/api/v1/messages", dict(get_params))
-        self.check_unauthenticated_response(result, www_authenticate='Basic realm="zulip"')
+        self.check_unauthenticated_response(
+            result,
+            www_authenticate='Bearer realm="zulip", Basic realm="zulip"',
+        )
 
         # Successful access to web-public channel messages.
         web_public_channel_get_params: dict[str, int | str | bool] = {

--- a/zerver/tests/test_oauth2.py
+++ b/zerver/tests/test_oauth2.py
@@ -1,0 +1,101 @@
+from oauth2_provider.models import Application, get_application_model
+
+from zerver.lib.test_classes import ZulipTestCase
+
+
+class OAuthApplicationFormTest(ZulipTestCase):
+    def test_register_page_fixes_grant_type_as_disabled_field(self) -> None:
+        self.login("hamlet")
+        result = self.client_get("/o/applications/register/")
+        self.assertEqual(result.status_code, 200)
+        self.assert_in_response("Register a new application", result)
+        self.assert_in_response("authorization_grant_type", result)
+        self.assert_in_response("disabled", result)
+        self.assert_in_response("Authorization code", result)
+        # Other grant types must not be offered as choices.
+        content = result.content.decode()
+        self.assertNotIn("Device Code", content)
+        self.assertNotIn("Resource owner password-based", content)
+        self.assertNotIn("Client credentials", content)
+        self.assertNotIn("Implicit", content)
+        self.assertNotIn("OpenID connect hybrid", content)
+
+    def test_register_ignores_tampered_grant_type(self) -> None:
+        """Disabled fields are not taken from POST; value stays authorization code."""
+        self.login("hamlet")
+        ApplicationModel = get_application_model()
+        before_count = ApplicationModel.objects.count()
+
+        result = self.client_post(
+            "/o/applications/register/",
+            {
+                "name": "Tampered Grant App",
+                "client_id": "test-client-id-password-grant",
+                "client_secret": "test-client-secret",
+                "client_type": Application.CLIENT_CONFIDENTIAL,
+                # Client tries to force password grant; disabled field ignores this.
+                "authorization_grant_type": Application.GRANT_PASSWORD,
+                "redirect_uris": "http://127.0.0.1:8000/callback",
+                "post_logout_redirect_uris": "",
+                "allowed_origins": "",
+            },
+        )
+
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(ApplicationModel.objects.count(), before_count + 1)
+        app = ApplicationModel.objects.get(name="Tampered Grant App")
+        self.assertEqual(app.authorization_grant_type, Application.GRANT_AUTHORIZATION_CODE)
+
+    def test_register_accepts_authorization_code_grant(self) -> None:
+        self.login("hamlet")
+        ApplicationModel = get_application_model()
+        before_count = ApplicationModel.objects.count()
+
+        result = self.client_post(
+            "/o/applications/register/",
+            {
+                "name": "Auth Code App",
+                "client_id": "test-client-id-auth-code",
+                "client_secret": "test-client-secret",
+                "client_type": Application.CLIENT_CONFIDENTIAL,
+                # Omitted on purpose: disabled fields are not submitted by browsers.
+                "redirect_uris": "http://127.0.0.1:8000/callback",
+                "post_logout_redirect_uris": "",
+                "allowed_origins": "",
+            },
+        )
+
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(ApplicationModel.objects.count(), before_count + 1)
+        app = ApplicationModel.objects.get(name="Auth Code App")
+        self.assertEqual(app.authorization_grant_type, Application.GRANT_AUTHORIZATION_CODE)
+
+    def test_update_keeps_authorization_code_grant(self) -> None:
+        self.login("hamlet")
+        user_profile = self.example_user("hamlet")
+        app = Application.objects.create(
+            name="Existing App",
+            user=user_profile,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="http://127.0.0.1:8000/callback",
+        )
+
+        result = self.client_post(
+            f"/o/applications/{app.id}/update/",
+            {
+                "name": "Existing App Renamed",
+                "client_id": app.client_id,
+                "client_secret": app.client_secret,
+                "client_type": Application.CLIENT_CONFIDENTIAL,
+                "authorization_grant_type": Application.GRANT_CLIENT_CREDENTIALS,
+                "redirect_uris": app.redirect_uris,
+                "post_logout_redirect_uris": "",
+                "allowed_origins": "",
+            },
+        )
+
+        self.assertEqual(result.status_code, 302)
+        app.refresh_from_db()
+        self.assertEqual(app.name, "Existing App Renamed")
+        self.assertEqual(app.authorization_grant_type, Application.GRANT_AUTHORIZATION_CODE)

--- a/zerver/tests/test_oauth2.py
+++ b/zerver/tests/test_oauth2.py
@@ -1,0 +1,235 @@
+from django.conf import settings
+from oauth2_provider.models import Application, get_application_model
+
+from zerver.actions.users import change_user_is_active
+from zerver.lib.oauth2 import ZulipAuthorizationView
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.test_helpers import HostRequestMock
+
+
+class OAuthApplicationFormTest(ZulipTestCase):
+    def test_register_page_fixes_grant_type_as_disabled_field(self) -> None:
+        self.login("iago")
+        result = self.client_get("/o/applications/register/")
+        self.assertEqual(result.status_code, 200)
+        self.assert_in_response("Register a new application", result)
+        self.assert_in_response("authorization_grant_type", result)
+        self.assert_in_response("Authorization code", result)
+        content = result.content.decode()
+        self.assertNotIn("hash_client_secret", content)
+        self.assertNotIn("post_logout_redirect_uris", content)
+        self.assertNotIn("allowed_origins", content)
+        self.assertNotIn("algorithm", content)
+        # Other grant types must not be offered as choices.
+        self.assertNotIn("Device Code", content)
+        self.assertNotIn("Resource owner password-based", content)
+        self.assertNotIn("Client credentials", content)
+        self.assertNotIn("Implicit", content)
+        self.assertNotIn("OpenID connect hybrid", content)
+
+    def test_register_ignores_tampered_grant_type(self) -> None:
+        """Disabled fields are not taken from POST; value stays authorization code."""
+        self.login("iago")
+        ApplicationModel = get_application_model()
+        before_count = ApplicationModel.objects.count()
+
+        result = self.client_post(
+            "/o/applications/register/",
+            {
+                "name": "Tampered Grant App",
+                "client_id": "test-client-id-password-grant",
+                "client_secret": "test-client-secret",
+                "client_type": Application.CLIENT_CONFIDENTIAL,
+                # Client tries to force password grant; disabled field ignores this.
+                "authorization_grant_type": Application.GRANT_PASSWORD,
+                "redirect_uris": "http://127.0.0.1:8000/callback",
+            },
+        )
+
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(ApplicationModel.objects.count(), before_count + 1)
+        app = ApplicationModel.objects.get(name="Tampered Grant App")
+        self.assertEqual(app.authorization_grant_type, Application.GRANT_AUTHORIZATION_CODE)
+
+    def test_register_accepts_authorization_code_grant(self) -> None:
+        self.login("iago")
+        ApplicationModel = get_application_model()
+        before_count = ApplicationModel.objects.count()
+        iago = self.example_user("iago")
+
+        result = self.client_post(
+            "/o/applications/register/",
+            {
+                "name": "Auth Code App",
+                "client_id": "test-client-id-auth-code",
+                "client_secret": "test-client-secret",
+                "client_type": Application.CLIENT_CONFIDENTIAL,
+                # Omitted on purpose: disabled fields are not submitted by browsers.
+                "redirect_uris": "http://127.0.0.1:8000/callback",
+            },
+        )
+
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(ApplicationModel.objects.count(), before_count + 1)
+        app = ApplicationModel.objects.get(name="Auth Code App")
+        self.assertEqual(app.authorization_grant_type, Application.GRANT_AUTHORIZATION_CODE)
+        self.assertEqual(app.user_id, iago.id)
+
+    def _create_iago_application(self) -> Application:
+        return Application.objects.create(
+            name="Iago App",
+            user=self.example_user("iago"),
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="http://127.0.0.1:8000/callback",
+        )
+
+    def _assert_cannot_manage_applications(self) -> None:
+        app = self._create_iago_application()
+        before_count = Application.objects.count()
+
+        for url in (
+            "/o/applications/",
+            "/o/applications/register/",
+            f"/o/applications/{app.id}/",
+            f"/o/applications/{app.id}/delete/",
+            f"/o/applications/{app.id}/update/",
+        ):
+            result = self.client_get(url)
+            self.assertEqual(result.status_code, 404, url)
+            self.assert_in_response("Page not found (404)", result)
+
+        result = self.client_post(
+            "/o/applications/register/",
+            {
+                "name": "Unauthorized App",
+                "client_id": "test-client-id-unauthorized",
+                "client_secret": "test-client-secret",
+                "client_type": Application.CLIENT_CONFIDENTIAL,
+                "redirect_uris": "http://127.0.0.1:8000/callback",
+            },
+        )
+        self.assertEqual(result.status_code, 404)
+        self.assertEqual(Application.objects.count(), before_count)
+
+        result = self.client_post(f"/o/applications/{app.id}/delete/")
+        self.assertEqual(result.status_code, 404)
+        self.assertTrue(Application.objects.filter(id=app.id).exists())
+
+    def test_member_cannot_manage_applications(self) -> None:
+        self.login("hamlet")
+        self._assert_cannot_manage_applications()
+
+    def test_moderator_cannot_manage_applications(self) -> None:
+        self.login("shiva")
+        self._assert_cannot_manage_applications()
+
+    def test_guest_cannot_manage_applications(self) -> None:
+        self.login("polonius")
+        self._assert_cannot_manage_applications()
+
+    def test_logged_out_user_cannot_manage_applications(self) -> None:
+        app = self._create_iago_application()
+        for url in (
+            "/o/applications/",
+            "/o/applications/register/",
+            f"/o/applications/{app.id}/",
+            f"/o/applications/{app.id}/delete/",
+            f"/o/applications/{app.id}/update/",
+        ):
+            result = self.client_get(url)
+            self.assertEqual(result.status_code, 302, url)
+            self.assertEqual(result["Location"].split("?")[0], settings.HOME_NOT_LOGGED_IN)
+
+    def test_update_keeps_authorization_code_grant(self) -> None:
+        self.login("iago")
+        user_profile = self.example_user("iago")
+        app = Application.objects.create(
+            name="Existing App",
+            user=user_profile,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="http://127.0.0.1:8000/callback",
+        )
+
+        result = self.client_post(
+            f"/o/applications/{app.id}/update/",
+            {
+                "name": "Existing App Renamed",
+                "client_id": app.client_id,
+                "client_secret": app.client_secret,
+                "client_type": Application.CLIENT_CONFIDENTIAL,
+                "authorization_grant_type": Application.GRANT_CLIENT_CREDENTIALS,
+                "redirect_uris": app.redirect_uris,
+            },
+        )
+
+        self.assertEqual(result.status_code, 302)
+        app.refresh_from_db()
+        self.assertEqual(app.name, "Existing App Renamed")
+        self.assertEqual(app.authorization_grant_type, Application.GRANT_AUTHORIZATION_CODE)
+
+    def test_authorization_view_ignores_prompt_none_redirect_uri(self) -> None:
+        # zulip_login_required wraps the URL, so this path is only hit
+        # if that wrap is skipped. Call the view method directly.
+        request = HostRequestMock()
+        request.GET["prompt"] = "none"
+        request.GET["redirect_uri"] = "https://evil.example/x"
+        view = ZulipAuthorizationView()
+        view.setup(request)
+        view.raise_exception = False
+        result = view.handle_no_permission()
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(result["Location"].split("?")[0], settings.LOGIN_URL)
+
+    def test_logged_out_prompt_none_redirects_to_login(self) -> None:
+        result = self.client_get(
+            "/o/authorize/",
+            {
+                "prompt": "none",
+                "client_id": "anything",
+                "redirect_uri": "https://evil.example/x",
+            },
+        )
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(result["Location"].split("?")[0], settings.HOME_NOT_LOGGED_IN)
+
+    def test_deactivated_user_cannot_authorize(self) -> None:
+        user_profile = self.example_user("hamlet")
+        self.login_user(user_profile)
+        change_user_is_active(user_profile, False)
+        result = self.client_get(
+            "/o/authorize/",
+            {
+                "response_type": "code",
+                "client_id": "anything",
+                "redirect_uri": "http://127.0.0.1:8000/callback",
+            },
+        )
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(result["Location"].split("?")[0], settings.HOME_NOT_LOGGED_IN)
+
+    def test_other_admin_cannot_update_application(self) -> None:
+        iago = self.example_user("iago")
+        app = Application.objects.create(
+            name="Iago App",
+            user=iago,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="http://127.0.0.1:8000/callback",
+        )
+
+        self.login("desdemona")
+        result = self.client_post(
+            f"/o/applications/{app.id}/update/",
+            {
+                "name": "Stolen App",
+                "client_id": app.client_id,
+                "client_secret": app.client_secret,
+                "client_type": Application.CLIENT_CONFIDENTIAL,
+                "redirect_uris": app.redirect_uris,
+            },
+        )
+        self.assertEqual(result.status_code, 404)
+        app.refresh_from_db()
+        self.assertEqual(app.name, "Iago App")

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -99,15 +99,15 @@ class TestNonSCIMAPIAccess(SCIMTestCase):
         with mock.patch("zerver.middleware.validate_scim_bearer_token", return_value=None) as m:
             result = self.client_get(f"/api/v1/users/{hamlet.id}", {}, **self.scim_headers())
 
-        # The SCIM format of the Authorization header (bearer token) is rejected as a bad request
-        # by our regular API authentication logic.
-        self.assert_json_error(result, "This endpoint requires HTTP basic authentication.", 400)
+        # The SCIM format of the Authorization header (bearer token) is rejected
+        # as an unauthorized request by our regular API authentication logic.
+        self.assert_json_error(result, "OAuth token verification failed", 401)
         m.assert_not_called()
 
         # Now simply test end-to-end that access gets denied, without any mocking
         # interfering with the process.
         result = self.client_get(f"/api/v1/users/{hamlet.id}", {}, **self.scim_headers())
-        self.assert_json_error(result, "This endpoint requires HTTP basic authentication.", 400)
+        self.assert_json_error(result, "OAuth token verification failed", 401)
 
 
 class TestExceptionDetailsNotRevealedToClient(SCIMTestCase):

--- a/zerver/tests/test_tusd.py
+++ b/zerver/tests/test_tusd.py
@@ -1,9 +1,12 @@
 import os
+from datetime import timedelta
 from unittest import mock
 
 import orjson
 from django.conf import settings
 from django.test import override_settings
+from django.utils.timezone import now as timezone_now
+from oauth2_provider.models import AccessToken, Application
 from typing_extensions import ParamSpec
 
 from zerver.lib.cache import cache_delete, get_realm_used_upload_space_cache_key
@@ -192,6 +195,59 @@ class TusdPreCreateTest(ZulipTestCase):
             orjson.loads(result_json["HttpResponse"]["Body"]), {"message": "Unauthenticated upload"}
         )
         self.assertEqual(result_json["RejectUpload"], True)
+
+    def test_oauth_token_auth(self) -> None:
+        user_profile = self.example_user("hamlet")
+        application = Application.objects.create(
+            name="test_app",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        access_token = AccessToken.objects.create(
+            user=user_profile,
+            token="test-bearer-token",
+            application=application,
+            expires=timezone_now() + timedelta(days=1),
+        )
+        result = self.client_post(
+            "/api/internal/tusd",
+            self.request().model_dump(),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {access_token.token}",
+        )
+        self.assertEqual(result.status_code, 200)
+        result_json = result.json()
+        self.assertEqual(result_json.get("HttpResponse", None), None)
+        self.assertEqual(result_json.get("RejectUpload", False), False)
+        self.assertEqual(list(result_json["ChangeFileInfo"].keys()), ["ID"])
+        self.assertTrue(result_json["ChangeFileInfo"]["ID"].endswith("/zulip.txt"))
+
+    def test_oauth_token_bad_auth(self) -> None:
+        user_profile = self.example_user("hamlet")
+        application = Application.objects.create(
+            name="test_app",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        AccessToken.objects.create(
+            user=user_profile,
+            token="test-bearer-token",
+            application=application,
+            expires=timezone_now() + timedelta(days=1),
+        )
+        result = self.client_post(
+            "/api/internal/tusd",
+            self.request().model_dump(),
+            content_type="application/json",
+            HTTP_AUTHORIZATION="Bearer badtoken",
+        )
+        self.assertEqual(result.status_code, 200)
+        result_json = result.json()
+        self.assertEqual(result_json["HttpResponse"]["StatusCode"], 401)
+        self.assertEqual(result_json["RejectUpload"], True)
+        self.assertEqual(
+            orjson.loads(result_json["HttpResponse"]["Body"]), {"message": "Unauthenticated upload"}
+        )
 
     def test_sanitize_filename(self) -> None:
         self.login("hamlet")

--- a/zerver/tests/test_tusd.py
+++ b/zerver/tests/test_tusd.py
@@ -1,9 +1,12 @@
 import os
+from datetime import timedelta
 from unittest import mock
 
 import orjson
 from django.conf import settings
 from django.test import override_settings
+from django.utils.timezone import now as timezone_now
+from oauth2_provider.models import AccessToken, Application
 from typing_extensions import ParamSpec
 
 from zerver.lib.cache import cache_delete, get_realm_used_upload_space_cache_key
@@ -193,6 +196,59 @@ class TusdPreCreateTest(ZulipTestCase):
             orjson.loads(result_json["HttpResponse"]["Body"]), {"message": "Unauthenticated upload"}
         )
         self.assertEqual(result_json["RejectUpload"], True)
+
+    def test_oauth_token_auth(self) -> None:
+        user_profile = self.example_user("hamlet")
+        application = Application.objects.create(
+            name="test_app",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        access_token = AccessToken.objects.create(
+            user=user_profile,
+            token="test-bearer-token",
+            application=application,
+            expires=timezone_now() + timedelta(days=1),
+        )
+        result = self.client_post(
+            "/api/internal/tusd",
+            self.request().model_dump(),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {access_token.token}",
+        )
+        self.assertEqual(result.status_code, 200)
+        result_json = result.json()
+        self.assertEqual(result_json.get("HttpResponse", None), None)
+        self.assertEqual(result_json.get("RejectUpload", False), False)
+        self.assertEqual(list(result_json["ChangeFileInfo"].keys()), ["ID"])
+        self.assertTrue(result_json["ChangeFileInfo"]["ID"].endswith("/zulip.txt"))
+
+    def test_oauth_token_bad_auth(self) -> None:
+        user_profile = self.example_user("hamlet")
+        application = Application.objects.create(
+            name="test_app",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        AccessToken.objects.create(
+            user=user_profile,
+            token="test-bearer-token",
+            application=application,
+            expires=timezone_now() + timedelta(days=1),
+        )
+        result = self.client_post(
+            "/api/internal/tusd",
+            self.request().model_dump(),
+            content_type="application/json",
+            HTTP_AUTHORIZATION="Bearer badtoken",
+        )
+        self.assertEqual(result.status_code, 200)
+        result_json = result.json()
+        self.assertEqual(result_json["HttpResponse"]["StatusCode"], 401)
+        self.assertEqual(result_json["RejectUpload"], True)
+        self.assertEqual(
+            orjson.loads(result_json["HttpResponse"]["Body"]), {"message": "Unauthenticated upload"}
+        )
 
     def test_sanitize_filename(self) -> None:
         self.login("hamlet")

--- a/zerver/views/tusd.py
+++ b/zerver/views/tusd.py
@@ -12,7 +12,12 @@ from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_pascal
 
 from confirmation.models import Confirmation, ConfirmationKeyError, get_object_from_key
-from zerver.decorator import get_basic_credentials, validate_api_key
+from zerver.decorator import (
+    check_and_get_authentication_scheme,
+    get_basic_credentials,
+    validate_api_key,
+    validate_oauth_key,
+)
 from zerver.lib.exceptions import AccessDeniedError, JsonableError
 from zerver.lib.mime_types import INLINE_MIME_TYPES, bare_content_type, guess_type
 from zerver.lib.rate_limiter import is_local_addr
@@ -243,17 +248,20 @@ def handle_upload_pre_terminate_hook(
 def authenticate_user(request: HttpRequest) -> UserProfile | AnonymousUser:
     # This acts like the authenticated_rest_api_view wrapper, while
     # allowing fallback to session-based request.user
-    if "Authorization" in request.headers:
-        try:
-            role, api_key = get_basic_credentials(request)
-            return validate_api_key(
-                request,
-                role,
-                api_key,
-            )
+    try:
+        auth_scheme = check_and_get_authentication_scheme(request)
+        if auth_scheme == "bearer":
+            return validate_oauth_key(request)
 
-        except JsonableError:
-            pass
+        role, api_key = get_basic_credentials(request)
+        return validate_api_key(
+            request,
+            role,
+            api_key,
+        )
+
+    except JsonableError:
+        pass
 
     # If that failed, fall back to session auth
     return request.user

--- a/zerver/views/tusd.py
+++ b/zerver/views/tusd.py
@@ -12,7 +12,12 @@ from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_pascal
 
 from confirmation.models import Confirmation, ConfirmationKeyError, get_object_from_key
-from zerver.decorator import get_basic_credentials, validate_api_key
+from zerver.decorator import (
+    check_and_get_authentication_scheme,
+    get_basic_credentials,
+    validate_api_key,
+    validate_oauth_key,
+)
 from zerver.lib.exceptions import AccessDeniedError, JsonableError
 from zerver.lib.mime_types import INLINE_MIME_TYPES, bare_content_type, guess_type
 from zerver.lib.rate_limiter import is_local_addr
@@ -256,17 +261,20 @@ def handle_upload_pre_terminate_hook(
 def authenticate_user(request: HttpRequest) -> UserProfile | AnonymousUser:
     # This acts like the authenticated_rest_api_view wrapper, while
     # allowing fallback to session-based request.user
-    if "Authorization" in request.headers:
-        try:
-            role, api_key = get_basic_credentials(request)
-            return validate_api_key(
-                request,
-                role,
-                api_key,
-            )
+    try:
+        auth_scheme = check_and_get_authentication_scheme(request)
+        if auth_scheme == "bearer":
+            return validate_oauth_key(request)
 
-        except JsonableError:
-            pass
+        role, api_key = get_basic_credentials(request)
+        return validate_api_key(
+            request,
+            role,
+            api_key,
+        )
+
+    except JsonableError:
+        pass
 
     # If that failed, fall back to session auth
     return request.user

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -36,6 +36,7 @@ from .configured_settings import (
     EMAIL_BACKEND,
     EMAIL_HOST,
     EMAIL_MAX_CONNECTION_LIFETIME_IN_MINUTES,
+    ENABLE_ZULIP_OAUTH,
     ERROR_REPORTING,
     EXTERNAL_HOST,
     EXTERNAL_HOST_WITHOUT_PORT,
@@ -276,6 +277,10 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.staticfiles",
     "confirmation",
+    # Experimental OAuth provider (django-oauth-toolkit). Only load when enabled
+    # so production installs with ENABLE_ZULIP_OAUTH=False do not register the
+    # app, its models, or its migrations.
+    *(["oauth2_provider"] if ENABLE_ZULIP_OAUTH else []),
     "zerver",
     "social_django",
     "django_scim",
@@ -728,6 +733,24 @@ TEMPLATES = [
     non_html_template_engine_settings,
     two_factor_template_engine_settings,
 ]
+
+if ENABLE_ZULIP_OAUTH:
+    # oauth2_provider uses the default Django template engine (not Jinja2), so we
+    # need to add config for it here.
+    oauth_templates_options = deepcopy(default_template_engine_settings["OPTIONS"])
+    del oauth_templates_options["environment"]
+    del oauth_templates_options["extensions"]
+    oauth_templates_options["loaders"] = ["zproject.template_loaders.OauthLoader"]
+
+    oauth_template_engine_settings = {
+        "NAME": "OAuth_Server",
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": False,
+        "OPTIONS": oauth_templates_options,
+    }
+    TEMPLATES.append(oauth_template_engine_settings)
+
 ########################################################################
 # LOGGING SETTINGS
 ########################################################################

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -36,6 +36,7 @@ from .configured_settings import (
     EMAIL_BACKEND,
     EMAIL_HOST,
     EMAIL_MAX_CONNECTION_LIFETIME_IN_MINUTES,
+    ENABLE_ZULIP_OAUTH,
     ERROR_REPORTING,
     EXTERNAL_HOST,
     EXTERNAL_HOST_WITHOUT_PORT,
@@ -276,6 +277,10 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.staticfiles",
     "confirmation",
+    # Experimental OAuth provider (django-oauth-toolkit). Only load when enabled
+    # so production installs with ENABLE_ZULIP_OAUTH=False do not register the
+    # app, its models, or its migrations.
+    *(["oauth2_provider"] if ENABLE_ZULIP_OAUTH else []),
     "zerver",
     "social_django",
     "django_scim",
@@ -735,6 +740,24 @@ TEMPLATES = [
     non_html_template_engine_settings,
     two_factor_template_engine_settings,
 ]
+
+if ENABLE_ZULIP_OAUTH:
+    # oauth2_provider uses the default Django template engine (not Jinja2), so we
+    # need to add config for it here.
+    oauth_templates_options = deepcopy(default_template_engine_settings["OPTIONS"])
+    del oauth_templates_options["environment"]
+    del oauth_templates_options["extensions"]
+    oauth_templates_options["loaders"] = ["zproject.template_loaders.OauthLoader"]
+
+    oauth_template_engine_settings = {
+        "NAME": "OAuth_Server",
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": False,
+        "OPTIONS": oauth_templates_options,
+    }
+    TEMPLATES.append(oauth_template_engine_settings)
+
 ########################################################################
 # LOGGING SETTINGS
 ########################################################################

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -789,3 +789,20 @@ SCIM_CONFIG: dict[str, SCIMConfigDict] = {}
 # Minimum number of subscribers in a channel for us to no longer
 # send full subscriber data to the client.
 MIN_PARTIAL_SUBSCRIBERS_CHANNEL_SIZE = 1000
+
+# Experimental OAuth support is under development. It is not supported in
+# production environments or covered by security support. When False,
+# oauth2_provider is omitted from INSTALLED_APPS and OAuth code paths are
+# not loaded; set True and run migrations before using /o/ endpoints.
+ENABLE_ZULIP_OAUTH = False
+
+# No real OAuth scopes for now (tokens match API-key access).
+# django-oauth-toolkit requires a non-empty SCOPES dict; replace its default
+# read/write labels with one full-access entry. API requests do not check
+# scopes yet (see validate_oauth_key).
+OAUTH2_PROVIDER: dict[str, object] = {
+    "SCOPES": {
+        "api": "Full Zulip API access, equivalent to the user's API key.",
+    },
+    "DEFAULT_SCOPES": ["api"],
+}

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -253,3 +253,6 @@ RATE_LIMITING_RULES = {
         (86400, 1000),
     ],
 }
+
+# Experimental OAuth setting to make Zulip an OAuth provider.
+ENABLE_ZULIP_OAUTH = True

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -251,3 +251,6 @@ RATE_LIMITING_RULES = {
         (86400, 1000),
     ],
 }
+
+# Experimental OAuth setting to make Zulip an OAuth provider.
+ENABLE_ZULIP_OAUTH = True

--- a/zproject/template_loaders.py
+++ b/zproject/template_loaders.py
@@ -16,3 +16,15 @@ class TwoFactorLoader(app_directories.Loader):
             if d.match("two_factor/*"):
                 two_factor_dirs.append(d)
         return two_factor_dirs
+
+
+class OauthLoader(app_directories.Loader):
+    @override
+    def get_dirs(self) -> list[str | Path]:
+        dirs = super().get_dirs()
+        oauth_dirs: list[str | Path] = []
+        for d in dirs:
+            assert isinstance(d, Path)
+            if d.match("oauth2_provider/*"):
+                oauth_dirs.append(d)
+        return oauth_dirs

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -319,3 +319,5 @@ VERIFY_WEBHOOK_SIGNATURES = False
 AUTH_LDAP_USER_ATTR_MAP = {
     "full_name": "cn",
 }
+
+ENABLE_ZULIP_OAUTH = True

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -1021,6 +1021,17 @@ urls += [
     path("api/v1/", include(v1_api_mobile_patterns)),
 ]
 
+# Experimental oauth provider support.
+if settings.ENABLE_ZULIP_OAUTH:
+    # Import only when enabled so oauth2_provider need not be installed
+    # in INSTALLED_APPS (and need not be importable at URL-load time)
+    # when the feature is off.
+    from zerver.lib.oauth2 import oauth2_endpoint_views
+
+    urls += [
+        path("o/", include((oauth2_endpoint_views, "oauth2_provider"))),
+    ]
+
 # Healthcheck URL
 urls += [path("health", health)]
 


### PR DESCRIPTION
Makes progress towards #17042.

We have not touched `zilencer/auth.py` because that feels out of scope for OAuth.


Vibecoded client implementation for showcase: https://github.com/apoorvapendse/zulip-oauth-client

[#backend > Zulip as an OAuth provider @ 💬](https://chat.zulip.org/#narrow/channel/3-backend/topic/Zulip.20as.20an.20OAuth.20provider/near/2494556)

[#backend > SCIM test fails when making Zulip an OAuth provider.](https://chat.zulip.org/#narrow/channel/3-backend/topic/SCIM.20test.20fails.20when.20making.20Zulip.20an.20OAuth.20provider.2E/with/2417122)

## Screenshots and screen captures

| Applications list | Application detail | Edit application |
| --- | --- | --- |
| ![Applications list](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-38610-screenshot-assets/01-applications-list.png?v=8) | ![Application detail](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-38610-screenshot-assets/02-application-detail.png?v=8) | ![Edit application](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-38610-screenshot-assets/03-application-update.png?v=8) |

| Delete application | Register application | Authorization consent |
| --- | --- | --- |
| ![Delete application](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-38610-screenshot-assets/04-application-delete.png?v=8) | ![Register application](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-38610-screenshot-assets/05-application-register.png?v=8) | ![Authorization consent](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-38610-screenshot-assets/06-authorize-consent.png?v=8) |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>




