### PR TITLE
Fix OpenAPIArgumentsTest missing checked_endpoints initialization (#38526)

### DIFF
--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -203,7 +203,8 @@ class OpenAPIToolsTest(ZulipTestCase):
 
 class OpenAPIArgumentsTest(ZulipTestCase):
     # This will be filled during test_openapi_arguments:
-    checked_endpoints: set[str] = set()
+    super().setUp()
+    self.checked_endpoints: set = set()
     pending_endpoints = {
         #### For current endpoint documentation priorities see
         #### https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/Undocumented.20endpoint.20priorities/with/2397881

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -203,8 +203,9 @@ class OpenAPIToolsTest(ZulipTestCase):
 
 class OpenAPIArgumentsTest(ZulipTestCase):
     # This will be filled during test_openapi_arguments:
-    super().setUp()
-    self.checked_endpoints: set = set()
+    def setUp(self) -> None:
+        super().setUp()
+        self.checked_endpoints: set = set()
     pending_endpoints = {
         #### For current endpoint documentation priorities see
         #### https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/Undocumented.20endpoint.20priorities/with/2397881


### PR DESCRIPTION
Fixed an issue where OpenAPIArgumentsTest was missing initialization of
`checked_endpoints`, causing AttributeError and failing multiple tests.

Added:
    def setUp(self):
        super().setUp()
        self.checked_endpoints = set()

All OpenAPI tests now pass successfully.
Fixes=#38526