### PR TITLE
reactions: Truncate long user names in reaction pills

### DIFF
--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -158,6 +158,7 @@ export type MessageCleanReaction = {
     reaction_type: "zulip_extra_emoji" | "realm_emoji" | "unicode_emoji";
     user_ids: number[];
     vote_text: string;
+    vote_text_html: string;
 };
 
 export type Message = (

--- a/web/src/reactions.ts
+++ b/web/src/reactions.ts
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import _ from "lodash";
 import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
@@ -264,9 +265,9 @@ export function get_add_reaction_button(message_id: number): JQuery {
     return $add_button;
 }
 
-export let set_reaction_vote_text = ($reaction: JQuery, vote_text: string): void => {
+export let set_reaction_vote_text = ($reaction: JQuery, vote_text_html: string): void => {
     const $count_element = $reaction.find(".message_reaction_count");
-    $count_element.text(vote_text);
+    $count_element.html(vote_text_html);
 };
 
 export function rewire_set_reaction_vote_text(value: typeof set_reaction_vote_text): void {
@@ -628,6 +629,7 @@ function make_clean_reaction({
         emoji_alt_code,
         is_realm_emoji,
         ...build_reaction_data(user_ids, emoji_name, should_display_reactors),
+        vote_text_html: get_vote_text(user_ids, should_display_reactors),
     };
 }
 
@@ -685,7 +687,27 @@ function get_reaction_counts_and_user_ids(message: Message): ReactionUserIdAndCo
 
 export function get_vote_text(user_ids: number[], should_display_reactors: boolean): string {
     if (should_display_reactors) {
-        return comma_separated_usernames(user_ids);
+        const sorted_ids = user_ids.toSorted((a, b) => {
+            if (people.is_my_user_id(a)) {
+                return -1;
+            }
+            if (people.is_my_user_id(b)) {
+                return 1;
+            }
+            return 0;
+        });
+
+        return sorted_ids
+            .map((id) => {
+                let name;
+                if (people.is_my_user_id(id)) {
+                    name = $t({defaultMessage: "You"});
+                } else {
+                    name = people.get_by_user_id(id).full_name;
+                }
+                return `<span class="reaction-author-name">${_.escape(name)}</span>`;
+            })
+            .join(", ");
     }
     return `${user_ids.length}`;
 }
@@ -704,20 +726,6 @@ function check_should_display_reactors(
     return total_reactions <= 3;
 }
 
-function comma_separated_usernames(user_list: number[]): string {
-    const usernames = people.get_display_full_names(user_list);
-    const current_user_has_reacted = user_list.includes(current_user.user_id);
-
-    if (current_user_has_reacted) {
-        const current_user_index = user_list.indexOf(current_user.user_id);
-        usernames[current_user_index] = $t({
-            defaultMessage: "You",
-        });
-    }
-    const comma_separated_usernames = usernames.join(", ");
-    return comma_separated_usernames;
-}
-
 export let update_vote_text_on_message = (message: Message): void => {
     // Because whether we display a count or the names of reacting
     // users depends on total reactions on the message, we need to
@@ -731,7 +739,7 @@ export let update_vote_text_on_message = (message: Message): void => {
         const vote_text = get_vote_text(clean_reaction.user_ids, should_display_reactors);
         const message_clean_reaction = message.clean_reactions.get(reaction);
         assert(message_clean_reaction !== undefined);
-        message_clean_reaction.vote_text = vote_text;
+        message_clean_reaction.vote_text_html = vote_text;
         set_reaction_vote_text(reaction_elem, vote_text);
     }
 };

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -90,6 +90,11 @@
            count/name.
            13px at 12.6/1em */
         line-height: 1.0317em;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 150px;
+        display: inline-block;
     }
 
     .message_reaction:hover .message_reaction_count {
@@ -302,4 +307,22 @@
 
 .typeahead .emoji {
     top: 2px;
+}
+
+.message_reaction .message_reaction_count {
+    display: inline-flex !important;
+    align-items: center !important;
+    white-space: nowrap !important;
+    max-width: none !important;
+    overflow: visible !important;
+}
+
+.message_reaction .reaction-author-name {
+    display: inline-block !important;
+    vertical-align: bottom !important;
+    max-width: 80px !important;
+    flex: 0 0 auto !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
 }

--- a/web/templates/message_reaction.hbs
+++ b/web/templates/message_reaction.hbs
@@ -7,6 +7,6 @@
         {{else}}
             <div class="emoji emoji-{{this.emoji_code}}"></div>
         {{/if}}
-        <div class="message_reaction_count">{{this.vote_text}}</div>
+        <div class="message_reaction_count">{{{this.vote_text_html}}}</div>
     </div>
 </div>


### PR DESCRIPTION
Long user names in reaction pills were extending beyond their intended container and disrupting the pill layout. 
This PR adds CSS text-overflow: ellipsis to truncate names that exceed the maximum width, maintaining a clean and consistent pill appearance.

Fixes: #38594


**How changes were tested:**
Using before and after screenshots 

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
**BEFORE :ONE USER WITH LONG NAME:** 
<img width="1106" height="148" alt="Screenshot 2026-04-16 221540" src="https://github.com/user-attachments/assets/f3f6ad85-ba7a-48bc-a647-a194f5cf0889" />

**AFTER :ONE USER WITH LONG NAME:**

<img width="1105" height="150" alt="Screenshot 2026-04-16 221518" src="https://github.com/user-attachments/assets/7be03fbb-9b42-44fc-a8d2-45af858634f9" />

**BEFORE: MULTIPLE USER WITH LONG NAME:**

<img width="1096" height="191" alt="Screenshot 2026-04-16 222201" src="https://github.com/user-attachments/assets/8c424a16-d57c-48d1-8167-f5c9b0225c2e" />

**AFTER: MULTIPLE USER WITH LONG NAME:**

<img width="465" height="137" alt="Screenshot 2026-05-01 020014" src="https://github.com/user-attachments/assets/4169e7de-36a1-4813-b007-048d14a40f55" />





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
