### PR TITLE
api-docs: Document /users/me/profile_data endpoint

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -95,6 +95,8 @@
 * [Reactivate a user](/api/reactivate-user)
 * [Get a user's status](/api/get-user-status)
 * [Update your status](/api/update-status)
+* [Update your profile data](/api/update-profile-data)
+* [Delete your profile data](/api/remove-profile-data)
 * [Update user status](/api/update-status-for-user)
 * [Set "typing" status](/api/set-typing-status)
 * [Set "typing" status for message editing](/api/set-typing-status-for-message-edit)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12293,6 +12293,121 @@ paths:
                           }
                         description: |
                           An example JSON error response when the custom emoji is invalid:
+  /users/me/profile_data:
+    patch:
+      operationId: update-profile-data
+      summary: Update your profile data
+      tags: ["users"]
+      description: |
+        Update the values of the [custom profile fields](/help/custom-profile-fields)
+        for the current user.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - data
+              properties:
+                data:
+                  type: array
+                  example:
+                    - id: 1
+                      value: "Software Engineer"
+                  items:
+                    type: object
+                    required:
+                      - id
+                      - value
+                    properties:
+                      id:
+                        type: integer
+                        description: |
+                          The ID of the custom profile field to update.
+                        example: 1
+                      value:
+                        oneOf:
+                          - type: string
+                          - type: array
+                            items:
+                              type: integer
+                        description: |
+                          The value for the custom profile field.
+                          This is usually a string, but for fields with predefined choices,
+                          it can be an array of integer choice IDs.
+                        example: "Software Engineer"
+                  description: |
+                    A list of objects, each containing the `id` of the custom
+                    profile field and the new `value` for that field.
+            encoding:
+              data:
+                contentType: application/json
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JsonSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                field_id_not_found:
+                  value:
+                    result: "error"
+                    msg: "Field id 9999 not found."
+                    code: "BAD_REQUEST"
+    delete:
+      operationId: remove-profile-data
+      summary: Delete your profile data
+      tags: ["users"]
+      description: |
+        Delete the values of the [custom profile fields](/help/custom-profile-fields)
+        for the current user.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - data
+              properties:
+                data:
+                  type: array
+                  items:
+                    type: integer
+                  description: |
+                    A list of integers, each being the ID of a custom profile
+                    field whose value should be deleted.
+                  example: [1, 2]
+            encoding:
+              data:
+                contentType: application/json
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JsonSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                invalid_profile_data:
+                  value:
+                    result: "error"
+                    msg: "Invalid profile data."
+                    code: "BAD_REQUEST"
   /users/me/{stream_id}/topics:
     get:
       operationId: get-stream-topics

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -225,7 +225,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         #### These personal settings endpoints have modest value to document:
         "/users/me/avatar",
         # Much more valuable would be an org admin bulk-upload feature.
-        "/users/me/profile_data",
         #### Should be documented as part of interactive bots documentation
         "/bot_storage",
         "/submessage",


### PR DESCRIPTION
Document PATCH and DELETE /users/me/profile_data.

This PR adds OpenAPI documentation for:
PATCH /users/me/profile_data to update custom profile field data
 DELETE /users/me/profile_data to remove custom profile field data

Files changed:
 zerver/openapi/zulip.yaml
 api_docs/include/rest-endpoints.md
 zerver/tests/test_openapi.py

What was added:
 endpoint documentation for PATCH and DELETE
 request/response examples
 sidebar links for the new API docs pages
 OpenAPI test update to remove this endpoint from undocumented endpoints

Testing:
 tools/test-backend zerver/tests/test_openapi.py
 CI checks passed