### PR TITLE
Fix channel icon spacing and remove hardcoded git push -u origin fix-channel-icon-spacing width (#34885)

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -757,7 +757,6 @@ input.settings_text_input {
     position: relative;
     top: 0.06rem;
     padding-right: 1px;
-    width: 12px;
 
     &.zulip-icon-globe,
     &.zulip-icon-archive,
@@ -769,6 +768,12 @@ input.settings_text_input {
     &.zulip-icon-users {
         font-size: 0.8em;
     }
+}
+
+.decorated-channel-and-icon-name {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
 }
 
 .zulip-icon-lock {

--- a/web/templates/inline_decorated_channel_name.hbs
+++ b/web/templates/inline_decorated_channel_name.hbs
@@ -1,10 +1,10 @@
 {{! This controls whether the swatch next to streams in the left sidebar has a lock icon. }}
 {{~#if stream.is_archived ~}}
-<i class="zulip-icon zulip-icon-archive channel-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> <span class="decorated-channel-name">{{stream.name ~}}</span>
+<i class="zulip-icon zulip-icon-archive channel-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i><span class="decorated-channel-name">{{stream.name ~}}</span>
 {{~ else if stream.invite_only ~}}
-<i class="zulip-icon zulip-icon-lock channel-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> <span class="decorated-channel-name">{{stream.name ~}}</span>
+<i class="zulip-icon zulip-icon-lock channel-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i><span class="decorated-channel-name">{{stream.name ~}}</span>
 {{~ else if stream.is_web_public ~}}
-<i class="zulip-icon zulip-icon-globe channel-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> <span class="decorated-channel-name">{{stream.name ~}}</span>
+<i class="zulip-icon zulip-icon-globe channel-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i><span class="decorated-channel-name">{{stream.name ~}}</span>
 {{~ else ~}}
-<i class="zulip-icon zulip-icon-hashtag channel-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> <span class="decorated-channel-name">{{stream.name ~}}</span>
+<i class="zulip-icon zulip-icon-hashtag channel-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i><span class="decorated-channel-name">{{stream.name ~}}</span>
 {{~/if~}}


### PR DESCRIPTION
This PR fixes the channel icon rendering issue described in #34885.

### Changes:

* Removed hardcoded `width: 12px` from `.channel-privacy-type-icon`
* Wrapped icon and channel name inside a flex container
* Removed hardcoded spacing and replaced with CSS `gap`

This improves alignment and responsiveness across different font sizes.