### PR TITLE
Fix: huge channel ID narrow collapse.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1959,9 +1959,23 @@ export class Filter {
         return JSON.stringify(
             this._terms.map((term) => {
                 if (term.operator === "channel") {
+                    // Keep non-canonical operands unchanged so server-side
+                    // validation handles them, rather than coercing them into
+                    // unrelated channel IDs.
+                    if (!/^\d+$/.test(term.operand)) {
+                        return term;
+                    }
+
+                    const channel_id = Number.parseInt(term.operand, 10);
+                    // Avoid converting huge IDs that are not safe integers;
+                    // coercing them can ultimately collapse to channel 1.
+                    if (!Number.isSafeInteger(channel_id)) {
+                        return term;
+                    }
+
                     return {
                         ...term,
-                        operand: Number.parseInt(term.operand, 10),
+                        operand: channel_id,
                     };
                 }
                 return term;

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -97,7 +97,20 @@ export function decode_operand(
     operand = internal_url.decodeHashComponent(operand);
 
     if (operator === "channel") {
-        return stream_data.slug_to_stream_id(operand)?.toString() ?? "";
+        const stream_id = stream_data.slug_to_stream_id(operand);
+        if (stream_id === undefined) {
+            return "";
+        }
+
+        const modern_slug_match = /^(\d+)(?:-.*)?$/.exec(operand);
+        if (modern_slug_match !== null && !stream_data.get_sub_by_id(stream_id)) {
+            // Preserve the exact integer from the URL for unknown/inaccessible
+            // channels. This avoids the issue where huge IDs can round-trip
+            // through scientific notation and then collapse to channel 1.
+            return modern_slug_match[1]!;
+        }
+
+        return stream_id.toString();
     }
 
     return operand;

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -3229,4 +3229,13 @@ run_test("get_stringified_narrow_for_server_query", () => {
         huge_channel_filter.get_stringified_narrow_for_server_query(),
         '[{"operator":"channel","operand":"11234879138471092384709182374","negated":false}]',
     );
+
+    // Keep non-canonical channel operands unchanged.
+    const non_canonical_channel_filter = new Filter([
+        {operator: "channel", operand: "11234879138471092384709182374xyz"},
+    ]);
+    assert.equal(
+        non_canonical_channel_filter.get_stringified_narrow_for_server_query(),
+        '[{"operator":"channel","operand":"11234879138471092384709182374xyz","negated":false}]',
+    );
 });

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -3220,4 +3220,13 @@ run_test("get_stringified_narrow_for_server_query", () => {
         narrow,
         '[{"operator":"channel","operand":1,"negated":false},{"operator":"topic","operand":"bar","negated":false}]',
     );
+
+    // Regression test: keep huge IDs as strings so they cannot collapse to 1.
+    const huge_channel_filter = new Filter([
+        {operator: "channel", operand: "11234879138471092384709182374"},
+    ]);
+    assert.equal(
+        huge_channel_filter.get_stringified_narrow_for_server_query(),
+        '[{"operator":"channel","operand":"11234879138471092384709182374","negated":false}]',
+    );
 });

--- a/web/tests/hash_util.test.cjs
+++ b/web/tests/hash_util.test.cjs
@@ -192,6 +192,12 @@ run_test("test_parse_narrow", () => {
         {negated: false, operator: "channel", operand: "42"},
     ]);
 
+    // Regression test: huge channel IDs should not collapse to channel 1.
+    const huge_channel_id = "11234879138471092384709182374";
+    assert.deepEqual(hash_util.parse_narrow(["narrow", "channel", huge_channel_id]), [
+        {negated: false, operator: "channel", operand: huge_channel_id},
+    ]);
+
     // Empty string as a topic name is valid.
     assert.deepEqual(hash_util.parse_narrow(["narrow", "stream", "99-frontend", "topic", ""]), [
         {negated: false, operator: "channel", operand: frontend.stream_id.toString()},


### PR DESCRIPTION
Fixes #35036.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
Fixed a client-side narrow bug where very large channel IDs could be lossy-converted and collapse to `1`, causing requests for the wrong channel. Updated `web/src/hash_util.ts` and `web/src/filter.ts` to preserve unsafe large IDs as strings, with regression tests added in `web/tests/hash_util.test.cjs` and `web/tests/filter.test.cjs`.


**How changes were tested:**
- **Manual verification done**
     1. Started the local dev server.
     2. Next enabled the network tab in browser devtools using (Ctrl + Shift + I)
     3. Navigate to /#narrow/channel/11234879138471092384709182374
     4. Before fix:
        - Observed repeated /json/messages requests with channel operand 1. and also observed loader-loop behavior.
     5. After fix:
        - No collapse from huge channel ID to 1 in narrow payload and huge operand remained preserved through client-side narrow handling.

- **Automated verification using regression test written in**
     - `./tools/test-js-with-node web/tests/hash_util.test.cjs web/tests/filter.test.cjs`
     - `./tools/lint web/src/hash_util.ts web/src/filter.ts`

**Screenshots**:
- **Before**:
  - Loader-loop and repeated request behavior with collapsed channel operand `1` observed through the console.
  - <img width="1908" height="325" alt="Screenshot 2026-03-22 180320" src="https://github.com/user-attachments/assets/a23352ea-1e80-4d4e-b038-f4cb8b4511f2" />

- **After**:
  - Observing the console for huge channel operand that were preserved, without channel-1 collapse, and forwarding it to 400 (Bad Request).
  - <img width="1919" height="993" alt="Screenshot 2026-03-22 180959" src="https://github.com/user-attachments/assets/9e571c2c-4a45-427c-8e75-3ec5140753a0" />

  
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
