### PR TITLE
tests: Use make_stream in buddy_data.test.cjs.

### DIFF
--- a/web/tests/buddy_data.test.cjs
+++ b/web/tests/buddy_data.test.cjs
@@ -422,7 +422,7 @@ test("show offline channel subscribers for small channels", ({override_rewire}) 
     set_presence(jill.user_id, "offline");
 
     const stream_id = 1001;
-    const sub = make_stream({name: "Rome", stream_id});
+    const sub = make_stream({name: "Rome", subscribed: true, stream_id});
     stream_data.add_sub_for_tests(sub);
     peer_data.set_subscribers(stream_id, [
         selma.user_id,
@@ -453,7 +453,7 @@ test("show offline channel subscribers for small channels", ({override_rewire}) 
 test("get_conversation_participants", () => {
     people.add_active_user(selma);
 
-    const rome_sub = make_stream({name: "Rome", stream_id: 1001});
+    const rome_sub = make_stream({name: "Rome", subscribed: true, stream_id: 1001});
     stream_data.add_sub_for_tests(rome_sub);
     peer_data.set_subscribers(rome_sub.stream_id, [selma.user_id, me.user_id]);
 
@@ -506,7 +506,7 @@ test("compare_function", () => {
     const second_user_shown_higher = 1;
 
     const stream_id = 1001;
-    const sub = make_stream({name: "Rome", stream_id});
+    const sub = make_stream({name: "Rome", subscribed: true, stream_id});
     stream_data.add_sub_for_tests(sub);
     people.add_active_user(alice);
     people.add_active_user(fred);


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: Part of the ongoing effort to improve type safety of node tests

Replace manual stream objects in `buddy_data.test.cjs`with the `make_stream` typed helper

**How changes were tested:**

run `./tools/test-js-with-node web/tests/buddy_data.test.cjs`



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
