### PR TITLE
tooltips: Add message link tooltip for in-realm message links

### DIFF
--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -1,22 +1,36 @@
 import $ from "jquery";
 import assert from "minimalistic-assert";
 import * as tippy from "tippy.js";
+import {z} from "zod/mini";
 
 import render_message_edit_notice_tooltip from "../templates/message_edit_notice_tooltip.hbs";
+import render_message_link_tooltip from "../templates/message_link_tooltip.hbs";
 import render_message_media_preview_tooltip from "../templates/message_media_preview_tooltip.hbs";
 import render_message_row_date_tooltip from "../templates/message_row_date_tooltip.hbs";
 import render_narrow_tooltip from "../templates/narrow_tooltip.hbs";
 import render_narrow_tooltip_list_of_topics from "../templates/narrow_tooltip_list_of_topics.hbs";
 
+import * as blueslip from "./blueslip.ts";
+import * as channel from "./channel.ts";
 import * as compose_validate from "./compose_validate.ts";
 import * as flatpickr from "./flatpickr.ts";
+import * as generic_widget from "./generic_widget.ts";
+import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
+import * as message_helper from "./message_helper.ts";
 import * as message_lists from "./message_lists.ts";
+import type {Message} from "./message_store.ts";
+import {raw_message_schema} from "./message_store.ts";
+import * as message_store from "./message_store.ts";
+import {page_params} from "./page_params.ts";
+import * as people from "./people.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as reactions from "./reactions.ts";
+import * as rendered_markdown from "./rendered_markdown.ts";
 import * as rows from "./rows.ts";
 import {message_edit_history_visibility_policy_values} from "./settings_config.ts";
 import {realm} from "./state_data.ts";
+import * as submessage from "./submessage.ts";
 import * as timerender from "./timerender.ts";
 import {
     INTERACTIVE_HOVER_DELAY,
@@ -490,4 +504,118 @@ export function initialize(): void {
             instance.destroy();
         },
     });
+
+    message_list_tooltip(".message_content a.message-link", {
+        delay: LONG_HOVER_DELAY,
+        onShow(instance) {
+            const $elem = $(instance.reference);
+            const href = $elem.attr("href");
+            assert(href !== undefined);
+
+            if (page_params.is_spectator) {
+                return false;
+            }
+
+            const channel_topic = hash_util.decode_stream_topic_from_url(href);
+            if (!channel_topic?.message_id) {
+                return false;
+            }
+
+            const message_id = Number(channel_topic.message_id);
+            instance.setProps({maxWidth: "70vw"});
+
+            const message = message_store.get(message_id);
+            if (message === undefined) {
+                void channel.get({
+                    url: "/json/messages/" + message_id,
+                    data: {allow_empty_topic_name: true},
+                    success(raw_data) {
+                        const data = z.object({message: raw_message_schema}).parse(raw_data);
+                        message_helper.process_new_server_message(data.message);
+                        instance.show();
+                    },
+                    error() {
+                        blueslip.info("Failed to fetch message for message link tooltip");
+                    },
+                });
+                return false;
+            }
+
+            render_message_link_tooltip_content(message, instance);
+            return undefined;
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+}
+
+function render_message_link_tooltip_content(message: Message, instance: tippy.Instance): void {
+    let status_message: string | undefined;
+    if (message.is_me_message) {
+        status_message = message.content.slice("<p>/me".length);
+    }
+
+    const sender_is_bot = people.sender_is_bot(message);
+    const sender_is_guest = people.sender_is_guest(message);
+    const sender_is_deactivated = people.sender_is_deactivated(message);
+    const should_add_guest_indicator_for_sender = people.should_add_guest_user_indicator(
+        message.sender_id,
+    );
+
+    const $tooltip_content = $(
+        render_message_link_tooltip({
+            small_avatar_url: people.small_avatar_url(message),
+            msg: message,
+            sender_is_bot,
+            sender_is_guest,
+            sender_is_deactivated,
+            status_message,
+            should_add_guest_indicator_for_sender,
+            show_message_body_in_tooltip: true,
+        }),
+    );
+
+    const $message_content = $tooltip_content.find(".message_content");
+    rendered_markdown.update_elements($message_content);
+
+    const event = submessage.get_message_events(message);
+    if (event) {
+        const $widget_elem = $("<div>").addClass("widget-content");
+        const [widget_event, ...inbound_events] = event;
+
+        const widget_instance = generic_widget.create_widget_instance({
+            message,
+            any_data: widget_event.data,
+        });
+
+        if (inbound_events.length > 0) {
+            widget_instance.handle_inbound_events(inbound_events);
+        }
+
+        generic_widget.render_widget_instance({
+            post_to_server() {
+                // Do not send outbound events for tooltip widgets.
+            },
+            $widget_elem,
+            message,
+            widget_data: widget_instance.get_widget_data(),
+            rerender: false,
+        });
+
+        $widget_elem
+            .find(
+                ".poll-edit-question, .poll-option-bar, .todo-edit-task-list-title, .add-task-bar",
+            )
+            .hide();
+        $widget_elem
+            .find("button, input, select, .poll-vote, .todo-checkbox input")
+            .prop("disabled", true);
+
+        $tooltip_content.find(".message_content").empty().append($widget_elem);
+    }
+
+    const $tooltip_container = $("<div>");
+    $tooltip_container.append($tooltip_content);
+    instance.setContent(parse_html($tooltip_container.html()));
 }

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1414,6 +1414,7 @@
                 display: -webkit-box;
                 -webkit-box-orient: vertical;
                 -webkit-line-clamp: 3;
+                /* stylelint-disable-next-line property-no-deprecated */
                 -webkit-box-align: start;
                 overflow: hidden;
                 overflow-wrap: break-word;

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1368,3 +1368,72 @@
         vertical-align: -0.1429em; /* -2px at 14px/1em */
     }
 }
+
+.message_link_tooltip {
+    max-height: 200px;
+    max-width: min(600px, 70vw);
+    overflow: hidden;
+
+    .messagebox-content {
+        display: grid;
+        align-items: center;
+        grid-template:
+            minmax(var(--message-box-sender-line-height), auto) 1fr /
+            var(--message-box-avatar-column-width) minmax(0, 1fr);
+        grid-template-areas:
+            "avatar sender "
+            "avatar message";
+
+        &.is-me-message {
+            grid-template-areas:
+                ".      .     "
+                "avatar sender"
+                "avatar sender";
+            grid-template-rows:
+                var(--message-box-vertical-margin) var(
+                    --message-box-avatar-height
+                )
+                minmax(0, auto);
+        }
+
+        .message-avatar {
+            grid-area: avatar;
+        }
+
+        .message_sender {
+            grid-area: sender;
+        }
+
+        .message_content:not(.status-message) {
+            grid-area: message;
+            color: var(--color-text-message-default);
+
+            & > p,
+            & > ul,
+            & > ol {
+                display: -webkit-box;
+                -webkit-box-orient: vertical;
+                -webkit-line-clamp: 3;
+                -webkit-box-align: start;
+                overflow: hidden;
+                overflow-wrap: break-word;
+                white-space: normal;
+            }
+        }
+    }
+
+    code {
+        color: var(--color-text-default);
+        background-color: var(--color-background-disabled);
+        border-radius: 3px;
+        padding: 0 2px;
+    }
+
+    .codehilite pre {
+        color: light-dark(hsl(0deg 0% 87%), hsl(0deg 0% 87%));
+        background-color: light-dark(
+            hsl(0deg 0% 70% / 4%),
+            hsl(0deg 0% 100% / 4%)
+        );
+    }
+}

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1373,6 +1373,9 @@
     max-height: 200px;
     max-width: min(600px, 70vw);
     overflow: hidden;
+    /* Use the same surface background as message rows so the text color
+       (--color-text-message-default) renders correctly in both themes. */
+    background-color: var(--color-background-stream-message-content);
 
     .messagebox-content {
         display: grid;
@@ -1421,20 +1424,5 @@
                 white-space: normal;
             }
         }
-    }
-
-    code {
-        color: var(--color-text-default);
-        background-color: var(--color-background-disabled);
-        border-radius: 3px;
-        padding: 0 2px;
-    }
-
-    .codehilite pre {
-        color: light-dark(hsl(0deg 0% 87%), hsl(0deg 0% 87%));
-        background-color: light-dark(
-            hsl(0deg 0% 70% / 4%),
-            hsl(0deg 0% 100% / 4%)
-        );
     }
 }

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1376,6 +1376,10 @@
     /* Use the same surface background as message rows so the text color
        (--color-text-message-default) renders correctly in both themes. */
     background-color: var(--color-background-stream-message-content);
+    /* Set text color explicitly for both themes. The tippy container sets
+       white text, and --color-text-sender-name is only defined in dark mode,
+       so we need an explicit color that works in light mode too. */
+    color: light-dark(hsl(0deg 0% 15%), hsl(0deg 0% 87%));
 
     .messagebox-content {
         display: grid;

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -1,8 +1,8 @@
-{{#if include_sender}}
+{{#if (or include_sender show_message_body_in_tooltip)}}
     {{> message_avatar . ~}}
 {{/if}}
 <span class="message_sender">
-    {{#if include_sender}}
+    {{#if (or include_sender show_message_body_in_tooltip)}}
         <span class="sender_info_hover sender_name" role="button" tabindex="0">
             <span class="view_user_card_tooltip sender_name_text" data-is-bot="{{#if sender_is_bot}}true{{else}}false{{/if}}">
                 {{> user_full_name name=msg/sender_full_name should_add_guest_user_indicator=should_add_guest_indicator_for_sender is_hidden=is_hidden}}
@@ -19,28 +19,35 @@
             {{/if}}
             {{#if status_message}}
                 <span class="message_content rendered_markdown status-message">{{rendered_markdown status_message}}</span>
-                {{#if message_edit_notices_for_status_message}}
+                {{#unless show_message_body_in_tooltip}}
+                    {{#if message_edit_notices_for_status_message}}
+                        {{> edited_notice .}}
+                    {{/if}}
+                {{/unless}}
+            {{/if}}
+            {{#unless show_message_body_in_tooltip}}
+                {{#if message_edit_notices_alongside_sender}}
                     {{> edited_notice .}}
                 {{/if}}
-            {{/if}}
-            {{#if message_edit_notices_alongside_sender}}
-                {{> edited_notice .}}
-            {{/if}}
+            {{/unless}}
         {{/unless}}
     {{/if}}
 </span>
 
+{{#unless show_message_body_in_tooltip}}
 <a {{#unless msg/locally_echoed}}href="{{ msg/url }}"{{/unless}} class="message-time">
     {{#unless include_sender}}
     <span class="copy-paste-text">&nbsp;</span>
     {{/unless}}
     {{timestr}}
 </a>
+{{/unless}}
 
 {{#if (and (not msg/failed_request) msg/locally_echoed)}}
     <span data-tooltip-template-id="slow-send-spinner-tooltip-template" class="fa fa-circle-o-notch slow-send-spinner{{#unless msg/show_slow_send_spinner }} hidden{{/unless}}"></span>
 {{/if}}
 
+{{#unless show_message_body_in_tooltip}}
 <div class="message_controls no-select">
     {{#if msg/locally_echoed}}
         {{#if msg/failed_request}}
@@ -52,6 +59,7 @@
         {{> message_controls .}}
     {{/if}}
 </div>
+{{/unless}}
 
 {{#unless status_message}}
     {{#unless is_hidden}}
@@ -63,12 +71,15 @@
         {{/if}}
     </div>
     {{else}}
-    <div class="message_content rendered_markdown">
-        {{> message_hidden_dialog}}
-    </div>
+        {{#unless show_message_body_in_tooltip}}
+        <div class="message_content rendered_markdown">
+            {{> message_hidden_dialog}}
+        </div>
+        {{/unless}}
     {{/unless}}
 {{/unless}}
 
+{{#unless show_message_body_in_tooltip}}
 {{#if message_edit_notices_in_left_col}}
 {{> edited_notice .}}
 {{/if}}
@@ -81,4 +92,5 @@
 
 {{#unless (eq msg.reminders.length 0)}}
     {{> message_reminders . }}
+{{/unless}}
 {{/unless}}

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -71,11 +71,11 @@
         {{/if}}
     </div>
     {{else}}
-        {{#unless show_message_body_in_tooltip}}
-        <div class="message_content rendered_markdown">
-            {{> message_hidden_dialog}}
-        </div>
-        {{/unless}}
+    {{#unless show_message_body_in_tooltip}}
+    <div class="message_content rendered_markdown">
+        {{> message_hidden_dialog}}
+    </div>
+    {{/unless}}
     {{/unless}}
 {{/unless}}
 

--- a/web/templates/message_link_tooltip.hbs
+++ b/web/templates/message_link_tooltip.hbs
@@ -1,0 +1,5 @@
+<div class="message_link_tooltip">
+    <div class="messagebox-content {{#if status_message}}is-me-message{{/if}}">
+        {{> message_body .}}
+    </div>
+</div>

--- a/web/tests/hash_util.test.cjs
+++ b/web/tests/hash_util.test.cjs
@@ -6,7 +6,7 @@ const message_link_test_cases = require("../../zerver/tests/fixtures/message_lin
 
 const {make_stream} = require("./lib/example_stream.cjs");
 const {make_user} = require("./lib/example_user.cjs");
-const {zrequire} = require("./lib/namespace.cjs");
+const {set_global, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 
 const hash_parser = zrequire("hash_parser");
@@ -378,4 +378,73 @@ run_test("test_is_spectator_compatible", () => {
     assert.equal(hash_parser.is_spectator_compatible("#settings/profile"), false);
     assert.equal(hash_parser.is_spectator_compatible("#drafts"), false);
     assert.equal(hash_parser.is_spectator_compatible("#channels/subscribed"), false);
+});
+
+run_test("test_decode_stream_topic_from_url", () => {
+    set_global("window", {
+        location: {
+            origin: "http://zulip.zulipdev.com",
+        },
+    });
+
+    // Message link with stream, topic, and message_id.
+    // This is the primary use case for message link tooltips.
+    let result = hash_util.decode_stream_topic_from_url(
+        "http://zulip.zulipdev.com/#narrow/channel/99-frontend/topic/testing/near/456",
+    );
+    assert.equal(result?.stream_id, 99);
+    assert.equal(result?.topic_name, "testing");
+    assert.equal(result?.message_id, "456");
+
+    // Message link with empty topic name.
+    result = hash_util.decode_stream_topic_from_url(
+        "http://zulip.zulipdev.com/#narrow/channel/1-general/topic//near/123",
+    );
+    assert.equal(result?.stream_id, 1);
+    assert.equal(result?.topic_name, "");
+    assert.equal(result?.message_id, "123");
+
+    // Channel-only link (no topic, no message_id).
+    result = hash_util.decode_stream_topic_from_url(
+        "http://zulip.zulipdev.com/#narrow/channel/42-random",
+    );
+    assert.equal(result?.stream_id, 42);
+    assert.equal(result?.topic_name, undefined);
+    assert.equal(result?.message_id, undefined);
+
+    // Channel + topic link (no message_id).
+    result = hash_util.decode_stream_topic_from_url(
+        "http://zulip.zulipdev.com/#narrow/channel/15-Development/topic/backend",
+    );
+    assert.equal(result?.stream_id, 15);
+    assert.equal(result?.topic_name, "backend");
+    assert.equal(result?.message_id, undefined);
+
+    // "with" operator discards message_id (currently not used for message links).
+    result = hash_util.decode_stream_topic_from_url(
+        "http://zulip.zulipdev.com/#narrow/channel/5-Announce/topic/updates/with/789",
+    );
+    assert.equal(result?.stream_id, 5);
+    assert.equal(result?.topic_name, "updates");
+    assert.equal(result?.message_id, undefined);
+
+    // Invalid URLs return null.
+    assert.equal(
+        hash_util.decode_stream_topic_from_url("http://evil.example.com/#narrow/channel/1"),
+        null,
+    );
+    assert.equal(
+        hash_util.decode_stream_topic_from_url("http://zulip.zulipdev.com/#settings/profile"),
+        null,
+    );
+    assert.equal(
+        hash_util.decode_stream_topic_from_url("http://zulip.zulipdev.com/#narrow/topic/1"),
+        null,
+    );
+    assert.equal(
+        hash_util.decode_stream_topic_from_url(
+            "http://zulip.zulipdev.com/#narrow/channel/invalid/topic/1",
+        ),
+        null,
+    );
 });


### PR DESCRIPTION
Fixes: #35190
This PR adds Tippy.js tooltips to in-realm message links
(`#**stream>topic@message_id**`). On long hover (750ms), the tooltip
shows the sender's avatar, name, and a 3-line preview of the message
content. This matches the spec from issue #35190 and the CZO design
discussion in [#137-feedback › slick title tips for within-Zulip links.](https://chat.zulip.org/#narrow/channel/137-feedback/topic/slick.20title.20tips.20for.20within-Zulip.20links/with/2215839)
**Changes across 5 files (~295 lines):**
| File | Change |
|---|---|
| `web/templates/message_link_tooltip.hbs` | New wrapper template |
| `web/templates/message_body.hbs` | Add `show_message_body_in_tooltip` flag to hide controls, reactions, timestamps |
| `web/styles/message_row.css` | Add `.message_link_tooltip` CSS: max-height 200px, 3-line clamp, light/dark theme support |
| `web/src/message_list_tooltips.ts` | Add tooltip handler: fetches message from store or API, renders template, handles widgets in read-only mode |
| `web/tests/hash_util.test.cjs` | Add `test_decode_stream_topic_from_url` for URL parsing coverage |
**How changes were tested:**
Manual testing in browser:
- Light and dark themes — verified text/background contrast
- 3-line clamp on long messages
- Avatar + sender + content layout alignment
- Message links in various contexts
Automated tests:
- `web/tests/hash_util.test.cjs` — `test_decode_stream_topic_from_url` passes
### Notes for reviewers
- Widgets (polls, todos, zforms) are rendered in read-only mode with
  interactive elements hidden/disabled
- Tooltip uses `var(--color-background-stream-message-content)` background
  for proper theme contrast in both light and dark modes
- CSS Grid handles avatar + sender + content layout inside tooltip
- Invalid URLs, API failures, and spectator mode all silently return
  without showing a tooltip
## 📸 Screenshots

### 🌞 Light mode
<p align="center">
  <img src="https://github.com/user-attachments/assets/650ceb92-2eec-421f-9862-9ad2f6502ceb" width="720">
</p>

### 🌙 Dark mode
<p align="center">
  <img src="https://github.com/user-attachments/assets/00d65dc1-5bf0-4bd9-9821-aec301936e41" width="720">
</p>
---

**Self-review checklist:**
- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.