### PR TITLE
search: Fix iOS swipe keyboard discarding search on Return.

### DIFF
--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -294,6 +294,13 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
         // `is_using_input_method` before searching.
         // More details in the commit message that added this line.
         is_using_input_method = true;
+        // Reset after the current event loop iteration so that the flag
+        // does not remain stale for iOS swipe keyboards, where
+        // compositionend fires on swipe completion, not on Enter.
+        // Fixes #27494.
+        setTimeout(() => {
+            is_using_input_method = false;
+        }, 0);
     });
 
     let typeahead_was_open_on_enter = false;


### PR DESCRIPTION
On iOS Safari with swipe keyboards, compositionend fires when a swipe word is completed, not when Enter is pressed. This caused is_using_input_method to remain true when the user later pressed Return to search, incorrectly suppressing the search and closing the search bar instead.

Fix this by resetting is_using_input_method asynchronously after the current event loop iteration using setTimeout, so that it only blocks Enter keypresses in the same tick as compositionend (for real IME input methods), but not later keypresses on iOS.

Fixes #27494.

**How changes were tested:**
Tested manually on iOS Safari 16 using the swipe keyboard:
1. Tapped the search icon to open the search bar.
2. Used the swipe keyboard to type a search term.
3. Pressed Return — search now correctly executes instead of closing the search bar.

Also verified that normal IME input (compositionend + Enter to confirm) still works correctly and does not trigger an unintended search.

Note: AI assistance was used only in identifying this fix.

**Screenshots and screen captures:**
N/A — this is a behavioral bug fix with no visual UI changes.

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the AI use policy.

Communicate decisions, questions, and potential concerns.
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see commit discipline).
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:
- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>