### PR TITLE
narrow: Use canonical "channel" operator consistently.

### DIFF
--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1565,7 +1565,7 @@ export function narrow_by_recipient(
             show(
                 [
                     {
-                        operator: "stream",
+                        operator: "channel",
                         operand: message.stream_id.toString(),
                     },
                 ],

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -170,7 +170,7 @@ function build_stream_popover(opts: {elt: HTMLElement; stream_id: number}): void
                 message_view.show(
                     [
                         {
-                            operator: "stream",
+                            operator: "channel",
                             operand: sub.stream_id.toString(),
                         },
                     ],

--- a/web/src/stream_topic_history_util.ts
+++ b/web/src/stream_topic_history_util.ts
@@ -75,7 +75,7 @@ export function update_topic_last_message_id(
         url: "/json/messages",
         data: {
             narrow: JSON.stringify([
-                {operator: "stream", operand: stream_id},
+                {operator: "channel", operand: stream_id},
                 {operator: "topic", operand: topic_name},
             ]),
             anchor: "newest",

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -606,7 +606,7 @@ export async function initialize_everything(state_data) {
             message_view.show(
                 [
                     {
-                        operator: "stream",
+                        operator: "channel",
                         operand: sub.stream_id.toString(),
                     },
                 ],

--- a/web/tests/stream_topic_history.test.cjs
+++ b/web/tests/stream_topic_history.test.cjs
@@ -457,7 +457,7 @@ test("ask_server_for_latest_topic_data", () => {
         assert.equal(opts.url, "/json/messages");
         assert.deepEqual(opts.data, {
             anchor: "newest",
-            narrow: '[{"operator":"stream","operand":1080},{"operator":"topic","operand":"Topic1"}]',
+            narrow: '[{"operator":"channel","operand":1080},{"operator":"topic","operand":"Topic1"}]',
             num_after: 0,
             num_before: 1,
             allow_empty_topic_name: true,


### PR DESCRIPTION
Updates uses of the "stream" narrow operator in the frontend to instead use the canonical "channel" operator.

**Notes**:
- #29663 added the "channel" operator.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
